### PR TITLE
fix(sp1-guest-code): avoid double serialization-deserialization

### DIFF
--- a/crates/zkvm/adapters/risc0/src/verifier.rs
+++ b/crates/zkvm/adapters/risc0/src/verifier.rs
@@ -76,6 +76,14 @@ impl ZKVMVerifier for Risc0Verifier {
         let receipt: Receipt = bincode::deserialize(proof.as_bytes())?;
         Ok(receipt.journal.decode()?)
     }
+
+    fn extract_borsh_public_output<T: borsh::BorshSerialize + borsh::BorshDeserialize>(
+        proof: &Proof,
+    ) -> anyhow::Result<T> {
+        let proof: Receipt = bincode::deserialize(proof.as_bytes())?;
+        let public_params_raw = proof.journal.bytes;
+        Ok(borsh::from_slice(&public_params_raw).unwrap())
+    }
 }
 
 #[cfg(test)]

--- a/crates/zkvm/adapters/sp1/src/input.rs
+++ b/crates/zkvm/adapters/sp1/src/input.rs
@@ -30,9 +30,8 @@ impl<'a> ZKVMInputBuilder<'a> for SP1ProofInputBuilder {
         let proof: SP1ProofWithPublicValues = bincode::deserialize(item.proof().as_bytes())?;
         let vkey: SP1VerifyingKey = bincode::deserialize(item.vk().as_bytes())?;
 
-        // Write the verification key and the public values of the program that'll be proven
-        // inside zkVM.
-        self.0.write(&proof.public_values);
+        // Write the public values of the program that'll be proven inside zkVM.
+        self.0.write_slice(proof.public_values.as_slice());
 
         // Write the proofs.
         //

--- a/crates/zkvm/adapters/sp1/src/verifier.rs
+++ b/crates/zkvm/adapters/sp1/src/verifier.rs
@@ -84,6 +84,15 @@ impl ZKVMVerifier for SP1Verifier {
         let public_params: T = proof.public_values.read();
         Ok(public_params)
     }
+
+    fn extract_borsh_public_output<T: borsh::BorshSerialize + borsh::BorshDeserialize>(
+        proof: &Proof,
+    ) -> anyhow::Result<T> {
+        let proof: SP1ProofWithPublicValues = bincode::deserialize(proof.as_bytes())?;
+        let buffer = proof.public_values.as_slice();
+        let output: T = borsh::from_slice(buffer)?;
+        Ok(output)
+    }
 }
 
 // NOTE: SP1 prover runs in release mode only; therefore run the tests on release mode only

--- a/crates/zkvm/zkvm/src/lib.rs
+++ b/crates/zkvm/zkvm/src/lib.rs
@@ -154,8 +154,15 @@ pub trait ZKVMVerifier {
         public_params_raw: &[u8],
     ) -> anyhow::Result<()>;
 
-    /// Extracts the public output from the proof.
+    /// Extracts the public output from the given proof using standard `serde`
+    /// serialization/deserialization.
     fn extract_public_output<T: Serialize + DeserializeOwned>(proof: &Proof) -> anyhow::Result<T>;
+
+    /// Extracts the public output from the given proof assuming the data was serialized using
+    /// Borsh.
+    fn extract_borsh_public_output<T: BorshSerialize + BorshDeserialize>(
+        proof: &Proof,
+    ) -> anyhow::Result<T>;
 }
 
 impl Default for ProverOptions {

--- a/provers/sp1/guest-btc-blockspace/src/main.rs
+++ b/provers/sp1/guest-btc-blockspace/src/main.rs
@@ -1,5 +1,5 @@
-use strata_primitives::params::RollupParams;
 use bitcoin::Block;
+use strata_primitives::params::RollupParams;
 use strata_proofimpl_btc_blockspace::logic::{process_blockspace_proof, BlockspaceProofInput};
 
 fn main() {
@@ -14,5 +14,5 @@ fn main() {
     };
     let output = process_blockspace_proof(&input);
 
-    sp1_zkvm::io::commit(&borsh::to_vec(&output).unwrap());
+    sp1_zkvm::io::commit_slice(&borsh::to_vec(&output).unwrap());
 }

--- a/provers/sp1/guest-cl-agg/src/main.rs
+++ b/provers/sp1/guest-cl-agg/src/main.rs
@@ -36,19 +36,17 @@ fn main() {
         rollup_params_commitment,
     };
 
-    sp1_zkvm::io::commit(&borsh::to_vec(&public_params).unwrap());
+    sp1_zkvm::io::commit_slice(&borsh::to_vec(&public_params).unwrap());
 }
 
 fn read_and_validate_next_proof() -> L2BatchProofOutput {
     let cl_block_vkey = vks::GUEST_CL_STF_ELF_ID;
-    let cl_proof_pp: Vec<u8> = sp1_zkvm::io::read();
+    let cl_proof_pp_raw = sp1_zkvm::io::read_vec();
 
     // Verify the CL block proof
-    let public_values_digest = Sha256::digest(&cl_proof_pp);
+    let public_values_digest = Sha256::digest(&cl_proof_pp_raw);
     sp1_zkvm::lib::verify::verify_sp1_proof(cl_block_vkey, &public_values_digest.into());
-
-    let cl_proof_pp_serialized: Vec<u8> = bincode::deserialize(&cl_proof_pp).unwrap();
-    borsh::from_slice(&cl_proof_pp_serialized).unwrap()
+    borsh::from_slice(&cl_proof_pp_raw).unwrap()
 }
 
 fn validate_proof_consistency(

--- a/provers/sp1/guest-cl-stf/src/main.rs
+++ b/provers/sp1/guest-cl-stf/src/main.rs
@@ -8,16 +8,16 @@ mod vks;
 
 fn main() {
     let rollup_params: RollupParams = sp1_zkvm::io::read();
-    let el_vkey = vks::GUEST_EVM_EE_STF_ELF_ID;
 
-    let el_pp = sp1_zkvm::io::read::<Vec<u8>>();
-    let input: Vec<u8> = sp1_zkvm::io::read();
-    let (prev_state, block): (ChainState, L2Block) = borsh::from_slice(&input).unwrap();
+    let input_raw = sp1_zkvm::io::read_vec();
+    let (prev_state, block): (ChainState, L2Block) = borsh::from_slice(&input_raw).unwrap();
 
     // Verify the EL proof
-    let public_values_digest = Sha256::digest(&el_pp);
-    sp1_zkvm::lib::verify::verify_sp1_proof(el_vkey, &public_values_digest.into());
-    let el_pp_deserialized: ELProofPublicParams = bincode::deserialize(&el_pp).unwrap();
+    let el_vkey = vks::GUEST_EVM_EE_STF_ELF_ID;
+    let el_pp_raw = sp1_zkvm::io::read_vec();
+    let el_pp_raw_digest = Sha256::digest(&el_pp_raw);
+    sp1_zkvm::lib::verify::verify_sp1_proof(el_vkey, &el_pp_raw_digest.into());
+    let el_pp_deserialized: ELProofPublicParams = bincode::deserialize(&el_pp_raw).unwrap();
 
     let new_state = verify_and_transition(
         prev_state.clone(),
@@ -46,5 +46,5 @@ fn main() {
         rollup_params_commitment: rollup_params.compute_hash(),
     };
 
-    sp1_zkvm::io::commit(&borsh::to_vec(&cl_stf_public_params).unwrap());
+    sp1_zkvm::io::commit_slice(&borsh::to_vec(&cl_stf_public_params).unwrap());
 }

--- a/provers/sp1/tests/btc-blockspace.rs
+++ b/provers/sp1/tests/btc-blockspace.rs
@@ -17,7 +17,7 @@ mod test {
 
         let prover_options = ProverOptions {
             enable_compression: true,
-            use_mock_prover: false,
+            use_mock_prover: true,
             ..Default::default()
         };
 
@@ -25,10 +25,7 @@ mod test {
             .get_proof(block, &prover_options)
             .unwrap();
 
-        // TODO: add `extract_public_output_borsh` function to Verifier
-        let raw_output = SP1Verifier::extract_public_output::<Vec<u8>>(&proof)
+        let _: BlockspaceProofOutput = SP1Verifier::extract_borsh_public_output(&proof)
             .expect("Failed to extract public outputs");
-
-        let _: BlockspaceProofOutput = borsh::from_slice(&raw_output).unwrap();
     }
 }

--- a/provers/sp1/tests/checkpoint.rs
+++ b/provers/sp1/tests/checkpoint.rs
@@ -2,13 +2,7 @@ mod helpers;
 #[cfg(all(feature = "prover", not(debug_assertions)))]
 mod test {
 
-    use num_bigint::BigUint;
-    use num_traits::Num;
-    use sp1_sdk::{HashableKey, MockProver, Prover};
-    use strata_proofimpl_checkpoint::{
-        CheckpointProofInput, CheckpointProofOutput, L2BatchProofOutput,
-    };
-    use strata_proofimpl_l1_batch::L1BatchProofOutput;
+    use strata_proofimpl_checkpoint::CheckpointProofOutput;
     use strata_sp1_adapter::{SP1Host, SP1ProofInputBuilder, SP1Verifier};
     use strata_sp1_guest_builder::GUEST_CHECKPOINT_ELF;
     use strata_test_utils::l2::gen_params;
@@ -46,35 +40,17 @@ mod test {
         let (l1_batch_proof, l1_batch_vk) = l1_batch_prover
             .get_proof(&(l1_start_height, l1_end_height), &prover_options)
             .unwrap();
-        let raw_output = SP1Verifier::extract_public_output::<Vec<u8>>(&l1_batch_proof).unwrap();
-        let l1_batch: L1BatchProofOutput = borsh::from_slice(&raw_output).unwrap();
         let l1_batch_proof_agg_input = AggregationInput::new(l1_batch_proof, l1_batch_vk);
 
         let (l2_batch_proof, l2_batch_vk) = l2_batch_prover
             .get_proof(&(l2_start_height, l2_end_height), &prover_options)
             .unwrap();
-        let raw_output = SP1Verifier::extract_public_output::<Vec<u8>>(&l2_batch_proof).unwrap();
-        let l2_batch: L2BatchProofOutput = borsh::from_slice(&raw_output).unwrap();
         let l2_batch_proof_agg_input = AggregationInput::new(l2_batch_proof, l2_batch_vk);
 
         let prover = SP1Host::init(GUEST_CHECKPOINT_ELF.into(), prover_options);
 
-        let mock_prover = MockProver::new();
-        let (_, vk) = mock_prover.setup(GUEST_CHECKPOINT_ELF);
-        let vk = BigUint::from_str_radix(vk.bytes32().strip_prefix("0x").unwrap(), 16)
-            .unwrap()
-            .to_bytes_be();
-
-        let checkpoint_proof_input = CheckpointProofInput {
-            l1_state: l1_batch,
-            l2_state: l2_batch,
-            vk,
-        };
-
         let prover_input = SP1ProofInputBuilder::new()
             .write(&rollup_params)
-            .unwrap()
-            .write_borsh(&checkpoint_proof_input)
             .unwrap()
             .write_proof(l1_batch_proof_agg_input)
             .unwrap()
@@ -87,8 +63,7 @@ mod test {
             .prove(prover_input)
             .expect("Failed to generate proof");
 
-        let output_raw = SP1Verifier::extract_public_output::<Vec<u8>>(&proof)
+        let _output: CheckpointProofOutput = SP1Verifier::extract_borsh_public_output(&proof)
             .expect("Failed to extract public outputs");
-        let _: CheckpointProofOutput = borsh::from_slice(&output_raw).unwrap();
     }
 }

--- a/provers/sp1/tests/cl-agg-test.rs
+++ b/provers/sp1/tests/cl-agg-test.rs
@@ -25,8 +25,7 @@ mod test {
 
         let (proof, _) = cl_agg_prover.get_proof(&(1, 3), &prover_options).unwrap();
 
-        let raw_output = SP1Verifier::extract_public_output::<Vec<u8>>(&proof)
+        let _: L2BatchProofOutput = SP1Verifier::extract_borsh_public_output(&proof)
             .expect("Failed to extract public outputs");
-        let _: L2BatchProofOutput = borsh::from_slice(&raw_output).unwrap();
     }
 }

--- a/provers/sp1/tests/cl-stf-test.rs
+++ b/provers/sp1/tests/cl-stf-test.rs
@@ -23,8 +23,7 @@ mod test {
 
         let (proof, _) = cl_prover.get_proof(&height, &prover_ops).unwrap();
 
-        let raw_output = SP1Verifier::extract_public_output::<Vec<u8>>(&proof)
+        let _: L2BatchProofOutput = SP1Verifier::extract_borsh_public_output(&proof)
             .expect("Failed to extract public outputs");
-        let _: L2BatchProofOutput = borsh::from_slice(&raw_output).unwrap();
     }
 }

--- a/provers/sp1/tests/helpers/cl.rs
+++ b/provers/sp1/tests/helpers/cl.rs
@@ -44,15 +44,13 @@ impl ProofGenerator<u64> for ClProofGenerator {
         let l2_block = l2_segment.get_block(*block_num);
         let pre_state = l2_segment.get_pre_state(*block_num);
 
-        let cl_witness = borsh::to_vec(&(pre_state, l2_block)).unwrap();
-
         // Generate CL proof
         let prover = SP1Host::init(self.get_elf().into(), *prover_options);
 
         let proof_input = SP1ProofInputBuilder::new()
             .write(rollup_params)?
+            .write_borsh(&(pre_state, l2_block))?
             .write_proof(agg_input)?
-            .write(&cl_witness)?
             .build()?;
 
         let proof = prover

--- a/provers/sp1/tests/helpers/l2_batch.rs
+++ b/provers/sp1/tests/helpers/l2_batch.rs
@@ -34,8 +34,7 @@ impl ProofGenerator<(u64, u64)> for L2BatchProofGenerator {
                 .cl_proof_generator
                 .get_proof(&block_num, prover_options)?;
 
-            let output_raw: Vec<u8> = SP1Verifier::extract_public_output(&proof)?;
-            let _output: L2BatchProofOutput = borsh::from_slice(&output_raw).unwrap();
+            let _output: L2BatchProofOutput = SP1Verifier::extract_borsh_public_output(&proof)?;
             agg_proof_inputs.push(AggregationInput::new(proof, vk));
         }
 

--- a/provers/sp1/tests/l1-batch.rs
+++ b/provers/sp1/tests/l1-batch.rs
@@ -29,8 +29,7 @@ mod test {
             .get_proof(&(l1_start_height, l1_end_height), &prover_options)
             .unwrap();
 
-        let raw_output = SP1Verifier::extract_public_output::<Vec<u8>>(&proof)
+        let _: L1BatchProofOutput = SP1Verifier::extract_borsh_public_output(&proof)
             .expect("Failed to extract public outputs");
-        let _: L1BatchProofOutput = borsh::from_slice(&raw_output).unwrap();
     }
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR eliminates the redundant deserialization in ZKVM guest code by switching to a single deserialization process. Previously, structs were deserialized twice—once using Serde and then again with Borsh. With this change, only Serde serialization/deserialization is used, streamlining the deserialization process in the guest code.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [X] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [X] I have performed a self-review of my code.
-   [X] I have commented my code where necessary.
-   [X] I have updated the documentation if needed.
-   [X] My changes do not introduce new warnings.
-   [X] I have added tests that prove my changes are effective or that my feature works.
-   [X] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
