### PR TITLE
ci: breakdown coverage from unit vs functional tests

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/functional.yml
 
   publish-coverage:
-    name: Check that all tests pass
+    name: Publish coverage reports
     runs-on: ubuntu-latest
     if: always()
     needs: [functional-tests, unit-tests]
@@ -48,17 +48,18 @@ jobs:
         with:
           name: unit-lcov
 
-      - name: Install lcov
-        run: sudo apt-get update && sudo apt-get install -y lcov
-
-      - name: Merge test coverage
-        run: |
-          lcov --add-tracefile ./lcov.unit.info \
-            --add-tracefile ./lcov.functional.info \
-            --output-file ./lcov.info
-
-      - name: Publish Test Coverage
+      - name: Publish Unit Test Coverage
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.unit.info
+          flags: unit
+          name: unit-coverage
+
+      - name: Publish Functional Test Coverage
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.functional.info
+          flags: functional
+          name: functional-coverage


### PR DESCRIPTION
## Description

[`codecov/codecov-action`](https://github.com/codecov/codecov-action) allows us to use `flags` as a

> Comma-separated list of flags to upload to group coverage metrics.

I think with this we can breakdown and further understand what is being covered by unit tests and what is covered by functional tests in `codecov`.

Did my own research and asked `gemini` to do the changes. Had to manually review and do the final polish.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I also removed the step that install `lcov` since we don't need that anymore in the `publish-coverage` job in `test-coverage.yml`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1624
