### PR TITLE
(btcio/writer): Remove 2x multiplier in fee estimation

### DIFF
--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -162,15 +162,15 @@ pub fn create_envelope_transactions(
     let reveal_fee = commit_value - env_config.reveal_amount;
 
     debug!(
-        commit_output_sats = commit_value,
-        reveal_amount_sats = env_config.reveal_amount,
-        reveal_fee_sats = reveal_fee,
+        commit_output_sats = %commit_value,
+        reveal_amount_sats = %env_config.reveal_amount,
+        reveal_fee_sats = %reveal_fee,
         reveal_fee_btc = format!(
             "{:.8}",
             reveal_fee as f64 / BitcoinAmount::SATS_FACTOR as f64
         ),
-        fee_rate_sats_per_byte = env_config.fee_rate,
-        reveal_script_size_bytes = reveal_script.len(),
+        fee_rate_sats_per_byte = %env_config.fee_rate,
+        reveal_script_size_bytes = %reveal_script.len(),
         "Calculated reveal transaction fees"
     );
 


### PR DESCRIPTION
## Description

It seems like the issue with excessive fees in signet is because of the existing 2x multiplier in the fee estimation. In signet, the issue most likely unfolds like this.
1. Let the existing fee rate be x.
2. When queried by the fee policy, it would be multiplied by 2 and the fee rate is interpreted as 2x.
3. Transactions are created and submitted to bitcoin with the fee rate of 2x.
4. Once the transactions are accepted, the network's fee rate becomes roughly 2x because signet mostly has empty blocks.
5. When queried by the fee policy it would again be multiplied by 2 and the new fee rate would be interpreted to be 4x, and so on.

This PR removes the 2x multiplier. The query made to `estimatesmartfee` RPC should already be enough because it returns the "conservative" estimation by default(which is slightly higher) than the other option("economical"). See https://chainquery.com/bitcoin-cli/estimatesmartfee.
The PR also adds some logging for observability of the fee rate and actual fee being paid in a transaction.
### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
