### PR TITLE
fix(primitives): cleaner Display/Debug for block commitment types

### DIFF
--- a/crates/primitives/src/epoch.rs
+++ b/crates/primitives/src/epoch.rs
@@ -97,13 +97,21 @@ impl fmt::Display for EpochCommitment {
         let first_2 = &blkid_bytes[..2];
         let last_2 = &blkid_bytes[30..];
 
-        let first_hex = hex::encode(first_2);
-        let last_hex = hex::encode(last_2);
+        let mut first_hex = [0u8; 4];
+        let mut last_hex = [0u8; 4];
+        hex::encode_to_slice(first_2, &mut first_hex)
+            .expect("Failed to encode first 2 bytes to hex");
+        hex::encode_to_slice(last_2, &mut last_hex).expect("Failed to encode last 2 bytes to hex");
 
         write!(
             f,
             "{}[{}]@{}..{}",
-            self.last_slot, self.epoch, first_hex, last_hex
+            self.last_slot,
+            self.epoch,
+            std::str::from_utf8(&first_hex)
+                .expect("Failed to convert first 2 hex bytes to UTF-8 string"),
+            std::str::from_utf8(&last_hex)
+                .expect("Failed to convert last 2 hex bytes to UTF-8 string")
         )
     }
 }

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -76,10 +76,21 @@ impl fmt::Display for L1BlockCommitment {
         let first_2 = &blkid_bytes[..2];
         let last_2 = &blkid_bytes[30..];
 
-        let first_hex = hex::encode(first_2);
-        let last_hex = hex::encode(last_2);
+        let mut first_hex = [0u8; 4];
+        let mut last_hex = [0u8; 4];
+        hex::encode_to_slice(first_2, &mut first_hex)
+            .expect("Failed to encode first 2 bytes to hex");
+        hex::encode_to_slice(last_2, &mut last_hex).expect("Failed to encode last 2 bytes to hex");
 
-        write!(f, "{}@{}..{}", self.height, first_hex, last_hex)
+        write!(
+            f,
+            "{}@{}..{}",
+            self.height,
+            std::str::from_utf8(&first_hex)
+                .expect("Failed to convert first 2 hex bytes to UTF-8 string"),
+            std::str::from_utf8(&last_hex)
+                .expect("Failed to convert last 2 hex bytes to UTF-8 string")
+        )
     }
 }
 

--- a/crates/primitives/src/l2.rs
+++ b/crates/primitives/src/l2.rs
@@ -88,10 +88,21 @@ impl fmt::Display for L2BlockCommitment {
         let first_2 = &blkid_bytes[..2];
         let last_2 = &blkid_bytes[30..];
 
-        let first_hex = hex::encode(first_2);
-        let last_hex = hex::encode(last_2);
+        let mut first_hex = [0u8; 4];
+        let mut last_hex = [0u8; 4];
+        hex::encode_to_slice(first_2, &mut first_hex)
+            .expect("Failed to encode first 2 bytes to hex");
+        hex::encode_to_slice(last_2, &mut last_hex).expect("Failed to encode last 2 bytes to hex");
 
-        write!(f, "{}@{}..{}", self.slot, first_hex, last_hex)
+        write!(
+            f,
+            "{}@{}..{}",
+            self.slot,
+            std::str::from_utf8(&first_hex)
+                .expect("Failed to convert first hex bytes to UTF-8 string"),
+            std::str::from_utf8(&last_hex)
+                .expect("Failed to convert last hex bytes to UTF-8 string")
+        )
     }
 }
 


### PR DESCRIPTION
## Description

Adds cleaner `Display`/`Debug` impls for block commitment types.

Used Cursor to generate the impls but manually edited so that we don't have shadowing of `std` imports.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

According to guidelines in the [STR-1398](https://alpenlabs.atlassian.net/browse/STR-1398) ticket.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1398


[STR-1398]: https://alpenlabs.atlassian.net/browse/STR-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ