### PR TITLE
backport: log: Bitcoin `Buf32` types reverse hex (#1065)

### DIFF
--- a/bin/strata-dbtool/src/output/broadcaster.rs
+++ b/bin/strata-dbtool/src/output/broadcaster.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+
+use hex::encode_to_slice;
 use serde::Serialize;
 use strata_db::types::L1TxStatus;
 use strata_primitives::buf::Buf32;
@@ -48,5 +51,46 @@ impl<'a> Formattable for BroadcasterTxInfo<'a> {
             porcelain_field("tx.raw_tx.len", format!("{:?} bytes", self.raw_tx.len())),
         ]
         .join("\n")
+    }
+}
+
+// Custom debug implementation to print txid in little endian
+impl<'a> fmt::Debug for BroadcasterTxInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut txid_buf = [0u8; 64];
+        {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            encode_to_slice(bytes, &mut txid_buf).expect("buf: enc hex");
+        }
+
+        f.debug_struct("BroadcasterTxInfo")
+            .field("index", &self.index)
+            .field("txid", &unsafe { std::str::from_utf8_unchecked(&txid_buf) })
+            .field("status", &self.status)
+            .field("raw_tx", &self.raw_tx)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl<'a> fmt::Display for BroadcasterTxInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut txid_buf = [0u8; 64];
+        {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            encode_to_slice(bytes, &mut txid_buf).expect("buf: enc hex");
+        }
+
+        write!(
+            f,
+            "BroadcasterTxInfo {{ index: {}, txid: {}, status: {:?}, raw_tx: {} bytes }}",
+            self.index,
+            // SAFETY: hex encoding always produces valid UTF-8
+            unsafe { str::from_utf8_unchecked(&txid_buf) },
+            self.status,
+            self.raw_tx.len()
+        )
     }
 }

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
+use std::{str, sync::Arc};
 
 use bitcoind_async_client::traits::{Broadcaster, Reader, Signer, Wallet};
+use hex::encode_to_slice;
 use strata_db::{
     types::{L1TxEntry, L1TxStatus},
     DbResult,
@@ -38,7 +39,14 @@ impl L1BroadcastHandle {
     /// This function is infallible. If the entry already exists it will update with the new
     /// `txentry`.
     pub async fn put_tx_entry(&self, txid: Buf32, txentry: L1TxEntry) -> DbResult<Option<u64>> {
-        trace!(%txid, "insert_new_tx_entry");
+        // NOTE: Reverse the txid to little endian so that it's consistent with block explorers.
+        let mut bytes = txid.0;
+        bytes.reverse();
+        let mut hex_buf = [0u8; 64];
+        encode_to_slice(bytes, &mut hex_buf).expect("buf: enc hex");
+        // SAFETY: hex encoding always produces valid UTF-8
+        let txid_le = unsafe { str::from_utf8_unchecked(&hex_buf) };
+        trace!(txid = %txid_le, "insert_new_tx_entry");
         assert!(txentry.try_to_tx().is_ok(), "invalid tx entry {txentry:?}");
         let Some(idx) = self.ops.put_tx_entry_async(txid, txentry.clone()).await? else {
             return Ok(None);

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -1,5 +1,7 @@
 //! Module for database local types
 
+use std::fmt;
+
 use arbitrary::Arbitrary;
 use bitcoin::{
     consensus::{self, deserialize, serialize},
@@ -56,7 +58,7 @@ pub enum IntentStatus {
 }
 
 /// Represents data for a payload we're still planning to post to L1.
-#[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
+#[derive(Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
 pub struct BundledPayloadEntry {
     pub payloads: Vec<L1Payload>,
     pub commit_txid: Buf32,
@@ -88,6 +90,51 @@ impl BundledPayloadEntry {
         let cid = Buf32::zero();
         let rid = Buf32::zero();
         Self::new(payloads, cid, rid, L1BundleStatus::Unsigned)
+    }
+}
+
+// Custom debug implementation to print commit_txid and reveal_txid in little endian
+impl fmt::Debug for BundledPayloadEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let commit_txid_le = {
+            let mut bytes = self.commit_txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+        let reveal_txid_le = {
+            let mut bytes = self.reveal_txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+
+        f.debug_struct("BundledPayloadEntry")
+            .field("payloads", &self.payloads)
+            .field("commit_txid", &commit_txid_le)
+            .field("reveal_txid", &reveal_txid_le)
+            .field("status", &self.status)
+            .finish()
+    }
+}
+
+// Custom display implementation to print commit_txid and reveal_txid in little endian
+impl fmt::Display for BundledPayloadEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let commit_txid_le = {
+            let mut bytes = self.commit_txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+        let reveal_txid_le = {
+            let mut bytes = self.reveal_txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+
+        write!(
+            f,
+            "BundledPayloadEntry {{ payloads: {} items, commit_txid: {}, reveal_txid: {}, status: {:?} }}",
+            self.payloads.len(), commit_txid_le, reveal_txid_le, self.status
+        )
     }
 }
 

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -1,10 +1,14 @@
+use std::{fmt, str};
+
 use arbitrary::Arbitrary;
 use bitcoin::{hashes::Hash, BlockHash};
 use borsh::{BorshDeserialize, BorshSerialize};
+use const_hex as hex;
+use hex::encode_to_slice;
 use serde::{Deserialize, Serialize};
 
 use super::{header_verification::HeaderVerificationState, L1HeaderRecord, L1Tx};
-use crate::{buf::Buf32, hash::sha256d, impl_buf_wrapper};
+use crate::{buf::Buf32, hash::sha256d};
 
 /// ID of an L1 block, usually the hash of its header.
 #[derive(
@@ -32,7 +36,24 @@ impl L1BlockId {
     }
 }
 
-impl_buf_wrapper!(L1BlockId, Buf32, 32);
+// Custom implementation without Debug/Display to avoid conflicts
+impl From<Buf32> for L1BlockId {
+    fn from(value: Buf32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<L1BlockId> for Buf32 {
+    fn from(value: L1BlockId) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<[u8; 32]> for L1BlockId {
+    fn as_ref(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
 
 impl From<BlockHash> for L1BlockId {
     fn from(value: BlockHash) -> Self {
@@ -47,7 +68,6 @@ impl From<L1BlockId> for BlockHash {
 }
 
 #[derive(
-    Debug,
     Copy,
     Clone,
     Eq,
@@ -67,6 +87,40 @@ pub struct L1BlockCommitment {
     blkid: L1BlockId,
 }
 
+impl fmt::Display for L1BlockCommitment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Show first 2 and last 2 bytes of block ID (4 hex chars each)
+        let blkid_bytes = self.blkid.as_ref();
+        let first_2 = &blkid_bytes[..2];
+        let last_2 = &blkid_bytes[30..];
+
+        let mut first_hex = [0u8; 4];
+        let mut last_hex = [0u8; 4];
+        hex::encode_to_slice(first_2, &mut first_hex)
+            .expect("Failed to encode first 2 bytes to hex");
+        hex::encode_to_slice(last_2, &mut last_hex).expect("Failed to encode last 2 bytes to hex");
+
+        write!(
+            f,
+            "{}@{}..{}",
+            self.height,
+            str::from_utf8(&first_hex)
+                .expect("Failed to convert first 2 hex bytes to UTF-8 string"),
+            str::from_utf8(&last_hex).expect("Failed to convert last 2 hex bytes to UTF-8 string")
+        )
+    }
+}
+
+impl fmt::Debug for L1BlockCommitment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "L1BlockCommitment(height={}, blkid={:?})",
+            self.height, self.blkid
+        )
+    }
+}
+
 impl L1BlockCommitment {
     pub fn new(height: u64, blkid: L1BlockId) -> Self {
         Self { height, blkid }
@@ -80,7 +134,6 @@ impl L1BlockCommitment {
         &self.blkid
     }
 }
-
 /// Reference to a transaction in a block.  This is the blockid and the
 /// position of the transaction in the block.
 #[derive(
@@ -220,5 +273,31 @@ impl L1BlockManifest {
 
     pub fn into_record(self) -> L1HeaderRecord {
         self.record
+    }
+}
+
+// Custom debug implementation to print the block hash in little endian
+impl fmt::Debug for L1BlockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut bytes = self.0 .0;
+        bytes.reverse();
+        let mut buf = [0u8; 64]; // 32 bytes * 2 for hex
+        encode_to_slice(bytes, &mut buf).expect("buf: enc hex");
+        // SAFETY: hex encoding always produces valid UTF-8
+        let hex_str = unsafe { str::from_utf8_unchecked(&buf) };
+        f.write_str(hex_str)
+    }
+}
+
+// Custom display implementation to print the block hash in little endian
+impl fmt::Display for L1BlockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut bytes = self.0 .0;
+        bytes.reverse();
+        let mut buf = [0u8; 64]; // 32 bytes * 2 for hex
+        encode_to_slice(bytes, &mut buf).expect("buf: enc hex");
+        // SAFETY: hex encoding always produces valid UTF-8
+        let hex_str = unsafe { str::from_utf8_unchecked(&buf) };
+        f.write_str(hex_str)
     }
 }

--- a/crates/primitives/src/l1/btc.rs
+++ b/crates/primitives/src/l1/btc.rs
@@ -1,8 +1,9 @@
 use std::{
-    fmt::Display,
+    fmt::{self, Debug, Display},
     io::{self, Read, Write},
     iter::Sum,
     ops::Add,
+    str,
 };
 
 use arbitrary::{Arbitrary, Unstructured};
@@ -20,6 +21,7 @@ use bitcoin::{
 };
 use bitcoin_bosd::Descriptor;
 use borsh::{BorshDeserialize, BorshSerialize};
+use hex::encode_to_slice;
 use rand::rngs::OsRng;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
@@ -704,10 +706,47 @@ impl<'a> Arbitrary<'a> for TaprootSpendPath {
 }
 
 /// Outpoint of a bitcoin tx
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, BorshSerialize, BorshDeserialize)]
 pub struct Outpoint {
     pub txid: Buf32,
     pub vout: u32,
+}
+
+// Custom debug implementation to print txid in little endian
+impl Debug for Outpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut txid_buf = [0u8; 64];
+        {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            encode_to_slice(bytes, &mut txid_buf).expect("buf: enc hex");
+        }
+
+        f.debug_struct("Outpoint")
+            .field("txid", &unsafe { std::str::from_utf8_unchecked(&txid_buf) })
+            .field("vout", &self.vout)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl Display for Outpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut txid_buf = [0u8; 64];
+        {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            encode_to_slice(bytes, &mut txid_buf).expect("buf: enc hex");
+        }
+
+        write!(
+            f,
+            "Outpoint {{ txid: {}, vout: {} }}",
+            // SAFETY: hex encoding always produces valid UTF-8
+            unsafe { str::from_utf8_unchecked(&txid_buf) },
+            self.vout
+        )
+    }
 }
 
 /// A wrapper around [`Buf32`] for XOnly Schnorr taproot pubkeys.

--- a/crates/primitives/src/l1/ops.rs
+++ b/crates/primitives/src/l1/ops.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use digest::Digest;
@@ -117,7 +119,7 @@ pub struct DepositRequestInfo {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
+    Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
 )]
 pub struct WithdrawalFulfillmentInfo {
     /// index of deposit this fulfillment is for
@@ -141,4 +143,39 @@ pub struct WithdrawalFulfillmentInfo {
 pub struct DepositSpendInfo {
     /// index of the deposit whose utxo is spent.
     pub deposit_idx: u32,
+}
+
+// Custom debug implementation to print txid in little endian
+impl fmt::Debug for WithdrawalFulfillmentInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+
+        f.debug_struct("WithdrawalFulfillmentInfo")
+            .field("deposit_idx", &self.deposit_idx)
+            .field("operator_idx", &self.operator_idx)
+            .field("amt", &self.amt)
+            .field("txid", &txid_le)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl fmt::Display for WithdrawalFulfillmentInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+
+        write!(
+            f,
+            "WithdrawalFulfillmentInfo {{ deposit_idx: {}, operator_idx: {}, amt: {:?}, txid: {} }}",
+            self.deposit_idx, self.operator_idx, self.amt, txid_le
+        )
+    }
 }

--- a/crates/primitives/src/l1/status.rs
+++ b/crates/primitives/src/l1/status.rs
@@ -1,10 +1,13 @@
+use std::{fmt, str};
+
 use arbitrary::Arbitrary;
+use const_hex as hex;
 use serde::{Deserialize, Serialize};
 
 use crate::buf::Buf32;
 
 /// Data that reflects what's happening around L1
-#[derive(Debug, Clone, Serialize, Deserialize, Default, Arbitrary)]
+#[derive(Clone, Serialize, Deserialize, Default, Arbitrary)]
 pub struct L1Status {
     /// If the last time we tried to poll the client (as of `last_update`)
     /// we were successful.
@@ -28,4 +31,153 @@ pub struct L1Status {
 
     /// Number of published reveal transactions.
     pub published_reveal_txs_count: u64,
+}
+
+// Custom debug implementation to print the txid in little endian
+impl fmt::Debug for L1Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("L1Status");
+        let mut debug_struct = debug
+            .field("bitcoin_rpc_connected", &self.bitcoin_rpc_connected)
+            .field("last_rpc_error", &self.last_rpc_error)
+            .field("cur_height", &self.cur_height);
+
+        // Handle cur_tip_blkid - reverse the hex string if it's a valid 32-byte hex
+        if self.cur_tip_blkid.len() == 64 {
+            // Try to parse as hex and reverse
+            let mut blkid_bytes = [0u8; 32];
+            if hex::decode_to_slice(&self.cur_tip_blkid, &mut blkid_bytes).is_ok() {
+                blkid_bytes.reverse();
+                let mut blkid_buf = [0u8; 64];
+                hex::encode_to_slice(blkid_bytes, &mut blkid_buf).expect("buf: enc hex");
+                // SAFETY: hex encoding always produces valid UTF-8
+                let blkid_str = unsafe { str::from_utf8_unchecked(&blkid_buf) };
+                debug_struct = debug_struct.field("cur_tip_blkid", &blkid_str);
+            } else {
+                debug_struct = debug_struct.field("cur_tip_blkid", &self.cur_tip_blkid);
+            }
+        } else {
+            debug_struct = debug_struct.field("cur_tip_blkid", &self.cur_tip_blkid);
+        }
+
+        // Handle last_published_txid
+        if let Some(txid) = self.last_published_txid {
+            let mut txid_buf = [0u8; 64];
+            {
+                let mut bytes = txid.0;
+                bytes.reverse();
+                hex::encode_to_slice(bytes, &mut txid_buf).expect("buf: enc hex");
+            }
+            // SAFETY: hex encoding always produces valid UTF-8
+            let txid_str = unsafe { str::from_utf8_unchecked(&txid_buf) };
+            debug_struct = debug_struct.field("last_published_txid", &txid_str);
+        } else {
+            debug_struct = debug_struct.field("last_published_txid", &"None");
+        }
+
+        debug_struct
+            .field("last_update", &self.last_update)
+            .field(
+                "published_reveal_txs_count",
+                &self.published_reveal_txs_count,
+            )
+            .finish()
+    }
+}
+
+// Custom display information to print the txid in little endian
+impl fmt::Display for L1Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(txid) = self.last_published_txid {
+            let mut txid_buf = [0u8; 64];
+            {
+                let mut bytes = txid.0;
+                bytes.reverse();
+                hex::encode_to_slice(bytes, &mut txid_buf).expect("buf: enc hex");
+            }
+            // SAFETY: hex encoding always produces valid UTF-8
+            let txid_str = unsafe { str::from_utf8_unchecked(&txid_buf) };
+
+            // Handle cur_tip_blkid - reverse the hex string if it's a valid 32-byte hex
+            if self.cur_tip_blkid.len() == 64 {
+                // Try to parse as hex and reverse
+                let mut blkid_bytes = [0u8; 32];
+                if hex::decode_to_slice(&self.cur_tip_blkid, &mut blkid_bytes).is_ok() {
+                    blkid_bytes.reverse();
+                    let mut blkid_buf = [0u8; 64];
+                    hex::encode_to_slice(blkid_bytes, &mut blkid_buf).expect("buf: enc hex");
+                    // SAFETY: hex encoding always produces valid UTF-8
+                    let blkid_str = unsafe { str::from_utf8_unchecked(&blkid_buf) };
+                    write!(
+                        f,
+                        "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: {}, published_reveal_txs_count: {} }}",
+                        self.bitcoin_rpc_connected,
+                        self.cur_height,
+                        blkid_str,
+                        txid_str,
+                        self.published_reveal_txs_count
+                    )
+                } else {
+                    write!(
+                        f,
+                        "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: {}, published_reveal_txs_count: {} }}",
+                        self.bitcoin_rpc_connected,
+                        self.cur_height,
+                        self.cur_tip_blkid,
+                        txid_str,
+                        self.published_reveal_txs_count
+                    )
+                }
+            } else {
+                write!(
+                    f,
+                    "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: {}, published_reveal_txs_count: {} }}",
+                    self.bitcoin_rpc_connected,
+                    self.cur_height,
+                    self.cur_tip_blkid,
+                    txid_str,
+                    self.published_reveal_txs_count
+                )
+            }
+        } else {
+            // Handle cur_tip_blkid - reverse the hex string if it's a valid 32-byte hex
+            if self.cur_tip_blkid.len() == 64 {
+                // Try to parse as hex and reverse
+                let mut blkid_bytes = [0u8; 32];
+                if hex::decode_to_slice(&self.cur_tip_blkid, &mut blkid_bytes).is_ok() {
+                    blkid_bytes.reverse();
+                    let mut blkid_buf = [0u8; 64];
+                    hex::encode_to_slice(blkid_bytes, &mut blkid_buf).expect("buf: enc hex");
+                    // SAFETY: hex encoding always produces valid UTF-8
+                    let blkid_str = unsafe { str::from_utf8_unchecked(&blkid_buf) };
+                    write!(
+                        f,
+                        "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: None, published_reveal_txs_count: {} }}",
+                        self.bitcoin_rpc_connected,
+                        self.cur_height,
+                        blkid_str,
+                        self.published_reveal_txs_count
+                    )
+                } else {
+                    write!(
+                        f,
+                        "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: None, published_reveal_txs_count: {} }}",
+                        self.bitcoin_rpc_connected,
+                        self.cur_height,
+                        self.cur_tip_blkid,
+                        self.published_reveal_txs_count
+                    )
+                }
+            } else {
+                write!(
+                    f,
+                    "L1Status {{ bitcoin_rpc_connected: {}, cur_height: {}, cur_tip_blkid: {}, last_published_txid: None, published_reveal_txs_count: {} }}",
+                    self.bitcoin_rpc_connected,
+                    self.cur_height,
+                    self.cur_tip_blkid,
+                    self.published_reveal_txs_count
+                )
+            }
+        }
+    }
 }

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -3,6 +3,8 @@
 //! This just implements a very simple n-of-n multisig bridge.  It will be
 //! extended to a more sophisticated design when we have that specced out.
 
+use std::fmt;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::{
@@ -544,7 +546,7 @@ impl WithdrawOutput {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct FulfilledState {
     /// The index of the operator that has fronted the funds for the withdrawal,
     /// and who will be reimbursed by the bridge notaries.
@@ -572,5 +574,39 @@ impl FulfilledState {
 
     pub fn amt(&self) -> BitcoinAmount {
         self.amt
+    }
+}
+
+// Custom debug implementation to print txid in little endian
+impl fmt::Debug for FulfilledState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+
+        f.debug_struct("FulfilledState")
+            .field("assignee", &self.assignee)
+            .field("amt", &self.amt)
+            .field("txid", &txid_le)
+            .finish()
+    }
+}
+
+// Custom display implementation to print txid in little endian
+impl fmt::Display for FulfilledState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txid_le = {
+            let mut bytes = self.txid.0;
+            bytes.reverse();
+            bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+        };
+
+        write!(
+            f,
+            "FulfilledState {{ assignee: {}, amt: {:?}, txid: {} }}",
+            self.assignee, self.amt, txid_le
+        )
     }
 }

--- a/crates/tasks/src/shutdown.rs
+++ b/crates/tasks/src/shutdown.rs
@@ -30,7 +30,7 @@ impl ShutdownSignal {
         self.0.load(Ordering::Relaxed)
     }
 
-    fn notified(&self) -> Notified {
+    fn notified(&self) -> Notified<'_> {
         self.1.notified()
     }
 }


### PR DESCRIPTION
## Description

Backport of #1065.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

STR-1478
STR-1494
STR-1478
STR-1498