### PR TITLE
ci: fix test-coverage.yml

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -181,7 +181,7 @@ jobs:
           cargo llvm-cov -F debug-utils report --lcov > lcov.functional.info
 
       - name: Upload coverage lcov artifact
-        if: steps.genFunctionalLcov.outcome == 'success'
+        if: hashFiles('lcov.functional.info') != ''
         continue-on-error: true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Description

Fix functional test coverage artifact upload failure in GitHub Actions workflow.

The coverage generation step was failing due to corrupted LLVM profile data files, but because it used `continue-on-error: true`, the step appeared successful while no coverage file was actually created.

This caused the subsequent artifact upload to be skipped, which in turn caused the test coverage job to fail when trying to download the non-existent artifact.

<img width="2722" height="1122" alt="CleanShot 2025-07-24 at 17 18 23@2x" src="https://github.com/user-attachments/assets/8d7ba0fa-4ba3-4633-8d6e-8b6ddf77752a" />

See: https://github.com/alpenlabs/alpen/actions/runs/16504944182/job/46674140939

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The issue was in the conditional logic for uploading the coverage artifact.
The original condition `if: steps.genFunctionalLcov.outcome == 'success'` was checking the step outcome, but when a step has `continue-on-error: true`, it can appear successful even when the underlying command fails.

The fix changes the condition to `if: hashFiles('lcov.functional.info') != ''` which directly checks if the coverage file was actually created, regardless of the step outcome.

The root cause was corrupted `.profraw` files causing `llvm-profdata merge` to fail, but this fix ensures the workflow continues gracefully even when coverage generation fails.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None
