### PR TITLE
chore(prover-client): log errors as error!

### DIFF
--- a/bin/prover-client/src/prover_manager.rs
+++ b/bin/prover-client/src/prover_manager.rs
@@ -4,7 +4,7 @@ use strata_db::traits::ProofDatabase;
 use strata_db_store_sled::prover::ProofDBSled;
 use strata_primitives::proof::{ProofContext, ProofKey, ProofZkVm};
 use tokio::{spawn, sync::Mutex, time::sleep};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     checkpoint_runner::errors::CheckpointError, errors::ProvingTaskError, operators::ProofOperator,
@@ -170,10 +170,7 @@ async fn make_proof(
 ) -> Result<(), ProvingTaskError> {
     // Handle the delay (if set) from the TransientFailure retries.
     if delay_seconds > 0 {
-        info!(
-            "scheduling transiently failed task {:?} to run in {} seconds",
-            task, delay_seconds
-        );
+        debug!("scheduling transiently failed task {task:?} to run in {delay_seconds} seconds",);
         sleep(Duration::from_secs(delay_seconds)).await;
     }
 
@@ -222,7 +219,7 @@ fn handle_task_error(task: ProofKey, e: ProvingTaskError) -> ProvingTaskStatus {
             // currently be unavailable.
             // NetworkRetryableError indicates network error on SP1 side.
             // See STR-1410 and STR-1473 for details.
-            info!(?task, ?e, "proving task failed transiently");
+            error!(?task, ?e, "proving task failed transiently");
             ProvingTaskStatus::TransientFailure
         }
         ProvingTaskError::IdempotentCompletion(_) => {


### PR DESCRIPTION
## Description

These should be `error!` to generate alerts in the logging system.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Also reducing the `info!` on the scheduling to a `debug!` since we have an `info` right below it outside the `if` block.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1630
