### PR TITLE
fix: use L1Height instead of u64 for L1 block heights

### DIFF
--- a/benches/benches/l1_database.rs
+++ b/benches/benches/l1_database.rs
@@ -167,10 +167,10 @@ fn bench_get_canonical_blockid_at_height_impl(backend: DatabaseBackend, c: &mut 
                                 setup.db.put_block_data(block.clone()).unwrap();
                                 setup
                                     .db
-                                    .set_canonical_chain_entry(i as u64, *block.blkid())
+                                    .set_canonical_chain_entry(i as u32, *block.blkid())
                                     .unwrap();
                             }
-                            let target_height = (block_count / 2) as u64;
+                            let target_height = (block_count / 2) as u32;
                             (setup, target_height)
                         },
                         |(setup, height)| {

--- a/bin/alpen-client/src/dummy_ol_client.rs
+++ b/bin/alpen-client/src/dummy_ol_client.rs
@@ -10,7 +10,7 @@ use alpen_ee_common::{
 };
 use async_trait::async_trait;
 use strata_acct_types::Hash;
-use strata_identifiers::{Buf32, Epoch, OLBlockCommitment};
+use strata_identifiers::{Buf32, Epoch, L1Height, OLBlockCommitment};
 use strata_primitives::EpochCommitment;
 use strata_snark_acct_types::{ProofState, Seqno, SnarkAccountUpdate};
 
@@ -101,8 +101,8 @@ impl SequencerOLClient for DummyOLClient {
         })
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: u64) -> Result<Hash, OLClientError> {
-        Ok(Hash::from(u64_to_256(l1_height)))
+    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError> {
+        Ok(Hash::from(u64_to_256(l1_height as u64)))
     }
 
     async fn submit_update(&self, _update: SnarkAccountUpdate) -> Result<(), OLClientError> {

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -62,7 +62,7 @@ use strata_btcio::{
 use strata_config::btcio::WriterConfig;
 use strata_identifiers::{CredRule, EpochCommitment, OLBlockId};
 use strata_l1_txfmt::MagicBytes;
-use strata_primitives::buf::Buf32;
+use strata_primitives::{buf::Buf32, L1Height};
 use tokio::sync::{mpsc, watch};
 use tracing::{error, info};
 #[cfg(feature = "sequencer")]
@@ -622,7 +622,7 @@ pub struct AdditionalConfig {
 
     /// Genesis L1 block height (the first L1 block the rollup cares about).
     #[arg(long, default_value = "0")]
-    pub genesis_l1_height: u64,
+    pub genesis_l1_height: L1Height,
 
     /// Number of blocks per batch before sealing.
     /// Lower values seal batches more frequently (useful for testing).

--- a/bin/alpen-client/src/ol_client.rs
+++ b/bin/alpen-client/src/ol_client.rs
@@ -5,7 +5,7 @@ use alpen_ee_common::{
     SequencerOLClient,
 };
 use async_trait::async_trait;
-use strata_identifiers::{Epoch, EpochCommitment, Hash};
+use strata_identifiers::{Epoch, EpochCommitment, Hash, L1Height};
 use strata_snark_acct_types::SnarkAccountUpdate;
 
 use crate::{dummy_ol_client::DummyOLClient, rpc_client::RpcOLClient};
@@ -73,7 +73,7 @@ impl SequencerOLClient for OLClientKind {
         }
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: u64) -> Result<Hash, OLClientError> {
+    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError> {
         match self {
             Self::Rpc(client) => client.get_l1_header_commitment(l1_height).await,
             Self::Dummy(client) => client.get_l1_header_commitment(l1_height).await,

--- a/bin/alpen-client/src/rpc_client.rs
+++ b/bin/alpen-client/src/rpc_client.rs
@@ -11,7 +11,7 @@ use strata_common::{
     },
     ws_client::{ManagedWsClient, WsClientConfig},
 };
-use strata_identifiers::{AccountId, Epoch, EpochCommitment, Hash};
+use strata_identifiers::{AccountId, Epoch, EpochCommitment, Hash, L1Height};
 use strata_ol_rpc_api::OLClientRpcClient;
 use strata_ol_rpc_types::{
     OLBlockOrTag, RpcOLTransaction, RpcSnarkAccountUpdate, RpcTransactionAttachment,
@@ -219,7 +219,7 @@ impl SequencerOLClient for RpcOLClient {
         })
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: u64) -> Result<Hash, OLClientError> {
+    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError> {
         retry_with_backoff_async(
             "ol_client_get_l1_header_commitment",
             DEFAULT_ENGINE_CALL_MAX_RETRIES,

--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -5,6 +5,7 @@ use std::{num::NonZero, path::PathBuf};
 use argh::FromArgs;
 use bitcoin::Network;
 use rand_core::OsRng;
+use strata_primitives::L1Height;
 
 use crate::util::resolve_network;
 
@@ -159,7 +160,7 @@ pub(crate) struct SubcParams {
         description = "genesis L1 block height (default 100)",
         short = 'g'
     )]
-    pub(crate) genesis_l1_height: Option<u64>,
+    pub(crate) genesis_l1_height: Option<L1Height>,
 
     #[argh(option, description = "block time in seconds (default 5)", short = 't')]
     pub(crate) block_time: Option<u64>,
@@ -230,7 +231,7 @@ pub(crate) struct SubcAsmParams {
         description = "genesis L1 block height (default 100)",
         short = 'g'
     )]
-    pub(crate) genesis_l1_height: Option<u64>,
+    pub(crate) genesis_l1_height: Option<L1Height>,
 
     #[argh(
         option,
@@ -286,7 +287,7 @@ pub(crate) struct SubcOlParams {
         description = "genesis L1 block height (default 100)",
         short = 'g'
     )]
-    pub(crate) genesis_l1_height: Option<u64>,
+    pub(crate) genesis_l1_height: Option<L1Height>,
 
     #[argh(
         option,
@@ -303,7 +304,7 @@ pub(crate) struct SubcOlParams {
 )]
 pub(crate) struct SubcGenL1View {
     #[argh(option, description = "genesis L1 block height", short = 'g')]
-    pub(crate) genesis_l1_height: u64,
+    pub(crate) genesis_l1_height: L1Height,
 
     #[argh(
         option,

--- a/bin/datatool/src/btc_client.rs
+++ b/bin/datatool/src/btc_client.rs
@@ -9,7 +9,7 @@ use strata_btc_types::BlockHashExt;
 use strata_btc_verification::get_relative_difficulty_adjustment_height;
 use strata_primitives::{
     constants::TIMESTAMPS_FOR_MEDIAN,
-    l1::{BtcParams, GenesisL1View, L1BlockCommitment},
+    l1::{BtcParams, GenesisL1View, L1BlockCommitment, L1Height},
 };
 
 use crate::args::BitcoindConfig;
@@ -20,7 +20,7 @@ use crate::args::BitcoindConfig;
 /// at the specified block height.
 pub(crate) async fn fetch_genesis_l1_view_with_config(
     config: &BitcoindConfig,
-    block_height: u64,
+    block_height: L1Height,
 ) -> anyhow::Result<GenesisL1View> {
     let client = create_client(config)?;
     fetch_genesis_l1_view(&client, block_height).await
@@ -28,7 +28,7 @@ pub(crate) async fn fetch_genesis_l1_view_with_config(
 
 async fn fetch_genesis_l1_view(
     client: &impl Reader,
-    block_height: u64,
+    block_height: L1Height,
 ) -> anyhow::Result<GenesisL1View> {
     // Create BTC parameters based on the current network.
     let network = client.network().await?;
@@ -39,11 +39,11 @@ async fn fetch_genesis_l1_view(
     let current_epoch_start_height =
         get_relative_difficulty_adjustment_height(0, block_height, btc_params.inner());
     let current_epoch_start_header = client
-        .get_block_header_at(current_epoch_start_height)
+        .get_block_header_at(current_epoch_start_height as u64)
         .await?;
 
     // Fetch the block header at the height
-    let block_header = client.get_block_header_at(block_height).await?;
+    let block_header = client.get_block_header_at(block_height as u64).await?;
 
     // Fetch timestamps
     let timestamps =
@@ -58,7 +58,7 @@ async fn fetch_genesis_l1_view(
     // If (block_height + 1) is the start of the new epoch, we need to calculate the
     // next_block_target, else next_block_target will be current block's target
     let next_block_target =
-        if (block_height + 1).is_multiple_of(btc_params.difficulty_adjustment_interval()) {
+        if (block_height as u64 + 1).is_multiple_of(btc_params.difficulty_adjustment_interval()) {
             CompactTarget::from_next_work_required(
                 block_header.bits,
                 (block_header.time - current_epoch_start_header.time) as u64,
@@ -67,7 +67,7 @@ async fn fetch_genesis_l1_view(
             .to_consensus()
         } else {
             client
-                .get_block_header_at(block_height)
+                .get_block_header_at(block_height as u64)
                 .await?
                 .target()
                 .to_compact_lossy()
@@ -76,7 +76,7 @@ async fn fetch_genesis_l1_view(
 
     // Build the genesis L1 view structure.
     let genesis_l1_view = GenesisL1View {
-        blk: L1BlockCommitment::from_height_u64(block_height, block_id).expect("valid height"),
+        blk: L1BlockCommitment::new(block_height, block_id),
         next_target: next_block_target,
         epoch_start_timestamp: current_epoch_start_header.time,
         last_11_timestamps: timestamps,
@@ -92,18 +92,18 @@ async fn fetch_genesis_l1_view(
 /// ascending order (oldest first).
 async fn fetch_block_timestamps_ascending(
     client: &impl Reader,
-    height: u64,
+    height: L1Height,
     count: usize,
 ) -> anyhow::Result<Vec<u32>> {
     let mut timestamps = Vec::with_capacity(count);
 
     for i in 0..count {
-        let current_height = height.saturating_sub(i as u64);
+        let current_height = height.saturating_sub(i as u32);
         // If we've gone past block 1, push 0 as a placeholder.
         if current_height < 1 {
             timestamps.push(0);
         } else {
-            let header = client.get_block_header_at(current_height).await?;
+            let header = client.get_block_header_at(current_height as u64).await?;
             timestamps.push(header.time);
         }
     }

--- a/bin/datatool/src/cmd/asm_params.rs
+++ b/bin/datatool/src/cmd/asm_params.rs
@@ -123,7 +123,7 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
 
     // Build checkpoint config.
     let checkpoint_predicate = resolve_checkpoint_predicate();
-    let genesis_l1_height = genesis_l1_view.blk.height_u32();
+    let genesis_l1_height = genesis_l1_view.blk.height();
 
     let checkpoint = CheckpointInitConfig {
         sequencer_predicate: PredicateKey::always_accept(),

--- a/bin/datatool/src/cmd/params.rs
+++ b/bin/datatool/src/cmd/params.rs
@@ -14,7 +14,7 @@ use strata_key_derivation::error::KeyError;
 use strata_l1_txfmt::MagicBytes;
 use strata_params::{ProofPublishMode, RollupParams};
 use strata_predicate::PredicateKey;
-use strata_primitives::{block_credential, buf::Buf32, l1::GenesisL1View};
+use strata_primitives::{block_credential, buf::Buf32, l1::GenesisL1View, L1Height};
 
 use crate::{
     args::{CmdContext, SubcParams},
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// The default L1 genesis height to use.
-const DEFAULT_L1_GENESIS_HEIGHT: u64 = 100;
+const DEFAULT_L1_GENESIS_HEIGHT: L1Height = 100;
 
 /// The default evm chainspec to use in params.
 const DEFAULT_CHAIN_SPEC: &str = alpen_chainspec::DEV_CHAIN_SPEC;
@@ -245,7 +245,7 @@ fn get_alpen_ee_genesis_block_info(genesis_json: &str) -> anyhow::Result<BlockIn
 /// 3. Otherwise, return an error
 pub(super) fn retrieve_genesis_l1_view(
     genesis_l1_view_file: Option<&str>,
-    genesis_l1_height: Option<u64>,
+    genesis_l1_height: Option<L1Height>,
     ctx: &CmdContext,
 ) -> anyhow::Result<GenesisL1View> {
     // Priority 1: Use file if provided

--- a/bin/strata-client/src/helpers.rs
+++ b/bin/strata-client/src/helpers.rs
@@ -216,6 +216,6 @@ pub(crate) fn rollup_to_btcio_params(rollup: &RollupParams) -> BtcioParams {
     BtcioParams::new(
         rollup.l1_reorg_safe_depth,
         rollup.magic_bytes,
-        rollup.genesis_l1_view.height_u64(),
+        rollup.genesis_l1_view.height(),
     )
 }

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -28,7 +28,7 @@ use strata_primitives::{
     buf::Buf32,
     crypto::EvenPublicKey,
     epoch::EpochCommitment,
-    l1::{L1BlockCommitment, L1BlockId},
+    l1::{L1BlockCommitment, L1BlockId, L1Height},
 };
 use strata_rpc_api::{
     StrataAdminApiServer, StrataApiServer, StrataDebugApiServer, StrataSequencerApiServer,
@@ -180,7 +180,7 @@ impl StrataApiServer for StrataRpcImpl {
         Ok(self.get_l1_status().await?.bitcoin_rpc_connected)
     }
 
-    async fn get_l1_block_hash(&self, height: u64) -> RpcResult<Option<String>> {
+    async fn get_l1_block_hash(&self, height: L1Height) -> RpcResult<Option<String>> {
         Ok(self
             .storage
             .l1()
@@ -210,8 +210,8 @@ impl StrataApiServer for StrataRpcImpl {
 
         // Maybe set buried L1 block.
         let depth = self.sync_manager.params().rollup().l1_reorg_safe_depth;
-        let current_height = l1_block.height() as u64;
-        let buried_height_checked = current_height.checked_sub(depth as u64);
+        let current_height = l1_block.height();
+        let buried_height_checked = current_height.checked_sub(depth);
         // Checked fetch the canonical chain.
         if let Some(buried_height) = buried_height_checked {
             let manifest = self
@@ -221,7 +221,7 @@ impl StrataApiServer for StrataRpcImpl {
                 .await;
 
             if let Ok(Some(block)) = manifest {
-                buried_l1_block = L1BlockCommitment::from_height_u64(buried_height, *block.blkid());
+                buried_l1_block = Some(L1BlockCommitment::new(buried_height, *block.blkid()));
             }
         }
 
@@ -624,7 +624,7 @@ impl StrataApiServer for StrataRpcImpl {
                 .l2_slot_at_or_before_end(block_slot)
             {
                 return Ok(L2BlockStatus::Finalized(
-                    last_checkpoint.l1_reference.block_height(),
+                    last_checkpoint.l1_reference.block_height().into(),
                 ));
             }
         }
@@ -632,7 +632,7 @@ impl StrataApiServer for StrataRpcImpl {
         // Verified check
         let verified_l1_height = cstate.get_last_checkpoint().and_then(|ckpt| {
             if ckpt.batch_info.l2_slot_at_or_before_end(block_slot) {
-                Some(ckpt.l1_reference.block_height())
+                Some(ckpt.l1_reference.block_height().into())
             } else {
                 None
             }
@@ -663,8 +663,7 @@ impl StrataApiServer for StrataRpcImpl {
             // TODO: better error?
             .ok_or(Error::MissingL1BlockManifest(0))?;
 
-        let commitment = L1BlockCommitment::from_height_u64(manifest.height(), *manifest.blkid())
-            .ok_or(Error::MissingL1BlockManifest(0))?;
+        let commitment = L1BlockCommitment::new(manifest.height(), *manifest.blkid());
 
         Ok(self
             .storage
@@ -984,8 +983,7 @@ impl StrataDebugApiServer for StrataDebugRpcImpl {
             // TODO: better error?
             .ok_or(Error::MissingL1BlockManifest(0))?;
 
-        let commitment = L1BlockCommitment::from_height_u64(manifest.height(), *manifest.blkid())
-            .ok_or(Error::MissingL1BlockManifest(0))?;
+        let commitment = L1BlockCommitment::new(manifest.height(), *manifest.blkid());
 
         Ok(self
             .storage

--- a/bin/strata-dbtool/src/cmd/chainstate.rs
+++ b/bin/strata-dbtool/src/cmd/chainstate.rs
@@ -9,7 +9,10 @@ use strata_db_types::{
     },
 };
 use strata_ol_chainstate_types::WriteBatch;
-use strata_primitives::{l1::L1BlockCommitment, l2::L2BlockId};
+use strata_primitives::{
+    l1::{L1BlockCommitment, L1Height},
+    l2::L2BlockId,
+};
 
 use super::{
     checkpoint::get_latest_checkpoint_entry,
@@ -88,13 +91,13 @@ pub(crate) fn get_latest_l2_write_batch(
 fn delete_client_states_from(
     db: &impl DatabaseBackend,
     from_l1_block: L1BlockCommitment,
-    l1_tip_height: u64,
+    l1_tip_height: L1Height,
     dry_run: bool,
 ) -> Result<Vec<L1BlockCommitment>, DisplayedError> {
     let client_state_db = db.client_state_db();
 
     // Calculate max possible entries from from_block to L1 tip
-    let from_height = from_l1_block.height_u64();
+    let from_height = from_l1_block.height();
     let max_count = if l1_tip_height >= from_height {
         (l1_tip_height - from_height + 1) as usize
     } else {
@@ -233,7 +236,7 @@ pub(crate) fn revert_chainstate(
     println!("Target slot is epoch finishing: {target_slot_is_terminal}");
     println!(
         "Target L1 safe block {}@{}",
-        target_l1_safe_block.height_u64(),
+        target_l1_safe_block.height(),
         target_l1_safe_block.blkid()
     );
     println!();
@@ -366,14 +369,8 @@ pub(crate) fn revert_chainstate(
 
     if needs_checkpoint_cleanup {
         // Process ClientState entries AFTER the target L1 safe block
-        let next_l1_height = target_l1_safe_block.height_u64() + 1;
-        let next_l1_block = L1BlockCommitment::from_height_u64(next_l1_height, Default::default())
-            .ok_or_else(|| {
-                DisplayedError::InternalError(
-                    "Failed to create next L1 block commitment".to_string(),
-                    Box::new(next_l1_height),
-                )
-            })?;
+        let next_l1_height = target_l1_safe_block.height() + 1;
+        let next_l1_block = L1BlockCommitment::new(next_l1_height, Default::default());
 
         // Get L1 tip for informational purposes
         let (l1_tip_height, l1_tip_block_id) = get_l1_chain_tip(db)?;
@@ -523,12 +520,8 @@ pub(crate) fn revert_chainstate(
 
             // ClientState entries (only if checkpoint cleanup is needed)
             if needs_checkpoint_cleanup && !client_state_entries_to_delete.is_empty() {
-                let first_height = client_state_entries_to_delete
-                    .first()
-                    .map(|b| b.height_u64());
-                let last_height = client_state_entries_to_delete
-                    .last()
-                    .map(|b| b.height_u64());
+                let first_height = client_state_entries_to_delete.first().map(|b| b.height());
+                let last_height = client_state_entries_to_delete.last().map(|b| b.height());
 
                 if let (Some(first), Some(last)) = (first_height, last_height) {
                     println!(
@@ -548,7 +541,7 @@ pub(crate) fn revert_chainstate(
                     println!(
                         "  - L1 block {} at height {}",
                         l1_block.blkid(),
-                        l1_block.height_u64()
+                        l1_block.height()
                     );
                 }
                 println!();

--- a/bin/strata-dbtool/src/cmd/checkpoint.rs
+++ b/bin/strata-dbtool/src/cmd/checkpoint.rs
@@ -6,7 +6,7 @@ use strata_db_types::{
     traits::{AsmDatabase, CheckpointDatabase, DatabaseBackend, L1Database},
     types::CheckpointEntry,
 };
-use strata_primitives::l1::L1BlockCommitment;
+use strata_primitives::l1::{L1BlockCommitment, L1Height};
 
 use crate::{
     cli::OutputFormat,
@@ -35,7 +35,7 @@ pub(crate) struct GetCheckpointArgs {
 pub(crate) struct GetCheckpointsSummaryArgs {
     /// start l1 height to query checkpoints from
     #[argh(positional)]
-    pub(crate) height_from: u64,
+    pub(crate) height_from: L1Height,
 
     /// output format: "porcelain" (default) or "json"
     #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
@@ -71,7 +71,7 @@ pub(crate) fn get_last_epoch(db: &impl DatabaseBackend) -> Result<Option<u64>, D
 /// checkpoint epoch commitments found in the logs.
 fn count_checkpoints_in_asm_logs(
     db: &impl DatabaseBackend,
-    height_from: u64,
+    height_from: L1Height,
 ) -> Result<u64, DisplayedError> {
     let asm_db = db.asm_db();
     let l1_db = db.l1_db();
@@ -97,13 +97,7 @@ fn count_checkpoints_in_asm_logs(
             )
         })?;
 
-    let start_l1_commitment = L1BlockCommitment::from_height_u64(height_from, block_id)
-        .ok_or_else(|| {
-            DisplayedError::InternalError(
-                "Invalid height for L1BlockCommitment".to_string(),
-                Box::new(height_from),
-            )
-        })?;
+    let start_l1_commitment = L1BlockCommitment::new(height_from, block_id);
 
     let mut checkpoint_count = 0u64;
 
@@ -123,7 +117,7 @@ fn count_checkpoints_in_asm_logs(
         // Process each ASM state's logs
         for (commitment, asm_state) in &asm_states {
             // Only process blocks at or after height_from
-            if commitment.height_u64() < height_from {
+            if commitment.height() < height_from {
                 continue;
             }
 

--- a/bin/strata-dbtool/src/cmd/client_state.rs
+++ b/bin/strata-dbtool/src/cmd/client_state.rs
@@ -34,10 +34,7 @@ pub(crate) fn get_client_state_update(
         "Block manifest not found".to_string(),
         Box::new(()),
     ))?;
-    let block_commitment =
-        L1BlockCommitment::from_height_u64(block_mf.height(), *block_mf.blkid()).ok_or(
-            DisplayedError::InternalError("Invalid height".to_string(), Box::new(())),
-        )?;
+    let block_commitment = L1BlockCommitment::new(block_mf.height(), *block_mf.blkid());
 
     let (client_state, actions) = db
         .client_state_db()

--- a/bin/strata-dbtool/src/cmd/l1.rs
+++ b/bin/strata-dbtool/src/cmd/l1.rs
@@ -2,7 +2,7 @@ use argh::FromArgs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_db_types::traits::{DatabaseBackend, L1Database};
 use strata_ol_chain_types::AsmManifest;
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::l1::{L1BlockId, L1Height};
 
 use crate::{
     cli::OutputFormat,
@@ -32,7 +32,7 @@ pub(crate) struct GetL1ManifestArgs {
 pub(crate) struct GetL1SummaryArgs {
     /// l1 height to look up the summary about
     #[argh(positional)]
-    pub(crate) height_from: u64,
+    pub(crate) height_from: L1Height,
 
     /// output format: "porcelain" (default) or "json"
     #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
@@ -42,7 +42,7 @@ pub(crate) struct GetL1SummaryArgs {
 /// Get the L1 chain tip (height, block_id) of the canonical chain tip.
 pub(crate) fn get_l1_chain_tip(
     db: &impl DatabaseBackend,
-) -> Result<(u64, L1BlockId), DisplayedError> {
+) -> Result<(L1Height, L1BlockId), DisplayedError> {
     db.l1_db()
         .get_canonical_chain_tip()
         .internal_error("Failed to get L1 tip")?
@@ -54,7 +54,7 @@ pub(crate) fn get_l1_chain_tip(
 /// Get L1 block ID at a specific height.
 pub(crate) fn get_l1_block_id_at_height(
     db: &impl DatabaseBackend,
-    height: u64,
+    height: L1Height,
 ) -> Result<L1BlockId, DisplayedError> {
     db.l1_db()
         .get_canonical_blockid_at_height(height)

--- a/bin/strata-dbtool/src/cmd/l2.rs
+++ b/bin/strata-dbtool/src/cmd/l2.rs
@@ -3,7 +3,10 @@ use strata_cli_common::errors::{DisplayableError, DisplayedError};
 #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_db_types::traits::{BlockStatus, DatabaseBackend, L2BlockDatabase};
 use strata_ol_chain_types::{L2BlockBundle, L2Header};
-use strata_primitives::{l1::L1BlockId, l2::L2BlockId};
+use strata_primitives::{
+    l1::{L1BlockId, L1Height},
+    l2::L2BlockId,
+};
 
 use super::checkpoint::get_last_epoch;
 use crate::{
@@ -135,7 +138,7 @@ pub(crate) fn get_l2_block(
     let l1_segment = l2_block.body().l1_segment();
 
     // Create L1 segment data
-    let l1_segment_data: Vec<(u64, &L1BlockId)> = l1_segment
+    let l1_segment_data: Vec<(L1Height, &L1BlockId)> = l1_segment
         .new_manifests()
         .iter()
         .map(|manifest| (manifest.height(), manifest.blkid()))

--- a/bin/strata-dbtool/src/output/chainstate.rs
+++ b/bin/strata-dbtool/src/output/chainstate.rs
@@ -1,6 +1,10 @@
 //! Chainstate formatting implementations
 
-use strata_primitives::{l1::L1BlockId, l2::L2BlockId, prelude::EpochCommitment};
+use strata_primitives::{
+    l1::{L1BlockId, L1Height},
+    l2::L2BlockId,
+    prelude::EpochCommitment,
+};
 
 use super::{helpers::porcelain_field, traits::Formattable};
 
@@ -13,8 +17,8 @@ pub(crate) struct ChainstateInfo<'a> {
     pub is_epoch_finishing: bool,
     pub previous_epoch: &'a EpochCommitment,
     pub finalized_epoch: &'a EpochCommitment,
-    pub l1_next_expected_height: u64,
-    pub l1_safe_block_height: u64,
+    pub l1_next_expected_height: L1Height,
+    pub l1_safe_block_height: L1Height,
     pub l1_safe_block_blkid: &'a L1BlockId,
 }
 

--- a/bin/strata-dbtool/src/output/l1.rs
+++ b/bin/strata-dbtool/src/output/l1.rs
@@ -1,7 +1,7 @@
 //! L1 block formatting implementations
 
 use strata_ol_chain_types::AsmManifest;
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::l1::{L1BlockId, L1Height};
 
 use super::{helpers::porcelain_field, traits::Formattable};
 
@@ -9,7 +9,7 @@ use super::{helpers::porcelain_field, traits::Formattable};
 #[derive(serde::Serialize)]
 pub(crate) struct L1BlockInfo<'a> {
     pub block_id: &'a L1BlockId,
-    pub height: u64,
+    pub height: L1Height,
     pub logs_count: usize,
 }
 
@@ -27,11 +27,11 @@ impl<'a> L1BlockInfo<'a> {
 /// L1 summary information displayed to the user
 #[derive(serde::Serialize)]
 pub(crate) struct L1SummaryInfo {
-    pub tip_height: u64,
+    pub tip_height: L1Height,
     pub tip_block_id: String,
-    pub from_height: u64,
+    pub from_height: L1Height,
     pub from_block_id: String,
-    pub expected_block_count: u64,
+    pub expected_block_count: u32,
     pub all_manifests_present: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub missing_blocks: Vec<MissingBlockInfo>,
@@ -40,7 +40,7 @@ pub(crate) struct L1SummaryInfo {
 /// Information about missing blocks
 #[derive(serde::Serialize)]
 pub(crate) struct MissingBlockInfo {
-    pub height: u64,
+    pub height: L1Height,
     pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_id: Option<String>,

--- a/bin/strata-dbtool/src/output/l2.rs
+++ b/bin/strata-dbtool/src/output/l2.rs
@@ -2,7 +2,7 @@
 
 use strata_db_types::traits::BlockStatus;
 use strata_ol_chain_types::{L2Header, SignedL2BlockHeader};
-use strata_primitives::{l1::L1BlockId, l2::L2BlockId};
+use strata_primitives::{l1::L1BlockId, l2::L2BlockId, L1Height};
 
 use super::{
     helpers::{porcelain_field, porcelain_optional},
@@ -15,7 +15,7 @@ pub(crate) struct L2BlockInfo<'a> {
     pub id: &'a L2BlockId,
     pub status: &'a BlockStatus,
     pub header: &'a SignedL2BlockHeader,
-    pub l1_segment: Vec<(u64, &'a L1BlockId)>,
+    pub l1_segment: Vec<(L1Height, &'a L1BlockId)>,
 }
 
 /// L2 Summary information displayed to the user

--- a/bin/strata-dbtool/src/output/syncinfo.rs
+++ b/bin/strata-dbtool/src/output/syncinfo.rs
@@ -2,7 +2,7 @@
 
 use strata_db_types::traits::BlockStatus;
 use strata_primitives::{
-    l1::L1BlockId,
+    l1::{L1BlockId, L1Height},
     l2::L2BlockId,
     prelude::{EpochCommitment, L1BlockCommitment, L2BlockCommitment},
 };
@@ -12,7 +12,7 @@ use super::{helpers::porcelain_field, traits::Formattable};
 /// Sync information displayed to the user
 #[derive(serde::Serialize)]
 pub(crate) struct SyncInfo<'a> {
-    pub l1_tip_height: u64,
+    pub l1_tip_height: L1Height,
     pub l1_tip_block_id: &'a L1BlockId,
     pub l2_tip_height: u64,
     pub l2_tip_block_id: &'a L2BlockId,
@@ -143,9 +143,9 @@ mod tests {
         L2BlockCommitment::new(slot, block_id)
     }
 
-    fn create_test_l1_block_commitment(height: u64) -> L1BlockCommitment {
+    fn create_test_l1_block_commitment(height: L1Height) -> L1BlockCommitment {
         let block_id = create_test_l1_block_id();
-        L1BlockCommitment::from_height_u64(height, block_id).expect("height should be valid")
+        L1BlockCommitment::new(height, block_id)
     }
 
     #[test]

--- a/bin/strata/src/helpers.rs
+++ b/bin/strata/src/helpers.rs
@@ -53,6 +53,6 @@ pub(crate) fn rollup_to_btcio_params(rollup: &RollupParams) -> BtcioParams {
     BtcioParams::new(
         rollup.l1_reorg_safe_depth,
         rollup.magic_bytes,
-        rollup.genesis_l1_view.height_u64(),
+        rollup.genesis_l1_view.height(),
     )
 }

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use ssz::Encode;
-use strata_identifiers::{AccountId, Epoch, EpochCommitment, OLBlockCommitment, OLBlockId, OLTxId};
+use strata_identifiers::{
+    AccountId, Epoch, EpochCommitment, L1Height, OLBlockCommitment, OLBlockId, OLTxId,
+};
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_ol_chain_types_new::OLBlock;
 use strata_ol_mempool::{MempoolHandle, OLMempoolTransaction};
@@ -347,7 +349,7 @@ impl OLClientRpcServer for OLRpcServer {
             .ok_or_else(|| not_found_error(format!("No epoch commitment found for epoch {epoch}")))
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: u64) -> RpcResult<Option<HexBytes32>> {
+    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> RpcResult<Option<HexBytes32>> {
         let manifest = self
             .storage
             .l1()

--- a/crates/alpen-ee/common/src/traits/ol_client.rs
+++ b/crates/alpen-ee/common/src/traits/ol_client.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use strata_identifiers::{Epoch, EpochCommitment, Hash, OLBlockCommitment};
+use strata_identifiers::{Epoch, EpochCommitment, Hash, L1Height, OLBlockCommitment};
 use strata_snark_acct_types::{MessageEntry, ProofState, Seqno, SnarkAccountUpdate};
 use thiserror::Error;
 
@@ -86,7 +86,7 @@ pub trait SequencerOLClient {
     /// Retrieves the canonical L1 header commitment for an L1 block height.
     ///
     /// The returned hash is the exact MMR leaf value used by OL ledger-ref verification.
-    async fn get_l1_header_commitment(&self, l1_height: u64) -> Result<Hash, OLClientError>;
+    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError>;
 
     /// Submits an account update with proof to the OL chain sequencer.
     async fn submit_update(&self, update: SnarkAccountUpdate) -> Result<(), OLClientError>;

--- a/crates/alpen-ee/da/src/envelope_provider.rs
+++ b/crates/alpen-ee/da/src/envelope_provider.rs
@@ -12,13 +12,13 @@ use eyre::{bail, ensure};
 use strata_btc_types::Buf32BitcoinExt;
 use strata_btcio::writer::chunked_envelope::ChunkedEnvelopeHandle;
 use strata_db_types::types::{ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxStatus};
-use strata_identifiers::{L1BlockCommitment, L1BlockId};
+use strata_identifiers::{L1BlockCommitment, L1BlockId, L1Height};
 use strata_l1_txfmt::MagicBytes;
 use strata_primitives::buf::Buf32;
 use tracing::*;
 
 /// Groups reveal txs by L1 block for [`L1DaBlockRef`] construction.
-type BlockMap = HashMap<(Buf32, u64), Vec<(Txid, Wtxid)>>;
+type BlockMap = HashMap<(Buf32, L1Height), Vec<(Txid, Wtxid)>>;
 
 /// [`BatchDaProvider`] that posts DA via chunked envelope inscription.
 pub struct ChunkedEnvelopeDaProvider {
@@ -154,12 +154,11 @@ impl ChunkedEnvelopeDaProvider {
         let mut refs: Vec<L1DaBlockRef> = block_map
             .into_iter()
             .map(|((hash, height), txns)| {
-                let commitment = L1BlockCommitment::from_height_u64(height, L1BlockId::from(hash))
-                    .expect("valid block height");
+                let commitment = L1BlockCommitment::new(height, L1BlockId::from(hash));
                 L1DaBlockRef::new(commitment, txns)
             })
             .collect();
-        refs.sort_by_key(|r| r.block.height_u64());
+        refs.sort_by_key(|r| r.block.height());
 
         Ok(refs)
     }

--- a/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
@@ -8,6 +8,7 @@ use futures::{future::try_join_all, FutureExt};
 use strata_acct_types::Hash;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::UpdateExtraData;
+use strata_identifiers::L1Height;
 use strata_snark_acct_types::{
     AccumulatorClaim, LedgerRefs, OutputMessage, OutputTransfer, ProofState, SnarkAccountUpdate,
     UpdateOperationData, UpdateOutputs,
@@ -59,11 +60,8 @@ pub(super) async fn build_update_from_batch(
 async fn fetch_l1_header_commitments_by_height(
     da_refs: &[L1DaBlockRef],
     ol_client: &impl SequencerOLClient,
-) -> Result<HashMap<u64, Hash>> {
-    let mut heights: Vec<u64> = da_refs
-        .iter()
-        .map(|da_ref| da_ref.block.height_u64())
-        .collect();
+) -> Result<HashMap<L1Height, Hash>> {
+    let mut heights: Vec<L1Height> = da_refs.iter().map(|da_ref| da_ref.block.height()).collect();
     heights.sort_unstable();
     heights.dedup();
 
@@ -85,7 +83,7 @@ async fn fetch_l1_header_commitments_by_height(
 fn build_update_operation(
     seq_no: u64,
     da_refs: &[L1DaBlockRef],
-    l1_header_commitments: &HashMap<u64, Hash>,
+    l1_header_commitments: &HashMap<L1Height, Hash>,
     blocks: Vec<ExecBlockRecord>,
 ) -> Result<UpdateOperationData> {
     // 1. Get info from final block
@@ -135,12 +133,12 @@ fn build_update_operation(
     let mut l1_header_refs: Vec<AccumulatorClaim> = da_refs
         .iter()
         .map(|da_ref| {
-            let height = da_ref.block.height_u64();
+            let height = da_ref.block.height();
             let hash = l1_header_commitments
                 .get(&height)
                 .copied()
                 .ok_or_else(|| eyre!("missing L1 header commitment for L1 height {height}"))?;
-            Ok(AccumulatorClaim::new(height, *hash.as_ref()))
+            Ok(AccumulatorClaim::new(height as u64, *hash.as_ref()))
         })
         .collect::<Result<Vec<_>>>()?;
     // Canonicalize by height before dedup: multiple DA txns may land in the same L1 block.

--- a/crates/asm/manifest-types/src/manifest.rs
+++ b/crates/asm/manifest-types/src/manifest.rs
@@ -2,7 +2,7 @@
 use arbitrary::Arbitrary;
 use ssz_types::FixedBytes;
 use strata_crypto::hash;
-use strata_identifiers::{L1BlockId, WtxidsRoot};
+use strata_identifiers::{L1BlockId, L1Height, WtxidsRoot};
 use tree_hash::{Sha256Hasher, TreeHash};
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 impl AsmManifest {
     /// Creates a new ASM manifest.
     pub fn new(
-        height: u64,
+        height: L1Height,
         blkid: L1BlockId,
         wtxids_root: WtxidsRoot,
         logs: Vec<AsmLogEntry>,
@@ -27,7 +27,7 @@ impl AsmManifest {
     }
 
     /// Returns the L1 block height.
-    pub fn height(&self) -> u64 {
+    pub fn height(&self) -> L1Height {
         self.height
     }
 
@@ -64,7 +64,7 @@ strata_identifiers::impl_borsh_via_ssz!(AsmManifest);
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for AsmManifest {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let height = u64::arbitrary(u)?;
+        let height = u32::arbitrary(u)?;
         let blkid = L1BlockId::arbitrary(u)?;
         let wtxids_root = WtxidsRoot::arbitrary(u)?;
 
@@ -127,7 +127,7 @@ mod tests {
 
     fn asm_manifest_strategy() -> impl Strategy<Value = AsmManifest> {
         (
-            any::<u64>(),
+            any::<u32>(),
             l1_block_id_strategy(),
             wtxids_root_strategy(),
             prop::collection::vec(asm_log_entry_strategy(), 0..10),

--- a/crates/asm/manifest-types/ssz/manifest.ssz
+++ b/crates/asm/manifest-types/ssz/manifest.ssz
@@ -10,7 +10,7 @@ MAX_LOGS_PER_MANIFEST = 1 << 10
 #~# derive: Serialize, Deserialize
 class AsmManifest(Container):
     ### The L1 block height
-    height: uint64
+    height: strata_identifiers.L1Height
 
     ### The L1 block identifier, essentially a bitcoin::BlockHash
     blkid: strata_identifiers.L1BlockId

--- a/crates/asm/params/src/params.rs
+++ b/crates/asm/params/src/params.rs
@@ -132,7 +132,7 @@ mod tests {
 
         // Verify key fields
         assert_eq!(params.magic, MagicBytes::new(*b"ALPN"));
-        assert_eq!(params.l1_view.blk.height_u32(), 50462976);
+        assert_eq!(params.l1_view.blk.height(), 50462976);
         assert_eq!(params.subprotocols.len(), 3);
     }
 }

--- a/crates/asm/stf/src/stf.rs
+++ b/crates/asm/stf/src/stf.rs
@@ -66,7 +66,7 @@ pub fn compute_asm_transition<'i, S: AsmSpec>(
     // 5. Construct the manifest with the logs.
     let (sections, logs) = manager.export_sections_and_logs();
     let manifest = AsmManifest::new(
-        current_l1ref.height_u64(),
+        current_l1ref.height(),
         *current_l1ref.blkid(),
         input.wtxids_root.into(),
         logs,

--- a/crates/asm/subprotocols/admin/src/handler.rs
+++ b/crates/asm/subprotocols/admin/src/handler.rs
@@ -8,7 +8,7 @@ use strata_asm_txs_admin::{
     parser::SignedPayload,
 };
 use strata_predicate::PredicateKey;
-use strata_primitives::buf::Buf32;
+use strata_primitives::{L1Height, buf::Buf32};
 
 use crate::{
     error::AdministrationError, queued_update::QueuedUpdate, state::AdministrationSubprotoState,
@@ -25,7 +25,7 @@ use crate::{
 pub(crate) fn handle_pending_updates(
     state: &mut AdministrationSubprotoState,
     relayer: &mut impl MsgRelayer,
-    current_height: u64,
+    current_height: L1Height,
 ) {
     // Get all the update actions that are ready to be enacted
     let queued_updates = state.process_queued(current_height);
@@ -100,7 +100,7 @@ pub(crate) fn handle_pending_updates(
 pub(crate) fn handle_action(
     state: &mut AdministrationSubprotoState,
     payload: SignedPayload,
-    current_height: u64,
+    current_height: L1Height,
     relayer: &mut impl MsgRelayer,
 ) -> Result<(), AdministrationError> {
     // Determine the required role based on the action type
@@ -139,7 +139,7 @@ pub(crate) fn handle_action(
                 }
                 action => {
                     // For all other update types, add to the queue with a future activation height
-                    let activation_height = current_height + state.confirmation_depth() as u64;
+                    let activation_height = current_height + state.confirmation_depth() as u32;
                     let queued_update = QueuedUpdate::new(id, action, activation_height);
                     state.enqueue(queued_update);
                 }
@@ -340,7 +340,7 @@ mod tests {
 
             assert_eq!(
                 queued_update.activation_height(),
-                current_height + params.confirmation_depth as u64
+                current_height + params.confirmation_depth as u32
             );
         }
     }

--- a/crates/asm/subprotocols/admin/src/queued_update.rs
+++ b/crates/asm/subprotocols/admin/src/queued_update.rs
@@ -1,16 +1,17 @@
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_asm_txs_admin::actions::{UpdateAction, UpdateId};
+use strata_primitives::L1Height;
 
 #[derive(Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize)]
 pub struct QueuedUpdate {
     id: UpdateId,
     action: UpdateAction,
-    activation_height: u64,
+    activation_height: L1Height,
 }
 
 impl QueuedUpdate {
-    pub fn new(id: UpdateId, action: UpdateAction, activation_height: u64) -> Self {
+    pub fn new(id: UpdateId, action: UpdateAction, activation_height: L1Height) -> Self {
         Self {
             id,
             action,
@@ -26,7 +27,7 @@ impl QueuedUpdate {
         &self.action
     }
 
-    pub fn activation_height(&self) -> u64 {
+    pub fn activation_height(&self) -> L1Height {
         self.activation_height
     }
 

--- a/crates/asm/subprotocols/admin/src/state.rs
+++ b/crates/asm/subprotocols/admin/src/state.rs
@@ -4,6 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use strata_asm_params::{AdministrationInitConfig, Role};
 use strata_asm_txs_admin::actions::UpdateId;
 use strata_crypto::threshold_signature::ThresholdConfigUpdate;
+use strata_primitives::L1Height;
 
 use crate::{
     authority::MultisigAuthority, error::AdministrationError, queued_update::QueuedUpdate,
@@ -121,7 +122,7 @@ impl AdministrationSubprotoState {
 
     /// Process all queued updates and remove any whose `activation_height` equals `current_height`
     /// from `queued`.
-    pub fn process_queued(&mut self, current_height: u64) -> Vec<QueuedUpdate> {
+    pub fn process_queued(&mut self, current_height: L1Height) -> Vec<QueuedUpdate> {
         let (ready, rest): (Vec<_>, Vec<_>) = take(&mut self.queued)
             .into_iter()
             .partition(|u| u.activation_height() <= current_height);
@@ -142,6 +143,7 @@ mod tests {
         keys::compressed::CompressedPublicKey,
         threshold_signature::{ThresholdConfig, ThresholdConfigUpdate},
     };
+    use strata_primitives::L1Height;
     use strata_test_utils::ArbitraryGenerator;
 
     use crate::{queued_update::QueuedUpdate, state::AdministrationSubprotoState};
@@ -204,7 +206,7 @@ mod tests {
     }
 
     /// Helper to seed queued updates with specific activation heights
-    fn seed_queued(ids: &[u32], activation_heights: &[u64]) -> AdministrationSubprotoState {
+    fn seed_queued(ids: &[u32], activation_heights: &[L1Height]) -> AdministrationSubprotoState {
         let mut arb = ArbitraryGenerator::new();
         let config = create_test_config();
         let mut state = AdministrationSubprotoState::new(&config);
@@ -220,7 +222,7 @@ mod tests {
     #[test]
     fn test_process_queued_table() {
         struct Case {
-            current: u64,
+            current: u32,
             want_queued: Vec<u32>,
             want_ready: Vec<u32>,
         }

--- a/crates/asm/subprotocols/admin/src/subprotocol.rs
+++ b/crates/asm/subprotocols/admin/src/subprotocol.rs
@@ -48,7 +48,7 @@ impl Subprotocol for AdministrationSubprotocol {
         _verified_aux_data: &VerifiedAuxData,
         relayer: &mut impl MsgRelayer,
     ) {
-        let current_height = l1ref.height_u64();
+        let current_height = l1ref.height();
 
         // Phase 1: Execute any pending updates that have reached their activation height
         handle_pending_updates(state, relayer, current_height);

--- a/crates/asm/subprotocols/checkpoint-v0/src/subprotocol.rs
+++ b/crates/asm/subprotocols/checkpoint-v0/src/subprotocol.rs
@@ -18,7 +18,7 @@ use strata_asm_txs_checkpoint_v0::{
 };
 use strata_identifiers::L1BlockCommitment;
 use strata_predicate::PredicateKey;
-use strata_primitives::{block_credential::CredRule, buf::Buf32, l1::BitcoinTxid};
+use strata_primitives::{L1Height, block_credential::CredRule, buf::Buf32, l1::BitcoinTxid};
 
 use crate::{
     error::{CheckpointV0Error, CheckpointV0Result},
@@ -77,7 +77,7 @@ impl Subprotocol for CheckpointV0Subproto {
         _verified_aux_data: &VerifiedAuxData,
         relayer: &mut impl MsgRelayer,
     ) {
-        let current_l1_height_u64 = l1ref.height() as u64;
+        let current_l1_height_u64 = l1ref.height();
 
         for tx in txs {
             let tx_type = tx.tag().tx_type();
@@ -145,7 +145,7 @@ impl Subprotocol for CheckpointV0Subproto {
 fn process_checkpoint_transaction_v0(
     state: &mut CheckpointV0VerifierState,
     tx: &TxInputRef<'_>,
-    current_l1_height: u64,
+    current_l1_height: L1Height,
     relayer: &mut impl MsgRelayer,
 ) -> CheckpointV0Result<bool> {
     // 1. Extract signed checkpoint from SPS-50 envelope
@@ -230,18 +230,12 @@ fn apply_rollup_vk_update(state: &mut CheckpointV0VerifierState, new_predicate: 
 
 #[cfg(test)]
 mod tests {
-    use strata_primitives::{
-        block_credential::CredRule,
-        buf::Buf32,
-        l1::{L1BlockCommitment, L1BlockId},
-    };
+    use strata_primitives::{block_credential::CredRule, buf::Buf32, l1::L1BlockCommitment};
 
     use super::*;
 
     fn test_params() -> CheckpointV0InitConfig {
-        let genesis_commitment =
-            L1BlockCommitment::from_height_u64(0, L1BlockId::from(Buf32::default()))
-                .expect("genesis height should be valid");
+        let genesis_commitment = L1BlockCommitment::default();
         let verification_params = CheckpointV0VerificationParams {
             genesis_l1_block: genesis_commitment,
             cred_rule: CredRule::Unchecked,

--- a/crates/asm/subprotocols/checkpoint-v0/src/types.rs
+++ b/crates/asm/subprotocols/checkpoint-v0/src/types.rs
@@ -10,7 +10,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use strata_checkpoint_types::Checkpoint;
 use strata_identifiers::Epoch;
 use strata_predicate::PredicateKey;
-use strata_primitives::{block_credential::CredRule, buf::Buf32, l1::L1BlockCommitment};
+use strata_primitives::{L1Height, block_credential::CredRule, buf::Buf32, l1::L1BlockCommitment};
 
 /// Checkpoint verifier state for checkpoint v0
 ///
@@ -22,7 +22,7 @@ pub struct CheckpointV0VerifierState {
     pub last_checkpoint: Option<Checkpoint>,
 
     /// Last L1 block where we got a valid checkpoint
-    pub last_checkpoint_l1_height: u64,
+    pub last_checkpoint_l1_height: L1Height,
 
     /// Current epoch we've verified up to
     pub current_verified_epoch: Epoch,
@@ -57,7 +57,7 @@ impl CheckpointV0VerifierState {
     pub fn new(params: &CheckpointV0VerificationParams) -> Self {
         Self {
             last_checkpoint: None,
-            last_checkpoint_l1_height: params.genesis_l1_block.height_u64(),
+            last_checkpoint_l1_height: params.genesis_l1_block.height(),
             current_verified_epoch: 0,
             cred_rule: params.cred_rule.clone(),
             predicate: params.predicate.clone(),
@@ -65,7 +65,7 @@ impl CheckpointV0VerifierState {
     }
 
     /// Update state with a newly verified checkpoint
-    pub fn update_with_checkpoint(&mut self, checkpoint: Checkpoint, l1_height: u64) {
+    pub fn update_with_checkpoint(&mut self, checkpoint: Checkpoint, l1_height: L1Height) {
         let epoch = checkpoint.batch_info().epoch();
         self.last_checkpoint = Some(checkpoint);
         self.last_checkpoint_l1_height = l1_height;

--- a/crates/asm/subprotocols/checkpoint-v0/src/verification.rs
+++ b/crates/asm/subprotocols/checkpoint-v0/src/verification.rs
@@ -11,6 +11,7 @@ use strata_asm_common::logging;
 use strata_checkpoint_types::{
     BatchTransition, Checkpoint, SignedCheckpoint, verify_signed_checkpoint_sig,
 };
+use strata_primitives::L1Height;
 
 use crate::{error::CheckpointV0Error, types::CheckpointV0VerifierState};
 
@@ -24,7 +25,7 @@ use crate::{error::CheckpointV0Error, types::CheckpointV0VerifierState};
 pub fn process_checkpoint_v0(
     state: &mut CheckpointV0VerifierState,
     signed_checkpoint: &SignedCheckpoint,
-    current_l1_height: u64,
+    current_l1_height: L1Height,
 ) -> Result<(), CheckpointV0Error> {
     let checkpoint = signed_checkpoint.checkpoint();
     let epoch = checkpoint.batch_info().epoch();

--- a/crates/asm/subprotocols/checkpoint/src/subprotocol.rs
+++ b/crates/asm/subprotocols/checkpoint/src/subprotocol.rs
@@ -69,7 +69,7 @@ impl Subprotocol for CheckpointSubprotocol {
         verified_aux_data: &VerifiedAuxData,
         relayer: &mut impl MsgRelayer,
     ) {
-        let current_l1_height = l1ref.height_u32();
+        let current_l1_height = l1ref.height();
 
         for tx in txs {
             if tx.tag().tx_type() == OL_STF_CHECKPOINT_TX_TYPE {

--- a/crates/asm/worker/src/aux_resolver.rs
+++ b/crates/asm/worker/src/aux_resolver.rs
@@ -170,7 +170,7 @@ impl<'a> AuxDataResolver<'a> {
 
         debug!(count = ranges.len(), "Resolving manifest hash ranges");
 
-        let genesis_height = self.l1_genesis.height_u64();
+        let genesis_height = self.l1_genesis.height() as u64;
 
         let mut resolved = Vec::new();
 

--- a/crates/asm/worker/src/service.rs
+++ b/crates/asm/worker/src/service.rs
@@ -67,11 +67,8 @@ impl<W: WorkerContext + Send + Sync + 'static> SyncService for AsmWorkerService<
         while pivot_anchor.is_err() && pivot_block.height() >= genesis_height {
             let block = ctx.get_l1_block(pivot_block.blkid())?;
             let parent_height = pivot_block.height() - 1;
-            let parent_block_id = L1BlockCommitment::from_height_u64(
-                parent_height as u64,
-                block.header.prev_blockhash.to_l1_block_id(),
-            )
-            .expect("parent height should be valid");
+            let parent_block_id =
+                L1BlockCommitment::new(parent_height, block.header.prev_blockhash.to_l1_block_id());
 
             // Push the unprocessed block.
             skipped_blocks.push((block, pivot_block));
@@ -126,7 +123,7 @@ impl<W: WorkerContext + Send + Sync + 'static> SyncService for AsmWorkerService<
                 .into();
 
             let genesis_manifest = strata_asm_common::AsmManifest::new(
-                pivot_block.height_u64(),
+                pivot_block.height(),
                 *pivot_block.blkid(),
                 wtxids_root.into(),
                 vec![], // TODO: this is not supposed to be empty right?

--- a/crates/asm/worker/src/state.rs
+++ b/crates/asm/worker/src/state.rs
@@ -62,7 +62,7 @@ impl<W: WorkerContext + Send + Sync + 'static> AsmWorkerServiceState<W> {
                 // Create genesis anchor state.
                 let genesis_l1_view = &self.asm_params.l1_view;
                 let empty_accumulator =
-                    AsmHistoryAccumulatorState::new(genesis_l1_view.height_u64());
+                    AsmHistoryAccumulatorState::new(genesis_l1_view.height() as u64);
                 let state = AnchorState {
                     chain_view: ChainViewState {
                         pow_state: HeaderVerificationState::new(

--- a/crates/btc-types/src/genesis.rs
+++ b/crates/btc-types/src/genesis.rs
@@ -16,10 +16,6 @@ impl GenesisL1View {
         self.blk.height()
     }
 
-    pub fn height_u64(&self) -> u64 {
-        self.blk.height_u64()
-    }
-
     pub fn blkid(&self) -> L1BlockId {
         *self.blk.blkid()
     }

--- a/crates/btc-types/src/lib.rs
+++ b/crates/btc-types/src/lib.rs
@@ -12,6 +12,3 @@ pub use convert::*;
 pub use errors::*;
 pub use genesis::*;
 pub use params::*;
-
-/// L1 block height type.
-pub type L1Height = u32;

--- a/crates/btc-verification/src/header_verification.rs
+++ b/crates/btc-verification/src/header_verification.rs
@@ -6,7 +6,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_btc_types::{BtcParams, GenesisL1View};
 use strata_crypto::hash::compute_borsh_hash;
-use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId};
+use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId, L1Height};
 use thiserror::Error;
 
 use crate::{BtcWork, timestamp_store::TimestampStore, utils_btc::compute_block_hash};
@@ -263,9 +263,15 @@ impl HeaderVerificationState {
 ///   the second, and so on.
 /// * `start` - The starting height from which to calculate.
 /// * `params` - [`Params`] of the bitcoin network in use
-pub fn get_relative_difficulty_adjustment_height(idx: u64, start: u64, params: &Params) -> u64 {
-    let difficulty_adjustment_interval = params.difficulty_adjustment_interval();
-    ((start / difficulty_adjustment_interval) + idx) * difficulty_adjustment_interval
+pub fn get_relative_difficulty_adjustment_height(
+    idx: usize,
+    start: L1Height,
+    params: &Params,
+) -> L1Height {
+    // `difficulty_adjustment_interval()` returns `u64` but the value is always less than u32, so
+    // the cast is safe. Upstream rust-bitcoin has since changed the return type to `u32` in https://github.com/rust-bitcoin/rust-bitcoin/commit/943a7863c8baeed9e06342fa98e67b390bedec43.
+    let difficulty_adjustment_interval = params.difficulty_adjustment_interval() as u32;
+    ((start / difficulty_adjustment_interval) + idx as u32) * difficulty_adjustment_interval
 }
 
 #[cfg(test)]
@@ -274,6 +280,7 @@ mod tests {
     use bitcoin::{BlockHash, CompactTarget, hashes::Hash, params::MAINNET};
     use borsh::{BorshDeserialize, BorshSerialize};
     use rand::{Rng, rngs::OsRng};
+    use strata_identifiers::L1Height;
     use strata_test_utils_btc::segment::BtcChainSegment;
 
     use crate::*;
@@ -294,10 +301,13 @@ mod tests {
 
     #[test]
     fn test_get_difficulty_adjustment_height() {
-        let start = 0;
-        let idx = OsRng.gen_range(1..1000);
+        let start: L1Height = 0;
+        let idx = OsRng.gen_range(1..1000usize);
         let h = get_relative_difficulty_adjustment_height(idx, start, &MAINNET);
-        assert_eq!(h, MAINNET.difficulty_adjustment_interval() * idx);
+        assert_eq!(
+            h,
+            MAINNET.difficulty_adjustment_interval() as u32 * idx as u32
+        );
     }
 
     #[test]
@@ -469,10 +479,7 @@ mod tests {
         }
 
         // Verify we successfully crossed the boundary
-        assert_eq!(
-            verification_state.last_verified_block.height(),
-            end_height as u32
-        );
+        assert_eq!(verification_state.last_verified_block.height(), end_height);
     }
 
     /// Test that epoch_start_timestamp is correctly tracked across multiple adjustments.
@@ -602,7 +609,7 @@ mod tests {
     #[test]
     fn test_difficulty_adjustment_height_calculation() {
         let params = &MAINNET;
-        let interval = params.difficulty_adjustment_interval();
+        let interval = params.difficulty_adjustment_interval() as L1Height;
 
         // Test various starting points and adjustment indices
         assert_eq!(

--- a/crates/btcio/src/broadcaster/task.rs
+++ b/crates/btcio/src/broadcaster/task.rs
@@ -163,9 +163,9 @@ async fn check_tx_confirmations(
                     .block_hash
                     .expect("confirmed tx must have block_hash")
                     .to_buf32();
-                let block_height =
-                    info.block_height
-                        .expect("confirmed tx must have block_height") as u64;
+                let block_height = info
+                    .block_height
+                    .expect("confirmed tx must have block_height");
 
                 if confirmations >= reorg_safe_depth {
                     Ok(L1TxStatus::Finalized {

--- a/crates/btcio/src/params.rs
+++ b/crates/btcio/src/params.rs
@@ -3,6 +3,7 @@
 //! This module provides [`BtcioParams`] which contains the subset of rollup parameters
 //! needed by btcio components.
 
+use strata_identifiers::L1Height;
 use strata_l1_txfmt::MagicBytes;
 
 /// Parameters required by btcio components for L1 interaction.
@@ -18,12 +19,16 @@ pub struct BtcioParams {
     pub magic_bytes: MagicBytes,
 
     /// Genesis L1 block height (the first L1 block the rollup cares about).
-    pub genesis_l1_height: u64,
+    pub genesis_l1_height: L1Height,
 }
 
 impl BtcioParams {
     /// Creates a new [`BtcioParams`] with the given values.
-    pub fn new(l1_reorg_safe_depth: u32, magic_bytes: MagicBytes, genesis_l1_height: u64) -> Self {
+    pub fn new(
+        l1_reorg_safe_depth: u32,
+        magic_bytes: MagicBytes,
+        genesis_l1_height: L1Height,
+    ) -> Self {
         Self {
             l1_reorg_safe_depth,
             magic_bytes,
@@ -42,7 +47,7 @@ impl BtcioParams {
     }
 
     /// Returns the genesis L1 block height.
-    pub fn genesis_l1_height(&self) -> u64 {
+    pub fn genesis_l1_height(&self) -> L1Height {
         self.genesis_l1_height
     }
 }

--- a/crates/btcio/src/reader/event.rs
+++ b/crates/btcio/src/reader/event.rs
@@ -1,5 +1,6 @@
 use bitcoin::Block;
 use strata_identifiers::{Epoch, L1BlockCommitment};
+use strata_primitives::L1Height;
 
 /// L1 events that we observe and want the persistence task to work on.
 #[derive(Clone, Debug)]
@@ -17,18 +18,18 @@ pub(crate) enum L1Event {
 #[derive(Clone, Debug)]
 pub(crate) struct BlockData {
     /// Block number.
-    block_num: u64,
+    block_num: L1Height,
 
     /// Raw block data.
     block: Block,
 }
 
 impl BlockData {
-    pub(crate) fn new(block_num: u64, block: Block) -> Self {
+    pub(crate) fn new(block_num: L1Height, block: Block) -> Self {
         Self { block_num, block }
     }
 
-    pub(crate) fn block_num(&self) -> u64 {
+    pub(crate) fn block_num(&self) -> L1Height {
         self.block_num
     }
 

--- a/crates/btcio/src/reader/handler.rs
+++ b/crates/btcio/src/reader/handler.rs
@@ -18,7 +18,7 @@ pub(crate) async fn handle_bitcoin_event<R: Reader>(
         L1Event::RevertTo(block) => {
             // L1 reorgs will be handled in L2 STF, we just have to reflect
             // what the client is telling us in the database.
-            let height = block.height_u64();
+            let height = block.height();
             ctx.storage
                 .l1()
                 .revert_canonical_chain_async(height)
@@ -70,7 +70,5 @@ async fn handle_blockdata<R: Reader>(
     info!(%height, %l1blockid, "stored L1 chain tracking data");
 
     // Create a sync event - the ASM worker will listen to this and create manifests
-    Ok(Option::Some(
-        L1BlockCommitment::from_height_u64(height, l1blockid).expect("valid height"),
-    ))
+    Ok(Option::Some(L1BlockCommitment::new(height, l1blockid)))
 }

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -12,7 +12,7 @@ use strata_btc_verification::{get_relative_difficulty_adjustment_height, HeaderV
 use strata_config::btcio::ReaderConfig;
 use strata_primitives::{
     constants::TIMESTAMPS_FOR_MEDIAN,
-    l1::{BtcParams, GenesisL1View, L1BlockCommitment},
+    l1::{BtcParams, GenesisL1View, L1BlockCommitment, L1Height},
 };
 use strata_state::BlockSubmitter;
 use strata_status::StatusChannel;
@@ -70,8 +70,8 @@ pub async fn bitcoin_data_reader_task<E: BlockSubmitter>(
 /// Calculates target next block to start polling l1 from.
 fn calculate_target_next_block(
     l1_manager: &L1BlockManager,
-    horz_height: u64,
-) -> anyhow::Result<u64> {
+    horz_height: L1Height,
+) -> anyhow::Result<L1Height> {
     // TODO switch to checking the L1 tip in the consensus/client state
     let target_next_block = l1_manager
         .get_canonical_chain_tip()?
@@ -84,7 +84,7 @@ fn calculate_target_next_block(
 /// Inner function that actually does the reading task.
 async fn do_reader_task<R: Reader>(
     ctx: ReaderContext<R>,
-    target_next_block: u64,
+    target_next_block: L1Height,
     event_submitter: &impl BlockSubmitter,
 ) -> anyhow::Result<()> {
     info!(%target_next_block, "started L1 reader task!");
@@ -140,32 +140,32 @@ fn handle_poll_error(err: &anyhow::Error, status_updates: &mut Vec<L1StatusUpdat
 /// Inits the reader state by trying to backfill blocks up to a target height.
 async fn init_reader_state<R: Reader>(
     ctx: &ReaderContext<R>,
-    target_next_block: u64,
+    target_next_block: L1Height,
 ) -> anyhow::Result<ReaderState> {
     // Init the reader state using the blockid we were given, fill in a few blocks back.
     debug!(%target_next_block, "initializing reader state");
     let mut init_queue = VecDeque::new();
 
-    let lookback = ctx.btcio_params.l1_reorg_safe_depth() as usize * 2;
+    let lookback = ctx.btcio_params.l1_reorg_safe_depth() as L1Height * 2;
     let client = ctx.client.as_ref();
     let genesis_height = ctx.btcio_params.genesis_l1_height();
     let pre_genesis = genesis_height.saturating_sub(1);
-    let target = target_next_block as i64;
 
     // Do some math to figure out where our start and end are.
     let chain_info = client.get_blockchain_info().await?;
-    let start_height = (target - lookback as i64)
-        .max(pre_genesis as i64)
-        .min(chain_info.blocks as i64) as u64;
-    let end_height =
-        (chain_info.blocks as u64).min(pre_genesis.max(target_next_block.saturating_sub(1)));
+    let chain_tip = chain_info.blocks as L1Height;
+    let start_height = target_next_block
+        .saturating_sub(lookback)
+        .max(pre_genesis)
+        .min(chain_tip);
+    let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
     debug!(%start_height, %end_height, "queried L1 client, have init range");
 
     // Loop through the range we've determined to be okay and pull the blocks we want to look back
     // through in.
     let mut real_cur_height = start_height;
     for height in start_height..=end_height {
-        let blkid = client.get_block_hash(height).await?;
+        let blkid = client.get_block_hash(height as u64).await?;
         debug!(%height, %blkid, "loaded recent L1 block");
         init_queue.push_back(blkid);
         real_cur_height = height;
@@ -175,7 +175,7 @@ async fn init_reader_state<R: Reader>(
 
     // Note: Transaction filtering is no longer needed since the ASM STF handles
     // parsing L1 blocks and producing manifests with logs.
-    let state = ReaderState::new(real_cur_height + 1, lookback, init_queue, epoch);
+    let state = ReaderState::new(real_cur_height + 1, lookback as usize, init_queue, epoch);
     Ok(state)
 }
 
@@ -189,7 +189,7 @@ async fn poll_for_new_blocks<R: Reader>(
 ) -> anyhow::Result<Vec<L1Event>> {
     let chain_info = ctx.client.get_blockchain_info().await?;
     status_updates.push(L1StatusUpdate::RpcConnected(true));
-    let client_height = chain_info.blocks;
+    let client_height = chain_info.blocks as L1Height;
     let fresh_best_block = chain_info.best_block_hash;
 
     if fresh_best_block == *state.best_block() {
@@ -203,9 +203,7 @@ async fn poll_for_new_blocks<R: Reader>(
     if let Some((pivot_height, pivot_blkid)) = find_pivot_block(ctx.client.as_ref(), state).await? {
         if pivot_height < state.best_block_idx() {
             info!(%pivot_height, %pivot_blkid, "found apparent reorg");
-            let block =
-                L1BlockCommitment::from_height_u64(pivot_height, pivot_blkid.to_l1_block_id())
-                    .expect("valid height");
+            let block = L1BlockCommitment::new(pivot_height, pivot_blkid.to_l1_block_id());
             state.rollback_to_height(pivot_height);
 
             // Return with the revert event immediately
@@ -222,7 +220,7 @@ async fn poll_for_new_blocks<R: Reader>(
 
     // Now process each block we missed.
     let scan_start_height = state.next_height();
-    for fetch_height in scan_start_height..=(client_height as u64) {
+    for fetch_height in scan_start_height..=client_height {
         match fetch_and_process_block(ctx, fetch_height, state, status_updates).await {
             Ok((blkid, ev)) => {
                 // Note: Checkpoint detection is now handled by the ASM STF via logs,
@@ -245,14 +243,14 @@ async fn poll_for_new_blocks<R: Reader>(
 async fn find_pivot_block(
     client: &impl Reader,
     state: &ReaderState,
-) -> anyhow::Result<Option<(u64, BlockHash)>> {
+) -> anyhow::Result<Option<(L1Height, BlockHash)>> {
     for (height, l1blkid) in state.iter_blocks_back() {
         // If at genesis, we can't reorg any farther.
         if height == 0 {
             return Ok(Some((height, *l1blkid)));
         }
 
-        let queried_l1blkid = client.get_block_hash(height).await?;
+        let queried_l1blkid = client.get_block_hash(height as u64).await?;
         trace!(%height, %l1blkid, %queried_l1blkid, "comparing blocks to find pivot");
         if queried_l1blkid == *l1blkid {
             return Ok(Some((height, *l1blkid)));
@@ -265,11 +263,11 @@ async fn find_pivot_block(
 /// Fetches a block at given height, extracts relevant transactions and emits an [`L1Event`].
 async fn fetch_and_process_block<R: Reader>(
     ctx: &ReaderContext<R>,
-    height: u64,
+    height: L1Height,
     state: &mut ReaderState,
     status_updates: &mut Vec<L1StatusUpdate>,
 ) -> anyhow::Result<(BlockHash, L1Event)> {
-    let block = ctx.client.get_block_at(height).await?;
+    let block = ctx.client.get_block_at(height as u64).await?;
     let (evs, l1blkid) = process_block(ctx, state, status_updates, height, block).await?;
 
     // Insert to new block, incrementing cur_height.
@@ -283,7 +281,7 @@ async fn process_block<R: Reader>(
     _ctx: &ReaderContext<R>,
     state: &mut ReaderState,
     status_updates: &mut Vec<L1StatusUpdate>,
-    height: u64,
+    height: L1Height,
     block: Block,
 ) -> anyhow::Result<(L1Event, BlockHash)> {
     let txs = block.txdata.len();
@@ -305,24 +303,23 @@ async fn process_block<R: Reader>(
 }
 
 /// Retrieves the timestamps for a specified number of blocks starting from the given block height,
-/// moving backwards. For each block from `height` down to `height - count + 1`, it fetches the
 /// block’s timestamp. If a block height is less than 1 (i.e. there is no block), it inserts a
 /// placeholder value of 0. The resulting vector is then reversed so that timestamps are returned in
 /// ascending order (oldest first).
 async fn fetch_block_timestamps_ascending(
     client: &impl Reader,
-    height: u64,
+    height: L1Height,
     count: usize,
 ) -> anyhow::Result<Vec<u32>> {
     let mut timestamps = Vec::with_capacity(count);
 
     for i in 0..count {
-        let current_height = height.saturating_sub(i as u64);
+        let current_height = height.saturating_sub(i as u32);
         // If we've gone past block 1, push 0 as a placeholder.
         if current_height < 1 {
             timestamps.push(0);
         } else {
-            let header = client.get_block_header_at(current_height).await?;
+            let header = client.get_block_header_at(current_height as u64).await?;
             timestamps.push(header.time);
         }
     }
@@ -333,7 +330,7 @@ async fn fetch_block_timestamps_ascending(
 
 pub async fn fetch_genesis_l1_view(
     client: &impl Reader,
-    block_height: u64,
+    block_height: L1Height,
 ) -> anyhow::Result<GenesisL1View> {
     // Create BTC parameters based on the current network.
     let network = client.network().await?;
@@ -344,11 +341,11 @@ pub async fn fetch_genesis_l1_view(
     let current_epoch_start_height =
         get_relative_difficulty_adjustment_height(0, block_height, btc_params.inner());
     let current_epoch_start_header = client
-        .get_block_header_at(current_epoch_start_height)
+        .get_block_header_at(current_epoch_start_height as u64)
         .await?;
 
     // Fetch the block header at the height
-    let block_header = client.get_block_header_at(block_height).await?;
+    let block_header = client.get_block_header_at(block_height as u64).await?;
 
     // Fetch timestamps
     let timestamps =
@@ -363,7 +360,7 @@ pub async fn fetch_genesis_l1_view(
     // If (block_height + 1) is the start of the new epoch, we need to calculate the
     // next_block_target, else next_block_target will be current block's target
     let next_block_target =
-        if (block_height + 1).is_multiple_of(btc_params.difficulty_adjustment_interval()) {
+        if (block_height as u64 + 1).is_multiple_of(btc_params.difficulty_adjustment_interval()) {
             CompactTarget::from_next_work_required(
                 block_header.bits,
                 (block_header.time - current_epoch_start_header.time) as u64,
@@ -372,7 +369,7 @@ pub async fn fetch_genesis_l1_view(
             .to_consensus()
         } else {
             client
-                .get_block_header_at(block_height)
+                .get_block_header_at(block_height as u64)
                 .await?
                 .target()
                 .to_compact_lossy()
@@ -381,7 +378,7 @@ pub async fn fetch_genesis_l1_view(
 
     // Build the genesis L1 view structure.
     let genesis_l1_view = GenesisL1View {
-        blk: L1BlockCommitment::from_height_u64(block_height, block_id).expect("valid height"),
+        blk: L1BlockCommitment::new(block_height, block_id),
         next_target: next_block_target,
         epoch_start_timestamp: current_epoch_start_header.time,
         last_11_timestamps: timestamps,
@@ -402,7 +399,7 @@ pub async fn fetch_genesis_l1_view(
 /// block's target.
 pub async fn fetch_verification_state(
     client: &impl Reader,
-    block_height: u64,
+    block_height: L1Height,
 ) -> anyhow::Result<HeaderVerificationState> {
     // Create BTC parameters based on the current network.
     let network = client.network().await?;

--- a/crates/btcio/src/reader/state.rs
+++ b/crates/btcio/src/reader/state.rs
@@ -2,12 +2,13 @@ use std::collections::VecDeque;
 
 use bitcoin::BlockHash;
 use strata_identifiers::Epoch;
+use strata_primitives::L1Height;
 
 /// State we use in various parts of the reader.
 #[derive(Debug)]
 pub(crate) struct ReaderState {
     /// The highest block in the chain, at `.back()` of queue + 1.
-    next_height: u64,
+    next_height: L1Height,
 
     /// The `.back()` of this should have the same height as cur_height.
     recent_blocks: VecDeque<BlockHash>,
@@ -23,7 +24,7 @@ impl ReaderState {
     /// Constructs a new reader state instance using some context about how we
     /// want to manage it.
     pub(crate) fn new(
-        next_height: u64,
+        next_height: L1Height,
         max_depth: usize,
         recent_blocks: VecDeque<BlockHash>,
         epoch: Epoch,
@@ -37,7 +38,7 @@ impl ReaderState {
         }
     }
 
-    pub(crate) fn next_height(&self) -> u64 {
+    pub(crate) fn next_height(&self) -> L1Height {
         self.next_height
     }
 
@@ -49,7 +50,7 @@ impl ReaderState {
         self.recent_blocks.back().unwrap()
     }
 
-    pub(crate) fn best_block_idx(&self) -> u64 {
+    pub(crate) fn best_block_idx(&self) -> L1Height {
         self.next_height - 1
     }
 
@@ -76,7 +77,7 @@ impl ReaderState {
         }
     }
 
-    pub(crate) fn rollback_to_height(&mut self, new_height: u64) -> Vec<BlockHash> {
+    pub(crate) fn rollback_to_height(&mut self, new_height: L1Height) -> Vec<BlockHash> {
         if new_height > self.next_height {
             panic!(
                 "reader: new height {new_height} greater than cur height {}",
@@ -85,7 +86,7 @@ impl ReaderState {
         }
 
         let rollback_cnt = self.best_block_idx() - new_height;
-        if rollback_cnt >= self.recent_blocks.len() as u64 {
+        if rollback_cnt >= self.recent_blocks.len() as u32 {
             panic!("reader: tried to rollback past deepest block");
         }
 
@@ -104,12 +105,12 @@ impl ReaderState {
 
     /// Iterates over the blocks back from the tip, giving both the height and
     /// the blockhash to compare against the chain.
-    pub(crate) fn iter_blocks_back(&self) -> impl Iterator<Item = (u64, &BlockHash)> {
+    pub(crate) fn iter_blocks_back(&self) -> impl Iterator<Item = (L1Height, &BlockHash)> {
         let best_blk_idx = self.best_block_idx();
         self.recent_blocks
             .iter()
             .rev()
             .enumerate()
-            .map(move |(i, b)| (best_blk_idx - i as u64, b))
+            .map(move |(i, b)| (best_blk_idx - i as u32, b))
     }
 }

--- a/crates/btcio/src/status.rs
+++ b/crates/btcio/src/status.rs
@@ -1,9 +1,10 @@
 use bitcoin::Txid;
+use strata_primitives::L1Height;
 use strata_status::StatusChannel;
 
 #[derive(Debug, Clone)]
 pub enum L1StatusUpdate {
-    CurHeight(u64),
+    CurHeight(L1Height),
     LastUpdate(u64),
     RpcConnected(bool),
     RpcError(String),

--- a/crates/chain-worker-new/src/output.rs
+++ b/crates/chain-worker-new/src/output.rs
@@ -77,7 +77,7 @@ mod tests {
         EpochalState::new(
             BitcoinAmount::from_sat(0),
             0,
-            L1BlockCommitment::from_height_u64(0, L1BlockId::from(Buf32::zero())).unwrap(),
+            L1BlockCommitment::new(0, L1BlockId::from(Buf32::zero())),
             EpochCommitment::new(0, 0, OLBlockId::from(Buf32::zero())),
             Mmr64B32::from_generic(&CompactMmr64::new(64)),
             1, // offset = genesis_height(0) + 1

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -321,10 +321,9 @@ impl ChainWorkerServiceState {
 
         // Get L1 info from the write batch (epochal state has latest L1 after manifest sealing)
         let epochal = last_block_output.write_batch().epochal();
-        let new_tip_height = epochal.last_l1_height().into();
+        let new_tip_height = epochal.last_l1_height();
         let new_tip_blkid = epochal.last_l1_blkid();
-        let new_l1_block = L1BlockCommitment::from_height_u64(new_tip_height, *new_tip_blkid)
-            .expect("valid height");
+        let new_l1_block = L1BlockCommitment::new(new_tip_height, *new_tip_blkid);
 
         let epoch_final_state = *last_block_output.computed_state_root();
 

--- a/crates/chain-worker/src/service.rs
+++ b/crates/chain-worker/src/service.rs
@@ -248,8 +248,7 @@ impl<W: WorkerContext + Send + Sync + 'static> ChainWorkerServiceState<W> {
         );
         let new_tip_height = l1seg.new_height();
         let new_tip_blkid = l1seg.new_tip_blkid().expect("fcm: missing l1seg final L1");
-        let new_l1_block = L1BlockCommitment::from_height_u64(new_tip_height, new_tip_blkid)
-            .expect("valid height");
+        let new_l1_block = L1BlockCommitment::new(new_tip_height, new_tip_blkid);
 
         let epoch_final_state = last_block_output.computed_state_root();
 

--- a/crates/chainexec/src/state_access.rs
+++ b/crates/chainexec/src/state_access.rs
@@ -80,9 +80,7 @@ impl StateAccessor for MemStateAccessor {
     }
 
     fn last_l1_block(&self) -> L1BlockCommitment {
-        let l1_view = self.state_cache.state().l1_view();
-        L1BlockCommitment::from_height_u64(l1_view.safe_height(), *l1_view.safe_blkid())
-            .expect("height should be valid")
+        self.state_cache.state().l1_view().get_safe_block()
     }
 
     fn epoch_finishing_flag(&self) -> bool {

--- a/crates/chaintsn/src/checkin.rs
+++ b/crates/chaintsn/src/checkin.rs
@@ -9,7 +9,7 @@ use strata_bridge_types::DepositIntent;
 use strata_identifiers::DepositDescriptor;
 use strata_ol_chain_types::L1Segment;
 use strata_params::RollupParams;
-use strata_primitives::l1::{BitcoinAmount, L1BlockCommitment};
+use strata_primitives::l1::{BitcoinAmount, L1BlockCommitment, L1Height};
 
 use crate::{
     context::{AuxProvider, ProviderError, ProviderResult, StateAccessor},
@@ -24,12 +24,12 @@ use crate::{
 /// pieces of the state transition logic.
 #[derive(Debug, Clone)]
 pub struct SegmentAuxData<'b> {
-    first_height: u64,
+    first_height: L1Height,
     segment: &'b L1Segment,
 }
 
 impl<'b> SegmentAuxData<'b> {
-    pub fn new(first_height: u64, segment: &'b L1Segment) -> Self {
+    pub fn new(first_height: L1Height, segment: &'b L1Segment) -> Self {
         Self {
             first_height,
             segment,
@@ -38,11 +38,11 @@ impl<'b> SegmentAuxData<'b> {
 }
 
 impl<'b> AuxProvider for SegmentAuxData<'b> {
-    fn get_l1_tip_height(&self) -> u64 {
+    fn get_l1_tip_height(&self) -> L1Height {
         self.segment.new_height()
     }
 
-    fn get_l1_block_manifest(&self, height: u64) -> ProviderResult<AsmManifest> {
+    fn get_l1_block_manifest(&self, height: L1Height) -> ProviderResult<AsmManifest> {
         if height < self.first_height {
             return Err(ProviderError::OutOfBounds);
         }
@@ -96,8 +96,7 @@ pub fn process_l1_view_update<'s, S: StateAccessor>(
         process_asm_logs(state, &mf)?;
 
         // Advance the verified L1 tip to the latest manifest we've processed.
-        let verified_blk = L1BlockCommitment::from_height_u64(mf.height(), *mf.blkid())
-            .expect("height should be valid");
+        let verified_blk = L1BlockCommitment::new(mf.height(), *mf.blkid());
         state.update_verified_blk(verified_blk);
     }
 

--- a/crates/chaintsn/src/context.rs
+++ b/crates/chaintsn/src/context.rs
@@ -138,10 +138,10 @@ pub trait StateAccessor {
 /// Provider for queries to sideloaded state like ASM manifests.
 pub trait AuxProvider {
     /// Returns the height of the new tip.
-    fn get_l1_tip_height(&self) -> u64;
+    fn get_l1_tip_height(&self) -> L1Height;
 
     /// Fetches an ASM manifest by height.
-    fn get_l1_block_manifest(&self, height: u64) -> ProviderResult<AsmManifest>;
+    fn get_l1_block_manifest(&self, height: L1Height) -> ProviderResult<AsmManifest>;
 }
 
 pub type ProviderResult<T> = Result<T, ProviderError>;

--- a/crates/checkpoint-types/src/batch.rs
+++ b/crates/checkpoint-types/src/batch.rs
@@ -4,7 +4,7 @@ use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_identifiers::{
-    Buf32, Epoch, EpochCommitment, L1BlockCommitment, L2BlockCommitment, L2BlockId, Slot,
+    Buf32, Epoch, EpochCommitment, L1BlockCommitment, L1Height, L2BlockCommitment, L2BlockId, Slot,
 };
 
 /// Summary generated when we accept the last block of an epoch.
@@ -197,8 +197,8 @@ impl BatchInfo {
     ///
     /// Note: This only checks the upper bound, not the lower bound. It returns `true`
     /// if the height is <= the checkpoint's final L1 height.
-    pub fn l1_height_at_or_before_end(&self, height: u64) -> bool {
+    pub fn l1_height_at_or_before_end(&self, height: L1Height) -> bool {
         let (_, last_l1_commitment) = self.l1_range;
-        height <= last_l1_commitment.height_u64()
+        height <= last_l1_commitment.height()
     }
 }

--- a/crates/consensus-logic/src/asm_worker_context.rs
+++ b/crates/consensus-logic/src/asm_worker_context.rs
@@ -62,7 +62,7 @@ impl WorkerContext for AsmWorkerCtx {
                 if bid == *blockid {
                     return self
                         .handle
-                        .block_on(self.bitcoin_client.get_block_at(height))
+                        .block_on(self.bitcoin_client.get_block_at(height.into()))
                         .map_err(|_| WorkerError::MissingL1Block(*blockid));
                 }
             }

--- a/crates/consensus-logic/src/genesis.rs
+++ b/crates/consensus-logic/src/genesis.rs
@@ -120,7 +120,7 @@ pub fn make_genesis_block(params: &Params) -> L2BlockBundle {
     );
 
     // This has to be empty since everyone should have an unambiguous view of the genesis block.
-    let l1_seg = L1Segment::new_empty(params.rollup().genesis_l1_view.blk.height_u64());
+    let l1_seg = L1Segment::new_empty(params.rollup().genesis_l1_view.blk.height());
 
     // TODO this is a total stub, we have to fill it in with something
     let exec_seg = ExecSegment::new(genesis_update);

--- a/crates/csm-types/src/client_state.rs
+++ b/crates/csm-types/src/client_state.rs
@@ -8,7 +8,7 @@ use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_checkpoint_types::{BatchInfo, BatchTransition};
-use strata_identifiers::{Buf32, Epoch, EpochCommitment, L1BlockCommitment, L1BlockId};
+use strata_identifiers::{Buf32, Epoch, EpochCommitment, L1BlockCommitment, L1BlockId, L1Height};
 
 /// High level client's checkpoint view of the network. This is local to the client, not
 /// coordinated as part of the L2 chain.
@@ -94,7 +94,7 @@ impl CheckpointState {
     }
 
     pub fn has_genesis_occurred(&self) -> bool {
-        self.block.height_u64() > 0
+        self.block.height() > 0
     }
 }
 
@@ -117,8 +117,8 @@ impl CheckpointL1Ref {
         }
     }
 
-    pub fn block_height(&self) -> u64 {
-        self.l1_commitment.height_u64()
+    pub fn block_height(&self) -> L1Height {
+        self.l1_commitment.height()
     }
 
     pub fn block_id(&self) -> &L1BlockId {

--- a/crates/csm-types/src/status.rs
+++ b/crates/csm-types/src/status.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use arbitrary::Arbitrary;
 use serde::{Deserialize, Serialize};
 use strata_btc_types::BitcoinTxid;
+use strata_primitives::L1Height;
 
 /// Data that reflects what's happening around L1
 #[derive(Clone, Serialize, Deserialize, Default, Arbitrary, Debug)]
@@ -16,7 +17,7 @@ pub struct L1Status {
     pub last_rpc_error: Option<String>,
 
     /// Current block height.
-    pub cur_height: u64,
+    pub cur_height: L1Height,
 
     /// Current tip block ID as string.
     pub cur_tip_blkid: String,

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -116,11 +116,11 @@ fn process_checkpoint_tip_log(
         "CSM is processing checkpoint tip update from ASM log"
     );
 
-    let l1_height = u64::from(tip.l1_height());
-    if l1_height != asm_block.height_u64() {
+    let l1_height = tip.l1_height();
+    if l1_height != asm_block.height() {
         debug!(
             tip_l1_height = l1_height,
-            asm_block_height = asm_block.height_u64(),
+            asm_block_height = asm_block.height(),
             "Checkpoint tip L1 height differs from current ASM block height; using ASM block commitment"
         );
     }
@@ -462,7 +462,7 @@ mod tests {
                 (epoch * 10) as u64,
                 L2BlockId::from(Buf32::from([epoch as u8; 32])),
             );
-            let tip = CheckpointTip::new(epoch, asm_block.height_u64() as u32, l2_tip);
+            let tip = CheckpointTip::new(epoch, asm_block.height(), l2_tip);
             let tip_update = CheckpointTipUpdate::new(tip);
             let log = AsmLogEntry::from_log(&tip_update).expect("make tip log");
 

--- a/crates/db/store-sled/src/l1/db.rs
+++ b/crates/db/store-sled/src/l1/db.rs
@@ -1,6 +1,6 @@
 use strata_asm_common::AsmManifest;
 use strata_db_types::{DbResult, traits::*};
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::{L1Height, l1::L1BlockId};
 use typed_sled::batch::SledBatch;
 
 use super::schemas::{L1BlockSchema, L1BlocksByHeightSchema, L1CanonicalBlockSchema};
@@ -18,7 +18,7 @@ define_sled_database!(
 );
 
 impl L1DBSled {
-    pub fn get_latest_block(&self) -> DbResult<Option<(u64, L1BlockId)>> {
+    pub fn get_latest_block(&self) -> DbResult<Option<(L1Height, L1BlockId)>> {
         Ok(self.l1_canonical_tree.last()?)
     }
 }
@@ -44,11 +44,15 @@ impl L1Database for L1DBSled {
             .map_err(to_db_error)
     }
 
-    fn set_canonical_chain_entry(&self, height: u64, blockid: L1BlockId) -> DbResult<()> {
+    fn set_canonical_chain_entry(&self, height: L1Height, blockid: L1BlockId) -> DbResult<()> {
         Ok(self.l1_canonical_tree.insert(&height, &blockid)?)
     }
 
-    fn remove_canonical_chain_entries(&self, start_height: u64, end_height: u64) -> DbResult<()> {
+    fn remove_canonical_chain_entries(
+        &self,
+        start_height: L1Height,
+        end_height: L1Height,
+    ) -> DbResult<()> {
         let mut batch = SledBatch::<L1CanonicalBlockSchema>::new();
         for height in (start_height..=end_height).rev() {
             batch.remove(height)?;
@@ -58,7 +62,7 @@ impl L1Database for L1DBSled {
         Ok(())
     }
 
-    fn prune_to_height(&self, end_height: u64) -> DbResult<()> {
+    fn prune_to_height(&self, end_height: L1Height) -> DbResult<()> {
         let earliest = self.l1_blks_height_tree.first()?.map(first);
         let Some(start_height) = earliest else {
             // empty db
@@ -90,14 +94,14 @@ impl L1Database for L1DBSled {
         Ok(())
     }
 
-    fn get_canonical_chain_tip(&self) -> DbResult<Option<(u64, L1BlockId)>> {
+    fn get_canonical_chain_tip(&self) -> DbResult<Option<(L1Height, L1BlockId)>> {
         self.get_latest_block()
     }
 
     fn get_canonical_blockid_range(
         &self,
-        start_idx: u64,
-        end_idx: u64,
+        start_idx: L1Height,
+        end_idx: L1Height,
     ) -> DbResult<Vec<L1BlockId>> {
         let mut result = Vec::new();
         for height in start_idx..end_idx {
@@ -108,7 +112,7 @@ impl L1Database for L1DBSled {
         Ok(result)
     }
 
-    fn get_canonical_blockid_at_height(&self, height: u64) -> DbResult<Option<L1BlockId>> {
+    fn get_canonical_blockid_at_height(&self, height: L1Height) -> DbResult<Option<L1BlockId>> {
         Ok(self.l1_canonical_tree.get(&height)?)
     }
 

--- a/crates/db/store-sled/src/l1/schemas.rs
+++ b/crates/db/store-sled/src/l1/schemas.rs
@@ -1,5 +1,5 @@
 use strata_asm_common::AsmManifest;
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::{L1Height, l1::L1BlockId};
 
 use crate::{
     define_table_with_default_codec, define_table_with_integer_key, define_table_without_codec,
@@ -13,10 +13,10 @@ define_table_with_default_codec!(
 
 define_table_with_integer_key!(
     /// A table to store canonical view of L1 chain
-    (L1CanonicalBlockSchema) u64 => L1BlockId
+    (L1CanonicalBlockSchema) L1Height => L1BlockId
 );
 
 define_table_with_integer_key!(
     /// A table to keep track of all added blocks
-    (L1BlocksByHeightSchema) u64 => Vec<L1BlockId>
+    (L1BlocksByHeightSchema) L1Height => Vec<L1BlockId>
 );

--- a/crates/db/tests/src/asm_tests.rs
+++ b/crates/db/tests/src/asm_tests.rs
@@ -19,8 +19,7 @@ pub fn test_get_asm(db: &impl AsmDatabase) {
     db.put_asm_state(L1BlockCommitment::default(), state.clone())
         .expect("test insert");
 
-    let another_block = L1BlockCommitment::from_height_u64(1, L1BlockId::default())
-        .expect("height should be valid");
+    let another_block = L1BlockCommitment::new(1, L1BlockId::default());
     db.put_asm_state(another_block, state.clone())
         .expect("test: insert");
 
@@ -29,8 +28,7 @@ pub fn test_get_asm(db: &impl AsmDatabase) {
 }
 
 pub fn test_put_get_aux_data(db: &impl AsmDatabase) {
-    let block = L1BlockCommitment::from_height_u64(1, L1BlockId::default())
-        .expect("height should be valid");
+    let block = L1BlockCommitment::new(1, L1BlockId::default());
 
     // Initially no aux data.
     let result = db.get_aux_data(block).expect("test: get empty");

--- a/crates/db/tests/src/client_state_tests.rs
+++ b/crates/db/tests/src/client_state_tests.rs
@@ -9,8 +9,7 @@ pub fn test_get_consensus_update(db: &impl ClientStateDatabase) {
     db.put_client_update(L1BlockCommitment::default(), output.clone())
         .expect("test: insert");
 
-    let another_block = L1BlockCommitment::from_height_u64(1, L1BlockId::default())
-        .expect("height should be valid");
+    let another_block = L1BlockCommitment::new(1, L1BlockId::default());
     db.put_client_update(another_block, output.clone())
         .expect("test: insert");
 

--- a/crates/db/tests/src/l1_tests.rs
+++ b/crates/db/tests/src/l1_tests.rs
@@ -1,5 +1,6 @@
 use strata_asm_common::AsmManifest;
 use strata_db_types::traits::L1Database;
+use strata_primitives::L1Height;
 use strata_test_utils::ArbitraryGenerator;
 
 pub fn test_insert_into_empty_db(db: &impl L1Database) {
@@ -130,7 +131,7 @@ pub fn test_get_blockid_range(db: &impl L1Database) {
 }
 
 // Helper function to insert block data
-fn insert_block_data(height: u64, db: &impl L1Database) -> AsmManifest {
+fn insert_block_data(height: L1Height, db: &impl L1Database) -> AsmManifest {
     let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
 
     let mf = AsmManifest::new(height, arb.generate(), arb.generate(), vec![]);

--- a/crates/db/types/src/errors.rs
+++ b/crates/db/types/src/errors.rs
@@ -1,6 +1,6 @@
 use strata_identifiers::AccountId;
 use strata_ol_chain_types::L2BlockId;
-use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId};
+use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId, L1Height};
 use strata_storage_common::exec::OpsError;
 use thiserror::Error;
 use typed_sled::error::Error;
@@ -18,7 +18,7 @@ pub enum DbError {
     EntryAlreadyExists,
 
     #[error("tried to insert into {0} out-of-order index {1}")]
-    OooInsert(&'static str, u64),
+    OooInsert(&'static str, L1Height),
 
     /// (type, missing, start, end)
     #[error("missing {0} block {1} in range {2}..{3}")]
@@ -28,7 +28,7 @@ pub enum DbError {
     MissingL1BlockManifest(L1BlockId),
 
     #[error("missing L1 block (height {0})")]
-    MissingL1Block(u64),
+    MissingL1Block(L1Height),
 
     #[error("L1 canonical chain is empty")]
     L1CanonicalChainEmpty,
@@ -37,10 +37,10 @@ pub enum DbError {
     OLCanonicalChainEmpty,
 
     #[error("Revert height {0} above chain tip height {0}")]
-    L1InvalidRevertHeight(u64, u64),
+    L1InvalidRevertHeight(L1Height, L1Height),
 
     #[error("Block does not extend canonical chain tip")]
-    L1InvalidNextBlock(u64, L1BlockId),
+    L1InvalidNextBlock(L1Height, L1BlockId),
 
     #[error("missing L2 block (id {0})")]
     MissingL2Block(L2BlockId),

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -10,7 +10,8 @@ use strata_asm_common::{AsmManifest, AuxData};
 use strata_checkpoint_types::EpochSummary;
 use strata_csm_types::{ClientState, ClientUpdateOutput};
 use strata_identifiers::{
-    AccountId, Epoch, EpochCommitment, Hash, OLBlockCommitment, OLBlockId, OLTxId, RawMmrId, Slot,
+    AccountId, Epoch, EpochCommitment, Hash, L1Height, OLBlockCommitment, OLBlockId, OLTxId,
+    RawMmrId, Slot,
 };
 use strata_ol_chain_types::L2BlockBundle;
 use strata_ol_chain_types_new::OLBlock;
@@ -102,30 +103,37 @@ pub trait L1Database: Send + Sync + 'static {
     fn put_block_data(&self, manifest: AsmManifest) -> DbResult<()>;
 
     /// Set a specific height, blockid in canonical chain records.
-    fn set_canonical_chain_entry(&self, height: u64, blockid: L1BlockId) -> DbResult<()>;
+    fn set_canonical_chain_entry(&self, height: L1Height, blockid: L1BlockId) -> DbResult<()>;
 
     /// remove canonical chain records in given range (inclusive)
-    fn remove_canonical_chain_entries(&self, start_height: u64, end_height: u64) -> DbResult<()>;
+    fn remove_canonical_chain_entries(
+        &self,
+        start_height: L1Height,
+        end_height: L1Height,
+    ) -> DbResult<()>;
 
     /// Prune earliest blocks till height
-    fn prune_to_height(&self, height: u64) -> DbResult<()>;
+    fn prune_to_height(&self, height: L1Height) -> DbResult<()>;
 
     // TODO DA scraping storage
 
     // Gets current chain tip height, blockid
-    fn get_canonical_chain_tip(&self) -> DbResult<Option<(u64, L1BlockId)>>;
+    fn get_canonical_chain_tip(&self) -> DbResult<Option<(L1Height, L1BlockId)>>;
 
     /// Gets the ASM manifest for a blockid.
     fn get_block_manifest(&self, blockid: L1BlockId) -> DbResult<Option<AsmManifest>>;
 
     /// Gets the blockid at height for the current chain.
-    fn get_canonical_blockid_at_height(&self, height: u64) -> DbResult<Option<L1BlockId>>;
+    fn get_canonical_blockid_at_height(&self, height: L1Height) -> DbResult<Option<L1BlockId>>;
 
     // TODO: This should not exist in database level and should be handled by downstream manager.
     /// Returns a half-open interval of block hashes, if we have all of them
     /// present.  Otherwise, returns error.
-    fn get_canonical_blockid_range(&self, start_idx: u64, end_idx: u64)
-        -> DbResult<Vec<L1BlockId>>;
+    fn get_canonical_blockid_range(
+        &self,
+        start_idx: L1Height,
+        end_idx: L1Height,
+    ) -> DbResult<Vec<L1BlockId>>;
 
     // TODO DA queries
 }

--- a/crates/db/types/src/types.rs
+++ b/crates/db/types/src/types.rs
@@ -16,7 +16,7 @@ use strata_csm_types::{CheckpointL1Ref, L1Payload, PayloadIntent};
 use strata_identifiers::OLTxId;
 use strata_l1_txfmt::MagicBytes;
 use strata_ol_chainstate_types::Chainstate;
-use strata_primitives::{buf::Buf32, OLBlockCommitment};
+use strata_primitives::{buf::Buf32, L1Height, OLBlockCommitment};
 use zkaleido::Proof;
 
 /// Represents an intent to publish to some DA, which will be bundled for efficiency.
@@ -239,7 +239,7 @@ pub enum L1TxStatus {
     Confirmed {
         confirmations: u64,
         block_hash: Buf32,
-        block_height: u64,
+        block_height: L1Height,
     },
 
     /// The transaction is finalized in L1 with the given number of confirmations.
@@ -248,7 +248,7 @@ pub enum L1TxStatus {
     Finalized {
         confirmations: u64,
         block_hash: Buf32,
-        block_height: u64,
+        block_height: L1Height,
     },
 
     /// The transaction is not included in L1 because it's inputs were invalid

--- a/crates/identifiers/src/l1.rs
+++ b/crates/identifiers/src/l1.rs
@@ -123,23 +123,6 @@ impl L1BlockCommitment {
         self.height
     }
 
-    /// Create a new L1 block commitment from a u64 height.
-    ///
-    /// Returns `None` if the height is invalid (greater than u32::MAX).
-    pub fn from_height_u64(height: u64, blkid: L1BlockId) -> Option<Self> {
-        let height = u32::try_from(height).ok()?;
-        Some(Self { height, blkid })
-    }
-
-    pub fn height_u32(&self) -> u32 {
-        self.height
-    }
-
-    /// Get the block height as u64 for compatibility.
-    pub fn height_u64(&self) -> u64 {
-        self.height as u64
-    }
-
     /// Get the block ID.
     pub fn blkid(&self) -> &L1BlockId {
         &self.blkid
@@ -203,7 +186,7 @@ mod tests {
 
             let encoded = commitment.as_ssz_bytes();
             let decoded = L1BlockCommitment::from_ssz_bytes(&encoded).unwrap();
-            assert_eq!(commitment.height_u64(), decoded.height_u64());
+            assert_eq!(commitment.height(), decoded.height());
             assert_eq!(commitment.blkid(), decoded.blkid());
         }
     }

--- a/crates/ol-chain-types/src/block.rs
+++ b/crates/ol-chain-types/src/block.rs
@@ -2,7 +2,7 @@ use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_asm_common::AsmManifest;
-use strata_primitives::prelude::*;
+use strata_primitives::{l1::L1Height, prelude::*};
 use strata_state::exec_update::ExecUpdate;
 
 use crate::header::{L2BlockHeader, SignedL2BlockHeader};
@@ -98,7 +98,7 @@ pub struct L1Segment {
     ///
     /// This partly serves as a safety measure to make sure we don't update the
     /// block heights wrong.
-    new_height: u64,
+    new_height: L1Height,
 
     /// New [`AsmManifest`]s that we've seen from L1 that we didn't see in the previous
     /// L2 block.
@@ -109,7 +109,7 @@ pub struct L1Segment {
 impl<'a> Arbitrary<'a> for L1Segment {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(L1Segment {
-            new_height: u64::arbitrary(u)?,
+            new_height: L1Height::arbitrary(u)?,
             // For testing, just use an empty vec of manifests since AsmManifest doesn't implement
             // Arbitrary
             new_manifests: Vec::new(),
@@ -120,7 +120,7 @@ impl<'a> Arbitrary<'a> for L1Segment {
 impl L1Segment {
     /// Constructs a new instance. These new [`AsmManifest`]s MUST be sorted in order
     /// of block height.
-    pub fn new(new_height: u64, new_manifests: Vec<AsmManifest>) -> Self {
+    pub fn new(new_height: L1Height, new_manifests: Vec<AsmManifest>) -> Self {
         Self {
             new_height,
             new_manifests,
@@ -128,12 +128,12 @@ impl L1Segment {
     }
 
     /// Constructs a new empty instance of [`L1Segment`] at the given height.
-    pub fn new_empty(cur_height: u64) -> Self {
+    pub fn new_empty(cur_height: L1Height) -> Self {
         Self::new(cur_height, Vec::new())
     }
 
     /// Returns the new height of the [`L1Segment`].
-    pub fn new_height(&self) -> u64 {
+    pub fn new_height(&self) -> L1Height {
         self.new_height
     }
 

--- a/crates/ol-chainstate-types/src/l1_view.rs
+++ b/crates/ol-chainstate-types/src/l1_view.rs
@@ -1,14 +1,14 @@
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_identifiers::L1BlockCommitment;
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::l1::{L1BlockId, L1Height};
 
 /// Describes state relating to the CL's view of L1.  Updated by entries in the
 /// L1 segment of CL blocks.
 #[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Arbitrary)]
 pub struct L1ViewState {
     /// The actual first block we ever looked at.
-    pub(crate) genesis_height: u64,
+    pub(crate) genesis_height: L1Height,
 
     /// Verified L1Block
     pub(crate) verified_blk: L1BlockCommitment,
@@ -18,7 +18,7 @@ impl L1ViewState {
     /// Creates a new instance with the genesis trigger L1 block already ingested.
     pub fn new_at_genesis(genesis_blk: L1BlockCommitment) -> Self {
         Self {
-            genesis_height: genesis_blk.height_u64(),
+            genesis_height: genesis_blk.height(),
             verified_blk: genesis_blk,
         }
     }
@@ -27,8 +27,8 @@ impl L1ViewState {
         self.verified_blk.blkid()
     }
 
-    pub fn safe_height(&self) -> u64 {
-        self.verified_blk.height_u64()
+    pub fn safe_height(&self) -> L1Height {
+        self.verified_blk.height()
     }
 
     /// Gets the safe block as a [`L1BlockCommitment`].
@@ -37,7 +37,7 @@ impl L1ViewState {
     }
 
     /// The height of the next block we expect to be added.
-    pub fn next_expected_height(&self) -> u64 {
+    pub fn next_expected_height(&self) -> L1Height {
         self.safe_height() + 1
     }
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -311,7 +311,7 @@ async fn fetch_asm_manifests_for_terminal_block<
     parent_state: &S,
 ) -> BlockAssemblyResult<Option<OLL1ManifestContainer>> {
     let last_l1_height = parent_state.last_l1_height();
-    let start_height = (last_l1_height + 1) as u64;
+    let start_height = last_l1_height + 1;
 
     // Fetch manifests using BlockAssemblyAnchorContext trait
     let manifests = ctx.fetch_asm_manifests_from(start_height).await?;
@@ -600,7 +600,7 @@ fn convert_snark_account_update<P: AccumulatorProofGenerator, S: IStateAccessor>
 mod tests {
     use strata_acct_types::AcctError;
     use strata_asm_manifest_types::AsmManifest;
-    use strata_identifiers::{Buf32, Buf64, L1BlockId, OLBlockId, WtxidsRoot};
+    use strata_identifiers::{Buf32, Buf64, L1BlockId, L1Height, OLBlockId, WtxidsRoot};
     use strata_ol_chain_types_new::{OLBlock, SignedOLBlockHeader};
     use strata_ol_state_types::OLState;
     use strata_snark_acct_types::AccumulatorClaim;
@@ -634,7 +634,7 @@ mod tests {
         let account_id = test_account_id(1);
         let mut state = create_test_genesis_state();
         add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-        state.append_manifest(manifest.height() as u32, manifest);
+        state.append_manifest(manifest.height(), manifest);
 
         // Create tx with claims from the tracker using builder
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
@@ -758,7 +758,7 @@ mod tests {
         let account_id = test_account_id(1);
         let mut state = create_test_genesis_state();
         add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-        state.append_manifest(manifest.height() as u32, manifest);
+        state.append_manifest(manifest.height(), manifest);
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
             .with_l1_claims(invalid_claims)
@@ -1032,7 +1032,7 @@ mod tests {
     // Helper to validate terminal block with L1 updates
     fn check_terminal_block_with_manifests(
         block_template: &FullBlockTemplate,
-        expected_heights: &[u64],
+        expected_heights: &[L1Height],
     ) {
         let body = block_template.body();
         let l1_update = body.l1_update();
@@ -1481,7 +1481,7 @@ mod tests {
 
         // Valid tx for account1: L1 header claims exist in both MMRs (using L1 block height)
         let valid_claims = vec![AccumulatorClaim::new(
-            env.manifests[0].height,
+            env.manifests[0].height as u64,
             env.manifests[0].hash,
         )];
         let valid_tx = MempoolSnarkTxBuilder::new(account1)
@@ -1492,7 +1492,7 @@ mod tests {
 
         // Invalid tx for account2: non-existent L1 height (no corresponding MMR leaf)
         let fake_hash = test_hash(99);
-        let missing_height = env.manifests.last().unwrap().height + 100;
+        let missing_height = env.manifests.last().unwrap().height as u64 + 100;
         let invalid_claims = vec![AccumulatorClaim::new(missing_height, fake_hash)];
         let invalid_tx = MempoolSnarkTxBuilder::new(account2)
             .with_seq_no(0)

--- a/crates/ol/block-assembly/src/builder.rs
+++ b/crates/ol/block-assembly/src/builder.rs
@@ -74,7 +74,7 @@ where
         S::Error: Display,
         S::State: BlockAssemblyStateAccess,
     {
-        let genesis_l1_height = self.params.rollup().genesis_l1_view.height_u64();
+        let genesis_l1_height = self.params.rollup().genesis_l1_view.height();
         let context = Arc::new(BlockAssemblyContext::new(
             self.storage,
             self.mempool_provider,

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use strata_acct_types::{AccountId, tree_hash::TreeHash};
 use strata_asm_manifest_types::AsmManifest;
 use strata_db_types::errors::DbError;
-use strata_identifiers::{Hash, MmrId, OLBlockCommitment, OLBlockId, OLTxId};
+use strata_identifiers::{Hash, L1Height, MmrId, OLBlockCommitment, OLBlockId, OLTxId};
 use strata_ledger_types::{
     IAccountStateConstructible, IAccountStateMut, IStateAccessor, asm_manifests_mmr_start_height,
 };
@@ -72,7 +72,7 @@ pub trait BlockAssemblyAnchorContext: Send + Sync + 'static {
     /// Fetch ASM manifests from `start_height` to latest (ascending).
     async fn fetch_asm_manifests_from(
         &self,
-        start_height: u64,
+        start_height: L1Height,
     ) -> BlockAssemblyResult<Vec<AsmManifest>>;
 }
 
@@ -105,7 +105,7 @@ pub struct BlockAssemblyContext<M, S> {
     storage: Arc<NodeStorage>,
     mempool_provider: M,
     state_provider: S,
-    _genesis_l1_height: u64,
+    _genesis_l1_height: L1Height,
 }
 
 impl<M, S> Debug for BlockAssemblyContext<M, S> {
@@ -122,7 +122,7 @@ impl<M, S> BlockAssemblyContext<M, S> {
         storage: Arc<NodeStorage>,
         mempool_provider: M,
         state_provider: S,
-        genesis_l1_height: u64,
+        genesis_l1_height: L1Height,
     ) -> Self {
         Self {
             storage,
@@ -244,7 +244,7 @@ where
 
     async fn fetch_asm_manifests_from(
         &self,
-        start_height: u64,
+        start_height: L1Height,
     ) -> BlockAssemblyResult<Vec<AsmManifest>> {
         let end_height = match self
             .storage
@@ -252,7 +252,7 @@ where
             .fetch_most_recent_state()
             .map_err(BlockAssemblyError::Database)?
         {
-            Some((commitment, _)) => commitment.height_u64(),
+            Some((commitment, _)) => commitment.height(),
             None => return Ok(Vec::new()),
         };
 
@@ -418,7 +418,7 @@ mod tests {
     // L1 Header Proof Generation Tests
     // =========================================================================
 
-    fn create_test_manifest(height: u64, seed: u8) -> AsmManifest {
+    fn create_test_manifest(height: L1Height, seed: u8) -> AsmManifest {
         let mut blkid_bytes = [0u8; 32];
         blkid_bytes[0] = seed;
         AsmManifest::new(
@@ -443,7 +443,7 @@ mod tests {
         let claims = asm_mmr.claims(0);
         let expected_hash = asm_mmr.hashes()[0];
         let mut state = create_test_genesis_state();
-        state.append_manifest(manifest.height() as u32, manifest);
+        state.append_manifest(manifest.height(), manifest);
 
         let ctx = create_test_context(storage);
 
@@ -475,7 +475,7 @@ mod tests {
         let claims = asm_mmr.claims(0);
         let mut state = create_test_genesis_state();
         for manifest in manifests {
-            state.append_manifest(manifest.height() as u32, manifest);
+            state.append_manifest(manifest.height(), manifest);
         }
 
         let ctx = create_test_context(storage);
@@ -503,7 +503,7 @@ mod tests {
         let claim = AccumulatorClaim::new(claim_height, wrong_hash);
         let expected_hash = asm_mmr.hashes()[0];
         let mut state = create_test_genesis_state();
-        state.append_manifest(manifest.height() as u32, manifest);
+        state.append_manifest(manifest.height(), manifest);
 
         let ctx = create_test_context(storage);
 
@@ -542,7 +542,7 @@ mod tests {
         let nonexistent_height = 999u64;
         let claim = AccumulatorClaim::new(nonexistent_height, asm_mmr.hashes()[0]);
         let mut state = create_test_genesis_state();
-        state.append_manifest(manifest.height() as u32, manifest);
+        state.append_manifest(manifest.height(), manifest);
 
         let ctx = create_test_context(storage);
 

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -16,8 +16,8 @@ use strata_config::SequencerConfig;
 use strata_db_store_sled::test_utils::get_test_sled_backend;
 use strata_db_types::errors::DbError;
 use strata_identifiers::{
-    Buf32, Buf64, L1BlockCommitment, L1BlockId, MmrId, OLBlockCommitment, OLBlockId, OLTxId,
-    WtxidsRoot, test_utils::ol_block_commitment_strategy,
+    Buf32, Buf64, L1BlockCommitment, L1BlockId, L1Height, MmrId, OLBlockCommitment, OLBlockId,
+    OLTxId, WtxidsRoot, test_utils::ol_block_commitment_strategy,
 };
 use strata_ledger_types::{
     AccountTypeState, IAccountStateMut, ISnarkAccountStateMut, IStateAccessor, NewAccountData,
@@ -586,8 +586,8 @@ pub(crate) fn generate_header_hashes(count: usize) -> Vec<Hash> {
 /// Returns the L1BlockCommitment for the highest block.
 pub(crate) async fn setup_asm_state_with_l1_manifests(
     storage: &NodeStorage,
-    start: u64,
-    end: u64,
+    start: L1Height,
+    end: L1Height,
 ) -> L1BlockCommitment {
     // Create and store ASM manifests
     let mut last_blkid = L1BlockId::from(Buf32::zero());
@@ -618,7 +618,7 @@ pub(crate) async fn setup_asm_state_with_l1_manifests(
     }
 
     // Store ASM state at the highest L1 block
-    let l1_commitment = L1BlockCommitment::new(end as u32, last_blkid);
+    let l1_commitment = L1BlockCommitment::new(end, last_blkid);
 
     // Create minimal ASM state for testing
     let pow_state = HeaderVerificationState::default();
@@ -646,7 +646,7 @@ pub(crate) const DEFAULT_ACCOUNT_BALANCE: u64 = 100_000_000_000;
 
 /// Manifest commitment metadata for tests (L1 height + committed manifest hash).
 pub(crate) struct ManifestCommitment {
-    pub height: u64,
+    pub height: L1Height,
     pub hash: Hash,
 }
 
@@ -663,7 +663,7 @@ pub(crate) struct TestEnv {
 #[derive(Default)]
 pub(crate) struct TestEnvBuilder {
     parent_slot: Option<u64>,
-    asm_manifest_heights: Vec<u64>,
+    asm_manifest_heights: Vec<L1Height>,
     claim_manifest_count: Option<usize>,
     accounts: Vec<(AccountId, u64)>,
 }
@@ -689,7 +689,7 @@ impl TestEnvBuilder {
 
     /// Stores L1 manifests in ASM storage for block's L1 update fetching.
     /// Used by tests that build terminal blocks with L1 manifests.
-    pub(crate) fn with_asm_manifests(mut self, heights: &[u64]) -> Self {
+    pub(crate) fn with_asm_manifests(mut self, heights: &[L1Height]) -> Self {
         self.asm_manifest_heights = heights.to_vec();
         self
     }
@@ -824,7 +824,7 @@ fn create_deterministic_manifests(count: usize) -> Vec<AsmManifest> {
             let mut blkid_bytes = [0u8; 32];
             blkid_bytes[0] = (i + 1) as u8; // Unique block ID for each manifest
             AsmManifest::new(
-                (i + 1) as u64, // height
+                (i + 1) as L1Height, // height
                 L1BlockId::from(Buf32::from(blkid_bytes)),
                 WtxidsRoot::from(Buf32::zero()),
                 vec![],
@@ -859,7 +859,7 @@ fn setup_manifests_in_state_and_storage(
         indices.push(leaf_idx);
 
         // Add to state's manifest MMR (for verification)
-        let height = manifest.height() as u32;
+        let height = manifest.height();
         state.append_manifest(height, manifest);
     }
 

--- a/crates/ol/checkpoint/src/state.rs
+++ b/crates/ol/checkpoint/src/state.rs
@@ -157,7 +157,7 @@ fn build_checkpoint_payload<C: CheckpointWorkerContext>(
     summary: &EpochSummary,
     ctx: &C,
 ) -> anyhow::Result<CheckpointPayload> {
-    let l1_height = summary.new_l1().height_u32();
+    let l1_height = summary.new_l1().height();
     let l2_commitment = *summary.terminal();
     let new_tip = CheckpointTip::new(summary.epoch(), l1_height, l2_commitment);
 
@@ -282,7 +282,7 @@ mod tests {
 
             for i in 0..=last_checkpoint {
                 let summary = &summaries[i];
-                let tip = CheckpointTip::new(summary.epoch(), summary.new_l1().height_u32(), *summary.terminal());
+                let tip = CheckpointTip::new(summary.epoch(), summary.new_l1().height(), *summary.terminal());
                 let payload = CheckpointPayload::new(tip, sidecars[i].clone(), Vec::new())
                     .expect("payload");
                 checkpoint_mgr

--- a/crates/ol/mempool/src/handle.rs
+++ b/crates/ol/mempool/src/handle.rs
@@ -142,8 +142,7 @@ mod tests {
         setup_test_state_for_tip(&storage, create_test_block_commitment(200)).await;
 
         let client_state = ClientState::new(None, None);
-        let l1_block = L1BlockCommitment::from_height_u64(0, L1BlockId::default())
-            .expect("Failed to create L1BlockCommitment");
+        let l1_block = L1BlockCommitment::new(0, L1BlockId::default());
         let l1_status = L1Status::default();
         let status_channel = StatusChannel::new(client_state, l1_block, l1_status, None, None);
 

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -3,7 +3,7 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 #[cfg(test)]
 use serde_json as _;
-use strata_identifiers::{AccountId, Epoch, EpochCommitment, OLBlockId, OLTxId};
+use strata_identifiers::{AccountId, Epoch, EpochCommitment, L1Height, OLBlockId, OLTxId};
 use strata_ol_rpc_types::*;
 use strata_ol_sequencer::BlockCompletionData;
 use strata_primitives::{HexBytes, HexBytes32, HexBytes64};
@@ -62,7 +62,7 @@ pub trait OLClientRpc {
 
     /// Get canonical L1 header commitment for the given L1 block height.
     #[method(name = "getL1HeaderCommitment")]
-    async fn get_l1_header_commitment(&self, l1_height: u64) -> RpcResult<Option<HexBytes32>>;
+    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> RpcResult<Option<HexBytes32>>;
 
     /// Submit transaction to the node. Returns immediately with tx ID.
     #[method(name = "submitTransaction")]

--- a/crates/ol/state-support-types/src/indexer_layer.rs
+++ b/crates/ol/state-support-types/src/indexer_layer.rs
@@ -742,7 +742,7 @@ mod tests {
         let height = L1Height::from(100u32);
         let l1_blkid = L1BlockId::from(Buf32::from([1u8; 32]));
         let wtxids_root = WtxidsRoot::from(Buf32::from([2u8; 32]));
-        let manifest = AsmManifest::new(height.into(), l1_blkid, wtxids_root, vec![]);
+        let manifest = AsmManifest::new(height, l1_blkid, wtxids_root, vec![]);
 
         // Append the manifest
         indexer.append_manifest(height, manifest.clone());

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -106,7 +106,7 @@ fn test_combined_manifest_tracking() {
     let height = L1Height::from(100u32);
     let l1_blkid = L1BlockId::from(Buf32::from([1u8; 32]));
     let wtxids_root = WtxidsRoot::from(Buf32::from([2u8; 32]));
-    let manifest = AsmManifest::new(height.into(), l1_blkid, wtxids_root, vec![]);
+    let manifest = AsmManifest::new(height, l1_blkid, wtxids_root, vec![]);
 
     indexer.append_manifest(height, manifest);
 

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -422,7 +422,7 @@ mod tests {
         let height = L1Height::from(100u32);
         let l1_blkid = L1BlockId::from(Buf32::from([1u8; 32]));
         let wtxids_root = WtxidsRoot::from(Buf32::from([2u8; 32]));
-        let manifest = AsmManifest::new(height.into(), l1_blkid, wtxids_root, vec![]);
+        let manifest = AsmManifest::new(height, l1_blkid, wtxids_root, vec![]);
 
         tracking.append_manifest(height, manifest);
 

--- a/crates/ol/state-types/src/epochal.rs
+++ b/crates/ol/state-types/src/epochal.rs
@@ -46,8 +46,7 @@ impl EpochalState {
 
     /// Last L1 block height.
     pub fn last_l1_height(&self) -> L1Height {
-        // FIXME this conversion is weird
-        self.last_l1_block.height_u64() as u32
+        self.last_l1_block.height()
     }
 
     /// Appends a new ASM manifest to the accumulator, also updating the last L1
@@ -57,9 +56,7 @@ impl EpochalState {
 
         Mmr::<StrataHasher>::add_leaf(&mut self.manifests_mmr, manifest_hash.into_inner())
             .expect("MMR capacity exceeded");
-        // FIXME make this conversion less weird
-        self.last_l1_block = L1BlockCommitment::from_height_u64(height as u64, *mf.blkid())
-            .expect("state: weird conversion")
+        self.last_l1_block = L1BlockCommitment::new(height, *mf.blkid());
     }
 
     /// Gets the field for the epoch that the ASM considers to be valid.

--- a/crates/ol/state-types/src/test_utils.rs
+++ b/crates/ol/state-types/src/test_utils.rs
@@ -41,8 +41,7 @@ pub fn epochal_state_strategy() -> impl Strategy<Value = EpochalState> {
             |(funds, epoch, l1_blkid, (cp_epoch, cp_slot, cp_blkid))| EpochalState {
                 total_ledger_funds: funds,
                 cur_epoch: epoch,
-                last_l1_block: L1BlockCommitment::from_height_u64(0, L1BlockId::from(l1_blkid))
-                    .unwrap(),
+                last_l1_block: L1BlockCommitment::new(0, L1BlockId::from(l1_blkid)),
                 checkpointed_epoch: EpochCommitment::new(
                     cp_epoch,
                     cp_slot,

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -26,7 +26,7 @@ impl OLState {
         let total_ledger_funds = ledger.calculate_total_funds();
 
         let global = GlobalState::new(params.header.slot);
-        let manifests_mmr_offset = params.last_l1_block.height_u64() + 1;
+        let manifests_mmr_offset = params.last_l1_block.height() as u64 + 1;
         let epoch = EpochalState::new(
             total_ledger_funds,
             params.header.epoch,

--- a/crates/ol/state-types/src/write_batch.rs
+++ b/crates/ol/state-types/src/write_batch.rs
@@ -51,11 +51,7 @@ impl<A> WriteBatch<A> {
         let epochal = EpochalState::new(
             state.total_ledger_balance(),
             state.cur_epoch(),
-            L1BlockCommitment::from_height_u64(
-                state.last_l1_height() as u64,
-                *state.last_l1_blkid(),
-            )
-            .expect("state: invalid L1 height"),
+            L1BlockCommitment::new(state.last_l1_height(), *state.last_l1_blkid()),
             *state.asm_recorded_epoch(),
             state.asm_manifests_mmr().clone(),
             manifests_mmr_start_height as u64,

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -36,7 +36,7 @@ pub fn process_block_manifests<S: IStateAccessor>(
         // New manifests in a segment are strictly after the state's current
         // last seen height.
         let real_height = orig_l1_height + i as u32 + 1;
-        if mf.height() != real_height as u64 {
+        if mf.height() != real_height {
             return Err(ExecError::ChainIntegrity);
         }
         last = Some((real_height, mf));

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -112,7 +112,7 @@ pub fn build_empty_chain(
         let components = if is_terminal {
             // Create a terminal block with a dummy manifest
             let dummy_manifest = AsmManifest::new(
-                (state.last_l1_height() + 1) as u64, // Next L1 height after state's last seen
+                (state.last_l1_height() + 1), // Next L1 height after state's last seen
                 L1BlockId::from(Buf32::from([0u8; 32])),
                 WtxidsRoot::from(Buf32::from([0u8; 32])),
                 vec![],
@@ -212,7 +212,7 @@ pub fn build_chain_with_transactions(
 
         let components = if is_terminal {
             let dummy_manifest = AsmManifest::new(
-                (state.last_l1_height() + 1) as u64, // Next L1 height after state's last seen
+                (state.last_l1_height() + 1), // Next L1 height after state's last seen
                 L1BlockId::from(Buf32::from([0u8; 32])),
                 WtxidsRoot::from(Buf32::from([0u8; 32])),
                 vec![],

--- a/crates/ol/stf/src/tests/stf.rs
+++ b/crates/ol/stf/src/tests/stf.rs
@@ -336,7 +336,7 @@ fn test_process_chain_with_multiple_epochs() {
         let components = if is_terminal {
             // Create a terminal block with a dummy manifest
             let dummy_manifest = AsmManifest::new(
-                (state.last_l1_height() + 1) as u64, // Next L1 height after state's last seen
+                (state.last_l1_height() + 1), // Next L1 height after state's last seen
                 L1BlockId::from(Buf32::from([0u8; 32])),
                 WtxidsRoot::from(Buf32::from([0u8; 32])),
                 vec![],
@@ -599,7 +599,7 @@ fn test_multi_block_chain_verification() {
         let components = if is_terminal {
             // Create a terminal block with a dummy manifest
             let dummy_manifest = AsmManifest::new(
-                (state.last_l1_height() + 1) as u64, // Next L1 height after state's last seen
+                (state.last_l1_height() + 1), // Next L1 height after state's last seen
                 L1BlockId::from(Buf32::from([0u8; 32])),
                 WtxidsRoot::from(Buf32::from([0u8; 32])),
                 vec![],

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -8,7 +8,7 @@ use strata_common::{Action, WorkerType};
 use strata_csm_types::{ClientState, ClientUpdateOutput};
 use strata_db_types::types::{L1TxEntry, L1TxStatus};
 use strata_ol_chain_types::{L2Block, L2BlockId};
-use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId};
+use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId, L1Height};
 #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_rpc_types::{
     types::{RpcBlockHeader, RpcClientStatus, RpcL1Status},
@@ -44,7 +44,7 @@ pub trait StrataApi {
     async fn get_l1_status(&self) -> RpcResult<RpcL1Status>;
 
     #[method(name = "getL1blockHash")]
-    async fn get_l1_block_hash(&self, height: u64) -> RpcResult<Option<String>>;
+    async fn get_l1_block_hash(&self, height: L1Height) -> RpcResult<Option<String>>;
 
     #[method(name = "clientStatus")]
     async fn get_client_status(&self) -> RpcResult<RpcClientStatus>;

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -23,6 +23,7 @@ use strata_primitives::{
     epoch::EpochCommitment,
     l1::{BitcoinAmount, L1BlockCommitment},
     l2::L2BlockCommitment,
+    L1Height,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,7 +37,7 @@ pub struct RpcL1Status {
     pub last_rpc_error: Option<String>,
 
     /// Current block height.
-    pub cur_height: u64,
+    pub cur_height: L1Height,
 
     /// Current tip block ID as string.
     pub cur_tip_blkid: String,
@@ -292,7 +293,7 @@ pub struct RpcCheckpointL1Ref {
 impl From<CheckpointL1Ref> for RpcCheckpointL1Ref {
     fn from(l1ref: CheckpointL1Ref) -> Self {
         Self {
-            block_height: l1ref.l1_commitment.height_u64(),
+            block_height: l1ref.l1_commitment.height() as u64,
             block_id: l1ref.l1_commitment.blkid().to_block_hash(),
             txid: l1ref.txid.to_txid(),
             wtxid: l1ref.wtxid.to_wtxid(),

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -21,7 +21,7 @@ use strata_ol_chain_types::{
 };
 use strata_ol_chainstate_types::Chainstate;
 use strata_params::{Params, RollupParams};
-use strata_primitives::buf::Buf32;
+use strata_primitives::{buf::Buf32, L1Height};
 use strata_state::exec_update::construct_ops_from_deposit_intents;
 #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
 use strata_storage::{CheckpointDbManager, L1BlockManager, NodeStorage};
@@ -177,7 +177,7 @@ fn prepare_l1_segment(
     let (cur_real_l1_height, _) = l1man
         .get_canonical_chain_tip()?
         .ok_or(Error::MissingTipBlock)?;
-    let target_height = cur_real_l1_height.saturating_sub(params.l1_reorg_safe_depth as u64); // -1 to give some buffer for very short reorgs
+    let target_height = cur_real_l1_height.saturating_sub(params.l1_reorg_safe_depth); // -1 to give some buffer for very short reorgs
 
     // Check to see if there's actually no blocks in the queue.  In that case we can just give
     // everything we know about.
@@ -255,7 +255,7 @@ fn prepare_l1_segment(
     }
 
     if is_epoch_final_block {
-        let new_height = cur_safe_height + payloads.len() as u64;
+        let new_height = cur_safe_height + payloads.len() as L1Height;
         Ok(L1Segment::new(new_height, payloads))
     } else {
         Ok(L1Segment::new(cur_safe_height, Vec::new()))
@@ -305,11 +305,11 @@ fn has_expected_checkpoint(
 }
 
 #[expect(unused, reason = "used for fetching manifest")]
-fn fetch_manifest(h: u64, l1man: &L1BlockManager) -> Result<AsmManifest, Error> {
-    try_fetch_manifest(h, l1man)?.ok_or(Error::MissingL1BlockHeight(h))
+fn fetch_manifest(h: L1Height, l1man: &L1BlockManager) -> Result<AsmManifest, Error> {
+    try_fetch_manifest(h, l1man)?.ok_or(Error::MissingL1BlockHeight(h as u64))
 }
 
-fn try_fetch_manifest(h: u64, l1man: &L1BlockManager) -> Result<Option<AsmManifest>, Error> {
+fn try_fetch_manifest(h: L1Height, l1man: &L1BlockManager) -> Result<Option<AsmManifest>, Error> {
     Ok(l1man.get_block_manifest_at_height(h)?)
 }
 

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -10,7 +10,10 @@ use strata_ol_chain_types::{L2BlockBundle, L2BlockHeader, L2BlockId, L2Header};
 use strata_ol_chainstate_types::Chainstate;
 use strata_params::{Params, RollupParams};
 use strata_primitives::{
-    self, epoch::EpochCommitment, l1::L1BlockCommitment, l2::L2BlockCommitment,
+    self,
+    epoch::EpochCommitment,
+    l1::{L1BlockCommitment, L1Height},
+    l2::L2BlockCommitment,
 };
 use strata_status::*;
 #[expect(deprecated, reason = "legacy old code is retained for compatibility")]
@@ -245,15 +248,14 @@ fn create_checkpoint_prep_data_from_summary(
 
     // Determine the ranges for each of the fields we commit to.
     let l1_start_height = if let Some(ps) = prev_summary {
-        ps.new_l1().height() as u64 + 1
+        ps.new_l1().height() + 1
     } else {
-        params.genesis_l1_view.height() as u64 + 1
+        params.genesis_l1_view.height() + 1
     };
 
     // Reconstruct the L1 range.
     let l1_start_mf = fetch_l1_block_manifest(l1_start_height, l1man)?;
-    let l1_start_block = L1BlockCommitment::from_height_u64(l1_start_height, *l1_start_mf.blkid())
-        .expect("height should be valid");
+    let l1_start_block = L1BlockCommitment::new(l1_start_height, *l1_start_mf.blkid());
     let l1_range = (l1_start_block, *summary.new_l1());
 
     // Now just pull out the data about the blocks from the transition here.
@@ -358,7 +360,10 @@ fn fetch_l2_block(blkid: &L2BlockId, l2man: &L2BlockManager) -> anyhow::Result<L
         .ok_or(Error::MissingL2Block(*blkid))?)
 }
 
-fn fetch_l1_block_manifest(height: u64, l1man: &L1BlockManager) -> anyhow::Result<AsmManifest> {
+fn fetch_l1_block_manifest(
+    height: L1Height,
+    l1man: &L1BlockManager,
+) -> anyhow::Result<AsmManifest> {
     Ok(l1man
         .get_block_manifest_at_height(height)?
         .ok_or(DbError::MissingL1Block(height))?)

--- a/crates/storage/src/managers/client_state.rs
+++ b/crates/storage/src/managers/client_state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use strata_csm_types::{ClientState, ClientUpdateOutput};
 use strata_db_types::{traits::ClientStateDatabase, DbResult};
-use strata_primitives::l1::L1BlockCommitment;
+use strata_primitives::{l1::L1BlockCommitment, L1Height};
 use threadpool::ThreadPool;
 use tokio::sync::Mutex;
 
@@ -22,8 +22,8 @@ pub struct ClientStateManager {
     ops: ClientStateOps,
 
     // TODO actually use caches
-    update_cache: cache::CacheTable<u64, Option<ClientUpdateOutput>>,
-    state_cache: cache::CacheTable<u64, Arc<ClientState>>,
+    update_cache: cache::CacheTable<L1Height, Option<ClientUpdateOutput>>,
+    state_cache: cache::CacheTable<L1Height, Arc<ClientState>>,
 
     cur_state: Mutex<CurStateTracker>,
 }
@@ -39,7 +39,7 @@ impl ClientStateManager {
 
         let latest_cs = ops.get_latest_client_state_blocking()?;
         if let Some((blk, cs)) = latest_cs {
-            cur_state.set(blk.height_u64(), Arc::new(cs));
+            cur_state.set(blk.height(), Arc::new(cs));
         }
 
         Ok(Self {
@@ -81,7 +81,7 @@ impl ClientStateManager {
         // FIXME this is a lot of cloning, good thing the type isn't gigantic,
         // still feels bad though
         let state = Arc::new(update.state().clone());
-        let height = block.height_u64();
+        let height = block.height();
         self.ops
             .put_client_update_blocking(*block, update.clone())?;
         self.maybe_update_cur_state_blocking(height, &state);
@@ -90,7 +90,7 @@ impl ClientStateManager {
         Ok(state)
     }
 
-    fn maybe_update_cur_state_blocking(&self, height: u64, state: &Arc<ClientState>) -> bool {
+    fn maybe_update_cur_state_blocking(&self, height: L1Height, state: &Arc<ClientState>) -> bool {
         let mut cur = self.cur_state.blocking_lock();
         cur.maybe_update(height, state)
     }
@@ -117,7 +117,7 @@ impl ClientStateManager {
 /// Internally tracks the current state so we can fetch it as needed.
 #[derive(Debug)]
 struct CurStateTracker {
-    last_idx: Option<u64>,
+    last_idx: Option<L1Height>,
     state: Option<Arc<ClientState>>,
 }
 
@@ -129,16 +129,16 @@ impl CurStateTracker {
         }
     }
 
-    fn set(&mut self, idx: u64, state: Arc<ClientState>) {
+    fn set(&mut self, idx: L1Height, state: Arc<ClientState>) {
         self.last_idx = Some(idx);
         self.state = Some(state);
     }
 
-    fn is_idx_better(&self, idx: u64) -> bool {
+    fn is_idx_better(&self, idx: L1Height) -> bool {
         self.last_idx.is_none_or(|v| idx >= v)
     }
 
-    fn maybe_update(&mut self, idx: u64, state: &Arc<ClientState>) -> bool {
+    fn maybe_update(&mut self, idx: L1Height, state: &Arc<ClientState>) -> bool {
         let should = self.is_idx_better(idx);
         if should {
             self.set(idx, state.clone());

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use strata_asm_common::AsmManifest;
 use strata_db_types::{traits::L1Database, DbError, DbResult};
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::{l1::L1BlockId, L1Height};
 use threadpool::ThreadPool;
 use tracing::{error, instrument};
 
@@ -16,7 +16,7 @@ use crate::{cache::CacheTable, instrumentation::components, ops};
 pub struct L1BlockManager {
     ops: ops::l1::L1DataOps,
     manifest_cache: CacheTable<L1BlockId, Option<AsmManifest>>,
-    blockheight_cache: CacheTable<u64, Option<L1BlockId>>,
+    blockheight_cache: CacheTable<L1Height, Option<L1BlockId>>,
 }
 
 impl L1BlockManager {
@@ -73,7 +73,7 @@ impl L1BlockManager {
             height,
         )
     )]
-    pub fn extend_canonical_chain(&self, blockid: &L1BlockId, height: u64) -> DbResult<()> {
+    pub fn extend_canonical_chain(&self, blockid: &L1BlockId, height: L1Height) -> DbResult<()> {
         if let Some((tip_height, _tip_blockid)) = self.get_canonical_chain_tip()? {
             if height != tip_height + 1 {
                 error!(expected = %(tip_height + 1), got = %height, "attempted to extend canonical chain out of order");
@@ -101,7 +101,7 @@ impl L1BlockManager {
     pub async fn extend_canonical_chain_async(
         &self,
         blockid: &L1BlockId,
-        height: u64,
+        height: L1Height,
     ) -> DbResult<()> {
         if let Some((tip_height, _tip_blockid)) = self.get_canonical_chain_tip_async().await? {
             if height != tip_height + 1 {
@@ -126,7 +126,7 @@ impl L1BlockManager {
             revert_to_height = height,
         )
     )]
-    pub fn revert_canonical_chain(&self, height: u64) -> DbResult<()> {
+    pub fn revert_canonical_chain(&self, height: L1Height) -> DbResult<()> {
         let Some((tip_height, _)) = self.ops.get_canonical_chain_tip_blocking()? else {
             // no chain to revert
             // but clear cache anyway for sanity
@@ -155,7 +155,7 @@ impl L1BlockManager {
             revert_to_height = height,
         )
     )]
-    pub async fn revert_canonical_chain_async(&self, height: u64) -> DbResult<()> {
+    pub async fn revert_canonical_chain_async(&self, height: L1Height) -> DbResult<()> {
         let Some((tip_height, _)) = self.ops.get_canonical_chain_tip_async().await? else {
             // no chain to revert
             // but clear cache anyway for sanity
@@ -179,22 +179,22 @@ impl L1BlockManager {
     }
 
     // Get tracked canonical chain tip height and blockid.
-    pub fn get_canonical_chain_tip(&self) -> DbResult<Option<(u64, L1BlockId)>> {
+    pub fn get_canonical_chain_tip(&self) -> DbResult<Option<(L1Height, L1BlockId)>> {
         self.ops.get_canonical_chain_tip_blocking()
     }
 
     // Get tracked canonical chain tip height and blockid.
-    pub async fn get_canonical_chain_tip_async(&self) -> DbResult<Option<(u64, L1BlockId)>> {
+    pub async fn get_canonical_chain_tip_async(&self) -> DbResult<Option<(L1Height, L1BlockId)>> {
         self.ops.get_canonical_chain_tip_async().await
     }
 
     // Get tracked canonical chain tip height.
-    pub fn get_chain_tip_height(&self) -> DbResult<Option<u64>> {
+    pub fn get_chain_tip_height(&self) -> DbResult<Option<L1Height>> {
         Ok(self.get_canonical_chain_tip()?.map(|(height, _)| height))
     }
 
     // Get tracked canonical chain tip height.
-    pub async fn get_chain_tip_height_async(&self) -> DbResult<Option<u64>> {
+    pub async fn get_chain_tip_height_async(&self) -> DbResult<Option<L1Height>> {
         Ok(self
             .get_canonical_chain_tip_async()
             .await?
@@ -218,7 +218,7 @@ impl L1BlockManager {
     }
 
     // Get [`AsmManifest`] at `height` in tracked canonical chain.
-    pub fn get_block_manifest_at_height(&self, height: u64) -> DbResult<Option<AsmManifest>> {
+    pub fn get_block_manifest_at_height(&self, height: L1Height) -> DbResult<Option<AsmManifest>> {
         let Some(blockid) = self.get_canonical_blockid_at_height(height)? else {
             return Ok(None);
         };
@@ -229,7 +229,7 @@ impl L1BlockManager {
     // Get [`AsmManifest`] at `height` in tracked canonical chain.
     pub async fn get_block_manifest_at_height_async(
         &self,
-        height: u64,
+        height: L1Height,
     ) -> DbResult<Option<AsmManifest>> {
         let Some(blockid) = self.get_canonical_blockid_at_height_async(height).await? else {
             return Ok(None);
@@ -239,7 +239,7 @@ impl L1BlockManager {
     }
 
     // Get [`L1BlockId`] at `height` in tracked canonical chain.
-    pub fn get_canonical_blockid_at_height(&self, height: u64) -> DbResult<Option<L1BlockId>> {
+    pub fn get_canonical_blockid_at_height(&self, height: L1Height) -> DbResult<Option<L1BlockId>> {
         self.blockheight_cache.get_or_fetch_blocking(&height, || {
             self.ops.get_canonical_blockid_at_height_blocking(height)
         })
@@ -248,7 +248,7 @@ impl L1BlockManager {
     // Get [`L1BlockId`] at `height` in tracked canonical chain.
     pub async fn get_canonical_blockid_at_height_async(
         &self,
-        height: u64,
+        height: L1Height,
     ) -> DbResult<Option<L1BlockId>> {
         self.blockheight_cache
             .get_or_fetch(&height, || {
@@ -259,8 +259,8 @@ impl L1BlockManager {
 
     pub fn get_canonical_blockid_range(
         &self,
-        start_idx: u64,
-        end_idx: u64,
+        start_idx: L1Height,
+        end_idx: L1Height,
     ) -> DbResult<Vec<L1BlockId>> {
         self.ops
             .get_canonical_blockid_range_blocking(start_idx, end_idx)
@@ -268,8 +268,8 @@ impl L1BlockManager {
 
     pub async fn get_canonical_blockid_range_async(
         &self,
-        start_idx: u64,
-        end_idx: u64,
+        start_idx: L1Height,
+        end_idx: L1Height,
     ) -> DbResult<Vec<L1BlockId>> {
         self.ops
             .get_canonical_blockid_range_async(start_idx, end_idx)

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -2,7 +2,7 @@
 
 use strata_asm_common::AsmManifest;
 use strata_db_types::traits::*;
-use strata_primitives::l1::L1BlockId;
+use strata_primitives::{l1::L1BlockId, L1Height};
 
 use crate::{exec::*, instrumentation::components};
 
@@ -10,13 +10,13 @@ inst_ops_simple! {
     (<D: L1Database> => L1DataOps, component = components::STORAGE_L1) {
         put_block_data(manifest: AsmManifest) => ();
         // put_mmr_checkpoint(blockid: L1BlockId, mmr: CompactMmr) => ();
-        set_canonical_chain_entry(height: u64, blockid: L1BlockId) => ();
-        remove_canonical_chain_entries(start_height: u64, end_height: u64) => ();
-        prune_to_height(height: u64) => ();
-        get_canonical_chain_tip() => Option<(u64, L1BlockId)>;
+        set_canonical_chain_entry(height: L1Height, blockid: L1BlockId) => ();
+        remove_canonical_chain_entries(start_height: L1Height, end_height: L1Height) => ();
+        prune_to_height(height: L1Height) => ();
+        get_canonical_chain_tip() => Option<(L1Height, L1BlockId)>;
         get_block_manifest(blockid: L1BlockId) => Option<AsmManifest>;
-        get_canonical_blockid_at_height(height: u64) => Option<L1BlockId>;
-        get_canonical_blockid_range(start_height: u64, end_height: u64) => Vec<L1BlockId>;
+        get_canonical_blockid_at_height(height: L1Height) => Option<L1BlockId>;
+        get_canonical_blockid_range(start_height: L1Height, end_height: L1Height) => Vec<L1BlockId>;
         // get_mmr(blockid: L1BlockId) => Option<CompactMmr>;
     }
 }

--- a/crates/test-utils/btc/src/segment.rs
+++ b/crates/test-utils/btc/src/segment.rs
@@ -21,16 +21,16 @@ use strata_btc_types::BlockHashExt;
 use strata_btc_verification::HeaderVerificationState;
 use strata_btcio::reader::query::{fetch_genesis_l1_view, fetch_verification_state};
 use strata_identifiers::WtxidsRoot;
-use strata_primitives::{buf::Buf32, l1::GenesisL1View};
+use strata_primitives::{buf::Buf32, l1::GenesisL1View, L1Height};
 use tokio::runtime;
 
 #[derive(Debug)]
 pub struct BtcChainSegment {
     pub headers: Vec<Header>,
-    pub start: u64,
-    pub end: u64,
-    pub custom_blocks: HashMap<u64, Block>,
-    pub custom_headers: HashMap<u64, Header>,
+    pub start: L1Height,
+    pub end: L1Height,
+    pub custom_blocks: HashMap<L1Height, Block>,
+    pub custom_headers: HashMap<L1Height, Header>,
     pub idx_by_blockhash: HashMap<BlockHash, usize>,
 }
 
@@ -56,7 +56,7 @@ impl BtcChainSegment {
             headers.push(header);
         }
 
-        let custom_headers: HashMap<u64, Header> = vec![(38304, "01000000858a5c6d458833aa83f7b7e56d71c604cb71165ebb8104b82f64de8d00000000e408c11029b5fdbb92ea0eeb8dfa138ffa3acce0f69d7deebeb1400c85042e01723f6b4bc38c001d09bd8bd5")].into_iter().map(|(h, raw_block)| {
+        let custom_headers: HashMap<L1Height, Header> = vec![(38304, "01000000858a5c6d458833aa83f7b7e56d71c604cb71165ebb8104b82f64de8d00000000e408c11029b5fdbb92ea0eeb8dfa138ffa3acce0f69d7deebeb1400c85042e01723f6b4bc38c001d09bd8bd5")].into_iter().map(|(h, raw_block)| {
             let header_bytes = hex::decode(raw_block).unwrap();
             let header: Header = consensus::deserialize(&header_bytes).unwrap();
             (h, header)
@@ -70,7 +70,7 @@ impl BtcChainSegment {
             .collect::<HashMap<BlockHash, usize>>();
 
         // This custom blocks are chose because this is where the first difficulty happened
-        let custom_blocks: HashMap<u64, Block> = vec![
+        let custom_blocks: HashMap<L1Height, Block> = vec![
         (40320, "010000001a231097b6ab6279c80f24674a2c8ee5b9a848e1d45715ad89b6358100000000a822bafe6ed8600e3ffce6d61d10df1927eafe9bbf677cb44c4d209f143c6ba8db8c784b5746651cce2221180101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08045746651c02db02ffffffff0100f2052a010000004341046477f88505bef7e3c1181a7e3975c4cd2ac77ffe23ea9b28162afbb63bd71d3f7c3a07b58cf637f1ec68ed532d5b6112d57a9744010aae100e4a48cd831123b8ac00000000"),
         (40321, "0100000045720d24eae33ade0d10397a2e02989edef834701b965a9b161e864500000000993239a44a83d5c427fd3d7902789ea1a4d66a37d5848c7477a7cf47c2b071cd7690784b5746651c3af7ca030101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08045746651c02db00ffffffff0100f2052a01000000434104c9f513361104db6a84fb6d5b364ba57a27cd19bd051239bf750d8999c6b437220df8fea6b932a248df3cad1fdebb501791e02b7b893a44718d696542ba92a0acac00000000"),
         (40322, "01000000fd1133cd53d00919b0bd77dd6ca512c4d552a0777cc716c00d64c60d0000000014cf92c7edbe8a75d1e328b4fec0d6143764ecbd0f5600aba9d22116bf165058e590784b5746651c1623dbe00101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08045746651c020509ffffffff0100f2052a010000004341043eb751f57bd4839a8f2922d5bf1ed15ade9b161774658fb39801f0b9da9c881f226fbe4ee0c240915f17ce5255dd499075ab49b199a7b1f898fb20cc735bc45bac00000000"),
@@ -98,7 +98,7 @@ impl BtcChainSegment {
 
 impl BtcChainSegment {
     /// Retrieve a block at a given height.
-    pub fn get_block_at(&self, height: u64) -> ClientResult<Block> {
+    pub fn get_block_at(&self, height: L1Height) -> ClientResult<Block> {
         if let Some(block) = self.custom_blocks.get(&height) {
             Ok(block.clone())
         } else {
@@ -109,7 +109,7 @@ impl BtcChainSegment {
     }
 
     /// Retrieve a block at a given height.
-    pub fn get_block_header_at(&self, height: u64) -> ClientResult<Header> {
+    pub fn get_block_header_at(&self, height: L1Height) -> ClientResult<Header> {
         if let Some(header) = self.custom_headers.get(&height) {
             return Ok(*header);
         }
@@ -134,7 +134,7 @@ impl BtcChainSegment {
         Ok(self.headers[*idx])
     }
 
-    pub fn get_block_manifest(&self, height: u64) -> AsmManifest {
+    pub fn get_block_manifest(&self, height: L1Height) -> AsmManifest {
         let header = self.get_block_header_at(height).unwrap();
         let blkid = header.block_hash().to_l1_block_id();
         let wtxs_root = WtxidsRoot::from(Buf32::from(
@@ -173,7 +173,7 @@ impl Reader for BtcChainSegment {
     async fn get_block_height(&self, hash: &BlockHash) -> ClientResult<u64> {
         for (height, block) in &self.custom_blocks {
             if &block.block_hash() == hash {
-                return Ok(*height);
+                return Ok(*height as u64);
             }
         }
         Err(ClientError::Body(format!(
@@ -183,23 +183,23 @@ impl Reader for BtcChainSegment {
 
     /// Retrieve a block at a given height.
     async fn get_block_at(&self, height: u64) -> ClientResult<Block> {
-        self.get_block_at(height)
+        self.get_block_at(height as L1Height)
     }
 
     /// Retrieve a block at a given height.
     async fn get_block_header_at(&self, height: u64) -> ClientResult<Header> {
-        self.get_block_header_at(height)
+        self.get_block_header_at(height as L1Height)
     }
 
     /// Return the height of the best (most-work) block.
     async fn get_block_count(&self) -> ClientResult<u64> {
         // In this segment, we assume the tip is at `end - 1`.
-        Ok(self.end - 1)
+        Ok((self.end - 1) as u64)
     }
 
     /// Retrieve the block hash for the block at the given height.
     async fn get_block_hash(&self, height: u64) -> ClientResult<BlockHash> {
-        let header = self.get_block_header_at(height)?;
+        let header = self.get_block_header_at(height as L1Height)?;
         Ok(header.block_hash())
     }
 
@@ -271,7 +271,7 @@ impl BtcChainSegment {
                 *blockhash
             )))?;
         };
-        let height = self.start + *idx as u64;
+        let height = self.start + *idx as L1Height;
 
         let manifest = self.get_block_manifest(height);
         Ok(manifest)
@@ -279,32 +279,35 @@ impl BtcChainSegment {
 
     pub fn get_block_manifests(
         &self,
-        from_height: u64,
+        from_height: L1Height,
         len: usize,
     ) -> Result<Vec<AsmManifest>, Error> {
         let mut manifests = Vec::with_capacity(len);
         for i in 0..len {
-            let height = from_height + i as u64;
+            let height = from_height + i as L1Height;
             let manifest = self.get_block_manifest(height);
             manifests.push(manifest);
         }
         Ok(manifests)
     }
 
-    pub fn get_blocks(&self, from_height: u64, len: usize) -> Result<Vec<Block>, Error> {
+    pub fn get_blocks(&self, from_height: L1Height, len: usize) -> Result<Vec<Block>, Error> {
         let mut blocks = Vec::with_capacity(len);
         for i in 0..len {
-            let block = self.get_block_at(from_height + i as u64)?;
+            let block = self.get_block_at(from_height + i as L1Height)?;
             blocks.push(block);
         }
         Ok(blocks)
     }
 
-    pub fn fetch_genesis_l1_view(&self, height: u64) -> Result<GenesisL1View, Error> {
+    pub fn fetch_genesis_l1_view(&self, height: L1Height) -> Result<GenesisL1View, Error> {
         block_on(fetch_genesis_l1_view(self, height))
     }
 
-    pub fn get_verification_state(&self, height: u64) -> Result<HeaderVerificationState, Error> {
+    pub fn get_verification_state(
+        &self,
+        height: L1Height,
+    ) -> Result<HeaderVerificationState, Error> {
         block_on(fetch_verification_state(self, height))
     }
 }

--- a/crates/test-utils/evm-ee/src/lib.rs
+++ b/crates/test-utils/evm-ee/src/lib.rs
@@ -104,15 +104,15 @@ impl L2Segment {
             // If it is a terminal block, fill L1Segment
             let genesis_height = params.rollup().genesis_l1_view.height();
             let l1_segment = if idx == evm_segment.get_inputs().len() - 1 {
-                let starting_height = genesis_height as u64 + 1;
-                let len = 3;
+                let starting_height = genesis_height + 1;
+                let len: u32 = 3;
                 let new_height = starting_height + len - 1; // because inclusive
                 let manifests = BtcChainSegment::load()
                     .get_block_manifests(starting_height, len as usize)
                     .expect("fetch manifests");
                 L1Segment::new(new_height, manifests)
             } else {
-                L1Segment::new_empty(genesis_height as u64)
+                L1Segment::new_empty(genesis_height)
             };
             let body = L2BlockBody::new(l1_segment, el_proof_out.clone());
 

--- a/tests/asm/core.rs
+++ b/tests/asm/core.rs
@@ -243,7 +243,7 @@ async fn test_proven_and_external_mmr_index_alignment() {
         let block_height = proven_offset + mmr_index as u64;
         let manifest = stored_manifests
             .iter()
-            .find(|m| m.height() == block_height)
+            .find(|m| m.height() as u64 == block_height)
             .unwrap_or_else(|| panic!("no stored manifest for height {block_height}"));
 
         let proven_leaf_hash: [u8; 32] = manifest.compute_hash();
@@ -259,7 +259,7 @@ async fn test_proven_and_external_mmr_index_alignment() {
     assert!(
         !stored_manifests
             .iter()
-            .filter(|m| m.height() == genesis_height)
+            .filter(|m| m.height() as u64 == genesis_height)
             .any(|genesis_mf| {
                 let genesis_hash: [u8; 32] = genesis_mf.compute_hash();
                 external_leaves.contains(&genesis_hash)


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
- Replace raw `u64` with the `L1Height` (u32) type alias for all L1 block height usage across the codebase
- Remove deprecated `height_u64()` and `from_height_u64()` methods from `L1BlockCommitment`, replacing with `height()` and `new()`

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Some external interfaces still require `u64` for block heights, so `L1Height` is widened to u64 at those boundaries. This includes Bitcoin RPC calls (via `bitcoind_async_client::Reader`), and `AccumulatorClaim` which needs heights as u64. The conversion always goes from L1Height → u64 (lossless widening) at the point of use.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
