### PR TITLE
feat(storage) `CacheTable` rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cache-advisor"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f89ab55ca4e6a46a0740a1c5346db1ad66e4a76598bbfa060dc3259935a7450"
+dependencies = [
+ "crossbeam-queue",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +2887,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-map"
+version = "5.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6542c565fbcba786db59307d7840f0bf5cd9e0aba6502755337e15f0e06fd65"
+dependencies = [
+ "ebr",
+ "stack-map",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3091,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3671,6 +3699,15 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "ebr"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1ea3b18359d566f360eaf811a2d69bc6c8eb6faaeecc8839975633860a076e"
+dependencies = [
+ "shared-local-state",
+]
 
 [[package]]
 name = "ecdsa"
@@ -5993,6 +6030,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanal"
+version = "0.1.0-pre8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
+dependencies = [
+ "futures-core",
+ "lock_api",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6129,7 +6176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12021,6 +12068,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared-local-state"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a50ccb2f45251772ed15abfd1e5f10a305288187b1582ab2e4295b29bbb4929"
+dependencies = [
+ "parking_lot 0.12.3",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12710,6 +12766,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stack-map"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49d6d36fee60faad91e23603db2356677b58ec2429237b39d5c60c26868f37c"
 
 [[package]]
 name = "static_assertions"
@@ -13663,9 +13725,13 @@ dependencies = [
 name = "strata-storage"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.11",
  "anyhow",
  "async-trait",
  "bitcoin",
+ "cache-advisor",
+ "concurrent-map",
+ "kanal",
  "lru",
  "paste",
  "strata-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,7 @@ reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev =
 reth-trie = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.0" }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.0" }
 
+ahash = "0.8.11"
 anyhow = "1.0.86"
 arbitrary = { version = "1.3.2", features = ["derive"] }
 argh = "0.1"
@@ -184,8 +185,10 @@ bitcoin = { version = "=0.32.3", features = ["serde"] }
 bitcoind = { version = "0.36.0", features = ["26_0"] }
 borsh = { version = "1.5.0", features = ["derive"] }
 bytes = "1.6.0"
+cache-advisor = "1.0.16"
 chrono = "0.4.38"
 clap = "4"
+concurrent-map = "5.0.37"
 digest = "0.10"
 ethnum = "1.5.0"
 eyre = "0.6"
@@ -199,6 +202,7 @@ jmt = "0.10.0"
 jsonrpsee = "0.24"
 jsonrpsee-http-client = "0.24"
 jsonrpsee-types = "0.24"
+kanal = "0.1.0-pre8"
 lazy_static = "1.5.0"
 lru = "0.12"
 miniscript = "12.2.0"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -8,9 +8,13 @@ strata-db.workspace = true
 strata-primitives.workspace = true
 strata-state.workspace = true
 
+ahash.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bitcoin.workspace = true
+cache-advisor.workspace = true
+concurrent-map.workspace = true
+kanal.workspace = true
 lru.workspace = true
 paste.workspace = true
 threadpool.workspace = true

--- a/crates/storage/src/managers/checkpoint.rs
+++ b/crates/storage/src/managers/checkpoint.rs
@@ -22,19 +22,19 @@ impl CheckpointDbManager {
 
     pub async fn put_checkpoint(&self, idx: u64, entry: CheckpointEntry) -> DbResult<()> {
         self.ops.put_batch_checkpoint_async(idx, entry).await?;
-        self.checkpoint_cache.purge_async(&idx).await;
+        self.checkpoint_cache.purge(&idx);
         Ok(())
     }
 
     pub fn put_checkpoint_blocking(&self, idx: u64, entry: CheckpointEntry) -> DbResult<()> {
         self.ops.put_batch_checkpoint_blocking(idx, entry)?;
-        self.checkpoint_cache.purge_blocking(&idx);
+        self.checkpoint_cache.purge(&idx);
         Ok(())
     }
 
     pub async fn get_checkpoint(&self, idx: u64) -> DbResult<Option<CheckpointEntry>> {
         self.checkpoint_cache
-            .get_or_fetch_async(&idx, || self.ops.get_batch_checkpoint_chan(idx))
+            .get_or_fetch(&idx, || self.ops.get_batch_checkpoint_chan(idx))
             .await
     }
 

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -26,7 +26,7 @@ impl L2BlockManager {
     pub async fn put_block_async(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let id = bundle.block().header().get_blockid();
         self.ops.put_block_async(bundle).await?;
-        self.block_cache.purge_async(&id).await;
+        self.block_cache.purge(&id);
         Ok(())
     }
 
@@ -34,14 +34,14 @@ impl L2BlockManager {
     pub fn put_block_blocking(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let id = bundle.block().header().get_blockid();
         self.ops.put_block_blocking(bundle)?;
-        self.block_cache.purge_blocking(&id);
+        self.block_cache.purge(&id);
         Ok(())
     }
 
     /// Gets a block either in the cache or from the underlying database.
     pub async fn get_block_async(&self, id: &L2BlockId) -> DbResult<Option<L2BlockBundle>> {
         self.block_cache
-            .get_or_fetch_async(id, || self.ops.get_block_chan(*id))
+            .get_or_fetch(id, || self.ops.get_block_chan(*id))
             .await
     }
 


### PR DESCRIPTION
## Description

This PR rewrites the `CacheTable` used for the L2 block manager (and soon the L1BM) to increase performance.

It adds the following dependencies:

| Dependency | About                       | Reason for addition |
|--------------|--------------------|--------------------|
| concurrent-map | A lock-free B+ tree based on [sled](https://github.com/spacejam/sled)’s internal index structure, but supporting richer Rust types as keys and values than raw bytes. This structure supports atomic compare and swap operations with the [ConcurrentMap::cas](https://docs.rs/concurrent-map/latest/concurrent_map/struct.ConcurrentMap.html#method.cas) method. | Powers the new in-memory cache, replaces the effective Mutex around a hashmap + arc<rwlock> rubbish we had going on before. |
| cache-advisor | A simple, high performance scan-resistant eviction manager. Tells you when to evict items from a cache. Features: two-segment LRU, protects against cache pollution from single-hit items, 256 shards accessed via non-blocking flatcombining, local access buffer that must fill up before accessing shared state, compresses the costs associated with each item to a u8 using a compression technique that will converge to the overall true sum of costs over time, but allows for much less memory to be used for accounting. | Concurrent map isn't an LRU by itself, so this gives us LRU functionality |
| kanal| Provides multi-producer and multi-consumer channels with advanced features and lock-free one-shot channels that only allocate the size of a pointer in the heap, allowing for fast communication. The library has a focus on unifying message passing between synchronous and asynchronous portions of Rust code through a combination of synchronous and asynchronous APIs while maintaining high performance. | Fastest channel design in Rust, so I want to move our internal channels to use this eventually. However, it was needed here for another reason. Tokio's `broadcast::Receiver`cannot be cloned - you need the `Sender`to create new `Receiver`s. Kanal's channels are cooler and let you do this, which gets rid of the Arcing we were previously doing, allowing concurrent map to clone `Slot`s when necessary |
| ahash | Rust's fastest `Hasher`implementation. Uses hardware AES when available. Non-cryptographic. | `CacheAdvisor`identifies objects via `u64` keys. To keep the cache generic, we require `V: Hash`and then internally use `u64`s to identify things in the map. So a bit of a hybrid between a B+ tree and a hash map. |

Note that the new `CacheTable`is `Send`but `!Sync`. You cannot share a single instantiation between threads. This is the biggest API-level change. The way to share it across threads is by cloning, and giving a new clone of the `CacheTable` whenever it might switch threads, like for a tokio task.

I haven't yet tested the performance of this implementation, but I've built something using the same tooling and similar algorithms before. These things are usually blisteringly quick.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->

STR-627