### PR TITLE
ci: sync rust toolchain with `rust-toolchain.toml` file

### DIFF
--- a/.github/actions/extract-rust-version/action.yml
+++ b/.github/actions/extract-rust-version/action.yml
@@ -1,0 +1,17 @@
+name: Extract Rust toolchain version
+description: "Extracts the Rust toolchain version from rust-toolchain.toml"
+inputs: {}
+outputs:
+  rust-version:
+    description: "The Rust toolchain version from rust-toolchain.toml"
+    value: ${{ steps.extract.outputs.rust-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract Rust toolchain version
+      id: extract
+      shell: bash
+      run: |
+        VERSION="$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')"
+        echo "rust-version=$VERSION" >> "$GITHUB_OUTPUT" 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,29 +44,35 @@ jobs:
       program: ${{ matrix.program }}
       sp1_value: ${{ steps.extract-sp1-value.outputs.sp1_value }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
       - name: Configure AWS ECR Details
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4
         with:
           role-to-assume: ${{ secrets.AWS_ECR_ROLE }}
           aws-region: us-east-1
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
         with:
           mask-password: "true"
+
       - name: Set up Clang
         uses: egor-tensin/setup-clang@ef434b41eb33a70396fb336b1bae39c76d740c3d # v1
         with:
           version: latest
           platform: x64
+
       - name: Install SP1 Toolchain
         run: |
           curl -fsSL --proto '=https' --tlsv1.2 https://sp1.succinct.xyz | bash && ~/.sp1/bin/sp1up
           export PATH=~/.sp1/bin:$PATH
           cargo prove --version
+
       - name: Build and push Docker image
         id: build-and-push
         # build and push the Docker image for every program
@@ -107,6 +113,7 @@ jobs:
 
           # Push the image to ECR
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${SHORT_TAG}"
+
       - name: Extract SP1 Value
         id: extract-sp1-value
         env:
@@ -133,6 +140,7 @@ jobs:
         uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.DEPLOYMENTS_REPO_WRITE }}
+
       - name: Clone deployments repo (specific branch)
         env:
           BRANCH_OF_DEPLOYMENT_REPO: ${{ vars.BRANCH_OF_DEPLOYMENT_REPO }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -28,19 +28,37 @@ env:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract Rust toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      rust-version: ${{ steps.extract.outputs.rust-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust toolchain version
+        id: extract
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
   update:
     name: Update
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     permissions:
       contents: write # Needed to create commits
       pull-requests: write # Needed to create a PR
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
-          toolchain: nightly-2024-07-27
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
 
       - name: cargo update
         # Remove first line that always just says "Updating crates.io index"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,17 +12,34 @@ env:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract Rust toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      rust-version: ${{ steps.extract.outputs.rust-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust toolchain version
+        id: extract
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
   docs:
     name: Generate docs
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
-          toolchain: nightly-2024-07-27
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -12,6 +12,21 @@ env:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract Rust toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      rust-version: ${{ steps.extract.outputs.rust-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust toolchain version
+        id: extract
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
   lint:
     name: Lint test files
     runs-on: ubuntu-latest
@@ -34,6 +49,7 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
@@ -57,6 +73,7 @@ jobs:
   run:
     name: Run functional tests
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 60
 
     steps:
@@ -107,8 +124,10 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
-          toolchain: nightly-2024-07-27
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
+        
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 
@@ -142,6 +161,7 @@ jobs:
           export PATH="${NEWPATH}:${PATH}"
           which strata-client
           cd functional-tests && poetry run python entry.py
+
       - name: Zip log files on failure
         if: steps.funcTestsRun2.outcome == 'failure'
         # Create a zip archive (logs.zip) that includes only service.log files,
@@ -152,6 +172,7 @@ jobs:
           find functional-tests/_dd -type f -name "service.log" | zip -@ logs.zip
           # functional test logs
           zip -r logs.zip functional-tests/_dd -i '*/logs/*.log'
+
       - name: Upload logs as build artifact on failure
         if: steps.funcTestsRun2.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -161,6 +182,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
           compression-level: 0 # already compressed
+
       - name: Fail job if functional tests fail
         if: steps.funcTestsRun2.outcome == 'failure'
         run: |

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -15,9 +15,12 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65
         with:
           fail_level: "any"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,25 +12,47 @@ env:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract Rust toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      rust-version: ${{ steps.extract.outputs.rust-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust toolchain version
+        id: extract
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
   clippy:
     name: Run clippy on crates
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@22a6a5b0f9f487c5f5587025ae9d4a1caf2a8a78 # clippy
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@22a6a5b0f9f487c5f5587025ae9d4a1caf2a8a78 # clippy
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --workspace --lib --examples --tests --benches --all-features --all-targets --locked
+      - name: Run clippy
+        run: cargo clippy --workspace --lib --examples --tests --benches --all-features --all-targets --locked
         env:
           RUSTFLAGS: -D warnings
 
   crate-checks:
     name: Check that crates compile on their own
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 90 # cold run takes a lot of time as each crate is compiled separately
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -42,7 +64,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
-          toolchain: nightly-2024-07-27
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
       - uses: taiki-e/install-action@1b0e852a3465a29cd0b17876f2de42a88d145e91 # cargo-hack
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
@@ -61,15 +83,17 @@ jobs:
   fmt:
     name: Check code formatting
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
           components: rustfmt
-          toolchain: nightly-2024-07-27
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
       - run: cargo fmt --all --check
 
   codespell:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -25,22 +25,31 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
+
       - name: Relative diff
         run: |
           git branch -av
           git diff "origin/$DEFAULT_BRANCH" | tee git.diff
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-      - uses: taiki-e/install-action@9903ab6feadaec33945de535fe9d181b91802a55 # v2
-        name: Install `cargo-mutants`
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Install `cargo-mutants`
+        uses: taiki-e/install-action@9903ab6feadaec33945de535fe9d181b91802a55 # v2
         with:
           tool: cargo-mutants
+
       - name: Run `cargo-mutants`
         run: |
           cargo mutants --no-shuffle -vV --in-diff git.diff --shard ${{ matrix.shard }}/8 --timeout 300
+
       - name: Archive mutants.out
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -5,6 +5,21 @@ on: pull_request
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract Rust toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      rust-version: ${{ steps.extract.outputs.rust-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+          
+      - name: Extract Rust toolchain version
+        id: extract
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
   eval_perf:
     permissions:
       # Needed to install the toolchain.
@@ -12,12 +27,18 @@ jobs:
       # Needed to post the performance report comments.
       pull-requests: write
     runs-on: ubuntu-latest
+    needs: extract-rust-version
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
-          toolchain: nightly-2024-07-27
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
 
       - name: Use Cargo cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,11 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@22a6a5b0f9f487c5f5587025ae9d4a1caf2a8a78 # clippy
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@22a6a5b0f9f487c5f5587025ae9d4a1caf2a8a78 # clippy
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,31 +18,53 @@ concurrency:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract Rust toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      rust-version: ${{ steps.extract.outputs.rust-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust toolchain version
+        id: extract
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
   test:
     name: Run unit tests and generate report
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 60 # better fail-safe than the default 360 in github actions
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
       - name: Cleanup space
         uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
-      - uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
         with:
           components: llvm-tools-preview
-          toolchain: nightly-2024-07-27
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
+          
       - name: Install latest nextest release
         uses: taiki-e/install-action@9903ab6feadaec33945de535fe9d181b91802a55 # v2
         with:
           tool: nextest
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@9903ab6feadaec33945de535fe9d181b91802a55 # v2
         with:
           tool: cargo-llvm-cov
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 
@@ -55,6 +77,7 @@ jobs:
         if: always()
         with:
           paths: "target/nextest/ci/junit.xml"
+
       - name: Publish Test Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         env:
@@ -64,19 +87,26 @@ jobs:
   doc:
     name: Run doc tests
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
       - name: Cleanup space
         uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
-      - uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4 # nightly
+        with:
+          toolchain: ${{ needs.extract-rust-version.outputs.rust-version }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 


### PR DESCRIPTION
## Description

CI jobs needs to specify a `toolchain` since `dtolnay/rust-toolchain` does not support `rust-toolchain.toml` (see https://github.com/dtolnay/rust-toolchain/issues/133).
This is annoying since we have manually sync the rust nightly version across multiple files, and also the damn thing is automatically updated every day 1.

This PR adds the feature for CI jobs to extract the nightly version from the `rust-toolchain.toml` using regex magic 🧙🏻 and saves the output in a ENV variable that can be used in further steps by the CI job to know which nightly version to use.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] CI improvements

## Notes to Reviewers



## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
