### PR TITLE
Minor changes to make consensus state on disk be operation-based.

### DIFF
--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -174,6 +174,7 @@ pub trait L2DataStore {
     fn del_block_data(&self, id: L2BlockId) -> DbResult<bool>;
 }
 
+/// Data provider for L2 blocks.
 pub trait L2DataProvider {
     /// Gets the L2 block by its ID, if we have it.
     fn get_block_data(&self, id: L2BlockId) -> DbResult<Option<L2Block>>;


### PR DESCRIPTION
This means the consensus STF will emit a series of "consensus writes" that are then applied to the consensus state.  We only have to store checkpoints periodically of the actual consensus states and reduce db footprint.