### PR TITLE
fix(asm): make Arbitrary impls infallible for EvenPublicKey and AdministrationInitConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13872,6 +13872,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "borsh",
+ "proptest",
  "serde",
  "serde_json",
  "strata-btc-types",
@@ -14498,6 +14499,7 @@ dependencies = [
  "borsh",
  "hex",
  "musig2",
+ "proptest",
  "rand 0.8.5",
  "secp256k1 0.29.1",
  "serde",

--- a/crates/asm/params/Cargo.toml
+++ b/crates/asm/params/Cargo.toml
@@ -18,6 +18,7 @@ borsh.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
+proptest.workspace = true
 serde_json.workspace = true
 
 [features]

--- a/crates/asm/params/src/params.rs
+++ b/crates/asm/params/src/params.rs
@@ -135,4 +135,21 @@ mod tests {
         assert_eq!(params.l1_view.blk.height(), 50462976);
         assert_eq!(params.subprotocols.len(), 3);
     }
+
+    #[cfg(feature = "arbitrary")]
+    mod proptest_arbitrary {
+        use arbitrary::{Arbitrary, Unstructured};
+        use proptest::{collection, prelude::*};
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn test_arbitrary(seed in collection::vec(any::<u8>(), 0..4096)) {
+                let mut u = Unstructured::new(&seed);
+                let res = AsmParams::arbitrary(&mut u);
+                prop_assert!(res.is_ok());
+            }
+        }
+    }
 }

--- a/crates/asm/params/src/subprotocols/admin.rs
+++ b/crates/asm/params/src/subprotocols/admin.rs
@@ -15,7 +15,6 @@ use strata_crypto::threshold_signature::ThresholdConfig;
 /// like using the same config for multiple roles or mismatched role-field assignments.
 /// The benefit is avoiding missing fields at compile-time rather than runtime validation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
-#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct AdministrationInitConfig {
     /// ThresholdConfig for [StrataAdministrator](Role::StrataAdministrator).
     pub strata_administrator: ThresholdConfig,
@@ -95,5 +94,25 @@ impl AdministrationInitConfig {
             (Role::StrataAdministrator, self.strata_administrator),
             (Role::StrataSequencerManager, self.strata_sequencer_manager),
         ]
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for AdministrationInitConfig {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let strata_administrator = u.arbitrary()?;
+        let strata_sequencer_manager = u.arbitrary()?;
+        let confirmation_depth = u.arbitrary()?;
+        // Generate a valid NonZero<u8> by mapping [0, 255) to [1, 256) via saturating add.
+        let raw: u8 = u.arbitrary()?;
+        let max_seqno_gap = NonZero::new(raw.saturating_add(1))
+            .expect("saturating_add(1) on u8 always produces a non-zero value");
+
+        Ok(Self {
+            strata_administrator,
+            strata_sequencer_manager,
+            confirmation_depth,
+            max_seqno_gap,
+        })
     }
 }

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -23,6 +23,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 bitcoin.workspace = true
+proptest.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 strata-test-utils.workspace = true

--- a/crates/crypto/src/keys/even.rs
+++ b/crates/crypto/src/keys/even.rs
@@ -163,9 +163,14 @@ impl<'de> Deserialize<'de> for EvenPublicKey {
 
 impl<'a> Arbitrary<'a> for EvenPublicKey {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        // Generate arbitrary bytes and try to create a valid secret key
-        let sk_bytes: [u8; 32] = u.arbitrary()?;
-        let sk = SecretKey::from_slice(&sk_bytes).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        let mut sk_bytes: [u8; 32] = u.arbitrary()?;
+        // Clamp the first byte to 0xFE so the value is always below the
+        // secp256k1 curve order (which starts with 0xFF), and set the last bit
+        // to ensure the scalar is non-zero.
+        sk_bytes[0] &= 0xFE;
+        sk_bytes[31] |= 1;
+        let sk =
+            SecretKey::from_slice(&sk_bytes).expect("clamped bytes are always a valid secret key");
         let pk = PublicKey::from_secret_key(SECP256K1, &sk);
         Ok(EvenPublicKey::from(pk))
     }
@@ -263,5 +268,21 @@ mod tests {
 
         assert_eq!(SecretKey::from(even_sk), odd_sk.negate());
         assert_eq!(PublicKey::from(even_pk), odd_pk.negate(SECP256K1));
+    }
+
+    mod proptest_arbitrary {
+        use arbitrary::{Arbitrary, Unstructured};
+        use proptest::{collection::vec, num::u8, proptest};
+
+        use super::EvenPublicKey;
+
+        proptest! {
+            #[test]
+            fn test_arbitrary_never_fails(seed in vec(u8::ANY, 64)) {
+                let mut u = Unstructured::new(&seed);
+                let result = EvenPublicKey::arbitrary(&mut u);
+                proptest::prop_assert!(result.is_ok(), "arbitrary should never return IncorrectFormat");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
`EvenPublicKey::arbitrary` could fail with `IncorrectFormat` when random bytes happened to exceed the secp256k1 curve order or be zero. Fix by clamping the secret key bytes to guarantee validity. Similarly, replace the derived `Arbitrary` impl for `AdministrationInitConfig` with a manual one that correctly generates NonZero<u8> values.

Add proptest-based fuzz tests to verify both implementations never fail.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [X]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
