### PR TITLE
STR-1593 fix l1 reader sync event crash

### DIFF
--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -4,6 +4,7 @@ name = "strata-btcio"
 version = "0.2.0"
 
 [dependencies]
+strata-common = { workspace = true, default-features = true }
 strata-config.workspace = true
 strata-db.workspace = true
 strata-primitives.workspace = true

--- a/crates/btcio/src/reader/handler.rs
+++ b/crates/btcio/src/reader/handler.rs
@@ -1,5 +1,6 @@
 use bitcoin::{consensus::serialize, hashes::Hash, Block};
 use bitcoind_async_client::traits::Reader;
+use strata_common::check_bail_trigger;
 use strata_primitives::{
     buf::Buf32,
     l1::{
@@ -74,7 +75,7 @@ async fn handle_blockdata<R: Reader>(
 
     storage.l1().put_block_data_async(manifest).await?;
 
-    strata_common::check_bail_trigger("btcio_pre_l1_write");
+    check_bail_trigger("btcio_pre_l1_write");
 
     // Create a sync event if it's something we care about.
     let blkid: Buf32 = blockdata.block().block_hash().into();
@@ -86,7 +87,7 @@ async fn handle_blockdata<R: Reader>(
         .await?;
     info!(%height, %l1blockid, txs = %num_txs, sync_ev = %sync_event_idx, "wrote L1 block manifest");
 
-    strata_common::check_bail_trigger("btcio_post_l1_write");
+    check_bail_trigger("btcio_post_l1_write");
 
     sync_evs.push(sync_event_idx);
 

--- a/crates/btcio/src/reader/handler.rs
+++ b/crates/btcio/src/reader/handler.rs
@@ -42,7 +42,7 @@ pub(crate) async fn handle_bitcoin_event<R: Reader>(
 
     // Write to sync event db.
     for ev in sync_evs {
-        event_submitter.submit_event_idx_async(ev).await?;
+        event_submitter.submit_event_idx_async(ev).await;
     }
     Ok(())
 }

--- a/crates/consensus-logic/src/csm/ctl.rs
+++ b/crates/consensus-logic/src/csm/ctl.rs
@@ -60,4 +60,15 @@ impl EventSubmitter for CsmController {
 
         Ok(())
     }
+
+    async fn submit_event_idx_async(&self, ev_idx: u64) -> anyhow::Result<()> {
+        let msg = CsmMessage::EventInput(ev_idx);
+        if self.csm_tx.send(msg).await.is_err() {
+            warn!(%ev_idx, "sync event receiver closed when submitting");
+        } else {
+            trace!(%ev_idx, "sent csm event input");
+        }
+
+        Ok(())
+    }
 }

--- a/crates/consensus-logic/src/csm/ctl.rs
+++ b/crates/consensus-logic/src/csm/ctl.rs
@@ -61,14 +61,12 @@ impl EventSubmitter for CsmController {
         Ok(())
     }
 
-    async fn submit_event_idx_async(&self, ev_idx: u64) -> anyhow::Result<()> {
+    async fn submit_event_idx_async(&self, ev_idx: u64) {
         let msg = CsmMessage::EventInput(ev_idx);
         if self.csm_tx.send(msg).await.is_err() {
             warn!(%ev_idx, "sync event receiver closed when submitting");
         } else {
             trace!(%ev_idx, "sent csm event input");
         }
-
-        Ok(())
     }
 }

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -170,7 +170,7 @@ pub fn client_worker_task<E: ExecEngineCtl>(
             &shutdown,
         ) {
             error!(err = %e, ?msg, "failed to process sync message, aborting!");
-            break;
+            return Err(e);
         }
 
         if shutdown.should_shutdown() {

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -62,6 +62,24 @@ pub trait L1Database {
     /// remove canonical chain records in given range (inclusive)
     fn remove_canonical_chain_entries(&self, start_height: u64, end_height: u64) -> DbResult<()>;
 
+    /// Set a specific height, blockid in canonical chain records and insert new sync event
+    /// atomically.
+    fn set_canonical_chain_entry_and_write_sync_event(
+        &self,
+        height: u64,
+        blockid: L1BlockId,
+        ev: SyncEvent,
+    ) -> DbResult<u64>;
+
+    /// remove canonical chain records in given range (inclusive) and insert new sync event
+    /// atomically.
+    fn remove_canonical_chain_entries_and_write_sync_event(
+        &self,
+        start_height: u64,
+        end_height: u64,
+        ev: SyncEvent,
+    ) -> DbResult<u64>;
+
     /// Prune earliest blocks till height
     fn prune_to_height(&self, height: u64) -> DbResult<()>;
 

--- a/crates/state/src/sync_event.rs
+++ b/crates/state/src/sync_event.rs
@@ -38,4 +38,6 @@ pub trait EventSubmitter {
     fn submit_event(&self, sync_event: SyncEvent) -> anyhow::Result<()>;
     /// Submit event async
     async fn submit_event_async(&self, sync_event: SyncEvent) -> anyhow::Result<()>;
+
+    async fn submit_event_idx_async(&self, sync_idx: u64) -> anyhow::Result<()>;
 }

--- a/crates/state/src/sync_event.rs
+++ b/crates/state/src/sync_event.rs
@@ -39,5 +39,5 @@ pub trait EventSubmitter {
     /// Submit event async
     async fn submit_event_async(&self, sync_event: SyncEvent) -> anyhow::Result<()>;
 
-    async fn submit_event_idx_async(&self, sync_idx: u64) -> anyhow::Result<()>;
+    async fn submit_event_idx_async(&self, sync_idx: u64);
 }

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use strata_db::traits::*;
 use strata_primitives::l1::{L1BlockId, L1BlockManifest, L1Tx, L1TxRef};
+use strata_state::sync_event::SyncEvent;
 
 use crate::exec::*;
 
@@ -21,5 +22,8 @@ inst_ops_simple! {
         get_block_txs(blockid: L1BlockId) => Option<Vec<L1TxRef>>;
         get_tx(tx_ref: L1TxRef) => Option<L1Tx>;
         // get_mmr(blockid: L1BlockId) => Option<CompactMmr>;
+
+        set_canonical_chain_entry_and_write_sync_event(height: u64, blockid: L1BlockId, ev: SyncEvent) => u64;
+        remove_canonical_chain_entries_and_write_sync_event(start_height: u64, end_height: u64, ev: SyncEvent) => u64;
     }
 }

--- a/functional-tests/tests/crash/crash_btcio_post_l1_write.py
+++ b/functional-tests/tests/crash/crash_btcio_post_l1_write.py
@@ -1,0 +1,30 @@
+import flexitest
+
+from envs import testenv
+from mixins import seq_crash_mixin
+from utils import ProverClientSettings, wait_until
+
+
+@flexitest.register
+class CrashBtcioSyncEventTest(seq_crash_mixin.SeqCrashMixin[int]):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(
+            testenv.BasicEnvConfig(
+                101,
+                prover_client_settings=ProverClientSettings.new_default(),
+            )
+        )
+
+    def get_recovery_metric(self):
+        return self.seqrpc.strata_clientStatus()["tip_l1_block"]["height"]
+
+    def main(self, ctx: flexitest.RunContext):
+        cur_tip_block = self.handle_bail(lambda: "btcio_post_l1_write")
+
+        wait_until(
+            lambda: self.get_recovery_metric() > cur_tip_block,
+            error_with="client state not progressing",
+            timeout=20,
+        )
+
+        return True

--- a/functional-tests/tests/crash/crash_btcio_pre_l1_write.py
+++ b/functional-tests/tests/crash/crash_btcio_pre_l1_write.py
@@ -1,0 +1,30 @@
+import flexitest
+
+from envs import testenv
+from mixins import seq_crash_mixin
+from utils import ProverClientSettings, wait_until
+
+
+@flexitest.register
+class CrashBtcioSyncEventTest(seq_crash_mixin.SeqCrashMixin[int]):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(
+            testenv.BasicEnvConfig(
+                101,
+                prover_client_settings=ProverClientSettings.new_default(),
+            )
+        )
+
+    def get_recovery_metric(self):
+        return self.seqrpc.strata_clientStatus()["tip_l1_block"]["height"]
+
+    def main(self, ctx: flexitest.RunContext):
+        cur_tip_block = self.handle_bail(lambda: "btcio_pre_l1_write")
+
+        wait_until(
+            lambda: self.get_recovery_metric() > cur_tip_block,
+            error_with="client state not progressing",
+            timeout=20,
+        )
+
+        return True

--- a/functional-tests/tests/crash/crash_duty_sign_block.py
+++ b/functional-tests/tests/crash/crash_duty_sign_block.py
@@ -6,7 +6,7 @@ from utils import wait_until
 
 
 @flexitest.register
-class CrashDutySignBlockTest(seq_crash_mixin.SeqCrashMixin):
+class CrashDutySignBlockTest(seq_crash_mixin.DefaultSeqCrashMixin):
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env(testenv.BasicEnvConfig(101))
 
@@ -14,7 +14,7 @@ class CrashDutySignBlockTest(seq_crash_mixin.SeqCrashMixin):
         cur_chain_tip = self.handle_bail(lambda: "duty_sign_block")
 
         wait_until(
-            lambda: self.seqrpc.strata_clientStatus()["chain_tip_slot"] > cur_chain_tip,
+            lambda: self.get_recovery_metric() > cur_chain_tip,
             error_with="chain tip slot not progressing",
             timeout=20,
         )

--- a/functional-tests/tests/crash/crash_fcm_new_block.py
+++ b/functional-tests/tests/crash/crash_fcm_new_block.py
@@ -6,7 +6,7 @@ from utils import wait_until
 
 
 @flexitest.register
-class CrashFcmNewBlockTest(seq_crash_mixin.SeqCrashMixin):
+class CrashFcmNewBlockTest(seq_crash_mixin.DefaultSeqCrashMixin):
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env(testenv.BasicEnvConfig(101))
 
@@ -14,7 +14,7 @@ class CrashFcmNewBlockTest(seq_crash_mixin.SeqCrashMixin):
         cur_chain_tip = self.handle_bail(lambda: "fcm_new_block")
 
         wait_until(
-            lambda: self.seqrpc.strata_clientStatus()["chain_tip_slot"] > cur_chain_tip + 1,
+            lambda: self.get_recovery_metric() > cur_chain_tip + 1,
             error_with="chain tip slot not progressing",
             timeout=20,
         )

--- a/functional-tests/tests/crash/crash_fcm_post_block.py
+++ b/functional-tests/tests/crash/crash_fcm_post_block.py
@@ -6,7 +6,7 @@ from utils import wait_until
 
 
 @flexitest.register
-class CrashFcmPostBlockTest(seq_crash_mixin.SeqCrashMixin):
+class CrashFcmPostBlockTest(seq_crash_mixin.DefaultSeqCrashMixin):
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env(testenv.BasicEnvConfig(101))
 
@@ -14,7 +14,7 @@ class CrashFcmPostBlockTest(seq_crash_mixin.SeqCrashMixin):
         cur_chain_tip = self.handle_bail(lambda: "fcm_post_block")
 
         wait_until(
-            lambda: self.seqrpc.strata_clientStatus()["chain_tip_slot"] > cur_chain_tip + 1,
+            lambda: self.get_recovery_metric() > cur_chain_tip + 1,
             error_with="chain tip slot not progressing",
             timeout=20,
         )

--- a/functional-tests/tests/crash/crash_sync_event.py
+++ b/functional-tests/tests/crash/crash_sync_event.py
@@ -6,7 +6,7 @@ from utils import wait_until
 
 
 @flexitest.register
-class CrashSyncEventTest(seq_crash_mixin.SeqCrashMixin):
+class CrashSyncEventTest(seq_crash_mixin.DefaultSeqCrashMixin):
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env(testenv.BasicEnvConfig(101))
 
@@ -14,7 +14,7 @@ class CrashSyncEventTest(seq_crash_mixin.SeqCrashMixin):
         cur_chain_tip = self.handle_bail(lambda: "sync_event")
 
         wait_until(
-            lambda: self.seqrpc.strata_clientStatus()["chain_tip_slot"] > cur_chain_tip,
+            lambda: self.get_recovery_metric() > cur_chain_tip,
             error_with="chain tip slot not progressing",
             timeout=20,
         )

--- a/functional-tests/tests/crash/crash_sync_event_finalize_epoch.py
+++ b/functional-tests/tests/crash/crash_sync_event_finalize_epoch.py
@@ -6,7 +6,7 @@ from utils import ProverClientSettings, wait_until
 
 
 @flexitest.register
-class CrashSyncEventFinalizeEpochTest(seq_crash_mixin.SeqCrashMixin):
+class CrashSyncEventFinalizeEpochTest(seq_crash_mixin.DefaultSeqCrashMixin):
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env(
             testenv.BasicEnvConfig(
@@ -20,7 +20,7 @@ class CrashSyncEventFinalizeEpochTest(seq_crash_mixin.SeqCrashMixin):
         cur_chain_tip = self.handle_bail(lambda: "sync_event_finalize_epoch", timeout=60)
 
         wait_until(
-            lambda: self.seqrpc.strata_syncStatus()["tip_height"] > cur_chain_tip + 1,
+            lambda: self.get_recovery_metric() > cur_chain_tip + 1,
             error_with="chain tip slot not progressing",
         )
 


### PR DESCRIPTION
## Description
- [x] CSM should propagate error to task manager to trigger shutdown/restart
- [x] prevent db inconsistency between l1 and sync_event dbs due to crash during btcio reader db writes

Note: in btcio reader, setting an l1 block as canonical and posting its corresponding sync event needs to be atomic in current implementation. As a quick fix, these operations have been put in a single db transaction, but this breaks the separation between l1 and sync_event dbs. 
Need to better handle cross database (and also cross system) atomicity, or ensure the code does not require atomicity in regards to persistence.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
