### PR TITLE
Refactor L1TxStatus to derive serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "mockall",
  "parking_lot 0.12.3",
  "serde",
+ "serde_json",
  "thiserror",
  "tracing",
 ]

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -73,7 +73,7 @@ async fn filter_unfinalized_from_db(
         };
 
         match txentry.status {
-            L1TxStatus::Finalized(_) | L1TxStatus::Excluded(_) => {}
+            L1TxStatus::Finalized { height: _ } | L1TxStatus::Excluded { reason: _ } => {}
             _ => {
                 unfinalized_entries.insert(idx, txentry);
             }
@@ -115,11 +115,11 @@ mod test {
     }
 
     fn gen_confirmed_entry() -> L1TxEntry {
-        gen_entry_with_status(L1TxStatus::Confirmed(1))
+        gen_entry_with_status(L1TxStatus::Confirmed { height: 1 })
     }
 
     fn gen_finalized_entry() -> L1TxEntry {
-        gen_entry_with_status(L1TxStatus::Finalized(1))
+        gen_entry_with_status(L1TxStatus::Finalized { height: 1 })
     }
 
     fn gen_unpublished_entry() -> L1TxEntry {
@@ -131,7 +131,9 @@ mod test {
     }
 
     fn gen_excluded_entry() -> L1TxEntry {
-        gen_entry_with_status(L1TxStatus::Excluded(ExcludeReason::MissingInputsOrSpent))
+        gen_entry_with_status(L1TxStatus::Excluded {
+            reason: ExcludeReason::MissingInputsOrSpent,
+        })
     }
 
     async fn populate_broadcast_db(ops: Arc<BroadcastDbOps>) -> Vec<(u64, L1TxEntry)> {
@@ -227,7 +229,9 @@ mod test {
         assert_eq!(state.next_idx, idx1 + 1);
         assert_eq!(
             state.unfinalized_entries.get(&0).unwrap().status,
-            L1TxStatus::Excluded(ExcludeReason::MissingInputsOrSpent)
+            L1TxStatus::Excluded {
+                reason: ExcludeReason::MissingInputsOrSpent
+            }
         );
 
         // check it does not contain idx of excluded but contains that of published tx

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -23,3 +23,6 @@ tracing = { workspace = true }
 default = []
 mocks = ["mockall"]
 stubs = []
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/rocksdb-store/src/broadcaster/db.rs
+++ b/crates/rocksdb-store/src/broadcaster/db.rs
@@ -202,7 +202,7 @@ mod tests {
             .unwrap();
 
         let mut updated_txentry = txentry;
-        updated_txentry.status = L1TxStatus::Finalized(1);
+        updated_txentry.status = L1TxStatus::Finalized { height: 1 };
 
         broadcast_db
             .update_tx_entry_by_id(txid, updated_txentry.clone())
@@ -228,7 +228,7 @@ mod tests {
             .unwrap();
 
         let mut updated_txentry = txentry;
-        updated_txentry.status = L1TxStatus::Finalized(1);
+        updated_txentry.status = L1TxStatus::Finalized { height: 1 };
 
         broadcast_db
             .update_tx_entry(idx, updated_txentry.clone())


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Removes manual serialization implementation and derives both Serialize and Deserialize. This makes it convenient since we don't have to roll out our own Deserialize implementation which is required for the client feature in the RPC. The RPC client itself is required for bridge scaffolding in #230 and possibly elsewhere.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

