### PR TITLE
test fix: prover checkpoint runner

### DIFF
--- a/functional-tests/tests/prover/prover_checkpoint_runner.py
+++ b/functional-tests/tests/prover/prover_checkpoint_runner.py
@@ -76,6 +76,7 @@ class ProverCheckpointRunnerTest(testenv.StrataTestBase):
         time.sleep(10)
         sequencer.start()
         sequencer_rpc = sequencer.create_rpc()
+        seq_waiter.wait_until_client_ready(timeout=15)
 
         # Wait for target epoch to be confirmed; for debug use the same function as above,
         # it has more logs.


### PR DESCRIPTION
## Description

A fix for a flaky test: the test is flaky because after we restart the sequencer and connect to it again (with `create_rpc()`, I believe) we _sometimes_ get an error (`WARNING:root:caught exception <class 'ConnectionRefusedError'>, will still wait for timeout: [Errno 111] Connection refused`), which probably retries and then succeeds.
In the current state this causes us to "miss" the checkpoint we are waiting for, as the sequencer already posts a new checkpoint.

Actually, the test was "broken": after the restart we were merely checking if an old checkpoint is on chain, but what we need to test is the prover keep on producing proofs. This is how it was in the original test (https://github.com/alpenlabs/alpen/pull/686/), but then changed to the current state (https://github.com/alpenlabs/alpen/pull/872).

This is 'reverted' and a more detailed test description is added.

The current modification should already fix the test flakiness, however there are few more things I want to look at, mainly the "weird implementation" part, but also the fact that if we miss the specific epoch we were waiting for (i.e. more advanced epochs are checkpointed), we don't end the test.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
