### PR TITLE
fix (ci): python version incompatibility

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
-          python-version: "^3.10" # Keep in sync with `pyproject.toml`
+          python-version: "3.13" # Keep in sync with `pyproject.toml`
 
       - name: Install poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
@@ -102,7 +102,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
-          python-version: "^3.10" # Keep in sync with `pyproject.toml`
+          python-version: "3.13" # Keep in sync with `pyproject.toml`
 
       - name: Install poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1

--- a/functional-tests/pyproject.toml
+++ b/functional-tests/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.10,<3.14"
 flexitest = { git = "https://codeberg.org/treyd/flexitest.git" }
 strata_utils = { path = "../crates/util/python-utils", develop = true }
 bitcoinlib = "^0.7.3"


### PR DESCRIPTION
## Description

This is a fix suggested by Claude Code for fixing python version incompatibility to make sure functional tests run in `releases/0.2.0` branch:

The functional tests were failing in CI with Python 3.14 because the `greenlet` package (a transitive dependency via `locust` -> `gevent` ->`greenlet`) does not yet support Python 3.14. The `greenlet` package uses
internal `CPython` C APIs that changed significantly in Python 3.14.

Changes:
- Pin Python version to 3.13 in `functional.yml` CI workflow
- Update `pyproject.toml` to exclude Python 3.14 (python = "^3.10,<3.14")

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
