### PR TITLE
ci(nix): disable devshell tests

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,11 +1,8 @@
 name: Nix
 
 on:
+  merge_group:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
     branches:
       - master
       - main


### PR DESCRIPTION
## Description

This disables the Nix DevShell tests in CI. These are very long-running tests that are started to error because of empty space left in the CI runner. To be honest, these tests are not that important to have running in every PR.

It also disables Nix CI checks for the PRs and only for the merge queue.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] CI

## Notes to Reviewers



Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

None
