### PR TITLE
chore: remove unused ZkVmVkProvider import

### DIFF
--- a/crates/zkvm/hosts/src/lib.rs
+++ b/crates/zkvm/hosts/src/lib.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use strata_primitives::proof::{ProofKey, ProofZkVm};
-use zkaleido::{VerifyingKey, ZkVmVkProvider};
+use zkaleido::VerifyingKey;
 
 pub mod native;
 #[cfg(feature = "sp1")]


### PR DESCRIPTION
Removes an unused ZkVmVkProvider import in zkvm hosts module