### PR TITLE
chore: deprecate old code

### DIFF
--- a/benches/benches/l2_database.rs
+++ b/benches/benches/l2_database.rs
@@ -21,6 +21,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
     reason = "used for benchmarking"
 )]
 use strata_asm_manifest_types as _;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::traits::{BlockStatus, L2BlockDatabase};
 use strata_ol_chain_types::{L2BlockBundle, L2Header};
 #[allow(
@@ -80,6 +81,7 @@ fn bench_put_block_data_impl(backend: DatabaseBackend, c: &mut Criterion) {
             |b, &payload_ops| match backend {
                 #[cfg(feature = "sled")]
                 DatabaseBackend::Sled => {
+                    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                     b.iter_with_setup(
                         || {
                             let setup = L2BenchSetupSled::new();
@@ -111,6 +113,7 @@ fn bench_get_block_data_impl(backend: DatabaseBackend, c: &mut Criterion) {
             &payload_ops,
             |b, &payload_ops| match backend {
                 #[cfg(feature = "sled")]
+                #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                 DatabaseBackend::Sled => {
                     b.iter_with_setup(
                         || {
@@ -145,6 +148,7 @@ fn bench_set_block_status_impl(backend: DatabaseBackend, c: &mut Criterion) {
             &payload_ops,
             |b, &payload_ops| match backend {
                 #[cfg(feature = "sled")]
+                #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                 DatabaseBackend::Sled => {
                     b.iter_with_setup(
                         || {
@@ -154,6 +158,7 @@ fn bench_set_block_status_impl(backend: DatabaseBackend, c: &mut Criterion) {
                             let bundle = L2BlockBundle::arbitrary(&mut unstructured)
                                 .expect("Failed to generate L2BlockBundle");
                             let block_id = bundle.block().header().get_blockid();
+
                             setup.db.put_block_data(bundle).unwrap();
                             (setup, block_id)
                         },
@@ -182,6 +187,7 @@ fn bench_get_block_status_impl(backend: DatabaseBackend, c: &mut Criterion) {
             &payload_ops,
             |b, &payload_ops| match backend {
                 #[cfg(feature = "sled")]
+                #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                 DatabaseBackend::Sled => {
                     b.iter_with_setup(
                         || {

--- a/bin/prover-client/src/checkpoint_runner/fetch.rs
+++ b/bin/prover-client/src/checkpoint_runner/fetch.rs
@@ -9,6 +9,7 @@ use crate::checkpoint_runner::errors::CheckpointError;
 pub(crate) async fn fetch_next_unproven_checkpoint_index(
     cl_client: &HttpClient,
 ) -> CheckpointResult<Option<u64>> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     cl_client
         .get_next_unproven_checkpoint_index()
         .await

--- a/bin/prover-client/src/checkpoint_runner/submit.rs
+++ b/bin/prover-client/src/checkpoint_runner/submit.rs
@@ -22,6 +22,7 @@ pub(crate) async fn submit_checkpoint_proof(
 
     info!(%proof_key, %checkpoint_index, "submitting ready checkpoint proof");
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     sequencer_client
         .submit_checkpoint_proof(checkpoint_index, proof.receipt().clone())
         .await

--- a/bin/prover-client/src/operators/checkpoint.rs
+++ b/bin/prover-client/src/operators/checkpoint.rs
@@ -6,6 +6,7 @@ use strata_db_types::traits::ProofDatabase;
 use strata_primitives::proof::{ProofContext, ProofKey};
 use strata_proofimpl_checkpoint::program::CheckpointProverInput;
 use strata_rpc_api::StrataApiClient;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_rpc_types::RpcCheckpointInfo;
 use strata_zkvm_hosts::get_verification_key;
 use tracing::{error, info};
@@ -35,10 +36,12 @@ impl CheckpointOperator {
     }
 
     /// Fetches checkpoint information from the CL client.
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub(crate) async fn fetch_ckp_info(
         &self,
         ckp_idx: u64,
     ) -> Result<RpcCheckpointInfo, ProvingTaskError> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         self.cl_client
             .get_checkpoint_info(ckp_idx)
             .await
@@ -82,6 +85,7 @@ impl CheckpointOperator {
         info!(%ckp_idx, "Creating ClStf dependency for checkpoint");
 
         // Create ClStf proof context from the checkpoint's L2 range
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let cl_stf_ctx = ProofContext::ClStf(ckp_info.l2_range.0, ckp_info.l2_range.1);
 
         // Store Checkpoint dependencies (ClStf)

--- a/bin/prover-client/src/rpc_server.rs
+++ b/bin/prover-client/src/rpc_server.rs
@@ -233,6 +233,7 @@ impl StrataProverClientApiServer for ProverClientRpc {
     }
 
     async fn prove_latest_checkpoint(&self) -> RpcResult<Vec<RpcProofKey>> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let next_unproven_idx = self
             .checkpoint_operator
             .cl_client()

--- a/bin/strata-client/src/el_sync.rs
+++ b/bin/strata-client/src/el_sync.rs
@@ -29,6 +29,7 @@ pub(crate) fn sync_chainstate_to_el(
     engine: &impl ExecEngineCtl,
 ) -> Result<(), Error> {
     let chainstate_manager = storage.chainstate();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2_block_manager = storage.l2();
 
     // Get the tip block - represents the canonical chain

--- a/bin/strata-client/src/helpers.rs
+++ b/bin/strata-client/src/helpers.rs
@@ -168,6 +168,7 @@ pub(crate) fn init_engine_controller(
     );
 
     let initial_fcs = fetch_init_fork_choice_state(storage, params.rollup())?;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let eng_ctl = RpcExecEngineCtl::new(client, initial_fcs, handle.clone(), storage.l2().clone());
     let eng_ctl = Arc::new(eng_ctl);
     Ok(eng_ctl)

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -106,6 +106,7 @@ fn main_inner(args: Args) -> anyhow::Result<()> {
     let database = init_db::init_database(&config.client.datadir, config.client.db_retry_count)?;
     let storage = Arc::new(create_node_storage(database.clone(), pool.clone())?);
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let checkpoint_handle: Arc<_> = CheckpointHandle::new(storage.checkpoint().clone()).into();
     let bitcoin_client = create_bitcoin_rpc_client(&config.bitcoind)?;
 
@@ -255,6 +256,7 @@ fn do_startup_checks(
         }
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let tip_blockid = match storage.l2().get_tip_block_blocking() {
         Ok(tip) => tip,
         Err(DbError::NotBootstrapped) => {
@@ -580,6 +582,7 @@ fn start_template_manager_task(
         block_template::worker_task(shutdown, worker_ctx, t_shared_state, rx)
     });
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     block_template::TemplateManagerHandle::new(
         tx,
         shared_state,

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;

--- a/bin/strata-dbtool/src/cmd/chainstate.rs
+++ b/bin/strata-dbtool/src/cmd/chainstate.rs
@@ -1,6 +1,7 @@
 use argh::FromArgs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_consensus_logic::chain_worker_context::conv_blkid_to_slot_wb_id;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{
     chainstate::ChainstateDatabase,
     traits::{
@@ -197,7 +198,9 @@ pub(crate) fn revert_chainstate(
 
     // Check if target block is inside checkpointed epoch
     let latest_checkpoint_entry = get_latest_checkpoint_entry(db)?;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let latest_checkpoint_epoch = latest_checkpoint_entry.checkpoint.batch_info().epoch;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let checkpoint_last_slot = latest_checkpoint_entry
         .checkpoint
         .batch_info()
@@ -271,6 +274,7 @@ pub(crate) fn revert_chainstate(
     let mut blocks_to_delete = Vec::new();
 
     for slot in target_slot + 1..=chain_tip_slot {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let l2_block_ids = db.l2_db().get_blocks_at_height(slot).unwrap_or_default();
         for block_id in l2_block_ids.iter() {
             // Convert block ID to write batch ID
@@ -303,6 +307,7 @@ pub(crate) fn revert_chainstate(
 
                     // Mark the status to unchecked
                     println!("Revert chainstate marking block unchecked {block_id:?}");
+                    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                     db.l2_db()
                         .set_block_status(*block_id, BlockStatus::Unchecked)
                         .internal_error(format!(
@@ -313,6 +318,10 @@ pub(crate) fn revert_chainstate(
                     // Delete blocks if requested
                     if args.delete_blocks {
                         println!("Revert chainstate deleting block {block_id:?}");
+                        #[expect(
+                            deprecated,
+                            reason = "legacy old code is retained for compatibility"
+                        )]
                         db.l2_db()
                             .del_block_data(*block_id)
                             .internal_error(format!(
@@ -345,6 +354,7 @@ pub(crate) fn revert_chainstate(
     let needs_checkpoint_cleanup = first_epoch_to_clean <= (latest_checkpoint_epoch as u64);
 
     // Check if there are epoch summaries to clean (may exist beyond latest checkpoint)
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let last_summarized_epoch = db
         .checkpoint_db()
         .get_last_summarized_epoch()
@@ -416,6 +426,7 @@ pub(crate) fn revert_chainstate(
             );
 
             // Use bulk deletion methods for efficiency
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let deleted_checkpoints = db
                 .checkpoint_db()
                 .del_checkpoints_from_epoch(first_epoch_to_clean)
@@ -442,6 +453,7 @@ pub(crate) fn revert_chainstate(
                 "Revert chainstate cleaning up epoch summaries from epoch {first_epoch_to_clean} to {last_epoch}"
             );
 
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let deleted_summaries = db
                 .checkpoint_db()
                 .del_epoch_summaries_from_epoch(first_epoch_to_clean)

--- a/bin/strata-dbtool/src/cmd/checkpoint.rs
+++ b/bin/strata-dbtool/src/cmd/checkpoint.rs
@@ -1,6 +1,7 @@
 use argh::FromArgs;
 use strata_asm_logs::CheckpointUpdate;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{
     traits::{AsmDatabase, CheckpointDatabase, DatabaseBackend, L1Database},
     types::CheckpointEntry,
@@ -58,6 +59,7 @@ pub(crate) struct GetEpochSummaryArgs {
 ///
 /// This finds the highest epoch index in the database.
 pub(crate) fn get_last_epoch(db: &impl DatabaseBackend) -> Result<Option<u64>, DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     db.checkpoint_db()
         .get_last_summarized_epoch()
         .internal_error("Failed to get last summarized epoch")
@@ -148,21 +150,27 @@ fn count_checkpoints_in_asm_logs(
 /// Get a checkpoint entry at a specific index.
 ///
 /// Returns `None` if no checkpoint exists at that index.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 pub(crate) fn get_checkpoint_at_index(
     db: &impl DatabaseBackend,
     index: u64,
 ) -> Result<Option<CheckpointEntry>, DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let chkpt_db = db.checkpoint_db();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     chkpt_db
         .get_checkpoint(index)
         .internal_error(format!("Failed to get checkpoint at index {}", index))
 }
 
 /// Get latest checkpoint entry.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 pub(crate) fn get_latest_checkpoint_entry(
     db: &impl DatabaseBackend,
 ) -> Result<CheckpointEntry, DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let chkpt_db = db.checkpoint_db();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let last_idx = chkpt_db
         .get_last_checkpoint_idx()
         .internal_error("Failed to get last checkpoint index")?
@@ -180,7 +188,9 @@ pub(crate) fn get_latest_checkpoint_entry(
 pub(crate) fn get_checkpoint_index_range(
     db: &impl DatabaseBackend,
 ) -> Result<Option<(u64, u64)>, DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let chkpt_db = db.checkpoint_db();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     if let Some(last_idx) = chkpt_db
         .get_last_checkpoint_idx()
         .internal_error("Failed to get last checkpoint index")?
@@ -205,6 +215,7 @@ pub(crate) fn get_checkpoint(
     })?;
 
     // Create the output data structure
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let checkpoint_info = CheckpointInfo {
         checkpoint_index: checkpoint_idx,
         checkpoint: &entry.checkpoint,
@@ -221,7 +232,9 @@ pub(crate) fn get_checkpoints_summary(
     db: &impl DatabaseBackend,
     args: GetCheckpointsSummaryArgs,
 ) -> Result<(), DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let chkpt_db = db.checkpoint_db();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let last_idx = chkpt_db
         .get_last_checkpoint_idx()
         .internal_error("Failed to get last checkpoint index")?
@@ -230,11 +243,13 @@ pub(crate) fn get_checkpoints_summary(
     let expected_checkpoints_count = last_idx + 1;
     let mut checkpoint_commitments = Vec::new();
     for idx in 0..=last_idx {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let entry = chkpt_db
             .get_checkpoint(idx)
             .internal_error(format!("Failed to get checkpoint at index {idx}"))?;
 
         if let Some(checkpoint_entry) = entry {
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             checkpoint_commitments.push(checkpoint_entry.checkpoint.commitment().clone());
         }
     }
@@ -261,9 +276,11 @@ pub(crate) fn get_epoch_summary(
     db: &impl DatabaseBackend,
     args: GetEpochSummaryArgs,
 ) -> Result<(), DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let chkpt_db = db.checkpoint_db();
     let epoch_idx = args.epoch_index;
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let epoch_commitments = chkpt_db
         .get_epoch_commitments_at(epoch_idx)
         .internal_error(format!(
@@ -277,6 +294,7 @@ pub(crate) fn get_epoch_summary(
         ));
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let epoch_summary = chkpt_db
         .get_epoch_summary(epoch_commitments[0])
         .internal_error(format!("Failed to get epoch summary for epoch {epoch_idx}",))?

--- a/bin/strata-dbtool/src/cmd/l2.rs
+++ b/bin/strata-dbtool/src/cmd/l2.rs
@@ -1,5 +1,6 @@
 use argh::FromArgs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::traits::{BlockStatus, DatabaseBackend, L2BlockDatabase};
 use strata_ol_chain_types::{L2BlockBundle, L2Header};
 use strata_primitives::{l1::L1BlockId, l2::L2BlockId};
@@ -40,6 +41,7 @@ pub(crate) struct GetL2SummaryArgs {
 pub(crate) fn get_chain_tip_block_id(
     db: &impl DatabaseBackend,
 ) -> Result<L2BlockId, DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     db.l2_db()
         .get_tip_block()
         .internal_error("Failed to get chain tip block")
@@ -50,6 +52,7 @@ pub(crate) fn get_earliest_l2_block_id(
     db: &impl DatabaseBackend,
 ) -> Result<L2BlockId, DisplayedError> {
     // Get blocks at slot 0
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let blocks_at_slot_0 = db
         .l2_db()
         .get_blocks_at_height(0)
@@ -101,6 +104,7 @@ pub(crate) fn get_l2_block_data(
     db: &impl DatabaseBackend,
     block_id: L2BlockId,
 ) -> Result<Option<L2BlockBundle>, DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     db.l2_db()
         .get_block_data(block_id)
         .internal_error("Failed to read block data")
@@ -115,6 +119,7 @@ pub(crate) fn get_l2_block(
     let block_id = parse_l2_block_id(&args.block_id)?;
 
     // Fetch block status and data
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let status = db
         .l2_db()
         .get_block_status(block_id)
@@ -176,6 +181,7 @@ pub(crate) fn get_l2_summary(
     // Check for gaps between earliest and tip slots
     let mut missing_slots = Vec::new();
     for slot in earliest_slot..=tip_slot {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let blocks_at_slot = db
             .l2_db()
             .get_blocks_at_height(slot)

--- a/bin/strata-dbtool/src/cmd/syncinfo.rs
+++ b/bin/strata-dbtool/src/cmd/syncinfo.rs
@@ -1,5 +1,6 @@
 use argh::FromArgs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::traits::{BlockStatus, DatabaseBackend, L2BlockDatabase};
 
 use super::{
@@ -26,6 +27,7 @@ pub(crate) fn get_syncinfo(
     db: &impl DatabaseBackend,
     args: GetSyncinfoArgs,
 ) -> Result<(), DisplayedError> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2_db = db.l2_db();
 
     // Get L1 tip
@@ -38,6 +40,7 @@ pub(crate) fn get_syncinfo(
     let l2_tip_height = get_chain_tip_slot(db)?;
 
     // Get L2 block status
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2_tip_block_status = l2_db
         .get_block_status(l2_tip_block_id)
         .internal_error("Failed to get L2 tip block status")?

--- a/bin/strata-dbtool/src/cmd/writer.rs
+++ b/bin/strata-dbtool/src/cmd/writer.rs
@@ -59,6 +59,7 @@ pub(crate) fn get_writer_summary(
             // Iterate through all checkpoint epochs
             for epoch in start_epoch..=end_epoch {
                 if let Some(checkpoint_entry) = get_checkpoint_at_index(db, epoch)? {
+                    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                     let checkpoint_hash = checkpoint_entry.checkpoint.hash();
 
                     if writer_db

--- a/bin/strata-dbtool/src/output/checkpoint.rs
+++ b/bin/strata-dbtool/src/output/checkpoint.rs
@@ -2,6 +2,7 @@
 
 use strata_checkpoint_types::{BatchInfo, BatchTransition, Checkpoint, EpochSummary};
 use strata_csm_types::CheckpointL1Ref;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::types::{CheckpointConfStatus, CheckpointProvingStatus};
 
 use super::{helpers::porcelain_field, traits::Formattable};
@@ -18,7 +19,9 @@ pub(crate) struct EpochInfo<'a> {
 pub(crate) struct CheckpointInfo<'a> {
     pub checkpoint_index: u64,
     pub checkpoint: &'a Checkpoint,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub confirmation_status: &'a CheckpointConfStatus,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub proving_status: &'a CheckpointProvingStatus,
 }
 
@@ -178,12 +181,14 @@ impl<'a> Formattable for CheckpointInfo<'a> {
 
         // Format confirmation status
         match self.confirmation_status {
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             CheckpointConfStatus::Pending => {
                 output.push(porcelain_field(
                     "checkpoint.confirmation_status",
                     format!("{:?}", self.confirmation_status),
                 ));
             }
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             CheckpointConfStatus::Confirmed(ref checkpoint_l1_ref) => {
                 output.push(porcelain_field(
                     "checkpoint.confirmation_status",
@@ -194,6 +199,7 @@ impl<'a> Formattable for CheckpointInfo<'a> {
                     "checkpoint.confirmation_status.l1_ref",
                 ));
             }
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             CheckpointConfStatus::Finalized(ref checkpoint_l1_ref) => {
                 output.push(porcelain_field(
                     "checkpoint.confirmation_status",

--- a/bin/strata-sequencer-client/src/duty_executor.rs
+++ b/bin/strata-sequencer-client/src/duty_executor.rs
@@ -146,6 +146,7 @@ where
 
     debug!(%epoch, %duty_id, %sig, "signed checkpoint");
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     rpc.complete_checkpoint_signature(duty.inner().batch_info().epoch() as u64, HexBytes64(sig.0))
         .await
         .map_err(DutyExecError::CompleteCheckpoint)?;

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -81,6 +81,7 @@ impl OLClientRpcServer for OLRpcServer {
         epoch: Epoch,
     ) -> RpcResult<RpcAccountEpochSummary> {
         // Get epoch commitments for the given epoch
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let commitments = self
             .storage
             .checkpoint()
@@ -140,6 +141,7 @@ impl OLClientRpcServer for OLRpcServer {
 
         // Get previous epoch commitment if available
         let prev_epoch_commitment = if epoch > 0 {
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let prev_commitments = self
                 .storage
                 .checkpoint()

--- a/crates/consensus-logic/src/chain_worker_context.rs
+++ b/crates/consensus-logic/src/chain_worker_context.rs
@@ -12,6 +12,7 @@ use strata_db_types::{
 use strata_ol_chain_types::{L2BlockBundle, L2BlockHeader};
 use strata_ol_chainstate_types::{Chainstate, WriteBatch};
 use strata_primitives::prelude::*;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{ChainstateManager, CheckpointDbManager, L2BlockManager};
 use tracing::*;
 
@@ -20,8 +21,10 @@ use tracing::*;
     reason = "Some inner types don't have Debug impls"
 )]
 pub struct ChainWorkerCtx {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     l2man: Arc<L2BlockManager>,
     chsman: Arc<ChainstateManager>,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     ckman: Arc<CheckpointDbManager>,
 
     /// Active state instance we build on top of for the current state.
@@ -29,6 +32,7 @@ pub struct ChainWorkerCtx {
 }
 
 impl ChainWorkerCtx {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn new(
         l2man: Arc<L2BlockManager>,
         chsman: Arc<ChainstateManager>,

--- a/crates/consensus-logic/src/exec_worker_context.rs
+++ b/crates/consensus-logic/src/exec_worker_context.rs
@@ -8,6 +8,7 @@ use strata_eectl::{
 };
 use strata_ol_chain_types::{L2BlockId, L2Header};
 use strata_primitives::{epoch::EpochCommitment, l2::L2BlockCommitment};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{ClientStateManager, L2BlockManager};
 
 #[expect(
@@ -15,11 +16,13 @@ use strata_storage::{ClientStateManager, L2BlockManager};
     reason = "Some inner types don't have Debug impls"
 )]
 pub struct ExecWorkerCtx {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     l2man: Arc<L2BlockManager>,
     client: Arc<ClientStateManager>,
 }
 
 impl ExecWorkerCtx {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn new(l2man: Arc<L2BlockManager>, client: Arc<ClientStateManager>) -> Self {
         Self { l2man, client }
     }

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -5,6 +5,7 @@ use std::{collections::VecDeque, sync::Arc};
 use strata_chain_worker::{ChainWorkerHandle, WorkerResult};
 use strata_chainexec::{validation_util, TipState};
 use strata_csm_types::{CheckpointState, ClientState};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{errors::DbError, traits::BlockStatus, types::CheckpointConfStatus};
 use strata_eectl::errors::EngineError;
 use strata_identifiers::Epoch;
@@ -13,6 +14,7 @@ use strata_ol_chainstate_types::Chainstate;
 use strata_params::Params;
 use strata_primitives::{epoch::EpochCommitment, l2::L2BlockCommitment};
 use strata_status::*;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{L2BlockManager, NodeStorage};
 use strata_tasks::ShutdownGuard;
 use tokio::{
@@ -92,16 +94,19 @@ impl ForkChoiceManager {
     }
 
     fn set_block_status(&self, id: &L2BlockId, status: BlockStatus) -> Result<(), DbError> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         self.storage.l2().set_block_status_blocking(id, status)?;
         Ok(())
     }
 
     #[expect(unused, reason = "used for fork choice manager")]
     fn get_block_status(&self, id: &L2BlockId) -> Result<Option<BlockStatus>, DbError> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         self.storage.l2().get_block_status_blocking(id)
     }
 
     fn get_block_data(&self, id: &L2BlockId) -> Result<Option<L2BlockBundle>, DbError> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         self.storage.l2().get_block_data_blocking(id)
     }
 
@@ -275,6 +280,7 @@ pub fn init_forkchoice_manager(
     // XXX right now we have to do some special casing for if we don't have an
     // initial checkpoint for the genesis epoch
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let latest_tip = storage.l2().get_tip_block_blocking()?;
     let latest_chainstate = storage
         .chainstate()
@@ -299,8 +305,10 @@ pub fn init_forkchoice_manager(
     // Populate the unfinalized block tracker.
     let mut chain_tracker =
         unfinalized_tracker::UnfinalizedBlockTracker::new_empty(finalized_epoch);
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     chain_tracker.load_unfinalized_blocks(storage.l2().as_ref())?;
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let cur_tip_block = determine_start_tip(&chain_tracker, storage.l2())?;
     debug!(?chain_tracker, "init chain tracker");
 
@@ -326,13 +334,16 @@ pub fn init_forkchoice_manager(
         // csm is ahead of chainstate
         // search for all pending checkpoints
         for epoch in finalized_epoch.epoch()..=csm_finalized_epoch.epoch() {
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let Some(checkpoint_entry) =
                 storage.checkpoint().get_checkpoint_blocking(epoch as u64)?
             else {
                 warn!(%epoch, "missing expected checkpoint entry");
                 continue;
             };
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             if let CheckpointConfStatus::Finalized(_) = checkpoint_entry.confirmation_status {
+                #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
                 let commitment = checkpoint_entry
                     .checkpoint
                     .batch_info()
@@ -347,6 +358,7 @@ pub fn init_forkchoice_manager(
 
 /// Determines the starting chain tip.  For now, this is just the block with the
 /// highest index, choosing the lowest ordered blockid in the case of ties.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 fn determine_start_tip(
     unfin: &UnfinalizedBlockTracker,
     l2_block_manager: &L2BlockManager,
@@ -393,6 +405,7 @@ pub fn tracker_task(
     info!("waiting for genesis before starting forkchoice logic");
 
     let genesis_block_id = handle.block_on(async {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         while storage
             .l2()
             .get_blocks_at_height_blocking(0)
@@ -401,6 +414,7 @@ pub fn tracker_task(
         {
             sleep(time::Duration::from_secs(1)).await;
         }
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         storage
             .l2()
             .get_blocks_at_height_blocking(0)
@@ -465,6 +479,7 @@ pub fn handle_unprocessed_blocks(
 ) -> anyhow::Result<()> {
     info!("checking for unprocessed L2 blocks");
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2_block_manager = storage.l2();
     let mut slot = fcm.cur_best_block.slot() + 1;
     loop {
@@ -687,6 +702,7 @@ fn handle_new_block(
     }
 
     // Now decide what the new tip should be and figure out how to get there.
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let best_block = pick_best_block(
         &cur_tip,
         fcm_state.chain_tracker.chain_tips_iter(),
@@ -744,6 +760,7 @@ fn handle_new_block(
 /// Returns if we should switch to the new fork.  This is dependent on our
 /// current tip and any of the competing forks.  It's "sticky" in that it'll try
 /// to stay where we currently are unless there's a definitely-better fork.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 fn pick_best_block<'t>(
     cur_tip: &'t L2BlockId,
     tips_iter: impl Iterator<Item = &'t L2BlockId>,

--- a/crates/consensus-logic/src/genesis.rs
+++ b/crates/consensus-logic/src/genesis.rs
@@ -16,6 +16,7 @@ use strata_state::{
     exec_update::{ExecUpdate, UpdateInput, UpdateOutput},
     prelude::*,
 };
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{L2BlockManager, NodeStorage};
 use tokio::{
     runtime::Handle,
@@ -63,7 +64,9 @@ pub fn init_genesis_chainstate(
     storage
         .chainstate()
         .put_slot_write_batch_blocking(gid, wb)?;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     storage.l2().put_block_data_blocking(gblock)?;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     storage
         .l2()
         .set_block_status_blocking(&gid, BlockStatus::Valid)?;
@@ -156,6 +159,7 @@ pub fn check_needs_client_init(storage: &NodeStorage) -> anyhow::Result<bool> {
 }
 
 /// Checks if we have a genesis block written to the L2 block database.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 pub fn check_needs_genesis(l2man: &L2BlockManager) -> anyhow::Result<bool> {
     // Check if there's any genesis block written.
     match l2man.get_blocks_at_height_blocking(0) {

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -225,6 +225,7 @@ fn spawn_exec_worker<E: ExecEngineCtl + Sync + Send + 'static>(
     engine: Arc<E>,
 ) -> anyhow::Result<ExecCtlHandle> {
     // Create the worker context - this stays in consensus-logic since it implements WorkerContext
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let context = ExecWorkerCtx::new(storage.l2().clone(), storage.client_state().clone());
 
     let handle = ExecWorkerBuilder::new()
@@ -246,6 +247,7 @@ fn spawn_chain_worker(
     exec_ctl_handle: ExecCtlHandle,
 ) -> anyhow::Result<ChainWorkerHandle> {
     // Create the worker context - this stays in consensus-logic since it implements WorkerContext
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let context = ChainWorkerCtx::new(
         storage.l2().clone(),
         storage.chainstate().clone(),

--- a/crates/consensus-logic/src/unfinalized_tracker.rs
+++ b/crates/consensus-logic/src/unfinalized_tracker.rs
@@ -7,6 +7,7 @@ use strata_identifiers::Slot;
 use strata_ol_chain_types::L2Header;
 use strata_primitives::{buf::Buf32, epoch::EpochCommitment, l2::L2BlockCommitment};
 use strata_state::prelude::*;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{L2BlockManager, OLBlockManager};
 use tracing::*;
 
@@ -279,6 +280,7 @@ impl UnfinalizedBlockTracker {
     }
 
     /// Loads the unfinalized blocks into the tracker which are already in the DB
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn load_unfinalized_blocks(&mut self, l2_blk_mgr: &L2BlockManager) -> anyhow::Result<()> {
         let mut height = self.finalized_epoch.last_slot() + 1;
 
@@ -471,14 +473,17 @@ mod tests {
     use std::collections::HashSet;
 
     use strata_db_store_sled::test_utils::get_test_sled_backend;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     use strata_db_types::traits::{BlockStatus, DatabaseBackend, L2BlockDatabase};
     use strata_ol_chain_types::L2Header;
     use strata_primitives::{epoch::EpochCommitment, l2::L2BlockId};
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     use strata_storage::L2BlockManager;
     use strata_test_utils_l2::gen_l2_chain;
 
     use crate::unfinalized_tracker;
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     fn setup_test_chain(l2_db: &impl L2BlockDatabase) -> [L2BlockId; 7] {
         // Chain A: g -> a1 -> a2 -> a3
         // Chain B: g -> a1 -> b2 -> b3
@@ -506,7 +511,9 @@ mod tests {
             .chain(c_chain.clone())
         {
             let blockid = b.header().get_blockid();
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             l2_db.put_block_data(b).unwrap();
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             l2_db.set_block_status(blockid, BlockStatus::Valid).unwrap();
         }
 
@@ -521,6 +528,7 @@ mod tests {
         ]
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     fn check_update_finalized(
         prev_finalized_tip: L2BlockId,
         new_finalized_tip: L2BlockId,
@@ -564,6 +572,7 @@ mod tests {
     #[test]
     fn test_load_unfinalized_blocks() {
         let db = get_test_sled_backend();
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let l2_db = db.l2_db();
 
         let [g, a1, c1, a2, b2, a3, b3] = setup_test_chain(l2_db.as_ref());
@@ -573,6 +582,7 @@ mod tests {
         let mut chain_tracker = unfinalized_tracker::UnfinalizedBlockTracker::new_empty(epoch);
 
         let pool = threadpool::ThreadPool::new(1);
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let blkman = L2BlockManager::new(pool, db.l2_db());
 
         chain_tracker.load_unfinalized_blocks(&blkman).unwrap();
@@ -610,6 +620,7 @@ mod tests {
     #[test]
     fn test_get_descendants() {
         let db = get_test_sled_backend();
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let l2_db = db.l2_db();
 
         let [g, a1, c1, a2, b2, a3, b3] = setup_test_chain(l2_db.as_ref());
@@ -619,6 +630,7 @@ mod tests {
         let mut chain_tracker = unfinalized_tracker::UnfinalizedBlockTracker::new_empty(epoch);
 
         let pool = threadpool::ThreadPool::new(1);
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let blkman = L2BlockManager::new(pool, db.l2_db());
 
         chain_tracker.load_unfinalized_blocks(&blkman).unwrap();
@@ -647,11 +659,13 @@ mod tests {
     #[test]
     fn test_update_finalized_tip() {
         let db = get_test_sled_backend();
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let l2_db = db.l2_db();
 
         let [g, a1, c1, a2, b2, a3, b3] = setup_test_chain(l2_db.as_ref());
 
         let pool = threadpool::ThreadPool::new(1);
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let blk_manager = L2BlockManager::new(pool, db.l2_db());
 
         check_update_finalized(

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -445,6 +445,7 @@ mod tests {
             );
 
             // Verify checkpoint was stored in database
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let stored_checkpoint = storage
                 .checkpoint()
                 .get_checkpoint_blocking(epoch as u64)
@@ -473,6 +474,7 @@ mod tests {
 
         // After processing 3 checkpoints, verify we have all of them in the database
         for epoch in 1u32..=3u32 {
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let stored_checkpoint = storage
                 .checkpoint()
                 .get_checkpoint_blocking(epoch as u64)

--- a/crates/csm-worker/src/sync_actions.rs
+++ b/crates/csm-worker/src/sync_actions.rs
@@ -3,12 +3,15 @@
 use std::sync::Arc;
 
 use strata_csm_types::SyncAction;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::types::{CheckpointConfStatus, CheckpointEntry, CheckpointProvingStatus};
 use strata_storage::NodeStorage;
 use tracing::*;
 
 /// Apply a sync action to storage.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 pub(crate) fn apply_action(action: SyncAction, storage: &Arc<NodeStorage>) -> anyhow::Result<()> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let ckpt_db = storage.checkpoint();
     match action {
         SyncAction::FinalizeEpoch(epoch_comm) => {
@@ -25,6 +28,7 @@ pub(crate) fn apply_action(action: SyncAction, storage: &Arc<NodeStorage>) -> an
                 return Ok(());
             };
 
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let CheckpointConfStatus::Confirmed(l1ref) = ckpt_entry.confirmation_status else {
                 warn!(
                     ?epoch_comm,

--- a/crates/db/store-sled/src/checkpoint/db.rs
+++ b/crates/db/store-sled/src/checkpoint/db.rs
@@ -1,4 +1,8 @@
 use strata_checkpoint_types::EpochSummary;
+#[expect(
+    deprecated,
+    reason = "legacy old Checkpoint code is retained for compatibility"
+)]
 use strata_db_types::{
     DbError, DbResult,
     traits::CheckpointDatabase,
@@ -17,6 +21,10 @@ define_sled_database!(
     }
 );
 
+#[expect(
+    deprecated,
+    reason = "legacy old Checkpoint code is retained for compatibility"
+)]
 impl CheckpointDatabase for CheckpointDBSled {
     fn insert_epoch_summary(&self, summary: EpochSummary) -> DbResult<()> {
         let epoch_idx = summary.epoch() as u64;

--- a/crates/db/store-sled/src/checkpoint/schemas.rs
+++ b/crates/db/store-sled/src/checkpoint/schemas.rs
@@ -1,3 +1,7 @@
+#![expect(
+    deprecated,
+    reason = "legacy old Checkpoint code is retained for compatibility"
+)]
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::types::CheckpointEntry;
 

--- a/crates/db/store-sled/src/l2/db.rs
+++ b/crates/db/store-sled/src/l2/db.rs
@@ -1,3 +1,4 @@
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{
     DbError, DbResult,
     traits::{BlockStatus, L2BlockDatabase},
@@ -18,6 +19,7 @@ define_sled_database!(
     }
 );
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 impl L2BlockDatabase for L2DBSled {
     fn put_block_data(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let block_id = bundle.block().header().get_blockid();
@@ -43,6 +45,7 @@ impl L2BlockDatabase for L2DBSled {
     }
 
     fn del_block_data(&self, id: L2BlockId) -> DbResult<bool> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let bundle = match self.get_block_data(id)? {
             Some(block) => block,
             None => return Ok(false),
@@ -68,6 +71,7 @@ impl L2BlockDatabase for L2DBSled {
     }
 
     fn set_block_status(&self, id: L2BlockId, status: BlockStatus) -> DbResult<()> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         if self.get_block_data(id)?.is_none() {
             return Ok(());
         }
@@ -91,8 +95,10 @@ impl L2BlockDatabase for L2DBSled {
         let mut height = bht.last()?.map(first).ok_or(DbError::NotBootstrapped)?;
 
         loop {
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let blocks = self.get_blocks_at_height(height)?;
             // collect all valid statuses at this height
+            #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
             let valid = blocks
                 .into_iter()
                 .filter_map(|blkid| match self.get_block_status(blkid) {

--- a/crates/db/store-sled/src/lib.rs
+++ b/crates/db/store-sled/src/lib.rs
@@ -42,6 +42,7 @@ use mempool::db::MempoolDBSled;
 use ol::db::OLBlockDBSled;
 use ol_checkpoint::db::OLCheckpointDBSled;
 use ol_state::db::OLStateDBSled;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{
     DbResult,
     chainstate::ChainstateDatabase,
@@ -153,6 +154,7 @@ impl DatabaseBackend for SledBackend {
         self.l1_db.clone()
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     fn l2_db(&self) -> Arc<impl L2BlockDatabase> {
         self.l2_db.clone()
     }
@@ -173,6 +175,7 @@ impl DatabaseBackend for SledBackend {
         self.ol_state_db.clone()
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     fn checkpoint_db(&self) -> Arc<impl CheckpointDatabase> {
         self.checkpoint_db.clone()
     }

--- a/crates/db/tests/src/checkpoint_tests.rs
+++ b/crates/db/tests/src/checkpoint_tests.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::{
     traits::CheckpointDatabase,

--- a/crates/db/tests/src/l2_tests.rs
+++ b/crates/db/tests/src/l2_tests.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::traits::{BlockStatus, L2BlockDatabase};
 use strata_ol_chain_types::{L2BlockBundle, L2Header};
 use strata_test_utils::ArbitraryGenerator;

--- a/crates/db/types/src/stubs/l2.rs
+++ b/crates/db/types/src/stubs/l2.rs
@@ -33,6 +33,10 @@ impl StubL2Db {
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy L2 stub implementation is retained for compatibility"
+)]
 impl L2BlockDatabase for StubL2Db {
     fn put_block_data(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let blkid = bundle.block().header().get_blockid();

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -22,6 +22,10 @@ use strata_primitives::{
 use strata_state::asm_state::AsmState;
 use zkaleido::ProofReceiptWithMetadata;
 
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointEntry is retained for compatibility"
+)]
 use crate::{
     chainstate::ChainstateDatabase,
     mmr_helpers::MmrAlgorithm,
@@ -35,6 +39,10 @@ use crate::{
 /// Common database backend interface that we can parameterize worker tasks over if
 /// parameterizing them over each individual trait gets cumbersome or if we need
 /// to use behavior that crosses different interfaces.
+#[expect(
+    deprecated,
+    reason = "legacy old code L2BlockDatabase and CheckpointDatabase are retained for compatibility"
+)]
 pub trait DatabaseBackend: Send + Sync {
     fn asm_db(&self) -> Arc<impl AsmDatabase>;
     fn l1_db(&self) -> Arc<impl L1Database>;
@@ -225,9 +233,17 @@ pub trait CheckpointDatabase: Send + Sync + 'static {
     /// `batchidx` for the Checkpoint is expected to increase monotonically and
     /// correspond to the value of `cur_epoch` in
     /// [`strata_ol_chainstate_types::Chainstate`].
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointEntry is retained for compatibility"
+    )]
     fn put_checkpoint(&self, epoch: u64, entry: CheckpointEntry) -> DbResult<()>;
 
     /// Get a [`CheckpointEntry`] by its index.
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointEntry is retained for compatibility"
+    )]
     fn get_checkpoint(&self, epoch: u64) -> DbResult<Option<CheckpointEntry>>;
 
     /// Get last written checkpoint index.

--- a/crates/db/types/src/types.rs
+++ b/crates/db/types/src/types.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")] // I have no idea how to make clippy be happy with precise expects in this module
 //! Module for database local types
 
 use std::fmt;
@@ -262,13 +263,29 @@ pub struct CheckpointEntry {
     pub checkpoint: Checkpoint,
 
     /// Proving Status
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointProvingStatus is retained for compatibility"
+    )]
     pub proving_status: CheckpointProvingStatus,
 
     /// Confirmation Status
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointConfStatus is retained for compatibility"
+    )]
     pub confirmation_status: CheckpointConfStatus,
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointEntry is retained for compatibility"
+)]
 impl CheckpointEntry {
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointProvingStatus and CheckpointConfStatus are retained for compatibility"
+    )]
     pub fn new(
         checkpoint: Checkpoint,
         proving_status: CheckpointProvingStatus,
@@ -281,11 +298,19 @@ impl CheckpointEntry {
         }
     }
 
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointEntry is retained for compatibility"
+    )]
     pub fn into_batch_checkpoint(self) -> Checkpoint {
         self.checkpoint
     }
 
     /// Creates a new instance for a freshly defined checkpoint.
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointEntry is retained for compatibility"
+    )]
     pub fn new_pending_proof(
         info: BatchInfo,
         transition: BatchTransition,
@@ -300,12 +325,19 @@ impl CheckpointEntry {
             CheckpointConfStatus::Pending,
         )
     }
-
+    #[expect(
+        deprecated,
+        reason = "legacy old code CheckpointEntry is retained for compatibility"
+    )]
     pub fn is_proof_ready(&self) -> bool {
         self.proving_status == CheckpointProvingStatus::ProofReady
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointEntry is retained for compatibility"
+)]
 impl From<CheckpointEntry> for Checkpoint {
     fn from(entry: CheckpointEntry) -> Checkpoint {
         entry.into_batch_checkpoint()

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -21,6 +21,7 @@ use strata_eectl::{
 use strata_ol_chain_types::{L2BlockBundle, L2BlockId};
 use strata_primitives::l1::BitcoinAmount;
 use strata_state::exec_update::{ELDepositData, ExecUpdate, Op, UpdateOutput};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::L2BlockManager;
 use tokio::{runtime::Handle, sync::Mutex};
 use tracing::*;
@@ -279,10 +280,12 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
 pub struct RpcExecEngineCtl<T: EngineRpc> {
     inner: RpcExecEngineInner<T>,
     tokio_handle: Handle,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     l2_block_manager: Arc<L2BlockManager>,
 }
 
 impl<T: EngineRpc> RpcExecEngineCtl<T> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn new(
         client: T,
         evm_head_block_hash: B256,

--- a/crates/evmexec/src/fork_choice_state.rs
+++ b/crates/evmexec/src/fork_choice_state.rs
@@ -37,6 +37,7 @@ fn compute_evm_fc_state_from_chainstate(
     tip_blockid: &L2BlockId,
     storage: &NodeStorage,
 ) -> Result<B256> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2man = storage.l2();
     let latest_evm_block_hash =
         get_evm_block_hash_by_id(tip_blockid, l2man)?.expect("evmexec: missing expected block");
@@ -44,6 +45,7 @@ fn compute_evm_fc_state_from_chainstate(
 }
 
 fn get_last_chainstate(storage: &NodeStorage) -> Result<Option<ChainstateEntry>> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let tip_blkid = match storage.l2().get_tip_block_blocking() {
         Ok(id) => id,
         Err(DbError::NotBootstrapped) => return Ok(None),
@@ -56,6 +58,7 @@ fn get_last_chainstate(storage: &NodeStorage) -> Result<Option<ChainstateEntry>>
         .map(|wb| ChainstateEntry::new(wb.into_toplevel(), tip_blkid)))
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 fn get_evm_block_hash_by_id(
     block_id: &L2BlockId,
     l2man: &L2BlockManager,

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")] // Don't know how to make clippy happy with precise line expects
 //! Macro trait def for the `strata_` RPC namespace using jsonrpsee.
 use bitcoin::Txid;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -8,6 +9,7 @@ use strata_csm_types::{ClientState, ClientUpdateOutput};
 use strata_db_types::types::{L1TxEntry, L1TxStatus};
 use strata_ol_chain_types::{L2Block, L2BlockId};
 use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_rpc_types::{
     types::{RpcBlockHeader, RpcClientStatus, RpcL1Status},
     HexBytes, HexBytes32, HexBytes64, L2BlockStatus, RpcChainState, RpcCheckpointConfStatus,
@@ -134,11 +136,13 @@ pub trait StrataApi {
 
     /// Get nth checkpoint info if any
     #[deprecated(note = "use OL checkpoint/account summary RPCs in `strata_ol_rpc_api`")]
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     #[method(name = "getCheckpointInfo")]
     async fn get_checkpoint_info(&self, idx: u64) -> RpcResult<Option<RpcCheckpointInfo>>;
 
     /// Get the checkpoint confirmation status if checkpoint exists
     #[deprecated(note = "use OL checkpoint signing/status RPCs in `strata_ol_rpc_api`")]
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     #[method(name = "getCheckpointConfStatus")]
     async fn get_checkpoint_conf_status(
         &self,
@@ -149,6 +153,7 @@ pub trait StrataApi {
     /// This assumes that the block finalization is always sequential. i.e all the blocks before the
     /// last finalized block are also finalized
     #[deprecated(note = "use `getChainStatus` in `strata_ol_rpc_api::OLClientRpc`")]
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     #[method(name = "getL2BlockStatus")]
     async fn get_l2_block_status(&self, block_height: u64) -> RpcResult<L2BlockStatus>;
 
@@ -229,6 +234,7 @@ pub trait StrataDebugApi {
     async fn get_block_by_id(&self, block_id: L2BlockId) -> RpcResult<Option<L2Block>>;
 
     /// Get the ChainState at a certain index
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     #[method(name = "debug_getChainstateById")]
     async fn get_chainstate_by_id(&self, block_id: L2BlockId) -> RpcResult<Option<RpcChainState>>;
 

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -10,6 +10,10 @@ use strata_asm_proto_bridge_v1::{DepositEntry, OperatorBitmap};
 use strata_bridge_types::WithdrawalIntent;
 use strata_checkpoint_types::BatchInfo;
 use strata_csm_types::{CheckpointL1Ref, L1Status};
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointConfStatus and CheckpointEntry are retained for compatibility"
+)]
 use strata_db_types::types::{CheckpointConfStatus, CheckpointEntry};
 use strata_ol_chain_types::L2BlockId;
 pub use strata_primitives::serde_helpers::serde_hex_bytes::{HexBytes, HexBytes32, HexBytes64};
@@ -217,6 +221,10 @@ pub enum RpcCheckpointConfStatus {
     Finalized,
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointConfStatus is retained for compatibility"
+)]
 impl From<CheckpointConfStatus> for RpcCheckpointConfStatus {
     fn from(value: CheckpointConfStatus) -> Self {
         match value {
@@ -227,6 +235,10 @@ impl From<CheckpointConfStatus> for RpcCheckpointConfStatus {
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointEntry is retained for compatibility"
+)]
 impl From<CheckpointEntry> for RpcCheckpointConfStatus {
     fn from(value: CheckpointEntry) -> Self {
         value.confirmation_status.into()
@@ -235,6 +247,10 @@ impl From<CheckpointEntry> for RpcCheckpointConfStatus {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[deprecated(note = "use OL checkpoint/account summary types in `strata_ol_rpc_types`")]
+#[expect(
+    deprecated,
+    reason = "legacy old code BatchInfo is retained for compatibility"
+)]
 pub struct RpcCheckpointInfo {
     /// The index of the checkpoint
     pub idx: u64,
@@ -248,6 +264,10 @@ pub struct RpcCheckpointInfo {
     pub confirmation_status: RpcCheckpointConfStatus,
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy old code BatchInfo is retained for compatibility"
+)]
 impl From<BatchInfo> for RpcCheckpointInfo {
     fn from(value: BatchInfo) -> Self {
         Self {
@@ -279,6 +299,10 @@ impl From<CheckpointL1Ref> for RpcCheckpointL1Ref {
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "legacy old code CheckpointEntry is retained for compatibility"
+)]
 impl From<CheckpointEntry> for RpcCheckpointInfo {
     fn from(value: CheckpointEntry) -> Self {
         let mut item: Self = value.checkpoint.batch_info().clone().into();

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -23,6 +23,7 @@ use strata_ol_chainstate_types::Chainstate;
 use strata_params::{Params, RollupParams};
 use strata_primitives::buf::Buf32;
 use strata_state::exec_update::construct_ops_from_deposit_intents;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{CheckpointDbManager, L1BlockManager, NodeStorage};
 use tracing::*;
 
@@ -39,6 +40,7 @@ fn get_total_gas_used_in_epoch(storage: &NodeStorage, prev_blkid: L2BlockId) -> 
     let prev_epoch = chainstate.prev_epoch();
     debug!(?prev_epoch);
     let epoch_start_slot = chainstate.prev_epoch().last_slot() + 1;
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let prev_header = storage
         .l2()
         .get_block_data_blocking(&prev_blkid)?
@@ -50,6 +52,7 @@ fn get_total_gas_used_in_epoch(storage: &NodeStorage, prev_blkid: L2BlockId) -> 
 
     let mut block_to_fetch = prev_blkid;
     for _ in epoch_start_slot..=prev_slot {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let block: L2BlockBundle = storage
             .l2()
             .get_block_data_blocking(&block_to_fetch)?
@@ -83,6 +86,7 @@ pub fn prepare_block(
 ) -> Result<(L2BlockHeader, L2BlockBody, L2BlockAccessory), Error> {
     let l1man = storage.l1();
     let chsman = storage.chainstate();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let ckptman = storage.checkpoint();
 
     let prev_global_sr = *prev_block.header().state_root();
@@ -161,6 +165,7 @@ pub fn prepare_block(
     Ok((header, body, block_acc))
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 #[instrument(skip_all, fields(cur_safe_height = prev_chstate.l1_view().safe_height(), cur_next_exp_height = prev_chstate.l1_view().next_expected_height()))]
 fn prepare_l1_segment(
     prev_chstate: &Chainstate,
@@ -210,6 +215,7 @@ fn prepare_l1_segment(
     } else {
         let prev_epoch = prev_chstate.prev_epoch().epoch();
         // previous checkpoint entry should exist in db
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let checkpoint = ckptman
             .get_checkpoint_blocking(prev_epoch as u64)?
             .ok_or(Error::MissingCheckpoint(prev_epoch))?

--- a/crates/sequencer/src/block_template/handle.rs
+++ b/crates/sequencer/src/block_template/handle.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use strata_consensus_logic::{message::ForkChoiceMessage, sync_manager::SyncManager};
 use strata_ol_chain_types::{L2BlockBundle, L2BlockId};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::L2BlockManager;
 use tokio::sync::{mpsc, oneshot};
 
@@ -35,6 +36,7 @@ pub enum TemplateManagerRequest {
 pub struct TemplateManagerHandle {
     tx: mpsc::Sender<TemplateManagerRequest>,
     shared: SharedState,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     l2_block_manager: Arc<L2BlockManager>,
     sync_manager: Arc<SyncManager>,
 }
@@ -42,6 +44,7 @@ pub struct TemplateManagerHandle {
 impl TemplateManagerHandle {
     /// Create new instance.
     // TODO make this not pub
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn new(
         tx: mpsc::Sender<TemplateManagerRequest>,
         shared: SharedState,

--- a/crates/sequencer/src/block_template/worker.rs
+++ b/crates/sequencer/src/block_template/worker.rs
@@ -181,6 +181,7 @@ fn generate_block_template_inner(
 ) -> Result<FullBlockTemplate, Error> {
     // get parent block
     let parent_blkid = config.parent_block_id();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2man = storage.l2();
     let parent = l2man
         .get_block_data_blocking(&parent_blkid)?

--- a/crates/sequencer/src/checkpoint/checkpoint_handle.rs
+++ b/crates/sequencer/src/checkpoint/checkpoint_handle.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{types::CheckpointEntry, DbResult};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::CheckpointDbManager;
 use tokio::sync::broadcast;
 use tracing::*;
@@ -13,6 +15,7 @@ use tracing::*;
 )]
 pub struct CheckpointHandle {
     /// Manager for underlying database.
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     db_manager: Arc<CheckpointDbManager>,
 
     /// Used to notify listeners about a checkpoint update in db.
@@ -21,6 +24,7 @@ pub struct CheckpointHandle {
 }
 
 impl CheckpointHandle {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn new(db_manager: Arc<CheckpointDbManager>) -> Self {
         let (update_notify_tx, _) = broadcast::channel::<u64>(10);
         Self {
@@ -35,6 +39,7 @@ impl CheckpointHandle {
         self.update_notify_tx.subscribe()
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub async fn put_checkpoint_and_notify(
         &self,
         idx: u64,
@@ -50,6 +55,7 @@ impl CheckpointHandle {
         Ok(())
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn put_checkpoint_and_notify_blocking(
         &self,
         idx: u64,
@@ -65,18 +71,22 @@ impl CheckpointHandle {
         Ok(())
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub async fn put_checkpoint(&self, idx: u64, entry: CheckpointEntry) -> DbResult<()> {
         self.db_manager.put_checkpoint(idx, entry).await
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn put_checkpoint_blocking(&self, idx: u64, entry: CheckpointEntry) -> DbResult<()> {
         self.db_manager.put_checkpoint_blocking(idx, entry)
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub async fn get_checkpoint(&self, idx: u64) -> DbResult<Option<CheckpointEntry>> {
         self.db_manager.get_checkpoint(idx).await
     }
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn get_checkpoint_blocking(&self, idx: u64) -> DbResult<Option<CheckpointEntry>> {
         self.db_manager.get_checkpoint_blocking(idx)
     }

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use strata_asm_common::AsmManifest;
 use strata_checkpoint_types::{BatchInfo, BatchTransition, ChainstateRootTransition, EpochSummary};
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{types::CheckpointEntry, DbError};
 use strata_ol_chain_types::{L2BlockBundle, L2BlockHeader, L2BlockId, L2Header};
 use strata_ol_chainstate_types::Chainstate;
@@ -12,6 +13,7 @@ use strata_primitives::{
     self, epoch::EpochCommitment, l1::L1BlockCommitment, l2::L2BlockCommitment,
 };
 use strata_status::*;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{CheckpointDbManager, L1BlockManager, L2BlockManager, NodeStorage};
 use strata_tasks::ShutdownGuard;
 use tokio::runtime::Handle;
@@ -30,6 +32,7 @@ pub fn checkpoint_worker(
     checkpoint_handle: Arc<CheckpointHandle>,
     rt: Handle,
 ) -> anyhow::Result<()> {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let ckman = storage.checkpoint();
 
     let mut chs_rx = SyncReceiver::new(status_ch.subscribe_chain_sync(), rt);
@@ -105,6 +108,7 @@ pub fn checkpoint_worker(
 
 /// Finds any epoch after a given epoch number that have been inserted but we
 /// haven't inserted checkpoint entries for.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 fn find_ready_checkpoints(
     from_epoch: u64,
     ckman: &CheckpointDbManager,
@@ -186,6 +190,7 @@ fn handle_ready_epoch(
 
     // else save a pending proof checkpoint entry
     debug!(%epoch, "saving unproven checkpoint");
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let entry = CheckpointEntry::new_pending_proof(cpd.info, cpd.tsn, &cpd.chainstate);
     if let Err(e) = ckhandle.put_checkpoint_and_notify_blocking(epoch as u64, entry) {
         warn!(%epoch, err = %e, "failed to save checkpoint");
@@ -218,6 +223,7 @@ fn create_checkpoint_prep_data_from_summary(
     params: &RollupParams,
 ) -> anyhow::Result<CheckpointPrepData> {
     let l1man = storage.l1();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2man = storage.l2();
     let chsman = storage.chainstate();
 
@@ -227,6 +233,7 @@ fn create_checkpoint_prep_data_from_summary(
     // There's some special handling we have to do if we're the genesis epoch.
     let prev_summary = if !is_genesis_epoch {
         let ec = summary.get_prev_epoch_commitment().unwrap();
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let ps = storage
             .checkpoint()
             .get_epoch_summary_blocking(ec)?
@@ -297,6 +304,7 @@ fn create_checkpoint_prep_data_from_summary(
     ))
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 fn fetch_epoch_l2_headers(
     summary: &EpochSummary,
     l2man: &L2BlockManager,
@@ -343,6 +351,7 @@ fn fetch_epoch_l2_headers(
     Ok(headers)
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 fn fetch_l2_block(blkid: &L2BlockId, l2man: &L2BlockManager) -> anyhow::Result<L2BlockBundle> {
     Ok(l2man
         .get_block_data_blocking(blkid)?

--- a/crates/sequencer/src/duty/extractor.rs
+++ b/crates/sequencer/src/duty/extractor.rs
@@ -1,9 +1,11 @@
 //! Extracts new duties for sequencer for a given consensus state.
 
 use strata_csm_types::ClientState;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::types::CheckpointConfStatus;
 use strata_ol_chain_types::{L2BlockId, L2Header};
 use strata_params::Params;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::L2BlockManager;
 use tracing::*;
 
@@ -14,6 +16,7 @@ use crate::{
 };
 
 /// Extracts new duties given a current chainstate and an identity.
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 pub async fn extract_duties(
     tip_blkid: L2BlockId,
     cistate: &ClientState,
@@ -32,6 +35,7 @@ pub async fn extract_duties(
     Ok(duties)
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 async fn extract_block_duties(
     tip_blkid: L2BlockId,
     l2_block_manager: &L2BlockManager,
@@ -78,7 +82,9 @@ async fn extract_batch_duties(
             break;
         };
 
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let epoch = ckpt.checkpoint.batch_info().epoch;
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let publish_ready =
             ckpt.is_proof_ready() && ckpt.confirmation_status == CheckpointConfStatus::Pending;
         trace!(%epoch, %publish_ready, "considering generating checkpoint publish duty");

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ops;
 use std::sync::Arc;
 
 use anyhow::Context;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 pub use managers::{
     account_genesis::AccountGenesisManager,
     asm::AsmStateManager,
@@ -44,6 +45,7 @@ pub struct NodeStorage {
     account_genesis_manager: Arc<AccountGenesisManager>,
     asm_state_manager: Arc<AsmStateManager>,
     l1_block_manager: Arc<L1BlockManager>,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     l2_block_manager: Arc<L2BlockManager>,
 
     chainstate_manager: Arc<ChainstateManager>,
@@ -52,6 +54,7 @@ pub struct NodeStorage {
 
     // TODO maybe move this into a different one?
     // update: probably not, would require moving data around
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     checkpoint_manager: Arc<CheckpointDbManager>,
 
     ol_block_manager: Arc<OLBlockManager>,
@@ -106,6 +109,7 @@ impl NodeStorage {
     }
 
     #[deprecated(note = "use `ol_block()` for OL/EE-decoupled block storage")]
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn l2(&self) -> &Arc<L2BlockManager> {
         &self.l2_block_manager
     }
@@ -119,6 +123,7 @@ impl NodeStorage {
     }
 
     #[deprecated(note = "use `ol_checkpoint()` for OL/EE-decoupled checkpoint storage")]
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn checkpoint(&self) -> &Arc<CheckpointDbManager> {
         &self.checkpoint_manager
     }
@@ -154,9 +159,11 @@ pub fn create_node_storage(
     let account_genesis_db = db.account_genesis_db();
     let asm_db = db.asm_db();
     let l1_db = db.l1_db();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2_db = db.l2_db();
     let chainstate_db = db.chain_state_db();
     let client_state_db = db.client_state_db();
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let checkpoint_db = db.checkpoint_db();
     let ol_block_db = db.ol_block_db();
     let mempool_db = db.mempool_db();
@@ -168,6 +175,7 @@ pub fn create_node_storage(
         Arc::new(AccountGenesisManager::new(pool.clone(), account_genesis_db));
     let asm_manager = Arc::new(AsmStateManager::new(pool.clone(), asm_db));
     let l1_block_manager = Arc::new(L1BlockManager::new(pool.clone(), l1_db));
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2_block_manager = Arc::new(L2BlockManager::new(pool.clone(), l2_db));
     let chainstate_manager = Arc::new(ChainstateManager::new(pool.clone(), chainstate_db));
 
@@ -175,6 +183,7 @@ pub fn create_node_storage(
         ClientStateManager::new(pool.clone(), client_state_db).context("open client state")?,
     );
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let checkpoint_manager = Arc::new(CheckpointDbManager::new(pool.clone(), checkpoint_db));
 
     let ol_block_manager = Arc::new(OLBlockManager::new(pool.clone(), ol_block_db));

--- a/crates/storage/src/managers/checkpoint.rs
+++ b/crates/storage/src/managers/checkpoint.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use strata_checkpoint_types::EpochSummary;
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{traits::CheckpointDatabase, types::CheckpointEntry, DbResult};
 use strata_primitives::epoch::EpochCommitment;
 use threadpool::ThreadPool;
@@ -15,9 +16,11 @@ use crate::{cache, ops};
 pub struct CheckpointDbManager {
     ops: ops::checkpoint::CheckpointDataOps,
     summary_cache: cache::CacheTable<EpochCommitment, Option<EpochSummary>>,
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     checkpoint_cache: cache::CacheTable<u64, Option<CheckpointEntry>>,
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 impl CheckpointDbManager {
     pub fn new(pool: ThreadPool, db: Arc<impl CheckpointDatabase + 'static>) -> Self {
         let ops = ops::checkpoint::Context::new(db).into_ops(pool);
@@ -31,7 +34,9 @@ impl CheckpointDbManager {
     }
 
     pub async fn insert_epoch_summary(&self, summary: EpochSummary) -> DbResult<()> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         self.ops.insert_epoch_summary_async(summary).await?;
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         self.summary_cache
             .insert_async(summary.get_epoch_commitment(), Some(summary))
             .await;

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::{
     traits::{BlockStatus, L2BlockDatabase},
     DbResult,
@@ -20,7 +21,9 @@ pub struct L2BlockManager {
     block_cache: cache::CacheTable<L2BlockId, Option<L2BlockBundle>>,
 }
 
+#[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 impl L2BlockManager {
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     pub fn new(pool: ThreadPool, db: Arc<impl L2BlockDatabase + 'static>) -> Self {
         let ops = ops::l2::Context::new(db).into_ops(pool);
         let block_cache = cache::CacheTable::new(64.try_into().unwrap());

--- a/crates/storage/src/ops/checkpoint.rs
+++ b/crates/storage/src/ops/checkpoint.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")]
 //! Checkpoint Proof data operation interface.
 
 use strata_checkpoint_types::EpochSummary;

--- a/crates/storage/src/ops/l2.rs
+++ b/crates/storage/src/ops/l2.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "legacy old code is retained for compatibility")]
 //! L2 block data operation interface.
 
 use strata_db_types::traits::*;

--- a/crates/sync/src/client.rs
+++ b/crates/sync/src/client.rs
@@ -70,6 +70,7 @@ impl<RPC: StrataApiClient + Send + Sync> RpcSyncPeer<RPC> {
         start_height: u64,
         end_height: u64,
     ) -> Result<Vec<L2BlockBundle>, ClientError> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let bytes = self
             .rpc_client
             .get_raw_bundles(start_height, end_height)
@@ -119,6 +120,7 @@ impl<RPC: StrataApiClient + Send + Sync> SyncClient for RpcSyncPeer<RPC> {
         &self,
         block_id: &L2BlockId,
     ) -> Result<Option<L2BlockBundle>, ClientError> {
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         let bytes = self
             .rpc_client
             .get_raw_bundle_by_id(*block_id)

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -74,6 +74,7 @@ pub(crate) async fn initialize_from_db(
 ) -> Result<L2SyncState, L2SyncError> {
     debug!(?finalized_epoch, "loading unfinalized blocks");
 
+    #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
     let l2man_tracker = storage.l2().clone();
 
     let tracker = Handle::current()

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -231,6 +231,7 @@ async fn handle_new_block<T: SyncClient>(
     // send ForkChoiceMessage::NewBlock for all pending blocks in correct order
     while let Some(block) = fetched_blocks.pop() {
         state.attach_block(block.header())?;
+        #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
         context
             .storage
             .l2()


### PR DESCRIPTION
## Description

We are getting a bunch of bugs because of old code that is not supposed to be called by new code. Examples:

- `checkpoint_db` instead of `ol_checkpoint_db`
- `l2_db` instead of `ol_block_db`
- `L2BlockDatabase` instead of `OLBlockDatabase`
- `CheckpointDatabase` instead of `OLCheckpointDatabase`
- `CheckpointProvingStatus`/`CheckpointConfStatus` instead of `OLCheckpointStatus`
- a bunch of API RPC calls

This PR deprecates all these things in 0ed93fd4aa6cbb7a28c915c09c6d295137a53073 and then painfully allow individually (as much as possible) violations of the lints in 428307cad10e27d8a7d4a7f9129dbf8dd8b8db8c.

I think that with this will be much harder to do naive mistakes when calling these OLD DEPRECATED functions/types.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers



Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

None.
