### PR TITLE
feat(zkvm): replace anyhow::Error with typed errors in EVM proof implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13920,7 +13920,6 @@ dependencies = [
  "alloy-trie",
  "alpen-reth-evm",
  "alpen-reth-primitives",
- "anyhow",
  "bincode",
  "reth-primitives",
  "reth-primitives-traits",
@@ -13932,6 +13931,7 @@ dependencies = [
  "strata-mpt",
  "strata-primitives",
  "strata-state",
+ "thiserror 2.0.12",
  "zkaleido",
  "zkaleido-native-adapter",
 ]

--- a/crates/proof-impl/evm-ee-stf/Cargo.toml
+++ b/crates/proof-impl/evm-ee-stf/Cargo.toml
@@ -22,13 +22,13 @@ alloy-rlp.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-trie.workspace = true
 
-anyhow.workspace = true
 reth-primitives = { workspace = true, features = ["serde-bincode-compat"] }
 reth-primitives-traits.workspace = true
 revm.workspace = true
 revm-primitives.workspace = true
 serde.workspace = true
 serde_with.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/crates/proof-impl/evm-ee-stf/src/error.rs
+++ b/crates/proof-impl/evm-ee-stf/src/error.rs
@@ -1,0 +1,75 @@
+//! Error types for EVM Execution Environment State Transition Function (EE-STF) proof
+//! implementation.
+
+use alloy_primitives::Address;
+use revm_primitives::alloy_primitives::U256;
+use thiserror::Error;
+
+/// EVM EE-STF proof implementation operations errors.
+#[derive(Error, Debug)]
+pub enum EvmEeStfError {
+    /// Database operations error.
+    #[error("Database error: {0}")]
+    Database(#[from] DatabaseError),
+
+    /// Merkle Patricia Trie operations error.
+    #[error("MPT error: {0}")]
+    Mpt(#[from] strata_mpt::Error),
+
+    /// Account operations error.
+    #[error("Account error: {0}")]
+    Account(#[from] AccountError),
+
+    /// Validation error.
+    #[error("Validation error: {message}")]
+    Validation { message: String },
+
+    /// Block processing error.
+    #[error("Block processing error: {message}")]
+    BlockProcessing { message: String },
+}
+
+/// Database operations errors.
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    /// Account not found.
+    #[error("Account not found: {address}")]
+    AccountNotFound { address: Address },
+
+    /// Storage slot not found for the specified account and index.
+    #[error("Storage slot not found for account {address} at index {index}")]
+    StorageSlotNotFound { address: Address, index: U256 },
+
+    /// Database operation failed.
+    #[error("Database operation failed: {message}")]
+    OperationFailed { message: String },
+
+    /// Error when committing changes to the database.
+    #[error("Failed to commit changes to database: {message}")]
+    CommitFailed { message: String },
+}
+
+/// Account operations errors.
+#[derive(Error, Debug)]
+pub enum AccountError {
+    /// Failed to increase account balance.
+    #[error("Failed to increase balance for account {address}: {message}")]
+    BalanceIncreaseFailed { address: Address, message: String },
+
+    /// Inconsistent account state.
+    #[error("Inconsistent account state for {address}: {message}")]
+    InconsistentState { address: Address, message: String },
+
+    /// Invalid account data.
+    #[error("Invalid account data for {address}: {message}")]
+    InvalidData { address: Address, message: String },
+}
+
+/// Results for EVM EE-STF proof implementation operations.
+pub type EvmEeStfResult<T> = Result<T, EvmEeStfError>;
+
+/// Results for Database operations.
+pub type DatabaseResult<T> = Result<T, DatabaseError>;
+
+/// Results for Account operations.
+pub type AccountResult<T> = Result<T, AccountError>;

--- a/crates/proof-impl/evm-ee-stf/src/lib.rs
+++ b/crates/proof-impl/evm-ee-stf/src/lib.rs
@@ -16,12 +16,14 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 pub mod db;
+pub mod error;
 pub mod primitives;
 pub mod processor;
 pub mod program;
 pub mod utils;
 use alpen_reth_evm::collect_withdrawal_intents;
 use db::InMemoryDBHelper;
+pub use error::{AccountError, DatabaseError, EvmEeStfError, EvmEeStfResult};
 pub use primitives::{EvmBlockStfInput, EvmBlockStfOutput};
 use processor::{EvmConfig, EvmProcessor};
 use revm::{primitives::SpecId, InMemoryDB};


### PR DESCRIPTION
## Description

This is the last bit of `anyhow` untyped errors that should be moved to typed errors in STR-315.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers



## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-315
