### PR TITLE
refactor(asm): use RollupParams directly in ASM worker

### DIFF
--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -29,7 +29,7 @@ pub(crate) fn start_services(nodectx: NodeContext) -> Result<RunContext> {
         &nodectx.executor,
         nodectx.executor.handle().clone(),
         nodectx.storage.clone(),
-        nodectx.params.clone(),
+        Arc::new(nodectx.params.rollup.clone()),
         nodectx.bitcoin_client.clone(),
     )?;
 

--- a/crates/asm/worker/src/aux_resolver.rs
+++ b/crates/asm/worker/src/aux_resolver.rs
@@ -25,7 +25,7 @@ use strata_asm_common::{
 };
 use strata_asm_manifest_types::Hash32;
 use strata_btc_types::BitcoinTxid;
-use strata_params::Params;
+use strata_params::RollupParams;
 use strata_primitives::prelude::*;
 use tracing::*;
 
@@ -44,7 +44,7 @@ pub struct AuxDataResolver<'a> {
     /// Worker context for accessing ASM state and MMR database
     context: &'a dyn WorkerContext,
     /// Rollup parameters for genesis height calculation
-    params: Arc<Params>,
+    params: Arc<RollupParams>,
 }
 
 impl<'a> AuxDataResolver<'a> {
@@ -54,7 +54,7 @@ impl<'a> AuxDataResolver<'a> {
     ///
     /// * `context` - Worker context for ASM state access and MMR database
     /// * `params` - Rollup parameters (needed for genesis height)
-    pub fn new(context: &'a dyn WorkerContext, params: Arc<Params>) -> Self {
+    pub fn new(context: &'a dyn WorkerContext, params: Arc<RollupParams>) -> Self {
         Self { context, params }
     }
 
@@ -168,12 +168,7 @@ impl<'a> AuxDataResolver<'a> {
 
         debug!(count = ranges.len(), "Resolving manifest hash ranges");
 
-        let genesis_height = self
-            .params
-            .rollup()
-            .genesis_l1_view
-            .height()
-            .to_consensus_u32() as u64;
+        let genesis_height = self.params.genesis_l1_view.height_u64();
 
         let mut resolved = Vec::new();
 

--- a/crates/asm/worker/src/builder.rs
+++ b/crates/asm/worker/src/builder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use strata_params::Params;
+use strata_params::RollupParams;
 use strata_service::ServiceBuilder;
 use strata_tasks::TaskExecutor;
 
@@ -18,7 +18,7 @@ use crate::{
 #[derive(Debug)]
 pub struct AsmWorkerBuilder<W> {
     context: Option<W>,
-    params: Option<Arc<Params>>,
+    params: Option<Arc<RollupParams>>,
 }
 
 impl<W> AsmWorkerBuilder<W> {
@@ -37,7 +37,7 @@ impl<W> AsmWorkerBuilder<W> {
     }
 
     /// Set the rollup parameters.
-    pub fn with_params(mut self, params: Arc<Params>) -> Self {
+    pub fn with_params(mut self, params: Arc<RollupParams>) -> Self {
         self.params = Some(params);
         self
     }

--- a/crates/asm/worker/src/service.rs
+++ b/crates/asm/worker/src/service.rs
@@ -44,7 +44,7 @@ impl<W: WorkerContext + Send + Sync + 'static> SyncService for AsmWorkerService<
         let ctx = &state.context;
 
         // Handle pre-genesis: if the block is before genesis we don't care about it.
-        let genesis_height = state.params.rollup().genesis_l1_view.height();
+        let genesis_height = state.params.genesis_l1_view.height();
         let height = incoming_block.height();
         if height < genesis_height {
             warn!(%height, "ignoring unexpected L1 block before genesis");

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -10,7 +10,7 @@ use strata_asm_worker::{AsmWorkerHandle, AsmWorkerStatus};
 use strata_chain_worker::ChainWorkerHandle;
 use strata_csm_worker::{CsmWorkerService, CsmWorkerState, CsmWorkerStatus};
 use strata_eectl::{builder::ExecWorkerBuilder, engine::ExecEngineCtl, handle::ExecCtlHandle};
-use strata_params::Params;
+use strata_params::{Params, RollupParams};
 use strata_primitives::prelude::L1BlockCommitment;
 use strata_service::{ServiceBuilder, ServiceMonitor, SyncAsyncInput};
 use strata_status::StatusChannel;
@@ -96,7 +96,8 @@ pub fn start_sync_tasks<E: ExecEngineCtl + Sync + Send + 'static>(
     // ASM worker.
     let asm_handle = executor.handle().clone();
     let asm_storage = storage.clone();
-    let asm_params = params.clone();
+    let asm_params = Arc::new(params.rollup().clone());
+
     let asm_controller = Arc::new(spawn_asm_worker(
         executor,
         asm_handle,
@@ -254,7 +255,7 @@ pub fn spawn_asm_worker(
     executor: &TaskExecutor,
     handle: Handle,
     storage: Arc<NodeStorage>,
-    params: Arc<Params>,
+    params: Arc<RollupParams>,
     bitcoin_client: Arc<Client>,
 ) -> anyhow::Result<AsmWorkerHandle> {
     // This feels weird to pass both L1BlockManager and Bitcoin client, but ASM consumes raw bitcoin

--- a/tests/asm/admin.rs
+++ b/tests/asm/admin.rs
@@ -461,7 +461,7 @@ async fn test_multiple_updates_same_block() {
 
     // Verify all 3 transactions were included in the block
     let block = harness.client.get_block(&block_hash).await.unwrap();
-    let parser = ParseConfig::new(harness.params.rollup().magic_bytes);
+    let parser = ParseConfig::new(harness.params.magic_bytes);
     let admin_tx_count = block
         .txdata
         .iter()

--- a/tests/harness/admin.rs
+++ b/tests/harness/admin.rs
@@ -33,7 +33,7 @@ use strata_asm_txs_admin::{
 use strata_crypto::{
     keys::compressed::CompressedPublicKey, threshold_signature::ThresholdConfigUpdate,
 };
-use strata_params::Params;
+use strata_params::RollupParams;
 use strata_predicate::PredicateKey;
 use strata_primitives::{
     buf::Buf32,
@@ -88,7 +88,7 @@ impl AdminContext {
     /// Create admin context from rollup parameters.
     ///
     /// Uses the test operator key which is configured for both admin roles.
-    pub fn from_params(_params: &Params) -> Self {
+    pub fn from_params(_params: &RollupParams) -> Self {
         Self {
             privkeys: vec![get_test_operator_secret_key()],
             signer_indices: vec![0],

--- a/tests/harness/test_harness.rs
+++ b/tests/harness/test_harness.rs
@@ -54,7 +54,7 @@ use corepc_node::Node;
 use rand::RngCore;
 use strata_asm_worker::{AsmWorkerBuilder, AsmWorkerHandle, WorkerContext};
 use strata_l1_txfmt::{ParseConfig, SubprotocolId, TagDataRef, TxType};
-use strata_params::Params;
+use strata_params::RollupParams;
 use strata_primitives::{
     buf::Buf32,
     l1::{L1BlockCommitment, L1BlockId},
@@ -91,7 +91,7 @@ pub struct AsmTestHarness {
     /// ASM worker context for querying state
     pub context: TestAsmWorkerContext,
     /// Rollup parameters
-    pub params: Arc<Params>,
+    pub params: Arc<RollupParams>,
     /// Task executor for spawning tasks
     pub executor: TaskExecutor,
     /// Genesis block height
@@ -124,10 +124,10 @@ impl AsmTestHarness {
         let genesis_hash = client.get_block_hash(genesis_height).await?;
 
         // 3. Setup parameters
-        let mut params = strata_test_utils_l2::gen_params();
-        params.rollup.network = Network::Regtest;
+        let mut params = strata_test_utils_l2::gen_params().rollup;
+        params.network = Network::Regtest;
         let genesis_view = get_genesis_l1_view(&client, &genesis_hash).await?;
-        params.rollup.genesis_l1_view = genesis_view;
+        params.genesis_l1_view = genesis_view;
         let params = Arc::new(params);
 
         // 4. Create worker context
@@ -490,7 +490,7 @@ impl AsmTestHarness {
 
         // Build SPS-50 compliant OP_RETURN tag using TagData and ParseConfig
         let tag_data = TagDataRef::new(subprotocol_id, tx_type, &[])?;
-        let parse_config = ParseConfig::new(self.params.rollup().magic_bytes);
+        let parse_config = ParseConfig::new(self.params.magic_bytes);
         let op_return_script = parse_config.encode_script_buf(&tag_data)?;
 
         let op_return_output = TxOut {


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
Changes ASM worker to accept `Arc<RollupParams>` instead of `Arc<Params>`, simplifying the interface since ASM only needs rollup configuration.

This reduces coupling and makes the ASM worker's dependencies clearer by eliminating access to unnecessary sync parameters.

This is needed for integration of ASM Worker in the bridge binary.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [X] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
