### PR TITLE
fix(prover-client): treat already submitted proofs as not an error

### DIFF
--- a/bin/prover-client/src/errors.rs
+++ b/bin/prover-client/src/errors.rs
@@ -69,4 +69,8 @@ pub(crate) enum ProvingTaskError {
     /// Represents an error returned by the ZKVM.
     #[error("{0:?}")]
     ZkVmError(ZkVmError),
+
+    /// Occurs when a proof already exists.
+    #[error("Proof already exists")]
+    ProofAlreadyExists,
 }


### PR DESCRIPTION
## Description

Treats already submitted proofs as not an error but a warning in the logs.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I honestly don't know how to handle STR-1411 comprehensively.
Is this approach an acceptable solution for addressing the "proof already created" scenario?

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1411
