### PR TITLE
ci: increase timeout for `hack check`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
   crate-checks:
     name: Check that crates compile on their own
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60 # cold run takes a lot of time as each crate is compiled separately
     steps:
       - name: Cleanup space
         # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR increases timeout for the `hack check` script in the `lint` workflow as it takes a lot of time to complete in the first run and fails due to a timeout.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.
