### PR TITLE
Remove download feature from corepc, update bitcoind version in CI

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -87,16 +87,16 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "28.1"
+          BITCOIND_VERSION: "29.0"
           BITCOIND_ARCH: "x86_64-linux-gnu"
-          SHASUM: "07f77afd326639145b9ba9562912b2ad2ccec47b8a305bd075b4f4cb127b7ed7"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
-          sha256sum -c <<< "$SHASUM bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/SHA256SUMS"
+          sha256sum --ignore-missing --check SHA256SUMS
           tar xzf "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
           sudo install -m 0755 -t /usr/local/bin bitcoin-"$BITCOIND_VERSION"/bin/*
           bitcoind --version
-          rm -rf "bitcoin-$BITCOIND_VERSION" "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          rm -rf SHA256SUMS "bitcoin-$BITCOIND_VERSION" "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -44,6 +44,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install bitcoind
+        env:
+          BITCOIND_VERSION: "29.0"
+          BITCOIND_ARCH: "x86_64-linux-gnu"
+        run: |
+          curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/SHA256SUMS"
+          sha256sum --ignore-missing --check SHA256SUMS
+          tar xzf "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          sudo install -m 0755 -t /usr/local/bin bitcoin-"$BITCOIND_VERSION"/bin/*
+          bitcoind --version
+          rm -rf SHA256SUMS "bitcoin-$BITCOIND_VERSION" "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+
       - name: Cleanup space
         uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ you can run the basic CI checks in your local environment:
   modern test runner for Rust.
 - [`cargo-audit`](https://docs.rs/cargo-audit/latest/cargo_audit/):
   tool to check `Cargo.lock` files for security vulnerabilities.
+- [`bitcoind`](https://bitcoin.org/en/download): to run the unit and functional tests.
 - Functional test runner:
   to run functional tests, see instructions in its
   [`README.md`](./functional-tests/README.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,16 +2652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,16 +3095,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "596e4ee1ff3616ae3f36e89e0b847604034ba689243cc5e7dd08da395b88ec58"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.14.0",
  "corepc-client",
- "flate2",
  "log",
- "minreq",
  "serde_json",
- "tar",
  "tempfile",
  "which",
- "zip 0.6.6",
 ]
 
 [[package]]
@@ -6779,11 +6764,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9"
 dependencies = [
  "log",
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
- "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -11662,7 +11644,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "tracing",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
@@ -14560,17 +14542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16462,16 +16433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
-dependencies = [
- "libc",
- "rustix 1.0.7",
-]
-
-[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16668,19 +16629,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
 ]
 
 [[package]]

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -38,7 +38,8 @@ strata-state = { workspace = true, features = ["test_utils"] }
 strata-status.workspace = true
 strata-test-utils.workspace = true
 
-corepc-node = { version = "0.8.0", features = ["29_0", "download"] }
+# update bitcoind version in CI to match corepc-node feature
+corepc-node = { version = "0.8.0", features = ["29_0"] }
 
 [features]
 test_utils = ["dep:hex", "dep:musig2"]

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -389,7 +389,7 @@ pub mod corepc_node_helpers {
     pub fn get_bitcoind_and_client() -> (Node, Client) {
         // setting the ENV variable `BITCOIN_XPRIV_RETRIEVABLE` to retrieve the xpriv
         env::set_var("BITCOIN_XPRIV_RETRIEVABLE", "true");
-        let bitcoind = Node::from_downloaded().unwrap();
+        let bitcoind = Node::new("bitcoind").unwrap();
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
         let client = Client::new(url, user, password, None, None).unwrap();

--- a/crates/util/python-utils/Cargo.toml
+++ b/crates/util/python-utils/Cargo.toml
@@ -38,6 +38,9 @@ strata-common.workspace = true
 
 anyhow.workspace = true
 bitcoind-async-client.workspace = true
-corepc-node = { version = "0.8.0", features = ["29_0", "download"] }
+
+# update bitcoind version in CI to match corepc-node feature
+corepc-node = { version = "0.8.0", features = ["29_0"] }
+
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -511,7 +511,7 @@ mod tests {
     async fn drt_mempool_accept() {
         init_logging("drt-tests");
 
-        let bitcoind = Node::from_downloaded().unwrap();
+        let bitcoind = Node::new("bitcoind").unwrap();
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
         let client = Client::new(url.clone(), user.clone(), password.clone(), None, None).unwrap();
@@ -539,7 +539,7 @@ mod tests {
     async fn recovery_path_mempool_accept() {
         init_logging("recovery-path-tests");
 
-        let bitcoind = Node::from_downloaded().unwrap();
+        let bitcoind = Node::new("bitcoind").unwrap();
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
         let client = Client::new(url.clone(), user.clone(), password.clone(), None, None).unwrap();
@@ -626,7 +626,7 @@ mod tests {
     async fn get_balance() {
         init_logging("balance-tests");
 
-        let bitcoind = Node::from_downloaded().unwrap();
+        let bitcoind = Node::new("bitcoind").unwrap();
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
         let client = Client::new(url.clone(), user.clone(), password.clone(), None, None).unwrap();
@@ -699,7 +699,7 @@ mod tests {
     async fn get_balance_recovery() {
         init_logging("recovery-balance-tests");
 
-        let bitcoind = Node::from_downloaded().unwrap();
+        let bitcoind = Node::new("bitcoind").unwrap();
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
         let client = Client::new(url.clone(), user.clone(), password.clone(), None, None).unwrap();

--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -18,11 +18,11 @@ Note that in macOS, you may need to specifically add a firewall rule to allow in
 
 ```bash
 # for Linux (x86_64)
-curl -fsSLO --proto "=https" --tlsv1.2 https://bitcoincore.org/bin/bitcoin-core-28.0/bitcoin-28.0-x86_64-linux-gnu.tar.gz
-tar xzf bitcoin-28.0-x86_64-linux-gnu.tar.gz
-sudo install -m 0755 -t /usr/local/bin bitcoin-28.0/bin/*
+curl -fsSLO --proto "=https" --tlsv1.2 https://bitcoincore.org/bin/bitcoin-core-29.0/bitcoin-29.0-x86_64-linux-gnu.tar.gz
+tar xzf bitcoin-29.0-x86_64-linux-gnu.tar.gz
+sudo install -m 0755 -t /usr/local/bin bitcoin-29.0/bin/*
 # remove the files, as we just copied it to /bin
-rm -rf bitcoin-28.0 bitcoin-28.0-x86_64-linux-gnu.tar.gz
+rm -rf bitcoin-29.0 bitcoin-29.0-x86_64-linux-gnu.tar.gz
 ```
 
 ```bash


### PR DESCRIPTION
## Description

Remove download feature from `corepc-node` package since it is expected that the `bitcoind` executable is installed by default on target testing machine (package is only use for testing currently). This will help us speed up local development by avoiding any unnecessary re-downloads.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
