### PR TITLE
feat(bridge-client): allow passing rpc addr as args

### DIFF
--- a/bin/bridge-client/src/args.rs
+++ b/bin/bridge-client/src/args.rs
@@ -21,6 +21,15 @@ pub(crate) struct Cli {
     )]
     pub xpriv_str: Option<String>,
 
+    #[argh(
+        option,
+        description = "host to run the rpc server on (default: 0.0.0.0)"
+    )]
+    pub rpc_host: Option<String>,
+
+    #[argh(option, description = "port to run the rpc server on (default: 4781)")]
+    pub rpc_port: Option<u32>,
+
     #[argh(option, description = "url for the bitcoin RPC client")]
     pub btc_url: String,
 

--- a/bin/bridge-client/src/constants.rs
+++ b/bin/bridge-client/src/constants.rs
@@ -1,8 +1,8 @@
 //! Common constants for the operator binary in both the operator and challenger modes.
 
-pub(super) const RPC_PORT: usize = 4781; // first 4 digits in the sha256 of "operator"
+pub(super) const DEFAULT_RPC_PORT: u32 = 4781; // first 4 digits in the sha256 of "operator"
 
-pub(super) const RPC_SERVER: &str = "127.0.0.1";
+pub(super) const DEFAULT_RPC_HOST: &str = "127.0.0.1";
 
 /// The default bridge rocksdb database retry count, if not overridden by the user.
 pub(super) const ROCKSDB_RETRY_COUNT: u16 = 3;

--- a/bin/bridge-client/src/rpc_server.rs
+++ b/bin/bridge-client/src/rpc_server.rs
@@ -15,9 +15,7 @@ use strata_storage::ops::bridge_duty::BridgeDutyOps;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
-use crate::constants::{RPC_PORT, RPC_SERVER};
-
-pub(crate) async fn start<T>(rpc_impl: &T) -> anyhow::Result<()>
+pub(crate) async fn start<T>(rpc_impl: &T, rpc_addr: &str) -> anyhow::Result<()>
 where
     T: StrataBridgeControlApiServer
         + StrataBridgeNetworkApiServer
@@ -36,9 +34,9 @@ where
     rpc_module.merge(network_api).context("merge network api")?;
     rpc_module.merge(tracker_api).context("merge network api")?;
 
-    let addr = format!("{RPC_SERVER}:{RPC_PORT}");
+    info!("Starting bridge RPC server at: {rpc_addr}");
     let rpc_server = jsonrpsee::server::ServerBuilder::new()
-        .build(&addr)
+        .build(&rpc_addr)
         .await
         .expect("build bridge rpc server");
 
@@ -48,7 +46,7 @@ where
     // At the moment, the impl below just stops the client from stopping.
     let (_stop_tx, stop_rx): (oneshot::Sender<bool>, oneshot::Receiver<bool>) = oneshot::channel();
 
-    info!("bridge RPC server started at: {addr}");
+    info!("bridge RPC server started at: {rpc_addr}");
 
     let _ = stop_rx.await;
     info!("stopping RPC server");

--- a/docker/bridge-client/entrypoint.sh
+++ b/docker/bridge-client/entrypoint.sh
@@ -14,6 +14,8 @@ if [ ! -f "$KEYFILE" ]; then
 fi
 
 XPRIV_STR=$(cat $KEYFILE | tr -d '\n')
+RPC_HOST=${RPC_HOST:-127.0.0.1}
+RPC_PORT=${RPC_PORT:-4781}
 
 # delayed start to allow other containers to spin up first
 # this is not enough for rollup genesis to be triggered
@@ -24,6 +26,8 @@ sleep 10
 # Start the Strata Operator Client
 strata-bridge-client operator \
   --xpriv-str $XPRIV_STR \
+  --rpc-host $RPC_HOST \
+  --rpc-port $RPC_PORT \
   --btc-url $BTC_URL \
   --btc-user $BTC_USER \
   --btc-pass $BTC_PASS \


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR allows passing `RPC_HOST` and `RPC_PORT` as optional args to the bridge client. If not provided, defaults are used. This is needed for testing purposes as the earlier default was 127.0.0.1 for the `RPC_HOST` which is inaccessible from the container's host, and would require a proxy container.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

