### PR TITLE
chore: add expect mandatory with reason to workspace lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14440,7 +14440,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "strata-asm-types",
- "strata-chainexec",
  "strata-crypto",
  "strata-ol-chain-types",
  "strata-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ members = [
   "crates/test-utils/test-utils",
   "crates/test-utils/tx-indexer",
   "crates/util/mmr",
-  "crates/db-tests",
   "provers/risc0",
   "provers/sp1",
 

--- a/benches/benches/l1_database.rs
+++ b/benches/benches/l1_database.rs
@@ -8,16 +8,32 @@ use std::hint::black_box;
 use alpen_benchmarks::db::DatabaseBackend;
 use arbitrary::Arbitrary;
 // Suppress unused crate warnings
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use bitcoin as _;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use strata_asm_types::L1BlockManifest;
 use strata_db::traits::L1Database;
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_ol_chain_types as _;
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_primitives as _;
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_state as _;
 use tempfile::TempDir;
 #[cfg(feature = "rocksdb")]

--- a/benches/benches/l2_database.rs
+++ b/benches/benches/l2_database.rs
@@ -8,16 +8,32 @@ use std::hint::black_box;
 use alpen_benchmarks::db::DatabaseBackend;
 use arbitrary::Arbitrary;
 // Suppress unused crate warnings
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use bitcoin as _;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_asm_types as _;
 use strata_db::traits::{BlockStatus, L2BlockDatabase};
 use strata_ol_chain_types::{L2BlockBundle, L2Header};
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_primitives as _;
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_state::prelude::*;
 use tempfile::TempDir;
 #[cfg(feature = "rocksdb")]

--- a/benches/src/db.rs
+++ b/benches/src/db.rs
@@ -73,7 +73,7 @@ pub enum DatabaseBackend {
 
 impl DatabaseBackend {
     /// Get all available backends based on enabled features.
-    #[allow(
+    #[expect(
         clippy::vec_init_then_push,
         reason = "highly complicated feature-gating"
     )]

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -2,29 +2,65 @@
 //!
 //! This crate contains benchmarks for various implementations.
 
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use arbitrary as _;
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use bitcoin as _;
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use criterion as _;
 #[cfg(feature = "db")]
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_asm_types as _;
 #[cfg(feature = "db")]
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_db as _;
 #[cfg(feature = "db")]
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_ol_chain_types as _;
 #[cfg(feature = "db")]
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_primitives as _;
 #[cfg(feature = "db")]
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use strata_state as _;
 #[cfg(feature = "db")]
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    clippy::allow_attributes,
+    reason = "used for benchmarking"
+)]
 use tempfile as _;
 
 #[cfg(feature = "db")]

--- a/bin/alpen-cli/src/recovery.rs
+++ b/bin/alpen-cli/src/recovery.rs
@@ -22,7 +22,10 @@ use tokio::io::AsyncReadExt;
 
 use crate::seed::Seed;
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Struct contains sensitive cryptographic data that should not be debug printed"
+)]
 pub struct DescriptorRecovery {
     db: sled::Db,
     cipher: Aes256GcmSiv,
@@ -229,29 +232,27 @@ impl DescriptorRecovery {
 }
 
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for recovery operations")]
 pub struct EntryTooShort {
     length: usize,
 }
 
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for invalid descriptor recovery")]
 pub struct InvalidDescriptor(OneOf<(FromUtf8Error, bdk_wallet::miniscript::Error)>);
 
 #[derive(Debug)]
-#[allow(unused)]
 pub struct InvalidNetwork;
 
 #[derive(Debug)]
-#[allow(unused)]
 pub struct InvalidNetworksLen;
 
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for invalid private key recovery")]
 pub struct InvalidPrivateKey(OneOf<(FromUtf8Error, DescriptorKeyParseError)>);
 
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for invalid public key recovery")]
 pub struct InvalidPublicKey(OneOf<(FromUtf8Error, DescriptorKeyParseError)>);
 
 #[derive(Debug)]

--- a/bin/alpen-cli/src/seed.rs
+++ b/bin/alpen-cli/src/seed.rs
@@ -26,7 +26,10 @@ use crate::constants::{
     AES_NONCE_LEN, AES_TAG_LEN, BIP44_ALPEN_EVM_WALLET_PATH, PW_SALT_LEN, SEED_LEN,
 };
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Struct contains sensitive wallet parameters that should not be debug printed"
+)]
 pub struct BaseWallet(LoadParams, CreateParams);
 
 impl BaseWallet {
@@ -131,7 +134,10 @@ impl Seed {
     }
 }
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Struct contains encrypted seed data that should not be debug printed"
+)]
 pub struct EncryptedSeed([u8; Self::LEN]);
 
 impl EncryptedSeed {

--- a/bin/alpen-cli/src/seed/keychain.rs
+++ b/bin/alpen-cli/src/seed/keychain.rs
@@ -81,10 +81,9 @@ use crate::signet::backend::BoxedErr;
 /// This indicates runtime failure in the underlying platform storage system. The details of the
 /// failure can be retrieved from the attached platform error.
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for platform storage failures")]
 pub struct PlatformFailure(BoxedErr);
 
-#[allow(unused)]
 impl PlatformFailure {
     pub fn new<E>(e: E) -> Self
     where
@@ -98,10 +97,9 @@ impl PlatformFailure {
 /// Typically this is because of access rules in the platform; for example, it might be that the
 /// credential store is locked. The underlying platform error will typically give the reason.
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for storage access failures")]
 pub struct NoStorageAccess(BoxedErr);
 
-#[allow(unused)]
 impl NoStorageAccess {
     pub fn new<E>(e: E) -> Self
     where
@@ -119,14 +117,17 @@ pub struct NoEntry;
 /// This indicates that the retrieved password blob was not a UTF-8 string. The underlying bytes are
 /// available for examination in the attached value.
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for bad encoding in credential storage")]
 pub struct BadEncoding(Vec<u8>);
 
 /// This indicates that one of the entry's credential attributes exceeded a length limit in the
 /// underlying platform. The attached values give the name of the attribute and the platform length
 /// limit that was exceeded.
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(
+    unused,
+    reason = "Error type for credential attributes that are too long"
+)]
 pub struct TooLong {
     name: String,
     limit: u32,
@@ -135,7 +136,7 @@ pub struct TooLong {
 /// This indicates that one of the entry's required credential attributes was invalid. The attached
 /// value gives the name of the attribute and the reason it's invalid.
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for invalid credential attributes")]
 pub struct Invalid {
     name: String,
     reason: String,
@@ -144,7 +145,7 @@ pub struct Invalid {
 /// This indicates that there is more than one credential found in the store that matches the entry.
 /// Its value is a vector of the matching credentials.
 #[derive(Debug)]
-#[allow(unused)]
+#[expect(unused, reason = "Error type for ambiguous credential matches")]
 pub struct Ambiguous(Vec<Box<Credential>>);
 
 #[cfg(not(target_os = "linux"))]

--- a/bin/alpen-cli/src/seed/password.rs
+++ b/bin/alpen-cli/src/seed/password.rs
@@ -6,7 +6,10 @@ use zxcvbn::{zxcvbn, Entropy};
 use super::PW_SALT_LEN;
 
 #[derive(ZeroizeOnDrop)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Struct contains sensitive password data that should not be debug printed"
+)]
 pub struct Password {
     inner: String,
 }

--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -43,7 +43,10 @@ pub(crate) struct Args {
     pub(crate) subc: Subcommand,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Enum contains large variants for different subcommands"
+)]
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand)]
 pub(crate) enum Subcommand {
@@ -254,7 +257,10 @@ pub(crate) struct BitcoindConfig {
 
 pub(crate) struct CmdContext {
     /// Resolved datadir for the network.
-    #[allow(unused)]
+    #[expect(
+        unused,
+        reason = "Field is used in command context but may not be directly accessed"
+    )]
     pub(crate) datadir: PathBuf,
 
     /// The Bitcoin network we're building on top of.

--- a/bin/datatool/src/util.rs
+++ b/bin/datatool/src/util.rs
@@ -89,7 +89,6 @@ pub(super) fn exec_subc(cmd: Subcommand, ctx: &mut CmdContext) -> anyhow::Result
 /// # Errors
 ///
 /// Returns an error if the export process fails.
-#[allow(clippy::missing_const_for_fn)]
 fn export_elf(_elf_path: &Path) -> anyhow::Result<()> {
     #[cfg(feature = "sp1-builder")]
     {
@@ -457,7 +456,6 @@ pub(crate) struct ParamsConfig {
     /// Tagname used to identify Checkpoint envelopes
     checkpoint_tag: String,
     /// Network to use.
-    #[allow(unused)]
     bitcoin_network: Network,
     /// Block time in seconds.
     block_time_sec: u64,

--- a/bin/prover-client/src/args.rs
+++ b/bin/prover-client/src/args.rs
@@ -238,7 +238,7 @@ pub(crate) struct ResolvedConfig {
     pub(crate) bitcoind_password: String,
 
     /// Path to the custom rollup configuration file.
-    #[expect(dead_code)] // Part of public API, may be used in future
+    #[expect(dead_code, reason = "Part of public API, may be used in future")]
     pub(crate) rollup_params: PathBuf,
 }
 

--- a/bin/prover-client/src/operators/mod.rs
+++ b/bin/prover-client/src/operators/mod.rs
@@ -112,7 +112,7 @@ pub(crate) trait ProvingOp {
     /// # Returns
     ///
     /// A [`Vec`] containing the [`ProofKey`] for the dependent proving operations.
-    #[allow(unused_variables)]
+    #[expect(unused_variables, reason = "used for overriding default impl")]
     async fn create_deps_tasks(
         &self,
         params: Self::Params,

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -223,7 +223,10 @@ fn init_logging(rt: &Handle) {
 
 /// Shared low-level services that secondary services depend on.
 #[derive(Clone)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "some inner types do not implement Debug"
+)]
 pub struct CoreContext {
     pub runtime: Handle,
     pub database: Arc<init_db::DatabaseImpl>,
@@ -371,7 +374,6 @@ fn start_core_tasks(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn start_sequencer_tasks(
     ctx: CoreContext,
     config: &Config,

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -69,7 +69,6 @@ pub(crate) struct StrataRpcImpl {
 }
 
 impl StrataRpcImpl {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         status_channel: StatusChannel,
         sync_manager: Arc<SyncManager>,
@@ -227,7 +226,6 @@ impl StrataApiServer for StrataRpcImpl {
             finalized_epoch = Some(fin_ckpt.batch_info.get_epoch_commitment());
         }
 
-        #[allow(deprecated)]
         Ok(RpcClientStatus {
             finalized_epoch,
             confirmed_epoch,
@@ -461,7 +459,7 @@ impl StrataApiServer for StrataRpcImpl {
     }
 
     // FIXME: remove deprecated
-    #[allow(deprecated)]
+    #[expect(deprecated, reason = "used for rpc server")]
     async fn sync_status(&self) -> RpcResult<RpcSyncStatus> {
         let cssu = self
             .status_channel
@@ -704,7 +702,6 @@ pub(crate) struct SequencerServerImpl {
 }
 
 impl SequencerServerImpl {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         envelope_handle: Arc<EnvelopeHandle>,
         broadcast_handle: Arc<L1BroadcastHandle>,

--- a/crates/asm-types/src/block.rs
+++ b/crates/asm-types/src/block.rs
@@ -75,7 +75,6 @@ impl L1BlockManifest {
         &self.record
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     pub fn txs(&self) -> &[L1Tx] {
         &self.txs
     }

--- a/crates/asm-types/src/header.rs
+++ b/crates/asm-types/src/header.rs
@@ -45,7 +45,6 @@ impl L1HeaderRecord {
         &self.blkid
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     pub fn buf(&self) -> &[u8] {
         &self.buf
     }

--- a/crates/asm-types/src/inclusion_proof.rs
+++ b/crates/asm-types/src/inclusion_proof.rs
@@ -41,7 +41,6 @@ impl<T> L1TxInclusionProof<T> {
         }
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     pub fn cohashes(&self) -> &[Buf32] {
         &self.cohashes
     }

--- a/crates/asm-types/src/ops.rs
+++ b/crates/asm-types/src/ops.rs
@@ -58,10 +58,10 @@ impl DaCommitment {
 /// Consensus level protocol operations extracted from a bitcoin transaction.
 ///
 /// These are submitted to the OL STF and impact state.
+#[expect(clippy::large_enum_variant, reason = "used for protocol operations")]
 #[derive(
     Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
 )]
-#[allow(clippy::large_enum_variant)]
 pub enum ProtocolOperation {
     /// Deposit Transaction
     Deposit(DepositInfo),

--- a/crates/asm-types/src/tx.rs
+++ b/crates/asm-types/src/tx.rs
@@ -33,7 +33,6 @@ impl L1Tx {
         &self.tx
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     pub fn protocol_ops(&self) -> &[ProtocolOperation] {
         &self.protocol_ops
     }

--- a/crates/asm/stf/src/manager.rs
+++ b/crates/asm/stf/src/manager.rs
@@ -187,7 +187,6 @@ impl SubprotoManager {
             .ok_or(AsmError::InvalidSubprotocol(id))
     }
 
-    #[allow(unused)]
     fn get_handler(&self, id: SubprotocolId) -> Result<&dyn SubprotoHandler, AsmError> {
         self.handlers
             .get(&id)
@@ -205,7 +204,7 @@ impl SubprotoManager {
     }
 
     /// Extracts the section state for a subprotocol.
-    #[allow(unused)]
+    #[expect(dead_code, reason = "Method is part of section state management API")]
     pub(crate) fn to_section_state<S: Subprotocol>(&self) -> SectionState {
         let h = self.get_handler(S::ID).expect("asm: unloaded subprotocol");
         h.to_section()

--- a/crates/asm/subprotocols/core/src/constants.rs
+++ b/crates/asm/subprotocols/core/src/constants.rs
@@ -8,7 +8,7 @@ macro_rules! define_ids {
         )*
 
         /// Array containing all defined type IDs
-        #[allow(dead_code)]
+        #[allow(dead_code, clippy::allow_attributes, reason = "some generated code is not used")]
         const $const_name: &'static [$type] = &[$($name),*];
     };
 }

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -13,7 +13,10 @@ use tracing::*;
 
 use super::task::broadcaster_task;
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct L1BroadcastHandle {
     ops: Arc<BroadcastDbOps>,
     sender: mpsc::Sender<(u64, L1TxEntry)>,

--- a/crates/btcio/src/reader/event.rs
+++ b/crates/btcio/src/reader/event.rs
@@ -4,7 +4,6 @@ use strata_primitives::l1::L1BlockCommitment;
 
 /// L1 events that we observe and want the persistence task to work on.
 #[derive(Clone, Debug)]
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum L1Event {
     /// Data that contains block number, block and relevant transactions, and also the epoch whose
     /// rules are applied to.

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -534,7 +534,6 @@ mod tests {
         writer::builder::EnvelopeError,
     };
 
-    #[allow(clippy::type_complexity)]
     fn get_mock_data() -> (
         Arc<WriterContext<TestBitcoinClient>>,
         Vec<u8>,

--- a/crates/btcio/src/writer/task.rs
+++ b/crates/btcio/src/writer/task.rs
@@ -30,7 +30,10 @@ use crate::{
 };
 
 /// A handle to the Envelope task.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have debug impls"
+)]
 pub struct EnvelopeHandle {
     ops: Arc<EnvelopeDataOps>,
     intent_tx: Sender<IntentEntry>,
@@ -111,7 +114,7 @@ impl EnvelopeHandle {
 /// # Returns
 ///
 /// [`Result<EnvelopeHandle>`](anyhow::Result)
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments, reason = "used for starting envelope task")]
 pub fn start_envelope_task<D: L1WriterDatabase + Send + Sync + 'static>(
     executor: &TaskExecutor,
     bitcoin_client: Arc<Client>,

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -7,8 +7,7 @@ use strata_primitives::prelude::*;
 use strata_state::{chain_state::Chainstate, state_op::StateCache};
 use strata_storage::ChainstateManager;
 
-#[allow(missing_debug_implementations)]
-#[allow(dead_code)]
+#[expect(dead_code, reason = "Some inner types don't have Debug impls")]
 pub(crate) struct WbStateAccessorImpl {
     /// Chainstate manager to fetch "deep" information we might not have in memory.
     // we aren't actually using this yet, but we will when we have accounts

--- a/crates/chaintsn/Cargo.toml
+++ b/crates/chaintsn/Cargo.toml
@@ -23,8 +23,6 @@ zkaleido.workspace = true
 [dev-dependencies]
 strata-test-utils.workspace = true
 strata-test-utils-l2.workspace = true
-strata-chainexec.workspace = true
-
 
 [features]
 default = ["fullstd"]

--- a/crates/consensus-logic/src/asm_worker_context.rs
+++ b/crates/consensus-logic/src/asm_worker_context.rs
@@ -10,7 +10,10 @@ use strata_state::asm_state::AsmState;
 use strata_storage::{AsmStateManager, L1BlockManager};
 use tokio::runtime::Handle;
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Inner types don't have Debug implementation"
+)]
 pub struct AsmWorkerCtx {
     handle: Handle,
     bitcoin_client: Arc<Client>,

--- a/crates/consensus-logic/src/chain_worker_context.rs
+++ b/crates/consensus-logic/src/chain_worker_context.rs
@@ -14,7 +14,10 @@ use strata_state::{batch::EpochSummary, chain_state::Chainstate, state_op::Write
 use strata_storage::{ChainstateManager, CheckpointDbManager, L2BlockManager};
 use tracing::*;
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct ChainWorkerCtx {
     l2man: Arc<L2BlockManager>,
     chsman: Arc<ChainstateManager>,

--- a/crates/consensus-logic/src/checkpoint_verification.rs
+++ b/crates/consensus-logic/src/checkpoint_verification.rs
@@ -68,7 +68,6 @@ fn verify_checkpoint_extends(
 /// This is here because we want to move `.get_proof_receipt()` out of the
 /// checkpoint type itself soon.
 pub fn construct_receipt(checkpoint: &Checkpoint) -> ProofReceipt {
-    #[allow(deprecated)]
     checkpoint.construct_receipt()
 }
 

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -22,7 +22,10 @@ pub trait EventContext {
 
 /// Event context using the main node storage interfaace.
 #[derive(Clone)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct StorageEventContext<'c> {
     storage: &'c NodeStorage,
 }

--- a/crates/consensus-logic/src/csm/ctl.rs
+++ b/crates/consensus-logic/src/csm/ctl.rs
@@ -6,7 +6,10 @@ use tracing::*;
 
 /// Controller handle for the consensus state machine.
 /// Used to submit new l1 blocks for processing.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct CsmController {
     csm_tx: mpsc::Sender<L1BlockCommitment>,
 }

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -22,7 +22,10 @@ use crate::csm::client_transition::{self, EventContext, StorageEventContext};
 ///
 /// Unable to be shared across threads.  Any data we want to export we'll do
 /// through another handle.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct WorkerState {
     /// Consensus parameters.
     params: Arc<Params>,

--- a/crates/consensus-logic/src/exec_worker_context.rs
+++ b/crates/consensus-logic/src/exec_worker_context.rs
@@ -10,7 +10,10 @@ use strata_ol_chain_types::{L2BlockId, L2Header};
 use strata_primitives::{epoch::EpochCommitment, l2::L2BlockCommitment};
 use strata_storage::{ClientStateManager, L2BlockManager};
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct ExecWorkerCtx {
     l2man: Arc<L2BlockManager>,
     client: Arc<ClientStateManager>,

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -23,7 +23,10 @@ use crate::{
 };
 
 /// Handle to the core pipeline tasks.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug impls"
+)]
 pub struct SyncManager {
     params: Arc<Params>,
     fc_manager_tx: mpsc::Sender<ForkChoiceMessage>,
@@ -71,7 +74,6 @@ impl SyncManager {
 }
 
 /// Starts the sync tasks using provided settings.
-#[allow(clippy::too_many_arguments)]
 pub fn start_sync_tasks<E: ExecEngineCtl + Sync + Send + 'static>(
     executor: &TaskExecutor,
     storage: &Arc<NodeStorage>,

--- a/crates/db-store-rocksdb/src/lib.rs
+++ b/crates/db-store-rocksdb/src/lib.rs
@@ -159,7 +159,7 @@ pub struct RocksDbBackend {
 }
 
 impl RocksDbBackend {
-    #[allow(clippy::too_many_arguments)] // hard to avoid here
+    #[expect(clippy::too_many_arguments, reason = "hard to avoid here")]
     pub fn new(
         asm_db: Arc<AsmDb>,
         l1_db: Arc<L1Db>,

--- a/crates/db-store-sled/src/lib.rs
+++ b/crates/db-store-sled/src/lib.rs
@@ -65,7 +65,6 @@ pub struct SledBackend {
 }
 
 impl SledBackend {
-    #[allow(clippy::too_many_arguments)] // hard to avoid here
     pub fn new(sled_db: Arc<SledDb>, config: SledDbConfig) -> DbResult<Self> {
         let db_ref = &sled_db;
         let config_ref = &config;

--- a/crates/db-store-sled/src/macros.rs
+++ b/crates/db-store-sled/src/macros.rs
@@ -166,7 +166,7 @@ macro_rules! define_sled_database {
             $(
                 $field: typed_sled::SledTree<$schema>,
             )*
-            #[allow(dead_code)]
+            #[allow(dead_code, clippy::allow_attributes, reason = "some generated code is not used")]
             config: $crate::SledDbConfig,
         }
 

--- a/crates/eectl/src/engine.rs
+++ b/crates/eectl/src/engine.rs
@@ -71,7 +71,7 @@ pub enum BlockStatus {
     Syncing,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant, reason = "don't want to box it")]
 #[derive(Debug)]
 pub enum PayloadStatus {
     /// Still building the payload.

--- a/crates/eectl/src/handle.rs
+++ b/crates/eectl/src/handle.rs
@@ -9,7 +9,10 @@ use tracing::debug;
 use crate::errors::{EngineError, EngineResult};
 
 /// Commands we send from the handle to the worker, with completion channels.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "some inner types don't have Debug impls"
+)]
 pub enum ExecCommand {
     /// Notifies the worker of a new block being produced.
     NewBlock(L2BlockCommitment, oneshot::Sender<EngineResult<()>>),
@@ -23,7 +26,7 @@ pub enum ExecCommand {
 
 #[derive(Debug)]
 pub struct ExecCtlHandle {
-    shared: Arc<ExecShared>,
+    _shared: Arc<ExecShared>,
     msg_tx: mpsc::Sender<ExecCommand>,
 }
 
@@ -100,7 +103,7 @@ impl ExecCtlHandle {
 
 #[derive(Debug)]
 pub struct ExecCtlInput {
-    shared: Arc<ExecShared>,
+    _shared: Arc<ExecShared>,
     msg_rx: mpsc::Receiver<ExecCommand>,
 }
 
@@ -122,11 +125,14 @@ pub fn make_handle_pair() -> (ExecCtlHandle, ExecCtlInput) {
     let shared = Arc::new(ExecShared {});
 
     let handle = ExecCtlHandle {
-        shared: shared.clone(),
+        _shared: shared.clone(),
         msg_tx: tx,
     };
 
-    let input = ExecCtlInput { shared, msg_rx: rx };
+    let input = ExecCtlInput {
+        _shared: shared,
+        msg_rx: rx,
+    };
 
     (handle, input)
 }

--- a/crates/eectl/src/lib.rs
+++ b/crates/eectl/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // TODO: remove once `WithdrawData` is used
 //! Infrastructure for controlling EVM execution.  This operates on similar
 //! principles to the Ethereum engine API used for CL clients to control their
 //! corresponding EL client.

--- a/crates/eectl/src/worker.rs
+++ b/crates/eectl/src/worker.rs
@@ -20,12 +20,15 @@ use crate::{
     messages::ExecPayloadData,
 };
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "some inner types don't have Debug impls"
+)]
 pub struct ExecWorkerState<E: ExecEngineCtl> {
     engine: Arc<E>,
     exec_env_id: ExecEnvId,
     safe_tip: L2BlockCommitment,
-    finalized_tip: L2BlockCommitment,
+    _finalized_tip: L2BlockCommitment,
 }
 
 impl<E: ExecEngineCtl> ExecWorkerState<E> {
@@ -40,7 +43,7 @@ impl<E: ExecEngineCtl> ExecWorkerState<E> {
             engine,
             exec_env_id,
             safe_tip,
-            finalized_tip,
+            _finalized_tip: finalized_tip,
         }
     }
 
@@ -70,6 +73,7 @@ impl<E: ExecEngineCtl> ExecWorkerState<E> {
         })
     }
 
+    #[expect(unused, reason = "will be used later")]
     fn update_finalized_tip(&mut self, new_finalized: &L2BlockCommitment) -> EngineResult<()> {
         self.call_engine("engine_update_finalized_tip", |eng| {
             eng.update_finalized_block(*new_finalized.blkid())?;
@@ -78,9 +82,10 @@ impl<E: ExecEngineCtl> ExecWorkerState<E> {
     }
 
     /// Calls the engine to update the reffed blocks.
+    #[expect(unused, reason = "will be used later")]
     fn update_engine_refs(&mut self) -> EngineResult<()> {
         let safe_blkid = *self.safe_tip.blkid();
-        let finalized_blkid = *self.finalized_tip.blkid();
+        let finalized_blkid = *self._finalized_tip.blkid();
         self.call_engine("engine_update_refs", |eng| {
             eng.update_safe_block(safe_blkid)?;
             eng.update_finalized_block(finalized_blkid)?;

--- a/crates/evmexec/src/block.rs
+++ b/crates/evmexec/src/block.rs
@@ -5,8 +5,7 @@ use strata_primitives::evm_exec::EVMExtraPayload;
 use thiserror::Error;
 
 pub(crate) struct EVML2Block {
-    #[allow(dead_code)]
-    l2_block: L2Block,
+    _l2_block: L2Block,
     extra_payload: EVMExtraPayload,
 }
 
@@ -15,7 +14,7 @@ impl EVML2Block {
     pub(crate) fn try_extract(bundle: &L2BlockBundle) -> Result<Self, ConversionError> {
         let extra_payload = get_extra_payload(bundle)?;
         Ok(Self {
-            l2_block: bundle.block().to_owned(),
+            _l2_block: bundle.block().to_owned(),
             extra_payload,
         })
     }

--- a/crates/evmexec/src/el_payload.rs
+++ b/crates/evmexec/src/el_payload.rs
@@ -43,13 +43,11 @@ pub(crate) struct ElPayload {
 }
 
 #[derive(Debug, Error)]
-#[allow(dead_code)]
 pub(crate) enum ElPayloadError {
     #[error("Failed to extract evm block from payload: {0}")]
     BlockConversionError(String),
 }
 
-#[allow(dead_code)]
 pub(crate) fn make_update_input_from_payload_and_ops(
     el_payload: ElPayload,
     ops: &[Op],

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -33,19 +33,16 @@ use crate::{
     http_client::EngineRpc,
 };
 
-#[allow(dead_code)]
 fn address_from_slice(slice: &[u8]) -> Option<Address> {
     let slice: Option<[u8; 20]> = slice.try_into().ok();
     slice.map(Address::from)
 }
 
-#[allow(dead_code)]
 fn sats_to_gwei(sats: u64) -> Option<u64> {
     // 1 BTC = 10^8 sats = 10^9 gwei
     sats.checked_mul(10)
 }
 
-#[allow(dead_code)]
 fn gwei_to_sats(gwei: u64) -> u64 {
     // 1 BTC = 10^8 sats = 10^9 gwei
     gwei / 10
@@ -65,7 +62,6 @@ struct RpcExecEngineInner<T: EngineRpc> {
 }
 
 impl<T: EngineRpc> RpcExecEngineInner<T> {
-    #[allow(dead_code)]
     fn new(client: T, head_block_hash: B256) -> Self {
         Self {
             client,
@@ -77,7 +73,6 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         }
     }
 
-    #[allow(dead_code)]
     async fn update_block_state(
         &self,
         fcs_partial: ForkchoiceStatePartial,
@@ -116,7 +111,6 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         }
     }
 
-    #[allow(dead_code)]
     async fn build_block_from_mempool(
         &self,
         payload_env: PayloadEnv,
@@ -174,7 +168,6 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         Ok(u64::from_be_bytes(raw_id))
     }
 
-    #[allow(dead_code)]
     async fn get_payload_status(&self, payload_id: u64) -> EngineResult<PayloadStatus> {
         let payload = self
             .client
@@ -223,7 +216,6 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         ))
     }
 
-    #[allow(dead_code)]
     async fn submit_new_payload(&self, payload: ExecPayloadData) -> EngineResult<BlockStatus> {
         let Ok(el_payload) = borsh::from_slice::<ElPayload>(payload.accessory_data()) else {
             // In particular, this happens if we try to call it with for genesis block.
@@ -276,7 +268,6 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         }
     }
 
-    #[allow(dead_code)]
     async fn check_block_exists(&self, block_hash: B256) -> EngineResult<bool> {
         let block = self
             .client
@@ -287,8 +278,10 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
     }
 }
 
-#[allow(dead_code)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "some inner types don't have Debug impls"
+)]
 pub struct RpcExecEngineCtl<T: EngineRpc> {
     inner: RpcExecEngineInner<T>,
     tokio_handle: Handle,

--- a/crates/evmexec/src/http_client.rs
+++ b/crates/evmexec/src/http_client.rs
@@ -20,7 +20,11 @@ use revm_primitives::alloy_primitives::{BlockHash, B256};
 
 type RpcResult<T> = Result<T, jsonrpsee::core::ClientError>;
 
-#[allow(async_fn_in_trait)]
+#[allow(
+    async_fn_in_trait,
+    clippy::allow_attributes,
+    reason = "we don't want async_trait"
+)]
 #[cfg_attr(test, automock)]
 pub trait EngineRpc {
     async fn fork_choice_updated_v3(

--- a/crates/l1tx/src/filter/withdrawal_fulfillment.rs
+++ b/crates/l1tx/src/filter/withdrawal_fulfillment.rs
@@ -159,7 +159,7 @@ mod test {
         DEPOSIT_AMT - OPERATOR_FEE
     }
 
-    #[expect(unused)]
+    #[expect(unused, reason = "used for testing")]
     fn generate_data() -> (Vec<Descriptor>, Vec<[u8; 32]>, TxFilterConfig) {
         let (addresses, txids, deposits) = generate_withdrawal_fulfillment_data(deposit_amt());
         let params: Params = gen_params();

--- a/crates/l1tx/src/messages.rs
+++ b/crates/l1tx/src/messages.rs
@@ -36,10 +36,8 @@ impl L1TxMessages {
 /// DA commitment and blob retrieved from L1 transaction.
 #[derive(Clone, Debug)]
 pub struct DaEntry {
-    #[allow(unused)]
     commitment: DaCommitment,
 
-    #[allow(unused)]
     blob_buf: Vec<u8>,
 }
 

--- a/crates/primitives/src/keys.rs
+++ b/crates/primitives/src/keys.rs
@@ -9,7 +9,10 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A zeroizable on [`Drop`] wrapper around [`Xpriv`].
 #[derive(Clone, PartialEq, Eq)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Debug implementation would expose sensitive key material"
+)]
 pub struct ZeroizableXpriv(Xpriv);
 
 impl ZeroizableXpriv {
@@ -53,7 +56,10 @@ impl ZeroizeOnDrop for ZeroizableXpriv {}
 
 /// A zeroizable on [`Drop`] wrapper around [`Keypair`].
 #[derive(Clone, PartialEq, Eq)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Debug implementation would expose sensitive key material"
+)]
 pub struct ZeroizableKeypair(Keypair);
 
 impl ZeroizableKeypair {

--- a/crates/primitives/src/l1/payload.rs
+++ b/crates/primitives/src/l1/payload.rs
@@ -78,7 +78,7 @@ impl BlobSpec {
         &self.commitment
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "Constructor for testing purposes")]
     fn new(dest: PayloadDest, commitment: Buf32) -> Self {
         Self { dest, commitment }
     }
@@ -146,7 +146,6 @@ impl L1Payload {
         Self::new(data, L1PayloadType::Da)
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     pub fn data(&self) -> &[u8] {
         &self.data
     }

--- a/crates/primitives/src/relay/types.rs
+++ b/crates/primitives/src/relay/types.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use core::fmt;
 
 use arbitrary::Arbitrary;
@@ -67,13 +65,11 @@ impl BridgeMessage {
     }
 
     /// Raw scope.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn scope(&self) -> &[u8] {
         &self.scope
     }
 
     /// Raw payload
-    #[allow(clippy::missing_const_for_fn)]
     pub fn payload(&self) -> &[u8] {
         &self.payload
     }
@@ -271,6 +267,7 @@ mod tests {
         l1::BitcoinTxid,
     };
 
+    #[expect(unused, reason = "used for testing")]
     fn get_arb_bridge_msg() -> BridgeMessage {
         let msg: BridgeMessage = ArbitraryGenerator::new().generate();
         msg

--- a/crates/primitives/src/sorted_vec.rs
+++ b/crates/primitives/src/sorted_vec.rs
@@ -512,7 +512,7 @@ mod tests {
         assert_eq!(sv1.as_slice(), &[1, 3, 3, 4, 4, 5, 5, 7, 8]);
     }
 
-    #[allow(unused)]
+    #[expect(unused, reason = "Test helper struct for table entry tests")]
     struct Pair(u32, u32);
 
     impl TableEntry for Pair {

--- a/crates/reth/db/src/lib.rs
+++ b/crates/reth/db/src/lib.rs
@@ -6,10 +6,18 @@ pub mod rocksdb;
 pub mod sled;
 
 #[cfg(feature = "rocksdb")]
-#[allow(unused_extern_crates)]
+#[allow(
+    unused_extern_crates,
+    clippy::allow_attributes,
+    reason = "feature-gated"
+)]
 extern crate rockbound as _;
 #[cfg(feature = "sled")]
-#[allow(unused_extern_crates)]
+#[allow(
+    unused_extern_crates,
+    clippy::allow_attributes,
+    reason = "feature-gated"
+)]
 extern crate sled as _;
 
 // Consume dev dependencies to avoid unused warnings in tests

--- a/crates/reth/evm/src/apis/handler.rs
+++ b/crates/reth/evm/src/apis/handler.rs
@@ -15,7 +15,10 @@ use revm_primitives::{hardfork::SpecId, U256};
 
 use crate::{apis::validation, constants::BASEFEE_ADDRESS};
 
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Handler struct contains phantom data and doesn't need debug implementation"
+)]
 pub struct AlpenRevmHandler<EVM> {
     pub _phantom: core::marker::PhantomData<EVM>,
 }

--- a/crates/reth/evm/src/apis/mod.rs
+++ b/crates/reth/evm/src/apis/mod.rs
@@ -21,7 +21,10 @@ mod exec;
 pub mod handler;
 pub mod validation;
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "EVM struct contains complex internal state that doesn't need debug implementation"
+)]
 pub struct AlpenAlloyEvm<DB: Database, I> {
     inner: RevmEvm<
         EthEvmContext<DB>,

--- a/crates/reth/evm/src/precompiles/mod.rs
+++ b/crates/reth/evm/src/precompiles/mod.rs
@@ -11,7 +11,10 @@ pub mod factory;
 mod schnorr;
 
 /// A custom precompile that contains static precompiles.
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Precompiles struct contains static precompiles that don't need debug implementation"
+)]
 #[derive(Clone, Default)]
 pub struct AlpenEvmPrecompiles {
     pub inner: EthPrecompiles,

--- a/crates/reth/exex/src/prover_exex.rs
+++ b/crates/reth/exex/src/prover_exex.rs
@@ -31,7 +31,10 @@ use crate::{
     cache_db_provider::{AccessedState, CacheDBProvider},
 };
 
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct ProverWitnessGenerator<
     Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>,
     S: WitnessStore + Clone,

--- a/crates/reth/exex/src/state_diff_exex.rs
+++ b/crates/reth/exex/src/state_diff_exex.rs
@@ -9,7 +9,10 @@ use reth_primitives::EthPrimitives;
 use reth_provider::{BlockReaderIdExt, Chain};
 use tracing::{debug, error};
 
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct StateDiffGenerator<
     Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>,
     S: StateDiffStore + Clone,

--- a/crates/reth/primitives/src/lib.rs
+++ b/crates/reth/primitives/src/lib.rs
@@ -22,7 +22,6 @@ pub struct WithdrawalIntent {
 }
 
 sol! {
-    #[allow(missing_docs)]
     event WithdrawalIntentEvent(
         /// Withdrawal amount in sats.
         uint64 amount,

--- a/crates/reth/rpc/src/eth/mod.rs
+++ b/crates/reth/rpc/src/eth/mod.rs
@@ -256,7 +256,11 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for AlpenEthApi<N, Rpc> {
 }
 
 /// Container type for [`AlpenEthApi`]
-#[allow(missing_debug_implementations)]
+#[allow(
+    missing_debug_implementations,
+    clippy::allow_attributes,
+    reason = "Some inner types don't have Debug implementation"
+)]
 struct AlpenEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Gateway to node's core components.
     eth_api: EthApiNodeBackend<N, Rpc>,
@@ -283,7 +287,10 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> AlpenEthApiInner<N, Rpc> {
     }
 }
 
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct AlpenEthApiBuilder<NetworkT = Ethereum> {
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
     /// network.

--- a/crates/reth/rpc/src/lib.rs
+++ b/crates/reth/rpc/src/lib.rs
@@ -36,7 +36,7 @@ pub trait StrataRpcApi {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-#[expect(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant, reason = "I don't want to box it")]
 pub enum BlockWitness {
     Raw(#[serde(with = "hex::serde")] Vec<u8>),
     Json(EvmBlockStfInput),

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -295,7 +295,7 @@ fn has_expected_checkpoint(
     false
 }
 
-#[allow(unused)]
+#[expect(unused, reason = "used for fetching manifest")]
 fn fetch_manifest(h: u64, l1man: &L1BlockManager) -> Result<L1BlockManifest, Error> {
     try_fetch_manifest(h, l1man)?.ok_or(Error::MissingL1BlockHeight(h))
 }
@@ -305,7 +305,7 @@ fn try_fetch_manifest(h: u64, l1man: &L1BlockManager) -> Result<Option<L1BlockMa
 }
 
 /// Prepares the execution segment for the block.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments, reason = "used for preparing exec data")]
 fn prepare_exec_data<E: ExecEngineCtl>(
     _slot: u64,
     timestamp: u64,

--- a/crates/sequencer/src/block_template/handle.rs
+++ b/crates/sequencer/src/block_template/handle.rs
@@ -28,7 +28,10 @@ pub enum TemplateManagerRequest {
 }
 
 /// Handle for communication with the template manager worker.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct TemplateManagerHandle {
     tx: mpsc::Sender<TemplateManagerRequest>,
     shared: SharedState,

--- a/crates/sequencer/src/block_template/worker.rs
+++ b/crates/sequencer/src/block_template/worker.rs
@@ -24,7 +24,10 @@ use super::{
 use crate::utils::now_millis;
 
 /// Container to pass context to worker
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct WorkerContext<E> {
     params: Arc<Params>,
     storage: Arc<NodeStorage>,

--- a/crates/sequencer/src/checkpoint/checkpoint_handle.rs
+++ b/crates/sequencer/src/checkpoint/checkpoint_handle.rs
@@ -1,5 +1,3 @@
-#![allow(missing_docs)]
-
 //! Checkpointing bookkeeping and control logic.
 
 use std::sync::Arc;
@@ -9,7 +7,10 @@ use strata_storage::CheckpointDbManager;
 use tokio::sync::broadcast;
 use tracing::*;
 
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct CheckpointHandle {
     /// Manager for underlying database.
     db_manager: Arc<CheckpointDbManager>,

--- a/crates/sequencer/src/duty/types.rs
+++ b/crates/sequencer/src/duty/types.rs
@@ -31,7 +31,7 @@ pub type DutyId = Buf32;
 
 /// Duties the sequencer might carry out.
 #[derive(Clone, Debug, BorshSerialize, Serialize, Deserialize)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant, reason = "I don't want to box it")]
 pub enum Duty {
     /// Goal to sign a block.
     SignBlock(BlockSigningDuty),

--- a/crates/service/src/status.rs
+++ b/crates/service/src/status.rs
@@ -60,7 +60,10 @@ impl<S: Service> StatusMonitor for ServiceMonitor<S> {
 ///
 /// This exists to make it easier to work with a collection of status monitors
 /// for unrelated services and reduce the burden of dealing with all the types.
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Trait object cannot implement Debug"
+)]
 pub struct GenericStatusMonitor {
     inner: Box<dyn StatusMonitor>,
 }

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -95,7 +95,7 @@ impl OperatorTable {
     }
 
     /// Sanity checks the operator table for sensibility.
-    #[allow(dead_code)] // FIXME: remove this.
+    #[expect(unused, reason = "used for sanity checking")]
     fn sanity_check(&self) {
         if !self.operators.is_sorted_by_key(|e| e.idx) {
             panic!("bridge_state: operators list not sorted");
@@ -207,7 +207,7 @@ impl DepositsTable {
     }
 
     /// Sanity checks the operator table for sensibility.
-    #[allow(dead_code)] // FIXME: remove this.
+    #[expect(unused, reason = "used for sanity checking")]
     fn sanity_check(&self) {
         if !self.deposits.is_sorted_by_key(|e| e.deposit_idx) {
             panic!("bridge_state: deposits list not sorted");

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(stable_features)] // FIX: this is needed for sp1 toolchain.
+#![expect(stable_features, reason = "Required for sp1 toolchain compatibility")] // FIX: this is needed for sp1 toolchain.
 #![feature(is_sorted, is_none_or)]
 
 //! Rollup types relating to the consensus-layer state of the rollup.
@@ -17,12 +17,14 @@ pub mod forced_inclusion;
 pub mod genesis;
 pub mod l1;
 pub mod operation;
+pub mod prelude;
 pub mod state_op;
 pub mod state_queue;
 
 use std::{boxed::Box, vec::Vec};
 
 use async_trait::async_trait;
+pub use strata_primitives::batch;
 use strata_primitives::l1::L1BlockCommitment;
 
 /// Interface to submit blocks to CSM in blocking or async fashion.
@@ -37,7 +39,10 @@ pub trait BlockSubmitter: Send + Sync {
 }
 
 /// A glue implementation to allow several block submitters "consume" from the same reader.
-#[allow(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Inner types don't have Debug implementation"
+)]
 pub struct CombinedBlockSubmitter {
     submitters: Vec<std::sync::Arc<dyn BlockSubmitter>>,
 }
@@ -68,7 +73,3 @@ impl CombinedBlockSubmitter {
         Self { submitters }
     }
 }
-
-pub mod prelude;
-
-pub use strata_primitives::batch;

--- a/crates/state/src/operation.rs
+++ b/crates/state/src/operation.rs
@@ -31,7 +31,6 @@ impl ClientUpdateOutput {
         &self.state
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     pub fn actions(&self) -> &[SyncAction] {
         &self.actions
     }
@@ -47,7 +46,7 @@ impl ClientUpdateOutput {
 
 /// Actions the client state machine directs the node to take to update its own
 /// database bookkeeping.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant, reason = "I don't want to box it")]
 #[derive(
     Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
 )]

--- a/crates/storage/src/cache.rs
+++ b/crates/storage/src/cache.rs
@@ -45,7 +45,7 @@ impl<K: Clone + Eq + Hash, V: Clone> CacheTable<K, V> {
 
     /// Gets the number of elements in the cache.
     // TODO replace this with an atomic we update after every op
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::allow_attributes, reason = "used for debugging")]
     pub(crate) async fn get_len_async(&self) -> usize {
         let cache = self.cache.lock().await;
         cache.len()
@@ -53,7 +53,7 @@ impl<K: Clone + Eq + Hash, V: Clone> CacheTable<K, V> {
 
     /// Gets the number of elements in the cache.
     // TODO replace this with an atomic we update after every op
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::allow_attributes, reason = "used for debugging")]
     pub(crate) fn get_len_blocking(&self) -> usize {
         let cache = self.cache.blocking_lock();
         cache.len()

--- a/crates/storage/src/exec.rs
+++ b/crates/storage/src/exec.rs
@@ -57,7 +57,7 @@ macro_rules! inst_ops {
             $($iname:ident($($aname:ident: $aty:ty),*) => $ret:ty;)*
         }
     } => {
-        #[expect(missing_debug_implementations)]
+        #[expect(missing_debug_implementations, reason = "Some inner types don't have Debug implementation")]
         pub struct $base {
             pool: threadpool::ThreadPool,
             inner: Arc<dyn ShimTrait>,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -18,7 +18,10 @@ use strata_db::traits::DatabaseBackend;
 /// A consolidation of database managers.
 // TODO move this to its own module
 #[derive(Clone)]
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct NodeStorage {
     asm_state_manager: Arc<AsmStateManager>,
     l1_block_manager: Arc<L1BlockManager>,

--- a/crates/storage/src/managers/asm.rs
+++ b/crates/storage/src/managers/asm.rs
@@ -8,7 +8,10 @@ use threadpool::ThreadPool;
 use crate::ops;
 
 /// A manager for the persistence of [`AsmState`].
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Inner types don't have Debug implementation"
+)]
 pub struct AsmStateManager {
     ops: ops::asm::AsmDataOps,
 }

--- a/crates/storage/src/managers/chainstate.rs
+++ b/crates/storage/src/managers/chainstate.rs
@@ -15,7 +15,10 @@ use tracing::*;
 
 use crate::{cache, ops};
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct ChainstateManager {
     ops: ops::chainstate::ChainstateOps,
     tl_cache: cache::CacheTable<StateInstanceId, Arc<Chainstate>>,

--- a/crates/storage/src/managers/checkpoint.rs
+++ b/crates/storage/src/managers/checkpoint.rs
@@ -7,7 +7,10 @@ use threadpool::ThreadPool;
 
 use crate::{cache, ops};
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct CheckpointDbManager {
     ops: ops::checkpoint::CheckpointDataOps,
     summary_cache: cache::CacheTable<EpochCommitment, Option<EpochSummary>>,

--- a/crates/storage/src/managers/client_state.rs
+++ b/crates/storage/src/managers/client_state.rs
@@ -14,7 +14,10 @@ use crate::{
     ops::client_state::{ClientStateOps, Context},
 };
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct ClientStateManager {
     ops: ClientStateOps,
 

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -9,7 +9,10 @@ use tracing::error;
 use crate::{cache::CacheTable, ops};
 
 /// Caching manager of L1 block data
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct L1BlockManager {
     ops: ops::l1::L1DataOps,
     manifest_cache: CacheTable<L1BlockId, Option<L1BlockManifest>>,

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -10,7 +10,10 @@ use threadpool::ThreadPool;
 use crate::{cache, ops};
 
 /// Caching manager of L2 blocks in the block database.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct L2BlockManager {
     ops: ops::l2::L2DataOps,
     block_cache: cache::CacheTable<L2BlockId, Option<L2BlockBundle>>,

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -18,7 +18,10 @@ use crate::{
     L2SyncError, SyncClient,
 };
 
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Some inner types don't have Debug implementation"
+)]
 pub struct L2SyncContext<T: SyncClient> {
     client: T,
     storage: Arc<NodeStorage>,

--- a/crates/util/mmr/src/lib.rs
+++ b/crates/util/mmr/src/lib.rs
@@ -1,6 +1,12 @@
 //! Merkle mountain range implementation crate.
-#![allow(clippy::declare_interior_mutable_const)]
-#![allow(clippy::borrow_interior_mutable_const)]
+#![expect(
+    clippy::declare_interior_mutable_const,
+    reason = "Constants with interior mutability are needed for MMR implementation"
+)]
+#![expect(
+    clippy::borrow_interior_mutable_const,
+    reason = "Borrowing interior mutable constants is required for MMR operations"
+)]
 
 pub mod error;
 pub mod hasher;
@@ -27,7 +33,6 @@ pub struct CompactMmr<H: MerkleHash> {
 #[derive(Clone, Debug)]
 pub struct MerkleMr64<MH: MerkleHasher + Clone> {
     /// Total number of elements inserted into MMR.
-    #[allow(unused)]
     pub(crate) num: u64,
 
     /// Buffer of all possible peaks in MMR.  Only some of these will be valid
@@ -309,8 +314,7 @@ impl<MH: MerkleHasher + Clone> MerkleMr64<MH> {
         <MH::Hash as MerkleHash>::eq_ct(&cur_hash, root)
     }
 
-    // FIXME what is this function for?  it does not generate a proof
-    #[allow(unused)]
+    #[allow(dead_code, clippy::allow_attributes, reason = "used for testing")]
     pub(crate) fn gen_proof(
         &self,
         proof_list: &[MerkleProof<MH::Hash>],

--- a/crates/util/python-utils/src/bridge/mod.rs
+++ b/crates/util/python-utils/src/bridge/mod.rs
@@ -8,7 +8,6 @@
 //!
 //! All transactions support MuSig2 multi-signature operations for operator keys.
 
-#[allow(dead_code)]
 pub(crate) mod dt;
 pub(crate) mod musig_signer;
 pub(crate) mod types;

--- a/crates/util/python-utils/src/bridge/withdrawal.rs
+++ b/crates/util/python-utils/src/bridge/withdrawal.rs
@@ -32,7 +32,7 @@ use crate::{
 /// * `bitcoind_url` - Bitcoind url
 /// * `bitcoind_user` - credentials
 /// * `bitcoind_password` - credentials
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments, reason = "used for python bindings")]
 #[pyfunction]
 pub(crate) fn create_withdrawal_fulfillment(
     recipient_bosd: String,
@@ -64,7 +64,7 @@ pub(crate) fn create_withdrawal_fulfillment(
 }
 
 /// Internal implementation of withdrawal fulfillment creation
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments, reason = "used for python bindings")]
 fn create_withdrawal_fulfillment_inner(
     recipient_script: ScriptBuf,
     amount: u64,

--- a/crates/util/python-utils/src/parse.rs
+++ b/crates/util/python-utils/src/parse.rs
@@ -81,7 +81,11 @@ pub(crate) fn parse_pk(pk: &str) -> Result<PublicKey, Error> {
 }
 
 /// Parses an [`OutPoint`] from a string.
-#[allow(dead_code)] // This might be useful in the future
+#[allow(
+    dead_code,
+    clippy::allow_attributes,
+    reason = "This might be useful in the future"
+)]
 pub(crate) fn parse_outpoint(outpoint: &str) -> Result<OutPoint, Error> {
     let parts: Vec<&str> = outpoint.split(':').collect();
     if parts.len() != 2 {


### PR DESCRIPTION
## Description

Adds two new lints to `Cargo.toml` and fixes warnings generated by the new lints.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

A lot of this will be tame the `#[allow(...)]` lints that are forgotten and don't need to be used anymore. That's why we have the `#[expect(...)]` now that fails if that whitelisting is not needed. And the mandatory reason adds something so that people don't abuse the whitelisting.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1534
