### PR TITLE
fix: properly handle multisig key duplication

### DIFF
--- a/crates/crypto/src/multisig/config.rs
+++ b/crates/crypto/src/multisig/config.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{collections::HashSet, marker::PhantomData};
 
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -185,11 +185,10 @@ impl<S: CryptoScheme> MultisigConfig<S> {
     /// - `ZeroThreshold`: New threshold is zero
     /// - `InvalidThreshold`: New threshold exceeds the total number of keys after update
     pub fn validate_update(&self, update: &MultisigConfigUpdate<S>) -> Result<(), MultisigError> {
-        let mut members_to_add = update.add_members().to_vec();
-        members_to_add.dedup();
-
-        let mut members_to_remove = update.remove_members().to_vec();
-        members_to_remove.dedup();
+        let members_to_add: HashSet<<S as CryptoScheme>::PubKey> =
+            update.add_members().iter().cloned().collect();
+        let members_to_remove: HashSet<<S as CryptoScheme>::PubKey> =
+            update.remove_members().iter().cloned().collect();
 
         // Ensure no duplicate members in the add list
         if members_to_add.len() != update.add_members().len() {

--- a/crates/crypto/src/multisig/traits.rs
+++ b/crates/crypto/src/multisig/traits.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -16,6 +16,7 @@ pub trait CryptoScheme: Clone + Debug + Send + Sync + 'static {
         + Debug
         + PartialEq
         + Eq
+        + Hash
         + Send
         + Sync
         + BorshSerialize


### PR DESCRIPTION
## Description

Currently, multisig key duplication is [detected](https://github.com/alpenlabs/alpen/blob/1798785184c2212af94af10a5cb78901e04f3fe7/crates/crypto/src/multisig/config.rs#L188-L192) using [vector deduplication](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.dedup), which only detects consecutive duplicates.

This PR does a simple fix by checking against a hash set.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

There are other ways to fix this that are likely more elegant, such as using hash sets at the struct level. However, this fix seems like the most straightforward.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

Closes STR-1743.
