### PR TITLE
fix!(btcio): remove parsing of DRTs

### DIFF
--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -4,17 +4,13 @@ use strata_l1tx::{
 };
 use strata_primitives::{
     batch::SignedCheckpoint,
-    l1::{
-        DepositInfo, DepositRequestInfo, DepositSpendInfo, ProtocolOperation,
-        WithdrawalFulfillmentInfo,
-    },
+    l1::{DepositInfo, DepositSpendInfo, ProtocolOperation, WithdrawalFulfillmentInfo},
 };
 
 /// Ops indexer for rollup client. Collects extra info like da blobs and deposit requests
 #[derive(Clone, Debug)]
 pub(crate) struct ReaderTxVisitorImpl {
     ops: Vec<ProtocolOperation>,
-    deposit_requests: Vec<DepositRequestInfo>,
     da_entries: Vec<DaEntry>,
 }
 
@@ -22,7 +18,6 @@ impl ReaderTxVisitorImpl {
     pub(crate) fn new() -> Self {
         Self {
             ops: Vec::new(),
-            deposit_requests: Vec::new(),
             da_entries: Vec::new(),
         }
     }
@@ -42,10 +37,6 @@ impl TxVisitor for ReaderTxVisitorImpl {
         self.ops.push(ProtocolOperation::Deposit(d));
     }
 
-    fn visit_deposit_request(&mut self, dr: DepositRequestInfo) {
-        self.deposit_requests.push(dr);
-    }
-
     fn visit_checkpoint(&mut self, chkpt: SignedCheckpoint) {
         self.ops.push(ProtocolOperation::Checkpoint(chkpt));
     }
@@ -60,14 +51,10 @@ impl TxVisitor for ReaderTxVisitorImpl {
     }
 
     fn finalize(self) -> Option<L1TxMessages> {
-        if self.ops.is_empty() && self.deposit_requests.is_empty() && self.da_entries.is_empty() {
+        if self.ops.is_empty() && self.da_entries.is_empty() {
             None
         } else {
-            Some(L1TxMessages::new(
-                self.ops,
-                self.deposit_requests,
-                self.da_entries,
-            ))
+            Some(L1TxMessages::new(self.ops, self.da_entries))
         }
     }
 }

--- a/crates/l1tx/src/deposit/deposit_request.rs
+++ b/crates/l1tx/src/deposit/deposit_request.rs
@@ -101,7 +101,13 @@ fn parse_tag_script(
     let dest = &buf[32..];
     if dest.len() != config.address_length as usize {
         // casting is safe as address.len() < buf.len() < 80
-        debug!(?buf, expected = config.address_length, got = %dest.len(), "incorrect number of bytes in dest");
+        debug!(
+            buf = ?buf,
+            dest = ?dest,
+            expected = config.address_length,
+            got = %dest.len(),
+            "incorrect number of bytes in dest buf"
+        );
         return Err(DepositParseError::InvalidDestLen(dest.len() as u8));
     }
 

--- a/crates/l1tx/src/filter/indexer.rs
+++ b/crates/l1tx/src/filter/indexer.rs
@@ -2,13 +2,12 @@ use bitcoin::{Block, Transaction};
 use strata_primitives::{
     batch::SignedCheckpoint,
     indexed::Indexed,
-    l1::{DepositInfo, DepositRequestInfo, DepositSpendInfo, WithdrawalFulfillmentInfo},
+    l1::{DepositInfo, DepositSpendInfo, WithdrawalFulfillmentInfo},
 };
 
 use super::{
-    extract_da_blobs, extract_deposit_requests, find_deposit_spends,
-    parse_valid_checkpoint_envelopes, try_parse_tx_as_withdrawal_fulfillment, try_parse_tx_deposit,
-    TxFilterConfig,
+    extract_da_blobs, find_deposit_spends, parse_valid_checkpoint_envelopes,
+    try_parse_tx_as_withdrawal_fulfillment, try_parse_tx_deposit, TxFilterConfig,
 };
 
 /// Interface to handle storage of extracted information from a transaction.
@@ -21,9 +20,6 @@ pub trait TxVisitor {
 
     /// Do stuffs with `DepositInfo`.
     fn visit_deposit(&mut self, _d: DepositInfo) {}
-
-    /// Do stuffs with `DepositRequest`.
-    fn visit_deposit_request(&mut self, _d: DepositRequestInfo) {}
 
     /// Do stuffs with DA.
     fn visit_da<'a>(&mut self, _d: impl Iterator<Item = &'a [u8]>) {}
@@ -70,11 +66,6 @@ fn index_tx<V: TxVisitor>(
 
     for da in extract_da_blobs(tx, filter_config) {
         visitor.visit_da(da);
-    }
-
-    // TODO: maybe remove this later when we do not require deposit request ops?
-    for dr in extract_deposit_requests(tx, filter_config) {
-        visitor.visit_deposit_request(dr);
     }
 
     if let Some(info) = try_parse_tx_as_withdrawal_fulfillment(tx, filter_config) {

--- a/crates/l1tx/src/messages.rs
+++ b/crates/l1tx/src/messages.rs
@@ -1,6 +1,6 @@
 use strata_primitives::{
     indexed::Indexed,
-    l1::{DaCommitment, DepositRequestInfo, ProtocolOperation},
+    l1::{DaCommitment, ProtocolOperation},
 };
 
 /// Container for the different kinds of messages that we could extract from a L1 tx.
@@ -9,23 +9,15 @@ pub struct L1TxMessages {
     /// Protocol consensus operations relevant to STF.
     protocol_ops: Vec<ProtocolOperation>,
 
-    /// Deposit requests which the node stores for non-stf related bookkeeping.
-    deposit_reqs: Vec<DepositRequestInfo>,
-
     /// DA entries which the node stores for state reconstruction.  These MUST
     /// reflect messages found in `ProtocolOperation`.
     da_entries: Vec<DaEntry>,
 }
 
 impl L1TxMessages {
-    pub fn new(
-        protocol_ops: Vec<ProtocolOperation>,
-        deposit_reqs: Vec<DepositRequestInfo>,
-        da_entries: Vec<DaEntry>,
-    ) -> Self {
+    pub fn new(protocol_ops: Vec<ProtocolOperation>, da_entries: Vec<DaEntry>) -> Self {
         Self {
             protocol_ops,
-            deposit_reqs,
             da_entries,
         }
     }
@@ -34,22 +26,12 @@ impl L1TxMessages {
         &self.protocol_ops
     }
 
-    pub fn deposit_reqs(&self) -> &[DepositRequestInfo] {
-        &self.deposit_reqs
-    }
-
     pub fn da_entries(&self) -> &[DaEntry] {
         &self.da_entries
     }
 
-    pub fn into_parts(
-        self,
-    ) -> (
-        Vec<ProtocolOperation>,
-        Vec<DepositRequestInfo>,
-        Vec<DaEntry>,
-    ) {
-        (self.protocol_ops, self.deposit_reqs, self.da_entries)
+    pub fn into_parts(self) -> (Vec<ProtocolOperation>, Vec<DaEntry>) {
+        (self.protocol_ops, self.da_entries)
     }
 }
 


### PR DESCRIPTION
## Description

Removes parsing of DRT (Deposit Request Transactions) to fix byte mismatch issues in DRT processing. This change simplifies the codebase by removing unused DRT parsing functionality that was causing processing errors and we don't need for OL/Rollup to keep tabs on.

Used Cursor for an AI-assisted workflow.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is a breaking change that removes DRT parsing functionality in `btcio`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1580
