### PR TITLE
Allow el reorg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9043,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9110,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9144,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9186,7 +9186,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.9.2",
@@ -9206,7 +9206,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-genesis 0.9.2",
  "clap",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "ahash",
  "alloy-consensus 0.9.2",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9352,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9380,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-primitives 0.8.19",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-genesis 0.9.2",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-genesis 0.9.2",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -9503,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rlp",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rlp",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "data-encoding",
@@ -9577,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9608,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "aes",
  "alloy-primitives 0.8.19",
@@ -9639,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-primitives 0.8.19",
@@ -9670,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-primitives 0.8.19",
@@ -9691,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "futures",
  "pin-project",
@@ -9715,7 +9715,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9791,7 +9791,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -9804,7 +9804,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives 0.8.19",
@@ -9832,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.9.2",
@@ -9853,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "eyre",
  "reth-chainspec",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -9914,7 +9914,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9951,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9977,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10067,7 +10067,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10082,7 +10082,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "serde",
  "serde_json",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10119,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "futures",
  "metrics",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
 ]
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rpc-types-admin",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10299,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rlp",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -10328,7 +10328,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10345,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10431,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10480,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "eyre",
  "reth-basic-payload-builder",
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "eyre",
  "http 1.2.0",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-rpc-types 0.9.2",
@@ -10588,7 +10588,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-rpc-types-engine",
  "async-trait",
@@ -10602,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-rpc-types 0.9.2",
  "reth-chainspec",
@@ -10641,7 +10641,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10700,7 +10700,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "derive_more 1.0.0",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-dyn-abi",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-json-rpc 0.9.2",
@@ -10897,7 +10897,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "http 1.2.0",
  "jsonrpsee",
@@ -10933,7 +10933,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -10965,7 +10965,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-dyn-abi",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -11051,7 +11051,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.2.0",
@@ -11065,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -11097,7 +11097,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -11135,7 +11135,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -11162,7 +11162,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "bytes",
@@ -11175,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "parking_lot 0.12.3",
@@ -11196,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "clap",
@@ -11208,7 +11208,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-eips 0.9.2",
  "alloy-primitives 0.8.19",
@@ -11248,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11266,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11276,7 +11276,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "clap",
  "eyre",
@@ -11291,7 +11291,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -11330,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
@@ -11355,7 +11355,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-primitives 0.8.19",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rlp",
@@ -11396,7 +11396,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rlp",
@@ -11419,7 +11419,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "alloy-primitives 0.8.19",
  "alloy-rlp",
@@ -11434,7 +11434,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
+source = "git+https://github.com/alpenlabs/reth.git?rev=e4940d6d09067bad#e4940d6d09067bad0cad281b1bcf6f0a3c612d7e"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,46 +132,46 @@ revm-primitives = { version = "15.1.0", features = [
 ], default-features = false }
 
 # reth itself:
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-ipc = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5", default-features = false, features = [
+reth = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-basic-payload-builder = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-chain-state = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-chainspec = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-cli = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-cli-commands = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-cli-util = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-db = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-errors = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-ethereum-forks = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-ethereum-payload-builder = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-evm = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-evm-ethereum = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-exex = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-ipc = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-network-api = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-node-api = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-node-builder = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-node-ethereum = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-payload-builder = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-payload-validator = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-primitives = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad", default-features = false, features = [
   "std",
   "serde-bincode-compat",
 ] }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5", default-features = false }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-rpc-types-compat = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.1.5" }
+reth-primitives-traits = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad", default-features = false }
+reth-provider = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-revm = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-rpc = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-rpc-api = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-rpc-eth-api = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-rpc-eth-types = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad", default-features = false }
+reth-rpc-layer = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-rpc-server-types = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-rpc-types-compat = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-tasks = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-transaction-pool = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-trie = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-trie-common = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
+reth-trie-db = { git = "https://github.com/alpenlabs/reth.git", rev = "e4940d6d09067bad" }
 
 anyhow = "1.0.86"
 arbitrary = { version = "1.3.2", features = ["derive"] }

--- a/bin/alpen-reth/src/main.rs
+++ b/bin/alpen-reth/src/main.rs
@@ -36,6 +36,8 @@ fn main() {
     command.chain = command.ext.custom_chain.clone();
     // disable peer discovery
     command.network.discovery.disable_discovery = true;
+    // allow chain fork blocks to be created
+    command.always_process_payload_attributes_on_canonical_head = true;
 
     if let Err(err) = run(command, |builder, ext| async move {
         let datadir = builder.config().datadir().data_dir().to_path_buf();

--- a/bin/strata-client/src/el_sync.rs
+++ b/bin/strata-client/src/el_sync.rs
@@ -71,8 +71,6 @@ pub fn sync_chainstate_to_el(
 }
 
 /// Sync missing or invalid L2 block status using chainstate.
-///
-/// TODO: retry on network errors
 pub fn sync_chainstate_l2_status(storage: &NodeStorage) -> Result<(), Error> {
     let chainstate_manager = storage.chainstate();
     let l2_block_manager = storage.l2();

--- a/bin/strata-client/src/el_sync.rs
+++ b/bin/strata-client/src/el_sync.rs
@@ -1,4 +1,4 @@
-use strata_db::DbError;
+use strata_db::{traits::BlockStatus, DbError};
 use strata_eectl::{
     engine::{ExecEngineCtl, L2BlockRef},
     errors::EngineError,
@@ -65,6 +65,55 @@ pub fn sync_chainstate_to_el(
 
         engine.submit_payload(payload)?;
         engine.update_safe_block(*tip_blockid)?;
+    }
+
+    Ok(())
+}
+
+/// Sync missing or invalid L2 block status using chainstate.
+///
+/// TODO: retry on network errors
+pub fn sync_chainstate_l2_status(storage: &NodeStorage) -> Result<(), Error> {
+    let chainstate_manager = storage.chainstate();
+    let l2_block_manager = storage.l2();
+    let earliest_idx = chainstate_manager.get_earliest_write_idx_blocking()?;
+    let latest_idx = chainstate_manager.get_last_write_idx_blocking()?;
+
+    info!(%earliest_idx, %latest_idx, "search for last known idx");
+
+    // last idx of chainstate whose corresponding block is present in el
+    let sync_from_idx = find_last_match((earliest_idx, latest_idx), |idx| {
+        let Some(entry) = chainstate_manager.get_toplevel_chainstate_blocking(idx)? else {
+            return Err(Error::MissingChainstate(idx));
+        };
+
+        match l2_block_manager.get_block_status_blocking(entry.tip_blockid())? {
+            Some(BlockStatus::Valid) => Ok(true),
+            _ => Ok(false),
+        }
+    })?
+    .map(|idx| idx + 1) // sync from next index
+    .unwrap_or(0); // sync from genesis
+
+    info!(%sync_from_idx, "last valid status");
+
+    for idx in sync_from_idx..=latest_idx {
+        debug!(?idx, "Syncing chainstate to L2 status");
+        let Some(chainstate_entry) = chainstate_manager.get_toplevel_chainstate_blocking(idx)?
+        else {
+            return Err(Error::MissingChainstate(idx));
+        };
+
+        let tip_blockid = chainstate_entry.tip_blockid();
+
+        if l2_block_manager
+            .get_block_data_blocking(tip_blockid)?
+            .is_none()
+        {
+            return Err(Error::MissingL2Block(*tip_blockid));
+        };
+
+        l2_block_manager.set_block_status_blocking(tip_blockid, BlockStatus::Valid)?;
     }
 
     Ok(())

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -47,7 +47,7 @@ use tokio::{
 };
 use tracing::*;
 
-use crate::{args::Args, helpers::*};
+use crate::{args::Args, el_sync::sync_chainstate_l2_status, helpers::*};
 
 mod args;
 mod el_sync;
@@ -289,6 +289,10 @@ fn do_startup_checks(
     };
 
     let (last_chain_state, tip_blockid) = last_chain_state_entry.to_parts();
+
+    // check that L2 block for latest chainstate is marked valid
+    sync_chainstate_l2_status(storage)?;
+
     // Check that we can connect to bitcoin client and block we believe to be matured in L1 is
     // actually present
     let safe_l1blockid = last_chain_state.l1_view().safe_block().blkid();

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -524,6 +524,8 @@ fn process_fc_message(
                 }
             };
 
+            strata_common::check_bail_trigger("fcm_post_block");
+
             let status = if ok {
                 // check if any pending blocks can be finalized
                 if let Err(err) = handle_epoch_finalization(fcm_state, engine) {

--- a/functional-tests/factory/factory.py
+++ b/functional-tests/factory/factory.py
@@ -134,6 +134,25 @@ class StrataFactory(flexitest.Factory):
         svc = flexitest.service.ProcService(props, cmd, stdout=logfile)
         svc.start()
         _inject_service_create_rpc(svc, rpc_url, "sequencer")
+
+        def snapshot_dir_path(idx: int):
+            return f"{datadir}.{idx}"
+
+        def _snapshot_datadir(idx: int):
+            snapshot_dir = snapshot_dir_path(idx)
+            os.makedirs(snapshot_dir, exist_ok=True)
+            shutil.copytree(datadir, snapshot_dir, dirs_exist_ok=True)
+
+        def _restore_snapshot(idx: int):
+            assert not svc.is_started(), "Should call restore only when service is stopped"
+            snapshot_dir = snapshot_dir_path(idx)
+            assert os.path.exists(snapshot_dir)
+            os.rename(datadir, f"{datadir}.b.{idx}")
+            os.rename(snapshot_dir, datadir)
+
+        svc.snapshot_datadir = _snapshot_datadir
+        svc.restore_snapshot = _restore_snapshot
+
         return svc
 
 
@@ -333,6 +352,7 @@ class RethFactory(flexitest.Factory):
         svc.create_web3 = _create_web3
         svc.snapshot_datadir = _snapshot_datadir
         svc.restore_snapshot = _restore_snapshot
+        svc.datadir = datadir
 
         return svc
 

--- a/functional-tests/tests/cl_reorg_resume_blockproduction.py
+++ b/functional-tests/tests/cl_reorg_resume_blockproduction.py
@@ -1,0 +1,134 @@
+import flexitest
+from web3 import Web3
+
+from envs import net_settings, testenv
+from utils import *
+
+
+def send_tx(web3: Web3):
+    dest = web3.to_checksum_address("deedf001900dca3ebeefdeadf001900dca3ebeef")
+    txid = web3.eth.send_transaction(
+        {
+            "to": dest,
+            "value": hex(1),
+            "gas": hex(100000),
+            "from": web3.address,
+        }
+    )
+    print("txid", txid.to_0x_hex())
+
+    web3.eth.wait_for_transaction_receipt(txid, timeout=5)
+
+
+@flexitest.register
+class CLReorgResumeBlockProductionTest(testenv.StrataTester):
+    """This tests sync when el is missing blocks"""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(
+            testenv.BasicEnvConfig(
+                101,
+                prover_client_settings=ProverClientSettings.new_with_proving(),
+                rollup_settings=net_settings.get_fast_batch_settings(),
+            )
+        )
+
+    def main(self, ctx: flexitest.RunContext):
+        seq = ctx.get_service("sequencer")
+        seq_signer = ctx.get_service("sequencer_signer")
+        reth = ctx.get_service("reth")
+        web3: Web3 = reth.create_web3()
+
+        seqrpc = seq.create_rpc()
+        rethrpc = reth.create_rpc()
+
+        wait_for_genesis(seqrpc, timeout=20)
+
+        # workaround for issue restarting reth with no transactions
+        for _ in range(3):
+            send_tx(web3)
+
+        wait_until_epoch_finalized(seqrpc, 0, timeout=30)
+
+        # ensure there are some blocks generated
+        wait_until(
+            lambda: int(rethrpc.eth_blockNumber(), base=16) > 0,
+            error_with="not building blocks",
+            timeout=5,
+        )
+
+        print("stop sequencer")
+        seq_signer.stop()
+        orig_blocknumber = seqrpc.strata_syncStatus()["tip_height"]
+        print(f"stop seq @{orig_blocknumber}")
+        seq.stop()
+
+        reth.stop()
+
+        # take snapshot of sequencer db
+        SNAPSHOT_IDX = 1
+        seq.snapshot_datadir(SNAPSHOT_IDX)
+
+        print("start reth")
+        reth.start()
+
+        # wait for reth to start
+        wait_until(
+            lambda: int(rethrpc.eth_blockNumber(), base=16) > 0,
+            error_with="reth did not start in time",
+            timeout=5,
+        )
+
+        print("start sequencer")
+        seq.start()
+        seq_signer.start()
+
+        # generate more blocks
+        wait_until(
+            lambda: int(rethrpc.eth_blockNumber(), base=16) > orig_blocknumber + 1,
+            error_with="not building blocks",
+            timeout=5,
+        )
+
+        print("stop sequencer")
+        seq_signer.stop()
+        final_blocknumber = seqrpc.strata_syncStatus()["tip_height"]
+        print(f"stop reth @{final_blocknumber}")
+
+        original_el_blockhash = rethrpc.eth_getBlockByNumber(hex(final_blocknumber), False)["hash"]
+
+        seq.stop()
+
+        reth.stop()
+
+        # replace sequencer db with older snapshot
+        seq.restore_snapshot(SNAPSHOT_IDX)
+
+        # sequencer now contains less blocks than in reth
+        print("start reth")
+        reth.start()
+
+        print("start sequencer")
+        seq.start()
+        # wait for reth to start
+        wait_until(
+            lambda: seqrpc.strata_syncStatus()["tip_height"] > 0,
+            error_with="reth did not start in time",
+            timeout=5,
+        )
+        # ensure sequencer db was reset to shorter chain
+        assert seqrpc.strata_syncStatus()["tip_height"] < final_blocknumber
+
+        seq_signer.start()
+
+        print("wait for block production to resume")
+        wait_until(
+            lambda: seqrpc.strata_syncStatus()["tip_height"] > final_blocknumber,
+            error_with="not syncing blocks",
+            timeout=10,
+        )
+
+        new_el_blockhash = rethrpc.eth_getBlockByNumber(hex(final_blocknumber), False)["hash"]
+        print(final_blocknumber, original_el_blockhash, new_el_blockhash)
+
+        assert original_el_blockhash != new_el_blockhash

--- a/functional-tests/tests/crash/crash_fcm_post_block.py
+++ b/functional-tests/tests/crash/crash_fcm_post_block.py
@@ -1,0 +1,22 @@
+import flexitest
+
+from envs import testenv
+from mixins import seq_crash_mixin
+from utils import wait_until
+
+
+@flexitest.register
+class CrashFcmPostBlockTest(seq_crash_mixin.SeqCrashMixin):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(testenv.BasicEnvConfig(101))
+
+    def main(self, ctx: flexitest.RunContext):
+        cur_chain_tip = self.handle_bail(lambda: "fcm_post_block")
+
+        wait_until(
+            lambda: self.seqrpc.strata_clientStatus()["chain_tip_slot"] > cur_chain_tip + 1,
+            error_with="chain tip slot not progressing",
+            timeout=20,
+        )
+
+        return True


### PR DESCRIPTION
## Description
Fixes for 2 error cases:
1. when strata client reorgs, alpen-reth client should follow
  a. use reth fork with required changes to allow block generation at fork of ancestor of canonical chain
2. fix missing db entries after strata-client restart during FCM processing (after `handle_new_block`) 

NOTE: The change in this linked reth fork does not need to be upstreamed. An equivalent feature has already been merged into reth 1.5.0. This release is using to reth 1.1.5, thus requiring the fork. This fork does not need to be maintained post testnet 1 lifetime. 

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
