### PR TITLE
fix: use seekable key codec for storing L1 block data in rocksdb

### DIFF
--- a/crates/rocksdb-store/src/l1/schemas.rs
+++ b/crates/rocksdb-store/src/l1/schemas.rs
@@ -5,6 +5,7 @@ use alpen_express_primitives::{
 };
 
 use crate::define_table_with_default_codec;
+use crate::define_table_with_seek_key_codec;
 use crate::define_table_without_codec;
 use crate::impl_borsh_value_codec;
 
@@ -12,7 +13,7 @@ use crate::impl_borsh_value_codec;
 type HeaderHash = Buf32;
 
 // L1 Block Schema and corresponding codecs implementation
-define_table_with_default_codec!(
+define_table_with_seek_key_codec!(
     /// A table to store L1 Block data. Maps block index to header
     (L1BlockSchema) u64 => L1BlockManifest
 );
@@ -24,7 +25,7 @@ define_table_with_default_codec!(
 );
 
 // Mmr Schema and corresponding codecs implementation
-define_table_with_default_codec!(
+define_table_with_seek_key_codec!(
     /// A table to store L1 Headers mmr
     (MmrSchema) u64 => CompactMmr
 );


### PR DESCRIPTION
## Description

Fixes issue seen when L1 has more than horizon_l1_height + 256 blocks.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
