### PR TITLE
fix(datatool): change default blocktime to 5 seconds

### DIFF
--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -163,11 +163,7 @@ pub(crate) struct SubcParams {
     )]
     pub(crate) genesis_l1_height: Option<u64>,
 
-    #[argh(
-        option,
-        description = "block time in seconds (default 15)",
-        short = 't'
-    )]
+    #[argh(option, description = "block time in seconds (default 5)", short = 't')]
     pub(crate) block_time: Option<u64>,
 
     #[argh(option, description = "epoch duration in slots (default 64)")]

--- a/bin/datatool/src/util.rs
+++ b/bin/datatool/src/util.rs
@@ -51,6 +51,12 @@ const DEFAULT_CHAIN_SPEC: &str = alpen_chainspec::DEV_CHAIN_SPEC;
 /// The default recovery delay to use in params.
 const DEFAULT_RECOVERY_DELAY: u32 = 1_008;
 
+/// The default block time in seconds to use in params.
+const DEFAULT_BLOCK_TIME_SEC: u64 = 5;
+
+/// The default epoch slots to use in params.
+const DEFAULT_EPOCH_SLOTS: u32 = 64;
+
 /// Resolves a [`Network`] from a string.
 ///
 /// Priority:
@@ -295,9 +301,8 @@ fn exec_genparams(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> {
         magic,
         bitcoin_network: ctx.bitcoin_network,
         genesis_l1_view,
-        // TODO make these consts
-        block_time_sec: cmd.block_time.unwrap_or(15),
-        epoch_slots: cmd.epoch_slots.unwrap_or(64),
+        block_time_sec: cmd.block_time.unwrap_or(DEFAULT_BLOCK_TIME_SEC),
+        epoch_slots: cmd.epoch_slots.unwrap_or(DEFAULT_EPOCH_SLOTS),
         seqkey,
         opkeys,
         checkpoint_predicate: rollup_vk,


### PR DESCRIPTION
## Description

Changes the default block time in the `datatool` to 5 seconds.
Also deals with some leftover TODOs that are related to it.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers


Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-1846