### PR TITLE
Add check for null epoch before handling finalization

### DIFF
--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -198,6 +198,9 @@ impl ForkChoiceManager {
 
     fn find_latest_finalizable_epoch(&self) -> Option<(usize, &EpochCommitment)> {
         // the latest epoch which we have processed and is safe to finalize
+        if self.cur_chainstate.prev_epoch().is_null() {
+            return None;
+        }
         let prev_epoch = self.cur_chainstate.prev_epoch().epoch();
         self.epochs_pending_finalization
             .iter()


### PR DESCRIPTION
## Description

FCM was trying to finalize the `0th` epoch when it should not have because of the case that `null_epoch.prev_epoch() == null_epoch`. Added a fix to handle that case.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
