### PR TITLE
add startup check for genesis config mismatch

### DIFF
--- a/bin/strata-client/src/el_sync.rs
+++ b/bin/strata-client/src/el_sync.rs
@@ -1,5 +1,9 @@
 use strata_db::DbError;
-use strata_eectl::{engine::ExecEngineCtl, errors::EngineError, messages::ExecPayloadData};
+use strata_eectl::{
+    engine::{ExecEngineCtl, L2BlockRef},
+    errors::EngineError,
+    messages::ExecPayloadData,
+};
 use strata_state::id::L2BlockId;
 use strata_storage::NodeStorage;
 use thiserror::Error;
@@ -37,7 +41,7 @@ pub fn sync_chainstate_to_el(
             return Err(Error::MissingChainstate(idx));
         };
 
-        Ok(engine.check_block_exists(*entry.tip_blockid())?)
+        Ok(engine.check_block_exists(L2BlockRef::Id(*entry.tip_blockid()))?)
     })?
     .map(|idx| idx + 1) // sync from next index
     .unwrap_or(0); // sync from genesis

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -252,7 +252,7 @@ fn do_startup_checks(
     // Ensure reth and strata are running on same params
     let genesis_block = make_genesis_block(params);
     let genesis_check_res = retry_with_backoff(
-        "engine_submit_payload",
+        "engine_check_block_exists",
         DEFAULT_ENGINE_CALL_MAX_RETRIES,
         &ExponentialBackoff::default(),
         || engine.check_block_exists(L2BlockRef::Ref(&genesis_block)),
@@ -309,7 +309,7 @@ fn do_startup_checks(
     // Check that tip L2 block exists (and engine can be connected to)
     let chain_tip = tip_blockid;
     let tip_check_res = retry_with_backoff(
-        "engine_submit_payload",
+        "engine_check_block_exists",
         DEFAULT_ENGINE_CALL_MAX_RETRIES,
         &ExponentialBackoff::default(),
         || engine.check_block_exists(L2BlockRef::Id(chain_tip)),

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -13,7 +13,10 @@ use strata_btcio::{
     reader::query::bitcoin_data_reader_task,
     writer::start_envelope_task,
 };
-use strata_common::logging;
+use strata_common::{
+    logging,
+    retry::{policies::ExponentialBackoff, retry_with_backoff, DEFAULT_ENGINE_CALL_MAX_RETRIES},
+};
 use strata_config::Config;
 use strata_consensus_logic::{
     genesis::{self, make_genesis_block},
@@ -248,7 +251,13 @@ fn do_startup_checks(
 ) -> anyhow::Result<()> {
     // Ensure reth and strata are running on same params
     let genesis_block = make_genesis_block(params);
-    match engine.check_block_exists(L2BlockRef::Ref(&genesis_block)) {
+    let genesis_check_res = retry_with_backoff(
+        "engine_submit_payload",
+        DEFAULT_ENGINE_CALL_MAX_RETRIES,
+        &ExponentialBackoff::default(),
+        || engine.check_block_exists(L2BlockRef::Ref(&genesis_block)),
+    );
+    match genesis_check_res {
         Ok(true) => {
             info!("startup: genesis params in sync with reth")
         }
@@ -299,7 +308,13 @@ fn do_startup_checks(
 
     // Check that tip L2 block exists (and engine can be connected to)
     let chain_tip = tip_blockid;
-    match engine.check_block_exists(L2BlockRef::Id(chain_tip)) {
+    let tip_check_res = retry_with_backoff(
+        "engine_submit_payload",
+        DEFAULT_ENGINE_CALL_MAX_RETRIES,
+        &ExponentialBackoff::default(),
+        || engine.check_block_exists(L2BlockRef::Id(chain_tip)),
+    );
+    match tip_check_res {
         Ok(true) => {
             info!("startup: last l2 block is synced")
         }

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -16,11 +16,11 @@ use strata_btcio::{
 use strata_common::logging;
 use strata_config::Config;
 use strata_consensus_logic::{
-    genesis,
+    genesis::{self, make_genesis_block},
     sync_manager::{self, SyncManager},
 };
 use strata_db::{traits::BroadcastDatabase, DbError};
-use strata_eectl::engine::ExecEngineCtl;
+use strata_eectl::engine::{ExecEngineCtl, L2BlockRef};
 use strata_evmexec::{engine::RpcExecEngineCtl, EngineRpcClient};
 use strata_primitives::params::{Params, ProofPublishMode};
 use strata_rocksdb::{
@@ -243,8 +243,25 @@ fn do_startup_checks(
     storage: &NodeStorage,
     engine: &impl ExecEngineCtl,
     bitcoin_client: &impl Reader,
+    params: &Params,
     handle: &Handle,
 ) -> anyhow::Result<()> {
+    // Ensure reth and strata are running on same params
+    let genesis_block = make_genesis_block(params);
+    match engine.check_block_exists(L2BlockRef::Ref(&genesis_block)) {
+        Ok(true) => {
+            info!("startup: genesis params in sync with reth")
+        }
+        Ok(false) => {
+            // expected genesis block not present in reth
+            anyhow::bail!("startup: genesis params mismatch with reth");
+        }
+        Err(error) => {
+            // Likely network issue
+            anyhow::bail!("could not connect to exec engine, err = {}", error);
+        }
+    }
+
     let last_state_idx = match storage.chainstate().get_last_write_idx_blocking() {
         Ok(idx) => idx,
         Err(DbError::NotBootstrapped) => {
@@ -282,7 +299,7 @@ fn do_startup_checks(
 
     // Check that tip L2 block exists (and engine can be connected to)
     let chain_tip = tip_blockid;
-    match engine.check_block_exists(chain_tip) {
+    match engine.check_block_exists(L2BlockRef::Id(chain_tip)) {
         Ok(true) => {
             info!("startup: last l2 block is synced")
         }
@@ -326,6 +343,7 @@ fn start_core_tasks(
         storage.as_ref(),
         engine.as_ref(),
         bitcoin_client.as_ref(),
+        params.as_ref(),
         executor.handle(),
     )?;
 

--- a/crates/consensus-logic/src/genesis.rs
+++ b/crates/consensus-logic/src/genesis.rs
@@ -130,7 +130,7 @@ pub fn make_l2_genesis(
 /// Create genesis L2 block based on rollup params
 /// NOTE: generate block MUST be deterministic
 /// repeated calls with same params MUST return identical blocks
-fn make_genesis_block(params: &Params) -> L2BlockBundle {
+pub fn make_genesis_block(params: &Params) -> L2BlockBundle {
     // Create a dummy exec state that we can build the rest of the genesis block
     // around and insert into the genesis state.
     // TODO this might need to talk to the EL to do the genesus setup *properly*

--- a/crates/eectl/src/engine.rs
+++ b/crates/eectl/src/engine.rs
@@ -8,7 +8,7 @@
 // errors as we'd be able to identify when our perspective on the state is
 // inconsistent with the remote state.
 
-use strata_state::id::L2BlockId;
+use strata_state::{block::L2BlockBundle, id::L2BlockId};
 
 use crate::{errors::*, messages::*};
 
@@ -46,7 +46,13 @@ pub trait ExecEngineCtl {
     /// Check if a block exists on the chain.
     /// If this returns true, it should be safe to use this id
     /// in any of update_*_block methods, submit_payload and prepare_payload
-    fn check_block_exists(&self, id: L2BlockId) -> EngineResult<bool>;
+    fn check_block_exists<'a>(&self, id_ref: L2BlockRef<'a>) -> EngineResult<bool>;
+}
+
+#[derive(Debug)]
+pub enum L2BlockRef<'a> {
+    Id(L2BlockId),
+    Ref(&'a L2BlockBundle),
 }
 
 /// The status of a block that we've just set chain fork.

--- a/crates/eectl/src/engine.rs
+++ b/crates/eectl/src/engine.rs
@@ -46,7 +46,7 @@ pub trait ExecEngineCtl {
     /// Check if a block exists on the chain.
     /// If this returns true, it should be safe to use this id
     /// in any of update_*_block methods, submit_payload and prepare_payload
-    fn check_block_exists<'a>(&self, id_ref: L2BlockRef<'a>) -> EngineResult<bool>;
+    fn check_block_exists(&self, id_ref: L2BlockRef<'_>) -> EngineResult<bool>;
 }
 
 #[derive(Debug)]

--- a/crates/eectl/src/stub.rs
+++ b/crates/eectl/src/stub.rs
@@ -93,7 +93,7 @@ impl ExecEngineCtl for StubController {
         Ok(())
     }
 
-    fn check_block_exists<'a>(&self, _ref: L2BlockRef<'a>) -> EngineResult<bool> {
+    fn check_block_exists(&self, _ref: L2BlockRef<'_>) -> EngineResult<bool> {
         Ok(true)
     }
 }

--- a/crates/eectl/src/stub.rs
+++ b/crates/eectl/src/stub.rs
@@ -93,7 +93,7 @@ impl ExecEngineCtl for StubController {
         Ok(())
     }
 
-    fn check_block_exists(&self, _id: L2BlockId) -> EngineResult<bool> {
+    fn check_block_exists<'a>(&self, _ref: L2BlockRef<'a>) -> EngineResult<bool> {
         Ok(true)
     }
 }

--- a/crates/evmexec/src/block.rs
+++ b/crates/evmexec/src/block.rs
@@ -12,11 +12,8 @@ pub(crate) struct EVML2Block {
 
 impl EVML2Block {
     /// Attempts to construct an instance from an L2 block bundle.
-    pub fn try_extract(bundle: &L2BlockBundle) -> Result<Self, ConversionError> {
-        let extra_payload_slice = bundle.exec_segment().update().input().extra_payload();
-        let extra_payload = EVMExtraPayload::try_from_slice(extra_payload_slice)
-            .or(Err(ConversionError::InvalidExecPayload))?;
-
+    pub(crate) fn try_extract(bundle: &L2BlockBundle) -> Result<Self, ConversionError> {
+        let extra_payload = get_extra_payload(bundle)?;
         Ok(Self {
             l2_block: bundle.block().to_owned(),
             extra_payload,
@@ -28,6 +25,17 @@ impl EVML2Block {
     pub fn block_hash(&self) -> B256 {
         FixedBytes(*self.extra_payload.block_hash().as_ref())
     }
+}
+
+fn get_extra_payload(bundle: &L2BlockBundle) -> Result<EVMExtraPayload, ConversionError> {
+    let extra_payload_slice = bundle.exec_segment().update().input().extra_payload();
+    EVMExtraPayload::try_from_slice(extra_payload_slice)
+        .or(Err(ConversionError::InvalidExecPayload))
+}
+
+pub(crate) fn evm_block_hash(bundle: &L2BlockBundle) -> Result<B256, ConversionError> {
+    let extra_payload = get_extra_payload(bundle)?;
+    Ok(FixedBytes(*extra_payload.block_hash().as_ref()))
 }
 
 #[derive(Debug, Error)]

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -392,7 +392,7 @@ impl<T: EngineRpc> ExecEngineCtl for RpcExecEngineCtl<T> {
         })
     }
 
-    fn check_block_exists<'a>(&self, id_ref: L2BlockRef<'a>) -> EngineResult<bool> {
+    fn check_block_exists(&self, id_ref: L2BlockRef<'_>) -> EngineResult<bool> {
         let block_hash = match id_ref {
             L2BlockRef::Id(id) => self
                 .get_l2block(&id)


### PR DESCRIPTION
## Description
Add startup check for early detection of genesis config mismatch between params.json and reth.

PR to main: #886  

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
