### PR TITLE
(btcio): Update interfaces for btcio writer

### DIFF
--- a/crates/btcio/src/writer/context.rs
+++ b/crates/btcio/src/writer/context.rs
@@ -8,7 +8,7 @@ use strata_status::StatusChannel;
 
 /// All the items that writer tasks need as context.
 #[derive(Debug, Clone)]
-pub struct WriterContext<R: Reader + Signer + Wallet> {
+pub(crate) struct WriterContext<R: Reader + Signer + Wallet> {
     /// Params for rollup.
     pub params: Arc<Params>,
 
@@ -26,7 +26,7 @@ pub struct WriterContext<R: Reader + Signer + Wallet> {
 }
 
 impl<R: Reader + Signer + Wallet> WriterContext<R> {
-    pub fn new(
+    pub(crate) fn new(
         params: Arc<Params>,
         config: Arc<WriterConfig>,
         sequencer_address: Address,

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -228,7 +228,7 @@ impl DepositsTable {
     /// Returns if the deposit table is empty.  This is practically probably
     /// never going to be true.
     pub fn is_empty(&self) -> bool {
-        self.len() > 0
+        self.len() == 0
     }
 
     /// Gets the position in the deposit table of a hypothetical deposit entry


### PR DESCRIPTION
## Description

Some minor enhancements to the btcio builder module so that the envelope transactions building can be reused by other crates.
This was especially needed for https://github.com/alpenlabs/strata-bridge/pull/202.

This also fixes a minor bug in the definition of `is_empty` for deposits_table in chainstate.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
