### PR TITLE
refactor: use `OLFoo` instead of `OlFoo`

### DIFF
--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -12,12 +12,12 @@ use alpen_ee_common::chain_status_checked;
 use alpen_ee_config::{AlpenEeConfig, AlpenEeParams};
 use alpen_ee_database::init_db_storage;
 use alpen_ee_engine::{create_engine_control_task, AlpenRethExecEngine};
-use alpen_ee_ol_tracker::{init_ol_tracker_state, OlTrackerBuilder};
+use alpen_ee_ol_tracker::{init_ol_tracker_state, OLTrackerBuilder};
 use alpen_reth_node::{
     args::AlpenNodeArgs, AlpenEthereumNode, AlpenGossipProtocolHandler, AlpenGossipState,
 };
 use clap::Parser;
-use ol_client::DummyOlClient;
+use ol_client::DummyOLClient;
 use reth_chainspec::ChainSpec;
 use reth_cli_commands::{launcher::FnLauncher, node::NodeCommand};
 use reth_cli_runner::CliRunner;
@@ -89,7 +89,7 @@ fn main() {
                 .into();
 
             // TODO: real ol client
-            let ol_client = Arc::new(DummyOlClient::default());
+            let ol_client = Arc::new(DummyOLClient::default());
 
             // TODO: startup consistency check
             let ol_chain_status = builder
@@ -132,7 +132,7 @@ fn main() {
                     }
                 })
                 .on_node_started(move |node| {
-                    let (ol_tracker, ol_tracker_task) = OlTrackerBuilder::new(
+                    let (ol_tracker, ol_tracker_task) = OLTrackerBuilder::new(
                         ol_tracker_state,
                         config.params().clone(),
                         storage,

--- a/bin/alpen-client/src/ol_client.rs
+++ b/bin/alpen-client/src/ol_client.rs
@@ -1,15 +1,15 @@
-use alpen_ee_common::{OlChainStatus, OlClient, OlClientError};
+use alpen_ee_common::{OLChainStatus, OLClient, OLClientError};
 use async_trait::async_trait;
 use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
 use strata_snark_acct_types::UpdateInputData;
 
 #[derive(Debug, Default)]
-pub(crate) struct DummyOlClient {}
+pub(crate) struct DummyOLClient {}
 
 #[async_trait]
-impl OlClient for DummyOlClient {
-    async fn chain_status(&self) -> Result<OlChainStatus, OlClientError> {
-        Ok(OlChainStatus {
+impl OLClient for DummyOLClient {
+    async fn chain_status(&self) -> Result<OLChainStatus, OLClientError> {
+        Ok(OLChainStatus {
             latest: OLBlockCommitment::null(),
             confirmed: OLBlockCommitment::null(),
             finalized: OLBlockCommitment::null(),
@@ -20,9 +20,9 @@ impl OlClient for DummyOlClient {
         &self,
         start_slot: u64,
         end_slot: u64,
-    ) -> Result<Vec<OLBlockCommitment>, OlClientError> {
+    ) -> Result<Vec<OLBlockCommitment>, OLClientError> {
         if end_slot < start_slot {
-            return Err(OlClientError::InvalidSlotRange {
+            return Err(OLClientError::InvalidSlotRange {
                 start_slot,
                 end_slot,
             });
@@ -36,7 +36,7 @@ impl OlClient for DummyOlClient {
     async fn get_update_operations_for_blocks(
         &self,
         blocks: Vec<OLBlockId>,
-    ) -> Result<Vec<Vec<UpdateInputData>>, OlClientError> {
+    ) -> Result<Vec<Vec<UpdateInputData>>, OLClientError> {
         Ok((blocks.iter().map(|_| vec![])).collect())
     }
 }

--- a/crates/alpen-ee/common/src/lib.rs
+++ b/crates/alpen-ee/common/src/lib.rs
@@ -8,14 +8,14 @@ pub use traits::{
     engine::{ExecutionEngine, ExecutionEngineError},
     ol_client::{
         block_commitments_in_range_checked, chain_status_checked,
-        get_update_operations_for_blocks_checked, OlClient, OlClientError,
+        get_update_operations_for_blocks_checked, OLClient, OLClientError,
     },
     payload_builder::{EnginePayload, PayloadBuilderEngine},
     storage::{ExecBlockStorage, OLBlockOrSlot, Storage, StorageError},
 };
 #[cfg(feature = "test-utils")]
 pub use traits::{
-    ol_client::MockOlClient,
+    ol_client::MockOLClient,
     storage::{
         exec_block_storage_test_fns, tests as storage_test_fns, MockExecBlockStorage, MockStorage,
     },
@@ -24,7 +24,7 @@ pub use types::{
     consensus_heads::ConsensusHeads,
     ee_account_state::EeAccountStateAtBlock,
     exec_record::ExecBlockRecord,
-    ol_chain_status::OlChainStatus,
+    ol_chain_status::OLChainStatus,
     payload_builder::{DepositInfo, PayloadBuildAttributes},
 };
 pub use utils::conversions::sats_to_gwei;

--- a/crates/alpen-ee/common/src/types/ol_chain_status.rs
+++ b/crates/alpen-ee/common/src/types/ol_chain_status.rs
@@ -2,7 +2,7 @@ use strata_identifiers::OLBlockCommitment;
 
 /// Status of the OL chain including latest, confirmed, and finalized blocks.
 #[derive(Debug)]
-pub struct OlChainStatus {
+pub struct OLChainStatus {
     /// Latest block commitment.
     pub latest: OLBlockCommitment,
     /// Confirmed block commitment.
@@ -11,7 +11,7 @@ pub struct OlChainStatus {
     pub finalized: OLBlockCommitment,
 }
 
-impl OlChainStatus {
+impl OLChainStatus {
     /// Returns the latest block commitment.
     pub fn latest(&self) -> &OLBlockCommitment {
         &self.latest

--- a/crates/alpen-ee/config/src/params.rs
+++ b/crates/alpen-ee/config/src/params.rs
@@ -18,7 +18,7 @@ pub struct AlpenEeParams {
     /// OL slot of Alpen ee account genesis
     genesis_ol_slot: u64,
 
-    /// Ol block of Alpen ee account genesis
+    /// OL block of Alpen ee account genesis
     genesis_ol_blockid: OLBlockId,
 }
 

--- a/crates/alpen-ee/database/src/error.rs
+++ b/crates/alpen-ee/database/src/error.rs
@@ -12,20 +12,20 @@ pub type DbResult<T> = Result<T, DbError>;
 #[derive(Debug, Clone, Error)]
 pub enum DbError {
     /// Attempted to persist a null OL block.
-    #[error("null Ol block should not be persisted")]
-    NullOlBlock,
+    #[error("null OL block should not be persisted")]
+    NullOLBlock,
 
     /// OL slot was skipped in sequential persistence.
     #[error("OL entries must be persisted sequentially; next: {expected}; got: {got}")]
-    SkippedOlSlot { expected: u64, got: u64 },
+    SkippedOLSlot { expected: u64, got: u64 },
 
     /// Transaction conflict: slot is already filled.
     #[error("Txn conflict: OL slot {0} already filled")]
-    TxnFilledOlSlot(u64),
+    TxnFilledOLSlot(u64),
 
     /// Transaction conflict: expected slot to be empty.
     #[error("Txn conflict: OL slot {0} should be empty")]
-    TxnExpectEmptyOlSlot(u64),
+    TxnExpectEmptyOLSlot(u64),
 
     /// Account state is missing for the given block.
     #[error("Account state expected to be present; block_id = {0}")]
@@ -74,7 +74,7 @@ pub enum DbError {
 
 impl DbError {
     pub(crate) fn skipped_ol_slot(expected: u64, got: u64) -> DbError {
-        DbError::SkippedOlSlot { expected, got }
+        DbError::SkippedOLSlot { expected, got }
     }
 }
 
@@ -99,7 +99,7 @@ impl From<TransactionError<SledError>> for DbError {
 impl From<DbError> for StorageError {
     fn from(err: DbError) -> Self {
         match err {
-            DbError::SkippedOlSlot { expected, got } => StorageError::MissingSlot {
+            DbError::SkippedOLSlot { expected, got } => StorageError::MissingSlot {
                 attempted_slot: got,
                 last_slot: expected,
             },

--- a/crates/alpen-ee/database/src/sleddb/db.rs
+++ b/crates/alpen-ee/database/src/sleddb/db.rs
@@ -8,7 +8,7 @@ use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use tracing::{error, warn};
 use typed_sled::{error::Error as TSledError, transaction::SledTransactional, SledDb, SledTree};
 
-use super::{AccountStateAtOlBlockSchema, OlBlockAtSlotSchema};
+use super::{AccountStateAtOLBlockSchema, OLBlockAtSlotSchema};
 use crate::{
     database::EeNodeDb,
     serialization_types::DBAccountStateAtSlot,
@@ -23,8 +23,8 @@ fn abort<T>(reason: impl std::error::Error + Send + Sync + 'static) -> Result<T,
 }
 
 pub(crate) struct EeNodeDBSled {
-    ol_blockid_tree: SledTree<OlBlockAtSlotSchema>,
-    account_state_tree: SledTree<AccountStateAtOlBlockSchema>,
+    ol_blockid_tree: SledTree<OLBlockAtSlotSchema>,
+    account_state_tree: SledTree<AccountStateAtOLBlockSchema>,
     exec_block_tree: SledTree<ExecBlockSchema>,
     exec_blocks_by_height_tree: SledTree<ExecBlocksAtHeightSchema>,
     exec_block_finalized_tree: SledTree<ExecBlockFinalizedSchema>,
@@ -54,7 +54,7 @@ impl EeNodeDb for EeNodeDBSled {
     ) -> DbResult<()> {
         // ensure null block is not persisted
         if ol_block.is_null() {
-            return Err(DbError::NullOlBlock);
+            return Err(DbError::NullOLBlock);
         }
 
         let slot = ol_block.slot();
@@ -81,7 +81,7 @@ impl EeNodeDb for EeNodeDBSled {
                 // empty. This check can still be bypassed by a race with a concurrent deletion.
 
                 if ol_blockid_tree.get(&slot)?.is_some() {
-                    return abort(DbError::TxnFilledOlSlot(slot))?;
+                    return abort(DbError::TxnFilledOLSlot(slot))?;
                 }
 
                 ol_blockid_tree.insert(&slot, &blockid)?;
@@ -115,7 +115,7 @@ impl EeNodeDb for EeNodeDBSled {
                 // NOTE: Cannot check for last slot inside txn, so check that next expected slot is
                 // empty. This check can still be bypassed by a race with inserting new state.
                 if ol_blockid_tree.get(&(max_slot + 1))?.is_some() {
-                    abort(DbError::TxnExpectEmptyOlSlot(max_slot + 1))?;
+                    abort(DbError::TxnExpectEmptyOLSlot(max_slot + 1))?;
                 }
 
                 for slot in (min_slot..=max_slot).rev() {

--- a/crates/alpen-ee/database/src/sleddb/mod.rs
+++ b/crates/alpen-ee/database/src/sleddb/mod.rs
@@ -5,6 +5,6 @@ mod schema;
 pub(crate) use db::EeNodeDBSled;
 pub(crate) use init::init_db;
 pub(crate) use schema::{
-    AccountStateAtOlBlockSchema, ExecBlockFinalizedSchema, ExecBlockPayloadSchema, ExecBlockSchema,
-    ExecBlocksAtHeightSchema, OlBlockAtSlotSchema,
+    AccountStateAtOLBlockSchema, ExecBlockFinalizedSchema, ExecBlockPayloadSchema, ExecBlockSchema,
+    ExecBlocksAtHeightSchema, OLBlockAtSlotSchema,
 };

--- a/crates/alpen-ee/database/src/sleddb/schema.rs
+++ b/crates/alpen-ee/database/src/sleddb/schema.rs
@@ -8,14 +8,14 @@ use crate::serialization_types::{DBAccountStateAtSlot, DBExecBlockRecord, DBOLBl
 
 define_table_without_codec!(
     /// store canonical OL block id at OL slot
-    (OlBlockAtSlotSchema) u64 => DBOLBlockId
+    (OLBlockAtSlotSchema) u64 => DBOLBlockId
 );
-// impl_bincode_key_codec!(OlBlockAtSlotSchema, u64);
-impl_borsh_value_codec!(OlBlockAtSlotSchema, DBOLBlockId);
+// impl_bincode_key_codec!(OLBlockAtSlotSchema, u64);
+impl_borsh_value_codec!(OLBlockAtSlotSchema, DBOLBlockId);
 
 define_table_with_default_codec!(
     /// EeAccountState at specific OL Block
-    (AccountStateAtOlBlockSchema) DBOLBlockId => DBAccountStateAtSlot
+    (AccountStateAtOLBlockSchema) DBOLBlockId => DBAccountStateAtSlot
 );
 
 define_table_with_default_codec!(

--- a/crates/alpen-ee/ol_tracker/src/ctx.rs
+++ b/crates/alpen-ee/ol_tracker/src/ctx.rs
@@ -5,9 +5,9 @@ use alpen_ee_config::AlpenEeParams;
 use strata_ee_acct_types::EeAccountState;
 use tokio::sync::watch;
 
-pub(crate) struct OlTrackerCtx<TStorage, TOlClient> {
+pub(crate) struct OLTrackerCtx<TStorage, TOLClient> {
     pub storage: Arc<TStorage>,
-    pub ol_client: Arc<TOlClient>,
+    pub ol_client: Arc<TOLClient>,
     pub params: Arc<AlpenEeParams>,
     pub ee_state_tx: watch::Sender<EeAccountState>,
     pub consensus_tx: watch::Sender<ConsensusHeads>,
@@ -16,7 +16,7 @@ pub(crate) struct OlTrackerCtx<TStorage, TOlClient> {
     pub reorg_fetch_size: u64,
 }
 
-impl<TStorage, TOlClient> OlTrackerCtx<TStorage, TOlClient> {
+impl<TStorage, TOLClient> OLTrackerCtx<TStorage, TOLClient> {
     /// Notify watchers of latest state update.
     pub(crate) fn notify_state_update(&self, state: &EeAccountState) {
         let _ = self.ee_state_tx.send(state.clone());

--- a/crates/alpen-ee/ol_tracker/src/error.rs
+++ b/crates/alpen-ee/ol_tracker/src/error.rs
@@ -1,4 +1,4 @@
-use alpen_ee_common::{OlClientError, StorageError};
+use alpen_ee_common::{OLClientError, StorageError};
 use thiserror::Error;
 
 /// Error type for OL tracker operations.
@@ -8,14 +8,14 @@ use thiserror::Error;
 ///   failures)
 /// - **NonRecoverable**: Fatal errors requiring intervention (no fork point found, data corruption)
 #[derive(Debug, Error)]
-pub enum OlTrackerError {
+pub enum OLTrackerError {
     /// Storage operation failed (recoverable - may be transient DB issue)
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 
     /// OL client operation failed (recoverable - network/RPC issues)
     #[error("OL client error: {0}")]
-    OlClient(#[from] OlClientError),
+    OLClient(#[from] OLClientError),
 
     /// Failed to build tracker state from storage data (recoverable - may succeed on retry)
     #[error("failed to build tracker state: {0}")]
@@ -36,19 +36,19 @@ pub enum OlTrackerError {
     Other(String),
 }
 
-impl OlTrackerError {
+impl OLTrackerError {
     /// Returns true if this error is recoverable and the operation can be retried.
     pub fn is_recoverable(&self) -> bool {
         match self {
             // Non-recoverable: requires manual intervention
-            OlTrackerError::NoForkPointFound { .. } => false,
+            OLTrackerError::NoForkPointFound { .. } => false,
 
             // All others are potentially recoverable
-            OlTrackerError::Storage(_)
-            | OlTrackerError::OlClient(_)
-            | OlTrackerError::BuildStateFailed(_)
-            | OlTrackerError::MissingBlock { .. }
-            | OlTrackerError::Other(_) => true,
+            OLTrackerError::Storage(_)
+            | OLTrackerError::OLClient(_)
+            | OLTrackerError::BuildStateFailed(_)
+            | OLTrackerError::MissingBlock { .. }
+            | OLTrackerError::Other(_) => true,
         }
     }
 
@@ -60,7 +60,7 @@ impl OlTrackerError {
     /// Creates a detailed panic message for non-recoverable errors.
     pub fn panic_message(&self) -> String {
         match self {
-            OlTrackerError::NoForkPointFound { genesis_slot } => {
+            OLTrackerError::NoForkPointFound { genesis_slot } => {
                 format!(
                     "FATAL: OL tracker cannot recover - no common fork point found.\n\
                      \n\
@@ -75,10 +75,10 @@ impl OlTrackerError {
     }
 }
 
-impl From<eyre::Error> for OlTrackerError {
+impl From<eyre::Error> for OLTrackerError {
     fn from(e: eyre::Error) -> Self {
-        OlTrackerError::Other(e.to_string())
+        OLTrackerError::Other(e.to_string())
     }
 }
 
-pub(crate) type Result<T> = std::result::Result<T, OlTrackerError>;
+pub(crate) type Result<T> = std::result::Result<T, OLTrackerError>;

--- a/crates/alpen-ee/ol_tracker/src/handle.rs
+++ b/crates/alpen-ee/ol_tracker/src/handle.rs
@@ -1,27 +1,27 @@
 use std::{future::Future, sync::Arc};
 
-use alpen_ee_common::{ConsensusHeads, OlClient, Storage};
+use alpen_ee_common::{ConsensusHeads, OLClient, Storage};
 use alpen_ee_config::AlpenEeParams;
 use strata_ee_acct_types::EeAccountState;
 use tokio::sync::watch;
 
-use crate::{ctx::OlTrackerCtx, state::OlTrackerState, task::ol_tracker_task};
+use crate::{ctx::OLTrackerCtx, state::OLTrackerState, task::ol_tracker_task};
 
-/// Default number of Ol blocks to process in each cycle
+/// Default number of OL blocks to process in each cycle
 const DEFAULT_MAX_BLOCKS_FETCH: u64 = 10;
 /// Default ms to wait between ol polls
 const DEFAULT_POLL_WAIT_MS: u64 = 100;
-/// Default number of Ol blocks to process in each cycle during reorg
+/// Default number of OL blocks to process in each cycle during reorg
 const DEFAULT_REORG_FETCH_SIZE: u64 = 10;
 
 /// Handle for accessing OL tracker state updates.
 #[derive(Debug)]
-pub struct OlTrackerHandle {
+pub struct OLTrackerHandle {
     ee_state_rx: watch::Receiver<EeAccountState>,
     consensus_rx: watch::Receiver<ConsensusHeads>,
 }
 
-impl OlTrackerHandle {
+impl OLTrackerHandle {
     /// Returns a watcher for EE account state updates.
     pub fn ee_state_watcher(&self) -> watch::Receiver<EeAccountState> {
         self.ee_state_rx.clone()
@@ -35,23 +35,23 @@ impl OlTrackerHandle {
 
 /// Builder for creating an OL tracker with custom configuration.
 #[derive(Debug)]
-pub struct OlTrackerBuilder<TStorage, TOlClient> {
-    state: OlTrackerState,
+pub struct OLTrackerBuilder<TStorage, TOLClient> {
+    state: OLTrackerState,
     params: Arc<AlpenEeParams>,
     storage: Arc<TStorage>,
-    ol_client: Arc<TOlClient>,
+    ol_client: Arc<TOLClient>,
     max_block_fetch: Option<u64>,
     poll_wait_ms: Option<u64>,
     reorg_fetch_size: Option<u64>,
 }
 
-impl<TStorage, TOlClient> OlTrackerBuilder<TStorage, TOlClient> {
+impl<TStorage, TOLClient> OLTrackerBuilder<TStorage, TOLClient> {
     /// Creates a new OL tracker builder with all required fields.
     pub fn new(
-        state: OlTrackerState,
+        state: OLTrackerState,
         params: Arc<AlpenEeParams>,
         storage: Arc<TStorage>,
-        ol_client: Arc<TOlClient>,
+        ol_client: Arc<TOLClient>,
     ) -> Self {
         Self {
             state,
@@ -83,18 +83,18 @@ impl<TStorage, TOlClient> OlTrackerBuilder<TStorage, TOlClient> {
     }
 
     /// Builds and returns the tracker handle and task.
-    pub fn build(self) -> (OlTrackerHandle, impl Future<Output = ()>)
+    pub fn build(self) -> (OLTrackerHandle, impl Future<Output = ()>)
     where
         TStorage: Storage,
-        TOlClient: OlClient,
+        TOLClient: OLClient,
     {
         let (ee_state_tx, ee_state_rx) = watch::channel(self.state.best_ee_state().clone());
         let (consensus_tx, consensus_rx) = watch::channel(self.state.get_consensus_heads());
-        let handle = OlTrackerHandle {
+        let handle = OLTrackerHandle {
             ee_state_rx,
             consensus_rx,
         };
-        let ctx = OlTrackerCtx {
+        let ctx = OLTrackerCtx {
             storage: self.storage,
             params: self.params,
             ol_client: self.ol_client,

--- a/crates/alpen-ee/ol_tracker/src/lib.rs
+++ b/crates/alpen-ee/ol_tracker/src/lib.rs
@@ -7,5 +7,5 @@ mod reorg;
 mod state;
 mod task;
 
-pub use handle::{OlTrackerBuilder, OlTrackerHandle};
-pub use state::{init_ol_tracker_state, OlTrackerState};
+pub use handle::{OLTrackerBuilder, OLTrackerHandle};
+pub use state::{init_ol_tracker_state, OLTrackerState};

--- a/crates/asm/subprotocols/admin/src/handler.rs
+++ b/crates/asm/subprotocols/admin/src/handler.rs
@@ -57,7 +57,7 @@ pub(crate) fn handle_pending_updates(
                     ProofType::Asm => {
                         // TODO: STR-1721 Emit ASM Log
                     }
-                    ProofType::OlStf => {
+                    ProofType::OLStf => {
                         relay_checkpoint_predicate(relayer, key);
                         info!(
                             %update_id,
@@ -489,7 +489,7 @@ mod tests {
 
         let predicate = PredicateKey::always_accept();
 
-        let update = PredicateUpdate::new(predicate.clone(), ProofType::OlStf);
+        let update = PredicateUpdate::new(predicate.clone(), ProofType::OLStf);
         let update_id = state.next_update_id();
         let activation_height = 42;
         state.enqueue(QueuedUpdate::new(

--- a/crates/asm/txs/admin/src/actions/mod.rs
+++ b/crates/asm/txs/admin/src/actions/mod.rs
@@ -63,7 +63,7 @@ impl MultisigAction {
                 UpdateAction::Sequencer(_) => SEQUENCER_UPDATE_TX_TYPE,
                 UpdateAction::VerifyingKey(vk) => match vk.kind() {
                     ProofType::Asm => ASM_STF_VK_UPDATE_TX_TYPE,
-                    ProofType::OlStf => OL_STF_VK_UPDATE_TX_TYPE,
+                    ProofType::OLStf => OL_STF_VK_UPDATE_TX_TYPE,
                 },
             },
         }

--- a/crates/primitives/src/roles.rs
+++ b/crates/primitives/src/roles.rs
@@ -36,7 +36,7 @@ pub enum Role {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize)]
 pub enum ProofType {
     Asm,
-    OlStf,
+    OLStf,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Renames all `OlFoo` to `OLFoo` in the whole codebase.
Because it can be confusing. Lowercase `L` can be 1, uppercase `i` etc.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I think I got all of them...

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

