### PR TITLE
fix(asm): make AuxRequestCollector bounds-aware to prevent DoS 

### DIFF
--- a/crates/asm/common/src/aux/collector.rs
+++ b/crates/asm/common/src/aux/collector.rs
@@ -4,7 +4,10 @@
 
 use bitcoin::Txid;
 
-use crate::aux::data::{AuxRequests, ManifestHashRange};
+use crate::{
+    aux::data::{AuxRequests, ManifestHashRange},
+    logging,
+};
 
 /// Collects auxiliary data requests from subprotocols.
 ///
@@ -19,14 +22,16 @@ use crate::aux::data::{AuxRequests, ManifestHashRange};
 #[derive(Debug)]
 pub struct AuxRequestCollector {
     requests: AuxRequests,
+    min_manifest_height: u64,
     max_manifest_height: u64,
 }
 
 impl AuxRequestCollector {
-    /// Creates a new empty collector bounded by the given maximum manifest height.
-    pub fn new(max_manifest_height: u64) -> Self {
+    /// Creates a new empty collector bounded by the given manifest height range.
+    pub fn new(min_manifest_height: u64, max_manifest_height: u64) -> Self {
         Self {
             requests: AuxRequests::default(),
+            min_manifest_height,
             max_manifest_height,
         }
     }
@@ -37,7 +42,17 @@ impl AuxRequestCollector {
     /// * `start_height` - Starting L1 block height (inclusive)
     /// * `end_height` - Ending L1 block height (inclusive)
     pub fn request_manifest_hashes(&mut self, start_height: u64, end_height: u64) {
-        if start_height > end_height || end_height > self.max_manifest_height {
+        if start_height > end_height
+            || start_height < self.min_manifest_height
+            || end_height > self.max_manifest_height
+        {
+            logging::warn!(
+                start_height,
+                end_height,
+                self.min_manifest_height,
+                self.max_manifest_height,
+                "dropping out-of-bounds manifest hash request"
+            );
             return;
         }
 
@@ -65,7 +80,7 @@ mod tests {
 
     #[test]
     fn test_collector_basic() {
-        let mut collector = AuxRequestCollector::new(500);
+        let mut collector = AuxRequestCollector::new(0, 500);
         assert!(collector.requests.manifest_hashes.is_empty());
         assert!(collector.requests.bitcoin_txs.is_empty());
 
@@ -85,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_collector_drops_beyond_max_height() {
-        let mut collector = AuxRequestCollector::new(200);
+        let mut collector = AuxRequestCollector::new(0, 200);
 
         collector.request_manifest_hashes(100, 200);
         assert_eq!(collector.requests.manifest_hashes.len(), 1);
@@ -96,8 +111,21 @@ mod tests {
     }
 
     #[test]
+    fn test_collector_drops_below_min_height() {
+        let mut collector = AuxRequestCollector::new(100, 500);
+
+        // start_height < min_manifest_height: dropped
+        collector.request_manifest_hashes(50, 200);
+        assert!(collector.requests.manifest_hashes.is_empty());
+
+        // within bounds: accepted
+        collector.request_manifest_hashes(100, 200);
+        assert_eq!(collector.requests.manifest_hashes.len(), 1);
+    }
+
+    #[test]
     fn test_collector_drops_inverted_range() {
-        let mut collector = AuxRequestCollector::new(500);
+        let mut collector = AuxRequestCollector::new(0, 500);
 
         // start > end: silently dropped
         collector.request_manifest_hashes(200, 100);
@@ -106,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_collector_bitcoin_tx() {
-        let mut collector = AuxRequestCollector::new(500);
+        let mut collector = AuxRequestCollector::new(0, 500);
 
         let txid1 = Txid::from_byte_array([1u8; 32]);
         let txid2 = Txid::from_byte_array([2u8; 32]);

--- a/crates/asm/stf/src/stage.rs
+++ b/crates/asm/stf/src/stage.rs
@@ -24,11 +24,10 @@ impl<'c> PreProcessStage<'c> {
         anchor_state: &'c AnchorState,
         tx_bufs: &'c BTreeMap<SubprotocolId, Vec<TxInputRef<'c>>>,
     ) -> Self {
-        let max_manifest_height = anchor_state
-            .chain_view
-            .history_accumulator
-            .last_inserted_height();
-        let aux_collector = AuxRequestCollector::new(max_manifest_height);
+        let accumulator = &anchor_state.chain_view.history_accumulator;
+        let min_manifest_height = accumulator.offset();
+        let max_manifest_height = accumulator.last_inserted_height();
+        let aux_collector = AuxRequestCollector::new(min_manifest_height, max_manifest_height);
         Self {
             manager,
             anchor_state,


### PR DESCRIPTION
## Description

      A malicious L1 transaction tagged as a checkpoint can claim an arbitrary
      L1 height (e.g. 999999). The old AuxRequestCollector blindly forwarded
      this to the aux resolver, which failed on non-existent manifest hashes
      blocking processing of the entire L1 block and stalling the ASM.

      Make the collector bounds-aware by passing the accumulator's last
      inserted height at construction. Requests for ranges beyond this bound
      or with inverted start/end are silently dropped. Invalid payloads are
      still rejected during process_txs validation.



<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
