### PR TITLE
STR 2042 mempool generalised priority ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15349,6 +15349,7 @@ dependencies = [
  "serde",
  "ssz",
  "strata-acct-types",
+ "strata-crypto",
  "strata-csm-types",
  "strata-db-store-sled",
  "strata-db-types",

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -12,7 +12,7 @@ use strata_consensus_logic::{
 use strata_identifiers::OLBlockCommitment;
 use strata_node_context::NodeContext;
 use strata_ol_checkpoint::OLCheckpointBuilder;
-use strata_ol_mempool::{MempoolBuilder, MempoolHandle, OLMempoolConfig};
+use strata_ol_mempool::{FifoPriority, MempoolBuilder, MempoolHandle, OLMempoolConfig};
 
 use crate::{
     context::check_and_init_genesis,
@@ -293,7 +293,7 @@ fn start_mempool(nodectx: &NodeContext) -> Result<MempoolHandle> {
     // to initialize the mempool which requires async operations. The mempool
     // handle must be available before RunContext is constructed.
     nodectx.task_manager().handle().block_on(async {
-        MempoolBuilder::new(config, storage, status_channel, current_tip)
+        MempoolBuilder::<FifoPriority>::new(config, storage, status_channel, current_tip)
             .launch(&executor)
             .await
     })

--- a/crates/ol/mempool/Cargo.toml
+++ b/crates/ol/mempool/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 strata-csm-types.workspace = true
+strata-crypto.workspace = true
 strata-db-store-sled.workspace = true
 strata-ol-params.workspace = true
 strata-predicate.workspace = true

--- a/crates/ol/mempool/src/builder.rs
+++ b/crates/ol/mempool/src/builder.rs
@@ -3,6 +3,7 @@
 use std::{
     fmt::{Debug, Formatter},
     future::Future,
+    marker::PhantomData,
     sync::Arc,
 };
 
@@ -15,6 +16,7 @@ use tokio::sync::{mpsc, watch};
 
 use crate::{
     MempoolCommand, MempoolHandle,
+    ordering::MempoolPriorityPolicy,
     service::MempoolService,
     state::{MempoolContext, MempoolServiceState},
     types::OLMempoolConfig,
@@ -23,14 +25,15 @@ use crate::{
 /// Builder for creating and launching mempool service.
 ///
 /// Separates service initialization logic from the handle interface.
-pub struct MempoolBuilder {
+pub struct MempoolBuilder<Prio: MempoolPriorityPolicy> {
     config: OLMempoolConfig,
     storage: Arc<NodeStorage>,
     status_channel: StatusChannel,
     current_tip: OLBlockCommitment,
+    _phantom: PhantomData<Prio>,
 }
 
-impl Debug for MempoolBuilder {
+impl<Prio: MempoolPriorityPolicy> Debug for MempoolBuilder<Prio> {
     #[expect(clippy::absolute_paths, reason = "qualified Result avoids ambiguity")]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MempoolBuilder")
@@ -40,7 +43,7 @@ impl Debug for MempoolBuilder {
     }
 }
 
-impl MempoolBuilder {
+impl<Prio: MempoolPriorityPolicy> MempoolBuilder<Prio> {
     /// Create a new mempool builder.
     pub fn new(
         config: OLMempoolConfig,
@@ -53,6 +56,7 @@ impl MempoolBuilder {
             storage,
             status_channel,
             current_tip,
+            _phantom: PhantomData,
         }
     }
 
@@ -70,7 +74,7 @@ impl MempoolBuilder {
 
         // Create mempool state with context and current tip
         let mut state =
-            MempoolServiceState::new_with_context(ctx.clone(), self.current_tip).await?;
+            MempoolServiceState::<_, Prio>::new_with_context(ctx.clone(), self.current_tip).await?;
 
         // Load existing transactions from database
         state.load_from_db().await?;
@@ -82,7 +86,7 @@ impl MempoolBuilder {
         let mempool_input = MempoolInput::new(command_rx, ol_sync_rx);
 
         // Launch service with mempool input
-        let monitor = ServiceBuilder::<MempoolService<_>, _>::new()
+        let monitor = ServiceBuilder::<MempoolService<_, Prio>, _>::new()
             .with_state(state)
             .with_input(mempool_input)
             .launch_async("mempool", texec)

--- a/crates/ol/mempool/src/handle.rs
+++ b/crates/ol/mempool/src/handle.rs
@@ -114,6 +114,7 @@ mod tests {
     use super::*;
     use crate::{
         MempoolBuilder,
+        ordering::FifoPriority,
         test_utils::{
             create_test_block_commitment, create_test_generic_tx_for_account,
             create_test_snark_tx_with_seq_no, create_test_snark_tx_with_seq_no_and_slots,
@@ -148,11 +149,15 @@ mod tests {
         let task_manager = TaskManager::new(Handle::current());
         let texec = task_manager.create_executor();
 
-        let handle =
-            MempoolBuilder::new(config, storage.clone(), status_channel.clone(), current_tip)
-                .launch(&texec)
-                .await
-                .unwrap();
+        let handle = MempoolBuilder::<FifoPriority>::new(
+            config,
+            storage.clone(),
+            status_channel.clone(),
+            current_tip,
+        )
+        .launch(&texec)
+        .await
+        .unwrap();
 
         (handle, storage, status_channel)
     }

--- a/crates/ol/mempool/src/lib.rs
+++ b/crates/ol/mempool/src/lib.rs
@@ -7,6 +7,8 @@ mod builder;
 mod command;
 mod error;
 mod handle;
+mod ordering;
+mod package;
 mod service;
 mod state;
 #[cfg(test)]
@@ -18,6 +20,7 @@ pub use builder::MempoolBuilder;
 pub use command::MempoolCommand;
 pub use error::OLMempoolError;
 pub use handle::MempoolHandle;
+pub use ordering::{FifoPriority, MempoolPriorityPolicy};
 pub use service::MempoolServiceStatus;
 pub use types::*;
 

--- a/crates/ol/mempool/src/ordering.rs
+++ b/crates/ol/mempool/src/ordering.rs
@@ -1,0 +1,124 @@
+//! Mempool ordering policies and ordering keys.
+
+use std::fmt::Debug;
+
+use strata_identifiers::OLTxId;
+use strata_ol_chain_types_new::OLTransaction;
+
+/// Policy trait for computing mempool transaction priorities.
+///
+/// Implementations define how priorities are computed from transaction data and insertion
+/// metadata. Priority ordering is interpreted with the invariant that iterating in ascending order
+/// yields highest-priority transactions first.
+pub trait MempoolPriorityPolicy: Clone + Copy + Debug + Send + Sync + 'static {
+    /// Ordering priority used by the policy.
+    type Priority: Ord + Copy + Debug + Send + Sync + 'static;
+
+    /// Compute an ordering priority for a transaction.
+    fn compute_priority(tx: &OLTransaction, timestamp_micros: u64) -> Self::Priority;
+}
+
+/// FIFO priority policy.
+///
+/// This is the current default behavior and will continue to be used unless another policy is
+/// explicitly selected.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct FifoPriority;
+
+impl MempoolPriorityPolicy for FifoPriority {
+    type Priority = FifoPriorityKey;
+
+    fn compute_priority(tx: &OLTransaction, timestamp_micros: u64) -> Self::Priority {
+        FifoPriorityKey::for_tx(timestamp_micros, tx)
+    }
+}
+
+/// FIFO package-ordering key.
+///
+/// This key is only for global package ordering and does not encode intra-package dependencies.
+/// The `timestamp_micros` is in microseconds since UNIX epoch.
+///
+/// Derived [`Ord`] is load-bearing here: field declaration order defines sort order.
+/// `timestamp_micros` is first and `txid` is second (tie-breaker); do not reorder fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FifoPriorityKey {
+    timestamp_micros: u64,
+    txid: OLTxId,
+}
+
+impl FifoPriorityKey {
+    /// Creates a FIFO priority key from `timestamp_micros` and `txid`.
+    pub(crate) fn new(timestamp_micros: u64, txid: OLTxId) -> Self {
+        Self {
+            timestamp_micros,
+            txid,
+        }
+    }
+
+    /// Create ordering key for a transaction.
+    pub(crate) fn for_tx(timestamp_micros: u64, tx: &OLTransaction) -> Self {
+        Self::new(timestamp_micros, tx.compute_txid())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use super::*;
+    use crate::{
+        test_utils::{
+            create_test_generic_tx, create_test_snark_tx_with_seq_no, create_test_txid_with,
+        },
+        types::MempoolEntry,
+    };
+
+    #[test]
+    fn test_priority_orders_by_timestamp_micros() {
+        let tx = create_test_snark_tx_with_seq_no(1, 0);
+        let entries: Vec<_> = (1..=3)
+            .map(|ts| {
+                MempoolEntry::<FifoPriority>::new(
+                    tx.clone(),
+                    FifoPriorityKey {
+                        timestamp_micros: ts,
+                        txid: create_test_txid_with(ts as u8),
+                    },
+                    100,
+                )
+            })
+            .collect();
+
+        for i in 0..entries.len() - 1 {
+            assert_eq!(
+                entries[i].priority.cmp(&entries[i + 1].priority),
+                Ordering::Less
+            );
+        }
+    }
+
+    #[test]
+    fn test_priority_tie_breaks_with_txid() {
+        let tx = create_test_generic_tx();
+        let key_a = FifoPriorityKey::for_tx(1_000_000, &tx);
+        let key_b = FifoPriorityKey {
+            timestamp_micros: key_a.timestamp_micros,
+            txid: create_test_txid_with(255),
+        };
+        assert!(key_a != key_b);
+        assert_ne!(key_a.cmp(&key_b), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_priority_tie_break_uses_txid() {
+        let key_a = FifoPriorityKey {
+            timestamp_micros: 99,
+            txid: create_test_txid_with(1),
+        };
+        let key_b = FifoPriorityKey {
+            timestamp_micros: 99,
+            txid: create_test_txid_with(2),
+        };
+        assert_eq!(key_a.cmp(&key_b), Ordering::Less);
+    }
+}

--- a/crates/ol/mempool/src/package.rs
+++ b/crates/ol/mempool/src/package.rs
@@ -1,0 +1,570 @@
+//! Package-level mempool bookkeeping.
+//!
+//! A package is a group of transactions that share an intrinsic ordering rule.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use strata_acct_types::AccountId;
+use strata_identifiers::OLTxId;
+use strata_ol_chain_types_new::{OLTransaction, TransactionPayload};
+use tracing::error;
+
+use crate::ordering::MempoolPriorityPolicy;
+
+/// Identifies a package by its grouping key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PackageKey {
+    /// Package for snark account updates targeting a specific account.
+    SnarkAccountUpdate(AccountId),
+
+    /// Standalone package for a transaction with no intrinsic dependencies.
+    Standalone(OLTxId),
+}
+
+/// A transaction's package identity and intra-package position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PackageMember {
+    /// Per-account ordered snark update.
+    SnarkAccountUpdate {
+        /// Target account ID.
+        account_id: AccountId,
+
+        /// Per-account sequence number.
+        seq_no: u64,
+    },
+
+    /// Standalone transaction with no intrinsic dependencies.
+    Standalone {
+        /// Transaction ID.
+        txid: OLTxId,
+    },
+}
+
+impl PackageMember {
+    /// Construct package membership metadata for a transaction.
+    pub(crate) fn from_tx(tx: &OLTransaction, txid: OLTxId) -> Self {
+        match tx.payload() {
+            TransactionPayload::SnarkAccountUpdate(payload) => Self::SnarkAccountUpdate {
+                account_id: *payload.target(),
+                seq_no: payload.operation().update().seq_no(),
+            },
+            TransactionPayload::GenericAccountMessage(_) => Self::Standalone { txid },
+        }
+    }
+
+    /// Return this member's package key.
+    pub(crate) fn package_key(&self) -> PackageKey {
+        match self {
+            Self::SnarkAccountUpdate { account_id, .. } => {
+                PackageKey::SnarkAccountUpdate(*account_id)
+            }
+            Self::Standalone { txid } => PackageKey::Standalone(*txid),
+        }
+    }
+}
+
+/// Internal package-index invariant violations used for diagnostics.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PackageInvariantError {
+    /// Attempted to insert a txid that already exists in the package index.
+    #[error("duplicate txid in package index: {0:?}")]
+    DuplicateTxId(OLTxId),
+
+    /// Transaction was mapped to a package key but package entry was missing.
+    #[error("missing package entry for key: {0:?}")]
+    MissingPackage(PackageKey),
+
+    /// Package entry shape and member shape did not match.
+    #[error("package/member mismatch (key: {key:?}, member: {member:?})")]
+    PackageMemberMismatch {
+        key: PackageKey,
+        member: PackageMember,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PackageTx<Prio: MempoolPriorityPolicy> {
+    txid: OLTxId,
+    priority: Prio::Priority,
+}
+
+/// Package contents with explicit intrinsic ordering semantics.
+#[derive(Debug, Clone)]
+enum PackageContents<Prio: MempoolPriorityPolicy> {
+    /// Ordered by snark seq_no.
+    SnarkAccountUpdate(BTreeMap<u64, PackageTx<Prio>>),
+
+    /// Single standalone transaction.
+    Standalone(Option<PackageTx<Prio>>),
+}
+
+impl<Prio: MempoolPriorityPolicy> PackageContents<Prio> {
+    fn new_for_member(member: PackageMember) -> Self {
+        match member {
+            PackageMember::SnarkAccountUpdate { .. } => Self::SnarkAccountUpdate(BTreeMap::new()),
+            PackageMember::Standalone { .. } => Self::Standalone(None),
+        }
+    }
+
+    fn front(&self) -> Option<PackageTx<Prio>> {
+        match self {
+            Self::SnarkAccountUpdate(txs) => txs.first_key_value().map(|(_, tx)| *tx),
+            Self::Standalone(tx) => *tx,
+        }
+    }
+
+    fn insert(
+        &mut self,
+        member: PackageMember,
+        txid: OLTxId,
+        priority: Prio::Priority,
+    ) -> Result<(), PackageInvariantError> {
+        match (self, member) {
+            (Self::SnarkAccountUpdate(txs), PackageMember::SnarkAccountUpdate { seq_no, .. }) => {
+                txs.insert(seq_no, PackageTx { txid, priority });
+                Ok(())
+            }
+            (Self::Standalone(slot), PackageMember::Standalone { .. }) => {
+                if slot.is_some() {
+                    debug_assert!(false, "standalone package already populated for member");
+                    return Err(PackageInvariantError::PackageMemberMismatch {
+                        key: member.package_key(),
+                        member,
+                    });
+                }
+                *slot = Some(PackageTx { txid, priority });
+                Ok(())
+            }
+            _ => {
+                debug_assert!(
+                    false,
+                    "package content/member mismatch for member {member:?}"
+                );
+                Err(PackageInvariantError::PackageMemberMismatch {
+                    key: member.package_key(),
+                    member,
+                })
+            }
+        }
+    }
+
+    fn remove(&mut self, member: PackageMember, txid: OLTxId) -> Result<(), PackageInvariantError> {
+        match (self, member) {
+            (Self::SnarkAccountUpdate(txs), PackageMember::SnarkAccountUpdate { seq_no, .. }) => {
+                txs.remove(&seq_no);
+                Ok(())
+            }
+            (Self::Standalone(slot), PackageMember::Standalone { .. }) => {
+                if slot.as_ref().is_some_and(|tx| tx.txid == txid) {
+                    *slot = None;
+                    return Ok(());
+                }
+                debug_assert!(
+                    false,
+                    "standalone package missing expected tx {txid:?} for member"
+                );
+                Err(PackageInvariantError::PackageMemberMismatch {
+                    key: member.package_key(),
+                    member,
+                })
+            }
+            _ => {
+                debug_assert!(
+                    false,
+                    "package content/member mismatch for member {member:?}"
+                );
+                Err(PackageInvariantError::PackageMemberMismatch {
+                    key: member.package_key(),
+                    member,
+                })
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::SnarkAccountUpdate(txs) => txs.is_empty(),
+            Self::Standalone(tx) => tx.is_none(),
+        }
+    }
+
+    fn ordered_txs(&self) -> VecDeque<PackageTx<Prio>> {
+        match self {
+            Self::SnarkAccountUpdate(txs) => txs.values().copied().collect(),
+            Self::Standalone(Some(tx)) => VecDeque::from([*tx]),
+            Self::Standalone(None) => VecDeque::new(),
+        }
+    }
+}
+
+/// Single materialized package entry.
+#[derive(Debug, Clone)]
+struct PackageEntry<Prio: MempoolPriorityPolicy> {
+    key: PackageKey,
+    contents: PackageContents<Prio>,
+    front_priority: Option<Prio::Priority>,
+}
+
+impl<Prio: MempoolPriorityPolicy> PackageEntry<Prio> {
+    fn new(key: PackageKey, member: PackageMember) -> Self {
+        Self {
+            key,
+            contents: PackageContents::new_for_member(member),
+            front_priority: None,
+        }
+    }
+
+    fn insert(
+        &mut self,
+        member: PackageMember,
+        txid: OLTxId,
+        priority: Prio::Priority,
+    ) -> Result<(), PackageInvariantError> {
+        if member.package_key() != self.key {
+            debug_assert!(
+                false,
+                "package/member key mismatch on insert for key {:?}, member {:?}",
+                self.key, member
+            );
+            return Err(PackageInvariantError::PackageMemberMismatch {
+                key: self.key,
+                member,
+            });
+        }
+
+        self.contents.insert(member, txid, priority)?;
+        self.front_priority = self.contents.front().map(|tx| tx.priority);
+        Ok(())
+    }
+
+    fn remove(&mut self, member: PackageMember, txid: OLTxId) -> Result<(), PackageInvariantError> {
+        if member.package_key() != self.key {
+            debug_assert!(
+                false,
+                "package/member key mismatch on remove for key {:?}, member {:?}",
+                self.key, member
+            );
+            return Err(PackageInvariantError::PackageMemberMismatch {
+                key: self.key,
+                member,
+            });
+        }
+
+        self.contents.remove(member, txid)?;
+        self.front_priority = self.contents.front().map(|tx| tx.priority);
+        Ok(())
+    }
+
+    fn front_priority(&self) -> Option<Prio::Priority> {
+        self.front_priority
+    }
+
+    fn is_empty(&self) -> bool {
+        self.contents.is_empty()
+    }
+
+    fn ordered_txs(&self) -> VecDeque<PackageTx<Prio>> {
+        self.contents.ordered_txs()
+    }
+}
+
+/// Manages package membership and package-first candidate ordering.
+#[derive(Debug, Clone)]
+pub(crate) struct PackageManager<Prio: MempoolPriorityPolicy> {
+    packages: HashMap<PackageKey, PackageEntry<Prio>>,
+    tx_to_package: HashMap<OLTxId, PackageKey>,
+}
+
+impl<Prio: MempoolPriorityPolicy> PackageManager<Prio> {
+    /// Create an empty package manager.
+    pub(crate) fn new() -> Self {
+        Self {
+            packages: HashMap::new(),
+            tx_to_package: HashMap::new(),
+        }
+    }
+
+    /// Insert a tx into package bookkeeping.
+    pub(crate) fn insert(&mut self, txid: OLTxId, tx: &OLTransaction, priority: Prio::Priority) {
+        let member = PackageMember::from_tx(tx, txid);
+        if let Err(err) = self.insert_member(txid, member, priority) {
+            error!(
+                ?txid,
+                error = %err,
+                "package bookkeeping invariant violation on insert"
+            );
+        }
+    }
+
+    fn insert_member(
+        &mut self,
+        txid: OLTxId,
+        member: PackageMember,
+        priority: Prio::Priority,
+    ) -> Result<(), PackageInvariantError> {
+        if self.tx_to_package.contains_key(&txid) {
+            return Err(PackageInvariantError::DuplicateTxId(txid));
+        }
+
+        let package_key = member.package_key();
+        let entry = self
+            .packages
+            .entry(package_key)
+            .or_insert_with(|| PackageEntry::new(package_key, member));
+        entry.insert(member, txid, priority)?;
+
+        self.tx_to_package.insert(txid, package_key);
+        Ok(())
+    }
+
+    /// Remove a tx from package bookkeeping.
+    ///
+    /// If the tx does not exist, this is a no-op.
+    pub(crate) fn remove(&mut self, txid: OLTxId, tx: &OLTransaction) {
+        let member = PackageMember::from_tx(tx, txid);
+        if let Err(err) = self.remove_member(txid, member) {
+            error!(
+                ?txid,
+                error = %err,
+                "package bookkeeping invariant violation on remove"
+            );
+        }
+    }
+
+    fn remove_member(
+        &mut self,
+        txid: OLTxId,
+        member: PackageMember,
+    ) -> Result<(), PackageInvariantError> {
+        let Some(&package_key) = self.tx_to_package.get(&txid) else {
+            return Ok(());
+        };
+
+        if member.package_key() != package_key {
+            debug_assert!(
+                false,
+                "tx/package-key mismatch for tx {txid:?}: mapped {package_key:?}, member {member:?}"
+            );
+            return Err(PackageInvariantError::PackageMemberMismatch {
+                key: package_key,
+                member,
+            });
+        }
+
+        let Some(entry) = self.packages.get_mut(&package_key) else {
+            return Err(PackageInvariantError::MissingPackage(package_key));
+        };
+
+        entry.remove(member, txid)?;
+        if entry.is_empty() {
+            self.packages.remove(&package_key);
+        }
+
+        self.tx_to_package.remove(&txid);
+        Ok(())
+    }
+
+    /// Return candidate txids in package-first order.
+    ///
+    /// This computes package-front ordering on demand in `O(p log p)` per call,
+    /// where `p` is number of active packages.
+    pub(crate) fn iter_candidates(&self, limit: usize) -> Vec<OLTxId> {
+        let mut package_queues: HashMap<PackageKey, VecDeque<PackageTx<Prio>>> = HashMap::new();
+        let mut ordering_index: BTreeMap<(Prio::Priority, OLTxId), PackageKey> = BTreeMap::new();
+
+        for (package_key, entry) in &self.packages {
+            debug_assert_eq!(*package_key, entry.key);
+            let queue = entry.ordered_txs();
+            if let (Some(front_priority), Some(front)) = (entry.front_priority(), queue.front()) {
+                ordering_index.insert((front_priority, front.txid), *package_key);
+            }
+            package_queues.insert(*package_key, queue);
+        }
+
+        let mut result = Vec::with_capacity(limit);
+        while result.len() < limit {
+            let Some((_, package_key)) = ordering_index.pop_first() else {
+                break;
+            };
+
+            let Some(queue) = package_queues.get_mut(&package_key) else {
+                continue;
+            };
+            let Some(package_tx) = queue.pop_front() else {
+                continue;
+            };
+            result.push(package_tx.txid);
+
+            if let Some(next_front) = queue.front() {
+                ordering_index.insert((next_front.priority, next_front.txid), package_key);
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ordering::{FifoPriority, FifoPriorityKey},
+        test_utils::{
+            create_test_account_id, create_test_generic_tx, create_test_snark_tx_with_seq_no,
+            create_test_txid_with,
+        },
+    };
+
+    #[test]
+    fn test_iter_candidates_orders_by_package_front_priority() {
+        let mut manager = PackageManager::<FifoPriority>::new();
+
+        let acct = create_test_account_id();
+        let snark_seq0 = create_test_txid_with(1);
+        let snark_seq1 = create_test_txid_with(2);
+        let standalone = create_test_txid_with(3);
+
+        manager
+            .insert_member(
+                snark_seq1,
+                PackageMember::SnarkAccountUpdate {
+                    account_id: acct,
+                    seq_no: 1,
+                },
+                FifoPriorityKey::new(20, snark_seq1),
+            )
+            .unwrap();
+        manager
+            .insert_member(
+                snark_seq0,
+                PackageMember::SnarkAccountUpdate {
+                    account_id: acct,
+                    seq_no: 0,
+                },
+                FifoPriorityKey::new(11, snark_seq0),
+            )
+            .unwrap();
+        manager
+            .insert_member(
+                standalone,
+                PackageMember::Standalone { txid: standalone },
+                FifoPriorityKey::new(10, standalone),
+            )
+            .unwrap();
+
+        let ordered = manager.iter_candidates(10);
+        assert_eq!(ordered, vec![standalone, snark_seq0, snark_seq1]);
+    }
+
+    #[test]
+    fn test_remove_updates_package_contents() {
+        let mut manager = PackageManager::<FifoPriority>::new();
+        let acct = create_test_account_id();
+        let txid0 = create_test_txid_with(1);
+        let txid1 = create_test_txid_with(2);
+
+        manager
+            .insert_member(
+                txid0,
+                PackageMember::SnarkAccountUpdate {
+                    account_id: acct,
+                    seq_no: 0,
+                },
+                FifoPriorityKey::new(10, txid0),
+            )
+            .unwrap();
+        manager
+            .insert_member(
+                txid1,
+                PackageMember::SnarkAccountUpdate {
+                    account_id: acct,
+                    seq_no: 1,
+                },
+                FifoPriorityKey::new(11, txid1),
+            )
+            .unwrap();
+
+        manager
+            .remove_member(
+                txid0,
+                PackageMember::SnarkAccountUpdate {
+                    account_id: acct,
+                    seq_no: 0,
+                },
+            )
+            .unwrap();
+        assert_eq!(manager.iter_candidates(10), vec![txid1]);
+
+        manager
+            .remove_member(
+                txid1,
+                PackageMember::SnarkAccountUpdate {
+                    account_id: acct,
+                    seq_no: 1,
+                },
+            )
+            .unwrap();
+        assert!(manager.iter_candidates(10).is_empty());
+    }
+
+    #[test]
+    fn test_package_key_for_snark_is_account_scoped() {
+        let tx = create_test_snark_tx_with_seq_no(7, 3);
+        let txid = tx.compute_txid();
+        let key = PackageMember::from_tx(&tx, txid).package_key();
+        assert_eq!(
+            key,
+            PackageKey::SnarkAccountUpdate(
+                tx.target()
+                    .expect("all OLTransaction payload variants must have a target")
+            )
+        );
+    }
+
+    #[test]
+    fn test_package_key_for_gam_is_standalone() {
+        let tx = create_test_generic_tx();
+        let txid = tx.compute_txid();
+        let key = PackageMember::from_tx(&tx, txid).package_key();
+        assert_eq!(key, PackageKey::Standalone(txid));
+    }
+
+    #[test]
+    fn test_package_member_snark_has_account_scoped_package_key() {
+        let account = create_test_account_id();
+        let member = PackageMember::SnarkAccountUpdate {
+            account_id: account,
+            seq_no: 10,
+        };
+        assert_eq!(
+            member.package_key(),
+            PackageKey::SnarkAccountUpdate(account)
+        );
+    }
+
+    #[test]
+    fn test_package_member_standalone_has_txid_scoped_package_key() {
+        let txid = create_test_txid_with(44);
+        let member = PackageMember::Standalone { txid };
+        assert_eq!(member.package_key(), PackageKey::Standalone(txid));
+    }
+
+    #[test]
+    fn test_package_member_for_snark_includes_seq_no() {
+        let tx = create_test_snark_tx_with_seq_no(5, 42);
+        let txid = tx.compute_txid();
+        let member = PackageMember::from_tx(&tx, txid);
+        match member {
+            PackageMember::SnarkAccountUpdate { seq_no, .. } => assert_eq!(seq_no, 42),
+            PackageMember::Standalone { .. } => panic!("expected snark member"),
+        }
+    }
+
+    #[test]
+    fn test_package_member_for_gam_is_standalone() {
+        let tx = create_test_generic_tx();
+        let txid = tx.compute_txid();
+        let member = PackageMember::from_tx(&tx, txid);
+        assert_eq!(member, PackageMember::Standalone { txid });
+    }
+}

--- a/crates/ol/mempool/src/service.rs
+++ b/crates/ol/mempool/src/service.rs
@@ -8,7 +8,8 @@ use strata_ol_state_types::StateProvider;
 use strata_service::{AsyncService, Response, Service};
 
 use crate::{
-    MempoolCommand, builder::MempoolInputMessage, state::MempoolServiceState, types::OLMempoolStats,
+    MempoolCommand, builder::MempoolInputMessage, ordering::MempoolPriorityPolicy,
+    state::MempoolServiceState, types::OLMempoolStats,
 };
 
 /// Service status for mempool.
@@ -21,14 +22,15 @@ pub struct MempoolServiceStatus {
 ///
 /// # Type Parameters
 ///
-/// - `P`: The state provider type that implements [`StateProvider`].
+/// - `SP`: The state provider type that implements [`StateProvider`].
+/// - `Prio`: The mempool priority policy.
 #[derive(Debug)]
-pub(crate) struct MempoolService<P: StateProvider> {
-    _phantom: PhantomData<P>,
+pub(crate) struct MempoolService<SP: StateProvider, Prio: MempoolPriorityPolicy> {
+    _phantom: PhantomData<(SP, Prio)>,
 }
 
-impl<P: StateProvider> Service for MempoolService<P> {
-    type State = MempoolServiceState<P>;
+impl<SP: StateProvider, Prio: MempoolPriorityPolicy> Service for MempoolService<SP, Prio> {
+    type State = MempoolServiceState<SP, Prio>;
     type Msg = MempoolInputMessage;
     type Status = MempoolServiceStatus;
 
@@ -39,7 +41,7 @@ impl<P: StateProvider> Service for MempoolService<P> {
     }
 }
 
-impl<P: StateProvider> AsyncService for MempoolService<P> {
+impl<SP: StateProvider, Prio: MempoolPriorityPolicy> AsyncService for MempoolService<SP, Prio> {
     async fn on_launch(_state: &mut Self::State) -> anyhow::Result<()> {
         Ok(())
     }
@@ -85,6 +87,7 @@ mod tests {
     use super::*;
     use crate::{
         MempoolTxInvalidReason, OLMempoolResult, OLTransaction,
+        ordering::FifoPriority,
         test_utils::{
             create_test_block_commitment, create_test_context, create_test_snark_tx_with_seq_no,
             create_test_state_provider,
@@ -101,7 +104,7 @@ mod tests {
             provider.clone(),
         ));
 
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -134,7 +137,7 @@ mod tests {
                 let provider = Arc::new(create_test_state_provider(tip));
                 let context = Arc::new(create_test_context(OLMempoolConfig::default(), provider.clone()));
 
-                let mut state = MempoolServiceState::new_with_context(context.clone(), tip).await.unwrap();
+                let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context.clone(), tip).await.unwrap();
 
                 // Add some transactions via handle_submit_transaction
                 // Use sequential seq_nos (0, 1) for the same account to pass gap checking
@@ -181,9 +184,10 @@ mod tests {
             provider.clone(),
         ));
 
-        let mut state = MempoolServiceState::new_with_context(context.clone(), tip)
-            .await
-            .unwrap();
+        let mut state =
+            MempoolServiceState::<_, FifoPriority>::new_with_context(context.clone(), tip)
+                .await
+                .unwrap();
 
         // Account 1: tx1 (seq 0), tx2 (seq 1) - tx2 cascades when tx1 removed
         // Account 2: tx3 (seq 0) - independent
@@ -233,9 +237,10 @@ mod tests {
             OLMempoolConfig::default(),
             provider.clone(),
         ));
-        let mut state = MempoolServiceState::new_with_context(context.clone(), tip)
-            .await
-            .unwrap();
+        let mut state =
+            MempoolServiceState::<_, FifoPriority>::new_with_context(context.clone(), tip)
+                .await
+                .unwrap();
 
         // Add a transaction via handle_submit_transaction
         let tx = create_test_snark_tx_with_seq_no(1, 0);

--- a/crates/ol/mempool/src/state.rs
+++ b/crates/ol/mempool/src/state.rs
@@ -1,7 +1,7 @@
 //! Mempool service state management.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap},
     fmt::{Debug, Formatter},
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -19,9 +19,9 @@ use tracing::warn;
 
 use crate::{
     MempoolTxInvalidReason, OLMempoolError, OLMempoolResult,
-    types::{
-        MempoolEntry, MempoolOrderingKey, OLMempoolConfig, OLMempoolRejectReason, OLMempoolStats,
-    },
+    ordering::MempoolPriorityPolicy,
+    package::{PackageManager, PackageMember},
+    types::{MempoolEntry, OLMempoolConfig, OLMempoolRejectReason, OLMempoolStats},
     validation::validate_transaction,
 };
 
@@ -37,7 +37,7 @@ pub(crate) struct AccountMempoolState {
     /// Sequence numbers for [`SnarkAccountUpdate`](strata_snark_acct_types::SnarkAccountUpdate)
     /// transactions from this account. Used for range queries (min/max) and gap detection.
     /// Empty for accounts with only
-    /// [`GenericAccountMessage`](crate::types::OLMempoolTxPayload::GenericAccountMessage)
+    /// [`GenericAccountMessage`](strata_ol_chain_types_new::TransactionPayload::GenericAccountMessage)
     /// transactions.
     pub(crate) seq_nos: BTreeSet<u64>,
 }
@@ -105,36 +105,37 @@ impl<P: StateProvider> Debug for MempoolContext<P> {
 ///
 /// # Type Parameters
 ///
-/// - `P`: The state provider type that implements [`StateProvider`]. This enables production use
+/// - `SP`: The state provider type that implements [`StateProvider`]. This enables production use
 ///   with database-backed state and fast in-memory testing.
+/// - `Prio`: The priority policy that determines transaction ordering.
 #[derive(Debug)]
-pub(crate) struct MempoolServiceState<P: StateProvider> {
-    ctx: Arc<MempoolContext<P>>,
+pub(crate) struct MempoolServiceState<SP: StateProvider, Prio: MempoolPriorityPolicy> {
+    ctx: Arc<MempoolContext<SP>>,
 
     /// In-memory entries indexed by transaction ID.
-    entries: HashMap<OLTxId, MempoolEntry>,
+    entries: HashMap<OLTxId, MempoolEntry<Prio>>,
 
-    /// Ordering index: MempoolOrderingKey → transaction ID.
-    ordering_index: BTreeMap<MempoolOrderingKey, OLTxId>,
+    /// Package-first ordering bookkeeping.
+    package_manager: PackageManager<Prio>,
 
     /// Per-account mempool state.
     /// Tracks all txids and sequence numbers for each account.
     account_state: HashMap<AccountId, AccountMempoolState>,
 
     /// State accessor for validation. Updated when chain tip changes.
-    state_accessor: Arc<P::State>,
+    state_accessor: Arc<SP::State>,
 
     /// Mempool statistics.
     stats: OLMempoolStats,
 }
 
-impl<P: StateProvider> MempoolServiceState<P> {
+impl<SP: StateProvider, Prio: MempoolPriorityPolicy> MempoolServiceState<SP, Prio> {
     /// Create new mempool service state.
     #[expect(dead_code, reason = "another constructor is used")]
     pub(crate) async fn new(
         config: OLMempoolConfig,
         storage: Arc<NodeStorage>,
-        provider: Arc<P>,
+        provider: Arc<SP>,
         tip: OLBlockCommitment,
     ) -> OLMempoolResult<Self> {
         let ctx = Arc::new(MempoolContext::new_with_provider(config, storage, provider));
@@ -146,7 +147,7 @@ impl<P: StateProvider> MempoolServiceState<P> {
     ///
     /// Fetches the state for the given tip from the provider.
     pub(crate) async fn new_with_context(
-        ctx: Arc<MempoolContext<P>>,
+        ctx: Arc<MempoolContext<SP>>,
         tip: OLBlockCommitment,
     ) -> OLMempoolResult<Self> {
         let state_accessor = ctx
@@ -166,7 +167,7 @@ impl<P: StateProvider> MempoolServiceState<P> {
         Ok(Self {
             ctx,
             entries: HashMap::new(),
-            ordering_index: BTreeMap::new(),
+            package_manager: PackageManager::new(),
             account_state: HashMap::new(),
             state_accessor,
             stats: OLMempoolStats::default(),
@@ -180,7 +181,9 @@ impl<P: StateProvider> MempoolServiceState<P> {
     pub(crate) async fn load_from_db(&mut self) -> OLMempoolResult<()> {
         let mut all_txs = self.ctx.storage.mempool().get_all_txs()?;
 
-        // Sort by `timestamp_micros` to validate transactions in order
+        // Sort by `timestamp_micros` to replay transactions in insertion order for validation.
+        // This ordering is for rebuilding per-account sequence-number state during load and is
+        // intentionally independent from policy-based transaction priority.
         all_txs.sort_by_key(|tx_data| tx_data.timestamp_micros);
 
         let mut loaded_count = 0;
@@ -205,10 +208,9 @@ impl<P: StateProvider> MempoolServiceState<P> {
 
             let txid = tx_data.txid;
 
-            // Validate transaction
-            // Note: this plays nice with sequence number validation because we don't allow gaps
-            // (sequence numbers and timestamps are guaranteed to be compatible). When we move to a
-            // different priority ordering, this should be revised.
+            // Validate transaction against the progressively rebuilt account_state.
+            // Because load replay is insertion-ordered, sequence-number checks are consistent with
+            // how transactions originally entered the mempool.
             if let Err(e) =
                 validate_transaction(txid, &tx, &self.state_accessor, &self.account_state)
             {
@@ -229,13 +231,13 @@ impl<P: StateProvider> MempoolServiceState<P> {
                 continue;
             }
 
-            // Create entry using stored timestamp from database
-            let ordering_key = MempoolOrderingKey::for_transaction(&tx, tx_data.timestamp_micros);
+            // Create entry using persisted insertion timestamp from database.
+            let priority = Prio::compute_priority(&tx, tx_data.timestamp_micros);
             let tx_size = tx_data.tx_bytes.len();
-            let entry = MempoolEntry::new(tx, ordering_key, tx_size);
+            let entry = MempoolEntry::new(tx, priority, tx_size);
 
             // Add to in-memory state (already in DB, so no write needed)
-            self.add_tx_to_in_memory_state(txid, entry);
+            self.add_tx_to_in_memory_state(txid, entry)?;
 
             loaded_count += 1;
         }
@@ -266,17 +268,13 @@ impl<P: StateProvider> MempoolServiceState<P> {
         &mut self,
         limit: usize,
     ) -> OLMempoolResult<Vec<(OLTxId, OLTransaction)>> {
-        // Gap checking at submission ensures no gaps exist.
-        // Simply return transactions in priority order.
-        let result: Vec<(OLTxId, OLTransaction)> = self
-            .ordering_index
-            .values()
-            .take(limit)
-            .filter_map(|txid| {
-                let entry = self.entries.get(txid)?;
-                Some((*txid, entry.tx.clone()))
-            })
-            .collect();
+        let candidate_txids = self.package_manager.iter_candidates(limit);
+        let mut result = Vec::with_capacity(candidate_txids.len());
+        for txid in candidate_txids {
+            if let Some(entry) = self.entries.get(&txid) {
+                result.push((txid, entry.tx.clone()));
+            }
+        }
 
         Ok(result)
     }
@@ -380,7 +378,13 @@ impl<P: StateProvider> MempoolServiceState<P> {
             return Ok(txid);
         }
 
-        // Encode transaction once for both size validation and database persistence
+        // Capture insertion timestamp for ordering and persistence.
+        let timestamp_micros = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before UNIX epoch")
+            .as_micros() as u64;
+
+        // Encode once and reuse for both validation accounting and persistence.
         let tx_bytes = ssz::Encode::as_ssz_bytes(&tx);
         let tx_size = tx_bytes.len();
 
@@ -409,21 +413,15 @@ impl<P: StateProvider> MempoolServiceState<P> {
             self.remove_transactions(&[old_txid], false);
         }
 
-        // Generate timestamp for ordering
-        let timestamp_micros = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before UNIX epoch")
-            .as_micros() as u64;
-
-        let ordering_key = MempoolOrderingKey::for_transaction(&tx, timestamp_micros);
-        let entry = MempoolEntry::new(tx.clone(), ordering_key, tx_size);
+        let priority = Prio::compute_priority(&tx, timestamp_micros);
+        let entry = MempoolEntry::new(tx.clone(), priority, tx_size);
 
         // Persist to database first
         let tx_data = MempoolTxData::new(txid, tx_bytes, timestamp_micros);
         self.ctx.storage.mempool().put_tx(tx_data)?;
 
         // Add to in-memory state
-        self.add_tx_to_in_memory_state(txid, entry);
+        self.add_tx_to_in_memory_state(txid, entry)?;
 
         Ok(txid)
     }
@@ -432,65 +430,72 @@ impl<P: StateProvider> MempoolServiceState<P> {
     ///
     /// Updates all in-memory data structures:
     /// - entries: Main transaction storage
-    /// - ordering_index: Priority queue for ordering
+    /// - package indexes: Package-first ordering structures
     /// - account_state: Per-account tracking for validation
     ///
     /// Also updates statistics. Does NOT write to database or perform validation.
-    fn add_tx_to_in_memory_state(&mut self, txid: OLTxId, entry: MempoolEntry) {
-        let ordering_key = entry.ordering_key;
+    fn add_tx_to_in_memory_state(
+        &mut self,
+        txid: OLTxId,
+        entry: MempoolEntry<Prio>,
+    ) -> OLMempoolResult<()> {
+        let package_member = PackageMember::from_tx(&entry.tx, txid);
+        let snark_seq_no = match package_member {
+            PackageMember::SnarkAccountUpdate { seq_no, .. } => Some(seq_no),
+            PackageMember::Standalone { .. } => None,
+        };
         let target_account = entry
             .tx
             .target()
             .expect("all OL payload variants must have a target");
+        let priority = entry.priority;
         let tx_size = entry.size_bytes;
 
-        // Add to ordering index
-        self.ordering_index.insert(ordering_key, txid);
-
-        // Add to entries
-        self.entries.insert(txid, entry.clone());
+        self.package_manager.insert(txid, &entry.tx, priority);
+        // Add to entries after package bookkeeping succeeds.
+        self.entries.insert(txid, entry);
 
         // Add to account_state index
         let acct_state = self.account_state.entry(target_account).or_default();
         acct_state.txids.insert(txid);
 
         // Add seq_no if this is a SnarkAccountUpdate
-        if let TransactionPayload::SnarkAccountUpdate(payload) = entry.tx.payload() {
-            acct_state
-                .seq_nos
-                .insert(payload.operation().update().seq_no());
+        if let Some(seq_no) = snark_seq_no {
+            acct_state.seq_nos.insert(seq_no);
         }
 
         // Update stats
         self.update_stats_on_add(tx_size);
+
+        Ok(())
     }
 
     /// Helper to remove a single transaction from all internal data structures.
-    fn remove_single_tx(&mut self, txid: OLTxId, entry: &MempoolEntry) -> OLMempoolResult<()> {
+    fn remove_single_tx(
+        &mut self,
+        txid: OLTxId,
+        entry: &MempoolEntry<Prio>,
+    ) -> OLMempoolResult<()> {
         // Remove from database first
         self.ctx.storage.mempool().del_tx(txid)?;
 
-        // Get ordering key for ordering index removal
-        let ordering_key = entry.ordering_key;
         let size_bytes = entry.size_bytes;
         let account_id = entry
             .tx
             .target()
             .expect("all OL payload variants must have a target");
+        let package_member = PackageMember::from_tx(&entry.tx, txid);
 
         // Remove from memory
         self.entries.remove(&txid);
-        self.ordering_index.remove(&ordering_key);
 
         // Remove from account_state index
         if let Some(acct_state) = self.account_state.get_mut(&account_id) {
             acct_state.txids.remove(&txid);
 
             // Remove seq_no if this is a SnarkAccountUpdate
-            if let TransactionPayload::SnarkAccountUpdate(payload) = entry.tx.payload() {
-                acct_state
-                    .seq_nos
-                    .remove(&payload.operation().update().seq_no());
+            if let PackageMember::SnarkAccountUpdate { seq_no, .. } = package_member {
+                acct_state.seq_nos.remove(&seq_no);
             }
 
             // Remove account state entirely if no more transactions
@@ -498,6 +503,8 @@ impl<P: StateProvider> MempoolServiceState<P> {
                 self.account_state.remove(&account_id);
             }
         }
+
+        self.package_manager.remove(txid, &entry.tx);
 
         // Update stats
         self.update_stats_on_remove(size_bytes);
@@ -540,13 +547,13 @@ impl<P: StateProvider> MempoolServiceState<P> {
                     .tx
                     .target()
                     .expect("all OL payload variants must have a target");
+                let package_member = PackageMember::from_tx(&entry.tx, *txid);
 
                 // Remove using helper
                 self.remove_single_tx(*txid, &entry)?;
 
                 // Track minimum seq_no for account (for cascade removal)
-                if let TransactionPayload::SnarkAccountUpdate(payload) = entry.tx.payload() {
-                    let seq_no = payload.operation().update().seq_no();
+                if let PackageMember::SnarkAccountUpdate { seq_no, .. } = package_member {
                     account_min_seq
                         .entry(account)
                         .and_modify(|min_seq| *min_seq = (*min_seq).min(seq_no))
@@ -767,7 +774,9 @@ impl<P: StateProvider> MempoolServiceState<P> {
     }
 }
 
-impl<P: StateProvider> ServiceState for MempoolServiceState<P> {
+impl<SP: StateProvider, Prio: MempoolPriorityPolicy> ServiceState
+    for MempoolServiceState<SP, Prio>
+{
     fn name(&self) -> &str {
         "mempool"
     }
@@ -805,6 +814,7 @@ mod tests {
     use super::*;
     use crate::{
         DEFAULT_COMMAND_BUFFER_SIZE, DEFAULT_MAX_MEMPOOL_BYTES, DEFAULT_MAX_REORG_DEPTH,
+        ordering::FifoPriority,
         test_utils::{
             create_test_account_id_with, create_test_block_commitment,
             create_test_constraints_with_slots, create_test_context,
@@ -828,7 +838,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -857,7 +867,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -885,7 +895,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -924,7 +934,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -963,7 +973,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1003,7 +1013,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1050,7 +1060,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1077,7 +1087,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1116,7 +1126,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1151,7 +1161,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1173,9 +1183,10 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context.clone(), tip)
-            .await
-            .unwrap();
+        let mut state =
+            MempoolServiceState::<_, FifoPriority>::new_with_context(context.clone(), tip)
+                .await
+                .unwrap();
 
         // Add transactions - mix of different accounts and sequential txs for same account
         let account1 = create_test_account_id_with(1);
@@ -1192,9 +1203,10 @@ mod tests {
         let txid4 = state.add_transaction(tx4).await.unwrap();
 
         // Create new state and load from DB
-        let mut state2 = MempoolServiceState::new_with_context(context.clone(), tip)
-            .await
-            .unwrap();
+        let mut state2 =
+            MempoolServiceState::<_, FifoPriority>::new_with_context(context.clone(), tip)
+                .await
+                .unwrap();
         state2.load_from_db().await.unwrap();
 
         // Should have 4 transactions
@@ -1233,7 +1245,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1282,7 +1294,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1331,7 +1343,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1382,9 +1394,10 @@ mod tests {
         };
         let provider2 = Arc::new(create_test_state_provider(tip2));
         let context_tiny = Arc::new(create_test_context(config_tiny, provider2.clone()));
-        let mut state2 = MempoolServiceState::new_with_context(context_tiny, tip2)
-            .await
-            .unwrap();
+        let mut state2 =
+            MempoolServiceState::<_, FifoPriority>::new_with_context(context_tiny, tip2)
+                .await
+                .unwrap();
 
         let large_tx = create_test_tx_with_id(99);
         let result = state2.add_transaction(large_tx).await;
@@ -1413,7 +1426,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1489,7 +1502,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1555,7 +1568,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1610,7 +1623,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1681,7 +1694,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1737,7 +1750,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1772,7 +1785,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1803,7 +1816,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1836,7 +1849,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1886,7 +1899,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1934,7 +1947,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -1976,7 +1989,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -2011,7 +2024,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -2046,7 +2059,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 
@@ -2081,7 +2094,7 @@ mod tests {
         };
         let provider = Arc::new(create_test_state_provider(tip));
         let context = Arc::new(create_test_context(config, provider.clone()));
-        let mut state = MempoolServiceState::new_with_context(context, tip)
+        let mut state = MempoolServiceState::<_, FifoPriority>::new_with_context(context, tip)
             .await
             .unwrap();
 

--- a/crates/ol/mempool/src/test_utils.rs
+++ b/crates/ol/mempool/src/test_utils.rs
@@ -13,8 +13,11 @@ use proptest::{
     test_runner::TestRunner,
 };
 use strata_acct_types::{AccountId, BitcoinAmount};
+use strata_crypto::hash;
 use strata_db_store_sled::test_utils::get_test_sled_backend;
-use strata_identifiers::{Buf32, Hash, L1BlockCommitment, OLBlockCommitment, OLBlockId, Slot};
+use strata_identifiers::{
+    Buf32, Hash, L1BlockCommitment, OLBlockCommitment, OLBlockId, OLTxId, Slot,
+};
 use strata_ledger_types::{
     AccountTypeState, IAccountStateMut, ISnarkAccountStateMut, IStateAccessor, NewAccountData,
 };
@@ -56,6 +59,11 @@ pub(crate) fn create_test_constraints() -> TxConstraints {
         .new_tree(&mut runner)
         .unwrap()
         .current()
+}
+
+/// Create a deterministic test transaction ID from a byte.
+pub(crate) fn create_test_txid_with(id: u8) -> OLTxId {
+    OLTxId::from(hash::raw(&[id]))
 }
 
 /// Create a test snark account update (base_update only, no accumulator proofs).

--- a/crates/ol/mempool/src/types.rs
+++ b/crates/ol/mempool/src/types.rs
@@ -1,12 +1,10 @@
 //! Core mempool types.
 
-use std::{cmp::Ordering, collections::BTreeMap};
+use std::collections::BTreeMap;
 
-use strata_acct_types::AccountId;
 pub use strata_ol_chain_types_new::OLTransaction;
-use strata_ol_chain_types_new::TransactionPayload;
 
-use crate::error::OLMempoolError;
+use crate::{error::OLMempoolError, ordering::MempoolPriorityPolicy};
 
 /// Default maximum number of transactions in the mempool.
 pub const DEFAULT_MAX_TX_COUNT: usize = 10_000;
@@ -56,147 +54,25 @@ impl Default for OLMempoolConfig {
     }
 }
 
-/// Ordering key for mempool transactions.
-///
-/// Provides collision-free ordering with different strategies for different transaction types:
-/// - **Snark transactions**: Strict per-account seq_no ordering with FIFO tiebreaking across
-///   accounts
-/// - **GAM transactions**: Pure FIFO ordering by `timestamp_micros`
-///
-/// The `timestamp_micros` is in microseconds since UNIX epoch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MempoolOrderingKey {
-    /// Snark account update transaction.
-    ///
-    /// Ordered by:
-    /// 1. Within same account: seq_no (strict ordering)
-    /// 2. Across accounts: timestamp (FIFO)
-    Snark {
-        /// Target account ID.
-        account_id: AccountId,
-        /// Sequence number for this account (from SnarkAccountUpdate).
-        seq_no: u64,
-        /// Timestamp (microseconds since UNIX epoch) for cross-account FIFO ordering.
-        timestamp_micros: u64,
-    },
-
-    /// Generic account message transaction.
-    ///
-    /// Ordered by timestamp only (pure FIFO).
-    Gam {
-        /// Timestamp (microseconds since UNIX epoch) for FIFO ordering.
-        timestamp_micros: u64,
-    },
-}
-
-impl MempoolOrderingKey {
-    /// Create ordering key for a transaction with the given timestamp_micros.
-    pub(crate) fn for_transaction(tx: &OLTransaction, timestamp_micros: u64) -> Self {
-        match tx.payload() {
-            TransactionPayload::SnarkAccountUpdate(payload) => Self::Snark {
-                account_id: *payload.target(),
-                seq_no: payload.operation().update().seq_no(),
-                timestamp_micros,
-            },
-            TransactionPayload::GenericAccountMessage(_) => Self::Gam { timestamp_micros },
-        }
-    }
-
-    /// Get the timestamp from this ordering key.
-    pub fn timestamp_micros(&self) -> u64 {
-        match self {
-            Self::Snark {
-                timestamp_micros, ..
-            } => *timestamp_micros,
-            Self::Gam { timestamp_micros } => *timestamp_micros,
-        }
-    }
-}
-
-impl PartialOrd for MempoolOrderingKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MempoolOrderingKey {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            // Both Snark: same account? order by seq_no, else by `timestamp_micros`
-            (
-                Self::Snark {
-                    account_id: a1,
-                    seq_no: s1,
-                    timestamp_micros: t1,
-                },
-                Self::Snark {
-                    account_id: a2,
-                    seq_no: s2,
-                    timestamp_micros: t2,
-                },
-            ) => {
-                if a1 == a2 {
-                    s1.cmp(s2)
-                } else {
-                    t1.cmp(t2)
-                }
-            }
-
-            // Both GAM: order by `timestamp_micros`
-            (
-                Self::Gam {
-                    timestamp_micros: t1,
-                },
-                Self::Gam {
-                    timestamp_micros: t2,
-                },
-            ) => t1.cmp(t2),
-
-            // Mixed Snark/GAM: use `timestamp_micros` for fair interleaving
-            (
-                Self::Snark {
-                    timestamp_micros, ..
-                },
-                Self::Gam {
-                    timestamp_micros: t2,
-                },
-            )
-            | (
-                Self::Gam { timestamp_micros },
-                Self::Snark {
-                    timestamp_micros: t2,
-                    ..
-                },
-            ) => timestamp_micros.cmp(t2),
-        }
-    }
-}
-
 /// Internal mempool entry combining transaction data with ordering metadata.
-///
-/// This is used internally by the mempool implementation and not exposed in the public API.
 #[derive(Clone, Debug)]
-pub(crate) struct MempoolEntry {
+pub(crate) struct MempoolEntry<P: MempoolPriorityPolicy> {
     /// The transaction data.
     pub(crate) tx: OLTransaction,
 
     /// Ordering key.
-    pub(crate) ordering_key: MempoolOrderingKey,
+    pub(crate) priority: P::Priority,
 
     /// Size of the transaction in bytes (for capacity management).
     pub(crate) size_bytes: usize,
 }
 
-impl MempoolEntry {
+impl<P: MempoolPriorityPolicy> MempoolEntry<P> {
     /// Create a new mempool entry.
-    pub(crate) fn new(
-        tx: OLTransaction,
-        ordering_key: MempoolOrderingKey,
-        size_bytes: usize,
-    ) -> Self {
+    pub(crate) fn new(tx: OLTransaction, priority: P::Priority, size_bytes: usize) -> Self {
         Self {
             tx,
-            ordering_key,
+            priority,
             size_bytes,
         }
     }
@@ -395,7 +271,6 @@ mod tests {
         OLTransaction, OLTransactionData, TransactionPayload, TxProofs, test_utils,
     };
 
-    use super::*;
     use crate::test_utils::{
         create_test_account_id, create_test_constraints, create_test_generic_tx,
         create_test_snark_tx, create_test_snark_tx_from_update, create_test_snark_tx_with_seq_no,
@@ -518,205 +393,6 @@ mod tests {
         fn test_mempool_tx_payload_has_target(tx in test_utils::ol_transaction_strategy()) {
             let target = tx.target().expect("all payload variants must have target");
             prop_assert!(target != AccountId::zero(), "Target should not be zero");
-        }
-    }
-
-    // Tests for MempoolOrderingKey::Ord implementation
-    mod ordering_tests {
-        use std::cmp::Ordering;
-
-        use super::*;
-        use crate::test_utils::{
-            create_test_account_id, create_test_generic_tx, create_test_snark_tx,
-        };
-
-        #[test]
-        fn test_gam_ordering_by_timestamp_micros() {
-            let tx = create_test_generic_tx();
-            let entries: Vec<_> = (1..=3)
-                .map(|ts| {
-                    MempoolEntry::new(
-                        tx.clone(),
-                        MempoolOrderingKey::Gam {
-                            timestamp_micros: ts,
-                        },
-                        100,
-                    )
-                })
-                .collect();
-
-            for i in 0..entries.len() - 1 {
-                assert_eq!(
-                    entries[i].ordering_key.cmp(&entries[i + 1].ordering_key),
-                    Ordering::Less
-                );
-            }
-        }
-
-        #[test]
-        fn test_snark_same_account_orders_by_seq_no() {
-            let account = create_test_account_id();
-            let tx = create_test_snark_tx();
-            let timestamps = [1_000_100, 1_000_050, 1_000_025]; // Decreasing timestamps
-            let entries: Vec<_> = timestamps
-                .iter()
-                .enumerate()
-                .map(|(i, &ts)| {
-                    MempoolEntry::new(
-                        tx.clone(),
-                        MempoolOrderingKey::Snark {
-                            account_id: account,
-                            seq_no: i as u64 + 1,
-                            timestamp_micros: ts,
-                        },
-                        100,
-                    )
-                })
-                .collect();
-
-            // Same account: seq_no determines order regardless of timestamp
-            for i in 0..entries.len() - 1 {
-                assert_eq!(
-                    entries[i].ordering_key.cmp(&entries[i + 1].ordering_key),
-                    Ordering::Less
-                );
-            }
-        }
-
-        #[test]
-        fn test_snark_different_accounts_orders_by_timestamp_micros() {
-            let account_a = create_test_account_id();
-            let mut account_b = create_test_account_id();
-            while account_b == account_a {
-                account_b = create_test_account_id();
-            }
-
-            // Different accounts - should order by `timestamp_micros`
-            let tx_a = create_test_snark_tx();
-            let tx_b = create_test_snark_tx();
-
-            // Lower seq_no, later timestamp
-            let entry_a = MempoolEntry::new(
-                tx_a,
-                MempoolOrderingKey::Snark {
-                    account_id: account_a,
-                    seq_no: 5,
-                    timestamp_micros: 2_000_100,
-                },
-                100,
-            );
-            // Higher seq_no, earlier timestamp
-            let entry_b = MempoolEntry::new(
-                tx_b,
-                MempoolOrderingKey::Snark {
-                    account_id: account_b,
-                    seq_no: 7,
-                    timestamp_micros: 1_000_050,
-                },
-                100,
-            );
-
-            // Different accounts: `timestamp_micros` determines order
-            assert_eq!(
-                entry_b.ordering_key.cmp(&entry_a.ordering_key),
-                Ordering::Less
-            );
-        }
-
-        #[test]
-        fn test_mixed_snark_gam_orders_by_timestamp_micros() {
-            let account = create_test_account_id();
-
-            let tx_snark = create_test_snark_tx();
-            let tx_gam = create_test_generic_tx();
-
-            // Snark with earlier `timestamp_micros` should come first
-            let entry_snark = MempoolEntry::new(
-                tx_snark,
-                MempoolOrderingKey::Snark {
-                    account_id: account,
-                    seq_no: 1,
-                    timestamp_micros: 1_000_050,
-                },
-                100,
-            );
-            let entry_gam = MempoolEntry::new(
-                tx_gam,
-                MempoolOrderingKey::Gam {
-                    timestamp_micros: 2_000_100,
-                },
-                100,
-            );
-
-            // Mixed: `timestamp_micros` determines order
-            assert_eq!(
-                entry_snark.ordering_key.cmp(&entry_gam.ordering_key),
-                Ordering::Less
-            );
-        }
-
-        #[test]
-        fn test_complex_ordering_scenario() {
-            let acc_a = create_test_account_id();
-            let mut acc_b = create_test_account_id();
-            while acc_b == acc_a {
-                acc_b = create_test_account_id();
-            }
-            let (tx_gam, tx_snark) = (create_test_generic_tx(), create_test_snark_tx());
-
-            let mut entries = [
-                MempoolEntry::new(
-                    tx_gam.clone(),
-                    MempoolOrderingKey::Gam {
-                        timestamp_micros: 1_000_010,
-                    },
-                    100,
-                ),
-                MempoolEntry::new(
-                    tx_snark.clone(),
-                    MempoolOrderingKey::Snark {
-                        account_id: acc_a,
-                        seq_no: 1,
-                        timestamp_micros: 1_000_020,
-                    },
-                    100,
-                ),
-                MempoolEntry::new(
-                    tx_gam,
-                    MempoolOrderingKey::Gam {
-                        timestamp_micros: 1_000_030,
-                    },
-                    100,
-                ),
-                MempoolEntry::new(
-                    tx_snark.clone(),
-                    MempoolOrderingKey::Snark {
-                        account_id: acc_a,
-                        seq_no: 2,
-                        timestamp_micros: 1_000_040,
-                    },
-                    100,
-                ),
-                MempoolEntry::new(
-                    tx_snark,
-                    MempoolOrderingKey::Snark {
-                        account_id: acc_b,
-                        seq_no: 1,
-                        timestamp_micros: 1_000_050,
-                    },
-                    100,
-                ),
-            ];
-
-            entries.sort_by(|a, b| a.ordering_key.cmp(&b.ordering_key));
-            let timestamps: Vec<u64> = entries
-                .iter()
-                .map(|e| e.ordering_key.timestamp_micros())
-                .collect();
-            assert_eq!(
-                timestamps,
-                vec![1_000_010, 1_000_020, 1_000_030, 1_000_040, 1_000_050]
-            );
         }
     }
 }


### PR DESCRIPTION
## Description

Generalizes OL mempool transaction ordering behind a pluggable `MempoolPriorityPolicy` trait, while preserving current FIFO behavior unchanged.

1. `MempoolPriorityPolicy` trait (`ordering.rs`)
- Associated type `Priority: Ord + Copy + Debug + Send + Sync + 'static`, used as `BTreeMap` keys in the priority index.
- `compute_priority(tx, timestamp_micros) -> Self::Priority` computes priority from the transaction and insertion timestamp. `txid` is derived internally to prevent mismatch.

2. `FifoPriority` default implementation
Reproduces current timestamp-FIFO semantics via `FifoPriorityKey`.

Intrinsic vs extrinsic ordering (`ordering.rs`)
- `PackageKey::SnarkAcctUpdate(AccountId)` groups same-account snark transactions that share an intrinsic ordering constraint.
- `IntrinsicOrder` with `PartialOrd`, comparable only within the same package (same-account `seq_no`).
- `FifoPriorityKey::Ord` applies intrinsic order first, falls back to FIFO timestamp cross-package.

3. `txid` tiebreaker (correctness fix)
All `FifoPriorityKey` variants include a `txid` field. Without it, two transactions with the same timestamp would silently overwrite each other in the `BTreeMap`.

4. Transaction ID
`compute_txid()` on canonical `OLTransaction` uses SSZ tree-hash over transaction data. Mempool reuses this directly, no bespoke txid computation or manual `TreeHash` impls.

5. Generic propagation
`MempoolEntry<P>`, `MempoolServiceState<SP, Prio>`, `MempoolService<SP, Prio>`, `MempoolBuilder<Prio>`. Default `= FifoPriority` only on `MempoolBuilder` (public entry point).

6. `load_from_db()`
Retains timestamp-based pre-sort for `seq_no` reconstruction correctness; explicitly documented as independent of the active priority policy.

This PR was created with help from Claude Code and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-2042](https://alpenlabs.atlassian.net/browse/STR-2042)

[STR-2042]: https://alpenlabs.atlassian.net/browse/STR-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ