### PR TITLE
(chaintsn): Correctly check if we are expecting null epoch's checkpoint

### DIFF
--- a/crates/chaintsn/src/errors.rs
+++ b/crates/chaintsn/src/errors.rs
@@ -67,4 +67,7 @@ pub enum OpError {
     /// Used to discard checkpoints we aren't looking for.
     #[error("op does not advance the finalized epoch")]
     EpochNotExtend,
+
+    #[error("checkpoint data is malformed")]
+    MalformedCheckpoint,
 }

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -243,6 +243,11 @@ fn process_l1_checkpoint(
         return Err(OpError::EpochNotExtend);
     }
 
+    // Also just check if the epoch numbers in batch transition and batch info match
+    if ckpt_epoch != ckpt.batch_info().epoch() {
+        return Err(OpError::MalformedCheckpoint);
+    }
+
     // TODO refactor this to encapsulate the conditional verification into
     // another fn so we don't have to think about it here
     if receipt.proof().is_empty() {


### PR DESCRIPTION
## Description

There's a small issue in OL block processing. When a checkpoint containing 0 epoch is posted to L1 even after some other epoch > 0 has been finalized, the current logic incorrectly passes that through the epoch continuity check(whether the current epoch matches the previous epoch or not).
This PR fixes that check and also adds an extra check to see if the batch info and batch transition in the checkpoint refer to same epoch.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
