### PR TITLE
fix(func-test): prevent revert target from falling inside finalized epoch

### DIFF
--- a/functional-tests/envs/testenv.py
+++ b/functional-tests/envs/testenv.py
@@ -236,10 +236,6 @@ class BasicEnvConfig(flexitest.EnvConfig):
         time.sleep(BLOCK_GENERATION_INTERVAL_SECS)
 
         brpc = _retry_bitcoind_rpc(logger, "create_rpc", bitcoind.create_rpc, timeout_s=180.0)
-        walletname = bitcoind.get_prop("walletname")
-        _retry_bitcoind_rpc(
-            logger, f"createwallet({walletname})", lambda: brpc.proxy.createwallet(walletname)
-        )
         seqaddr = _retry_bitcoind_rpc(logger, "getnewaddress", brpc.proxy.getnewaddress)
 
         # Generate enough blocks to ensure we can fetch the genesis trigger block
@@ -395,12 +391,6 @@ class HubNetworkEnvConfig(flexitest.EnvConfig):
         time.sleep(BLOCK_GENERATION_INTERVAL_SECS)
 
         brpc = _retry_bitcoind_rpc(logger, "create_rpc", bitcoind.create_rpc, timeout_s=180.0)
-
-        walletname = bitcoind.get_prop("walletname")
-        _retry_bitcoind_rpc(
-            logger, f"createwallet({walletname})", lambda: brpc.proxy.createwallet(walletname)
-        )
-
         seqaddr = _retry_bitcoind_rpc(logger, "getnewaddress", brpc.proxy.getnewaddress)
 
         if self.pre_generate_blocks > 0:

--- a/functional-tests/factory/factory.py
+++ b/functional-tests/factory/factory.py
@@ -18,7 +18,7 @@ from factory.config import (
 from load.cfg import LoadConfig
 from load.service import LoadGeneratorService
 from utils.constants import BD_PASSWORD, BD_USERNAME
-from utils.utils import ProverClientSettings
+from utils.utils import ProverClientSettings, wait_until
 
 
 class BitcoinFactory(flexitest.Factory):
@@ -31,6 +31,8 @@ class BitcoinFactory(flexitest.Factory):
         p2p_port = self.next_port()
         rpc_port = self.next_port()
         logfile = os.path.join(datadir, "service.log")
+
+        walletname = "testwallet"
 
         cmd = [
             "bitcoind",
@@ -45,6 +47,7 @@ class BitcoinFactory(flexitest.Factory):
             f"-rpcport={rpc_port}",
             f"-rpcuser={BD_USERNAME}",
             f"-rpcpassword={BD_PASSWORD}",
+            f"-wallet={walletname}",
         ]
 
         props = {
@@ -52,7 +55,7 @@ class BitcoinFactory(flexitest.Factory):
             "rpc_port": rpc_port,
             "rpc_user": BD_USERNAME,
             "rpc_password": BD_PASSWORD,
-            "walletname": "testwallet",
+            "walletname": walletname,
         }
 
         svc = flexitest.service.ProcService(props, cmd, stdout=logfile)
@@ -66,6 +69,14 @@ class BitcoinFactory(flexitest.Factory):
             return BitcoindClient(base_url=url, network="regtest")
 
         svc.create_rpc = _create_rpc
+
+        # Create wallet on first start; on restarts -wallet flag auto-loads it
+        def _create_wallet():
+            rpc = _create_rpc()
+            rpc.proxy.createwallet(walletname)
+            return True
+
+        wait_until(_create_wallet, error_with="bitcoind wallet not ready", timeout=30)
 
         return svc
 

--- a/functional-tests/tests/dbtool/revert_checkpointed_block_fn.py
+++ b/functional-tests/tests/dbtool/revert_checkpointed_block_fn.py
@@ -1,9 +1,8 @@
-import time
-
 import flexitest
 
 from envs import net_settings, testenv
 from mixins.dbtool_mixin import FullnodeDbtoolMixin
+from utils.constants import BLOCK_GENERATION_INTERVAL_SECS
 from utils.dbtool import (
     get_latest_checkpoint,
     restart_fullnode_after_revert,
@@ -12,7 +11,7 @@ from utils.dbtool import (
     verify_checkpoint_deleted,
     verify_revert_success,
 )
-from utils.utils import wait_until
+from utils.utils import generate_blocks, wait_until
 
 
 @flexitest.register
@@ -31,16 +30,21 @@ class RevertCheckpointedBlockFnTest(FullnodeDbtoolMixin):
         # Setup: generate blocks, finalize epoch 1, and wait for checkpoint 2
         setup_revert_chainstate_test(self, web3_attr="web3")
 
+        # Stop bitcoin immediately to prevent further checkpoint finalization,
+        # which would finalize more epochs and cause the revert target to
+        # fall inside a finalized epoch.
+        self.btc.stop()
+
         cur_block = int(self.rethrpc.eth_blockNumber(), base=16)
 
-        # ensure there are some blocks more than our tip height
+        # Ensure L2 is still producing blocks (sequencer works independently of L1)
         wait_until(
             lambda: int(self.rethrpc.eth_blockNumber(), base=16) > cur_block + 3,
             error_with="not building blocks",
             timeout=10,
         )
 
-        # Stop signer early to ensure no more blocks
+        # Stop signer to freeze L2 state before capturing block numbers
         self.seq_signer.stop()
 
         # Capture state before revert
@@ -69,9 +73,6 @@ class RevertCheckpointedBlockFnTest(FullnodeDbtoolMixin):
                 f"Fullnode OL and EL are not in sync: OL={old_fn_ol_block_number}, "
                 f"EL={old_fn_el_block_number}"
             )
-
-        # extra buffer time to let latest checkpoint get final
-        time.sleep(3)
 
         # Stop services to use dbtool
         self.seq.stop()
@@ -110,6 +111,22 @@ class RevertCheckpointedBlockFnTest(FullnodeDbtoolMixin):
         # When reverting to the BEGINNING of a checkpointed epoch, checkpoint should be deleted
         if not verify_checkpoint_deleted(self, checkpt["idx"]):
             return False
+
+        # Restart bitcoin so L1 blocks can confirm new checkpoints.
+        # The -wallet flag auto-loads the wallet from the persisted datadir.
+        self.btc.start()
+
+        # Wait for bitcoind to be ready, then restart L1 block generation
+        # (the old generation thread exited when bitcoin was stopped).
+        def _start_block_generation():
+            self.btcrpc = self.btc.create_rpc()
+            gen_addr = self.btcrpc.proxy.getnewaddress()
+            generate_blocks(self.btcrpc, BLOCK_GENERATION_INTERVAL_SECS, gen_addr)
+            return True
+
+        wait_until(
+            _start_block_generation, error_with="bitcoind not ready after restart", timeout=30
+        )
 
         # Restart services and verify
         restart_fullnode_after_revert(self, target_slot, old_seq_ol_block_number, checkpt["idx"])


### PR DESCRIPTION
This functional test (`revert_checkpointed_block_fn`) has been flaky because epochs can be finalized for the targeted reversal block when bitcoin is running and sequencer taking some time to shut down. As a result chainstate could not be reverted since the targeted block may fall in a finalized epoch.
I have also moved the wallet creation logic to `bitcoind -wallet` since its needed to every env.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
