### PR TITLE
EXP-308 Create RPC endpoint on sequencer to serve CL Block witness

### DIFF
--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -3,7 +3,7 @@ use alpen_express_db::types::L1TxStatus;
 use alpen_express_primitives::bridge::OperatorIdx;
 use alpen_express_rpc_types::{
     types::{BlockHeader, ClientStatus, DepositEntry, ExecUpdate, L1Status},
-    HexBytes, HexBytes32, NodeSyncStatus,
+    HexBytes, HexBytes32, NodeSyncStatus, RawBlockWitness,
 };
 use alpen_express_state::{bridge_duties::BridgeDuties, id::L2BlockId};
 use bitcoin::{secp256k1::schnorr::Signature, Transaction, Txid};
@@ -44,6 +44,9 @@ pub trait AlpenApi {
 
     #[method(name = "getExecUpdateById")]
     async fn get_exec_update_by_id(&self, block_id: L2BlockId) -> RpcResult<Option<ExecUpdate>>;
+
+    #[method(name = "getBlockWitness")]
+    async fn get_block_witness_raw(&self, index: u64) -> RpcResult<Option<RawBlockWitness>>;
 
     #[method(name = "getCurrentDeposits")]
     async fn get_current_deposits(&self) -> RpcResult<Vec<u32>>;

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -155,8 +155,14 @@ pub struct NodeSyncStatus {
     pub tip_height: u64,
 
     /// Last L2 block we've chosen as the current tip.
-    pub tip_block_id: L2BlockId,
+    pub tip_block_id: alpen_express_state::id::L2BlockId,
 
     /// L2 block that's been finalized and proven on L1.
     pub finalized_block_id: L2BlockId,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RawBlockWitness {
+    pub raw_l2_block: Vec<u8>,
+    pub raw_chain_state: Vec<u8>,
 }

--- a/functional-tests/fn_cl_block_witness.py
+++ b/functional-tests/fn_cl_block_witness.py
@@ -1,0 +1,27 @@
+import time
+
+import flexitest
+
+from constants import SEQ_SLACK_TIME_SECS
+
+REORG_DEPTH = 3
+
+
+@flexitest.register
+class CLBlockWitnessDataGenerationTest(flexitest.Test):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env("basic")
+
+    def main(self, ctx: flexitest.RunContext):
+        seq = ctx.get_service("sequencer")
+        seqrpc = seq.create_rpc()
+
+        time.sleep(SEQ_SLACK_TIME_SECS)
+
+        witness_1 = seqrpc.alp_getBlockWitness(1)
+        assert witness_1 is not None
+
+        witness_2 = seqrpc.alp_getBlockWitness(2)
+        assert witness_2 is not None
+
+        return True


### PR DESCRIPTION
## Description
Adds the rpc endpoint `alp_getBlockWitness(cl_block_idx)`.
It returns cl_block for the given index, along with the chain_state that the cl_block will be applied to in the raw form
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Resolves: EXP-308
