### PR TITLE
Backport: STR-1450 SELFDESTRUCT opcode EL PROVER fix.

### DIFF
--- a/crates/proof-impl/evm-ee-stf/src/db.rs
+++ b/crates/proof-impl/evm-ee-stf/src/db.rs
@@ -84,7 +84,15 @@ impl InMemoryDBHelper for InMemoryDB {
             let bytecode = if state_account.code_hash.0 == KECCAK_EMPTY.0 {
                 Bytecode::new()
             } else {
-                let bytes = contracts.get(&state_account.code_hash).unwrap().clone();
+                // N.B. It can happen that contract's code isn't present in the witness,
+                // but it's *only* possible (as a special case) for SELFDESTRUCT opcode.
+                // For such a case the code is not required because the contract's
+                // balance is modified directly (without fallback or receive methods).
+                // So it's ok to fallback to default code in such a case.
+                let bytes = contracts
+                    .get(&state_account.code_hash)
+                    .unwrap_or_default()
+                    .clone();
                 Bytecode::new_raw(bytes)
             };
 

--- a/functional-tests/contracts/SelfDestruct.sol
+++ b/functional-tests/contracts/SelfDestruct.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-/// @title Selfdestruct Contract
+/// @title Selfdestruct Contract with sending to self.
 /// @notice Demonstrates updating state and self-destruction of the contract
 contract SelfDestruct {
     uint256 public state;

--- a/functional-tests/contracts/SelfDestructToAddress.sol
+++ b/functional-tests/contracts/SelfDestructToAddress.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Selfdestruct Contract with receiver.
+/// @notice Demonstrates updating state and self-destruction of the contract
+contract SelfDestructToAddress {
+    address payable public receiver;
+
+    // Constructor receives the address to send the funds to on sefldestruct.
+    constructor(address payable _receiver) payable {
+        receiver = _receiver;
+    }
+
+    // Suicide method - anyone can call this to selfdestruct
+    function suicide() external {
+        selfdestruct(receiver);
+    }
+}

--- a/functional-tests/tests/prover/prover_el_selfdestruct_to_address.py
+++ b/functional-tests/tests/prover/prover_el_selfdestruct_to_address.py
@@ -1,0 +1,88 @@
+import flexitest
+from solcx import install_solc, set_solc_version
+from web3 import Web3
+
+from envs import testenv
+from utils import (
+    el_slot_to_block_commitment,
+    wait_for_proof_with_time_out,
+    wait_until_with_value,
+)
+from utils.transaction import SmartContracts
+
+
+@flexitest.register
+class ElSelfDestructToAddressContractTest(testenv.StrataTester):
+    def __init__(self, ctx: flexitest.InitContext):
+        install_solc(version="0.8.16")
+        set_solc_version("0.8.16")
+        ctx.set_env("prover")
+
+    def main(self, ctx: flexitest.RunContext):
+        reth = ctx.get_service("reth")
+        reth_rpc = reth.create_rpc()
+
+        prover_client = ctx.get_service("prover_client")
+        prover_client_rpc = prover_client.create_rpc()
+
+        web3: Web3 = reth.create_web3()
+        web3.eth.default_account = web3.address
+
+        # Deploy the contracts
+        # The setup is a simple two contacts relation:
+        #  - Delegator is a receiver of the SELFDESTRUCT opcode.
+        #  - Suicider's only purpose is to be constructed with delegator's address
+        #       and suicide itself.
+        # Later on, the Suicider is called to be destructed and reproduce the bug.
+
+        # STEP 1: deploy delegator and fetch its address
+        delegator_abi, delegator_bytecode = SmartContracts.compile_contract(
+            "Counter.sol", "Counter"
+        )
+        delegator_contract = web3.eth.contract(abi=delegator_abi, bytecode=delegator_bytecode)
+        delegator_tx_hash = delegator_contract.constructor().transact()
+        tx_receipt_delegator = web3.eth.wait_for_transaction_receipt(delegator_tx_hash, timeout=30)
+        delegator_address = tx_receipt_delegator["contractAddress"]
+
+        # STEP 2: deploy suicider with delegator's address and fetch its address.
+        suicider_abi, suicider_bytecode = SmartContracts.compile_contract(
+            "SelfDestructToAddress.sol", "SelfDestructToAddress"
+        )
+        suicider_contract = web3.eth.contract(abi=suicider_abi, bytecode=suicider_bytecode)
+        suicider_deploy_tx_hash = suicider_contract.constructor(delegator_address).transact()
+        suicider_deploy_tx_receipt = web3.eth.wait_for_transaction_receipt(
+            suicider_deploy_tx_hash, timeout=30
+        )
+        suicider_address = suicider_deploy_tx_receipt["contractAddress"]
+
+        # STEP 3: Call the SelfDestructToAddress::suicide() contract function and invoke EL prove.
+        contract_instance = web3.eth.contract(abi=suicider_abi, address=suicider_address)
+        tx_hash = contract_instance.functions.suicide().transact()
+        suicide_call_tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+
+        # Prove the corresponding EE block
+        ee_prover_params = {
+            "start_block": suicide_call_tx_receipt["blockNumber"] - 1,
+            "end_block": suicide_call_tx_receipt["blockNumber"] + 1,
+        }
+
+        # Wait until the end EE block is generated.
+        wait_until_with_value(
+            lambda: web3.eth.get_block("latest")["number"],
+            lambda height: height >= ee_prover_params["end_block"],
+            error_with="EE blocks not generated",
+        )
+
+        start_block = el_slot_to_block_commitment(reth_rpc, ee_prover_params["start_block"])
+        end_block = el_slot_to_block_commitment(reth_rpc, ee_prover_params["end_block"])
+
+        task_ids = prover_client_rpc.dev_strata_proveElBlocks((start_block, end_block))
+        self.debug(f"Prover task IDs received: {task_ids}")
+
+        if not task_ids:
+            raise Exception("No task IDs received from prover_client_rpc")
+
+        task_id = task_ids[0]
+        self.debug(f"Using task ID: {task_id}")
+
+        assert wait_for_proof_with_time_out(prover_client_rpc, task_id, time_out=30)


### PR DESCRIPTION
Backport from #853
* Reproduce selfdestruct to contract bug in fntests.

* Fix: allow default contract code in EL Prover init logic.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
