### PR TITLE
ci: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Create a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+        If you believe you have found a vulnerability, please provide details [here](mailto:security@alpenlabs.io) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+
+        If the bug is in a crate you are using (i.e. you are not running the standard `strata` binaries) please mention that as well.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide any steps you think might be relevant to reproduce the bug.
+      placeholder: |
+        Steps to reproduce:
+
+        1. Start '...'
+        2. Then '...'
+        3. Check '...'
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform(s)
+      description: If the issue is with the full node, what platform(s) did this occur on?
+      multiple: true
+      options:
+        - Linux (x86)
+        - Linux (ARM)
+        - Mac (Intel)
+        - Mac (Apple Silicon)
+        - Windows (x86)
+        - Windows (ARM)
+    validations:
+      required: false
+  - type: textarea
+    id: fullnode-version
+    attributes:
+      # FIXME: use `--version` instead
+      label: What is the sha256 checksum of the full node you are running?
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: If you've built the full node from source, provide the full command you used
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/alpenlabs/strata/blob/main/CONTRIBUTING.md#code-of-conduct)
+      options:
+        - label: I agree to follow the Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/alpenlabs/strata/discussions
+    about: Please ask and answer questions here to keep the issue tracker clean.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest a feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the feature has not already been requested in the issue tracker.
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: |
+        Please describe the feature and what it is aiming to solve, if relevant.
+
+        If the feature is for a crate, please include a proposed API surface.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR adds issue templates to the repository for external contributors to use/follow (based on [reth](https://github.com/paradigmxyz/reth/tree/main/.github/ISSUE_TEMPLATE)). Right now, the issue types that are supported are:

* Bug reports
* Feature Requests / Enhancements

For discussions about a particular questions/features, users are requested to use the `Discussions` page to keep the issue tracker clean.

@storopoli the bug report template also assumes that we have a `Code of Conduct` section in our `CONTRIBUTING.md` file which needs to be added.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

Closes STR-340