### PR TITLE
Reth block witness generation mode separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ ensure `horizon_l1_height` <= `genesis_l1_height` < bitcoin_block_height
 Start EL Client:
 
 ```sh
+# Normal mode
 cargo run --bin alpen-express-reth  -- --datadir .data/reth --http -vvvv
+
+# Block witness generation mode
+cargo run --bin alpen-express-reth  -- --datadir .data/reth --http --enable-witness-gen -vvvv
 ```
 
 Start CL Client/Sequencer

--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -191,6 +191,7 @@ class RethFactory(flexitest.Factory):
             "--port", str(listener_port),
             "--ws",
             "--ws.port", str(ethrpc_port),
+            "--enable-witness-gen",
             "-vvvv"
         ]
         # fmt: on


### PR DESCRIPTION
## Description
Reth Block Witness Mode: Separate witness generation, its  storage and rpc to exclude full nodes running these features.<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Resolves EXP-45