### PR TITLE
feat: initial Nixification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,8 @@ Makefile               @alpenlabs/rust @alpenlabs/ci @alpenlabs/bin
 codecov.yml            @alpenlabs/ci
 contrib/               @alpenlabs/ci   @alpenlabs/bin
 tests/                 @alpenlabs/rust @alpenlabs/ci
+**/*.nix               @alpenlabs/ci
+flake.lock             @alpenlabs/ci
 
 # Libs
 # Note that the globbing here is to future-proof against new crates

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,135 @@
+name: Nix
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+permissions: {}
+
+jobs:
+  self-care:
+    name: Flake self-check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
+        with:
+          fail-mode: true
+
+  build-packages:
+    name: "${{ matrix.os-name }} - Build ${{ matrix.package }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        package:
+          # TODO: add more packages
+          - alpen-cli
+        include:
+          - os: ubuntu-latest
+            os-name: "Linux"
+          - os: macos-latest
+            os-name: "Apple Silicon"
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@379b47b8e270e906339a489d56466ccfd2f69d8c # v3.8.5
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until the Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824
+          gc-max-store-size-linux: 1G
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: nix-${{ runner.os }}-
+          # created more than this number of seconds ago
+          purge-created: 0
+          # or, last accessed more than this number of seconds ago
+          # relative to the start of the `Post Restore and save Nix store` phase
+          purge-last-accessed: 0
+          # except any version with the key that is the same as the `primary-key`
+          purge-primary-key: never
+
+      - name: "Build ${{ matrix.package }}"
+        run: nix build -L --show-trace .#${{ matrix.package }}
+
+  devshell:
+    name: "${{ matrix.os-name }} - Test devshells"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os-name: "Linux"
+          - os: macos-latest
+            os-name: "Apple Silicon"
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@379b47b8e270e906339a489d56466ccfd2f69d8c # v3.8.5
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until the Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824
+          gc-max-store-size-linux: 1G
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: nix-${{ runner.os }}-
+          # created more than this number of seconds ago
+          purge-created: 0
+          # or, last accessed more than this number of seconds ago
+          # relative to the start of the `Post Restore and save Nix store` phase
+          purge-last-accessed: 0
+          # except any version with the key that is the same as the `primary-key`
+          purge-primary-key: never
+
+      - name: "Test devshell"
+        env:
+          RISC0_SKIP_BUILD_KERNELS: "1"
+        run: nix develop --command bash -c 'cargo build --workspace --all-features --bins --lib --locked'

--- a/.github/workflows/update_flake_lock.yml
+++ b/.github/workflows/update_flake_lock.yml
@@ -1,0 +1,32 @@
+name: Update Flake Lock File
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: "0 0 1 * *" # runs monthly on day 1 at 00:00
+
+permissions: {}
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@90bb610b90bf290cad97484ba341453bd1cbefea # v19
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@c5930b397a673a70ca70be06020e943aeac310a1 # v27
+        with:
+          pr-title: "fix: update flake.lock" # Title of PR to be created
+          pr-labels: | # Labels to be set on the PR
+            dependencies
+            automated

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,13 @@ mutants.out*
 lcov.info
 
 ########
+# Nix
+########
+result
+.envrc
+.direnv
+
+########
 # Python
 ########
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,14 @@ you can run the basic CI checks in your local environment:
   to run functional tests, see instructions in its
   [`README.md`](./functional-tests/README.md).
 
+We also provide a [`flake.nix`](flake.nix) with a `devShell` with all the dependencies
+necessary for local development.
+Install [Nix](https://nixos.org) and run:
+
+```sh
+nix develop
+```
+
 ## Locally running CI
 
 Before you create a PR, make sure that all the required CI checks pass locally.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,208 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754393734,
+        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "risc0-nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "risc0-src": "risc0-src",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1754577772,
+        "narHash": "sha256-6f9vvucM+WqYxN3MIJhG8YjxrnJfF/ZlbRzrAwv+qKY=",
+        "owner": "alpenlabs",
+        "repo": "risc0.nix",
+        "rev": "505d84db8d7dd1eb75bbf7386764a793f25292a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "alpenlabs",
+        "repo": "risc0.nix",
+        "type": "github"
+      }
+    },
+    "risc0-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1706738775,
+        "narHash": "sha256-oxM7tYkFMUhBj1AlxGEbrL/ZqB3yueEilJC0R0aqOZA=",
+        "owner": "risc0",
+        "repo": "rust",
+        "rev": "b2060c0fa7b0f6f42a180e9c85e28bddc174c777",
+        "type": "github"
+      },
+      "original": {
+        "owner": "risc0",
+        "repo": "rust",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "risc0-nix": "risc0-nix",
+        "rust-overlay": "rust-overlay_2",
+        "sp1-nix": "sp1-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "risc0-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754534980,
+        "narHash": "sha256-8cAquqasyPRvgJfKVKxz+gQ+SRoRxiHhX91Avtl9Rn8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "89e92794124b93bddb5f8f92485ed924bd179287",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754575663,
+        "narHash": "sha256-afOx8AG0KYtw7mlt6s6ahBBy7eEHZwws3iCRoiuRQS4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6db0fb0e9cec2e9729dc52bf4898e6c135bb8a0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
+        "nixpkgs": [
+          "sp1-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754534980,
+        "narHash": "sha256-8cAquqasyPRvgJfKVKxz+gQ+SRoRxiHhX91Avtl9Rn8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "89e92794124b93bddb5f8f92485ed924bd179287",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "sp1-nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_3",
+        "sp1-src": "sp1-src"
+      },
+      "locked": {
+        "lastModified": 1754571907,
+        "narHash": "sha256-yv6QQPfEulSr37+jySqO0YH2724AW3E2EWRDTpnj5Bo=",
+        "owner": "alpenlabs",
+        "repo": "sp1.nix",
+        "rev": "866a26afe96b193aff76a50241e2328e148a0558",
+        "type": "github"
+      },
+      "original": {
+        "owner": "alpenlabs",
+        "repo": "sp1.nix",
+        "type": "github"
+      }
+    },
+    "sp1-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754501687,
+        "narHash": "sha256-No5idq4BGD6YGHQ0u5EEnWcMeTsPJBf8wT51lX8NuLg=",
+        "owner": "succinctlabs",
+        "repo": "sp1",
+        "rev": "429e95e00a51db1f3d7257e7db73c7fe0fd40801",
+        "type": "github"
+      },
+      "original": {
+        "owner": "succinctlabs",
+        "repo": "sp1",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,125 @@
+{
+  description = "Alpen Nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    sp1-nix = {
+      url = "github:alpenlabs/sp1.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+    risc0-nix = {
+      url = "github:alpenlabs/risc0.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      sp1-nix,
+      risc0-nix,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlays.default
+            sp1-nix.overlays.default
+            risc0-nix.overlays.default
+          ];
+        };
+        rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        alpen-cli-toml = builtins.fromTOML (builtins.readFile ./bin/alpen-cli/Cargo.toml);
+      in
+      rec {
+        packages = {
+          default = packages.alpen-cli;
+
+          alpen-cli = pkgs.rustPlatform.buildRustPackage {
+            pname = alpen-cli-toml.package.name;
+            version = alpen-cli-toml.package.version;
+            src = ./.;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+            buildType = "release";
+            doCheck = false;
+            cargoBuildFlags = [
+              "--package"
+              "alpen-cli"
+              "--bin"
+              "alpen"
+            ];
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              rust-toolchain
+            ];
+            buildInputs = with pkgs; [
+              openssl
+            ];
+            env = {
+              RISC0_SKIP_BUILD_KERNELS = "1";
+            };
+            meta = {
+              mainProgram = "alpen";
+            };
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            bashInteractive
+            openssl
+
+            # rust
+            rust-toolchain
+
+            # zkVMs
+            cargo-prove
+            sp1-rust-toolchain
+            risc0-toolchain
+
+            # devtools
+            git
+            taplo
+            codespell
+            just
+            cargo-nextest
+            cargo-audit
+            bitcoind
+
+            # C/C++ build dependencies for bindgen and RISC0
+            pkg-config
+            clang
+            llvmPackages.libclang.lib
+            llvmPackages.libcxxStdenv.cc.cc.lib
+            stdenv.cc.cc.lib
+            cmake
+            ninja
+
+            # TODO: Add python stuff from poetry's in functional-tests/
+          ];
+
+          env = {
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.llvmPackages.libcxxStdenv.cc.cc.lib}/lib";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Description

We all know that Nix will conquer the world in portable developer environments and with the best in-class developer experience.

<img width="490" height="486" alt="CleanShot 2025-08-07 at 12 32 51@2x" src="https://github.com/user-attachments/assets/798ff165-6c8d-4151-bdb9-8f28008de8f4" />

This PR adds a basic devshell support with:

- Rust toolchain that follows the `rust-toolchain.toml` file (from [`oxalica/rust-overlay`](https://github.com/oxalica/rust-overlay))
- zkVMs (sourced from our overlays at [`alpenlabs/sp1.nix`](https://github.com/alpenlabs/sp1.nix) and [`alpenlabs/risc0.nix`](https://github.com/alpenlabs/risc0.nix))
- Development tools: `taplo`, `cargo-nextest`, `bitcoind`, etc.
- CI that tests the packages and the devshells.

I am also adding the `alpen-cli` binary as the main package.
You can run in any Nix-enabled setup with either:

- `nix run` (using the `default`)
- `nix run .#alpen-cli`
- `nix run github:alpenlabs/alpen` (without even cloning the repo)

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] Developer environment/Nix

## Notes to Reviewers

There's a bunch of things that we can do in incremental following PRs:

- Aggressive caching of Rust build artifacts with [`ipetkov/crane`](https://github.com/ipetkov/crane) so that `cargo {check,test,clippy}` does not incur major recompiles.
- Automatic git-hooks with [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix). Imagine running `rustfmt`, `clippy`, `rustdocs`, `codespell`, `taplo`, and even tests before committing so that's VIRTUALLY IMPOSSIBLE to unintentionally have commits that break CI.
- Automatic python environment setup from `poetry` with [`nix-community/poetry2nix`](https://github.com/nix-community/poetry2nix)
- (This is controversial) replacing Docker as the testing tool and (even more controversial) as the deployment tool. (Or less controversial) generating 100% reproducible and very lean docker images from nix.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None