### PR TITLE
fix(asm-bridge): harden the aux data handling in ASM Bridge subproto txs

### DIFF
--- a/crates/asm/subprotocols/bridge-v1/src/errors.rs
+++ b/crates/asm/subprotocols/bridge-v1/src/errors.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use bitcoin::ScriptBuf;
-use strata_asm_common::AuxError;
 use strata_asm_txs_bridge_v1::errors::{BridgeTxParseError, Mismatch, TxStructureError};
 use strata_bridge_types::OperatorIdx;
 use strata_primitives::l1::BitcoinAmount;
@@ -23,9 +22,6 @@ pub enum BridgeSubprotocolError {
 
     #[error("failed to validate slash tx")]
     UnstakeTxValidation(#[from] UnstakeValidationError),
-
-    #[error("failed to get proper aux data")]
-    Aux(#[from] AuxError),
 }
 
 /// Errors that can occur when validating deposit transactions at the subprotocol level.
@@ -63,10 +59,6 @@ pub enum DepositValidationError {
     /// Failed to parse the Deposit Request Transaction.
     #[error("failed to parse DRT")]
     DrtParseError(#[from] TxStructureError),
-
-    /// Failed to fetch required auxiliary data (e.g., Deposit Request Tx).
-    #[error("auxiliary data lookup failed")]
-    Aux(#[from] AuxError),
 }
 
 /// Errors that can occur during deposit output lock validation.
@@ -109,10 +101,6 @@ pub enum SlashValidationError {
     /// Stake connector input is not locked to the expected N/N multisig script
     #[error("stake connector not locked to N/N multisig script")]
     InvalidStakeConnectorScript,
-
-    /// Failed to retrieve the stake connector from auxiliary data.
-    #[error("auxiliary data lookup failed")]
-    Aux(#[from] AuxError),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
Harden the aux data handling for Bridge Subprotocol Transactions.

Because the transactions must always refer to other valid and confirmed transactions, we must panic instead of throwing errors while handling aux data.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
