### PR TITLE
fix(cli) don't expect a txid from the faucet api

### DIFF
--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -161,7 +161,9 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     let status = res.status();
     let body = res.text().await.expect("invalid response");
     if status == StatusCode::OK {
-        let _ = term.write_line("Successful. Check your balance with `strata balance`");
+        let _ = term.write_line(
+            "Successful queued request for signet bitcoin. It should arrive in your wallet soon.",
+        );
     } else {
         let _ = term.write_line(&format!("Failed: faucet responded with {status}: {body}"));
     }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

The CLI now won't expect a transaction ID in the response, as the API won't have that data available when batching. This should be patched into the 0.1.0 release branch. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
