### PR TITLE
Str 829 enable eoa flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13669,6 +13669,7 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc",

--- a/bin/strata-reth/src/main.rs
+++ b/bin/strata-reth/src/main.rs
@@ -1,12 +1,13 @@
 mod db;
 
-use std::{fs, future::Future, path::PathBuf, sync::Arc};
+use std::{fs, future::Future, path::PathBuf, str::FromStr, sync::Arc};
 
 use alloy_genesis::Genesis;
 use clap::Parser;
 use reth::{
     args::LogArgs,
     builder::{NodeBuilder, WithLaunchContext},
+    revm::primitives::Address,
     CliRunner,
 };
 use reth_chainspec::ChainSpec;
@@ -39,8 +40,16 @@ fn main() {
     if let Err(err) = run(command, |builder, ext| async move {
         let datadir = builder.config().datadir().data_dir().to_path_buf();
 
+        let allowed_addrs: Vec<Address> = ext
+            .allowed_eoa_addrs
+            .into_iter()
+            .map(|x| Address::from_str(&x))
+            .collect::<Result<_, _>>()?; // TODO: better error messaging
+
         let node_args = StrataNodeArgs {
             sequencer_http: ext.sequencer_http.clone(),
+            allowed_eoa_addrs: allowed_addrs,
+            enable_eoa: ext.enable_eoa,
         };
 
         let mut node_builder = builder.node(StrataEthereumNode::new(node_args));
@@ -102,6 +111,14 @@ pub struct AdditionalConfig {
     /// Rpc of sequener's reth node to forward transactions to.
     #[arg(long, required = false)]
     pub sequencer_http: Option<String>,
+
+    /// To enable EOA txs or not.
+    #[arg(long, default_value_t = false)]
+    pub enable_eoa: bool,
+
+    /// Allowed EOA addresses, if `enable_eoa` is set to false.
+    #[arg(long, num_args(1..))]
+    pub allowed_eoa_addrs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/reth/node/src/args.rs
+++ b/crates/reth/node/src/args.rs
@@ -1,4 +1,8 @@
+use revm_primitives::Address;
+
 #[derive(Debug, Clone, Default)]
 pub struct StrataNodeArgs {
     pub sequencer_http: Option<String>,
+    pub enable_eoa: bool,
+    pub allowed_eoa_addrs: Vec<Address>,
 }

--- a/crates/reth/rpc/Cargo.toml
+++ b/crates/reth/rpc/Cargo.toml
@@ -28,6 +28,7 @@ reth-network-api.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-revm.workspace = true
 reth-rpc.workspace = true

--- a/crates/reth/rpc/src/eth/transaction.rs
+++ b/crates/reth/rpc/src/eth/transaction.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{Bytes, PrimitiveSignature as Signature, B256};
 use alloy_rpc_types_eth::{Transaction, TransactionInfo, TransactionRequest};
 use reth_node_api::FullNodeComponents;
 use reth_primitives::{RecoveredTx, TransactionSigned};
+use reth_primitives_traits::SignedTransaction;
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ProviderTx, ReceiptProvider, TransactionsProvider,
 };
@@ -30,8 +31,20 @@ where
     ///
     /// Returns the hash of the transaction.
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error> {
-        let recovered = recover_raw_transaction(&tx)?;
+        let recovered: RecoveredTx<
+            <<Self::Pool as TransactionPool>::Transaction as PoolTransaction>::Pooled,
+        > = recover_raw_transaction(&tx)?;
+        let sender = recovered.recover_signer_unchecked();
         let pool_transaction = <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
+
+        // Check if EOA disabled and if so the sender is in the allowed list
+        if !self.inner.enable_eoa
+            && sender
+                .map(|x| self.inner.allowed_eoa_addrs.contains(&x))
+                .unwrap_or(false)
+        {
+            return Err(EthApiError::Unsupported("EOA txs are not allowed").into());
+        }
 
         // On Strata, transactions are forwarded directly to the sequencer to be included in
         // blocks that it builds.

--- a/crates/reth/rpc/src/lib.rs
+++ b/crates/reth/rpc/src/lib.rs
@@ -6,7 +6,7 @@ pub mod sequencer;
 
 pub use eth::{StrataEthApi, StrataNodeCore};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use revm_primitives::alloy_primitives::B256;
+use revm_primitives::{alloy_primitives::B256, Address};
 pub use rpc::StrataRPC;
 pub use sequencer::SequencerClient;
 use serde::{Deserialize, Serialize};
@@ -30,4 +30,32 @@ pub trait StrataRpcApi {
 pub enum BlockWitness {
     Raw(#[serde(with = "hex::serde")] Vec<u8>),
     Json(EvmBlockStfInput),
+}
+
+#[derive(Debug, Clone)]
+pub enum EOAMode {
+    Disabled { allowed_eoa_addrs: Vec<Address> }, // TODO: Maybe use NonEmptyVec like struct
+    // one element
+    Enabled,
+}
+
+impl EOAMode {
+    pub fn new(enable: bool, allowed_eoa_addrs: Vec<Address>) -> Self {
+        if enable {
+            if !allowed_eoa_addrs.is_empty() {
+                // TODO: possibly warn, but would be better if this happened around the boundary
+            }
+            Self::Enabled
+        } else {
+            Self::Disabled { allowed_eoa_addrs }
+        }
+    }
+}
+
+impl Default for EOAMode {
+    fn default() -> Self {
+        Self::Disabled {
+            allowed_eoa_addrs: Vec::new(),
+        }
+    }
 }


### PR DESCRIPTION
## Description
This PR does the following in light of enabling/disabling EOA transactions in strata evm execution layer:
1. Adds two node arguments `enable_eoa`(with default `false`) and `allowed_eoa_addrs`(in case eoa is disabled, this would contain bundler address).
2. Internally creates an `EOAMode` enum that is either `Enabled` or `Disabled { allowed_eoa_addrs }`.

TODO: fn and unit tests

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
