### PR TITLE
fix(evm): use stateful precompile for bridge (backport)

### DIFF
--- a/crates/reth/evm/src/precompiles/factory.rs
+++ b/crates/reth/evm/src/precompiles/factory.rs
@@ -13,7 +13,7 @@ pub fn create_precompiles_map(spec: SpecId) -> PrecompilesMap {
 
     // Add bridge precompile using DynPrecompile for compatibility
     precompiles.apply_precompile(&BRIDGEOUT_PRECOMPILE_ADDRESS, |_| {
-        Some(DynPrecompile::new(
+        Some(DynPrecompile::new_stateful(
             PrecompileId::custom(BRIDGEOUT_PRECOMPILE_ID),
             bridge_context_call,
         ))


### PR DESCRIPTION
## Description
Mark bridge precompile as stateful. This resolves an issue of mismatched receipt root during block execution due to precompile caching.

Backport of #1154 to release/0.2.0
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
