### PR TITLE
ci: update all bitcoin versions to 30.2

### DIFF
--- a/.github/workflows/functional-new.yml
+++ b/.github/workflows/functional-new.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "29.2"
+          BITCOIND_VERSION: "30.2"
           BITCOIND_ARCH: "x86_64-linux-gnu"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.3 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "29.2"
+          BITCOIND_VERSION: "30.2"
           BITCOIND_ARCH: "x86_64-linux-gnu"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.3 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
@@ -201,7 +201,7 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "29.2"
+          BITCOIND_VERSION: "30.2"
           BITCOIND_ARCH: "x86_64-linux-gnu"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.3 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"

--- a/.github/workflows/main-eest.yml
+++ b/.github/workflows/main-eest.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "29.2"
+          BITCOIND_VERSION: "30.2"
           BITCOIND_ARCH: "x86_64-linux-gnu"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.3 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "29.2"
+          BITCOIND_VERSION: "30.2"
           BITCOIND_ARCH: "x86_64-linux-gnu"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.3 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"


### PR DESCRIPTION
## Description

Updates all CI bitcoin core versions to 30.2

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

30.0 and 30.1 had a nasty wallet migration bug (who the fuck uses bitcoin core wallet?) and was removed from the canonical bitcoin download URL.
This is now fixed with 30.2.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-2051