### PR TITLE
ci: fix name for test-coverage

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/functional.yml
 
   publish-coverage:
-    name: Check that unit tests pass
+    name: Check that all tests pass
     runs-on: ubuntu-latest
     if: always()
     needs: [functional-tests, unit-tests]


### PR DESCRIPTION
## Description

Now that we unified the testing CI the current name is confusing since it covers all the tests and not only unit:

https://github.com/alpenlabs/alpen/blob/78224829a07c1c3562ae646fefefbb3bd84ffd48/.github/workflows/test-coverage.yml#L21-L31


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

NOTE to myself: need to update the merging rules for `main` after this is merged.

## Checklist


- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
