### PR TITLE
feat(rpc): extend `getBridgeDuties` to return withdrawal duties

### DIFF
--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -351,7 +351,7 @@ fn next_rand_op_pos(rng: &mut SlotRng, num: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use alpen_express_primitives::{buf::Buf32, params::OperatorConfig};
+    use alpen_express_primitives::{buf::Buf32, l1::BitcoinAmount, params::OperatorConfig};
     use alpen_express_state::{
         block::{ExecSegment, L1Segment, L2BlockBody},
         bridge_state::OperatorTable,
@@ -381,7 +381,7 @@ mod tests {
         let maturation_queue = header_record.maturation_queue();
 
         let mut state_cache = StateCache::new(chs);
-        let amt = 100_000_000_000;
+        let amt: BitcoinAmount = ArbitraryGenerator::new().generate();
 
         let new_payloads_with_deposit_update_tx: Vec<L1HeaderPayload> =
             (1..=params.rollup().l1_reorg_safe_depth + 1)

--- a/crates/primitives/src/bridge.rs
+++ b/crates/primitives/src/bridge.rs
@@ -28,6 +28,9 @@ use crate::{
 /// mathematical operations on it while managing the operator table.
 pub type OperatorIdx = u32;
 
+/// The bitcoin block height that a withdrawal command references.
+pub type BitcoinBlockHeight = u64;
+
 /// A table that maps [`OperatorIdx`] to the corresponding [`PublicKey`].
 ///
 /// We use a [`PublicKey`] instead of an [`bitcoin::secp256k1::XOnlyPublicKey`] for convenience

--- a/crates/primitives/src/l1.rs
+++ b/crates/primitives/src/l1.rs
@@ -38,6 +38,8 @@ use crate::{buf::Buf32, constants::HASH_SIZE, errors::ParseError};
     Arbitrary,
     BorshDeserialize,
     BorshSerialize,
+    Serialize,
+    Deserialize,
 )]
 pub struct L1TxRef(u64, u32);
 

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -2,10 +2,10 @@
 use alpen_express_db::types::L1TxStatus;
 use alpen_express_primitives::bridge::{OperatorIdx, PublickeyTable};
 use alpen_express_rpc_types::{
-    types::{BlockHeader, ClientStatus, DepositEntry, ExecUpdate, L1Status},
+    types::{BlockHeader, ClientStatus, ExecUpdate, L1Status},
     BridgeDuties, HexBytes, HexBytes32, NodeSyncStatus, RawBlockWitness, RpcCheckpointInfo,
 };
-use alpen_express_state::id::L2BlockId;
+use alpen_express_state::{bridge_state::DepositEntry, id::L2BlockId};
 use bitcoin::Txid;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -178,27 +178,6 @@ pub struct ExecUpdate {
     pub da_blobs: Vec<DaBlob>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum DepositState {
-    Created,
-    Accepted,
-    Dispatched,
-    Executed,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DepositEntry {
-    /// The index of the deposit, used to identify or track the deposit within the system.
-    pub deposit_idx: u32,
-
-    /// The amount of currency deposited.
-    pub amt: u64,
-
-    /// Deposit state.
-    pub state: DepositState,
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NodeSyncStatus {
     /// Current head L2 slot known to this node

--- a/crates/state/src/bridge_ops.rs
+++ b/crates/state/src/bridge_ops.rs
@@ -74,9 +74,9 @@ pub struct DepositIntent {
 }
 
 impl DepositIntent {
-    pub fn new(amt: u64, dest_ident: &[u8]) -> Self {
+    pub fn new(amt: BitcoinAmount, dest_ident: &[u8]) -> Self {
         Self {
-            amt: BitcoinAmount::from_sat(amt),
+            amt,
             dest_ident: dest_ident.to_vec(),
         }
     }

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -3,13 +3,16 @@
 //! decide to expand the chain state in the future such that we can't keep it
 //! entire in memory.
 
-use alpen_express_primitives::{bridge::OperatorIdx, buf::Buf32};
+use alpen_express_primitives::{
+    bridge::{BitcoinBlockHeight, OperatorIdx},
+    buf::Buf32,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 use tracing::*;
 
 use crate::{
     bridge_ops::DepositIntent,
-    bridge_state::{BitcoinBlockHeight, DepositState, DispatchCommand, DispatchedState},
+    bridge_state::{DepositState, DispatchCommand, DispatchedState},
     chain_state::ChainState,
     header::L2Header,
     id::L2BlockId,
@@ -138,7 +141,7 @@ fn apply_op_to_chainstate(op: &StateOp, state: &mut ChainState) {
             let (_, deposit_txs, _) = matured_block.into_parts();
             for tx in deposit_txs {
                 if let Deposit(deposit_info) = tx.tx().protocol_operation() {
-                    println!("we got some deposit_txs");
+                    trace!("we got some deposit_txs");
                     let amt = deposit_info.amt;
                     let deposit_intent = DepositIntent::new(amt, &deposit_info.address);
                     deposits.push_back(deposit_intent);

--- a/crates/state/src/tx.rs
+++ b/crates/state/src/tx.rs
@@ -1,4 +1,4 @@
-use alpen_express_primitives::l1::OutputRef;
+use alpen_express_primitives::l1::{BitcoinAmount, OutputRef};
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -16,8 +16,8 @@ pub enum ProtocolOperation {
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary)]
 pub struct DepositInfo {
-    /// amount in satoshis
-    pub amt: u64,
+    /// Bitcoin amount
+    pub amt: BitcoinAmount,
 
     /// outpoint
     pub outpoint: OutputRef,

--- a/crates/tx-parser/src/deposit/deposit_tx.rs
+++ b/crates/tx-parser/src/deposit/deposit_tx.rs
@@ -26,7 +26,7 @@ pub fn extract_deposit_info(tx: &Transaction, config: &DepositTxConfig) -> Optio
 
     // Construct and return the DepositInfo
     Some(DepositInfo {
-        amt: output_0.value.to_sat(),
+        amt: output_0.value.into(),
         address: ee_address.to_vec(),
         outpoint: OutputRef::from(prev_out.previous_output),
     })
@@ -103,7 +103,7 @@ mod tests {
         assert!(out.is_some());
         let out = out.unwrap();
 
-        assert_eq!(out.amt, amt.to_sat());
+        assert_eq!(out.amt, amt.into());
         assert_eq!(out.address, ee_addr);
     }
 }

--- a/crates/tx-parser/src/filter.rs
+++ b/crates/tx-parser/src/filter.rs
@@ -79,6 +79,7 @@ mod test {
     use alpen_express_btcio::test_utils::{
         build_reveal_transaction_test, generate_inscription_script_test,
     };
+    use alpen_express_primitives::l1::BitcoinAmount;
     use alpen_express_state::{
         batch::SignedBatchCheckpoint,
         tx::{InscriptionData, ProtocolOperation},
@@ -266,7 +267,8 @@ mod test {
         if let ProtocolOperation::Deposit(deposit_info) = &result[0].proto_op() {
             assert_eq!(deposit_info.address, ee_addr, "EE address should match");
             assert_eq!(
-                deposit_info.amt, config.deposit_quantity,
+                deposit_info.amt,
+                BitcoinAmount::from_sat(config.deposit_quantity),
                 "Deposit amount should match"
             );
         } else {
@@ -389,7 +391,8 @@ mod test {
                     i
                 );
                 assert_eq!(
-                    deposit_info.amt, config.deposit_quantity,
+                    deposit_info.amt,
+                    BitcoinAmount::from_sat(config.deposit_quantity),
                     "Deposit amount should match for transaction {}",
                     i
                 );

--- a/tests/cooperative-bridge-flow.rs
+++ b/tests/cooperative-bridge-flow.rs
@@ -86,7 +86,7 @@ async fn full_flow() {
     event!(Level::INFO, event = "assigning withdrawal", operator_idx = %assigned_operator_idx);
 
     let withdrawal_info =
-        CooperativeWithdrawalInfo::new(outpoint, user_x_only_pk, assigned_operator_idx);
+        CooperativeWithdrawalInfo::new(outpoint, user_x_only_pk, assigned_operator_idx, 0);
 
     event!(Level::DEBUG, action = "creating withdrawal duty", withdrawal_info = ?withdrawal_info);
     let duty = BridgeDuty::Withdrawal(withdrawal_info);

--- a/tests/cooperative-bridge-out-flow.rs
+++ b/tests/cooperative-bridge-out-flow.rs
@@ -51,7 +51,7 @@ async fn withdrawal_flow() {
     event!(Level::INFO, event = "assigning withdrawal", operator_idx = %assigned_operator_idx);
 
     let withdrawal_info =
-        CooperativeWithdrawalInfo::new(outpoint, user_x_only_pk, assigned_operator_idx);
+        CooperativeWithdrawalInfo::new(outpoint, user_x_only_pk, assigned_operator_idx, 0);
 
     event!(Level::DEBUG, action = "creating withdrawal duty", withdrawal_info = ?withdrawal_info);
     let duty = BridgeDuty::Withdrawal(withdrawal_info);


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR:

* extends the `getBridgeDuties` RPC to return withdrawal duties from the chain state.
* updates states to use `BitcoinAmount` instead of `u64`.
* removes redundant `DepositState` from `primitives` in favor of the one in `state`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Resolves STR-435
