### PR TITLE
ChainState: Calculate state root

### DIFF
--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -1,5 +1,6 @@
 //! Common wrapper around whatever we choose our native hash function to be.
 
+use borsh::BorshSerialize;
 use digest::Digest;
 use sha2::Sha256;
 
@@ -8,4 +9,12 @@ use crate::buf::Buf32;
 /// Direct untagged hash.
 pub fn raw(buf: &[u8]) -> Buf32 {
     Buf32::from(<[u8; 32]>::from(Sha256::digest(buf)))
+}
+
+pub fn compute_borsh_hash<T: BorshSerialize>(v: &T) -> Buf32 {
+    let mut hasher = Sha256::new();
+    v.serialize(&mut hasher).expect("Serialization failed");
+    let result = hasher.finalize();
+    let arr: [u8; 32] = result.into();
+    Buf32::from(arr)
 }


### PR DESCRIPTION
Resolves #130 

Very basic implementation since we may swap out our internal type definitions with SSZ type definitions.

Related:
(WIP) Explore SSZ implementation: https://github.com/alpenlabs/vertex-core/tree/feature/ssz
