### PR TITLE
Replace FINALITY_DEPTH with params.l1_reorg_safe_depth

### DIFF
--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -4,7 +4,7 @@ use alpen_express_db::{
     types::{L1TxEntry, L1TxStatus},
     DbResult,
 };
-use alpen_express_primitives::buf::Buf32;
+use alpen_express_primitives::{buf::Buf32, params::Params};
 use express_storage::BroadcastDbOps;
 use express_tasks::TaskExecutor;
 use tokio::sync::mpsc;
@@ -55,6 +55,7 @@ pub fn spawn_broadcaster_task<T>(
     executor: &TaskExecutor,
     l1_rpc_client: Arc<T>,
     broadcast_ops: Arc<BroadcastDbOps>,
+    params: Arc<Params>,
 ) -> L1BroadcastHandle
 where
     T: Reader + Broadcaster + Wallet + Signer + Send + Sync + 'static,
@@ -62,7 +63,7 @@ where
     let (broadcast_entry_tx, broadcast_entry_rx) = mpsc::channel::<(u64, L1TxEntry)>(64);
     let ops = broadcast_ops.clone();
     executor.spawn_critical_async("l1_broadcaster_task", async move {
-        broadcaster_task(l1_rpc_client, ops, broadcast_entry_rx)
+        broadcaster_task(l1_rpc_client, ops, broadcast_entry_rx, params)
             .await
             .map_err(Into::into)
     });

--- a/crates/btcio/src/writer/task.rs
+++ b/crates/btcio/src/writer/task.rs
@@ -18,9 +18,6 @@ use crate::{
     writer::{builder::InscriptionError, signer::create_and_sign_blob_inscriptions},
 };
 
-// TODO: from config
-const FINALITY_DEPTH: u64 = 6;
-
 /// A handle to the Inscription task.
 pub struct InscriptionHandle {
     ops: Arc<InscriptionDataOps>,

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -129,7 +129,7 @@ fn main_inner(args: Args) -> anyhow::Result<()> {
         pool,
         &runtime,
         &config,
-        params,
+        params.clone(),
         database,
         l2_block_manager,
         checkpoint_manager,
@@ -146,6 +146,7 @@ fn main_inner(args: Args) -> anyhow::Result<()> {
                 ctx.pool.clone(),
                 &executor,
                 ctx.bitcoin_client.clone(),
+                params.clone(),
             );
             let seq_db = init_sequencer_database(rbdb.clone(), ops_config);
 
@@ -384,12 +385,14 @@ fn start_broadcaster_tasks(
     pool: threadpool::ThreadPool,
     executor: &TaskExecutor,
     bitcoin_client: Arc<BitcoinClient>,
+    params: Arc<Params>,
 ) -> Arc<L1BroadcastHandle> {
     // Set up L1 broadcaster.
     let broadcast_ctx = express_storage::ops::l1tx_broadcast::Context::new(broadcast_database);
     let broadcast_ops = Arc::new(broadcast_ctx.into_ops(pool));
     // start broadcast task
-    let broadcast_handle = spawn_broadcaster_task(executor, bitcoin_client.clone(), broadcast_ops);
+    let broadcast_handle =
+        spawn_broadcaster_task(executor, bitcoin_client.clone(), broadcast_ops, params);
     Arc::new(broadcast_handle)
 }
 


### PR DESCRIPTION
## Description

This replaces the FINALITY_DEPTH const with the equivalent `l1_reorg_safe_depth` from rollup params.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
