### PR TITLE
feat(btcio): Add async RPC client #30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,15 @@ reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.2
 reth-revm = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.2.0-beta.6" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.2.0-beta.6" }
 reth-rpc-types = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.2.0-beta.6" }
-serde = "1.0"
-serde_json = "1.0"
+serde_json = {version="1.0", features=["alloc", "raw_value"]}
+serde = { version = "1.0", features = [ "alloc", "derive", ] }
+serde_derive = "1.0.202"
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+bitcoin = { version = "0.32", features=["serde", "rand"] }
+hex = "0.4.3"
+bitcoincore-rpc-json = "0.19.0"
+reqwest = {version = "0.12.4", features = ["json"]}
+base64 = "0.22.1"

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitcoin = {workspace=true}
+bitcoincore-rpc-json = {workspace=true} 
+reqwest = {workspace = true, features = ["json"]}
+serde = { workspace = true, features = [ "alloc", "derive", ] }
+serde_derive = { workspace=true } 
+serde_json = { workspace=true,  features = [ "alloc", "raw_value", ] }
+tokio = { workspace=true, features = ["full"]}
+tracing = {workspace=true} 
+async-trait = {workspace=true}
+base64 = {workspace=true} 

--- a/crates/btcio/README.md
+++ b/crates/btcio/README.md
@@ -1,0 +1,9 @@
+# btcio 
+
+For Input-output with Bitcoin, implementing L1 chain trait.
+
+### Run the test for rpc `Client`
+> prerequisite: `bitcoind` should be installed on the system
+
+
+

--- a/crates/btcio/scripts/rpc_test.sh
+++ b/crates/btcio/scripts/rpc_test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+RPCUSER=alpen
+RPCPASSWORD=testnet
+RPCPORT=18443
+
+WALLET=alpen
+
+bcli_start() {
+    bitcoind -regtest -daemon --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWORD --rpcport=$RPCPORT 
+}
+
+bcli() {
+    bitcoin-cli -regtest --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWORD --rpcport=$RPCPORT $@
+}
+
+kill_daemon() {
+    echo killing daemon
+    killall bitcoind
+}
+
+create_wallet() {
+    bcli -named createwallet wallet_name=$1 load_on_startup=true
+}
+
+generate_address() {
+    bcli -rpcwallet=$1 getnewaddress "bridge" "bech32"
+}
+
+check_bitcoind_rpc() {
+  if bcli -getinfo > /dev/null 2>&1; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+setup_wallet() {
+    if bcli listwallets | grep -q "\"$1\"";then
+      return 0
+    else
+      if bcli loadwallet $1 | grep -q "loaded successfully"; then
+        return 0
+      else
+          create_wallet $1
+          user_addr=$(generate_address $1)
+
+          # load some btc to wallet
+          bcli -rpcwallet=$1 generatetoaddress 100 $user_addr
+          echo User address is $user_addr
+      fi
+    fi
+}
+
+#kill the already running bitcoind process
+if pgrep -x "bitcoind" > /dev/null; then
+    echo "Killing the already running bitcoind process"
+    kill_daemon
+    sleep 0.5 
+fi
+
+
+echo "starting bitcoin regnet"
+bcli_start
+
+# check if bitcoind rpc has started or not
+while ! check_bitcoind_rpc; do
+  echo "bcli hasn't started yet... retrying in 3 seconds"
+  sleep 3
+done
+
+setup_wallet $WALLET
+
+REGTEST_HOST=http://localhost REGTEST_PORT=$RPCPORT REGTEST_USERNAME=$RPCUSER REGTEST_PASSWORD=$RPCPASSWORD REGTEST_WALLET=$WALLET cargo test --package alpen-vertex-btcio --all-targets -- --nocapture
+
+
+
+
+
+
+
+

--- a/crates/btcio/src/lib.rs
+++ b/crates/btcio/src/lib.rs
@@ -1,1 +1,2 @@
 //! Input-output with Bitcoin, implementing L1 chain trait.
+pub mod rpc;

--- a/crates/btcio/src/rpc.rs
+++ b/crates/btcio/src/rpc.rs
@@ -1,0 +1,1717 @@
+use ::bitcoin::{
+    address::{NetworkChecked, NetworkUnchecked},
+    ecdsa::Signature,
+    hex::{DisplayHex, FromHex},
+    Address, Amount, Block, OutPoint, PrivateKey, PublicKey, Script, Transaction,
+};
+use bitcoin::secp256k1;
+
+use bitcoincore_rpc_json::*;
+use core::fmt;
+use reqwest::header::HeaderMap;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::io::{BufRead, BufReader};
+use std::{collections::HashMap, fmt::Display, fs::File, path::PathBuf};
+
+use async_trait::async_trait;
+use std::env;
+use std::fmt::Debug;
+use std::{error, io, result};
+
+use ::bitcoin::consensus::encode::deserialize_hex;
+use base64::engine::general_purpose;
+use base64::Engine;
+use bitcoincore_rpc_json::bitcoin::hashes::hex;
+
+#[derive(Debug)]
+pub enum Error {
+    Hex(hex::HexToBytesError),
+    Json(serde_json::error::Error),
+    BitcoinSerialization(bitcoin::consensus::encode::Error),
+    Secp256k1(secp256k1::Error),
+    Io(io::Error),
+    InvalidAmount(bitcoin::amount::ParseAmountError),
+    InvalidCookieFile,
+    /// The JSON result had an unexpected structure.
+    UnexpectedStructure,
+    /// The daemon returned an error string.
+    ReturnedError(String),
+}
+
+impl From<hex::HexToBytesError> for Error {
+    fn from(e: hex::HexToBytesError) -> Error {
+        Error::Hex(e)
+    }
+}
+
+impl From<serde_json::error::Error> for Error {
+    fn from(e: serde_json::error::Error) -> Error {
+        Error::Json(e)
+    }
+}
+
+impl From<bitcoin::consensus::encode::Error> for Error {
+    fn from(e: bitcoin::consensus::encode::Error) -> Error {
+        Error::BitcoinSerialization(e)
+    }
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Error {
+        Error::Secp256k1(e)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Error {
+        Error::Io(e)
+    }
+}
+
+impl From<bitcoin::amount::ParseAmountError> for Error {
+    fn from(e: bitcoin::amount::ParseAmountError) -> Error {
+        Error::InvalidAmount(e)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Hex(ref e) => write!(f, "hex decode error: {}", e),
+            Error::Json(ref e) => write!(f, "JSON error: {}", e),
+            Error::BitcoinSerialization(ref e) => write!(f, "Bitcoin serialization error: {}", e),
+            Error::Secp256k1(ref e) => write!(f, "secp256k1 error: {}", e),
+            Error::Io(ref e) => write!(f, "I/O error: {}", e),
+            Error::InvalidAmount(ref e) => write!(f, "invalid amount: {}", e),
+            Error::InvalidCookieFile => write!(f, "invalid cookie file"),
+            Error::UnexpectedStructure => write!(f, "the JSON result had an unexpected structure"),
+            Error::ReturnedError(ref s) => write!(f, "the daemon returned an error string: {}", s),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "bitcoincore-rpc error"
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match *self {
+            Error::Hex(ref e) => Some(e),
+            Error::Json(ref e) => Some(e),
+            Error::BitcoinSerialization(ref e) => Some(e),
+            Error::Secp256k1(ref e) => Some(e),
+            Error::Io(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonOutPoint {
+    pub txid: bitcoin::Txid,
+    pub vout: u32,
+}
+
+impl From<OutPoint> for JsonOutPoint {
+    fn from(o: OutPoint) -> JsonOutPoint {
+        JsonOutPoint {
+            txid: o.txid,
+            vout: o.vout,
+        }
+    }
+}
+
+impl Into<OutPoint> for JsonOutPoint {
+    fn into(self) -> OutPoint {
+        OutPoint {
+            txid: self.txid,
+            vout: self.vout,
+        }
+    }
+}
+
+/// Shorthand for converting a variable into a serde_json::Value.
+fn into_json<T>(val: T) -> Result<serde_json::Value>
+where
+    T: serde::ser::Serialize,
+{
+    Ok(serde_json::to_value(val)?)
+}
+
+/// Shorthand for converting an Option into an Option<serde_json::Value>.
+fn opt_into_json<T>(opt: Option<T>) -> Result<serde_json::Value>
+where
+    T: serde::ser::Serialize,
+{
+    match opt {
+        Some(val) => Ok(into_json(val)?),
+        None => Ok(serde_json::Value::Null),
+    }
+}
+
+/// Shorthand for `serde_json::Value::Null`.
+fn null() -> serde_json::Value {
+    serde_json::Value::Null
+}
+
+/// Shorthand for an empty serde_json::Value array.
+fn empty_arr() -> serde_json::Value {
+    serde_json::Value::Array(vec![])
+}
+
+/// Shorthand for an empty serde_json object.
+fn empty_obj() -> serde_json::Value {
+    serde_json::Value::Object(Default::default())
+}
+
+/// Handle default values in the argument list
+///
+/// Substitute `Value::Null`s with corresponding values from `defaults` table,
+/// except when they are trailing, in which case just skip them altogether
+/// in returned list.
+///
+/// Note, that `defaults` corresponds to the last elements of `args`.
+///
+/// ```norust
+/// arg1 arg2 arg3 arg4
+///           def1 def2
+/// ```
+///
+/// Elements of `args` without corresponding `defaults` value, won't
+/// be substituted, because they are required.
+fn handle_defaults<'a, 'b>(
+    args: &'a mut [serde_json::Value],
+    defaults: &'b [serde_json::Value],
+) -> &'a [serde_json::Value] {
+    assert!(args.len() >= defaults.len());
+
+    // Pass over the optional arguments in backwards order, filling in defaults after the first
+    // non-null optional argument has been observed.
+    let mut first_non_null_optional_idx = None;
+    for i in 0..defaults.len() {
+        let args_i = args.len() - 1 - i;
+        let defaults_i = defaults.len() - 1 - i;
+        if args[args_i] == serde_json::Value::Null {
+            if first_non_null_optional_idx.is_some() {
+                if defaults[defaults_i] == serde_json::Value::Null {
+                    panic!("Missing `default` for argument idx {}", args_i);
+                }
+                args[args_i] = defaults[defaults_i].clone();
+            }
+        } else if first_non_null_optional_idx.is_none() {
+            first_non_null_optional_idx = Some(args_i);
+        }
+    }
+
+    let required_num = args.len() - defaults.len();
+
+    if let Some(i) = first_non_null_optional_idx {
+        &args[..i + 1]
+    } else {
+        &args[..required_num]
+    }
+}
+
+/// Convert a possible-null result into an Option.
+fn opt_result<T: for<'a> serde::de::Deserialize<'a>>(
+    result: serde_json::Value,
+) -> Result<Option<T>> {
+    if result == serde_json::Value::Null {
+        Ok(None)
+    } else {
+        Ok(serde_json::from_value(result)?)
+    }
+}
+
+pub trait RawTx: Sized + Clone {
+    fn raw_hex(self) -> String;
+}
+
+impl<'a> RawTx for &'a Transaction {
+    fn raw_hex(self) -> String {
+        ::bitcoin::consensus::encode::serialize_hex(self)
+    }
+}
+
+impl<'a> RawTx for &'a [u8] {
+    fn raw_hex(self) -> String {
+        self.to_lower_hex_string()
+    }
+}
+
+impl<'a> RawTx for &'a Vec<u8> {
+    fn raw_hex(self) -> String {
+        self.to_lower_hex_string()
+    }
+}
+
+impl<'a> RawTx for &'a str {
+    fn raw_hex(self) -> String {
+        self.to_owned()
+    }
+}
+
+impl RawTx for String {
+    fn raw_hex(self) -> String {
+        self
+    }
+}
+
+/// The different authentication methods for the client.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Auth {
+    None,
+    UserPass(String, String),
+    CookieFile(PathBuf),
+}
+
+impl Auth {
+    /// Convert into the arguments that jsonrpc::Client needs.
+    pub fn get_user_pass(self) -> Result<(Option<String>, Option<String>)> {
+        match self {
+            Auth::None => Ok((None, None)),
+            Auth::UserPass(u, p) => Ok((Some(u), Some(p))),
+            Auth::CookieFile(path) => {
+                let line = BufReader::new(File::open(path).unwrap())
+                    .lines()
+                    .next()
+                    .ok_or(Error::InvalidCookieFile)??;
+                let colon = line.find(':').ok_or(Error::InvalidCookieFile)?;
+                Ok((Some(line[..colon].into()), Some(line[colon + 1..].into())))
+            }
+        }
+    }
+}
+
+pub struct Client {
+    url: String,
+    client: reqwest::Client,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "bitcoincore_rpc::Client({:?})", self.client)
+    }
+}
+
+impl Client {
+    /// Creates a client to a bitcoind JSON-RPC server.
+    ///
+    /// Can only return [Err] when using cookie authentication.
+    pub fn new(url: &str, auth: Auth) -> Result<Self> {
+        let (user, pass) = auth.get_user_pass()?;
+
+        let mut headers = HeaderMap::new();
+        let mut buf = String::new();
+        general_purpose::STANDARD.encode_string(
+            format!("{}:{}", user.unwrap(), pass.unwrap()).as_bytes(),
+            &mut buf,
+        );
+
+        headers.insert(
+            "Authorization",
+            format!("Basic {}", buf)
+                .parse()
+                .expect("Failed to parse auth header!"),
+        );
+        headers.insert(
+            "Content-Type",
+            "application/json"
+                .parse()
+                .expect("Failed to parse content type header!"),
+        );
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("Failed to build client!");
+
+        Ok(Self {
+            url: url.to_string(),
+            client,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn get_test_node() -> Self {
+        let host = env::var("REGTEST_HOST").unwrap_or("http://localhost".to_string());
+        let port = env::var("REGTEST_PORT").unwrap_or("18443".to_string());
+        let wallet = env::var("REGTEST_WALLET").unwrap_or("alpen".to_string());
+
+        let username = env::var("REGTEST_USERNAME").unwrap_or("alpen".to_string());
+        let password = env::var("REGTEST_PASSWORD").unwrap_or("testnet".to_string());
+        let url = format!("{}:{}/wallet/{}", host, port, wallet);
+        Self::new(&url, Auth::UserPass(username, password)).unwrap()
+    }
+}
+
+#[async_trait]
+pub trait AsyncRpcApi {
+    /// Call a `cmd` rpc with given `args` list
+    ///
+    async fn call<T: for<'a> serde::de::Deserialize<'a>>(
+        &self,
+        cmd: &str,
+        args: &[serde_json::Value],
+    ) -> Result<T>;
+
+    /// TODO(voidash) : port queryable to async
+    /// Query an object implementing `Querable` type
+    // async fn get_by_id<T: Queryable<Self>>(
+    //     &self,
+    //     id: &<T as Queryable<Self>>::Id,
+    // ) -> Result<T> {
+    //     T::query(&self, &id)
+    // }
+
+    async fn get_network_info(&self) -> Result<GetNetworkInfoResult> {
+        self.call("getnetworkinfo", &[]).await
+    }
+
+    async fn get_index_info(&self) -> Result<GetIndexInfoResult> {
+        self.call("getindexinfo", &[]).await
+    }
+
+    async fn version(&self) -> Result<usize> {
+        #[derive(Deserialize)]
+        struct Response {
+            pub version: usize,
+        }
+        let res: Response = self.call("getnetworkinfo", &[]).await?;
+        Ok(res.version)
+    }
+
+    async fn add_multisig_address(
+        &self,
+        nrequired: usize,
+        keys: &[PubKeyOrAddress<'_>],
+        label: Option<&str>,
+        address_type: Option<AddressType>,
+    ) -> Result<AddMultiSigAddressResult> {
+        let mut args = [
+            into_json(nrequired)?,
+            into_json(keys)?,
+            opt_into_json(label)?,
+            opt_into_json(address_type)?,
+        ];
+        self.call(
+            "addmultisigaddress",
+            handle_defaults(&mut args, &[into_json("")?, null()]),
+        )
+        .await
+    }
+
+    async fn load_wallet(&self, wallet: &str) -> Result<LoadWalletResult> {
+        self.call("loadwallet", &[wallet.into()]).await
+    }
+
+    async fn unload_wallet(&self, wallet: Option<&str>) -> Result<Option<UnloadWalletResult>> {
+        let mut args = [opt_into_json(wallet)?];
+        self.call("unloadwallet", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn create_wallet(
+        &self,
+        wallet: &str,
+        disable_private_keys: Option<bool>,
+        blank: Option<bool>,
+        passphrase: Option<&str>,
+        avoid_reuse: Option<bool>,
+    ) -> Result<LoadWalletResult> {
+        let mut args = [
+            wallet.into(),
+            opt_into_json(disable_private_keys)?,
+            opt_into_json(blank)?,
+            opt_into_json(passphrase)?,
+            opt_into_json(avoid_reuse)?,
+        ];
+        self.call(
+            "createwallet",
+            handle_defaults(
+                &mut args,
+                &[false.into(), false.into(), into_json("")?, false.into()],
+            ),
+        )
+        .await
+    }
+
+    async fn list_wallets(&self) -> Result<Vec<String>> {
+        self.call("listwallets", &[]).await
+    }
+
+    async fn list_wallet_dir(&self) -> Result<Vec<String>> {
+        let result: ListWalletDirResult = self.call("listwalletdir", &[]).await?;
+        let names = result.wallets.into_iter().map(|x| x.name).collect();
+        Ok(names)
+    }
+
+    async fn get_wallet_info(&self) -> Result<GetWalletInfoResult> {
+        self.call("getwalletinfo", &[]).await
+    }
+
+    async fn backup_wallet(&self, destination: Option<&str>) -> Result<()> {
+        let mut args = [opt_into_json(destination)?];
+        self.call("backupwallet", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    // async fn dump_private_key(&self, address: &Address) -> Result<PrivateKey> {
+    //     self.call("dumpprivkey", &[address.to_string().into()]).await
+    // }
+
+    async fn encrypt_wallet(&self, passphrase: &str) -> Result<()> {
+        self.call("encryptwallet", &[into_json(passphrase)?]).await
+    }
+
+    async fn get_difficulty(&self) -> Result<f64> {
+        self.call("getdifficulty", &[]).await
+    }
+
+    async fn get_connection_count(&self) -> Result<usize> {
+        self.call("getconnectioncount", &[]).await
+    }
+
+    async fn get_block(&self, hash: &bitcoin::BlockHash) -> Result<Block> {
+        let hex: String = self.call("getblock", &[into_json(hash)?, 0.into()]).await?;
+        Ok(deserialize_hex(&hex).unwrap())
+    }
+
+    async fn get_block_hex(&self, hash: &bitcoin::BlockHash) -> Result<String> {
+        self.call("getblock", &[into_json(hash)?, 0.into()]).await
+    }
+
+    async fn get_block_info(&self, hash: &bitcoin::BlockHash) -> Result<GetBlockResult> {
+        self.call("getblock", &[into_json(hash)?, 1.into()]).await
+    }
+
+    //TODO(voidash) add getblock_txs
+
+    async fn get_block_header(&self, hash: &bitcoin::BlockHash) -> Result<bitcoin::block::Header> {
+        let hex: String = self
+            .call("getblockheader", &[into_json(hash)?, false.into()])
+            .await
+            .unwrap();
+        Ok(deserialize_hex(&hex).unwrap())
+    }
+
+    async fn get_block_header_info(
+        &self,
+        hash: &bitcoin::BlockHash,
+    ) -> Result<GetBlockHeaderResult> {
+        self.call("getblockheader", &[into_json(hash)?, true.into()])
+            .await
+    }
+
+    async fn get_mining_info(&self) -> Result<GetMiningInfoResult> {
+        self.call("getmininginfo", &[]).await
+    }
+
+    async fn get_block_template(
+        &self,
+        mode: GetBlockTemplateModes,
+        rules: &[GetBlockTemplateRules],
+        capabilities: &[GetBlockTemplateCapabilities],
+    ) -> Result<GetBlockTemplateResult> {
+        #[derive(Serialize)]
+        struct Argument<'a> {
+            mode: GetBlockTemplateModes,
+            rules: &'a [GetBlockTemplateRules],
+            capabilities: &'a [GetBlockTemplateCapabilities],
+        }
+
+        self.call(
+            "getblocktemplate",
+            &[into_json(Argument {
+                mode,
+                rules,
+                capabilities,
+            })?],
+        )
+        .await
+    }
+
+    /// Returns a data structure containing various state info regarding
+    /// blockchain processing.
+    async fn get_blockchain_info(&self) -> Result<GetBlockchainInfoResult> {
+        let mut raw: serde_json::Value = self.call("getblockchaininfo", &[]).await?;
+        // The softfork fields are not backwards compatible:
+        // - 0.18.x returns a "softforks" array and a "bip9_softforks" map.
+        // - 0.19.x returns a "softforks" map.
+        Ok(if self.version().await? < 190000 {
+            use Error::UnexpectedStructure as err;
+
+            // First, remove both incompatible softfork fields.
+            // We need to scope the mutable ref here for v1.29 borrowck.
+            let (bip9_softforks, old_softforks) = {
+                let map = raw.as_object_mut().ok_or(err)?;
+                let bip9_softforks = map.remove("bip9_softforks").ok_or(err)?;
+                let old_softforks = map.remove("softforks").ok_or(err)?;
+                // Put back an empty "softforks" field.
+                map.insert("softforks".into(), serde_json::Map::new().into());
+                (bip9_softforks, old_softforks)
+            };
+            let mut ret: GetBlockchainInfoResult = serde_json::from_value(raw)?;
+
+            // Then convert both softfork types and add them.
+            for sf in old_softforks.as_array().ok_or(err)?.iter() {
+                let json = sf.as_object().ok_or(err)?;
+                let id = json.get("id").ok_or(err)?.as_str().ok_or(err)?;
+                let reject = json.get("reject").ok_or(err)?.as_object().ok_or(err)?;
+                let active = reject.get("status").ok_or(err)?.as_bool().ok_or(err)?;
+                ret.softforks.insert(
+                    id.into(),
+                    Softfork {
+                        type_: SoftforkType::Buried,
+                        bip9: None,
+                        height: None,
+                        active,
+                    },
+                );
+            }
+            for (id, sf) in bip9_softforks.as_object().ok_or(err)?.iter() {
+                #[derive(Deserialize)]
+                struct OldBip9SoftFork {
+                    pub status: Bip9SoftforkStatus,
+                    pub bit: Option<u8>,
+                    #[serde(rename = "startTime")]
+                    pub start_time: i64,
+                    pub timeout: u64,
+                    pub since: u32,
+                    pub statistics: Option<Bip9SoftforkStatistics>,
+                }
+                let sf: OldBip9SoftFork = serde_json::from_value(sf.clone())?;
+                ret.softforks.insert(
+                    id.clone(),
+                    Softfork {
+                        type_: SoftforkType::Bip9,
+                        bip9: Some(Bip9SoftforkInfo {
+                            status: sf.status,
+                            bit: sf.bit,
+                            start_time: sf.start_time,
+                            timeout: sf.timeout,
+                            since: sf.since,
+                            statistics: sf.statistics,
+                        }),
+                        height: None,
+                        active: sf.status == Bip9SoftforkStatus::Active,
+                    },
+                );
+            }
+            ret
+        } else {
+            serde_json::from_value(raw)?
+        })
+    }
+
+    /// Returns the numbers of block in the longest chain.
+    async fn get_block_count(&self) -> Result<u64> {
+        self.call("getblockcount", &[]).await
+    }
+
+    /// Returns the hash of the best (tip) block in the longest blockchain.
+    async fn get_best_block_hash(&self) -> Result<bitcoin::BlockHash> {
+        self.call("getbestblockhash", &[]).await
+    }
+
+    /// Get block hash at a given height
+    async fn get_block_hash(&self, height: u64) -> Result<bitcoin::BlockHash> {
+        self.call("getblockhash", &[height.into()]).await
+    }
+
+    async fn get_block_stats(&self, height: u64) -> Result<GetBlockStatsResult> {
+        self.call("getblockstats", &[height.into()]).await
+    }
+
+    async fn get_block_stats_fields(
+        &self,
+        height: u64,
+        fields: &[BlockStatsFields],
+    ) -> Result<GetBlockStatsResultPartial> {
+        self.call("getblockstats", &[height.into(), fields.into()])
+            .await
+    }
+
+    async fn get_raw_transaction(
+        &self,
+        txid: &bitcoin::Txid,
+        block_hash: Option<&bitcoin::BlockHash>,
+    ) -> Result<Transaction> {
+        let mut args = [
+            into_json(txid)?,
+            into_json(false)?,
+            opt_into_json(block_hash)?,
+        ];
+        let hex: String = self
+            .call("getrawtransaction", handle_defaults(&mut args, &[null()]))
+            .await?;
+        Ok(deserialize_hex(&hex).unwrap())
+    }
+
+    async fn get_raw_transaction_hex(
+        &self,
+        txid: &bitcoin::Txid,
+        block_hash: Option<&bitcoin::BlockHash>,
+    ) -> Result<String> {
+        let mut args = [
+            into_json(txid)?,
+            into_json(false)?,
+            opt_into_json(block_hash)?,
+        ];
+        self.call("getrawtransaction", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn get_raw_transaction_info(
+        &self,
+        txid: &bitcoin::Txid,
+        block_hash: Option<&bitcoin::BlockHash>,
+    ) -> Result<GetRawTransactionResult> {
+        let mut args = [
+            into_json(txid)?,
+            into_json(true)?,
+            opt_into_json(block_hash)?,
+        ];
+        self.call("getrawtransaction", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn get_block_filter(
+        &self,
+        block_hash: &bitcoin::BlockHash,
+    ) -> Result<GetBlockFilterResult> {
+        self.call("getblockfilter", &[into_json(block_hash)?]).await
+    }
+
+    async fn get_balance(
+        &self,
+        minconf: Option<usize>,
+        include_watchonly: Option<bool>,
+    ) -> Result<Amount> {
+        let mut args = [
+            "*".into(),
+            opt_into_json(minconf)?,
+            opt_into_json(include_watchonly)?,
+        ];
+
+        Ok(Amount::from_btc(
+            self.call(
+                "getbalance",
+                handle_defaults(&mut args, &[0.into(), null()]),
+            )
+            .await?,
+        )
+        .unwrap())
+    }
+
+    async fn get_balances(&self) -> Result<GetBalancesResult> {
+        Ok(self.call("getbalances", &[]).await?)
+    }
+
+    async fn get_received_by_address(
+        &self,
+        address: &Address,
+        minconf: Option<u32>,
+    ) -> Result<Amount> {
+        let mut args = [address.to_string().into(), opt_into_json(minconf)?];
+        Ok(Amount::from_btc(
+            self.call(
+                "getreceivedbyaddress",
+                handle_defaults(&mut args, &[null()]),
+            )
+            .await?,
+        )
+        .unwrap())
+    }
+
+    async fn get_transaction(
+        &self,
+        txid: &bitcoin::Txid,
+        include_watchonly: Option<bool>,
+    ) -> Result<GetTransactionResult> {
+        let mut args = [into_json(txid)?, opt_into_json(include_watchonly)?];
+        self.call("gettransaction", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn list_transactions(
+        &self,
+        label: Option<&str>,
+        count: Option<usize>,
+        skip: Option<usize>,
+        include_watchonly: Option<bool>,
+    ) -> Result<Vec<ListTransactionResult>> {
+        let mut args = [
+            label.unwrap_or("*").into(),
+            opt_into_json(count)?,
+            opt_into_json(skip)?,
+            opt_into_json(include_watchonly)?,
+        ];
+        self.call(
+            "listtransactions",
+            handle_defaults(&mut args, &[10.into(), 0.into(), null()]),
+        )
+        .await
+    }
+
+    async fn list_since_block(
+        &self,
+        blockhash: Option<&bitcoin::BlockHash>,
+        target_confirmations: Option<usize>,
+        include_watchonly: Option<bool>,
+        include_removed: Option<bool>,
+    ) -> Result<ListSinceBlockResult> {
+        let mut args = [
+            opt_into_json(blockhash)?,
+            opt_into_json(target_confirmations)?,
+            opt_into_json(include_watchonly)?,
+            opt_into_json(include_removed)?,
+        ];
+        self.call("listsinceblock", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn get_tx_out(
+        &self,
+        txid: &bitcoin::Txid,
+        vout: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<Option<GetTxOutResult>> {
+        let mut args = [
+            into_json(txid)?,
+            into_json(vout)?,
+            opt_into_json(include_mempool)?,
+        ];
+        opt_result(
+            self.call("gettxout", handle_defaults(&mut args, &[null()]))
+                .await?,
+        )
+    }
+
+    async fn get_tx_out_proof(
+        &self,
+        txids: &[bitcoin::Txid],
+        block_hash: Option<&bitcoin::BlockHash>,
+    ) -> Result<Vec<u8>> {
+        let mut args = [into_json(txids)?, opt_into_json(block_hash)?];
+        let hex: String = self
+            .call("gettxoutproof", handle_defaults(&mut args, &[null()]))
+            .await?;
+        Ok(FromHex::from_hex(&hex)?)
+    }
+
+    async fn import_public_key(
+        &self,
+        pubkey: &PublicKey,
+        label: Option<&str>,
+        rescan: Option<bool>,
+    ) -> Result<()> {
+        let mut args = [
+            pubkey.to_string().into(),
+            opt_into_json(label)?,
+            opt_into_json(rescan)?,
+        ];
+        self.call(
+            "importpubkey",
+            handle_defaults(&mut args, &[into_json("")?, null()]),
+        )
+        .await
+    }
+
+    async fn import_private_key(
+        &self,
+        privkey: &PrivateKey,
+        label: Option<&str>,
+        rescan: Option<bool>,
+    ) -> Result<()> {
+        let mut args = [
+            privkey.to_string().into(),
+            opt_into_json(label)?,
+            opt_into_json(rescan)?,
+        ];
+        self.call(
+            "importprivkey",
+            handle_defaults(&mut args, &[into_json("")?, null()]),
+        )
+        .await
+    }
+
+    async fn import_address(
+        &self,
+        address: &Address,
+        label: Option<&str>,
+        rescan: Option<bool>,
+    ) -> Result<()> {
+        let mut args = [
+            address.to_string().into(),
+            opt_into_json(label)?,
+            opt_into_json(rescan)?,
+        ];
+        self.call(
+            "importaddress",
+            handle_defaults(&mut args, &[into_json("")?, null()]),
+        )
+        .await
+    }
+
+    async fn import_address_script(
+        &self,
+        script: &Script,
+        label: Option<&str>,
+        rescan: Option<bool>,
+        p2sh: Option<bool>,
+    ) -> Result<()> {
+        let mut args = [
+            script.to_hex_string().into(),
+            opt_into_json(label)?,
+            opt_into_json(rescan)?,
+            opt_into_json(p2sh)?,
+        ];
+        self.call(
+            "importaddress",
+            handle_defaults(&mut args, &[into_json("")?, true.into(), null()]),
+        )
+        .await
+    }
+
+    async fn import_multi(
+        &self,
+        requests: &[ImportMultiRequest<'_>],
+        options: Option<&ImportMultiOptions>,
+    ) -> Result<Vec<ImportMultiResult>> {
+        let mut json_requests = Vec::with_capacity(requests.len());
+        for req in requests {
+            json_requests.push(serde_json::to_value(req)?);
+        }
+        let mut args = [json_requests.into(), opt_into_json(options)?];
+        self.call("importmulti", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn import_descriptors(&self, req: ImportDescriptors) -> Result<Vec<ImportMultiResult>> {
+        let json_request = vec![serde_json::to_value(req)?];
+        self.call(
+            "importdescriptors",
+            handle_defaults(&mut [json_request.into()], &[null()]),
+        )
+        .await
+    }
+
+    async fn set_label(&self, address: &Address, label: &str) -> Result<()> {
+        self.call("setlabel", &[address.to_string().into(), label.into()])
+            .await
+    }
+
+    async fn key_pool_refill(&self, new_size: Option<usize>) -> Result<()> {
+        let mut args = [opt_into_json(new_size)?];
+        self.call("keypoolrefill", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn list_unspent(
+        &self,
+        minconf: Option<usize>,
+        maxconf: Option<usize>,
+        addresses: Option<&[&Address<NetworkChecked>]>,
+        include_unsafe: Option<bool>,
+        query_options: Option<ListUnspentQueryOptions>,
+    ) -> Result<Vec<ListUnspentResultEntry>> {
+        let mut args = [
+            opt_into_json(minconf)?,
+            opt_into_json(maxconf)?,
+            opt_into_json(addresses)?,
+            opt_into_json(include_unsafe)?,
+            opt_into_json(query_options)?,
+        ];
+        let defaults = [
+            into_json(0)?,
+            into_json(9999999)?,
+            empty_arr(),
+            into_json(true)?,
+            null(),
+        ];
+        self.call("listunspent", handle_defaults(&mut args, &defaults))
+            .await
+    }
+
+    /// To unlock, use [unlock_unspent].
+    async fn lock_unspent(&self, outputs: &[OutPoint]) -> Result<bool> {
+        let outputs: Vec<_> = outputs
+            .into_iter()
+            .map(|o| serde_json::to_value(JsonOutPoint::from(*o)).unwrap())
+            .collect();
+        self.call("lockunspent", &[false.into(), outputs.into()])
+            .await
+    }
+
+    async fn unlock_unspent(&self, outputs: &[OutPoint]) -> Result<bool> {
+        let outputs: Vec<_> = outputs
+            .into_iter()
+            .map(|o| serde_json::to_value(JsonOutPoint::from(*o)).unwrap())
+            .collect();
+        self.call("lockunspent", &[true.into(), outputs.into()])
+            .await
+    }
+
+    /// Unlock all unspent UTXOs.
+    async fn unlock_unspent_all(&self) -> Result<bool> {
+        self.call("lockunspent", &[true.into()]).await
+    }
+
+    async fn list_received_by_address(
+        &self,
+        address_filter: Option<&Address>,
+        minconf: Option<u32>,
+        include_empty: Option<bool>,
+        include_watchonly: Option<bool>,
+    ) -> Result<Vec<ListReceivedByAddressResult>> {
+        let mut args = [
+            opt_into_json(minconf)?,
+            opt_into_json(include_empty)?,
+            opt_into_json(include_watchonly)?,
+            opt_into_json(address_filter)?,
+        ];
+        let defaults = [1.into(), false.into(), false.into(), null()];
+        self.call(
+            "listreceivedbyaddress",
+            handle_defaults(&mut args, &defaults),
+        )
+        .await
+    }
+
+    async fn create_psbt(
+        &self,
+        inputs: &[CreateRawTransactionInput],
+        outputs: &HashMap<String, Amount>,
+        locktime: Option<i64>,
+        replaceable: Option<bool>,
+    ) -> Result<String> {
+        let outs_converted = serde_json::Map::from_iter(
+            outputs
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::from(v.to_btc()))),
+        );
+        self.call(
+            "createpsbt",
+            &[
+                into_json(inputs)?,
+                into_json(outs_converted)?,
+                into_json(locktime)?,
+                into_json(replaceable)?,
+            ],
+        )
+        .await
+    }
+
+    async fn create_raw_transaction_hex(
+        &self,
+        utxos: &[CreateRawTransactionInput],
+        outs: &HashMap<String, Amount>,
+        locktime: Option<i64>,
+        replaceable: Option<bool>,
+    ) -> Result<String> {
+        let outs_converted = serde_json::Map::from_iter(
+            outs.iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::from(v.to_btc()))),
+        );
+        let mut args = [
+            into_json(utxos)?,
+            into_json(outs_converted)?,
+            opt_into_json(locktime)?,
+            opt_into_json(replaceable)?,
+        ];
+        let defaults = [into_json(0i64)?, null()];
+        self.call(
+            "createrawtransaction",
+            handle_defaults(&mut args, &defaults),
+        )
+        .await
+    }
+
+    async fn create_raw_transaction(
+        &self,
+        utxos: &[CreateRawTransactionInput],
+        outs: &HashMap<String, Amount>,
+        locktime: Option<i64>,
+        replaceable: Option<bool>,
+    ) -> Result<Transaction> {
+        let hex: String = self
+            .create_raw_transaction_hex(utxos, outs, locktime, replaceable)
+            .await?;
+        Ok(deserialize_hex(&hex).unwrap())
+    }
+
+    async fn decode_raw_transaction<R: RawTx + std::marker::Send>(
+        &self,
+        tx: R,
+        is_witness: Option<bool>,
+    ) -> Result<DecodeRawTransactionResult> {
+        let mut args = [tx.raw_hex().into(), opt_into_json(is_witness)?];
+        let defaults = [null()];
+        self.call(
+            "decoderawtransaction",
+            handle_defaults(&mut args, &defaults),
+        )
+        .await
+    }
+
+    async fn fund_raw_transaction<R: RawTx + std::marker::Send>(
+        &self,
+        tx: R,
+        options: Option<&FundRawTransactionOptions>,
+        is_witness: Option<bool>,
+    ) -> Result<FundRawTransactionResult> {
+        let mut args = [
+            tx.raw_hex().into(),
+            opt_into_json(options)?,
+            opt_into_json(is_witness)?,
+        ];
+        let defaults = [empty_obj(), null()];
+        self.call("fundrawtransaction", handle_defaults(&mut args, &defaults))
+            .await
+    }
+
+    #[deprecated]
+    async fn sign_raw_transaction<R: RawTx + std::marker::Send>(
+        &self,
+        tx: R,
+        utxos: Option<&[SignRawTransactionInput]>,
+        private_keys: Option<&[PrivateKey]>,
+        sighash_type: Option<SigHashType>,
+    ) -> Result<SignRawTransactionResult> {
+        let mut args = [
+            tx.raw_hex().into(),
+            opt_into_json(utxos)?,
+            opt_into_json(private_keys)?,
+            opt_into_json(sighash_type)?,
+        ];
+        let defaults = [empty_arr(), empty_arr(), null()];
+        self.call("signrawtransaction", handle_defaults(&mut args, &defaults))
+            .await
+    }
+
+    async fn sign_raw_transaction_with_wallet<R: RawTx + std::marker::Send>(
+        &self,
+        tx: R,
+        utxos: Option<&[SignRawTransactionInput]>,
+        sighash_type: Option<SigHashType>,
+    ) -> Result<SignRawTransactionResult> {
+        let mut args = [
+            tx.raw_hex().into(),
+            opt_into_json(utxos)?,
+            opt_into_json(sighash_type)?,
+        ];
+        let defaults = [empty_arr(), null()];
+        self.call(
+            "signrawtransactionwithwallet",
+            handle_defaults(&mut args, &defaults),
+        )
+        .await
+    }
+
+    async fn sign_raw_transaction_with_key<R: RawTx + std::marker::Send>(
+        &self,
+        tx: R,
+        privkeys: &[PrivateKey],
+        prevtxs: Option<&[SignRawTransactionInput]>,
+        sighash_type: Option<SigHashType>,
+    ) -> Result<SignRawTransactionResult> {
+        let mut args = [
+            tx.raw_hex().into(),
+            into_json(privkeys)?,
+            opt_into_json(prevtxs)?,
+            opt_into_json(sighash_type)?,
+        ];
+        let defaults = [empty_arr(), null()];
+        self.call(
+            "signrawtransactionwithkey",
+            handle_defaults(&mut args, &defaults),
+        )
+        .await
+    }
+
+    async fn test_mempool_accept<R: RawTx + std::marker::Send + std::marker::Sync>(
+        &self,
+        rawtxs: &[R],
+    ) -> Result<Vec<TestMempoolAcceptResult>> {
+        let hexes: Vec<serde_json::Value> = rawtxs
+            .to_vec()
+            .into_iter()
+            .map(|r| r.raw_hex().into())
+            .collect();
+        self.call("testmempoolaccept", &[hexes.into()]).await
+    }
+
+    async fn stop(&self) -> Result<String> {
+        self.call("stop", &[]).await
+    }
+
+    async fn verify_message(
+        &self,
+        address: &Address,
+        signature: &Signature,
+        message: &str,
+    ) -> Result<bool> {
+        let args = [
+            address.to_string().into(),
+            signature.to_string().into(),
+            into_json(message)?,
+        ];
+        self.call("verifymessage", &args).await
+    }
+
+    /// Generate new address under own control
+    async fn get_new_address(
+        &self,
+        label: Option<&str>,
+        address_type: Option<AddressType>,
+    ) -> Result<Address<NetworkUnchecked>> {
+        self.call(
+            "getnewaddress",
+            &[opt_into_json(label)?, opt_into_json(address_type)?],
+        )
+        .await
+    }
+
+    /// Generate new address for receiving change
+    async fn get_raw_change_address(
+        &self,
+        address_type: Option<AddressType>,
+    ) -> Result<Address<NetworkUnchecked>> {
+        self.call("getrawchangeaddress", &[opt_into_json(address_type)?])
+            .await
+    }
+
+    async fn get_address_info(&self, address: &Address) -> Result<GetAddressInfoResult> {
+        self.call("getaddressinfo", &[address.to_string().into()])
+            .await
+    }
+
+    /// Mine `block_num` blocks and pay coinbase to `address`
+    ///
+    /// Returns hashes of the generated blocks
+    async fn generate_to_address(
+        &self,
+        block_num: u64,
+        address: &Address<NetworkChecked>,
+    ) -> Result<Vec<bitcoin::BlockHash>> {
+        self.call(
+            "generatetoaddress",
+            &[block_num.into(), address.to_string().into()],
+        )
+        .await
+    }
+
+    /// Mine up to block_num blocks immediately (before the RPC call returns)
+    /// to an address in the wallet.
+    async fn generate(
+        &self,
+        block_num: u64,
+        maxtries: Option<u64>,
+    ) -> Result<Vec<bitcoin::BlockHash>> {
+        self.call("generate", &[block_num.into(), opt_into_json(maxtries)?])
+            .await
+    }
+
+    /// Mark a block as invalid by `block_hash`
+    async fn invalidate_block(&self, block_hash: &bitcoin::BlockHash) -> Result<()> {
+        self.call("invalidateblock", &[into_json(block_hash)?])
+            .await
+    }
+
+    /// Mark a block as valid by `block_hash`
+    async fn reconsider_block(&self, block_hash: &bitcoin::BlockHash) -> Result<()> {
+        self.call("reconsiderblock", &[into_json(block_hash)?])
+            .await
+    }
+
+    /// Returns details on the active state of the TX memory pool
+    async fn get_mempool_info(&self) -> Result<GetMempoolInfoResult> {
+        self.call("getmempoolinfo", &[]).await
+    }
+
+    /// Get txids of all transactions in a memory pool
+    async fn get_raw_mempool(&self) -> Result<Vec<bitcoin::Txid>> {
+        self.call("getrawmempool", &[]).await
+    }
+
+    /// Get details for the transactions in a memory pool
+    async fn get_raw_mempool_verbose(
+        &self,
+    ) -> Result<HashMap<bitcoin::Txid, GetMempoolEntryResult>> {
+        self.call("getrawmempool", &[into_json(true)?]).await
+    }
+
+    /// Get mempool data for given transaction
+    async fn get_mempool_entry(&self, txid: &bitcoin::Txid) -> Result<GetMempoolEntryResult> {
+        self.call("getmempoolentry", &[into_json(txid)?]).await
+    }
+
+    /// Get information about all known tips in the block tree, including the
+    /// main chain as well as stale branches.
+    async fn get_chain_tips(&self) -> Result<GetChainTipsResult> {
+        self.call("getchaintips", &[]).await
+    }
+
+    async fn send_to_address(
+        &self,
+        address: &Address<NetworkChecked>,
+        amount: Amount,
+        comment: Option<&str>,
+        comment_to: Option<&str>,
+        subtract_fee: Option<bool>,
+        replaceable: Option<bool>,
+        confirmation_target: Option<u32>,
+        estimate_mode: Option<EstimateMode>,
+    ) -> Result<bitcoin::Txid> {
+        let mut args = [
+            address.to_string().into(),
+            into_json(amount.to_btc())?,
+            opt_into_json(comment)?,
+            opt_into_json(comment_to)?,
+            opt_into_json(subtract_fee)?,
+            opt_into_json(replaceable)?,
+            opt_into_json(confirmation_target)?,
+            opt_into_json(estimate_mode)?,
+        ];
+        self.call(
+            "sendtoaddress",
+            handle_defaults(
+                &mut args,
+                &[
+                    "".into(),
+                    "".into(),
+                    false.into(),
+                    false.into(),
+                    6.into(),
+                    null(),
+                ],
+            ),
+        )
+        .await
+    }
+
+    /// Attempts to add a node to the addnode list.
+    /// Nodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be full nodes/support SegWit as other outbound peers are (though such peers will not be synced from).
+    async fn add_node(&self, addr: &str) -> Result<()> {
+        self.call("addnode", &[into_json(&addr)?, into_json("add")?])
+            .await
+    }
+
+    /// Attempts to remove a node from the addnode list.
+    async fn remove_node(&self, addr: &str) -> Result<()> {
+        self.call("addnode", &[into_json(&addr)?, into_json("remove")?])
+            .await
+    }
+
+    /// Attempts to connect to a node without permanently adding it to the addnode list.
+    async fn onetry_node(&self, addr: &str) -> Result<()> {
+        self.call("addnode", &[into_json(&addr)?, into_json("onetry")?])
+            .await
+    }
+
+    /// Immediately disconnects from the specified peer node.
+    async fn disconnect_node(&self, addr: &str) -> Result<()> {
+        self.call("disconnectnode", &[into_json(&addr)?]).await
+    }
+
+    async fn disconnect_node_by_id(&self, node_id: u32) -> Result<()> {
+        self.call("disconnectnode", &[into_json("")?, into_json(node_id)?])
+            .await
+    }
+
+    /// Returns information about the given added node, or all added nodes (note that onetry addnodes are not listed here)
+    async fn get_added_node_info(&self, node: Option<&str>) -> Result<Vec<GetAddedNodeInfoResult>> {
+        if let Some(addr) = node {
+            self.call("getaddednodeinfo", &[into_json(&addr)?]).await
+        } else {
+            self.call("getaddednodeinfo", &[]).await
+        }
+    }
+
+    /// Return known addresses which can potentially be used to find new nodes in the network
+    async fn get_node_addresses(
+        &self,
+        count: Option<usize>,
+    ) -> Result<Vec<GetNodeAddressesResult>> {
+        let cnt = count.unwrap_or(1);
+        self.call("getnodeaddresses", &[into_json(&cnt)?]).await
+    }
+
+    /// List all banned IPs/Subnets.
+    async fn list_banned(&self) -> Result<Vec<ListBannedResult>> {
+        self.call("listbanned", &[]).await
+    }
+
+    /// Clear all banned IPs.
+    async fn clear_banned(&self) -> Result<()> {
+        self.call("clearbanned", &[]).await
+    }
+
+    /// Attempts to add an IP/Subnet to the banned list.
+    async fn add_ban(&self, subnet: &str, bantime: u64, absolute: bool) -> Result<()> {
+        self.call(
+            "setban",
+            &[
+                into_json(&subnet)?,
+                into_json("add")?,
+                into_json(&bantime)?,
+                into_json(&absolute)?,
+            ],
+        )
+        .await
+    }
+
+    /// Attempts to remove an IP/Subnet from the banned list.
+    async fn remove_ban(&self, subnet: &str) -> Result<()> {
+        self.call("setban", &[into_json(&subnet)?, into_json("remove")?])
+            .await
+    }
+
+    /// Disable/enable all p2p network activity.
+    async fn set_network_active(&self, state: bool) -> Result<bool> {
+        self.call("setnetworkactive", &[into_json(&state)?]).await
+    }
+
+    /// Returns data about each connected network node as an array of
+    /// [`PeerInfo`][]
+    ///
+    /// [`PeerInfo`]: net/struct.PeerInfo.html
+    async fn get_peer_info(&self) -> Result<Vec<GetPeerInfoResult>> {
+        self.call("getpeerinfo", &[]).await
+    }
+
+    /// Requests that a ping be sent to all other nodes, to measure ping
+    /// time.
+    ///
+    /// Results provided in `getpeerinfo`, `pingtime` and `pingwait` fields
+    /// are decimal seconds.
+    ///
+    /// Ping command is handled in queue with all other commands, so it
+    /// measures processing backlog, not just network ping.
+    async fn ping(&self) -> Result<()> {
+        self.call("ping", &[]).await
+    }
+
+    async fn send_raw_transaction<R: RawTx + std::marker::Send>(
+        &self,
+        tx: R,
+    ) -> Result<bitcoin::Txid> {
+        self.call("sendrawtransaction", &[tx.raw_hex().into()])
+            .await
+    }
+
+    async fn estimate_smart_fee(
+        &self,
+        conf_target: u16,
+        estimate_mode: Option<EstimateMode>,
+    ) -> Result<EstimateSmartFeeResult> {
+        let mut args = [into_json(conf_target)?, opt_into_json(estimate_mode)?];
+        self.call("estimatesmartfee", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    /// Waits for a specific new block and returns useful info about it.
+    /// Returns the current block on timeout or exit.
+    ///
+    /// # Arguments
+    ///
+    /// 1. `timeout`: Time in milliseconds to wait for a response. 0
+    /// indicates no timeout.
+    async fn wait_for_new_block(&self, timeout: u64) -> Result<BlockRef> {
+        self.call("waitfornewblock", &[into_json(timeout)?]).await
+    }
+
+    /// Waits for a specific new block and returns useful info about it.
+    /// Returns the current block on timeout or exit.
+    ///
+    /// # Arguments
+    ///
+    /// 1. `blockhash`: Block hash to wait for.
+    /// 2. `timeout`: Time in milliseconds to wait for a response. 0
+    /// indicates no timeout.
+    async fn wait_for_block(
+        &self,
+        blockhash: &bitcoin::BlockHash,
+        timeout: u64,
+    ) -> Result<BlockRef> {
+        let args = [into_json(blockhash)?, into_json(timeout)?];
+        self.call("waitforblock", &args).await
+    }
+
+    async fn wallet_create_funded_psbt(
+        &self,
+        inputs: &[CreateRawTransactionInput],
+        outputs: &HashMap<String, Amount>,
+        locktime: Option<i64>,
+        options: Option<WalletCreateFundedPsbtOptions>,
+        bip32derivs: Option<bool>,
+    ) -> Result<WalletCreateFundedPsbtResult> {
+        let outputs_converted = serde_json::Map::from_iter(
+            outputs
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::from(v.to_btc()))),
+        );
+        let mut args = [
+            into_json(inputs)?,
+            into_json(outputs_converted)?,
+            opt_into_json(locktime)?,
+            opt_into_json(options)?,
+            opt_into_json(bip32derivs)?,
+        ];
+        self.call(
+            "walletcreatefundedpsbt",
+            handle_defaults(
+                &mut args,
+                &[0.into(), serde_json::Map::new().into(), false.into()],
+            ),
+        )
+        .await
+    }
+
+    async fn wallet_process_psbt(
+        &self,
+        psbt: &str,
+        sign: Option<bool>,
+        sighash_type: Option<SigHashType>,
+        bip32derivs: Option<bool>,
+    ) -> Result<WalletProcessPsbtResult> {
+        let mut args = [
+            into_json(psbt)?,
+            opt_into_json(sign)?,
+            opt_into_json(sighash_type)?,
+            opt_into_json(bip32derivs)?,
+        ];
+        let defaults = [
+            true.into(),
+            into_json(SigHashType::from(bitcoin::sighash::EcdsaSighashType::All))?,
+            true.into(),
+        ];
+        self.call("walletprocesspsbt", handle_defaults(&mut args, &defaults))
+            .await
+    }
+
+    async fn get_descriptor_info(&self, desc: &str) -> Result<GetDescriptorInfoResult> {
+        self.call("getdescriptorinfo", &[desc.to_string().into()])
+            .await
+    }
+
+    async fn join_psbt(&self, psbts: &[String]) -> Result<String> {
+        self.call("joinpsbts", &[into_json(psbts)?]).await
+    }
+
+    async fn combine_psbt(&self, psbts: &[String]) -> Result<String> {
+        self.call("combinepsbt", &[into_json(psbts)?]).await
+    }
+
+    async fn combine_raw_transaction(&self, hex_strings: &[String]) -> Result<String> {
+        self.call("combinerawtransaction", &[into_json(hex_strings)?])
+            .await
+    }
+
+    async fn finalize_psbt(&self, psbt: &str, extract: Option<bool>) -> Result<FinalizePsbtResult> {
+        let mut args = [into_json(psbt)?, opt_into_json(extract)?];
+        self.call("finalizepsbt", handle_defaults(&mut args, &[true.into()]))
+            .await
+    }
+
+    async fn derive_addresses(
+        &self,
+        descriptor: &str,
+        range: Option<[u32; 2]>,
+    ) -> Result<Vec<Address<NetworkUnchecked>>> {
+        let mut args = [into_json(descriptor)?, opt_into_json(range)?];
+        self.call("deriveaddresses", handle_defaults(&mut args, &[null()]))
+            .await
+    }
+
+    async fn rescan_blockchain(
+        &self,
+        start_from: Option<usize>,
+        stop_height: Option<usize>,
+    ) -> Result<(usize, Option<usize>)> {
+        let mut args = [opt_into_json(start_from)?, opt_into_json(stop_height)?];
+
+        #[derive(Deserialize)]
+        struct Response {
+            pub start_height: usize,
+            pub stop_height: Option<usize>,
+        }
+        let res: Response = self
+            .call(
+                "rescanblockchain",
+                handle_defaults(&mut args, &[0.into(), null()]),
+            )
+            .await?;
+        Ok((res.start_height, res.stop_height))
+    }
+
+    /// Returns statistics about the unspent transaction output set.
+    /// Note this call may take some time if you are not using coinstatsindex.
+    async fn get_tx_out_set_info(
+        &self,
+        hash_type: Option<TxOutSetHashType>,
+        hash_or_height: Option<HashOrHeight>,
+        use_index: Option<bool>,
+    ) -> Result<GetTxOutSetInfoResult> {
+        let mut args = [
+            opt_into_json(hash_type)?,
+            opt_into_json(hash_or_height)?,
+            opt_into_json(use_index)?,
+        ];
+        self.call(
+            "gettxoutsetinfo",
+            handle_defaults(&mut args, &[null(), null(), null()]),
+        )
+        .await
+    }
+
+    /// Returns information about network traffic, including bytes in, bytes out,
+    /// and current time.
+    async fn get_net_totals(&self) -> Result<GetNetTotalsResult> {
+        self.call("getnettotals", &[]).await
+    }
+
+    /// Returns the estimated network hashes per second based on the last n blocks.
+    async fn get_network_hash_ps(&self, nblocks: Option<u64>, height: Option<u64>) -> Result<f64> {
+        let mut args = [opt_into_json(nblocks)?, opt_into_json(height)?];
+        self.call(
+            "getnetworkhashps",
+            handle_defaults(&mut args, &[null(), null()]),
+        )
+        .await
+    }
+
+    /// Returns the total uptime of the server in seconds
+    async fn uptime(&self) -> Result<u64> {
+        self.call("uptime", &[]).await
+    }
+
+    /// Submit a block
+    async fn submit_block(&self, block: &bitcoin::Block) -> Result<()> {
+        let block_hex: String = bitcoin::consensus::encode::serialize_hex(block);
+        self.submit_block_hex(&block_hex).await
+    }
+
+    /// Submit a raw block
+    async fn submit_block_bytes(&self, block_bytes: &[u8]) -> Result<()> {
+        let block_hex: String = block_bytes.to_lower_hex_string();
+        self.submit_block_hex(&block_hex).await
+    }
+
+    /// Submit a block as a hex string
+    async fn submit_block_hex(&self, block_hex: &str) -> Result<()> {
+        match self.call("submitblock", &[into_json(&block_hex)?]).await {
+            Ok(serde_json::Value::Null) => Ok(()),
+            Ok(res) => Err(Error::ReturnedError(res.to_string())),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn scan_tx_out_set_blocking(
+        &self,
+        descriptors: &[ScanTxOutRequest],
+    ) -> Result<ScanTxOutResult> {
+        self.call("scantxoutset", &["start".into(), into_json(descriptors)?])
+            .await
+    }
+}
+
+// RPCError is a struct that represents an error returned by the Bitcoin RPC
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct RPCError {
+    pub code: i32,
+    pub message: String,
+}
+impl Display for RPCError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "RPCError {}: {}", self.code, self.message)
+    }
+}
+
+// Response is a struct that represents a response returned by the Bitcoin RPC
+// It is generic over the type of the result field, which is usually a String in Bitcoin Core
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+struct Response<R = String> {
+    pub result: Option<R>,
+    pub error: Option<RPCError>,
+    pub id: String,
+}
+
+#[async_trait]
+impl AsyncRpcApi for Client {
+    async fn call<T: for<'a> serde::de::Deserialize<'a>>(
+        &self,
+        cmd: &str,
+        args: &[serde_json::Value],
+    ) -> Result<T> {
+        let response = self
+            .client
+            .post(&self.url)
+            .json(&json!({
+                "jsonrpc": "1.0",
+                "id": cmd,
+                "method": cmd,
+                "params": args
+            }))
+            .send()
+            .await;
+
+        if let Err(ref error) = response {
+            if error.is_connect() || error.is_timeout() || error.is_request() {
+                return self.call(cmd, args).await;
+            }
+            // println!("there is a error {:?}", error);
+        }
+
+        let response = response.unwrap().json::<Response<T>>().await.unwrap();
+        if let Some(error) = response.error {
+            println!("the error is {:?}", error);
+            // return Err(error);
+        }
+
+        Ok(response.result.unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn check_listed_wallets() {
+        let client = Client::get_test_node();
+
+        let op = client.list_wallets().await;
+        println!("{:?}", op);
+        assert!(op.is_ok(), "Unable to check listed wallets");
+    }
+
+    #[tokio::test]
+    async fn check_blockhash_at_height() {
+        let client = Client::get_test_node();
+
+        let op = client.get_block_hash(0).await;
+        assert!(op.is_ok(), "Unable to get blockhash at the given height ");
+    }
+
+    #[tokio::test]
+    async fn get_best_blockhash() {
+        let client = Client::get_test_node();
+
+        let op = client.get_best_block_hash().await;
+        assert!(op.is_ok(), "Unable to get best block hash");
+    }
+
+    #[tokio::test]
+    async fn get_block_from_given_blockhash() {
+        let client = Client::get_test_node();
+        let op = client.get_block_hash(0).await;
+        assert!(op.is_ok(), "Unable to get blockhash from block height");
+        let block = client.get_block(&op.unwrap()).await;
+        assert!(block.is_ok(), "Unable to get block from blockhash");
+    }
+}


### PR DESCRIPTION
Reqwest based RPC client for interfacing with bitcoin network which is rework on `bitcoincore-rpc`. The main difference is that it is a async client and doesn't use `rust-jsonrpc`, so tokio runtime is supported. 

This implementation uses rust data structures that represent the json responses from the Bitcoin Core JSON-RPC APIs as given by [`bitcoincore-rpc-json`](https://docs.rs/bitcoincore-rpc-json/latest/bitcoincore_rpc_json/)

Currently tested  for 
  - Read block hash at given height
  - Get latest block height
  - Read block given the block hash
  - reading the wallet
  
Closes #30 
 
