### PR TITLE
CODEOWNERS: add uv.lock to python

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@ functional-tests/ @alpenlabs/python # catch all
 functional-tests/fn_*.py @alpenlabs/python @alpenlabs/ci
 functional-tests/constants.py @alpenlabs/python @alpenlabs/ci
 functional-tests/entry.py @alpenlabs/python @alpenlabs/ci
+functional-tests/uv.lock @alpenlabs/python
 
 # Docker/Containers
 **/Docker* @alpenlabs/docker


### PR DESCRIPTION
## Description

I just realized that `uv.lock` is getting flagged as a "rust" codeowners, see #1175.


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] Admin stuff (CODEOWNERS)

## Notes to Reviewers


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

None
