### PR TITLE
Move test impls into new generic crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13786,6 +13786,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-db-tests"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "strata-db",
+ "strata-l1tx",
+ "strata-primitives",
+ "strata-state",
+ "strata-test-utils",
+ "zkaleido",
+]
+
+[[package]]
 name = "strata-eectl"
 version = "0.3.0-alpha.1"
 dependencies = [
@@ -14113,6 +14126,7 @@ dependencies = [
  "borsh",
  "rockbound",
  "strata-db",
+ "strata-db-tests",
  "strata-primitives",
  "strata-state",
  "strata-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "crates/util/mmr",
   "crates/util/shrex",
   "crates/vtxjmt",
+  "crates/db-tests",
   "provers/risc0",
   "provers/sp1",
 
@@ -113,6 +114,7 @@ strata-proofimpl-cl-stf = { path = "crates/proof-impl/cl-stf" }
 strata-proofimpl-evm-ee-stf = { path = "crates/proof-impl/evm-ee-stf" }
 strata-prover-client-rpc-api = { path = "crates/rpc/prover-client-api" }
 strata-rocksdb = { path = "crates/rocksdb-store" }
+strata-db-tests = { path = "crates/db-tests" }
 strata-rpc-api = { path = "crates/rpc/api" }
 strata-rpc-types = { path = "crates/rpc/types" }
 strata-rpc-utils = { path = "crates/rpc/utils" }

--- a/crates/db-tests/Cargo.toml
+++ b/crates/db-tests/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "strata-db-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+strata-db = { path = "../db" }
+strata-primitives = { path = "../primitives" }
+strata-state = { path = "../state" }
+strata-test-utils = { path = "../test-utils" }
+bitcoin = { workspace = true }
+strata-l1tx = { path = "../l1tx" }
+zkaleido = { workspace = true }
+
+[dev-dependencies]
+# This crate is intended for testing, so no dev-dependencies needed

--- a/crates/db-tests/src/bridge_tx_tests.rs
+++ b/crates/db-tests/src/bridge_tx_tests.rs
@@ -1,0 +1,90 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use strata_db::interfaces::bridge_relay::BridgeMessageDb;
+use strata_primitives::relay::types::BridgeMessage;
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_write_msgs<T: BridgeMessageDb>(db: &T) {
+    let (timestamp, msg) = make_bridge_msg();
+
+    let result = db.write_msg(timestamp, msg);
+    assert!(result.is_ok());
+}
+
+pub fn test_get_msg_ids_before_timestamp<T: BridgeMessageDb>(db: &T) {
+    let (timestamp1, msg1) = make_bridge_msg();
+    let (_timestamp2, _) = make_bridge_msg();
+    let (timestamp3, msg2) = make_bridge_msg();
+
+    // Write messages to the database
+    db.write_msg(timestamp1, msg1).unwrap();
+    db.write_msg(timestamp3, msg2).unwrap();
+
+    // Retrieve message IDs before the second timestamp
+    let result = db.get_msgs_by_scope(b"dummy_scope");
+    assert!(result.is_ok());
+}
+
+pub fn test_delete_msgs_before_timestamp<T: BridgeMessageDb>(db: &T) {
+    let (timestamp1, msg1) = make_bridge_msg();
+    let (timestamp2, msg2) = make_bridge_msg();
+
+    // Write messages to the database
+    db.write_msg(timestamp1, msg1).unwrap();
+    db.write_msg(timestamp2, msg2).unwrap();
+    // Delete messages before the second timestamp
+    let result = db.delete_msgs_before_timestamp(timestamp2);
+    assert!(result.is_ok());
+}
+
+pub fn test_get_msgs_by_scope<T: BridgeMessageDb>(db: &T) {
+    let (timestamp1, msg1) = make_bridge_msg();
+    let (timestamp2, msg2) = make_bridge_msg();
+
+    // Write messages to the database
+    db.write_msg(timestamp1, msg1.clone()).unwrap();
+    db.write_msg(timestamp2, msg2.clone()).unwrap();
+
+    // Retrieve messages by scope
+    let result = db.get_msgs_by_scope(msg1.scope());
+    assert!(result.is_ok());
+
+    assert!(!result.unwrap().is_empty());
+}
+
+pub fn test_no_messages_for_nonexistent_scope<T: BridgeMessageDb>(db: &T) {
+    let (timestamp, msg) = make_bridge_msg();
+    let scope = msg.scope().to_vec();
+
+    // Write message to the database
+    db.write_msg(timestamp, msg)
+        .expect("test: insert bridge msg");
+
+    // Try to retrieve messages with a different scope
+    let result = db
+        .get_msgs_by_scope(&[42])
+        .expect("test: fetch bridge msg");
+    assert!(result.is_empty());
+
+    // Try to retrieve messages with a different scope
+    let result = db
+        .get_msgs_by_scope(&scope)
+        .expect("test: fetch bridge msg");
+
+    // Should not be empty since we're using the scope of the message we put in.
+    assert!(!result.is_empty());
+}
+
+// Helper function to make bridge messages
+fn make_bridge_msg() -> (u128, BridgeMessage) {
+    let mut arb = ArbitraryGenerator::new();
+
+    let msg: BridgeMessage = arb.generate();
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+
+    (timestamp, msg)
+}

--- a/crates/db-tests/src/chain_state_tests.rs
+++ b/crates/db-tests/src/chain_state_tests.rs
@@ -1,0 +1,173 @@
+use strata_db::traits::ChainstateDatabase;
+use strata_db::errors::DbError;
+use strata_state::{
+    chain_state::Chainstate,
+    id::L2BlockId,
+    state_op::{WriteBatch, WriteBatchEntry},
+};
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_write_genesis_state<T: ChainstateDatabase>(db: &T) {
+    let mut generator = ArbitraryGenerator::new();
+    let genesis_state: Chainstate = generator.generate();
+    let genesis_blockid: L2BlockId = generator.generate();
+
+    let res = db.get_earliest_write_idx();
+    assert!(res.is_err_and(|x| matches!(x, DbError::NotBootstrapped)));
+
+    let res = db.get_last_write_idx();
+    assert!(res.is_err_and(|x| matches!(x, DbError::NotBootstrapped)));
+
+    let res = db.write_genesis_state(genesis_state.clone(), genesis_blockid);
+    assert!(res.is_ok());
+
+    let res = db.get_earliest_write_idx();
+    assert!(res.is_ok_and(|x| matches!(x, 0)));
+
+    let res = db.get_last_write_idx();
+    assert!(res.is_ok_and(|x| matches!(x, 0)));
+
+    let res = db.write_genesis_state(genesis_state, genesis_blockid);
+    assert!(res.is_err_and(|x| matches!(x, DbError::OverwriteStateUpdate(0))));
+}
+
+pub fn test_write_state_update<T: ChainstateDatabase>(db: &T) {
+    let mut generator = ArbitraryGenerator::new();
+    let genesis_state: Chainstate = generator.generate();
+    let genesis_blockid: L2BlockId = generator.generate();
+    let batch = WriteBatch::new_replace(genesis_state.clone());
+
+    let res = db.put_write_batch(1, WriteBatchEntry::new(batch.clone(), genesis_blockid));
+    assert!(res.is_err_and(|x| matches!(x, DbError::NotBootstrapped)));
+
+    db.write_genesis_state(genesis_state, genesis_blockid)
+        .unwrap();
+
+    let res = db.put_write_batch(1, WriteBatchEntry::new(batch.clone(), generator.generate()));
+    assert!(res.is_ok());
+
+    let res = db.put_write_batch(2, WriteBatchEntry::new(batch.clone(), generator.generate()));
+    assert!(res.is_ok());
+
+    let res = db.put_write_batch(2, WriteBatchEntry::new(batch.clone(), generator.generate()));
+    assert!(res.is_err_and(|x| matches!(x, DbError::OverwriteStateUpdate(2))));
+
+    let res = db.put_write_batch(4, WriteBatchEntry::new(batch.clone(), generator.generate()));
+    assert!(res.is_err_and(|x| matches!(x, DbError::OooInsert("Chainstate", 4))));
+}
+
+pub fn test_get_earliest_and_last_state_idx<T: ChainstateDatabase>(db: &T) {
+    let mut generator = ArbitraryGenerator::new();
+    let genesis_state: Chainstate = generator.generate();
+    let genesis_blockid: L2BlockId = generator.generate();
+
+    let batch = WriteBatch::new_replace(genesis_state.clone());
+
+    db.write_genesis_state(genesis_state, genesis_blockid)
+        .unwrap();
+    for i in 1..=5 {
+        assert_eq!(db.get_earliest_write_idx().unwrap(), 0);
+        db.put_write_batch(i, WriteBatchEntry::new(batch.clone(), generator.generate()))
+            .unwrap();
+        assert_eq!(db.get_last_write_idx().unwrap(), i);
+    }
+}
+
+pub fn test_purge<T: ChainstateDatabase>(db: &T) {
+    let mut generator = ArbitraryGenerator::new();
+    let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+    let batch = WriteBatch::new_replace(genesis_state.clone());
+
+    db.write_genesis_state(genesis_state, generator.generate())
+        .unwrap();
+    for i in 1..=5 {
+        assert_eq!(db.get_earliest_write_idx().unwrap(), 0);
+        db.put_write_batch(i, WriteBatchEntry::new(batch.clone(), generator.generate()))
+            .unwrap();
+        assert_eq!(db.get_last_write_idx().unwrap(), i);
+    }
+
+    db.purge_entries_before(3).unwrap();
+    // Ensure that calling the purge again does not fail
+    db.purge_entries_before(3).unwrap();
+
+    assert_eq!(db.get_earliest_write_idx().unwrap(), 3);
+    assert_eq!(db.get_last_write_idx().unwrap(), 5);
+
+    for i in 0..3 {
+        assert!(db.get_write_batch(i).unwrap().is_none());
+    }
+
+    for i in 3..=5 {
+        assert!(db.get_write_batch(i).unwrap().is_some());
+    }
+
+    let res = db.purge_entries_before(2);
+    assert!(res.is_err_and(|x| matches!(x, DbError::MissingL2State(2))));
+
+    let res = db.purge_entries_before(1);
+    assert!(res.is_err_and(|x| matches!(x, DbError::MissingL2State(1))));
+}
+
+pub fn test_rollback<T: ChainstateDatabase>(db: &T) {
+    let mut generator = ArbitraryGenerator::new();
+    let genesis_state: Chainstate = generator.generate();
+    let batch = WriteBatch::new_replace(genesis_state.clone());
+
+    db.write_genesis_state(genesis_state, generator.generate())
+        .unwrap();
+    for i in 1..=5 {
+        db.put_write_batch(i, WriteBatchEntry::new(batch.clone(), generator.generate()))
+            .unwrap();
+    }
+
+    db.rollback_writes_to(3).unwrap();
+    // Ensures that calling the rollback again does not fail
+    db.rollback_writes_to(3).unwrap();
+
+    for i in 4..=5 {
+        assert!(db.get_write_batch(i).unwrap().is_none());
+    }
+
+    // For genesis there is no BatchWrites
+    for i in 1..=3 {
+        assert!(db.get_write_batch(i).unwrap().is_some());
+    }
+
+    assert_eq!(db.get_earliest_write_idx().unwrap(), 0);
+    assert_eq!(db.get_last_write_idx().unwrap(), 3);
+
+    let res = db.rollback_writes_to(5);
+    assert!(res.is_err_and(|x| matches!(x, DbError::RevertAboveCurrent(5, 3))));
+
+    let res = db.rollback_writes_to(4);
+    assert!(res.is_err_and(|x| matches!(x, DbError::RevertAboveCurrent(4, 3))));
+
+    let res = db.rollback_writes_to(3);
+    assert!(res.is_ok());
+
+    db.rollback_writes_to(2).unwrap();
+    assert_eq!(db.get_earliest_write_idx().unwrap(), 0);
+    assert_eq!(db.get_last_write_idx().unwrap(), 2);
+}
+
+pub fn test_purge_and_rollback<T: ChainstateDatabase>(db: &T) {
+    let mut generator = ArbitraryGenerator::new();
+    let genesis_state: Chainstate = generator.generate();
+    let batch = WriteBatch::new_replace(genesis_state.clone());
+
+    db.write_genesis_state(genesis_state, generator.generate())
+        .unwrap();
+    for i in 1..=5 {
+        db.put_write_batch(i, WriteBatchEntry::new(batch.clone(), generator.generate()))
+            .unwrap();
+    }
+
+    db.purge_entries_before(3).unwrap();
+
+    let res = db.rollback_writes_to(3);
+    assert!(res.is_ok());
+
+    let res = db.rollback_writes_to(2);
+    assert!(res.is_err_and(|x| matches!(x, DbError::MissingL2State(2))));
+}

--- a/crates/db-tests/src/checkpoint_tests.rs
+++ b/crates/db-tests/src/checkpoint_tests.rs
@@ -1,0 +1,118 @@
+use strata_db::traits::CheckpointDatabase;
+use strata_db::types::CheckpointEntry;
+use strata_state::batch::EpochSummary;
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_insert_summary_single<T: CheckpointDatabase>(db: &T) {
+    let summary: EpochSummary = ArbitraryGenerator::new().generate();
+    let commitment = summary.get_epoch_commitment();
+    db.insert_epoch_summary(summary.clone()).expect("test: insert");
+
+    let stored = db
+        .get_epoch_summary(commitment)
+        .expect("test: get")
+        .expect("test: get missing");
+    assert_eq!(stored, summary);
+
+    let commitments = db
+        .get_epoch_commitments_at(commitment.epoch())
+        .expect("test: get at epoch");
+
+    assert_eq!(commitments.as_slice(), &[commitment]);
+}
+
+pub fn test_insert_summary_overwrite<T: CheckpointDatabase>(db: &T) {
+    let summary: EpochSummary = ArbitraryGenerator::new().generate();
+    db.insert_epoch_summary(summary.clone()).expect("test: insert");
+    db.insert_epoch_summary(summary)
+        .expect_err("test: passed unexpectedly");
+}
+
+pub fn test_insert_summary_multiple<T: CheckpointDatabase>(db: &T) {
+    let mut ag = ArbitraryGenerator::new();
+    let summary1: EpochSummary = ag.generate();
+    let epoch = summary1.epoch();
+    let summary2 = EpochSummary::new(
+        epoch,
+        ag.generate(),
+        ag.generate(),
+        ag.generate(),
+        ag.generate(),
+    );
+
+    let commitment1 = summary1.get_epoch_commitment();
+    let commitment2 = summary2.get_epoch_commitment();
+    db.insert_epoch_summary(summary1.clone()).expect("test: insert");
+    db.insert_epoch_summary(summary2.clone()).expect("test: insert");
+
+    let stored1 = db
+        .get_epoch_summary(commitment1)
+        .expect("test: get")
+        .expect("test: get missing");
+    assert_eq!(stored1, summary1);
+
+    let stored2 = db
+        .get_epoch_summary(commitment2)
+        .expect("test: get")
+        .expect("test: get missing");
+    assert_eq!(stored2, summary2);
+
+    let mut commitments = vec![commitment1, commitment2];
+    commitments.sort();
+
+    let mut stored_commitments = db
+        .get_epoch_commitments_at(epoch)
+        .expect("test: get at epoch");
+    stored_commitments.sort();
+
+    assert_eq!(stored_commitments, commitments);
+}
+
+pub fn test_batch_checkpoint_new_entry<T: CheckpointDatabase>(db: &T) {
+    let batchidx = 1;
+    let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+    db.put_checkpoint(batchidx, checkpoint.clone()).unwrap();
+
+    let retrieved_batch = db.get_checkpoint(batchidx).unwrap().unwrap();
+    assert_eq!(checkpoint, retrieved_batch);
+}
+
+pub fn test_batch_checkpoint_existing_entry<T: CheckpointDatabase>(db: &T) {
+    let batchidx = 1;
+    let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+    db.put_checkpoint(batchidx, checkpoint.clone()).unwrap();
+    db.put_checkpoint(batchidx, checkpoint.clone()).unwrap();
+}
+
+pub fn test_batch_checkpoint_non_monotonic_entries<T: CheckpointDatabase>(db: &T) {
+    let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+    db.put_checkpoint(100, checkpoint.clone()).unwrap();
+    db.put_checkpoint(1, checkpoint.clone()).unwrap();
+    db.put_checkpoint(3, checkpoint.clone()).unwrap();
+}
+
+pub fn test_get_last_batch_checkpoint_idx<T: CheckpointDatabase>(db: &T) {
+    let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+    db.put_checkpoint(100, checkpoint.clone()).unwrap();
+    db.put_checkpoint(1, checkpoint.clone()).unwrap();
+    db.put_checkpoint(3, checkpoint.clone()).unwrap();
+
+    let last_idx = db.get_last_checkpoint_idx().unwrap().unwrap();
+    assert_eq!(last_idx, 100);
+
+    db.put_checkpoint(50, checkpoint.clone()).unwrap();
+    let last_idx = db.get_last_checkpoint_idx().unwrap().unwrap();
+    assert_eq!(last_idx, 100);
+}
+
+pub fn test_256_checkpoints<T: CheckpointDatabase>(db: &T) {
+    let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+
+    for expected_idx in 0..=256 {
+        let last_idx = db.get_last_checkpoint_idx().unwrap().unwrap_or(0);
+        assert_eq!(last_idx, expected_idx);
+
+        // Insert one to db
+        db.put_checkpoint(last_idx + 1, checkpoint.clone()).unwrap();
+    }
+}

--- a/crates/db-tests/src/client_state_tests.rs
+++ b/crates/db-tests/src/client_state_tests.rs
@@ -1,0 +1,47 @@
+use strata_db::traits::ClientStateDatabase;
+use strata_db::errors::DbError;
+use strata_state::operation::ClientUpdateOutput;
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_write_consensus_output<T: ClientStateDatabase>(db: &T) {
+    let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
+
+    let res = db.put_client_update(2, output.clone());
+    assert!(matches!(res, Err(DbError::OooInsert("consensus_store", 2))));
+
+    db.put_client_update(0, output.clone())
+        .expect("test: insert");
+
+    let res = db.put_client_update(0, output.clone());
+    assert!(matches!(res, Err(DbError::OooInsert("consensus_store", 0))));
+
+    let res = db.put_client_update(2, output.clone());
+    assert!(matches!(res, Err(DbError::OooInsert("consensus_store", 2))));
+}
+
+pub fn test_get_last_write_idx<T: ClientStateDatabase>(db: &T) {
+    let idx = db.get_last_state_idx();
+    assert!(matches!(idx, Err(DbError::NotBootstrapped)));
+
+    let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
+    db.put_client_update(0, output.clone())
+        .expect("test: insert");
+    db.put_client_update(1, output.clone())
+        .expect("test: insert");
+
+    let idx = db.get_last_state_idx().expect("test: get last");
+    assert_eq!(idx, 1);
+}
+
+pub fn test_get_consensus_update<T: ClientStateDatabase>(db: &T) {
+    let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
+
+    db.put_client_update(0, output.clone())
+        .expect("test: insert");
+
+    db.put_client_update(1, output.clone())
+        .expect("test: insert");
+
+    let update = db.get_client_update(1).expect("test: get").unwrap();
+    assert_eq!(update, output);
+}

--- a/crates/db-tests/src/l1_broadcast_tests.rs
+++ b/crates/db-tests/src/l1_broadcast_tests.rs
@@ -1,0 +1,91 @@
+use bitcoin::hashes::Hash;
+use strata_db::{traits::L1BroadcastDatabase, types::{L1TxEntry, L1TxStatus}};
+use strata_primitives::buf::Buf32;
+use strata_test_utils::bitcoin::get_test_bitcoin_txs;
+
+pub fn test_get_last_tx_entry<T: L1BroadcastDatabase>(db: &T) {
+    for _ in 0..2 {
+        let (txid, txentry) = generate_l1_tx_entry();
+
+        let _ = db.put_tx_entry(txid, txentry.clone()).unwrap();
+        let last_entry = db.get_last_tx_entry().unwrap();
+
+        assert_eq!(last_entry, Some(txentry));
+    }
+}
+
+pub fn test_add_tx_new_entry<T: L1BroadcastDatabase>(db: &T) {
+    let (txid, txentry) = generate_l1_tx_entry();
+
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap();
+
+    assert_eq!(idx, Some(0));
+
+    let stored_entry = db.get_tx_entry(idx.unwrap()).unwrap();
+    assert_eq!(stored_entry, Some(txentry));
+}
+
+pub fn test_put_tx_existing_entry<T: L1BroadcastDatabase>(db: &T) {
+    let (txid, txentry) = generate_l1_tx_entry();
+
+    let _ = db.put_tx_entry(txid, txentry.clone()).unwrap();
+
+    // Update the same txid
+    let result = db.put_tx_entry(txid, txentry);
+
+    assert!(result.is_ok());
+}
+
+pub fn test_update_tx_entry<T: L1BroadcastDatabase>(db: &T) {
+    let (txid, txentry) = generate_l1_tx_entry();
+
+    // Attempt to update non-existing index
+    let result = db.put_tx_entry_by_idx(0, txentry.clone());
+    assert!(result.is_err());
+
+    // Add and then update the entry by index
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap();
+
+    let mut updated_txentry = txentry;
+    updated_txentry.status = L1TxStatus::Finalized { confirmations: 1 };
+
+    db.put_tx_entry_by_idx(idx.unwrap(), updated_txentry.clone())
+        .unwrap();
+
+    let stored_entry = db.get_tx_entry(idx.unwrap()).unwrap();
+    assert_eq!(stored_entry, Some(updated_txentry));
+}
+
+pub fn test_get_txentry_by_idx<T: L1BroadcastDatabase>(db: &T) {
+    // Test non-existing entry
+    let result = db.get_tx_entry(0);
+    assert!(result.is_err());
+
+    let (txid, txentry) = generate_l1_tx_entry();
+
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap();
+
+    let stored_entry = db.get_tx_entry(idx.unwrap()).unwrap();
+    assert_eq!(stored_entry, Some(txentry));
+}
+
+pub fn test_get_next_txidx<T: L1BroadcastDatabase>(db: &T) {
+    let next_txidx = db.get_next_tx_idx().unwrap();
+    assert_eq!(next_txidx, 0, "The next txidx is 0 in the beginning");
+
+    let (txid, txentry) = generate_l1_tx_entry();
+
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap();
+
+    let next_txidx = db.get_next_tx_idx().unwrap();
+
+    assert_eq!(next_txidx, idx.unwrap() + 1);
+}
+
+// Helper function to generate L1TxEntry
+fn generate_l1_tx_entry() -> (Buf32, L1TxEntry) {
+    let txns = get_test_bitcoin_txs();
+    let txid = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let txentry = L1TxEntry::from_tx(&txns[0]);
+    (txid, txentry)
+}

--- a/crates/db-tests/src/l1_tests.rs
+++ b/crates/db-tests/src/l1_tests.rs
@@ -1,0 +1,295 @@
+use strata_db::traits::L1Database;
+use strata_primitives::l1::{L1BlockManifest, L1Tx, L1TxRef, L1TxProof, ProtocolOperation};
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_insert_into_empty_db<T: L1Database>(db: &T) {
+    let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
+    let idx = 1;
+    
+    // TODO maybe tweak this to make it a bit more realistic?
+    let txs: Vec<L1Tx> = (0..10)
+        .map(|i| {
+            let proof = L1TxProof::new(i as u32, arb.generate());
+            let parsed_tx: ProtocolOperation = arb.generate();
+            L1Tx::new(proof, arb.generate(), vec![parsed_tx])
+        })
+        .collect();
+    let mf = L1BlockManifest::new(
+        arb.generate(),
+        arb.generate(),
+        txs.clone(),
+        arb.generate(),
+        arb.generate(),
+    );
+
+    // Insert block data
+    let res = db.put_block_data(mf.clone());
+    assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
+    let res = db.set_canonical_chain_entry(idx, *mf.blkid());
+    assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
+    
+    // insert another block with arbitrary id
+    let idx = 200_011;
+    let txs: Vec<L1Tx> = (0..10)
+        .map(|i| {
+            let proof = L1TxProof::new(i as u32, arb.generate());
+            let parsed_tx: ProtocolOperation = arb.generate();
+            L1Tx::new(proof, arb.generate(), vec![parsed_tx])
+        })
+        .collect();
+    let mf = L1BlockManifest::new(
+        arb.generate(),
+        arb.generate(),
+        txs.clone(),
+        arb.generate(),
+        arb.generate(),
+    );
+
+    // Insert block data
+    let res = db.put_block_data(mf.clone());
+    assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
+    let res = db.set_canonical_chain_entry(idx, *mf.blkid());
+    assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
+}
+
+pub fn test_insert_into_canonical_chain<T: L1Database>(db: &T) {
+    let heights = vec![1, 2, 5000, 1000, 1002, 999];
+    let mut blockids = Vec::new();
+    for height in &heights {
+        let mut arb = ArbitraryGenerator::new();
+        let txs: Vec<L1Tx> = (0..10).map(|_| arb.generate()).collect();
+        let mf = L1BlockManifest::new(
+            arb.generate(),
+            arb.generate(),
+            txs,
+            arb.generate(),
+            arb.generate(),
+        );
+        let blockid = *mf.blkid();
+        db.put_block_data(mf).unwrap();
+        assert!(db.set_canonical_chain_entry(*height, blockid).is_ok());
+        blockids.push(blockid);
+    }
+
+    for (height, expected_blockid) in heights.into_iter().zip(blockids) {
+        assert!(matches!(
+            db.get_canonical_blockid_at_height(height),
+            Ok(Some(blockid)) if blockid == expected_blockid
+        ));
+    }
+}
+
+pub fn test_remove_canonical_chain_range<T: L1Database>(db: &T) {
+    // First insert a couple of manifests
+    let num_txs = 10;
+    let start_height = 1;
+    let end_height = 10;
+    for h in start_height..=end_height {
+        insert_block_data(h, db, num_txs);
+    }
+
+    let remove_start_height = 5;
+    let remove_end_height = 15;
+    assert!(db
+        .remove_canonical_chain_entries(remove_start_height, remove_end_height)
+        .is_ok());
+
+    // all removed items are gone from canonical chain
+    for h in remove_start_height..=remove_end_height {
+        assert!(matches!(db.get_canonical_blockid_at_height(h), Ok(None)));
+    }
+    // everything else is retained
+    for h in start_height..remove_start_height {
+        assert!(matches!(db.get_canonical_blockid_at_height(h), Ok(Some(_))));
+    }
+}
+
+pub fn test_get_block_data<T: L1Database>(db: &T) {
+    let idx = 1;
+
+    // insert
+    let (mf, txs) = insert_block_data(idx, db, 10);
+
+    // fetch non existent block
+    let non_idx = 200;
+    let observed_blockid = db
+        .get_canonical_blockid_at_height(non_idx)
+        .expect("Could not fetch from db");
+    assert_eq!(observed_blockid, None);
+
+    // fetch and check, existent block
+    let blockid = db
+        .get_canonical_blockid_at_height(idx)
+        .expect("Could not fetch from db")
+        .expect("Expected block missing");
+    let observed_mf = db
+        .get_block_manifest(blockid)
+        .expect("Could not fetch from db");
+    assert_eq!(observed_mf, Some(mf));
+
+    // Fetch txs
+    for (i, tx) in txs.iter().enumerate() {
+        let tx_from_db = db
+            .get_tx((blockid, i as u32).into())
+            .expect("Can't fetch from db")
+            .unwrap();
+        assert_eq!(*tx, tx_from_db, "Txns should match at index {i}");
+    }
+}
+
+pub fn test_get_tx<T: L1Database>(db: &T) {
+    let idx = 1; // block number
+    // Insert a block
+    let (mf, txns) = insert_block_data(idx, db, 10);
+    let blockid = mf.blkid();
+    let txidx: u32 = 3; // some tx index
+    assert!(txns.len() > txidx as usize);
+    let tx_ref: L1TxRef = (*blockid, txidx).into();
+    let tx = db.get_tx(tx_ref);
+    assert!(tx.as_ref().unwrap().is_some());
+    let tx = tx.unwrap().unwrap().clone();
+    assert_eq!(
+        tx,
+        *txns.get(txidx as usize).unwrap(),
+        "Should fetch correct transaction"
+    );
+    // Check txn at different index. It should not match
+    assert_ne!(
+        tx,
+        *txns.get(txidx as usize + 1).unwrap(),
+        "Txn at different index should not match"
+    );
+}
+
+pub fn test_get_chain_tip<T: L1Database>(db: &T) {
+    assert_eq!(
+        db.get_canonical_chain_tip().unwrap(),
+        None,
+        "chain tip of empty db should be unset"
+    );
+
+    // Insert some block data
+    let num_txs = 10;
+    insert_block_data(1, db, num_txs);
+    assert!(matches!(
+        db.get_canonical_chain_tip().unwrap(),
+        Some((1, _))
+    ));
+    insert_block_data(2, db, num_txs);
+    assert!(matches!(
+        db.get_canonical_chain_tip().unwrap(),
+        Some((2, _))
+    ));
+}
+
+pub fn test_get_block_txs<T: L1Database>(db: &T) {
+    let num_txs = 10;
+    insert_block_data(1, db, num_txs);
+    insert_block_data(2, db, num_txs);
+    insert_block_data(3, db, num_txs);
+
+    let blockid = db.get_canonical_blockid_at_height(2).unwrap().unwrap();
+    let block_txs = db.get_block_txs(blockid).unwrap().unwrap();
+    let expected: Vec<_> = (0..num_txs).map(|i| (blockid, i as u32).into()).collect(); // 10 because insert_block_data inserts 10 txs
+    assert_eq!(block_txs, expected);
+}
+
+pub fn test_get_blockid_invalid_range<T: L1Database>(db: &T) {
+    let num_txs = 10;
+    let _ = insert_block_data(1, db, num_txs);
+    let _ = insert_block_data(2, db, num_txs);
+    let _ = insert_block_data(3, db, num_txs);
+
+    let range = db.get_canonical_blockid_range(3, 1).unwrap();
+    assert_eq!(range.len(), 0);
+}
+
+pub fn test_get_blockid_range<T: L1Database>(db: &T) {
+    let num_txs = 10;
+    let (mf1, _) = insert_block_data(1, db, num_txs);
+    let (mf2, _) = insert_block_data(2, db, num_txs);
+    let (mf3, _) = insert_block_data(3, db, num_txs);
+
+    let range = db.get_canonical_blockid_range(1, 4).unwrap();
+    assert_eq!(range.len(), 3);
+    for (exp, obt) in vec![mf1, mf2, mf3].iter().zip(range) {
+        assert_eq!(*exp.blkid(), obt);
+    }
+}
+
+pub fn test_get_txs_fancy<T: L1Database>(db: &T) {
+    let num_txs = 3;
+    let total_num_blocks = 4;
+
+    let mut l1_txs = Vec::with_capacity(total_num_blocks);
+    for i in 0..total_num_blocks {
+        let (mf, block_txs) = insert_block_data(i as u64, db, num_txs);
+        l1_txs.push((*mf.blkid(), block_txs));
+    }
+
+    let (latest_idx, _) = db
+        .get_canonical_chain_tip()
+        .expect("should not error")
+        .expect("should have latest");
+
+    assert_eq!(
+        latest_idx,
+        (total_num_blocks - 1) as u64,
+        "the latest index must match the total number of blocks inserted"
+    );
+
+    for (blockid, block_txs) in l1_txs.iter() {
+        for (i, exp_tx) in block_txs.iter().enumerate() {
+            let real_tx = db
+                .get_tx(L1TxRef::from((*blockid, i as u32)))
+                .expect("test: database failed")
+                .expect("test: missing expected tx");
+
+            assert_eq!(
+                &real_tx, exp_tx,
+                "tx mismatch in block {blockid} at idx {i}"
+            );
+        }
+    }
+
+    // get past the final index.
+    let (latest_idx, _) = db
+        .get_canonical_chain_tip()
+        .expect("should not error")
+        .expect("should have latest");
+    let expected_latest = (total_num_blocks - 1) as u64;
+
+    assert_eq!(
+        latest_idx, expected_latest,
+        "test: wrong latest block number",
+    );
+}
+
+// Helper function to insert block data
+fn insert_block_data<T: L1Database>(height: u64, db: &T, num_txs: usize) -> (L1BlockManifest, Vec<L1Tx>) {
+    let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
+
+    // TODO maybe tweak this to make it a bit more realistic?
+    let txs: Vec<L1Tx> = (0..num_txs)
+        .map(|i| {
+            let proof = L1TxProof::new(i as u32, arb.generate());
+            let parsed_tx: ProtocolOperation = arb.generate();
+            L1Tx::new(proof, arb.generate(), vec![parsed_tx])
+        })
+        .collect();
+    let mf = L1BlockManifest::new(
+        arb.generate(),
+        arb.generate(),
+        txs.clone(),
+        arb.generate(),
+        arb.generate(),
+    );
+
+    // Insert block data
+    let res = db.put_block_data(mf.clone());
+    assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
+    let res = db.set_canonical_chain_entry(height, *mf.blkid());
+    assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
+
+    (mf, txs)
+}

--- a/crates/db-tests/src/l1_writer_tests.rs
+++ b/crates/db-tests/src/l1_writer_tests.rs
@@ -1,0 +1,80 @@
+use strata_db::traits::L1WriterDatabase;
+use strata_db::types::{BundledPayloadEntry, IntentEntry};
+use strata_primitives::buf::Buf32;
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_put_blob_new_entry<T: L1WriterDatabase>(db: &T) {
+    let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+
+    db.put_payload_entry(0, blob.clone()).unwrap();
+
+    let stored_blob = db.get_payload_entry_by_idx(0).unwrap();
+    assert_eq!(stored_blob, Some(blob));
+}
+
+pub fn test_put_blob_existing_entry<T: L1WriterDatabase>(db: &T) {
+    let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+
+    db.put_payload_entry(0, blob.clone()).unwrap();
+
+    let result = db.put_payload_entry(0, blob);
+
+    // Should be ok to put to existing key
+    assert!(result.is_ok());
+}
+
+pub fn test_update_entry<T: L1WriterDatabase>(db: &T) {
+    let entry: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+
+    // Insert
+    db.put_payload_entry(0, entry.clone()).unwrap();
+
+    let updated_entry: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+
+    // Update existing idx
+    db.put_payload_entry(0, updated_entry.clone()).unwrap();
+    let retrieved_entry = db.get_payload_entry_by_idx(0).unwrap().unwrap();
+    assert_eq!(updated_entry, retrieved_entry);
+}
+
+pub fn test_get_last_entry_idx<T: L1WriterDatabase>(db: &T) {
+    let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+
+    let next_blob_idx = db.get_next_payload_idx().unwrap();
+    assert_eq!(
+        next_blob_idx, 0,
+        "There is no last blobidx in the beginning"
+    );
+
+    db.put_payload_entry(next_blob_idx, blob.clone()).unwrap();
+    // Now the next idx is 1
+
+    let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+
+    db.put_payload_entry(1, blob.clone()).unwrap();
+    let next_blob_idx = db.get_next_payload_idx().unwrap();
+    // Now the last idx is 2
+
+    assert_eq!(next_blob_idx, 2);
+}
+
+pub fn test_put_intent_new_entry<T: L1WriterDatabase>(db: &T) {
+    let intent: IntentEntry = ArbitraryGenerator::new().generate();
+    let intent_id: Buf32 = [0; 32].into();
+
+    db.put_intent_entry(intent_id, intent.clone()).unwrap();
+
+    let stored_intent = db.get_intent_by_id(intent_id).unwrap();
+    assert_eq!(stored_intent, Some(intent));
+}
+
+pub fn test_put_intent_entry<T: L1WriterDatabase>(db: &T) {
+    let intent: IntentEntry = ArbitraryGenerator::new().generate();
+    let intent_id: Buf32 = [0; 32].into();
+
+    let result = db.put_intent_entry(intent_id, intent.clone());
+    assert!(result.is_ok());
+
+    let retrieved = db.get_intent_by_id(intent_id).unwrap().unwrap();
+    assert_eq!(retrieved, intent);
+}

--- a/crates/db-tests/src/l2_tests.rs
+++ b/crates/db-tests/src/l2_tests.rs
@@ -1,0 +1,112 @@
+use strata_db::traits::{L2BlockDatabase, BlockStatus};
+use strata_state::{block::L2BlockBundle, prelude::*};
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_set_and_get_block_data<T: L2BlockDatabase>(db: &T) {
+    let bundle = get_mock_data();
+    let block_hash = bundle.block().header().get_blockid();
+    let block_height = bundle.block().header().slot();
+
+    db.put_block_data(bundle.clone())
+        .expect("failed to put block data");
+
+    // assert block was stored
+    let received_block = db
+        .get_block_data(block_hash)
+        .expect("failed to retrieve block data")
+        .unwrap();
+    assert_eq!(received_block, bundle);
+
+    // assert block status was set to `BlockStatus::Unchecked``
+    let block_status = db
+        .get_block_status(block_hash)
+        .expect("failed to retrieve block data")
+        .unwrap();
+    assert_eq!(block_status, BlockStatus::Unchecked);
+
+    // assert block height data was stored
+    let block_ids = db
+        .get_blocks_at_height(block_height)
+        .expect("failed to retrieve block data");
+    assert!(block_ids.contains(&block_hash))
+}
+
+pub fn test_del_and_get_block_data<T: L2BlockDatabase>(db: &T) {
+    let bundle = get_mock_data();
+    let block_hash = bundle.block().header().get_blockid();
+    let block_height = bundle.block().header().slot();
+
+    // deleting non existing block should return false
+    let res = db
+        .del_block_data(block_hash)
+        .expect("failed to remove the block");
+    assert!(!res);
+
+    // deleting existing block should return true
+    db.put_block_data(bundle.clone())
+        .expect("failed to put block data");
+    let res = db
+        .del_block_data(block_hash)
+        .expect("failed to remove the block");
+    assert!(res);
+
+    // assert block is deleted from the db
+    let received_block = db
+        .get_block_data(block_hash)
+        .expect("failed to retrieve block data");
+    assert!(received_block.is_none());
+
+    // assert block status is deleted from the db
+    let block_status = db
+        .get_block_status(block_hash)
+        .expect("failed to retrieve block status");
+    assert!(block_status.is_none());
+
+    // assert block height data is deleted
+    let block_ids = db
+        .get_blocks_at_height(block_height)
+        .expect("failed to retrieve block data");
+    assert!(!block_ids.contains(&block_hash))
+}
+
+pub fn test_set_and_get_block_status<T: L2BlockDatabase>(db: &T) {
+    let bundle = get_mock_data();
+    let block_hash = bundle.block().header().get_blockid();
+
+    db.put_block_data(bundle.clone())
+        .expect("failed to put block data");
+
+    // assert block status was set to `BlockStatus::Valid``
+    db.set_block_status(block_hash, BlockStatus::Valid)
+        .expect("failed to update block status");
+    let block_status = db
+        .get_block_status(block_hash)
+        .expect("failed to retrieve block status")
+        .unwrap();
+    assert_eq!(block_status, BlockStatus::Valid);
+
+    // assert block status was set to `BlockStatus::Invalid``
+    db.set_block_status(block_hash, BlockStatus::Invalid)
+        .expect("failed to update block status");
+    let block_status = db
+        .get_block_status(block_hash)
+        .expect("failed to retrieve block status")
+        .unwrap();
+    assert_eq!(block_status, BlockStatus::Invalid);
+
+    // assert block status was set to `BlockStatus::Unchecked``
+    db.set_block_status(block_hash, BlockStatus::Unchecked)
+        .expect("failed to update block status");
+    let block_status = db
+        .get_block_status(block_hash)
+        .expect("failed to retrieve block status")
+        .unwrap();
+    assert_eq!(block_status, BlockStatus::Unchecked);
+}
+
+// Helper function to generate mock data
+fn get_mock_data() -> L2BlockBundle {
+    let mut arb = ArbitraryGenerator::new_with_size(1 << 14);
+    let l2_block: L2BlockBundle = arb.generate();
+    l2_block
+}

--- a/crates/db-tests/src/lib.rs
+++ b/crates/db-tests/src/lib.rs
@@ -1,0 +1,13 @@
+// Generic database test utilities for database trait implementations
+// This crate provides reusable test functions for database trait implementations
+
+pub mod l1_tests;
+pub mod l2_tests;
+pub mod checkpoint_tests;
+pub mod client_state_tests;
+pub mod chain_state_tests;
+pub mod sync_event_tests;
+pub mod l1_broadcast_tests;
+pub mod bridge_tx_tests;
+pub mod l1_writer_tests;
+pub mod proof_tests;

--- a/crates/db-tests/src/proof_tests.rs
+++ b/crates/db-tests/src/proof_tests.rs
@@ -1,0 +1,127 @@
+use strata_db::traits::ProofDatabase;
+use strata_primitives::{
+    buf::Buf32,
+    evm_exec::EvmEeBlockCommitment,
+    l1::L1BlockCommitment,
+    l2::L2BlockCommitment,
+    proof::{ProofContext, ProofKey, ProofZkVm},
+};
+use zkaleido::{Proof, ProofMetadata, ProofReceipt, ProofReceiptWithMetadata, PublicValues, ZkVm};
+
+pub fn test_insert_new_proof<T: ProofDatabase>(db: &T) {
+    let (proof_key, proof) = generate_proof();
+
+    let result = db.put_proof(proof_key, proof.clone());
+    assert!(
+        result.is_ok(),
+        "ProofReceiptWithMetadata should be inserted successfully"
+    );
+
+    let stored_proof = db.get_proof(&proof_key).unwrap();
+    assert_eq!(stored_proof, Some(proof));
+}
+
+pub fn test_insert_duplicate_proof<T: ProofDatabase>(db: &T) {
+    let (proof_key, proof) = generate_proof();
+
+    db.put_proof(proof_key, proof.clone()).unwrap();
+
+    let result = db.put_proof(proof_key, proof);
+    assert!(result.is_err(), "Duplicate proof insertion should fail");
+}
+
+pub fn test_get_nonexistent_proof<T: ProofDatabase>(db: &T) {
+    let (proof_key, proof) = generate_proof();
+    db.put_proof(proof_key, proof.clone()).unwrap();
+
+    let res = db.del_proof(proof_key);
+    assert!(matches!(res, Ok(true)));
+
+    let res = db.del_proof(proof_key);
+    assert!(matches!(res, Ok(false)));
+
+    let stored_proof = db.get_proof(&proof_key).unwrap();
+    assert_eq!(stored_proof, None, "Nonexistent proof should return None");
+}
+
+pub fn test_insert_new_deps<T: ProofDatabase>(db: &T) {
+    let (proof_context, deps) = generate_proof_context_with_deps();
+
+    let result = db.put_proof_deps(proof_context, deps.clone());
+    assert!(
+        result.is_ok(),
+        "ProofReceiptWithMetadata should be inserted successfully"
+    );
+
+    let stored_deps = db.get_proof_deps(proof_context).unwrap();
+    assert_eq!(stored_deps, Some(deps));
+}
+
+pub fn test_insert_duplicate_proof_deps<T: ProofDatabase>(db: &T) {
+    let (proof_context, deps) = generate_proof_context_with_deps();
+
+    db.put_proof_deps(proof_context, deps.clone()).unwrap();
+
+    let result = db.put_proof_deps(proof_context, deps);
+    assert!(
+        result.is_err(),
+        "Duplicate proof deps insertion should fail"
+    );
+}
+
+pub fn test_get_nonexistent_proof_deps<T: ProofDatabase>(db: &T) {
+    let (proof_context, deps) = generate_proof_context_with_deps();
+    db.put_proof_deps(proof_context, deps.clone()).unwrap();
+
+    let res = db.del_proof_deps(proof_context);
+    assert!(matches!(res, Ok(true)));
+
+    let res = db.del_proof_deps(proof_context);
+    assert!(matches!(res, Ok(false)));
+
+    let stored_proof = db.get_proof_deps(proof_context).unwrap();
+    assert_eq!(
+        stored_proof, None,
+        "Nonexistent proof deps should return None"
+    );
+}
+
+// Helper functions
+fn generate_proof() -> (ProofKey, ProofReceiptWithMetadata) {
+    let proof_context = ProofContext::BtcBlockspace(
+        0,
+        L1BlockCommitment::default(),
+        L1BlockCommitment::default(),
+    );
+    let host = ProofZkVm::Native;
+    let proof_key = ProofKey::new(proof_context, host);
+    let proof = Proof::default();
+    let public_values = PublicValues::default();
+    let receipt = ProofReceipt::new(proof, public_values);
+    let metadata = ProofMetadata::new(ZkVm::Native, "0.1".to_string());
+    let proof_receipt = ProofReceiptWithMetadata::new(receipt, metadata);
+    (proof_key, proof_receipt)
+}
+
+fn generate_proof_context_with_deps() -> (ProofContext, Vec<ProofContext>) {
+    // Constants for test block IDs
+    const BLOCK_1_ID: [u8; 32] = [1u8; 32];
+    const BLOCK_2_ID: [u8; 32] = [2u8; 32];
+
+    // Create block IDs
+    let evm_block_1 = Buf32::from(BLOCK_1_ID);
+    let evm_block_2 = Buf32::from(BLOCK_2_ID);
+
+    // Create L2 block commitments
+    let evm_commitment_1 = EvmEeBlockCommitment::new(1, evm_block_1);
+    let evm_commitment_2 = EvmEeBlockCommitment::new(2, evm_block_2);
+
+    // Create main proof context
+    let main_context =
+        ProofContext::ClStf(L2BlockCommitment::null(), L2BlockCommitment::null());
+
+    // Create dependency proof contexts
+    let deps = vec![ProofContext::EvmEeStf(evm_commitment_1, evm_commitment_2)];
+
+    (main_context, deps)
+}

--- a/crates/db-tests/src/sync_event_tests.rs
+++ b/crates/db-tests/src/sync_event_tests.rs
@@ -1,0 +1,96 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use strata_db::traits::SyncEventDatabase;
+use strata_db::errors::DbError;
+use strata_state::sync_event::SyncEvent;
+use strata_test_utils::ArbitraryGenerator;
+
+pub fn test_get_sync_event<T: SyncEventDatabase>(db: &T) {
+    let ev1 = db.get_sync_event(1).unwrap();
+    assert!(ev1.is_none());
+
+    let ev = insert_event(db);
+
+    let ev1 = db.get_sync_event(1).unwrap();
+    assert!(ev1.is_some());
+
+    assert_eq!(ev1.unwrap(), ev);
+}
+
+pub fn test_get_last_idx_1<T: SyncEventDatabase>(db: &T) {
+    let idx = db.get_last_idx().unwrap().unwrap_or(0);
+    assert_eq!(idx, 0);
+
+    let n = 5;
+    for i in 1..=n {
+        let _ = insert_event(db);
+        let idx = db.get_last_idx().unwrap().unwrap_or(0);
+        assert_eq!(idx, i);
+    }
+}
+
+pub fn test_get_timestamp<T: SyncEventDatabase>(db: &T) {
+    let mut timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let n = 5;
+    for i in 1..=n {
+        let _ = insert_event(db);
+        let ts = db.get_event_timestamp(i).unwrap().unwrap();
+        assert!(ts >= timestamp);
+        timestamp = ts;
+    }
+}
+
+pub fn test_clear_sync_event<T: SyncEventDatabase>(db: &T) {
+    let n = 5;
+    for _ in 1..=n {
+        let _ = insert_event(db);
+    }
+
+    // Delete events 2..4
+    let res = db.clear_sync_event_range(2, 4);
+    assert!(res.is_ok());
+
+    let ev1 = db.get_sync_event(1).unwrap();
+    let ev2 = db.get_sync_event(2).unwrap();
+    let ev3 = db.get_sync_event(3).unwrap();
+    let ev4 = db.get_sync_event(4).unwrap();
+    let ev5 = db.get_sync_event(5).unwrap();
+
+    assert!(ev1.is_some());
+    assert!(ev2.is_none());
+    assert!(ev3.is_none());
+    assert!(ev4.is_some());
+    assert!(ev5.is_some());
+}
+
+pub fn test_clear_sync_event_2<T: SyncEventDatabase>(db: &T) {
+    let n = 5;
+    for _ in 1..=n {
+        let _ = insert_event(db);
+    }
+    let res = db.clear_sync_event_range(6, 7);
+    assert!(res.is_err_and(|x| matches!(x, DbError::Other(ref msg) if msg == "end_idx must be less than or equal to last_key")));
+}
+
+pub fn test_get_last_idx_2<T: SyncEventDatabase>(db: &T) {
+    let n = 5;
+    for _ in 1..=n {
+        let _ = insert_event(db);
+    }
+    let res = db.clear_sync_event_range(2, 3);
+    assert!(res.is_ok());
+
+    let new_idx = db.get_last_idx().unwrap().unwrap();
+    assert_eq!(new_idx, 5);
+}
+
+// Helper function to insert events
+fn insert_event<T: SyncEventDatabase>(db: &T) -> SyncEvent {
+    let ev: SyncEvent = ArbitraryGenerator::new().generate();
+    let res = db.write_sync_event(ev.clone());
+    assert!(res.is_ok());
+    ev
+}

--- a/crates/rocksdb-store/Cargo.toml
+++ b/crates/rocksdb-store/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 strata-test-utils.workspace = true
+strata-db-tests.workspace = true
 
 bitcoin.workspace = true
 

--- a/crates/rocksdb-store/src/client_state/db.rs
+++ b/crates/rocksdb-store/src/client_state/db.rs
@@ -70,7 +70,7 @@ impl ClientStateDatabase for ClientStateDb {
 
 #[cfg(test)]
 mod tests {
-    use strata_test_utils::*;
+    use strata_db_tests::client_state_tests;
 
     use super::*;
     use crate::test_utils::get_rocksdb_tmp_instance;
@@ -91,51 +91,19 @@ mod tests {
 
     #[test]
     fn test_write_consensus_output() {
-        let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
         let db = setup_db();
-
-        let res = db.put_client_update(2, output.clone());
-        assert!(matches!(res, Err(DbError::OooInsert("consensus_store", 2))));
-
-        db.put_client_update(0, output.clone())
-            .expect("test: insert");
-
-        let res = db.put_client_update(0, output.clone());
-        assert!(matches!(res, Err(DbError::OooInsert("consensus_store", 0))));
-
-        let res = db.put_client_update(2, output.clone());
-        assert!(matches!(res, Err(DbError::OooInsert("consensus_store", 2))));
+        client_state_tests::test_write_consensus_output(&db);
     }
 
     #[test]
     fn test_get_last_write_idx() {
         let db = setup_db();
-
-        let idx = db.get_last_state_idx();
-        assert!(matches!(idx, Err(DbError::NotBootstrapped)));
-
-        let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
-        db.put_client_update(0, output.clone())
-            .expect("test: insert");
-        db.put_client_update(1, output.clone())
-            .expect("test: insert");
-
-        let idx = db.get_last_state_idx().expect("test: get last");
-        assert_eq!(idx, 1);
+        client_state_tests::test_get_last_write_idx(&db);
     }
 
     #[test]
     fn test_get_consensus_update() {
-        let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
-
         let db = setup_db();
-        db.put_client_update(0, output.clone())
-            .expect("test: insert");
-
-        db.put_client_update(1, output.clone())
-            .expect("test: insert");
-
-        let update = db.get_client_update(1).expect("test: get").unwrap();
-        assert_eq!(update, output);
+        client_state_tests::test_get_consensus_update(&db);
     }
 }

--- a/crates/rocksdb-store/src/l1/db.rs
+++ b/crates/rocksdb-store/src/l1/db.rs
@@ -175,8 +175,7 @@ impl L1Database for L1Db {
 #[cfg(feature = "test_utils")]
 #[cfg(test)]
 mod tests {
-    use strata_primitives::l1::{L1TxProof, ProtocolOperation};
-    use strata_test_utils::ArbitraryGenerator;
+    use strata_db_tests::l1_tests;
 
     use super::*;
     use crate::test_utils::get_rocksdb_tmp_instance;
@@ -186,284 +185,63 @@ mod tests {
         L1Db::new(db, db_ops)
     }
 
-    fn insert_block_data(height: u64, db: &L1Db, num_txs: usize) -> (L1BlockManifest, Vec<L1Tx>) {
-        let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
-
-        // TODO maybe tweak this to make it a bit more realistic?
-        let txs: Vec<L1Tx> = (0..num_txs)
-            .map(|i| {
-                let proof = L1TxProof::new(i as u32, arb.generate());
-                let parsed_tx: ProtocolOperation = arb.generate();
-                L1Tx::new(proof, arb.generate(), vec![parsed_tx])
-            })
-            .collect();
-        let mf = L1BlockManifest::new(
-            arb.generate(),
-            arb.generate(),
-            txs.clone(),
-            arb.generate(),
-            arb.generate(),
-        );
-
-        // Insert block data
-        let res = db.put_block_data(mf.clone());
-        assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
-        let res = db.set_canonical_chain_entry(height, *mf.blkid());
-        assert!(res.is_ok(), "put should work but got: {}", res.unwrap_err());
-
-        (mf, txs)
-    }
-
-    // TEST STORE METHODS
-
     #[test]
     fn test_insert_into_empty_db() {
         let db = setup_db();
-        let idx = 1;
-        insert_block_data(idx, &db, 10);
-        drop(db);
-
-        // insert another block with arbitrary id
-        let db = setup_db();
-        let idx = 200_011;
-        insert_block_data(idx, &db, 10);
+        l1_tests::test_insert_into_empty_db(&db);
     }
 
     #[test]
     fn test_insert_into_canonical_chain() {
         let db = setup_db();
-
-        let heights = vec![1, 2, 5000, 1000, 1002, 999];
-        let mut blockids = Vec::new();
-        for height in &heights {
-            let mut arb = ArbitraryGenerator::new();
-            let txs: Vec<L1Tx> = (0..10).map(|_| arb.generate()).collect();
-            let mf = L1BlockManifest::new(
-                arb.generate(),
-                arb.generate(),
-                txs,
-                arb.generate(),
-                arb.generate(),
-            );
-            let blockid = *mf.blkid();
-            db.put_block_data(mf).unwrap();
-            assert!(db.set_canonical_chain_entry(*height, blockid).is_ok());
-            blockids.push(blockid);
-        }
-
-        for (height, expected_blockid) in heights.into_iter().zip(blockids) {
-            assert!(matches!(
-                db.get_canonical_blockid_at_height(height),
-                Ok(Some(blockid)) if blockid == expected_blockid
-            ));
-        }
+        l1_tests::test_insert_into_canonical_chain(&db);
     }
 
     #[test]
     fn test_remove_canonical_chain_range() {
         let db = setup_db();
-        // First insert a couple of manifests
-        let num_txs = 10;
-        let start_height = 1;
-        let end_height = 10;
-        for h in start_height..=end_height {
-            insert_block_data(h, &db, num_txs);
-        }
-
-        let remove_start_height = 5;
-        let remove_end_height = 15;
-        assert!(db
-            .remove_canonical_chain_entries(remove_start_height, remove_end_height)
-            .is_ok());
-
-        // all removed items are gone from canonical chain
-        for h in remove_start_height..=remove_end_height {
-            assert!(matches!(db.get_canonical_blockid_at_height(h), Ok(None)));
-        }
-        // everything else is retained
-        for h in start_height..remove_start_height {
-            assert!(matches!(db.get_canonical_blockid_at_height(h), Ok(Some(_))));
-        }
+        l1_tests::test_remove_canonical_chain_range(&db);
     }
-
-    // TEST PROVIDER METHODS
 
     #[test]
     fn test_get_block_data() {
         let db = setup_db();
-        let idx = 1;
-
-        // insert
-        let (mf, txs) = insert_block_data(idx, &db, 10);
-
-        // fetch non existent block
-        let non_idx = 200;
-        let observed_blockid = db
-            .get_canonical_blockid_at_height(non_idx)
-            .expect("Could not fetch from db");
-        assert_eq!(observed_blockid, None);
-
-        // fetch and check, existent block
-        let blockid = db
-            .get_canonical_blockid_at_height(idx)
-            .expect("Could not fetch from db")
-            .expect("Expected block missing");
-        let observed_mf = db
-            .get_block_manifest(blockid)
-            .expect("Could not fetch from db");
-        assert_eq!(observed_mf, Some(mf));
-
-        // Fetch txs
-        for (i, tx) in txs.iter().enumerate() {
-            let tx_from_db = db
-                .get_tx((blockid, i as u32).into())
-                .expect("Can't fetch from db")
-                .unwrap();
-            assert_eq!(*tx, tx_from_db, "Txns should match at index {i}");
-        }
+        l1_tests::test_get_block_data(&db);
     }
 
     #[test]
     fn test_get_tx() {
         let db = setup_db();
-        let idx = 1; // block number
-                     // Insert a block
-        let (mf, txns) = insert_block_data(idx, &db, 10);
-        let blockid = mf.blkid();
-        let txidx: u32 = 3; // some tx index
-        assert!(txns.len() > txidx as usize);
-        let tx_ref: L1TxRef = (*blockid, txidx).into();
-        let tx = db.get_tx(tx_ref);
-        assert!(tx.as_ref().unwrap().is_some());
-        let tx = tx.unwrap().unwrap().clone();
-        assert_eq!(
-            tx,
-            *txns.get(txidx as usize).unwrap(),
-            "Should fetch correct transaction"
-        );
-        // Check txn at different index. It should not match
-        assert_ne!(
-            tx,
-            *txns.get(txidx as usize + 1).unwrap(),
-            "Txn at different index should not match"
-        );
+        l1_tests::test_get_tx(&db);
     }
 
     #[test]
     fn test_get_chain_tip() {
         let db = setup_db();
-        assert_eq!(
-            db.get_canonical_chain_tip().unwrap(),
-            None,
-            "chain tip of empty db should be unset"
-        );
-
-        // Insert some block data
-        let num_txs = 10;
-        insert_block_data(1, &db, num_txs);
-        assert!(matches!(
-            db.get_canonical_chain_tip().unwrap(),
-            Some((1, _))
-        ));
-        insert_block_data(2, &db, num_txs);
-        assert!(matches!(
-            db.get_canonical_chain_tip().unwrap(),
-            Some((2, _))
-        ));
+        l1_tests::test_get_chain_tip(&db);
     }
 
     #[test]
     fn test_get_block_txs() {
         let db = setup_db();
-
-        let num_txs = 10;
-        insert_block_data(1, &db, num_txs);
-        insert_block_data(2, &db, num_txs);
-        insert_block_data(3, &db, num_txs);
-
-        let blockid = db.get_canonical_blockid_at_height(2).unwrap().unwrap();
-        let block_txs = db.get_block_txs(blockid).unwrap().unwrap();
-        let expected: Vec<_> = (0..num_txs).map(|i| (blockid, i as u32).into()).collect(); // 10 because insert_block_data inserts 10 txs
-        assert_eq!(block_txs, expected);
+        l1_tests::test_get_block_txs(&db);
     }
 
     #[test]
     fn test_get_blockid_invalid_range() {
         let db = setup_db();
-
-        let num_txs = 10;
-        let _ = insert_block_data(1, &db, num_txs);
-        let _ = insert_block_data(2, &db, num_txs);
-        let _ = insert_block_data(3, &db, num_txs);
-
-        let range = db.get_canonical_blockid_range(3, 1).unwrap();
-        assert_eq!(range.len(), 0);
+        l1_tests::test_get_blockid_invalid_range(&db);
     }
 
     #[test]
     fn test_get_blockid_range() {
         let db = setup_db();
-
-        let num_txs = 10;
-        let (mf1, _) = insert_block_data(1, &db, num_txs);
-        let (mf2, _) = insert_block_data(2, &db, num_txs);
-        let (mf3, _) = insert_block_data(3, &db, num_txs);
-
-        let range = db.get_canonical_blockid_range(1, 4).unwrap();
-        assert_eq!(range.len(), 3);
-        for (exp, obt) in vec![mf1, mf2, mf3].iter().zip(range) {
-            assert_eq!(*exp.blkid(), obt);
-        }
+        l1_tests::test_get_blockid_range(&db);
     }
 
     #[test]
     fn test_get_txs_fancy() {
         let db = setup_db();
-
-        let num_txs = 3;
-        let total_num_blocks = 4;
-
-        let mut l1_txs = Vec::with_capacity(total_num_blocks);
-        for i in 0..total_num_blocks {
-            let (mf, block_txs) = insert_block_data(i as u64, &db, num_txs);
-            l1_txs.push((*mf.blkid(), block_txs));
-        }
-
-        let (latest_idx, _) = db
-            .get_latest_block()
-            .expect("should not error")
-            .expect("should have latest");
-
-        assert_eq!(
-            latest_idx,
-            (total_num_blocks - 1) as u64,
-            "the latest index must match the total number of blocks inserted"
-        );
-
-        for (blockid, block_txs) in l1_txs.iter() {
-            for (i, exp_tx) in block_txs.iter().enumerate() {
-                let real_tx = db
-                    .get_tx(L1TxRef::from((*blockid, i as u32)))
-                    .expect("test: database failed")
-                    .expect("test: missing expected tx");
-
-                assert_eq!(
-                    &real_tx, exp_tx,
-                    "tx mismatch in block {blockid} at idx {i}"
-                );
-            }
-        }
-
-        // get past the final index.
-        let (latest_idx, _) = db
-            .get_latest_block()
-            .expect("should not error")
-            .expect("should have latest");
-        let expected_latest = (total_num_blocks - 1) as u64;
-
-        assert_eq!(
-            latest_idx, expected_latest,
-            "test: wrong latest block number",
-        );
+        l1_tests::test_get_txs_fancy(&db);
     }
 }

--- a/crates/rocksdb-store/src/l2/db.rs
+++ b/crates/rocksdb-store/src/l2/db.rs
@@ -109,17 +109,10 @@ impl L2BlockDatabase for L2Db {
 #[cfg(feature = "test_utils")]
 #[cfg(test)]
 mod tests {
-    use strata_test_utils::ArbitraryGenerator;
+    use strata_db_tests::l2_tests;
 
     use super::*;
     use crate::test_utils::get_rocksdb_tmp_instance;
-
-    fn get_mock_data() -> L2BlockBundle {
-        let mut arb = ArbitraryGenerator::new_with_size(1 << 14);
-        let l2_block: L2BlockBundle = arb.generate();
-
-        l2_block
-    }
 
     fn setup_db() -> L2Db {
         let (db, ops) = get_rocksdb_tmp_instance().unwrap();
@@ -129,115 +122,18 @@ mod tests {
     #[test]
     fn set_and_get_block_data() {
         let l2_db = setup_db();
-
-        let bundle = get_mock_data();
-        let block_hash = bundle.block().header().get_blockid();
-        let block_height = bundle.block().header().slot();
-
-        l2_db
-            .put_block_data(bundle.clone())
-            .expect("failed to put block data");
-
-        // assert block was stored
-        let received_block = l2_db
-            .get_block_data(block_hash)
-            .expect("failed to retrieve block data")
-            .unwrap();
-        assert_eq!(received_block, bundle);
-
-        // assert block status was set to `BlockStatus::Unchecked``
-        let block_status = l2_db
-            .get_block_status(block_hash)
-            .expect("failed to retrieve block data")
-            .unwrap();
-        assert_eq!(block_status, BlockStatus::Unchecked);
-
-        // assert block height data was stored
-        let block_ids = l2_db
-            .get_blocks_at_height(block_height)
-            .expect("failed to retrieve block data");
-        assert!(block_ids.contains(&block_hash))
+        l2_tests::test_set_and_get_block_data(&l2_db);
     }
 
     #[test]
     fn del_and_get_block_data() {
         let l2_db = setup_db();
-        let bundle = get_mock_data();
-        let block_hash = bundle.block().header().get_blockid();
-        let block_height = bundle.block().header().slot();
-
-        // deleting non existing block should return false
-        let res = l2_db
-            .del_block_data(block_hash)
-            .expect("failed to remove the block");
-        assert!(!res);
-
-        // deleting existing block should return true
-        l2_db
-            .put_block_data(bundle.clone())
-            .expect("failed to put block data");
-        let res = l2_db
-            .del_block_data(block_hash)
-            .expect("failed to remove the block");
-        assert!(res);
-
-        // assert block is deleted from the db
-        let received_block = l2_db
-            .get_block_data(block_hash)
-            .expect("failed to retrieve block data");
-        assert!(received_block.is_none());
-
-        // assert block status is deleted from the db
-        let block_status = l2_db
-            .get_block_status(block_hash)
-            .expect("failed to retrieve block status");
-        assert!(block_status.is_none());
-
-        // assert block height data is deleted
-        let block_ids = l2_db
-            .get_blocks_at_height(block_height)
-            .expect("failed to retrieve block data");
-        assert!(!block_ids.contains(&block_hash))
+        l2_tests::test_del_and_get_block_data(&l2_db);
     }
 
     #[test]
     fn set_and_get_block_status() {
         let l2_db = setup_db();
-        let bundle = get_mock_data();
-        let block_hash = bundle.block().header().get_blockid();
-
-        l2_db
-            .put_block_data(bundle.clone())
-            .expect("failed to put block data");
-
-        // assert block status was set to `BlockStatus::Valid``
-        l2_db
-            .set_block_status(block_hash, BlockStatus::Valid)
-            .expect("failed to update block status");
-        let block_status = l2_db
-            .get_block_status(block_hash)
-            .expect("failed to retrieve block status")
-            .unwrap();
-        assert_eq!(block_status, BlockStatus::Valid);
-
-        // assert block status was set to `BlockStatus::Invalid``
-        l2_db
-            .set_block_status(block_hash, BlockStatus::Invalid)
-            .expect("failed to update block status");
-        let block_status = l2_db
-            .get_block_status(block_hash)
-            .expect("failed to retrieve block status")
-            .unwrap();
-        assert_eq!(block_status, BlockStatus::Invalid);
-
-        // assert block status was set to `BlockStatus::Unchecked``
-        l2_db
-            .set_block_status(block_hash, BlockStatus::Unchecked)
-            .expect("failed to update block status");
-        let block_status = l2_db
-            .get_block_status(block_hash)
-            .expect("failed to retrieve block status")
-            .unwrap();
-        assert_eq!(block_status, BlockStatus::Unchecked);
+        l2_tests::test_set_and_get_block_status(&l2_db);
     }
 }


### PR DESCRIPTION
## Description

This first PR is to refactor the tests in the RocksDB module to make them generic.  This will aid us in building new DB backends.  This also includes some general cleanup to the database modules.  The actual substance of this related ticket will be in a subsequent PR.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This was mostly performed by Claude Code.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.