### PR TITLE
fix (dbtool): epoch range check

### DIFF
--- a/bin/strata-dbtool/src/cmd/chainstate.rs
+++ b/bin/strata-dbtool/src/cmd/chainstate.rs
@@ -283,7 +283,7 @@ pub(crate) fn revert_chainstate(
 
     let target_epoch = top_level_state.cur_epoch();
     let latest_checkpoint_epoch = latest_checkpoint_entry.checkpoint.batch_info().epoch;
-    if target_epoch < latest_checkpoint_epoch {
+    if target_epoch <= latest_checkpoint_epoch {
         // Clean up checkpoints and related data from target epoch onwards
         println!(
             "Revert chainstate cleaning up checkpoints and L1 entries from epoch {target_epoch}"


### PR DESCRIPTION
## Description

While testing the backport of #1042 to `releases/0.2.0` (see #1062), I noticed that the condition to delete checkpoints etc. needs a small update "<" to "<=". Logically it makes sense to update `main` as well, although fn tests have been passing in CI.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Verified that the change makes `revert_checkpointed_block_seq` test less flaky in local run.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
