### PR TITLE
chore: make clean-dd visible in `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ activate: ensure-poetry ## Activate poetry environment for integration tests.
 	cd $(FUNCTIONAL_TESTS_DIR) && poetry install --no-root
 
 .PHONY: clean-dd
-clean-dd:
+clean-dd: ## Remove the data directory used by functional tests.
 	rm -rf $(FUNCTIONAL_TESTS_DIR)/$(FUNCTIONAL_TESTS_DATADIR) 2>/dev/null
 
 .PHONY: test-functional


### PR DESCRIPTION
## Description

I think we should have `clean-dd` visible in `make`.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

None. just out of the blue
