### PR TITLE
fix(functional-tests): add dbtool timeout

### DIFF
--- a/functional-tests/utils/dbtool.py
+++ b/functional-tests/utils/dbtool.py
@@ -25,7 +25,9 @@ def run_dbtool_command(datadir: str, subcommand: str, *args) -> tuple[int, str, 
     cmd = ["strata-dbtool", "-d", datadir, subcommand] + list(args)
     print(f"Running command: {' '.join(cmd)}")
 
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=os.path.dirname(datadir))
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=os.path.dirname(datadir), timeout=60
+    )
 
     if result.stdout:
         print(f"Stdout: {result.stdout}")


### PR DESCRIPTION
## Description

**Add subprocess timeout to `dbtool` commands** - Adds a 60-second timeout to `subprocess.run()` in `run_dbtool_command` to prevent CI jobs from hanging indefinitely if `dbtool` doesn't respond. Does not help with flakiness.


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Used Claude Code and GPT-5.2 to help find issues in current fn-tests.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

None that I am aware of.