### PR TITLE
ci: cleanup runner space in doctests and increase timeout

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -1,0 +1,19 @@
+name: Cleanup GitHub runner bloat
+description: "Removes unnecessary files and frees up disk space on the runner."
+inputs: {}
+outputs: {}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cleanup space
+      shell: bash
+      # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+      run: |
+        echo "Starting cleanup..."
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
   docs:
     name: Generate docs
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     name: Lint test files
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -47,18 +47,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Cleanup space
-        # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Cleanup Space
+        uses: ./.github/actions/cleanup
 
       - name: Install bitcoind
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,26 +17,23 @@ jobs:
   test:
     name: Run integration tests and generate report
     runs-on: ubuntu-latest
-    timeout-minutes: 40 # better fail-safe than the default 360 in github actions
+    timeout-minutes: 60 # better fail-safe than the default 360 in github actions
     steps:
-      - name: Cleanup space
-        # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
+
+      - name: Cleanup space
+        uses: ./.github/actions/cleanup
+
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install latest nextest release
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+
       - name: Run tests
         run: |
           cargo nextest run -p integration-tests --locked --profile ci --no-capture

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   clippy:
     name: Run clippy on crates
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
@@ -29,16 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60 # cold run takes a lot of time as each crate is compiled separately
     steps:
-      - name: Cleanup space
-        # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
+
+      - name: Cleanup space
+        uses: ./.github/actions/cleanup
+
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2024-07-27
@@ -54,6 +49,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.5
         with:
           version: "v0.8.1" # sccache version
+
       - run: cargo hack check --locked
 
   fmt:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -19,18 +19,13 @@ jobs:
   test:
     name: Run unit tests and generate report
     runs-on: ubuntu-latest
-    timeout-minutes: 40 # better fail-safe than the default 360 in github actions
+    timeout-minutes: 60 # better fail-safe than the default 360 in github actions
     steps:
-      - name: Cleanup space
-        # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
+
+      - name: Cleanup space
+        uses: ./.github/actions/cleanup
+
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
@@ -46,9 +41,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+
       - name: Run tests with coverage
         run: |
           cargo llvm-cov --workspace --locked nextest --profile ci --lcov --output-path lcov.info
+
       - name: Test Summary
         uses: test-summary/action@v2
         if: always()
@@ -65,15 +62,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cleanup space
+        uses: ./.github/actions/cleanup
+
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2024-07-27
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+
       - name: Run doctests
         run: cargo test --doc --workspace
 

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ lint-check-toml: ensure-taplo ## Lints TOML files
 lint-check-func-tests: ensure-poetry activate ## Lints the functional tests
 	cd $(FUNCTIONAL_TESTS_DIR) && poetry run ruff check
 
-.PHONY: lint-fix-functional-tests
+.PHONY: lint-fix-func-tests
 lint-fix-func-tests: ensure-poetry activate ## Lints the functional tests and applies fixes where possible
 	cd $(FUNCTIONAL_TESTS_DIR) && poetry run ruff check --fix
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR adds the following changes to the CI:

* Create a separate reusable action for cleanup to replace the existing ones.
* Add the action to the doctests workflow.
* Increase timeout for all `cargo` steps (except `fmt`) to 60 minutes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.
