### PR TITLE
refactor: move bridge types to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14284,10 +14284,10 @@ dependencies = [
  "bitcoin",
  "borsh",
  "strata-asm-common",
+ "strata-bridge-types",
  "strata-checkpoint-types",
  "strata-l1tx",
  "strata-ol-chainstate-types",
- "strata-state",
  "strata-test-utils",
  "thiserror 2.0.16",
 ]
@@ -14446,6 +14446,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-bridge-types"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "arbitrary",
+ "bitcoin",
+ "borsh",
+ "musig2",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "strata-primitives",
+ "strata-test-utils",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "strata-btcio"
 version = "0.3.0-alpha.1"
 dependencies = [
@@ -14520,6 +14536,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "strata-asm-types",
+ "strata-bridge-types",
  "strata-checkpoint-types",
  "strata-crypto",
  "strata-ol-chain-types",
@@ -14563,6 +14580,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "serde_json",
+ "strata-bridge-types",
  "strata-btcio",
  "strata-checkpoint-types",
  "strata-common",
@@ -14638,6 +14656,7 @@ dependencies = [
  "rand 0.8.5",
  "strata-asm-types",
  "strata-asm-worker",
+ "strata-bridge-types",
  "strata-chain-worker",
  "strata-chainexec",
  "strata-chaintsn",
@@ -14883,6 +14902,7 @@ dependencies = [
  "reth-rpc-api",
  "reth-rpc-layer",
  "revm-primitives",
+ "strata-bridge-types",
  "strata-db",
  "strata-eectl",
  "strata-ol-chain-types",
@@ -14926,13 +14946,13 @@ dependencies = [
  "borsh",
  "secp256k1 0.29.1",
  "strata-asm-types",
+ "strata-bridge-types",
  "strata-btcio",
  "strata-checkpoint-types",
  "strata-crypto",
  "strata-l1-txfmt",
  "strata-ol-chainstate-types",
  "strata-primitives",
- "strata-state",
  "strata-test-utils",
  "strata-test-utils-btc",
  "strata-test-utils-l2",
@@ -14997,6 +15017,7 @@ dependencies = [
  "bitcoin",
  "borsh",
  "strata-asm-types",
+ "strata-bridge-types",
  "strata-primitives",
  "strata-state",
  "tracing",
@@ -15015,7 +15036,6 @@ dependencies = [
  "digest 0.10.7",
  "hex",
  "k256",
- "musig2",
  "num_enum 0.7.4",
  "rand 0.8.5",
  "secp256k1 0.29.1",
@@ -15074,6 +15094,7 @@ dependencies = [
  "rsp-client-executor",
  "serde",
  "serde_json",
+ "strata-bridge-types",
  "strata-ol-chain-types",
  "strata-primitives",
  "strata-state",
@@ -15204,6 +15225,7 @@ version = "0.3.0-alpha.1"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
+ "strata-bridge-types",
  "strata-checkpoint-types",
  "strata-common",
  "strata-db",
@@ -15224,6 +15246,7 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "serde_json",
+ "strata-bridge-types",
  "strata-checkpoint-types",
  "strata-db",
  "strata-ol-chain-types",
@@ -15352,6 +15375,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-stf",
  "strata-asm-types",
+ "strata-bridge-types",
  "strata-checkpoint-types",
  "strata-primitives",
 ]
@@ -15360,6 +15384,7 @@ dependencies = [
 name = "strata-status"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "strata-bridge-types",
  "strata-ol-chain-types",
  "strata-ol-chainstate-types",
  "strata-primitives",
@@ -15438,9 +15463,9 @@ dependencies = [
  "bitcoind-async-client",
  "hex",
  "strata-asm-types",
+ "strata-bridge-types",
  "strata-btcio",
  "strata-primitives",
- "strata-state",
  "strata-test-utils",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ strata-asm-txs-admin = { path = "crates/asm/txs/admin" }
 strata-asm-txs-bridge-v1 = { path = "crates/asm/txs/bridge-v1" }
 strata-asm-types = { path = "crates/asm-types" }
 strata-asm-worker = { path = "crates/asm/worker" }
+strata-bridge-types = { path = "crates/bridge-types" }
 strata-btcio = { path = "crates/btcio" }
 strata-chain-worker = { path = "crates/chain-worker" }
 strata-chainexec = { path = "crates/chainexec" }

--- a/bin/strata-client/Cargo.toml
+++ b/bin/strata-client/Cargo.toml
@@ -11,6 +11,7 @@ name = "strata-client"
 path = "src/main.rs"
 
 [dependencies]
+strata-bridge-types.workspace = true
 strata-btcio.workspace = true
 strata-checkpoint-types.workspace = true
 strata-common = { workspace = true, default-features = true }

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -10,6 +10,7 @@ use bitcoin::{
 };
 use futures::TryFutureExt;
 use jsonrpsee::core::RpcResult;
+use strata_bridge_types::{DepositState, PublickeyTable, WithdrawalIntent};
 use strata_btcio::{broadcaster::L1BroadcastHandle, writer::EnvelopeHandle};
 use strata_checkpoint_types::{Checkpoint, EpochSummary, SignedCheckpoint};
 #[cfg(feature = "debug-utils")]
@@ -20,7 +21,6 @@ use strata_db::types::{CheckpointConfStatus, CheckpointProvingStatus, L1TxEntry,
 use strata_ol_chain_types::{L2Block, L2BlockBundle, L2BlockId, L2Header};
 use strata_ol_chainstate_types::Chainstate;
 use strata_primitives::{
-    bridge::{OperatorIdx, PublickeyTable},
     buf::Buf32,
     epoch::EpochCommitment,
     hash,
@@ -28,6 +28,7 @@ use strata_primitives::{
         payload::{L1Payload, PayloadDest, PayloadIntent},
         L1BlockCommitment, L1BlockId,
     },
+    operator::OperatorIdx,
     params::Params,
 };
 use strata_rpc_api::{
@@ -46,10 +47,7 @@ use strata_sequencer::{
     checkpoint::{verify_checkpoint_sig, CheckpointHandle},
     duty::{extractor::extract_duties, types::Duty},
 };
-use strata_state::{
-    bridge_ops::WithdrawalIntent, bridge_state::DepositState, client_state::ClientState,
-    operation::ClientUpdateOutput,
-};
+use strata_state::{client_state::ClientState, operation::ClientUpdateOutput};
 use strata_status::StatusChannel;
 use strata_storage::NodeStorage;
 use tokio::sync::{oneshot, Mutex};

--- a/crates/asm/subprotocols/bridge-v1/src/errors.rs
+++ b/crates/asm/subprotocols/bridge-v1/src/errors.rs
@@ -6,8 +6,8 @@ use strata_asm_txs_bridge_v1::errors::{
 };
 use strata_l1_txfmt::TxType;
 use strata_primitives::{
-    bridge::OperatorIdx,
     l1::{BitcoinAmount, BitcoinTxid},
+    operator::OperatorIdx,
 };
 use thiserror::Error;
 

--- a/crates/asm/subprotocols/bridge-v1/src/state/assignment.rs
+++ b/crates/asm/subprotocols/bridge-v1/src/state/assignment.rs
@@ -12,9 +12,9 @@ use rand_chacha::{
 };
 use serde::{Deserialize, Serialize};
 use strata_primitives::{
-    bridge::{BitcoinBlockHeight, OperatorIdx},
     buf::Buf32,
-    l1::{BitcoinAmount, BitcoinTxid, L1BlockId},
+    l1::{BitcoinAmount, BitcoinBlockHeight, BitcoinTxid, L1BlockId},
+    operator::OperatorIdx,
     sorted_vec::SortedVec,
 };
 
@@ -400,7 +400,10 @@ impl AssignmentTable {
 
 #[cfg(test)]
 mod tests {
-    use strata_primitives::{bridge::BitcoinBlockHeight, l1::L1BlockId};
+    use strata_primitives::{
+        l1::{BitcoinBlockHeight, L1BlockId},
+        operator::OperatorIdx,
+    };
     use strata_test_utils::ArbitraryGenerator;
 
     use super::*;

--- a/crates/asm/subprotocols/bridge-v1/src/state/deposit.rs
+++ b/crates/asm/subprotocols/bridge-v1/src/state/deposit.rs
@@ -9,8 +9,8 @@ use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::{
-    bridge::OperatorIdx,
     l1::{BitcoinAmount, OutputRef},
+    operator::OperatorIdx,
     sorted_vec::SortedVec,
 };
 

--- a/crates/asm/subprotocols/bridge-v1/src/state/operator.rs
+++ b/crates/asm/subprotocols/bridge-v1/src/state/operator.rs
@@ -6,7 +6,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_crypto::multisig::aggregate_schnorr_keys;
 use strata_primitives::{
-    bridge::OperatorIdx, buf::Buf32, l1::XOnlyPk, operator::OperatorPubkeys, sorted_vec::SortedVec,
+    buf::Buf32,
+    l1::XOnlyPk,
+    operator::{OperatorIdx, OperatorPubkeys},
+    sorted_vec::SortedVec,
 };
 
 /// Bridge operator entry containing identification and cryptographic keys.

--- a/crates/asm/subprotocols/bridge-v1/src/state/withdrawal.rs
+++ b/crates/asm/subprotocols/bridge-v1/src/state/withdrawal.rs
@@ -10,8 +10,8 @@ use moho_types::ExportEntry;
 use serde::{Deserialize, Serialize};
 use strata_primitives::{
     bitcoin_bosd::Descriptor,
-    bridge::OperatorIdx,
     l1::{BitcoinAmount, BitcoinTxid},
+    operator::OperatorIdx,
 };
 
 /// Command specifying a Bitcoin output for a withdrawal operation.

--- a/crates/asm/txs/bridge-v1/src/withdrawal_fulfillment/parse.rs
+++ b/crates/asm/txs/bridge-v1/src/withdrawal_fulfillment/parse.rs
@@ -2,8 +2,8 @@ use arbitrary::{Arbitrary, Unstructured};
 use bitcoin::{ScriptBuf, Txid, hashes::Hash};
 use strata_asm_common::TxInputRef;
 use strata_primitives::{
-    bridge::OperatorIdx,
     l1::{BitcoinAmount, BitcoinTxid},
+    operator::OperatorIdx,
 };
 
 use crate::{

--- a/crates/asm/txs/checkpoint/Cargo.toml
+++ b/crates/asm/txs/checkpoint/Cargo.toml
@@ -8,10 +8,10 @@ workspace = true
 
 [dependencies]
 strata-asm-common.workspace = true
+strata-bridge-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-l1tx.workspace = true
 strata-ol-chainstate-types.workspace = true
-strata-state.workspace = true
 
 bitcoin.workspace = true
 borsh.workspace = true

--- a/crates/asm/txs/checkpoint/src/parser.rs
+++ b/crates/asm/txs/checkpoint/src/parser.rs
@@ -7,10 +7,10 @@ use bitcoin::{
 };
 use borsh::BorshDeserialize;
 use strata_asm_common::TxInputRef;
+use strata_bridge_types::WithdrawalIntent;
 use strata_checkpoint_types::{Checkpoint, SignedCheckpoint};
 use strata_l1tx::envelope::parser::enter_envelope;
 use strata_ol_chainstate_types::Chainstate;
-use strata_state::bridge_ops::WithdrawalIntent;
 
 use crate::errors::{CheckpointTxError, CheckpointTxResult};
 

--- a/crates/bridge-types/Cargo.toml
+++ b/crates/bridge-types/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+edition = "2021"
+name = "strata-bridge-types"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[dependencies]
+strata-primitives.workspace = true
+
+arbitrary.workspace = true
+bitcoin.workspace = true
+borsh.workspace = true
+musig2.workspace = true
+rand.workspace = true
+serde.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+strata-test-utils.workspace = true
+
+[features]
+default = ["std"]
+std = []
+test_utils = []

--- a/crates/bridge-types/src/bridge_ops.rs
+++ b/crates/bridge-types/src/bridge_ops.rs
@@ -4,9 +4,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32, l1::BitcoinAmount};
 
-// TODO make this not hardcoded!
-pub const WITHDRAWAL_DENOMINATION: BitcoinAmount = BitcoinAmount::from_int_btc(10);
-
 /// Describes an intent to withdraw that hasn't been dispatched yet.
 #[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct WithdrawalIntent {

--- a/crates/bridge-types/src/bridge_state.rs
+++ b/crates/bridge-types/src/bridge_state.rs
@@ -128,15 +128,15 @@ impl OperatorTable {
     }
 
     /// Inserts a new operator entry.
-    pub fn insert(&mut self, signing_pk: Buf32, wallet_pk: Buf32) {
+    pub fn insert(&mut self, operator_pubkeys: OperatorPubkeys) {
         let entry = OperatorEntry {
             idx: {
                 let idx = self.next_idx;
                 self.next_idx += 1;
                 idx
             },
-            signing_pk,
-            wallet_pk,
+            signing_pk: *operator_pubkeys.signing_pk(),
+            wallet_pk: *operator_pubkeys.wallet_pk(),
         };
         self.operators.push(entry);
     }

--- a/crates/bridge-types/src/bridge_state.rs
+++ b/crates/bridge-types/src/bridge_state.rs
@@ -9,10 +9,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::{
     bitcoin_bosd::Descriptor,
-    bridge::{BitcoinBlockHeight, OperatorIdx},
     buf::Buf32,
-    l1::{BitcoinAmount, OutputRef},
-    operator::{OperatorKeyProvider, OperatorPubkeys},
+    l1::{BitcoinAmount, BitcoinBlockHeight, OutputRef},
+    operator::{OperatorIdx, OperatorKeyProvider, OperatorPubkeys},
 };
 
 /// Entry for an operator.
@@ -524,7 +523,7 @@ impl DispatchCommand {
     }
 }
 
-/// An output constructed from [`crate::bridge_ops::WithdrawalIntent`].
+/// An output constructed from [`super::bridge_ops::WithdrawalIntent`].
 #[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct WithdrawOutput {

--- a/crates/bridge-types/src/constants.rs
+++ b/crates/bridge-types/src/constants.rs
@@ -1,0 +1,19 @@
+//! Constants for bridge-related types.
+
+use strata_primitives::l1::BitcoinAmount;
+
+/// The size (in bytes) of a [`musig2::PartialSignature`].
+pub(crate) const MUSIG2_PARTIAL_SIG_SIZE: usize = 32;
+
+/// The size (in bytes) of a [`musig2::NonceSeed`].
+pub(crate) const NONCE_SEED_SIZE: usize = 32;
+
+/// The size (in bytes) of a [`musig2::PubNonce`].
+pub(crate) const PUB_NONCE_SIZE: usize = 66;
+
+/// The size (in bytes) of a [`musig2::SecNonce`].
+pub(crate) const SEC_NONCE_SIZE: usize = 64;
+
+// TODO make this not hardcoded!
+/// The denomination for withdrawal batches in Bitcoin.
+pub const WITHDRAWAL_DENOMINATION: BitcoinAmount = BitcoinAmount::from_int_btc(10);

--- a/crates/bridge-types/src/lib.rs
+++ b/crates/bridge-types/src/lib.rs
@@ -1,0 +1,27 @@
+//! Bridge types for the Strata protocol.
+//!
+//! This crate contains types related to bridge operations, including operator management,
+//! bridge messages, and bridge state management.
+
+mod bridge;
+mod bridge_ops;
+mod bridge_state;
+mod constants;
+mod operator;
+mod relay;
+
+// Re-export commonly used types
+pub use bridge::{
+    Musig2PartialSig, Musig2PubNonce, Musig2SecNonce, OperatorPartialSig, PublickeyTable,
+    TxSigningData,
+};
+pub use bridge_ops::{DepositIntent, WithdrawalBatch, WithdrawalIntent};
+pub use bridge_state::{
+    CreatedState, DepositEntry, DepositState, DepositsTable, DispatchCommand, DispatchedState,
+    FulfilledState, OperatorEntry, OperatorTable, WithdrawOutput,
+};
+pub use constants::WITHDRAWAL_DENOMINATION;
+pub use operator::{OperatorKeyProvider, StubOpKeyProv};
+pub use relay::{
+    verify_bridge_msg_sig, BridgeMessage, BridgeMsgId, MessageSigner, Scope, VerifyError,
+};

--- a/crates/bridge-types/src/operator.rs
+++ b/crates/bridge-types/src/operator.rs
@@ -1,0 +1,30 @@
+use strata_primitives::{operator::OperatorIdx, prelude::Buf32};
+
+/// Some type that can provide operator keys.
+pub trait OperatorKeyProvider {
+    /// Returns the operator's signing pubkey, if it exists in the table.
+    fn get_operator_signing_pk(&self, idx: OperatorIdx) -> Option<Buf32>;
+}
+
+/// Stub key provider that can be used for testing.
+#[derive(Debug)]
+pub struct StubOpKeyProv {
+    expected_idx: OperatorIdx,
+    pk: Buf32,
+}
+
+impl StubOpKeyProv {
+    pub fn new(expected_idx: OperatorIdx, pk: Buf32) -> Self {
+        Self { expected_idx, pk }
+    }
+}
+
+impl OperatorKeyProvider for StubOpKeyProv {
+    fn get_operator_signing_pk(&self, idx: OperatorIdx) -> Option<Buf32> {
+        if idx == self.expected_idx {
+            Some(self.pk)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/bridge-types/src/relay/message.rs
+++ b/crates/bridge-types/src/relay/message.rs
@@ -4,10 +4,9 @@ use arbitrary::Arbitrary;
 use borsh::{io, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-
-use crate::{
-    bridge::OperatorIdx,
+use strata_primitives::{
     buf::{Buf32, Buf64},
+    operator::OperatorIdx,
     prelude::BitcoinTxid,
 };
 
@@ -258,14 +257,11 @@ impl fmt::Display for BridgeMsgId {
 
 #[cfg(test)]
 mod tests {
+    use strata_primitives::{buf::Buf64, l1::BitcoinTxid};
     use strata_test_utils::ArbitraryGenerator;
 
     use super::{BridgeMessage, Scope};
-    use crate::{
-        bridge::{Musig2PartialSig, Musig2PubNonce},
-        buf::Buf64,
-        l1::BitcoinTxid,
-    };
+    use crate::bridge::{Musig2PartialSig, Musig2PubNonce};
 
     #[expect(unused, reason = "used for testing")]
     fn get_arb_bridge_msg() -> BridgeMessage {

--- a/crates/bridge-types/src/relay/mod.rs
+++ b/crates/bridge-types/src/relay/mod.rs
@@ -1,0 +1,5 @@
+mod message;
+mod util;
+
+pub use message::{BridgeMessage, BridgeMsgId, Scope};
+pub use util::{verify_bridge_msg_sig, MessageSigner, VerifyError};

--- a/crates/chaintsn/Cargo.toml
+++ b/crates/chaintsn/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 strata-asm-types.workspace = true
+strata-bridge-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-crypto.workspace = true
 strata-ol-chain-types.workspace = true

--- a/crates/chaintsn/src/checkin.rs
+++ b/crates/chaintsn/src/checkin.rs
@@ -4,11 +4,11 @@ use bitcoin::{block::Header, consensus};
 use strata_asm_types::{
     DepositInfo, DepositSpendInfo, L1BlockManifest, ProtocolOperation, WithdrawalFulfillmentInfo,
 };
+use strata_bridge_types::DepositIntent;
 use strata_checkpoint_types::{verify_signed_checkpoint_sig, SignedCheckpoint};
 use strata_crypto::groth16_verifier::verify_rollup_groth16_proof_receipt;
 use strata_ol_chain_types::L1Segment;
 use strata_primitives::params::RollupParams;
-use strata_state::bridge_ops::DepositIntent;
 
 use crate::{
     context::{AuxProvider, ProviderError, ProviderResult, StateAccessor},

--- a/crates/chaintsn/src/errors.rs
+++ b/crates/chaintsn/src/errors.rs
@@ -1,5 +1,5 @@
 use strata_asm_types::L1VerificationError;
-use strata_primitives::{bridge::OperatorIdx, l1::L1BlockId};
+use strata_primitives::{l1::L1BlockId, operator::OperatorIdx};
 use strata_state::prelude::*;
 use thiserror::Error;
 

--- a/crates/chaintsn/src/legacy.rs
+++ b/crates/chaintsn/src/legacy.rs
@@ -2,13 +2,15 @@
 
 use bitcoin::block::Header;
 use strata_asm_types::{L1VerificationError, WithdrawalFulfillmentInfo};
+use strata_bridge_types::{
+    DepositEntry, DepositIntent, DepositState, DispatchCommand, DispatchedState, FulfilledState,
+};
 use strata_ol_chainstate_types::Chainstate;
 use strata_primitives::{
-    bridge::{BitcoinBlockHeight, OperatorIdx},
-    l1::*,
+    l1::{BitcoinBlockHeight, *},
+    operator::OperatorIdx,
     prelude::*,
 };
-use strata_state::{bridge_ops::DepositIntent, bridge_state::*};
 
 use crate::{context::StateAccessor, macros::*};
 

--- a/crates/chaintsn/src/legacy.rs
+++ b/crates/chaintsn/src/legacy.rs
@@ -8,7 +8,7 @@ use strata_bridge_types::{
 use strata_ol_chainstate_types::Chainstate;
 use strata_primitives::{
     l1::{BitcoinBlockHeight, *},
-    operator::OperatorIdx,
+    operator::{OperatorIdx, OperatorPubkeys},
     prelude::*,
 };
 
@@ -80,9 +80,10 @@ impl<'s, S: StateAccessor> FauxStateCache<'s, S> {
 
     /// Inserts a new operator with the specified pubkeys into the operator table.
     pub fn insert_operator(&mut self, signing_pk: Buf32, wallet_pk: Buf32) {
+        let operator_pubkeys = OperatorPubkeys::new(signing_pk, wallet_pk);
         self.state_mut()
             .operator_table_mut()
-            .insert(signing_pk, wallet_pk);
+            .insert(operator_pubkeys);
     }
 
     /// Inserts a new deposit with some settings.

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -5,6 +5,9 @@ use rand_core::{RngCore, SeedableRng};
 use strata_asm_types::{
     DepositInfo, DepositSpendInfo, L1BlockManifest, ProtocolOperation, WithdrawalFulfillmentInfo,
 };
+use strata_bridge_types::{
+    DepositIntent, DepositState, DispatchCommand, WithdrawOutput, WithdrawalIntent,
+};
 use strata_checkpoint_types::{verify_signed_checkpoint_sig, Checkpoint, SignedCheckpoint};
 use strata_crypto::groth16_verifier::verify_rollup_groth16_proof_receipt;
 use strata_ol_chain_types::{L2BlockBody, L2BlockHeader, L2Header};
@@ -12,11 +15,7 @@ use strata_ol_chainstate_types::StateCache;
 use strata_primitives::{
     epoch::EpochCommitment, l1::L1BlockId, l2::L2BlockCommitment, params::RollupParams,
 };
-use strata_state::{
-    bridge_ops::{DepositIntent, WithdrawalIntent},
-    bridge_state::{DepositState, DispatchCommand, WithdrawOutput},
-    exec_update::{self, Op},
-};
+use strata_state::exec_update::{self, Op};
 use tracing::warn;
 use zkaleido::ZkVmResult;
 
@@ -522,11 +521,9 @@ fn next_rand_op_pos(rng: &mut SlotRng, num: u32) -> u32 {
 mod tests {
     use rand_core::SeedableRng;
     use strata_asm_types::{L1BlockManifest, L1Tx, ProtocolOperation, WithdrawalFulfillmentInfo};
+    use strata_bridge_types::{DepositState, DepositsTable, DispatchCommand, DispatchedState};
     use strata_ol_chainstate_types::{Chainstate, StateCache};
     use strata_primitives::{buf::Buf32, l1::BitcoinAmount};
-    use strata_state::bridge_state::{
-        DepositState, DepositsTable, DispatchCommand, DispatchedState,
-    };
     use strata_test_utils::ArbitraryGenerator;
     use strata_test_utils_l2::gen_params;
 

--- a/crates/consensus-logic/Cargo.toml
+++ b/crates/consensus-logic/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 strata-asm-types.workspace = true
 strata-asm-worker.workspace = true
+strata-bridge-types.workspace = true
 strata-chain-worker.workspace = true
 strata-chainexec.workspace = true
 strata-chaintsn.workspace = true

--- a/crates/consensus-logic/src/genesis.rs
+++ b/crates/consensus-logic/src/genesis.rs
@@ -1,4 +1,5 @@
 use strata_asm_types::HeaderVerificationState;
+use strata_bridge_types::OperatorTable;
 use strata_db::errors::DbError;
 use strata_ol_chain_types::{
     ExecSegment, L1Segment, L2Block, L2BlockAccessory, L2BlockBody, L2BlockBundle, L2BlockHeader,
@@ -12,7 +13,6 @@ use strata_primitives::{
     params::{OperatorConfig, Params},
 };
 use strata_state::{
-    bridge_state::OperatorTable,
     client_state::ClientState,
     exec_env::ExecEnvState,
     exec_update::{ExecUpdate, UpdateInput, UpdateOutput},

--- a/crates/evmexec/Cargo.toml
+++ b/crates/evmexec/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 alpen-reth-evm.workspace = true
 alpen-reth-node.workspace = true
+strata-bridge-types.workspace = true
 strata-db.workspace = true
 strata-eectl.workspace = true
 strata-ol-chain-types.workspace = true

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -11,6 +11,7 @@ use alloy_rpc_types::{
 use alpen_reth_evm::constants::COINBASE_ADDRESS;
 use alpen_reth_node::AlpenPayloadAttributes;
 use revm_primitives::{Address, B256};
+use strata_bridge_types::WithdrawalIntent;
 use strata_db::DbError;
 use strata_eectl::{
     engine::{BlockStatus, ExecEngineCtl, L2BlockRef, PayloadStatus},
@@ -19,10 +20,7 @@ use strata_eectl::{
 };
 use strata_ol_chain_types::{L2BlockBundle, L2BlockId};
 use strata_primitives::l1::BitcoinAmount;
-use strata_state::{
-    bridge_ops,
-    exec_update::{ELDepositData, ExecUpdate, Op, UpdateOutput},
-};
+use strata_state::exec_update::{ELDepositData, ExecUpdate, Op, UpdateOutput};
 use strata_storage::L2BlockManager;
 use tokio::{runtime::Handle, sync::Mutex};
 use tracing::*;
@@ -424,13 +422,13 @@ struct ForkchoiceStatePartial {
 
 fn to_bridge_withdrawal_intent(
     rpc_withdrawal_intent: alpen_reth_node::WithdrawalIntent,
-) -> bridge_ops::WithdrawalIntent {
+) -> WithdrawalIntent {
     let alpen_reth_node::WithdrawalIntent {
         amt,
         destination,
         withdrawal_txid,
     } = rpc_withdrawal_intent;
-    bridge_ops::WithdrawalIntent::new(BitcoinAmount::from_sat(amt), destination, withdrawal_txid)
+    WithdrawalIntent::new(BitcoinAmount::from_sat(amt), destination, withdrawal_txid)
 }
 
 #[cfg(test)]

--- a/crates/l1tx/Cargo.toml
+++ b/crates/l1tx/Cargo.toml
@@ -8,11 +8,11 @@ workspace = true
 
 [dependencies]
 strata-asm-types.workspace = true
+strata-bridge-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-crypto.workspace = true
 strata-ol-chainstate-types.workspace = true
 strata-primitives.workspace = true
-strata-state.workspace = true
 
 anyhow.workspace = true
 bitcoin.workspace = true

--- a/crates/l1tx/src/filter/types.rs
+++ b/crates/l1tx/src/filter/types.rs
@@ -1,5 +1,6 @@
 use bitcoin::{hashes::Hash, Amount};
 use borsh::{BorshDeserialize, BorshSerialize};
+use strata_bridge_types::{DepositEntry, DepositState};
 use strata_ol_chainstate_types::Chainstate;
 use strata_primitives::{
     block_credential::CredRule,
@@ -8,7 +9,6 @@ use strata_primitives::{
     params::{DepositTxParams, RollupParams},
     sorted_vec::{FlatTable, SortedVec, TableEntry},
 };
-use strata_state::bridge_state::{DepositEntry, DepositState};
 
 use crate::utils::{generate_taproot_address, get_operator_wallet_pks};
 

--- a/crates/l1tx/src/utils.rs
+++ b/crates/l1tx/src/utils.rs
@@ -92,12 +92,12 @@ pub mod test_utils {
         secp256k1::{Keypair, Secp256k1, SecretKey},
         Address, Network,
     };
+    use strata_bridge_types::DepositEntry;
     use strata_primitives::{
         l1::{BitcoinAddress, XOnlyPk},
         params::Params,
         sorted_vec::FlatTable,
     };
-    use strata_state::bridge_state::DepositEntry;
 
     use crate::{filter::types::conv_deposit_to_fulfillment, TxFilterConfig};
 

--- a/crates/ol-chainstate-types/Cargo.toml
+++ b/crates/ol-chainstate-types/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 strata-asm-types.workspace = true
+strata-bridge-types.workspace = true
 strata-primitives.workspace = true
 strata-state.workspace = true
 

--- a/crates/ol-chainstate-types/src/chain_state.rs
+++ b/crates/ol-chainstate-types/src/chain_state.rs
@@ -2,6 +2,7 @@
 
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
+use strata_bridge_types::{DepositsTable, OperatorTable, WithdrawalIntent};
 use strata_primitives::{
     buf::Buf32,
     epoch::EpochCommitment,
@@ -9,8 +10,6 @@ use strata_primitives::{
     l2::{L2BlockCommitment, L2BlockId},
 };
 use strata_state::{
-    bridge_ops,
-    bridge_state::{self, DepositsTable, OperatorTable},
     exec_env::{self, ExecEnvState},
     state_queue::StateQueue,
 };
@@ -54,17 +53,17 @@ pub struct Chainstate {
     pub(crate) l1_state: L1ViewState,
 
     /// Pending withdrawals that have been initiated but haven't been sent out.
-    pub(crate) pending_withdraws: StateQueue<bridge_ops::WithdrawalIntent>,
+    pub(crate) pending_withdraws: StateQueue<WithdrawalIntent>,
 
     /// Execution environment state.  This is just for the single EE we support
     /// right now.
     pub(crate) exec_env_state: exec_env::ExecEnvState,
 
     /// Operator table we store registered operators for.
-    pub(crate) operator_table: bridge_state::OperatorTable,
+    pub(crate) operator_table: OperatorTable,
 
     /// Deposits table tracking each deposit's state.
-    pub(crate) deposits_table: bridge_state::DepositsTable,
+    pub(crate) deposits_table: DepositsTable,
 }
 
 impl Chainstate {
@@ -81,7 +80,7 @@ impl Chainstate {
             pending_withdraws: StateQueue::new_empty(),
             exec_env_state: gdata.exec_state().clone(),
             operator_table: gdata.operator_table().clone(),
-            deposits_table: bridge_state::DepositsTable::new_empty(),
+            deposits_table: DepositsTable::new_empty(),
         }
     }
 
@@ -164,7 +163,7 @@ impl Chainstate {
         self.is_epoch_finishing
     }
 
-    pub fn pending_withdraws(&self) -> &StateQueue<bridge_ops::WithdrawalIntent> {
+    pub fn pending_withdraws(&self) -> &StateQueue<WithdrawalIntent> {
         &self.pending_withdraws
     }
 }

--- a/crates/ol-chainstate-types/src/genesis.rs
+++ b/crates/ol-chainstate-types/src/genesis.rs
@@ -1,7 +1,8 @@
 //! Types relating to constructing the genesis chainstate.
 
 use arbitrary::Arbitrary;
-use strata_state::{bridge_state::OperatorTable, exec_env::ExecEnvState};
+use strata_bridge_types::OperatorTable;
+use strata_state::exec_env::ExecEnvState;
 
 use crate::l1_view::L1ViewState;
 

--- a/crates/ol-chainstate-types/src/state_op.rs
+++ b/crates/ol-chainstate-types/src/state_op.rs
@@ -15,7 +15,7 @@ use strata_primitives::{
     epoch::EpochCommitment,
     l1::{BitcoinAmount, BitcoinBlockHeight, OutputRef},
     l2::{L2BlockCommitment, L2BlockId},
-    operator::OperatorIdx,
+    operator::{OperatorIdx, OperatorPubkeys},
 };
 use tracing::warn;
 
@@ -201,7 +201,8 @@ impl StateCache {
     /// Inserts a new operator with the specified pubkeys into the operator table.
     pub fn insert_operator(&mut self, signing_pk: Buf32, wallet_pk: Buf32) {
         let state = self.state_mut();
-        state.operator_table.insert(signing_pk, wallet_pk);
+        let operator_pubkeys = OperatorPubkeys::new(signing_pk, wallet_pk);
+        state.operator_table.insert(operator_pubkeys);
     }
 
     /// Inserts a new deposit with some settings.

--- a/crates/ol-chainstate-types/src/state_op.rs
+++ b/crates/ol-chainstate-types/src/state_op.rs
@@ -7,16 +7,15 @@
 use bitcoin::block::Header;
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_asm_types::{L1VerificationError, WithdrawalFulfillmentInfo};
+use strata_bridge_types::{
+    DepositEntry, DepositIntent, DepositState, DispatchCommand, DispatchedState, FulfilledState,
+};
 use strata_primitives::{
-    bridge::{BitcoinBlockHeight, OperatorIdx},
     buf::Buf32,
     epoch::EpochCommitment,
-    l1::{BitcoinAmount, OutputRef},
+    l1::{BitcoinAmount, BitcoinBlockHeight, OutputRef},
     l2::{L2BlockCommitment, L2BlockId},
-};
-use strata_state::{
-    bridge_ops::DepositIntent,
-    bridge_state::{DepositEntry, DepositState, DispatchCommand, DispatchedState, FulfilledState},
+    operator::OperatorIdx,
 };
 use tracing::warn;
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -20,9 +20,7 @@ borsh.workspace = true
 const-hex = "1.14"
 digest.workspace = true
 hex.workspace = true
-musig2 = { workspace = true, features = ["serde"] }
 num_enum.workspace = true
-rand = { workspace = true, optional = true }
 secp256k1 = { workspace = true, optional = true }
 serde.workspace = true
 sha2.workspace = true
@@ -37,10 +35,10 @@ k256 = { version = "0.13.4", features = ["schnorr"] }
 
 [dev-dependencies]
 strata-test-utils.workspace = true
+rand.workspace = true
 
 serde_json.workspace = true
 
 [features]
-default = ["std", "rand"]
-rand = ["std", "dep:rand"]
+default = ["std"]
 std = ["dep:secp256k1"]

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -5,18 +5,6 @@ use std::sync::LazyLock;
 use bitcoin::{bip32::ChildNumber, XOnlyPublicKey};
 use secp256k1::hashes::{sha256, Hash};
 
-/// The size (in bytes) of a [`musig2::PartialSignature`].
-pub const MUSIG2_PARTIAL_SIG_SIZE: usize = 32;
-
-/// The size (in bytes) of a [`musig2::NonceSeed`].
-pub const NONCE_SEED_SIZE: usize = 32;
-
-/// The size (in bytes) of a [`musig2::PubNonce`].
-pub const PUB_NONCE_SIZE: usize = 66;
-
-/// The size (in bytes) of a [`musig2::SecNonce`].
-pub const SEC_NONCE_SIZE: usize = 64;
-
 /// The size (in bytes) of a Hash (such as [`Txid`](bitcoin::Txid)).
 pub const HASH_SIZE: usize = 32;
 

--- a/crates/primitives/src/crypto.rs
+++ b/crates/primitives/src/crypto.rs
@@ -7,7 +7,6 @@ use secp256k1::{
 
 use crate::buf::{Buf32, Buf64};
 
-#[cfg(feature = "rand")]
 pub fn sign_schnorr_sig(msg: &Buf32, sk: &Buf32) -> Buf64 {
     let sk = SecretKey::from_slice(sk.as_ref()).expect("Invalid private key");
     let kp = Keypair::from_secret_key(SECP256K1, &sk);

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -9,6 +9,9 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{buf::Buf32, hash::sha256d};
 
+/// The bitcoin block height
+pub type BitcoinBlockHeight = u64;
+
 /// ID of an L1 block, usually the hash of its header.
 #[derive(
     Copy,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,6 @@
 mod macros;
 
 pub mod block_credential;
-pub mod bridge;
 pub mod buf;
 pub mod constants;
 pub mod crypto;
@@ -23,7 +22,6 @@ pub mod operator;
 pub mod params;
 pub mod prelude;
 pub mod proof;
-pub mod relay;
 pub mod roles;
 pub mod serde_helpers;
 pub mod sorted_vec;

--- a/crates/primitives/src/operator.rs
+++ b/crates/primitives/src/operator.rs
@@ -1,8 +1,13 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-use super::bridge::OperatorIdx;
 use crate::prelude::Buf32;
+
+/// The ID of an operator.
+///
+/// We define it as a type alias over [`u32`] instead of a newtype because we perform a bunch of
+/// mathematical operations on it while managing the operator table.
+pub type OperatorIdx = u32;
 
 /// Some type that can provide operator keys.
 pub trait OperatorKeyProvider {

--- a/crates/primitives/src/relay/mod.rs
+++ b/crates/primitives/src/relay/mod.rs
@@ -1,2 +1,0 @@
-pub mod types;
-pub mod util;

--- a/crates/proof-impl/evm-ee-stf/Cargo.toml
+++ b/crates/proof-impl/evm-ee-stf/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 alpen-reth-evm.workspace = true
 alpen-reth-primitives.workspace = true
+strata-bridge-types.workspace = true
 strata-ol-chain-types.workspace = true
 strata-primitives.workspace = true
 strata-state.workspace = true

--- a/crates/proof-impl/evm-ee-stf/src/utils.rs
+++ b/crates/proof-impl/evm-ee-stf/src/utils.rs
@@ -1,9 +1,7 @@
+use strata_bridge_types::WithdrawalIntent;
 use strata_ol_chain_types::ExecSegment;
 use strata_primitives::{buf::Buf32, evm_exec::create_evm_extra_payload, l1::BitcoinAmount};
-use strata_state::{
-    bridge_ops,
-    exec_update::{ELDepositData, ExecUpdate, Op, UpdateInput, UpdateOutput},
-};
+use strata_state::exec_update::{ELDepositData, ExecUpdate, Op, UpdateInput, UpdateOutput};
 
 use crate::EvmBlockStfOutput;
 
@@ -14,7 +12,7 @@ pub fn generate_exec_update(el_proof_pp: &EvmBlockStfOutput) -> ExecSegment {
         .iter()
         .map(|intent| {
             // TODO: proper error handling
-            bridge_ops::WithdrawalIntent::new(
+            WithdrawalIntent::new(
                 BitcoinAmount::from_sat(intent.amt),
                 intent.destination.clone(),
                 intent.withdrawal_txid,

--- a/crates/reth/primitives/src/lib.rs
+++ b/crates/reth/primitives/src/lib.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32};
 
 /// Type for withdrawal_intents in rpc.
-/// Distinct from `strata_state::bridge_ops::WithdrawalIntent`
+/// Distinct from `strata_bridge_types::WithdrawalIntent`
 /// as this will live in reth repo eventually
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct WithdrawalIntent {

--- a/crates/rpc/api/Cargo.toml
+++ b/crates/rpc/api/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+strata-bridge-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-common.workspace = true
 strata-db.workspace = true

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -1,11 +1,12 @@
 //! Macro trait def for the `strata_` RPC namespace using jsonrpsee.
 use bitcoin::Txid;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use strata_bridge_types::PublickeyTable;
 use strata_checkpoint_types::EpochSummary;
 use strata_common::{Action, WorkerType};
 use strata_db::types::{L1TxEntry, L1TxStatus};
 use strata_ol_chain_types::{L2Block, L2BlockId};
-use strata_primitives::{bridge::PublickeyTable, epoch::EpochCommitment, l1::L1BlockId};
+use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId};
 use strata_rpc_types::{
     types::{RpcBlockHeader, RpcClientStatus, RpcL1Status},
     HexBytes, HexBytes32, HexBytes64, L2BlockStatus, RpcChainState, RpcCheckpointConfStatus,

--- a/crates/rpc/types/Cargo.toml
+++ b/crates/rpc/types/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+strata-bridge-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-db.workspace = true
 strata-ol-chain-types.workspace = true

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -6,23 +6,20 @@
 
 use bitcoin::{BlockHash, Network, Txid, Wtxid};
 use serde::{Deserialize, Serialize};
+use strata_bridge_types::{DepositEntry, DepositState, WithdrawalIntent};
 use strata_checkpoint_types::BatchInfo;
 use strata_db::types::{CheckpointConfStatus, CheckpointEntry};
 use strata_ol_chain_types::L2BlockId;
 use strata_primitives::{
     bitcoin_bosd::Descriptor,
-    bridge::OperatorIdx,
     buf::Buf32,
     epoch::EpochCommitment,
     l1::{BitcoinAmount, L1BlockCommitment, OutputRef},
     l2::L2BlockCommitment,
+    operator::OperatorIdx,
     prelude::L1Status,
 };
-use strata_state::{
-    bridge_ops::WithdrawalIntent,
-    bridge_state::{DepositEntry, DepositState},
-    client_state::CheckpointL1Ref,
-};
+use strata_state::client_state::CheckpointL1Ref;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HexBytes(#[serde(with = "hex::serde")] pub Vec<u8>);

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 strata-asm-common.workspace = true
 strata-asm-stf.workspace = true
 strata-asm-types.workspace = true
+strata-bridge-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-primitives.workspace = true
 

--- a/crates/state/src/exec_env.rs
+++ b/crates/state/src/exec_env.rs
@@ -2,9 +2,10 @@
 
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
+use strata_bridge_types::DepositIntent;
 use strata_primitives::{buf::Buf32, l1::payload::BlobSpec};
 
-use crate::{bridge_ops, exec_update, forced_inclusion, state_queue::StateQueue};
+use crate::{exec_update, forced_inclusion, state_queue::StateQueue};
 
 #[derive(Debug, Clone, Eq, PartialEq, BorshDeserialize, BorshSerialize)]
 pub struct ExecEnvState {
@@ -25,7 +26,7 @@ pub struct ExecEnvState {
     /// an update yet.  The sequencer should be processing these as soon as
     /// possible.
     // TODO make this not pub
-    pub pending_deposits: StateQueue<bridge_ops::DepositIntent>,
+    pub pending_deposits: StateQueue<DepositIntent>,
 
     /// Forced inclusions that have been accepted by the CL but not processed by
     /// a CL payload yet.
@@ -55,11 +56,11 @@ impl ExecEnvState {
         &self.cur_state
     }
 
-    pub fn pending_deposits(&self) -> &StateQueue<bridge_ops::DepositIntent> {
+    pub fn pending_deposits(&self) -> &StateQueue<DepositIntent> {
         &self.pending_deposits
     }
 
-    pub fn pending_deposits_mut(&mut self) -> &mut StateQueue<bridge_ops::DepositIntent> {
+    pub fn pending_deposits_mut(&mut self) -> &mut StateQueue<DepositIntent> {
         &mut self.pending_deposits
     }
 }

--- a/crates/state/src/exec_update.rs
+++ b/crates/state/src/exec_update.rs
@@ -4,14 +4,12 @@
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use strata_bridge_types::{DepositIntent, WithdrawalIntent};
 use strata_primitives::{
     buf::Buf32, evm_exec::create_evm_extra_payload, prelude::payload::BlobSpec,
 };
 
-use crate::{
-    bridge_ops::{self, DepositIntent},
-    prelude::StateQueue,
-};
+use crate::prelude::StateQueue;
 
 /// Full update payload containing inputs and outputs to an EE state update.
 #[derive(
@@ -120,7 +118,7 @@ pub struct UpdateOutput {
     new_state: Buf32,
 
     /// Bridge withdrawal intents.
-    withdrawals: Vec<bridge_ops::WithdrawalIntent>,
+    withdrawals: Vec<WithdrawalIntent>,
 
     /// DA blobs that we expect to see on L1.  This may be empty, probably is
     /// only set near the end of the range of blocks in a batch since we only
@@ -137,7 +135,7 @@ impl UpdateOutput {
         }
     }
 
-    pub fn with_withdrawals(mut self, withdrawals: Vec<bridge_ops::WithdrawalIntent>) -> Self {
+    pub fn with_withdrawals(mut self, withdrawals: Vec<WithdrawalIntent>) -> Self {
         self.withdrawals = withdrawals;
         self
     }
@@ -146,7 +144,7 @@ impl UpdateOutput {
         &self.new_state
     }
 
-    pub fn withdrawals(&self) -> &[bridge_ops::WithdrawalIntent] {
+    pub fn withdrawals(&self) -> &[WithdrawalIntent] {
         &self.withdrawals
     }
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -7,8 +7,6 @@
 //! reusing any Reth types.
 
 pub mod asm_state;
-pub mod bridge_ops;
-pub mod bridge_state;
 pub mod client_state;
 pub mod exec_env;
 pub mod exec_update;

--- a/crates/status/Cargo.toml
+++ b/crates/status/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+strata-bridge-types.workspace = true
 strata-ol-chain-types.workspace = true
 strata-ol-chainstate-types.workspace = true
 strata-primitives.workspace = true

--- a/crates/status/src/status_manager.rs
+++ b/crates/status/src/status_manager.rs
@@ -1,13 +1,11 @@
 //! Manages and updates unified status bundles
 use std::sync::Arc;
 
+use strata_bridge_types::{DepositsTable, OperatorTable};
 use strata_ol_chain_types::L2BlockId;
 use strata_ol_chainstate_types::Chainstate;
 use strata_primitives::l1::{L1BlockCommitment, L1Status};
-use strata_state::{
-    bridge_state::{DepositsTable, OperatorTable},
-    client_state::{CheckpointState, ClientState, L1Checkpoint},
-};
+use strata_state::client_state::{CheckpointState, ClientState, L1Checkpoint};
 use thiserror::Error;
 use tokio::sync::watch::{self, error::RecvError};
 use tracing::warn;

--- a/crates/test-utils/btc/Cargo.toml
+++ b/crates/test-utils/btc/Cargo.toml
@@ -8,9 +8,9 @@ workspace = true
 
 [dependencies]
 strata-asm-types.workspace = true
+strata-bridge-types = { workspace = true, features = ["test_utils"] }
 strata-btcio.workspace = true
 strata-primitives.workspace = true
-strata-state = { workspace = true, features = ["test_utils"] }
 strata-test-utils.workspace = true
 
 anyhow.workspace = true

--- a/crates/test-utils/btc/src/lib.rs
+++ b/crates/test-utils/btc/src/lib.rs
@@ -15,14 +15,14 @@ use bitcoin::{
     Transaction, TxIn, TxOut, Witness,
 };
 use strata_asm_types::L1HeaderRecord;
+use strata_bridge_types::{
+    DepositEntry, DepositState, DispatchCommand, DispatchedState, WithdrawOutput,
+};
 use strata_primitives::{
     bitcoin_bosd::Descriptor,
     buf::Buf32,
     l1::{BitcoinAddress, BitcoinAmount, OutputRef},
     params::DepositTxParams,
-};
-use strata_state::bridge_state::{
-    DepositEntry, DepositState, DispatchCommand, DispatchedState, WithdrawOutput,
 };
 use strata_test_utils::ArbitraryGenerator;
 


### PR DESCRIPTION
## Description

Move bridge-related types to a `bridge-types` crate.

This PR was created with some help from Cursor AI.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

We should move some crypto stuff to `crypto` crate in a follow-up PR.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
