### PR TITLE
[releases/0.2.0] STR-1194 make alpen-cli constants configurable 

### DIFF
--- a/bin/alpen-cli/src/cmd/deposit.rs
+++ b/bin/alpen-cli/src/cmd/deposit.rs
@@ -20,7 +20,7 @@ use strata_primitives::constants::RECOVER_DELAY;
 
 use crate::{
     alpen::AlpenWallet,
-    constants::{BRIDGE_IN_AMOUNT, RECOVER_AT_DELAY, SIGNET_BLOCK_TIME},
+    constants::{RECOVER_AT_DELAY, SIGNET_BLOCK_TIME},
     errors::{DisplayableError, DisplayedError},
     link::{OnchainObject, PrettyPrint},
     recovery::DescriptorRecovery,
@@ -77,7 +77,7 @@ pub async fn deposit(
     let alpen_address = requested_alpen_address.unwrap_or(l2w.default_signer_address());
     println!(
         "Bridging {} to Alpen address {}",
-        BRIDGE_IN_AMOUNT.to_string().green(),
+        settings.bridge_in_amount.to_string().green(),
         alpen_address.to_string().cyan(),
     );
 
@@ -143,7 +143,7 @@ pub async fn deposit(
         let mut builder = l1w.build_tx();
         // Important: the deposit won't be found by the sequencer if the order isn't correct.
         builder.ordering(TxOrdering::Untouched);
-        builder.add_recipient(bridge_in_address.script_pubkey(), BRIDGE_IN_AMOUNT);
+        builder.add_recipient(bridge_in_address.script_pubkey(), settings.bridge_in_amount);
         builder.add_data(&push_bytes);
         builder.fee_rate(fee_rate);
         match builder.finish() {

--- a/bin/alpen-cli/src/cmd/withdraw.rs
+++ b/bin/alpen-cli/src/cmd/withdraw.rs
@@ -11,7 +11,7 @@ use strata_primitives::bitcoin_bosd::Descriptor;
 
 use crate::{
     alpen::AlpenWallet,
-    constants::{BRIDGE_OUT_AMOUNT, SATS_TO_WEI},
+    constants::SATS_TO_WEI,
     errors::{DisplayableError, DisplayedError},
     link::{OnchainObject, PrettyPrint},
     seed::Seed,
@@ -66,14 +66,17 @@ pub async fn withdraw(
             info.address
         }
     };
-    println!("Bridging out {BRIDGE_OUT_AMOUNT} to {address}");
+
+    println!("Bridging out {} to {address}", settings.bridge_out_amount);
 
     let bosd: Descriptor = address.into();
 
     let tx = l2w
         .transaction_request()
         .with_to(settings.bridge_alpen_address)
-        .with_value(U256::from(BRIDGE_OUT_AMOUNT.to_sat() as u128 * SATS_TO_WEI))
+        .with_value(U256::from(
+            settings.bridge_out_amount.to_sat() as u128 * SATS_TO_WEI,
+        ))
         // calldata for the Alpen EVM-BOSD descriptor
         .input(TransactionInput::new(bosd.to_bytes().into()));
 

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -16,10 +16,10 @@ pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 
 /// 10 BTC + 1,000 satoshi to cover fees in the following transaction where the bridge spends it
 /// into the federation.
-pub const BRIDGE_IN_AMOUNT: Amount = Amount::from_sat(1_000_001_000);
+pub const DEFAULT_BRIDGE_IN_AMOUNT: Amount = Amount::from_sat(1_000_001_000);
 
 /// Bridge outs are enforced to be exactly 10 BTC
-pub const BRIDGE_OUT_AMOUNT: Amount = Amount::from_int_btc(10);
+pub const DEFAULT_BRIDGE_OUT_AMOUNT: Amount = Amount::from_int_btc(10);
 
 pub const BTC_TO_WEI: u128 = ETH_TO_WEI;
 pub const SATS_TO_WEI: u128 = BTC_TO_WEI / 100_000_000;
@@ -36,7 +36,7 @@ pub const AES_TAG_LEN: usize = 16;
 pub const MAGIC_BYTES_LEN: usize = 4;
 
 pub const DEFAULT_NETWORK: Network = Network::Signet;
-pub const BRIDGE_ALPEN_ADDRESS: &str = "0x5400000000000000000000000000000000000001";
+pub const DEFAULT_BRIDGE_ALPEN_ADDRESS: &str = "0x5400000000000000000000000000000000000001";
 pub const SIGNET_BLOCK_TIME: Duration = Duration::from_secs(10 * 60); // 10 minutes
 
 /// Alpen CLI [`DerivationPath`](bdk_wallet::bitcoin::bip32::DerivationPath) for Alpen EVM wallet

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -2,15 +2,10 @@ use std::time::Duration;
 
 use alloy::consensus::constants::ETH_TO_WEI;
 use bdk_wallet::bitcoin::{bip32::ChildNumber, Amount, Network};
-use strata_primitives::constants::RECOVER_DELAY;
 
 /// Number of blocks that the wallet considers a transaction "buried" or final taking into account
 /// reorgs that might happen.
 pub const FINALITY_DEPTH: u32 = 6;
-
-/// Number of blocks after which the wallet actually enables recovery. This is mostly to account
-/// for any reorgs that may happen at the recovery height.
-pub const RECOVER_AT_DELAY: u32 = RECOVER_DELAY + FINALITY_DEPTH;
 
 pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 

--- a/bin/alpen-cli/src/settings.rs
+++ b/bin/alpen-cli/src/settings.rs
@@ -13,6 +13,7 @@ use config::Config;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use shrex::Hex;
+use strata_primitives::constants::RECOVER_DELAY as DEFAULT_RECOVER_DELAY;
 use terrors::OneOf;
 
 use crate::{
@@ -37,6 +38,7 @@ pub struct SettingsFromFile {
     pub bridge_pubkey: Hex<[u8; 32]>,
     pub magic_bytes: String,
     pub network: Option<Network>,
+    pub recover_delay: Option<u32>,
     pub bridge_in_amount_sats: Option<u64>,
     pub bridge_out_amount_sats: Option<u64>,
     pub bridge_alpen_address: Option<String>,
@@ -60,6 +62,7 @@ pub struct Settings {
     pub network: Network,
     pub config_file: PathBuf,
     pub signet_backend: Arc<dyn SignetBackend>,
+    pub recover_delay: u32,
     pub bridge_in_amount: Amount,
     pub bridge_out_amount: Amount,
 }
@@ -143,6 +146,7 @@ impl Settings {
             network: from_file.network.unwrap_or(DEFAULT_NETWORK),
             config_file: CONFIG_FILE.clone(),
             signet_backend: sync_backend,
+            recover_delay: from_file.recover_delay.unwrap_or(DEFAULT_RECOVER_DELAY),
             bridge_in_amount: from_file
                 .bridge_in_amount_sats
                 .map(Amount::from_sat)


### PR DESCRIPTION
## Description
Adds optional file config for following in alpen-cli:
* recover_delay
* bridge_in_amount_sats
* bridge_out_amount_sats
* bridge_alpen_address

This is mainly intended for testing in different environments. The default values of these options should suffice for normal deployments.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
