### PR TITLE
fix: gas price handling when from_rpc is true

### DIFF
--- a/functional-tests/utils/transaction.py
+++ b/functional-tests/utils/transaction.py
@@ -69,7 +69,7 @@ class TransactionBuilder(_TransactionFaucet):
             tx.setdefault("accessList", [{"address": tx["to"], "storageKeys": []}])
 
             tx.setdefault(
-                "gasPrice", self.w3.eth.gas_price if from_rpc else self.w3.to_wei("1", "gwei")
+                "gasPrice", self.w3.eth.gas_price if not from_rpc else self.w3.to_wei("1", "gwei"))
             )
 
         elif tx_type == TransactionType.EIP1559:


### PR DESCRIPTION
## Description

fixed the backwards logic for `from_rpc`.
now when `from_rpc` is true, the script actually fetches the current gas price from the network instead of using a hardcoded 1 gwei.
this should prevent transactions from getting stuck due to wrong gas pricing.

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactor
* [ ] New or updated tests
* [ ] Dependency Update

## Notes to Reviewers

just a quick fix on the gas price logic - nothing else changed. should be smooth to review.

## Checklist

* [x] I have performed a self-review of my code.
* [x] I have commented my code where necessary.
* [ ] I have updated the documentation if needed.
* [x] My changes do not introduce new warnings.
* [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
* [ ] New and existing tests pass with my changes.