### PR TITLE
fix: duplicate fulfilment tx should not panic

### DIFF
--- a/crates/chaintsn/src/errors.rs
+++ b/crates/chaintsn/src/errors.rs
@@ -1,4 +1,4 @@
-use strata_primitives::l1::L1VerificationError;
+use strata_primitives::{bridge::OperatorIdx, l1::L1VerificationError};
 use strata_state::prelude::*;
 use thiserror::Error;
 
@@ -58,8 +58,11 @@ pub enum OpError {
     #[error("op referenced non-existent deposit {0}")]
     UnknownDeposit(u32),
 
-    #[error("op referenced invalid deposit {0}; operator idx: {1}")]
-    InvalidDeposit(u32, u32),
+    #[error("op referenced invalid deposit {deposit_idx}; operator idx: {operator_idx}")]
+    InvalidDeposit {
+        deposit_idx: u32,
+        operator_idx: OperatorIdx,
+    },
 
     /// Used to discard checkpoints we aren't looking for.
     #[error("operation does not advance the finalized epoch")]

--- a/crates/chaintsn/src/errors.rs
+++ b/crates/chaintsn/src/errors.rs
@@ -58,13 +58,13 @@ pub enum OpError {
     #[error("op referenced non-existent deposit {0}")]
     UnknownDeposit(u32),
 
-    #[error("op referenced invalid deposit {deposit_idx}; operator idx: {operator_idx}")]
+    #[error("op referenced invalid deposit {deposit_idx} (operator {operator_idx})")]
     InvalidDeposit {
         deposit_idx: u32,
         operator_idx: OperatorIdx,
     },
 
     /// Used to discard checkpoints we aren't looking for.
-    #[error("operation does not advance the finalized epoch")]
+    #[error("op does not advance the finalized epoch")]
     EpochNotExtend,
 }

--- a/crates/chaintsn/src/errors.rs
+++ b/crates/chaintsn/src/errors.rs
@@ -58,6 +58,9 @@ pub enum OpError {
     #[error("op referenced non-existent deposit {0}")]
     UnknownDeposit(u32),
 
+    #[error("op referenced invalid deposit {0}; operator idx: {1}")]
+    InvalidDeposit(u32, u32),
+
     /// Used to discard checkpoints we aren't looking for.
     #[error("operation does not advance the finalized epoch")]
     EpochNotExtend,

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -307,7 +307,7 @@ fn process_withdrawal_fulfillment(
     state: &mut StateCache,
     info: &WithdrawalFulfillmentInfo,
 ) -> Result<(), OpError> {
-    if !state.check_deposit_fulfillment_valid(info.deposit_idx, info.operator_idx) {
+    if !state.is_valid_withdrawal_fulfillment(info.deposit_idx, info.operator_idx) {
         return Err(OpError::InvalidDeposit {
             deposit_idx: info.deposit_idx,
             operator_idx: info.operator_idx,

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -682,7 +682,7 @@ mod tests {
 
         let mut state_cache = StateCache::new(chs.clone());
         let result = process_l1_block(&mut state_cache, &block_manifest, params.rollup());
-        assert!(result.is_ok(), "should succeed");
+        assert!(result.is_ok(), "test: invoke process_l1_block");
         let new_deposit_state = state_cache
             .state()
             .deposits_table()
@@ -691,7 +691,7 @@ mod tests {
             .deposit_state();
         assert!(
             matches!(new_deposit_state, DepositState::Fulfilled(_)),
-            "should convert state to fulfilled"
+            "test: deposit state not set to fulfilled"
         );
 
         // Duplicate withdrawal fulfillment seen. Should be ignored and chainstate not updated
@@ -710,7 +710,11 @@ mod tests {
         let chs = state_cache.state();
         let mut state_cache = StateCache::new(chs.clone());
         let result = process_l1_block(&mut state_cache, &block_manifest, params.rollup());
-        assert!(result.is_ok(), "should succeed");
-        assert_eq!(state_cache.state(), chs, "should not update chainstate");
+        assert!(result.is_ok(), "test: invoke process_l1_block");
+        assert_eq!(
+            state_cache.state(),
+            chs,
+            "test: chainstate changed unexpectedly"
+        );
     }
 }

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -308,7 +308,10 @@ fn process_withdrawal_fulfillment(
     info: &WithdrawalFulfillmentInfo,
 ) -> Result<(), OpError> {
     if !state.check_deposit_fulfillment_valid(info.deposit_idx, info.operator_idx) {
-        return Err(OpError::InvalidDeposit(info.deposit_idx, info.operator_idx));
+        return Err(OpError::InvalidDeposit {
+            deposit_idx: info.deposit_idx,
+            operator_idx: info.operator_idx,
+        });
     }
 
     state.mark_deposit_fulfilled(info);

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -307,8 +307,8 @@ fn process_withdrawal_fulfillment(
     state: &mut StateCache,
     info: &WithdrawalFulfillmentInfo,
 ) -> Result<(), OpError> {
-    if !state.check_deposit_exists(info.deposit_idx) {
-        return Err(OpError::UnknownDeposit(info.deposit_idx));
+    if !state.check_deposit_fulfilment_valid(info.deposit_idx, info.operator_idx) {
+        return Err(OpError::InvalidDeposit(info.deposit_idx, info.operator_idx));
     }
 
     state.mark_deposit_fulfilled(info);
@@ -575,14 +575,17 @@ mod tests {
         buf::Buf32,
         l1::{
             BitcoinAmount, DepositInfo, DepositUpdateTx, L1BlockManifest, L1HeaderRecord, L1Tx,
-            ProtocolOperation,
+            ProtocolOperation, WithdrawalFulfillmentInfo,
         },
         l2::L2BlockId,
         params::OperatorConfig,
     };
     use strata_state::{
         block::{ExecSegment, L1Segment, L2BlockBody},
-        bridge_state::OperatorTable,
+        bridge_state::{
+            DepositState, DepositsTable, DispatchCommand, DispatchedState, FulfilledState,
+            OperatorTable,
+        },
         chain_state::Chainstate,
         exec_env::ExecEnvState,
         exec_update::{ExecUpdate, UpdateInput, UpdateOutput},
@@ -594,7 +597,10 @@ mod tests {
     use strata_test_utils::{l2::gen_params, ArbitraryGenerator};
 
     use super::{next_rand_op_pos, process_block};
-    use crate::{slot_rng::SlotRng, transition::process_l1_view_update};
+    use crate::{
+        slot_rng::SlotRng,
+        transition::{process_l1_block, process_l1_view_update},
+    };
 
     #[test]
     // Confirm that operator index sampling is deterministic and in bounds
@@ -625,5 +631,83 @@ mod tests {
         let result = process_l1_view_update(&mut state_cache, &l1_segment, params.rollup());
         assert_eq!(state_cache.state(), &chs);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_process_l1_block_with_duplicate_withdrawal_fulfilment() {
+        let mut arb = ArbitraryGenerator::new();
+
+        // Setup chainstate with a deposit in dispatched state
+        let mut chs: Chainstate = arb.generate();
+        let mut deposit_table = DepositsTable::new_empty();
+        deposit_table.create_next_deposit(
+            arb.generate(),
+            vec![0, 1, 2],
+            BitcoinAmount::from_int_btc(10),
+        );
+        let mut deposit = deposit_table.get_deposit_mut(0).expect("should exist");
+        deposit.set_state(DepositState::Dispatched(DispatchedState::new(
+            DispatchCommand::new(vec![]),
+            0,
+            100,
+        )));
+        *chs.deposits_table_mut() = deposit_table;
+
+        let params = gen_params();
+
+        // withdrawal fulfilment op that will be seen twice
+        let withdrawal_fulfilment_protocol_op =
+            ProtocolOperation::WithdrawalFulfillment(WithdrawalFulfillmentInfo {
+                deposit_idx: 0,
+                operator_idx: 0,
+                amt: BitcoinAmount::from_int_btc(10),
+                txid: Buf32::zero(),
+            });
+
+        // send protocol op for first time. Should set deposit to fulfilled state
+        let block_manifest = L1BlockManifest::new(
+            arb.generate(),
+            None,
+            vec![L1Tx::new(
+                arb.generate(),
+                arb.generate(),
+                vec![withdrawal_fulfilment_protocol_op.clone()],
+            )],
+            chs.cur_epoch(),
+            chs.l1_view().safe_height() + 1,
+        );
+
+        let mut state_cache = StateCache::new(chs.clone());
+        let result = process_l1_block(&mut state_cache, &block_manifest, params.rollup());
+        assert!(result.is_ok(), "should succeed");
+        let new_deposit_state = state_cache
+            .state()
+            .deposits_table()
+            .get_deposit(0)
+            .expect("should exist")
+            .deposit_state();
+        assert!(
+            matches!(new_deposit_state, DepositState::Fulfilled(_)),
+            "should convert state to fulfilled"
+        );
+
+        // Duplicate withdrawal fulfilment seen. Should be ignored and chainstate not updated
+        let block_manifest = L1BlockManifest::new(
+            arb.generate(),
+            None,
+            vec![L1Tx::new(
+                arb.generate(),
+                arb.generate(),
+                vec![withdrawal_fulfilment_protocol_op],
+            )],
+            chs.cur_epoch(),
+            chs.l1_view().safe_height() + 1,
+        );
+
+        let chs = state_cache.state();
+        let mut state_cache = StateCache::new(chs.clone());
+        let result = process_l1_block(&mut state_cache, &block_manifest, params.rollup());
+        assert!(result.is_ok(), "should succeed");
+        assert_eq!(state_cache.state(), chs, "should not update chainstate");
     }
 }

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -307,7 +307,7 @@ fn process_withdrawal_fulfillment(
     state: &mut StateCache,
     info: &WithdrawalFulfillmentInfo,
 ) -> Result<(), OpError> {
-    if !state.check_deposit_fulfilment_valid(info.deposit_idx, info.operator_idx) {
+    if !state.check_deposit_fulfillment_valid(info.deposit_idx, info.operator_idx) {
         return Err(OpError::InvalidDeposit(info.deposit_idx, info.operator_idx));
     }
 
@@ -634,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_l1_block_with_duplicate_withdrawal_fulfilment() {
+    fn test_process_l1_block_with_duplicate_withdrawal_fulfillment() {
         let mut arb = ArbitraryGenerator::new();
 
         // Setup chainstate with a deposit in dispatched state
@@ -655,8 +655,8 @@ mod tests {
 
         let params = gen_params();
 
-        // withdrawal fulfilment op that will be seen twice
-        let withdrawal_fulfilment_protocol_op =
+        // withdrawal fulfillment op that will be seen twice
+        let withdrawal_fulfillment_protocol_op =
             ProtocolOperation::WithdrawalFulfillment(WithdrawalFulfillmentInfo {
                 deposit_idx: 0,
                 operator_idx: 0,
@@ -671,7 +671,7 @@ mod tests {
             vec![L1Tx::new(
                 arb.generate(),
                 arb.generate(),
-                vec![withdrawal_fulfilment_protocol_op.clone()],
+                vec![withdrawal_fulfillment_protocol_op.clone()],
             )],
             chs.cur_epoch(),
             chs.l1_view().safe_height() + 1,
@@ -691,14 +691,14 @@ mod tests {
             "should convert state to fulfilled"
         );
 
-        // Duplicate withdrawal fulfilment seen. Should be ignored and chainstate not updated
+        // Duplicate withdrawal fulfillment seen. Should be ignored and chainstate not updated
         let block_manifest = L1BlockManifest::new(
             arb.generate(),
             None,
             vec![L1Tx::new(
                 arb.generate(),
                 arb.generate(),
-                vec![withdrawal_fulfilment_protocol_op],
+                vec![withdrawal_fulfillment_protocol_op],
             )],
             chs.cur_epoch(),
             chs.l1_view().safe_height() + 1,

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -310,7 +310,7 @@ impl StateCache {
             .is_some()
     }
 
-    pub fn check_deposit_fulfilment_valid(
+    pub fn check_deposit_fulfillment_valid(
         &self,
         deposit_idx: u32,
         assigned_operator_idx: u32,

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -310,6 +310,19 @@ impl StateCache {
             .is_some()
     }
 
+    pub fn check_deposit_fulfilment_valid(
+        &self,
+        deposit_idx: u32,
+        assigned_operator_idx: u32,
+    ) -> bool {
+        let Some(deposit_ent) = self.state().deposits_table().get_deposit(deposit_idx) else {
+            return false;
+        };
+        deposit_ent
+            .deposit_state()
+            .is_dispatched_to(assigned_operator_idx)
+    }
+
     /// Updates the deposit state to `Fulfilled`.
     ///
     /// # Panics

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -310,7 +310,7 @@ impl StateCache {
             .is_some()
     }
 
-    pub fn check_deposit_fulfillment_valid(
+    pub fn is_valid_withdrawal_fulfillment(
         &self,
         deposit_idx: u32,
         assigned_operator_idx: OperatorIdx,

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -313,7 +313,7 @@ impl StateCache {
     pub fn check_deposit_fulfillment_valid(
         &self,
         deposit_idx: u32,
-        assigned_operator_idx: u32,
+        assigned_operator_idx: OperatorIdx,
     ) -> bool {
         let Some(deposit_ent) = self.state().deposits_table().get_deposit(deposit_idx) else {
             return false;


### PR DESCRIPTION
## Description
Prevent FCM panic when duplicate withdrawal fulfillment transaction is seen.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1530
