### PR TITLE
fix: functional-test of `btcio_resubmit_checkpoint`

### DIFF
--- a/crates/primitives/src/serde_helpers.rs
+++ b/crates/primitives/src/serde_helpers.rs
@@ -38,6 +38,7 @@ pub mod serde_hex_bytes {
     use strata_identifiers::L2BlockId;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(transparent)]
     pub struct HexBytes(#[serde(with = "hex::serde")] pub Vec<u8>);
 
     impl HexBytes {


### PR DESCRIPTION
## Description

The `strataadmin_submitDABlob` RPC method is failing with "Invalid params" error when called from Python tests. The issue is that `HexBytes` is defined as a tuple struct:

https://github.com/alpenlabs/alpen/blob/3118bfc2c15a8e3bcb2512568e54ebde842b9271/crates/primitives/src/serde_helpers.rs#L42

When serialized via JSON-RPC, tuple structs serialize as arrays (e.g., `["hexstring"]`), but the Python client in `functional-tests/utils/utils.py` passes a plain string `"hexstring"`. This mismatch causes the `"Invalid params` error.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Add `#[serde(transparent)] to the `HexBytes` struct definition in

https://github.com/alpenlabs/alpen/blob/3118bfc2c15a8e3bcb2512568e54ebde842b9271/crates/primitives/src/serde_helpers.rs#L42

This attribute makes serde serialize/deserialize the struct as if it were just the inner value, so it will accept a plain hex string from the Python client.

Done with Cursor (AI-assisted).

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

None
