### PR TITLE
(docker): Fix params generation script

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -21,6 +21,8 @@ which also includes some details on the necessary non-docker pre-setup.
 
 Generate the required keys:
 
+**NOTE**: Datatool requires a connection to bitcoin network to generate params. If the bitcoin network is other than regtest, make sure it is set to the environment variable `BITCOIN_NETWORK`.
+
 ```bash
 # build the datatool
 cargo build --bin strata-datatool
@@ -83,3 +85,6 @@ docker start alpen_reth_fn # if you want to test the full node
     ```bash
     rm -rf .data && docker compose up prover-client
     ```
+
+## Troubleshooting
+- If you get an error `ERROR Max retries 3 exceeded` while running `init-keys.sh`, make sure the bitcoin node's endpoint provided via `BITCOIN_RPC_URL` is running.

--- a/docker/init-keys.sh
+++ b/docker/init-keys.sh
@@ -9,6 +9,7 @@
 # Or passed as additional arguments after the datatool path
 
 DATATOOL_PATH=${1:-./strata-datatool}
+BITCOIN_NETWORK=${BITCOIN_NETWORK:-"regtest"}
 shift
 
 # Set default Bitcoin RPC credentials if not provided
@@ -86,7 +87,7 @@ if [ -z "$output_found" ]; then
 fi
 
 # Add Bitcoin RPC credentials to genparams command
-$DATATOOL_PATH -b regtest \
+"$DATATOOL_PATH" -b "$BITCOIN_NETWORK" \
     --bitcoin-rpc-url "$BITCOIN_RPC_URL" \
     --bitcoin-rpc-user "$BITCOIN_RPC_USER" \
     --bitcoin-rpc-password "$BITCOIN_RPC_PASSWORD" \


### PR DESCRIPTION
## Description
This PR fixes the following in `docker/init-keys.sh`:
1. Pass operator xprivs instead of wrongly passed xpubs to datatool's `genparam` command.
2. Correctly rename `alpenstrata` to `alpn` while passing rollup name as param.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
