### PR TITLE
chore(deps): downgrade ed25519-dalek to 2.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,7 +408,7 @@ clap = { version = "4.5.39", default-features = false, features = ["derive"] }
 criterion = { version = "0.7.0", features = ["html_reports"] }
 deadpool = "0.12.1"
 digest = "0.10"
-ed25519-dalek = { version = "2.2.0", features = ["zeroize"] }
+ed25519-dalek = { version = "2.1.1", features = ["zeroize"] }
 ethnum = "1.5.0"
 eyre = "0.6"
 format_serde_error = { git = "https://github.com/AlexanderThaller/format_serde_error" }


### PR DESCRIPTION
## Description

Downgrades `ed25519-dalek` to 2.1.1 since we’re expericencing issues in `strata-bridge` update of `strata-p2p` due to the fact that `libp2p` uses 2.1.1 and `strata-key-derivation` (used by the bridge’s secret service to generate keys) uses 2.2.0.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Needed for https://github.com/alpenlabs/strata-bridge/pull/289

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues


