### PR TITLE
Fix key initialization in bridge-client

### DIFF
--- a/bin/datatool/src/main.rs
+++ b/bin/datatool/src/main.rs
@@ -256,7 +256,7 @@ fn exec_genseqpubkey(cmd: SubcGenSeqPubkey, _ctx: &mut CmdContext) -> anyhow::Re
     let raw_buf = seq_xpub.to_x_only_pub().serialize();
     let s = base58::encode_check(&raw_buf);
 
-    eprintln!("{s}");
+    println!("{s}");
 
     Ok(())
 }
@@ -271,7 +271,7 @@ fn exec_genopxpub(cmd: SubcGenOpXpub, _ctx: &mut CmdContext) -> anyhow::Result<(
     let raw_buf = op_xpub.encode();
     let s = base58::encode_check(&raw_buf);
 
-    eprintln!("{s}");
+    println!("{s}");
 
     Ok(())
 }
@@ -417,27 +417,6 @@ fn derive_seq_xpriv(master: &Xpriv) -> anyhow::Result<Xpriv> {
 /// and used in network init.
 fn derive_op_root_xpub(master: &Xpriv) -> anyhow::Result<Xpriv> {
     derive_strata_scheme_xpriv(master, DERIV_OP_IDX)
-}
-
-/// Derives the signing and wallet xprivs for a Strata operator.
-#[allow(unused)]
-fn derive_op_purpose_xprivs(master: &Xpriv) -> anyhow::Result<(Xpriv, Xpriv)> {
-    let signing_path = DerivationPath::master().extend([
-        ChildNumber::from_hardened_idx(DERIV_BASE_IDX).unwrap(),
-        ChildNumber::from_hardened_idx(DERIV_OP_IDX).unwrap(),
-        ChildNumber::from_normal_idx(DERIV_OP_SIGNING_IDX).unwrap(),
-    ]);
-
-    let wallet_path = DerivationPath::master().extend([
-        ChildNumber::from_hardened_idx(DERIV_BASE_IDX).unwrap(),
-        ChildNumber::from_hardened_idx(DERIV_OP_IDX).unwrap(),
-        ChildNumber::from_normal_idx(DERIV_OP_WALLET_IDX).unwrap(),
-    ]);
-
-    let signing_xpriv = master.derive_priv(bitcoin::secp256k1::SECP256K1, &signing_path)?;
-    let wallet_xpriv = master.derive_priv(bitcoin::secp256k1::SECP256K1, &wallet_path)?;
-
-    Ok((signing_xpriv, wallet_xpriv))
 }
 
 /// Derives the signing and wallet xprivs for a Strata operator.


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR fixes the key initialization in `bridge-client` in relation to the `strata-datatool` by:

* Checking if the `PublicKey` has an odd parity and then, negating the private key if that is the case
* Generating the `wallet_xpriv` from the master/root xpriv passed in from the args
* Using the xpriv directly from the args without using the bitcoin-core wallet as that involves an unnecessary roundtrip and removing it will simplify the deployment greatly by not requiring a separate bitcoin-core for each bridge-client. We can consider adding it in later when we load the descriptor into the wallet from _outside_ the bridge client.

This PR also moves the unused `derive_op_purpose_xprivs` from the `datatool` to the `bridge-client` where it is used.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

