### PR TITLE
STR-2434: use canonical tip as fallback for duty fetcher instead of genesis

### DIFF
--- a/bin/strata/src/sequencer/duty_fetcher.rs
+++ b/bin/strata/src/sequencer/duty_fetcher.rs
@@ -23,14 +23,14 @@ pub(crate) async fn duty_fetcher_worker(
         interval.tick().await;
         let tip_blkid = match status_channel.get_ol_sync_status().map(|s| *s.tip_blkid()) {
             Some(tip) => tip,
-            None => match storage.ol_block().get_canonical_block_at_async(0).await {
+            None => match storage.ol_block().get_canonical_tip_async().await {
                 Ok(Some(commitment)) => *commitment.blkid(),
                 Ok(None) => {
-                    warn!("genesis block not found yet");
+                    warn!("canonical tip not found yet");
                     continue;
                 }
                 Err(err) => {
-                    error!(%err, "failed to load genesis block");
+                    error!(%err, "failed to load canonical tip");
                     continue;
                 }
             },


### PR DESCRIPTION
## Description

After a node restart where epoch 1+ has been finalized, the sequencer duty fetcher incorrectly uses the genesis block as its starting tip. This prevents the chain from resuming when the fork choice manager (FCM) is initialized with a finalized epoch above genesis.

### Root Cause
`duty_fetcher_worker` polls `status_channel.get_ol_sync_status()` for the current tip. On fresh restart, `StatusChannel` is initialized with `ol_state: None`, so no status is available until FCM processes its first block. The fallback is:
`storage.ol_block().get_canonical_block_at_async(0)  // always returns genesis`

On first-ever startup this is harmless: FCM's finalized epoch defaults to genesis-level, so genesis is the root of its pending_table. A slot 1 block built on top of genesis attaches successfully, FCM publishes a status, and the chain moves forward.

After any restart where epoch 1+ is finalized, FCM initializes with the epoch terminal block (e.g. slot 4) as its pending_table root — genesis is not present. The duty fetcher still falls back to genesis, generates a slot 1 block, and FCM fails to attach it with:
```
error processing block, interpreting as invalid: tried to attach blkid <slot-1-id> but missing parent blkid <genesis-id>
```
No status is ever published, the duty fetcher keeps retrying with genesis, and the chain is stuck.

### Why we didn’t catch this with existing functional tests
We do have a functional test `test_sequencer_restart`, which does not catch the issue because it does not wait for epoch finalization.

The fix has been tested in `strata-dbtool` functional tests migration branch. PR not open yet.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-2434](https://alpenlabs.atlassian.net/browse/STR-2434)

[STR-2434]: https://alpenlabs.atlassian.net/browse/STR-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ