### PR TITLE
test: add environment option to pre gen bitcoin blocks before running sequencer

### DIFF
--- a/functional-tests/fn_sync_genesis_with_btcblocks.py
+++ b/functional-tests/fn_sync_genesis_with_btcblocks.py
@@ -1,0 +1,32 @@
+import time
+
+from bitcoinlib.services.bitcoind import BitcoindClient
+import flexitest
+
+from entry import BasicEnvConfig
+
+UNSET_ID = "0000000000000000000000000000000000000000000000000000000000000000"
+
+
+@flexitest.register
+class SyncGenesisTest(flexitest.Test):
+    def __init__(self, ctx: flexitest.InitContext):
+        # generate 100 bitcoin blocks before starting sequencer
+        ctx.set_env(BasicEnvConfig(pre_generate_blocks=100))
+
+    def main(self, ctx: flexitest.RunContext):
+        btc = ctx.get_service("bitcoin")
+        seq = ctx.get_service("sequencer")
+
+        # create both btc and sequencer RPC
+        seqrpc = seq.create_rpc()
+
+        time.sleep(1)
+
+        stat = None
+        for _ in range(10):
+            stat = seqrpc.alp_clientStatus()
+            print(stat)
+            time.sleep(1)
+
+        assert stat["finalized_blkid"] != UNSET_ID, "did not notice genesis"


### PR DESCRIPTION

## Description
Add functional test case with 100 bitcoin blocks pre-generated before sequencer is started.
Models case where the sequencer needs to catch up from genesis block to latest block.  


<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [X] Add test case
## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
