### PR TITLE
refactor(prover-perf): switch from clap to argh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15264,7 +15264,7 @@ name = "strata-provers-perf"
 version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
- "clap",
+ "argh",
  "num-format",
  "reqwest 0.12.28",
  "serde_json",

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -24,7 +24,7 @@ strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }
 zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc18", optional = true }
 
 anyhow.workspace = true
-clap = { workspace = true, features = ["derive"] }
+argh.workspace = true
 num-format = "0.4.4"
 reqwest.workspace = true
 serde_json.workspace = true

--- a/bin/prover-perf/src/args.rs
+++ b/bin/prover-perf/src/args.rs
@@ -1,29 +1,119 @@
-use clap::Parser;
+use argh::FromArgs;
 
 use crate::programs::GuestProgram;
 
-/// Flags for CLI invocation being parsed.
-#[derive(Debug, Clone, Parser)]
-#[command(about = "Evaluate the performance of SP1 on programs.")]
+/// Evaluate the performance of SP1 on programs.
+#[derive(Debug, Clone, FromArgs)]
 pub struct EvalArgs {
-    /// Whether to post on github or run locally and only log the results.
-    #[arg(long, default_value_t = false)]
+    /// whether to post on github or run locally and only log the results
+    #[argh(switch)]
     pub post_to_gh: bool,
 
-    /// The GitHub token for authentication.
-    #[arg(long, default_value = "")]
+    /// the GitHub token for authentication
+    #[argh(option, default = "String::new()")]
     pub github_token: String,
 
-    /// The GitHub PR number.
-    #[arg(long, default_value = "")]
+    /// the GitHub PR number
+    #[argh(option, default = "String::new()")]
     pub pr_number: String,
 
-    /// The commit hash.
-    #[arg(long, default_value = "local_commit")]
+    /// the commit hash
+    #[argh(option, default = "String::from(\"local_commit\")")]
     pub commit_hash: String,
 
-    /// Programs to run (comma-delimited).
-    /// e.g. `--programs fibonacci,sha2-chain,schnorr-sig-verify`
-    #[arg(long, value_enum, value_delimiter = ',')]
-    pub programs: Vec<GuestProgram>,
+    /// programs to run (comma-delimited and/or repeated),
+    /// e.g. `--programs evm-ee-stf,cl-stf` or `--programs evm-ee-stf --programs cl-stf`
+    #[argh(option)]
+    pub programs: Vec<String>,
+}
+
+/// Parses program strings into [`GuestProgram`] variants.
+///
+/// Supports both comma-separated values and repeated options:
+/// - `--programs evm-ee-stf,cl-stf`
+/// - `--programs evm-ee-stf --programs cl-stf`
+pub fn parse_programs(raw: &[String]) -> Result<Vec<GuestProgram>, String> {
+    raw.iter()
+        .flat_map(|s| s.split(','))
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.parse::<GuestProgram>())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_programs_comma_separated() {
+        let input = vec!["evm-ee-stf,cl-stf,checkpoint".to_string()];
+        let result = parse_programs(&input).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(matches!(result[0], GuestProgram::EvmEeStf));
+        assert!(matches!(result[1], GuestProgram::ClStf));
+        assert!(matches!(result[2], GuestProgram::Checkpoint));
+    }
+
+    #[test]
+    fn test_parse_programs_repeated_options() {
+        let input = vec![
+            "evm-ee-stf".to_string(),
+            "cl-stf".to_string(),
+            "checkpoint".to_string(),
+        ];
+        let result = parse_programs(&input).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(matches!(result[0], GuestProgram::EvmEeStf));
+        assert!(matches!(result[1], GuestProgram::ClStf));
+        assert!(matches!(result[2], GuestProgram::Checkpoint));
+    }
+
+    #[test]
+    fn test_parse_programs_mixed() {
+        let input = vec!["evm-ee-stf,cl-stf".to_string(), "checkpoint".to_string()];
+        let result = parse_programs(&input).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(matches!(result[0], GuestProgram::EvmEeStf));
+        assert!(matches!(result[1], GuestProgram::ClStf));
+        assert!(matches!(result[2], GuestProgram::Checkpoint));
+    }
+
+    #[test]
+    fn test_parse_programs_with_whitespace() {
+        let input = vec!["evm-ee-stf , cl-stf".to_string()];
+        let result = parse_programs(&input).unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(matches!(result[0], GuestProgram::EvmEeStf));
+        assert!(matches!(result[1], GuestProgram::ClStf));
+    }
+
+    #[test]
+    fn test_parse_programs_empty_input() {
+        let input: Vec<String> = vec![];
+        let result = parse_programs(&input).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_programs_empty_strings() {
+        let input = vec!["".to_string(), "  ".to_string()];
+        let result = parse_programs(&input).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_programs_invalid() {
+        let input = vec!["invalid-program".to_string()];
+        let result = parse_programs(&input);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unknown program"));
+    }
+
+    #[test]
+    fn test_parse_programs_partial_invalid() {
+        let input = vec!["evm-ee-stf,invalid".to_string()];
+        let result = parse_programs(&input);
+        assert!(result.is_err());
+    }
 }

--- a/bin/prover-perf/src/main.rs
+++ b/bin/prover-perf/src/main.rs
@@ -1,6 +1,6 @@
 //! Prover performance evaluation.
 
-use std::error::Error;
+use std::{error::Error, process};
 
 use sp1_sdk::utils::setup_logger;
 #[cfg(feature = "sp1")]
@@ -14,8 +14,7 @@ pub mod github;
 pub mod programs;
 
 use anyhow::Result;
-use args::EvalArgs;
-use clap::Parser;
+use args::{parse_programs, EvalArgs};
 use format::{format_header, format_results};
 use github::{format_github_message, post_to_github_pr};
 use zkaleido::PerformanceReport;
@@ -23,17 +22,21 @@ use zkaleido::PerformanceReport;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     setup_logger();
-    let args = EvalArgs::parse();
+    let args: EvalArgs = argh::from_env();
+
+    // Parse programs
+    let programs = parse_programs(&args.programs).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
 
     let mut results_text = vec![format_header(&args)];
 
     #[cfg(feature = "sp1")]
     {
-        let sp1_reports = programs::run_sp1_programs(&args.programs);
+        let sp1_reports = programs::run_sp1_programs(&programs);
         results_text.push(format_results(&sp1_reports, "SP1".to_owned()));
         if !sp1_reports.iter().all(|r| r.success) {
-            use std::process;
-
             println!("Some SP1 programs failed. Please check the results below.");
             process::exit(1);
         }

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -1,14 +1,12 @@
 use std::str::FromStr;
 
-use clap::ValueEnum;
-
 mod checkpoint;
 mod cl_stf;
 mod evm_ee;
 
 use crate::PerformanceReport;
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum GuestProgram {
     EvmEeStf,


### PR DESCRIPTION
## Description

Clap to argh switch. This is what is possible now. Without spending a lot of time on work that may need to be redone.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Based on discussions with @prajwolrg, @delbonis, @bewakes and @sapinb, it makes sense to leave clap in `alpen-reth` and `alpen-ee-client`. They will end up in separate repos at some point.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
