### PR TITLE
chore(justfile): Remove int-tests, add `pr-lite` cmd without func-tests

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -43,11 +43,6 @@ cov-unit: ensure-cargo-llvm-cov ensure-cargo-nextest
 cov-report-html: ensure-cargo-llvm-cov ensure-cargo-nextest
     cargo llvm-cov --open --workspace --locked nextest
 
-# Run integration tests
-[group('test')]
-test-int: ensure-cargo-nextest
-    cargo nextest run -p "integration-tests" --status-level=fail --no-capture
-
 # Runs `nextest` under `cargo-mutants`. Caution: This can take *really* long to run
 [group('test')]
 mutants-test: ensure-cargo-mutants
@@ -325,7 +320,16 @@ test: test-unit test-doc
 
 # Runs lints (without fixing), audit, docs, and tests (run this before creating a PR)
 [group('code-quality')]
-pr: lint rustdocs test-doc test-unit test-int test-functional
+pr: lint rustdocs test-doc test-unit test-functional
+    @echo "\n\033[36m======== CHECKS_COMPLETE ========\033[0m\n"
+    @test -z \`git status --porcelain\` || echo "WARNING: You have uncommitted changes"
+    @echo "All good to create a PR!"
+
+# Runs lints (without fixing), audit, docs, and tests(except functional tests)
+# NOTE: This is a command to check everything else except the functional tests pass
+# because sometimes running functional tests might be redundant.
+[group('code-quality')]
+pr-lite: lint rustdocs test-doc test-unit
     @echo "\n\033[36m======== CHECKS_COMPLETE ========\033[0m\n"
     @test -z \`git status --porcelain\` || echo "WARNING: You have uncommitted changes"
     @echo "All good to create a PR!"


### PR DESCRIPTION
## Description

This PR enhances the justfile by:
- Removing the redundant `test-int` command that tried to run "integration-tests" and failed.
- Introducing a `pr-lite` command that runs everything else except the functional tests. This should speed up the pre-PR checks when func-tests are not involved.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
