### PR TITLE
STR-1461: Enhance fntests with keep-alive execution mode.

### DIFF
--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -110,3 +110,25 @@ PROVER_TEST=1 ./run_test.sh -g prover
 ```
 
 The test harness script will be extended with more functionality as we need it.
+
+
+## Keep-alive env setup
+
+During development it's quite handy to have local services spin up quickly,
+instead of bothering with Docker's (build time is heavy if built from scratch).
+
+To do that, you can use the following command:
+```bash
+./run_test.sh -e <env_name>
+```
+
+For instance:
+```bash
+./run_test.sh -e basic
+```
+
+As a result, services will be kept alive, so you can send RPCs and play around.
+
+To see the full list of supported envs as well as insights of each of them,
+navigate to `entry.py` and follow along.
+

--- a/functional-tests/tests/keepalive_stub_test.py
+++ b/functional-tests/tests/keepalive_stub_test.py
@@ -1,0 +1,20 @@
+import time
+
+import flexitest
+
+from envs import testenv
+
+
+@flexitest.register
+class KeepAliveEnvMockTest(testenv.StrataTester):
+    """
+    A dynamically populated mock test for the keep-alive mode.
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env("{ENV}")
+
+    def main(self, _ctx: flexitest.RunContext):
+        while True:
+            print("running fn-tests in keep-alive mode")
+            time.sleep(60)


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->


Oftentimes, during development and local testing, I find myself:
- taking a random fntest,
- substituting it with indefinite while true: pass
- running it and using it as a keep-alive mechanism (to have the local env spin up).

Thus, I propose a small enhancement to `fntests` to make it easy and lightweight mechanism to play around and test stuff locally.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

This is **the first change** in the series of upcoming small cleanup/improvements as part of **STR-1461**.
Given it's quite isolated and independent thing, I squeezed it out in a separate PR.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
