### PR TITLE
fix(docker): store master Xpriv in sequencer.key to avoid double derivation

### DIFF
--- a/docker/init-keys.sh
+++ b/docker/init-keys.sh
@@ -59,9 +59,6 @@ $DATATOOL_PATH -b regtest genxpriv -f $OP3_SEED_FILE
 $DATATOOL_PATH -b regtest genxpriv -f $OP4_SEED_FILE
 $DATATOOL_PATH -b regtest genxpriv -f $OP5_SEED_FILE
 
-# sequencer.key must contain the master Xpriv (not a derived key).
-# load_seqkey() and genseqpubkey both derive m/20000'/10' internally,
-# so passing an already-derived key would cause double derivation.
 cp "${SEQ_SEED_FILE}" "$CONFIG_FILE/sequencer.key"
 
 op1xpriv=$(cat $OP1_SEED_FILE)


### PR DESCRIPTION
## Summary

`init-keys.sh` was saving the output of `genseqprivkey` (a derived Xpriv at `m/20000'/10'`, depth=2) to `sequencer.key`. Both `genseqpubkey` and `load_seqkey()` call `SequencerKeys::new()` on whatever Xpriv they are given, which derives `m/20000'/10'` internally. This caused double derivation (`m/20000'/10'/20000'/10'`).

The fix copies the master Xpriv (`sequencer.bin`, depth=0) directly to `sequencer.key`, so the single derivation in `load_seqkey()` and `genseqpubkey` produces the correct key.

[STR-2537](https://alpenlabs.atlassian.net/browse/STR-2537)

[STR-2537]: https://alpenlabs.atlassian.net/browse/STR-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ