### PR TITLE
Backport #917: make prover client network errors as transient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16362,7 +16362,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -16375,7 +16375,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "bincode",
  "borsh",
@@ -16386,7 +16386,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-risc0-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "hex",
  "risc0-binfmt",
@@ -16398,7 +16398,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-risc0-host"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "bincode",
  "borsh",
@@ -16411,7 +16411,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "hex",
  "sp1-verifier",
@@ -16421,7 +16421,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -16433,7 +16433,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-host"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc11#a1c73b01641b1a46c73acb4851a8e913a2ce216d"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc13#3daf4d485756ee1618598d6129c5288e18715b2d"
 dependencies = [
  "bincode",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,10 +102,10 @@ strata-tasks = { path = "crates/tasks" }
 strata-test-utils = { path = "crates/test-utils" }
 strata-zkvm-hosts = { path = "crates/zkvm/hosts" }
 
-zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
-zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
-zkaleido-risc0-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
+zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
+zkaleido-risc0-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 # IMPORTANT: ensure alloy-* and revm packages are of the same version as inside reth dependency
 # reth dependencies:

--- a/bin/prover-client/Cargo.toml
+++ b/bin/prover-client/Cargo.toml
@@ -41,11 +41,11 @@ tracing.workspace = true
 
 # sp1
 strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11", optional = true }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13", optional = true }
 
 # risc0
 strata-risc0-guest-builder = { path = "../../provers/risc0", optional = true }
-zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11", optional = true }
+zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13", optional = true }
 
 [dev-dependencies]
 strata-test-utils.workspace = true

--- a/bin/prover-client/src/prover_manager.rs
+++ b/bin/prover-client/src/prover_manager.rs
@@ -167,22 +167,14 @@ async fn make_proof(
 /// Handles the task error by determining the next status based on [`ProvingTaskError`] nature.
 fn handle_task_error(task: ProofKey, e: ProvingTaskError) -> ProvingTaskStatus {
     match e {
-        ProvingTaskError::RpcError(_) => {
+        ProvingTaskError::RpcError(_)
+        | ProvingTaskError::ZkVmError(zkaleido::ZkVmError::NetworkRetryableError(_)) => {
             // RpcError is retryable as it usually indicates the downstream services may
             // currently be unavailable.
+            // NetworkRetryableError indicates network error on SP1 side.
+            // See STR-1410 and STR-1473 for details.
             info!(?task, ?e, "proving task failed transiently");
             ProvingTaskStatus::TransientFailure
-        }
-        ProvingTaskError::ZkVmError(zkaleido::ZkVmError::ProofGenerationError(ref message)) => {
-            if message.to_lowercase().contains("unavailable") {
-                // This type of error with status:Unavailable indicates network error on SP1 side.
-                // See STR-1410 for details.
-                info!(?task, ?e, "proving task failed transiently");
-                ProvingTaskStatus::TransientFailure
-            } else {
-                error!(?task, ?e, "proving task failed");
-                ProvingTaskStatus::Failed
-            }
         }
         _ => {
             // Other errors are treated as non-retryable, so the task is failed permanently.
@@ -231,8 +223,8 @@ mod tests {
             ProofContext::Checkpoint(0),
             strata_primitives::proof::ProofZkVm::SP1,
         );
-        let err = ProvingTaskError::ZkVmError(zkaleido::ZkVmError::ProofGenerationError(
-            "Unavailable".to_string(),
+        let err = ProvingTaskError::ZkVmError(zkaleido::ZkVmError::NetworkRetryableError(
+            "Some Network Error".to_string(),
         ));
 
         assert_eq!(

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -19,11 +19,11 @@ strata-zkvm-hosts.workspace = true
 # sp1
 sp1-sdk = "5.0.0"
 strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11", optional = true }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13", optional = true }
 
 # risc0
 strata-risc0-guest-builder = { path = "../../provers/risc0", optional = true }
-zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11", optional = true }
+zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13", optional = true }
 
 anyhow.workspace = true
 bincode.workspace = true

--- a/crates/zkvm/hosts/Cargo.toml
+++ b/crates/zkvm/hosts/Cargo.toml
@@ -9,11 +9,11 @@ zkaleido-native-adapter.workspace = true
 
 # sp1
 strata-sp1-guest-builder = { path = "../../../provers/sp1", optional = true }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11", optional = true }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13", optional = true }
 
 # risc0
 strata-risc0-guest-builder = { path = "../../../provers/risc0", optional = true }
-zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11", optional = true }
+zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13", optional = true }
 
 strata-primitives.workspace = true
 strata-proofimpl-btc-blockspace.workspace = true

--- a/provers/risc0/Cargo.toml
+++ b/provers/risc0/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.0"
 
 [dependencies]
 risc0-zkvm = "2.0.1"
-zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-risc0-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [dev-dependencies]
 bincode.workspace = true

--- a/provers/risc0/guest-btc-blockspace/Cargo.toml
+++ b/provers/risc0/guest-btc-blockspace/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-btc-blockspace = { path = "../../../crates/proof-impl/btc-blockspace" }
-zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" } # This has been used because on riscv32, we need to build C libraries using the riscv-gnu-toolchain and clang for compiling C code. sp1-patches does this. This works for risc0 as well because the `target_vendor` is not `succinct`, so this does not try to use the succinct precompile.

--- a/provers/risc0/guest-checkpoint/Cargo.toml
+++ b/provers/risc0/guest-checkpoint/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-checkpoint = { path = "../../../crates/proof-impl/checkpoint" }
-zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/provers/risc0/guest-cl-stf/Cargo.toml
+++ b/provers/risc0/guest-cl-stf/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-cl-stf = { path = "../../../crates/proof-impl/cl-stf" }
-zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }

--- a/provers/risc0/guest-evm-ee-stf/Cargo.toml
+++ b/provers/risc0/guest-evm-ee-stf/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-evm-ee-stf = { path = "../../../crates/proof-impl/evm-ee-stf" }
-zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-risc0-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }

--- a/provers/sp1/Cargo.toml
+++ b/provers/sp1/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.0"
 
 [dependencies]
 once_cell = "1.20.2"
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [build-dependencies]
 bincode.workspace = true

--- a/provers/sp1/guest-btc-blockspace/Cargo.toml
+++ b/provers/sp1/guest-btc-blockspace/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-btc-blockspace = { path = "../../../crates/proof-impl/btc-blockspace" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-5.0.0" }

--- a/provers/sp1/guest-checkpoint/Cargo.toml
+++ b/provers/sp1/guest-checkpoint/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-checkpoint = { path = "../../../crates/proof-impl/checkpoint" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-5.0.0" }

--- a/provers/sp1/guest-cl-stf/Cargo.toml
+++ b/provers/sp1/guest-cl-stf/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-cl-stf = { path = "../../../crates/proof-impl/cl-stf" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [patch.crates-io]
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-5.0.0" }

--- a/provers/sp1/guest-evm-ee-stf/Cargo.toml
+++ b/provers/sp1/guest-evm-ee-stf/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-evm-ee-stf = { path = "../../../crates/proof-impl/evm-ee-stf" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc11" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc13" }
 
 [patch.crates-io]
 bn = { git = "https://github.com/sp1-patches/bn", package = "substrate-bn", tag = "patch-0.6.0-sp1-5.0.0" }


### PR DESCRIPTION

STR-1473: make prover client network errors as transient. ([#917])
* chore: bump zkaleido version.

* fix(prover-client): treat kVmError::NetworkRetryableError as transient.

* fix: adjust unit test.

* fix: use zkaleido rc13 in prover guest code as well.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
