### PR TITLE
log: Bitcoin `Buf32` types reverse hex

### DIFF
--- a/bin/strata-dbtool/src/output/broadcaster.rs
+++ b/bin/strata-dbtool/src/output/broadcaster.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::Serialize;
 use strata_db::types::L1TxStatus;
 use strata_primitives::buf::Buf32;
@@ -48,5 +50,43 @@ impl<'a> Formattable for BroadcasterTxInfo<'a> {
             porcelain_field("tx.raw_tx.len", format!("{:?} bytes", self.raw_tx.len())),
         ]
         .join("\n")
+    }
+}
+
+// Custom debug implementation to print txid in little endian
+impl<'a> fmt::Debug for BroadcasterTxInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+
+        f.debug_struct("BroadcasterTxInfo")
+            .field("index", &self.index)
+            .field("txid", &txid_le)
+            .field("status", &self.status)
+            .field("raw_tx", &self.raw_tx)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl<'a> fmt::Display for BroadcasterTxInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+
+        write!(
+            f,
+            "BroadcasterTxInfo {{ index: {}, txid: {}, status: {:?}, raw_tx: {} bytes }}",
+            self.index,
+            txid_le,
+            self.status,
+            self.raw_tx.len()
+        )
     }
 }

--- a/crates/asm-types/src/ops.rs
+++ b/crates/asm-types/src/ops.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use digest::Digest;
@@ -116,7 +118,7 @@ pub struct DepositRequestInfo {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
+    Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
 )]
 pub struct WithdrawalFulfillmentInfo {
     /// index of deposit this fulfillment is for
@@ -140,4 +142,45 @@ pub struct WithdrawalFulfillmentInfo {
 pub struct DepositSpendInfo {
     /// index of the deposit whose utxo is spent.
     pub deposit_idx: u32,
+}
+
+// Custom debug implementation to print txid in little endian
+impl fmt::Debug for WithdrawalFulfillmentInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+
+        f.debug_struct("WithdrawalFulfillmentInfo")
+            .field("deposit_idx", &self.deposit_idx)
+            .field("operator_idx", &self.operator_idx)
+            .field("amt", &self.amt)
+            .field("txid", &txid_le)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl fmt::Display for WithdrawalFulfillmentInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+
+        write!(
+            f,
+            "WithdrawalFulfillmentInfo {{ deposit_idx: {}, operator_idx: {}, amt: {:?}, txid: {} }}",
+            self.deposit_idx, self.operator_idx, self.amt, txid_le
+        )
+    }
 }

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -20,7 +20,7 @@ anyhow.workspace = true
 bitcoin.workspace = true
 bitcoind-async-client.workspace = true
 borsh.workspace = true
-hex = { workspace = true, optional = true }
+hex.workspace = true
 musig2 = { workspace = true, features = ["serde"], optional = true }
 rand.workspace = true
 reqwest.workspace = true
@@ -46,4 +46,4 @@ strata-test-utils-tx-indexer.workspace = true
 corepc-node = { version = "0.8.0", features = ["29_0"] }
 
 [features]
-test_utils = ["dep:hex", "dep:musig2"]
+test_utils = ["dep:musig2"]

--- a/crates/primitives/src/batch.rs
+++ b/crates/primitives/src/batch.rs
@@ -466,7 +466,7 @@ pub struct TxFilterConfigTransition {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Arbitrary, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+    Clone, PartialEq, Eq, Arbitrary, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
 )]
 pub struct CommitmentInfo {
     pub blockhash: Buf32,
@@ -536,4 +536,60 @@ pub fn verify_signed_checkpoint_sig(
         &checkpoint_sighash,
         seq_pubkey,
     )
+}
+
+// Custom debug implementation to print txid and wtxid in little endian
+impl fmt::Debug for CommitmentInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+        let wtxid_le = {
+            let mut bytes = self.wtxid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+        let blockhash_le = {
+            let mut bytes = self.blockhash.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+
+        f.debug_struct("CommitmentInfo")
+            .field("blockhash", &blockhash_le)
+            .field("txid", &txid_le)
+            .field("wtxid", &wtxid_le)
+            .field("block_height", &self.block_height)
+            .field("position", &self.position)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid and wtxid in little endian
+impl fmt::Display for CommitmentInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+        let wtxid_le = {
+            let mut bytes = self.wtxid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+        let blockhash_le = {
+            let mut bytes = self.blockhash.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+
+        write!(
+            f,
+            "CommitmentInfo {{ blockhash: {}, txid: {}, wtxid: {}, block_height: {}, position: {} }}",
+            blockhash_le, txid_le, wtxid_le, self.block_height, self.position
+        )
+    }
 }

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -4,6 +4,7 @@ use arbitrary::Arbitrary;
 use bitcoin::{hashes::Hash, BlockHash};
 use borsh::{BorshDeserialize, BorshSerialize};
 use const_hex as hex;
+use hex::encode_to_slice;
 use serde::{Deserialize, Serialize};
 
 use crate::{buf::Buf32, hash::sha256d};
@@ -138,8 +139,11 @@ impl fmt::Debug for L1BlockId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut bytes = self.0 .0;
         bytes.reverse();
-        let hex_str = hex::encode(bytes);
-        f.write_str(&hex_str)
+        let mut buf = [0u8; 64]; // 32 bytes * 2 for hex
+        encode_to_slice(bytes, &mut buf).expect("buf: enc hex");
+        // SAFETY: hex encoding always produces valid UTF-8
+        let hex_str = unsafe { str::from_utf8_unchecked(&buf) };
+        f.write_str(hex_str)
     }
 }
 
@@ -148,7 +152,10 @@ impl fmt::Display for L1BlockId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut bytes = self.0 .0;
         bytes.reverse();
-        let hex_str = hex::encode(bytes);
-        f.write_str(&hex_str)
+        let mut buf = [0u8; 64]; // 32 bytes * 2 for hex
+        encode_to_slice(bytes, &mut buf).expect("buf: enc hex");
+        // SAFETY: hex encoding always produces valid UTF-8
+        let hex_str = unsafe { str::from_utf8_unchecked(&buf) };
+        f.write_str(hex_str)
     }
 }

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str};
 
 use arbitrary::Arbitrary;
 use bitcoin::{hashes::Hash, BlockHash};
@@ -102,10 +102,9 @@ impl fmt::Display for L1BlockCommitment {
             f,
             "{}@{}..{}",
             self.height,
-            std::str::from_utf8(&first_hex)
+            str::from_utf8(&first_hex)
                 .expect("Failed to convert first 2 hex bytes to UTF-8 string"),
-            std::str::from_utf8(&last_hex)
-                .expect("Failed to convert last 2 hex bytes to UTF-8 string")
+            str::from_utf8(&last_hex).expect("Failed to convert last 2 hex bytes to UTF-8 string")
         )
     }
 }

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -6,7 +6,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use const_hex as hex;
 use serde::{Deserialize, Serialize};
 
-use crate::{buf::Buf32, hash::sha256d, impl_buf_wrapper};
+use crate::{buf::Buf32, hash::sha256d};
 
 /// ID of an L1 block, usually the hash of its header.
 #[derive(
@@ -34,7 +34,24 @@ impl L1BlockId {
     }
 }
 
-impl_buf_wrapper!(L1BlockId, Buf32, 32);
+// Custom implementation without Debug/Display to avoid conflicts
+impl From<Buf32> for L1BlockId {
+    fn from(value: Buf32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<L1BlockId> for Buf32 {
+    fn from(value: L1BlockId) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<[u8; 32]> for L1BlockId {
+    fn as_ref(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
 
 impl From<BlockHash> for L1BlockId {
     fn from(value: BlockHash) -> Self {
@@ -114,5 +131,25 @@ impl L1BlockCommitment {
 
     pub fn blkid(&self) -> &L1BlockId {
         &self.blkid
+    }
+}
+
+// Custom debug implementation to print the block hash in little endian
+impl fmt::Debug for L1BlockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut bytes = self.0 .0;
+        bytes.reverse();
+        let hex_str = hex::encode(bytes);
+        f.write_str(&hex_str)
+    }
+}
+
+// Custom display implementation to print the block hash in little endian
+impl fmt::Display for L1BlockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut bytes = self.0 .0;
+        bytes.reverse();
+        let hex_str = hex::encode(bytes);
+        f.write_str(&hex_str)
     }
 }

--- a/crates/primitives/src/l1/btc.rs
+++ b/crates/primitives/src/l1/btc.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::Display,
+    fmt::{self, Debug, Display},
     io::{self, Read, Write},
     iter::Sum,
     ops::Add,
@@ -708,10 +708,39 @@ impl<'a> Arbitrary<'a> for TaprootSpendPath {
 }
 
 /// Outpoint of a bitcoin tx
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, BorshSerialize, BorshDeserialize)]
 pub struct Outpoint {
     pub txid: Buf32,
     pub vout: u32,
+}
+
+// Custom debug implementation to print txid in little endian
+impl Debug for Outpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+
+        f.debug_struct("Outpoint")
+            .field("txid", &txid_le)
+            .field("vout", &self.vout)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl Display for Outpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        };
+
+        write!(f, "Outpoint {{ txid: {}, vout: {} }}", txid_le, self.vout)
+    }
 }
 
 /// A wrapper around [`Buf32`] for XOnly Schnorr taproot pubkeys.

--- a/crates/primitives/src/l1/status.rs
+++ b/crates/primitives/src/l1/status.rs
@@ -1,10 +1,13 @@
+use std::fmt;
+
 use arbitrary::Arbitrary;
+use const_hex as hex;
 use serde::{Deserialize, Serialize};
 
 use crate::buf::Buf32;
 
 /// Data that reflects what's happening around L1
-#[derive(Debug, Clone, Serialize, Deserialize, Default, Arbitrary)]
+#[derive(Clone, Serialize, Deserialize, Default, Arbitrary)]
 pub struct L1Status {
     /// If the last time we tried to poll the client (as of `last_update`)
     /// we were successful.
@@ -28,4 +31,49 @@ pub struct L1Status {
 
     /// Number of published reveal transactions.
     pub published_reveal_txs_count: u64,
+}
+
+// Custom debug implementation to print the txid in little endian
+impl fmt::Debug for L1Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let last_published_txid_le = self.last_published_txid.map(|txid| {
+            let mut bytes = txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        });
+
+        f.debug_struct("L1Status")
+            .field("bitcoin_rpc_connected", &self.bitcoin_rpc_connected)
+            .field("last_rpc_error", &self.last_rpc_error)
+            .field("cur_height", &self.cur_height)
+            .field("cur_tip_blkid", &self.cur_tip_blkid)
+            .field("last_published_txid", &last_published_txid_le)
+            .field("last_update", &self.last_update)
+            .field(
+                "published_reveal_txs_count",
+                &self.published_reveal_txs_count,
+            )
+            .finish()
+    }
+}
+
+// Custom display information to print the txid in little endian
+impl fmt::Display for L1Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let last_published_txid_le = self.last_published_txid.map(|txid| {
+            let mut bytes = txid.0;
+            bytes.reverse();
+            hex::encode(bytes)
+        });
+
+        write!(
+            f,
+            "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: {}, published_reveal_txs_count: {} }}",
+            self.bitcoin_rpc_connected,
+            self.cur_height,
+            self.cur_tip_blkid,
+            last_published_txid_le.as_deref().unwrap_or("None"),
+            self.published_reveal_txs_count
+        )
+    }
 }

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -3,6 +3,8 @@
 //! This just implements a very simple n-of-n multisig bridge.  It will be
 //! extended to a more sophisticated design when we have that specced out.
 
+use std::fmt;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::{
@@ -544,7 +546,7 @@ impl WithdrawOutput {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct FulfilledState {
     /// The index of the operator that has fronted the funds for the withdrawal,
     /// and who will be reimbursed by the bridge notaries.
@@ -572,5 +574,45 @@ impl FulfilledState {
 
     pub fn amt(&self) -> BitcoinAmount {
         self.amt
+    }
+}
+
+// Custom debug implementation to print txid in little endian
+impl fmt::Debug for FulfilledState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+
+        f.debug_struct("FulfilledState")
+            .field("assignee", &self.assignee)
+            .field("amt", &self.amt)
+            .field("txid", &txid_le)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl fmt::Display for FulfilledState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+
+        write!(
+            f,
+            "FulfilledState {{ assignee: {}, amt: {:?}, txid: {} }}",
+            self.assignee, self.amt, txid_le
+        )
     }
 }

--- a/crates/state/src/client_state.rs
+++ b/crates/state/src/client_state.rs
@@ -104,7 +104,7 @@ impl CheckpointState {
 
 /// Represents a reference to a transaction in bitcoin. Redundantly puts block_height a well.
 #[derive(
-    Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
+    Clone, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
 )]
 pub struct CheckpointL1Ref {
     pub l1_commitment: L1BlockCommitment,
@@ -161,5 +161,61 @@ impl L1Checkpoint {
             batch_transition,
             l1_reference,
         }
+    }
+}
+
+// Custom debug implementation to print txid and wtxid in little endian
+impl fmt::Debug for CheckpointL1Ref {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+        let wtxid_le = {
+            let mut bytes = self.wtxid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+
+        f.debug_struct("CheckpointL1Ref")
+            .field("l1_commitment", &self.l1_commitment)
+            .field("txid", &txid_le)
+            .field("wtxid", &wtxid_le)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid and wtxid in little endian
+impl fmt::Display for CheckpointL1Ref {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+        let wtxid_le = {
+            let mut bytes = self.wtxid.0;
+            bytes.reverse();
+            bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+
+        write!(
+            f,
+            "CheckpointL1Ref {{ l1_commitment: {}, txid: {}, wtxid: {} }}",
+            self.l1_commitment, txid_le, wtxid_le
+        )
     }
 }


### PR DESCRIPTION
## Description

Some 32-byte bitcoin things are represented as `Buf32`.
That creates an issue when we log them because block explorers reverse the bytes as little-endian for things like TXID, WTXID and block hashes.

This PR fixes that by adding custom `Debug`/`Display` impls that reverse these bytes for these bitcoin tuple struct wrappers around `Buf32`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The tickets STR-1478, STR-1494, STR-1498, and STR-1478 suggest creating a new `Buf32R` type.
But I disagree. The type Tetris is pretty solid in the codebase and I don't want to add more types to represent the same thing, zkVM-friendly 32-bytes.

Hence, I went with the custom `Debug`/`Display` impl with a quick dirty fix in `btcio` in 653bb2f4e3ffddf1f958df6c43d817f6c7c4b107

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1478
STR-1494
STR-1478
STR-1498
