### PR TITLE
refactor(mmr): hide getting an arbitrary node hash, only expose getting leaf hash

### DIFF
--- a/crates/consensus-logic/src/asm_worker_context.rs
+++ b/crates/consensus-logic/src/asm_worker_context.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use bitcoind_async_client::{client::Client, traits::Reader};
 use strata_asm_worker::{WorkerContext, WorkerError, WorkerResult};
-use strata_db_types::{mmr_helpers::leaf_index_to_pos, DbError};
+use strata_db_types::DbError;
 use strata_identifiers::Hash;
 use strata_primitives::prelude::*;
 use strata_state::asm_state::AsmState;
@@ -138,9 +138,8 @@ impl WorkerContext for AsmWorkerCtx {
     }
 
     fn get_manifest_hash(&self, index: u64) -> WorkerResult<Option<Hash>> {
-        let pos = leaf_index_to_pos(index);
-        self.mmr_handle.get_node_blocking(pos).map_err(|e| {
-            error!(?e, index, pos, "Failed to get leaf hash from MMR");
+        self.mmr_handle.get_leaf_blocking(index).map_err(|e| {
+            error!(?e, index, "Failed to get leaf hash from MMR");
             WorkerError::DbError
         })
     }

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -8,12 +8,7 @@ use std::{
 use async_trait::async_trait;
 use strata_acct_types::{AccountId, tree_hash::TreeHash};
 use strata_asm_manifest_types::AsmManifest;
-use strata_db_types::{
-    errors::DbError,
-    mmr_helpers::{
-        BitManipulatedMmrAlgorithm, MmrAlgorithm, leaf_index_to_pos, num_leaves_to_mmr_size,
-    },
-};
+use strata_db_types::errors::DbError;
 use strata_identifiers::{Hash, MmrId, OLBlockCommitment, OLBlockId, OLTxId};
 use strata_ledger_types::{
     IAccountStateConstructible, IAccountStateMut, IStateAccessor, asm_manifests_mmr_start_height,
@@ -164,9 +159,8 @@ impl<M, S> BlockAssemblyContext<M, S> {
             if mmr_idx >= mmr_num_leaves {
                 return Err(BlockAssemblyError::L1HeaderLeafNotFound(mmr_idx));
             }
-            let pos = leaf_index_to_pos(mmr_idx);
             let actual_hash = mmr_handle
-                .get_node_blocking(pos)
+                .get_leaf_blocking(mmr_idx)
                 .map_err(map_l1_header_mmr_error)?
                 .ok_or(BlockAssemblyError::L1HeaderLeafNotFound(mmr_idx))?;
             let claimed_hash = claim.entry_hash();
@@ -196,10 +190,9 @@ impl<M, S> BlockAssemblyContext<M, S> {
             .get_handle(MmrId::SnarkMsgInbox(target));
         for (offset, message) in messages.iter().enumerate() {
             let idx = start_idx + offset as u64;
-            let pos = leaf_index_to_pos(idx);
             let expected_hash: Hash = <MessageEntry as TreeHash>::tree_hash_root(message).into();
             let actual_hash = mmr_handle
-                .get_node_blocking(pos)
+                .get_leaf_blocking(idx)
                 .map_err(|e| map_inbox_mmr_error(e, target))?
                 .ok_or(BlockAssemblyError::InboxLeafNotFound {
                     idx,
@@ -389,22 +382,15 @@ where
         l1_header_refs: &[AccumulatorClaim],
         state: &T,
     ) -> BlockAssemblyResult<LedgerRefProofs> {
-        let mmr_num_leaves = state.asm_manifests_mmr().num_entries();
         let mmr_handle = self.storage.global_mmr().as_ref().get_handle(MmrId::Asm);
 
         let resolved_refs = self.validate_l1_header_claims(l1_header_refs, state)?;
-        let mmr_size = num_leaves_to_mmr_size(mmr_num_leaves);
 
-        // Generate proofs using MMR indices (height -> index conversion)
+        // Generate proofs using MMR leaf indices
         let mut l1_header_proofs = Vec::new();
         for (mmr_idx, entry_hash) in resolved_refs {
-            let merkle_proof =
-                BitManipulatedMmrAlgorithm::generate_proof(mmr_idx, mmr_size, |pos| {
-                    mmr_handle
-                        .get_node_blocking(pos)?
-                        .map(|x| x.0)
-                        .ok_or(DbError::MmrLeafNotFound(pos))
-                })
+            let merkle_proof = mmr_handle
+                .generate_proof(mmr_idx)
                 .map_err(map_l1_header_mmr_error)?;
 
             let mmr_proof = MmrEntryProof::new(entry_hash, merkle_proof);

--- a/crates/storage/src/managers/global_mmr.rs
+++ b/crates/storage/src/managers/global_mmr.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_db_types::{
-    mmr_helpers::{BitManipulatedMmrAlgorithm, MmrAlgorithm},
+    mmr_helpers::{leaf_index_to_pos, BitManipulatedMmrAlgorithm, MmrAlgorithm},
     traits::GlobalMmrDatabase,
     DbError, DbResult,
 };
@@ -99,8 +99,16 @@ impl MmrHandle {
         self.ops.append_leaf_blocking(self.mmr_id.to_bytes(), hash)
     }
 
-    /// Get a node at a specific position (blocking)
-    pub fn get_node_blocking(&self, pos: u64) -> DbResult<Option<Hash>> {
+    /// Get a leaf hash by leaf index (blocking).
+    ///
+    /// Converts the leaf index to the internal MMR position automatically.
+    pub fn get_leaf_blocking(&self, leaf_index: u64) -> DbResult<Option<Hash>> {
+        let pos = leaf_index_to_pos(leaf_index);
+        self.get_node_blocking(pos)
+    }
+
+    /// Get a node at a specific MMR position (blocking).
+    fn get_node_blocking(&self, pos: u64) -> DbResult<Option<Hash>> {
         self.ops.get_node_blocking(self.mmr_id.to_bytes(), pos)
     }
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Small adjustment to MMR API - to hide getting an arbitrary node hash, only expose getting leaf hash

previously, any node can be accessed and it required careful handling&thinking of whether to pass "mmr position" or "leaf index". we also had a bug because of that recently.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
