### PR TITLE
Mark known RustSec advisories as ignored pending upstream fixes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,9 +35,9 @@ jobs:
 
         #  HACK: not denying warnings as we depend on `yaml-rust` via `format-serde-error` which is unmaintained
       - name: Check for audit warnings
-        run: cargo audit -D warnings
+        run: cargo audit -D warnings --file audit.toml
         continue-on-error: true
 
         # HACK: re-run without denying warnings so that we don't miss any vulnerabilities
       - name: Check for vulnerabilities
-        run: cargo audit
+        run: cargo audit --file audit.toml

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+ignore = [
+  # RUSTSEC-2025-0055 (tracing-subscriber 0.2.25)
+  # Pulled in via ark-relations.
+  # Upgrade blocked until upstream bumps tracing-subscriber >= 0.3.20.
+  # Low risk: affects ANSI escape sequences in logs only.
+  "RUSTSEC-2025-0055",
+]


### PR DESCRIPTION
## Description
Temporarily ignore known RustSec advisories that are blocked on upstream dependency fixes. Adds an audit.toml configuration and updates the security workflow to use it, keeping cargo audit noise low.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
