### PR TITLE
fix: no need to set status on delete block

### DIFF
--- a/bin/strata-dbtool/src/cmd/chainstate.rs
+++ b/bin/strata-dbtool/src/cmd/chainstate.rs
@@ -4,8 +4,7 @@ use strata_consensus_logic::chain_worker_context::conv_blkid_to_slot_wb_id;
 use strata_db::{
     chainstate::ChainstateDatabase,
     traits::{
-        BlockStatus, CheckpointDatabase, DatabaseBackend, L1BroadcastDatabase, L1WriterDatabase,
-        L2BlockDatabase,
+        CheckpointDatabase, DatabaseBackend, L1BroadcastDatabase, L1WriterDatabase, L2BlockDatabase,
     },
     types::IntentStatus,
 };
@@ -273,16 +272,6 @@ pub(crate) fn revert_chainstate<T: DatabaseBackend, B: L1BroadcastDatabase>(
                 println!("Revert chainstate no write batch found {block_id:?} {slot}");
                 continue;
             }
-
-            // Mark the status to unchecked
-            println!("Revert chainstate marking block unchecked {block_id:?}");
-            core_db
-                .l2_db()
-                .set_block_status(*block_id, BlockStatus::Unchecked)
-                .internal_error(format!(
-                    "Failed to update status for block with id {}",
-                    *block_id
-                ))?;
 
             // Delete blocks if requested
             if args.delete_blocks {


### PR DESCRIPTION
## Description

The fix in #1003 removes status for deleted block, so no need to set block status to `Unchecked`.

Related to [STR-1632](https://alpenlabs.atlassian.net/browse/STR-1632).

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
