### PR TITLE
bakport: STR-1422 Alpen-CLI gives the wrong block duration when depositing

### DIFF
--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -35,7 +35,7 @@ pub const AES_TAG_LEN: usize = 16;
 
 pub const DEFAULT_NETWORK: Network = Network::Signet;
 pub const BRIDGE_ALPEN_ADDRESS: &str = "0x5400000000000000000000000000000000000001";
-pub const SIGNET_BLOCK_TIME: Duration = Duration::from_secs(30);
+pub const SIGNET_BLOCK_TIME: Duration = Duration::from_secs(10 * 60); // 10 minutes
 
 /// Alpen CLI [`DerivationPath`](bdk_wallet::bitcoin::bip32::DerivationPath) for Alpen EVM wallet
 ///


### PR DESCRIPTION
## Description

Backport [fix for STR-1422](https://github.com/alpenlabs/alpen/pull/829) to `releases/0.2.0`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
