### PR TITLE
chore(ci): Make sled's loglevel warn in ci func tests

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -129,7 +129,7 @@ jobs:
         if: steps.funcTestsRun1.outcome == 'failure'
         continue-on-error: true
         env:
-          RUST_LOG: "trace,hyper=warn,soketto=warn,jsonrpsee-server=warn,mio=warn"
+          RUST_LOG: "trace,sled=warn,hyper=warn,soketto=warn,jsonrpsee-server=warn,mio=warn"
           NO_COLOR: "1"
           RUST_BACKTRACE: "1"
           LOG_LEVEL: "info"


### PR DESCRIPTION
## Description

It's very difficult to view functional tests logs for the second run in ci because the loglevel is TRACE and sled emits a lot of TRACEs which are not necessary. This PR sets sled log level to WARN.
### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
