### PR TITLE
feat(btcio): add mempool esplora fee policy for writer (STR-2997)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14361,6 +14361,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "strata-btc-types",
  "strata-config",
  "strata-csm-types",

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -62,7 +62,7 @@ use strata_btcio::{
     BtcioParams,
 };
 #[cfg(feature = "sequencer")]
-use strata_config::btcio::WriterConfig;
+use strata_config::btcio::{FeePolicy, WriterConfig};
 use strata_identifiers::{EpochCommitment, OLBlockId};
 use strata_l1_txfmt::MagicBytes;
 use strata_predicate::PredicateKey;
@@ -550,7 +550,13 @@ fn main() {
                     .map_err(|e| eyre::eyre!("starting broadcaster service: {e}"))?,
                 );
 
-                let writer_config = Arc::new(WriterConfig::default());
+                // TODO(STR-2982): support custom btcio.write configurations via CLI flags or TOML
+                // config file. For now, we hardcode to `BitcoinD` so that functional-tests can
+                // pass.
+                let writer_config = Arc::new(WriterConfig {
+                    fee_policy: FeePolicy::BitcoinD,
+                    ..WriterConfig::default()
+                });
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(
                     btc_client,
                     writer_config,

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -554,7 +554,7 @@ fn main() {
                 // config file. For now, we hardcode to `BitcoinD` so that functional-tests can
                 // pass.
                 let writer_config = Arc::new(WriterConfig {
-                    fee_policy: FeePolicy::BitcoinD,
+                    fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
                     ..WriterConfig::default()
                 });
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -37,6 +37,7 @@ tracing.workspace = true
 hex.workspace = true
 musig2 = { workspace = true, features = ["serde"] }
 proptest.workspace = true
+serde_json.workspace = true
 strata-db-store-sled = { workspace = true, features = ["test_utils"] }
 strata-state = { workspace = true, features = ["test_utils"] }
 strata-status.workspace = true

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -590,7 +590,7 @@ pub(crate) mod test_context {
             .require_network(Network::Regtest)
             .unwrap();
         let cfg = Arc::new(WriterConfig {
-            fee_policy: FeePolicy::BitcoinD,
+            fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
             ..WriterConfig::default()
         });
         let status_channel = StatusChannel::new(

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -575,7 +575,7 @@ pub(crate) mod test_context {
     use std::sync::Arc;
 
     use bitcoin::{Address, Network};
-    use strata_config::btcio::WriterConfig;
+    use strata_config::btcio::{FeePolicy, WriterConfig};
     use strata_l1_txfmt::MagicBytes;
     use strata_status::StatusChannel;
     use strata_test_utils::ArbitraryGenerator;
@@ -589,7 +589,10 @@ pub(crate) mod test_context {
             .unwrap()
             .require_network(Network::Regtest)
             .unwrap();
-        let cfg = Arc::new(WriterConfig::default());
+        let cfg = Arc::new(WriterConfig {
+            fee_policy: FeePolicy::BitcoinD,
+            ..WriterConfig::default()
+        });
         let status_channel = StatusChannel::new(
             ArbitraryGenerator::new().generate(),
             ArbitraryGenerator::new().generate(),

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -24,13 +24,13 @@ use bitcoind_async_client::{
     traits::{Reader, Signer, Wallet},
 };
 use rand::{rngs::OsRng, RngCore};
-use strata_config::btcio::FeePolicy;
 use strata_csm_types::L1Payload;
 use strata_l1_envelope_fmt::{builder::EnvelopeScriptBuilder, errors::EnvelopeBuildError};
 use strata_l1_txfmt::{self, MagicBytes, ParseConfig, TxFmtError};
 use thiserror::Error;
 
 use super::context::WriterContext;
+use crate::writer::fees::resolve_fee_rate;
 
 pub(crate) const BITCOIN_DUST_LIMIT: u64 = 546;
 
@@ -126,10 +126,7 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
         .await?
         .0;
 
-    let fee_rate = match ctx.config.fee_policy {
-        FeePolicy::Smart => ctx.client.estimate_smart_fee(1).await? * 2,
-        FeePolicy::Fixed(val) => val,
-    };
+    let fee_rate = resolve_fee_rate(ctx.client.as_ref(), ctx.config.as_ref()).await?;
     let mut env_config = EnvelopeConfig::new(
         ctx.btcio_params.magic_bytes(),
         ctx.sequencer_address.clone(),

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -80,7 +80,6 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
                     .estimate_smart_fee(1)
                     .await
                     .map_err(|e| EnvelopeError::Other(e.into()))?
-                    * 2
             }
             FeePolicy::Fixed(val) => val,
         };

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use bitcoin::consensus::encode::serialize as btc_serialize;
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::{TxidExt, WtxidExt};
-use strata_config::btcio::FeePolicy;
 use strata_db_types::types::{
     ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxEntry, RevealTxMeta,
 };
@@ -27,7 +26,10 @@ use tracing::*;
 use super::{builder::build_chunked_envelope_txs, context::ChunkedWriterContext};
 use crate::{
     broadcaster::L1BroadcastHandle,
-    writer::builder::{EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT},
+    writer::{
+        builder::{EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT},
+        fees::resolve_fee_rate,
+    },
 };
 
 fn format_reveal_refs(reveals: &[RevealTxMeta]) -> Vec<String> {
@@ -74,15 +76,9 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .map_err(|e| EnvelopeError::Other(e.into()))?
             .0;
 
-        let fee_rate = match ctx.config.fee_policy {
-            FeePolicy::Smart => {
-                ctx.client
-                    .estimate_smart_fee(1)
-                    .await
-                    .map_err(|e| EnvelopeError::Other(e.into()))?
-            }
-            FeePolicy::Fixed(val) => val,
-        };
+        let fee_rate = resolve_fee_rate(ctx.client.as_ref(), ctx.config.as_ref())
+            .await
+            .map_err(EnvelopeError::Other)?;
 
         let env_config = EnvelopeConfig::new(
             ctx.btcio_params.magic_bytes,

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Context};
 use bitcoind_async_client::traits::Reader;
 use reqwest::Url;
 use serde::Deserialize;
-use strata_config::btcio::{FeePolicy, WriterConfig};
+use strata_config::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
 use tracing::warn;
 
 /// Represents the response from the mempool.space recommended fees endpoint.
@@ -35,7 +35,9 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
             .estimate_smart_fee(*conf_target)
             .await
             .context("failed to estimate smart fee"),
-        FeePolicy::MempoolExplorer => resolve_mempool_fee_rate(client, config).await,
+        FeePolicy::MempoolExplorer { policy } => {
+            resolve_mempool_fee_rate(client, config, *policy).await
+        }
         FeePolicy::Fixed { fee_rate } => Ok(*fee_rate),
     }
 }
@@ -45,6 +47,7 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
 async fn resolve_mempool_fee_rate<R: Reader>(
     client: &R,
     config: &WriterConfig,
+    mempool_fee_policy: MempoolExplorerFeePolicy,
 ) -> anyhow::Result<u64> {
     let base_url = config
         .mempool_base_url
@@ -53,7 +56,13 @@ async fn resolve_mempool_fee_rate<R: Reader>(
     let url = mempool_recommended_fees_url(base_url)?;
 
     match fetch_mempool_recommended_fees(url).await {
-        Ok(fees) => Ok(fees.fastest_fee),
+        Ok(fees) => match mempool_fee_policy {
+            MempoolExplorerFeePolicy::Fastest => Ok(fees.fastest_fee),
+            MempoolExplorerFeePolicy::HalfHour => Ok(fees.half_hour_fee),
+            MempoolExplorerFeePolicy::Hour => Ok(fees.hour_fee),
+            MempoolExplorerFeePolicy::Economy => Ok(fees.economy_fee),
+            MempoolExplorerFeePolicy::Minimum => Ok(fees.minimum_fee),
+        },
         Err(err) => {
             warn!(
                 %base_url,
@@ -96,7 +105,7 @@ async fn fetch_mempool_recommended_fees(url: Url) -> anyhow::Result<MempoolRecom
 mod tests {
     use std::sync::Arc;
 
-    use strata_config::btcio::{FeePolicy, WriterConfig};
+    use strata_config::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
@@ -182,7 +191,9 @@ mod tests {
         .await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer,
+            fee_policy: FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Fastest,
+            },
             mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
@@ -195,11 +206,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_fee_rate_uses_selected_mempool_policy() {
+        let server = spawn_single_response_server(
+            "200 OK",
+            "{\"fastestFee\":7,\"halfHourFee\":6,\"hourFee\":5,\"economyFee\":4,\"minimumFee\":3}",
+        )
+        .await;
+        let client = TestBitcoinClient::new(1);
+        let config = WriterConfig {
+            fee_policy: FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Economy,
+            },
+            mempool_base_url: Some(server),
+            ..WriterConfig::default()
+        };
+
+        let fee_rate = resolve_fee_rate(&client, &config)
+            .await
+            .expect("mempool fee lookup should succeed");
+
+        assert_eq!(fee_rate, 4);
+    }
+
+    #[tokio::test]
     async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_invalid_json() {
         let server = spawn_single_response_server("200 OK", "not-json").await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer,
+            fee_policy: FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Fastest,
+            },
             mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
@@ -216,7 +252,9 @@ mod tests {
         let server = spawn_single_response_server("500 Internal Server Error", "").await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer,
+            fee_policy: FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Fastest,
+            },
             mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
@@ -232,7 +270,9 @@ mod tests {
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_missing() {
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer,
+            fee_policy: FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Fastest,
+            },
             mempool_base_url: None,
             ..WriterConfig::default()
         };
@@ -250,7 +290,9 @@ mod tests {
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_invalid() {
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer,
+            fee_policy: FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Fastest,
+            },
             mempool_base_url: Some("not a url".to_string()),
             ..WriterConfig::default()
         };

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -30,7 +30,7 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
     client: &R,
     config: &WriterConfig,
 ) -> anyhow::Result<u64> {
-    match &config.fee_policy {
+    let fee_rate = match &config.fee_policy {
         FeePolicy::BitcoinD { conf_target } => client
             .estimate_smart_fee(*conf_target)
             .await
@@ -39,7 +39,15 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
             resolve_mempool_fee_rate(client, config, *policy).await
         }
         FeePolicy::Fixed { fee_rate } => Ok(*fee_rate),
-    }
+    }?;
+
+    // NOTE(STR-2545, STR-2433): fee estimation is currently being doubled since we don't fully
+    //                           support fee bumping ostensive mechanisms for making sure
+    //                           transactions confirm in a timely manner. This is a temporary
+    //                           measure until we implement more robust fee bumping strategies,
+    //                           at which point we can remove the doubling and rely on the fee
+    //                           policies to provide accurate fee rates.
+    Ok(fee_rate * 2)
 }
 
 /// Resolves the fee rate using the mempool.space recommended fees endpoint, falling back to
@@ -202,7 +210,8 @@ mod tests {
             .await
             .expect("mempool fee lookup should succeed");
 
-        assert_eq!(fee_rate, 7);
+        // NOTE: double the fees here
+        assert_eq!(fee_rate, 7 * 2);
     }
 
     #[tokio::test]
@@ -225,7 +234,8 @@ mod tests {
             .await
             .expect("mempool fee lookup should succeed");
 
-        assert_eq!(fee_rate, 4);
+        // NOTE: double the fees here
+        assert_eq!(fee_rate, 4 * 2);
     }
 
     #[tokio::test]
@@ -244,7 +254,8 @@ mod tests {
             .await
             .expect("smart fee fallback should succeed");
 
-        assert_eq!(fee_rate, 3);
+        // NOTE: double the fees here
+        assert_eq!(fee_rate, 3 * 2);
     }
 
     #[tokio::test]
@@ -263,7 +274,8 @@ mod tests {
             .await
             .expect("smart fee fallback should succeed");
 
-        assert_eq!(fee_rate, 3);
+        // NOTE: double the fees here
+        assert_eq!(fee_rate, 3 * 2);
     }
 
     #[tokio::test]
@@ -316,6 +328,7 @@ mod tests {
             .await
             .expect("smart fee lookup should succeed");
 
-        assert_eq!(fee_rate, 3);
+        // NOTE: double the fees here
+        assert_eq!(fee_rate, 3 * 2);
     }
 }

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use strata_config::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
 use tracing::warn;
 
-/// Represents the response from the mempool.space recommended fees endpoint.
+/// Represents the response from the mempool explorer recommended fees endpoint.
 // TODO(STR-3038): once we update Alpen's mempool explorers we can use `api/v1/fees/precise`
 //                 for more granular sub-1 sat/vB fee rates if desired.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -23,6 +23,62 @@ pub(crate) struct MempoolRecommendedFees {
     economy_fee: u64,
     #[serde(rename = "minimumFee")]
     minimum_fee: u64,
+}
+
+impl MempoolRecommendedFees {
+    /// Selects the fee rate according to the given policy.
+    fn select(self, policy: MempoolExplorerFeePolicy) -> u64 {
+        match policy {
+            MempoolExplorerFeePolicy::Fastest => self.fastest_fee,
+            MempoolExplorerFeePolicy::HalfHour => self.half_hour_fee,
+            MempoolExplorerFeePolicy::Hour => self.hour_fee,
+            MempoolExplorerFeePolicy::Economy => self.economy_fee,
+            MempoolExplorerFeePolicy::Minimum => self.minimum_fee,
+        }
+    }
+}
+
+/// HTTP client for querying a mempool explorer's fee estimation API.
+struct MempoolExplorerClient {
+    base_url: Url,
+    http: reqwest::Client,
+}
+
+impl MempoolExplorerClient {
+    /// Creates a new client from a base URL string (e.g. `https://mempool.space/signet`).
+    fn new(base_url: &str) -> anyhow::Result<Self> {
+        let mut url = Url::parse(base_url)
+            .with_context(|| format!("invalid mempool_base_url: {base_url}"))?;
+
+        if !url.path().ends_with('/') {
+            let path = format!("{}/", url.path());
+            url.set_path(&path);
+        }
+
+        Ok(Self {
+            base_url: url,
+            http: reqwest::Client::new(),
+        })
+    }
+
+    /// Fetches the recommended fees from the mempool explorer.
+    async fn fetch_recommended_fees(&self) -> anyhow::Result<MempoolRecommendedFees> {
+        let url = self
+            .base_url
+            .join("api/v1/fees/recommended")
+            .with_context(|| format!("invalid recommended-fees URL for base: {}", self.base_url))?;
+
+        self.http
+            .get(url)
+            .send()
+            .await
+            .context("failed to call mempool recommended fees endpoint")?
+            .error_for_status()
+            .context("mempool recommended fees endpoint returned an error status")?
+            .json::<MempoolRecommendedFees>()
+            .await
+            .context("failed to decode mempool recommended fees response")
+    }
 }
 
 /// Resolves the fee rate to use for a transaction based on the provided configuration.
@@ -50,7 +106,7 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
     Ok(fee_rate * 2)
 }
 
-/// Resolves the fee rate using the mempool.space recommended fees endpoint, falling back to
+/// Resolves the fee rate using the mempool explorer recommended fees endpoint, falling back to
 /// Bitcoin Core's `estimatesmartfee` on failure.
 async fn resolve_mempool_fee_rate<R: Reader>(
     client: &R,
@@ -61,16 +117,11 @@ async fn resolve_mempool_fee_rate<R: Reader>(
         .mempool_base_url
         .as_deref()
         .ok_or_else(|| anyhow!("mempool_base_url must be set when fee_policy = \"mempool\""))?;
-    let url = mempool_recommended_fees_url(base_url)?;
 
-    match fetch_mempool_recommended_fees(url).await {
-        Ok(fees) => match mempool_fee_policy {
-            MempoolExplorerFeePolicy::Fastest => Ok(fees.fastest_fee),
-            MempoolExplorerFeePolicy::HalfHour => Ok(fees.half_hour_fee),
-            MempoolExplorerFeePolicy::Hour => Ok(fees.hour_fee),
-            MempoolExplorerFeePolicy::Economy => Ok(fees.economy_fee),
-            MempoolExplorerFeePolicy::Minimum => Ok(fees.minimum_fee),
-        },
+    let explorer = MempoolExplorerClient::new(base_url)?;
+
+    match explorer.fetch_recommended_fees().await {
+        Ok(fees) => Ok(fees.select(mempool_fee_policy)),
         Err(err) => {
             warn!(
                 %base_url,
@@ -85,30 +136,6 @@ async fn resolve_mempool_fee_rate<R: Reader>(
     }
 }
 
-fn mempool_recommended_fees_url(base_url: &str) -> anyhow::Result<Url> {
-    let mut url =
-        Url::parse(base_url).with_context(|| format!("invalid mempool_base_url: {base_url}"))?;
-
-    if !url.path().ends_with('/') {
-        let path = format!("{}/", url.path());
-        url.set_path(&path);
-    }
-
-    url.join("api/v1/fees/recommended")
-        .with_context(|| format!("invalid recommended-fees URL for base: {base_url}"))
-}
-
-async fn fetch_mempool_recommended_fees(url: Url) -> anyhow::Result<MempoolRecommendedFees> {
-    reqwest::get(url)
-        .await
-        .context("failed to call mempool recommended fees endpoint")?
-        .error_for_status()
-        .context("mempool recommended fees endpoint returned an error status")?
-        .json::<MempoolRecommendedFees>()
-        .await
-        .context("failed to decode mempool recommended fees response")
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -119,7 +146,7 @@ mod tests {
         net::TcpListener,
     };
 
-    use super::{mempool_recommended_fees_url, resolve_fee_rate, MempoolRecommendedFees};
+    use super::{resolve_fee_rate, MempoolExplorerClient, MempoolRecommendedFees};
     use crate::test_utils::TestBitcoinClient;
 
     async fn spawn_single_response_server(status_line: &'static str, body: &'static str) -> String {
@@ -177,17 +204,17 @@ mod tests {
     }
 
     #[test]
-    fn test_mempool_recommended_fees_url_handles_trailing_slash() {
+    fn test_mempool_explorer_client_normalizes_trailing_slash() {
         let without_slash =
-            mempool_recommended_fees_url("https://mempool.space/signet").expect("url should parse");
-        let with_slash = mempool_recommended_fees_url("https://mempool.space/signet/")
-            .expect("url should parse");
+            MempoolExplorerClient::new("https://mempool.space/signet").expect("url should parse");
+        let with_slash =
+            MempoolExplorerClient::new("https://mempool.space/signet/").expect("url should parse");
 
         assert_eq!(
-            without_slash.as_str(),
-            "https://mempool.space/signet/api/v1/fees/recommended"
+            without_slash.base_url.as_str(),
+            "https://mempool.space/signet/"
         );
-        assert_eq!(without_slash, with_slash);
+        assert_eq!(without_slash.base_url, with_slash.base_url);
     }
 
     #[tokio::test]

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -1,12 +1,17 @@
 //! Module for resolving fee rates for transactions, supporting multiple fee policies including
 //! Bitcoin Core's `estimatesmartfee` and mempool.space's recommended fees endpoint.
 
+use std::sync::LazyLock;
+
 use anyhow::{anyhow, Context};
 use bitcoind_async_client::traits::Reader;
 use reqwest::Url;
 use serde::Deserialize;
 use strata_config::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
 use tracing::warn;
+
+/// Shared HTTP client reused across mempool fee lookups for connection pooling.
+static SHARED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 /// Represents the response from the mempool explorer recommended fees endpoint.
 // TODO(STR-3038): once we update Alpen's mempool explorers we can use `api/v1/fees/precise`
@@ -39,9 +44,10 @@ impl MempoolRecommendedFees {
 }
 
 /// HTTP client for querying a mempool explorer's fee estimation API.
+///
+/// Reuses a module-level [`reqwest::Client`] for connection pooling across calls.
 struct MempoolExplorerClient {
     base_url: Url,
-    http: reqwest::Client,
 }
 
 impl MempoolExplorerClient {
@@ -55,10 +61,7 @@ impl MempoolExplorerClient {
             url.set_path(&path);
         }
 
-        Ok(Self {
-            base_url: url,
-            http: reqwest::Client::new(),
-        })
+        Ok(Self { base_url: url })
     }
 
     /// Fetches the recommended fees from the mempool explorer.
@@ -68,7 +71,7 @@ impl MempoolExplorerClient {
             .join("api/v1/fees/recommended")
             .with_context(|| format!("invalid recommended-fees URL for base: {}", self.base_url))?;
 
-        self.http
+        SHARED_HTTP_CLIENT
             .get(url)
             .send()
             .await

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -31,12 +31,12 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
     config: &WriterConfig,
 ) -> anyhow::Result<u64> {
     match &config.fee_policy {
-        FeePolicy::BitcoinD => client
-            .estimate_smart_fee(1)
+        FeePolicy::BitcoinD { conf_target } => client
+            .estimate_smart_fee(*conf_target)
             .await
             .context("failed to estimate smart fee"),
         FeePolicy::MempoolExplorer => resolve_mempool_fee_rate(client, config).await,
-        FeePolicy::Fixed(value) => Ok(*value),
+        FeePolicy::Fixed { fee_rate } => Ok(*fee_rate),
     }
 }
 
@@ -266,7 +266,7 @@ mod tests {
     async fn test_resolve_fee_rate_smart_uses_raw_estimate() {
         let client = Arc::new(TestBitcoinClient::new(1));
         let config = WriterConfig {
-            fee_policy: FeePolicy::BitcoinD,
+            fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
             ..WriterConfig::default()
         };
 

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -119,6 +119,7 @@ async fn resolve_mempool_fee_rate<R: Reader>(
         .ok_or_else(|| anyhow!("mempool_base_url must be set when fee_policy = \"mempool\""))?;
 
     let explorer = MempoolExplorerClient::new(base_url)?;
+    let fallback_conf_target = config.mempool_fallback_conf_target;
 
     match explorer.fetch_recommended_fees().await {
         Ok(fees) => Ok(fees.select(mempool_fee_policy)),
@@ -126,10 +127,11 @@ async fn resolve_mempool_fee_rate<R: Reader>(
             warn!(
                 %base_url,
                 %err,
+                fallback_conf_target,
                 "mempool fee lookup failed, falling back to bitcoind's estimatesmartfee"
             );
             client
-                .estimate_smart_fee(1)
+                .estimate_smart_fee(fallback_conf_target)
                 .await
                 .context("failed to estimate smart fee after mempool fallback")
         }

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -33,7 +33,7 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
             .estimate_smart_fee(1)
             .await
             .context("failed to estimate smart fee"),
-        FeePolicy::Mempool => resolve_mempool_fee_rate(client, config).await,
+        FeePolicy::MempoolExplorer => resolve_mempool_fee_rate(client, config).await,
         FeePolicy::Fixed(value) => Ok(*value),
     }
 }
@@ -180,7 +180,7 @@ mod tests {
         .await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::Mempool,
+            fee_policy: FeePolicy::MempoolExplorer,
             mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
@@ -197,7 +197,7 @@ mod tests {
         let server = spawn_single_response_server("200 OK", "not-json").await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::Mempool,
+            fee_policy: FeePolicy::MempoolExplorer,
             mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
@@ -214,7 +214,7 @@ mod tests {
         let server = spawn_single_response_server("500 Internal Server Error", "").await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::Mempool,
+            fee_policy: FeePolicy::MempoolExplorer,
             mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
@@ -230,7 +230,7 @@ mod tests {
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_missing() {
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::Mempool,
+            fee_policy: FeePolicy::MempoolExplorer,
             mempool_base_url: None,
             ..WriterConfig::default()
         };
@@ -248,7 +248,7 @@ mod tests {
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_invalid() {
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::Mempool,
+            fee_policy: FeePolicy::MempoolExplorer,
             mempool_base_url: Some("not a url".to_string()),
             ..WriterConfig::default()
         };

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -1,0 +1,273 @@
+//! Module for resolving fee rates for transactions, supporting multiple fee policies including
+//! Bitcoin Core's `estimatesmartfee` and mempool.space's recommended fees endpoint.
+
+use anyhow::{anyhow, Context};
+use bitcoind_async_client::traits::Reader;
+use reqwest::Url;
+use serde::Deserialize;
+use strata_config::btcio::{FeePolicy, WriterConfig};
+use tracing::warn;
+
+/// Represents the response from the mempool.space recommended fees endpoint.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub(crate) struct MempoolRecommendedFees {
+    #[serde(rename = "fastestFee")]
+    fastest_fee: u64,
+    #[serde(rename = "halfHourFee")]
+    half_hour_fee: u64,
+    #[serde(rename = "hourFee")]
+    hour_fee: u64,
+    #[serde(rename = "economyFee")]
+    economy_fee: u64,
+    #[serde(rename = "minimumFee")]
+    minimum_fee: u64,
+}
+
+/// Resolves the fee rate to use for a transaction based on the provided configuration.
+pub(crate) async fn resolve_fee_rate<R: Reader>(
+    client: &R,
+    config: &WriterConfig,
+) -> anyhow::Result<u64> {
+    match &config.fee_policy {
+        FeePolicy::BitcoinD => client
+            .estimate_smart_fee(1)
+            .await
+            .context("failed to estimate smart fee"),
+        FeePolicy::Mempool => resolve_mempool_fee_rate(client, config).await,
+        FeePolicy::Fixed(value) => Ok(*value),
+    }
+}
+
+/// Resolves the fee rate using the mempool.space recommended fees endpoint, falling back to
+/// Bitcoin Core's `estimatesmartfee` on failure.
+async fn resolve_mempool_fee_rate<R: Reader>(
+    client: &R,
+    config: &WriterConfig,
+) -> anyhow::Result<u64> {
+    let base_url = config
+        .mempool_base_url
+        .as_deref()
+        .ok_or_else(|| anyhow!("mempool_base_url must be set when fee_policy = \"mempool\""))?;
+    let url = mempool_recommended_fees_url(base_url)?;
+
+    match fetch_mempool_recommended_fees(url).await {
+        Ok(fees) => Ok(fees.fastest_fee),
+        Err(err) => {
+            warn!(
+                %base_url,
+                %err,
+                "mempool fee lookup failed, falling back to bitcoind's estimatesmartfee"
+            );
+            client
+                .estimate_smart_fee(1)
+                .await
+                .context("failed to estimate smart fee after mempool fallback")
+        }
+    }
+}
+
+fn mempool_recommended_fees_url(base_url: &str) -> anyhow::Result<Url> {
+    let mut url =
+        Url::parse(base_url).with_context(|| format!("invalid mempool_base_url: {base_url}"))?;
+
+    if !url.path().ends_with('/') {
+        let path = format!("{}/", url.path());
+        url.set_path(&path);
+    }
+
+    url.join("api/v1/fees/recommended")
+        .with_context(|| format!("invalid recommended-fees URL for base: {base_url}"))
+}
+
+async fn fetch_mempool_recommended_fees(url: Url) -> anyhow::Result<MempoolRecommendedFees> {
+    reqwest::get(url)
+        .await
+        .context("failed to call mempool recommended fees endpoint")?
+        .error_for_status()
+        .context("mempool recommended fees endpoint returned an error status")?
+        .json::<MempoolRecommendedFees>()
+        .await
+        .context("failed to decode mempool recommended fees response")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use strata_config::btcio::{FeePolicy, WriterConfig};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    use super::{mempool_recommended_fees_url, resolve_fee_rate, MempoolRecommendedFees};
+    use crate::test_utils::TestBitcoinClient;
+
+    async fn spawn_single_response_server(status_line: &'static str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let addr = listener
+            .local_addr()
+            .expect("listener should have local addr");
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept should succeed");
+
+            let mut buf = [0_u8; 1024];
+            let _ = stream
+                .read(&mut buf)
+                .await
+                .expect("request read should succeed");
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("response write should succeed");
+        });
+
+        format!("http://{addr}")
+    }
+
+    #[test]
+    fn test_mempool_recommended_fees_json_deserializes() {
+        let json = r#"{
+            "fastestFee": 1,
+            "halfHourFee": 2,
+            "hourFee": 3,
+            "economyFee": 4,
+            "minimumFee": 5
+        }"#;
+
+        let fees: MempoolRecommendedFees =
+            serde_json::from_str(json).expect("response should deserialize");
+
+        assert_eq!(
+            fees,
+            MempoolRecommendedFees {
+                fastest_fee: 1,
+                half_hour_fee: 2,
+                hour_fee: 3,
+                economy_fee: 4,
+                minimum_fee: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn test_mempool_recommended_fees_url_handles_trailing_slash() {
+        let without_slash =
+            mempool_recommended_fees_url("https://mempool.space/signet").expect("url should parse");
+        let with_slash = mempool_recommended_fees_url("https://mempool.space/signet/")
+            .expect("url should parse");
+
+        assert_eq!(
+            without_slash.as_str(),
+            "https://mempool.space/signet/api/v1/fees/recommended"
+        );
+        assert_eq!(without_slash, with_slash);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_uses_mempool_fastest_fee() {
+        let server = spawn_single_response_server(
+            "200 OK",
+            "{\"fastestFee\":7,\"halfHourFee\":6,\"hourFee\":5,\"economyFee\":4,\"minimumFee\":3}",
+        )
+        .await;
+        let client = TestBitcoinClient::new(1);
+        let config = WriterConfig {
+            fee_policy: FeePolicy::Mempool,
+            mempool_base_url: Some(server),
+            ..WriterConfig::default()
+        };
+
+        let fee_rate = resolve_fee_rate(&client, &config)
+            .await
+            .expect("mempool fee lookup should succeed");
+
+        assert_eq!(fee_rate, 7);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_invalid_json() {
+        let server = spawn_single_response_server("200 OK", "not-json").await;
+        let client = TestBitcoinClient::new(1);
+        let config = WriterConfig {
+            fee_policy: FeePolicy::Mempool,
+            mempool_base_url: Some(server),
+            ..WriterConfig::default()
+        };
+
+        let fee_rate = resolve_fee_rate(&client, &config)
+            .await
+            .expect("smart fee fallback should succeed");
+
+        assert_eq!(fee_rate, 3);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_http_error() {
+        let server = spawn_single_response_server("500 Internal Server Error", "").await;
+        let client = TestBitcoinClient::new(1);
+        let config = WriterConfig {
+            fee_policy: FeePolicy::Mempool,
+            mempool_base_url: Some(server),
+            ..WriterConfig::default()
+        };
+
+        let fee_rate = resolve_fee_rate(&client, &config)
+            .await
+            .expect("smart fee fallback should succeed");
+
+        assert_eq!(fee_rate, 3);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_missing() {
+        let client = TestBitcoinClient::new(1);
+        let config = WriterConfig {
+            fee_policy: FeePolicy::Mempool,
+            mempool_base_url: None,
+            ..WriterConfig::default()
+        };
+
+        let err = resolve_fee_rate(&client, &config)
+            .await
+            .expect_err("missing mempool_base_url should error");
+
+        assert!(err
+            .to_string()
+            .contains("mempool_base_url must be set when fee_policy = \"mempool\""));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_invalid() {
+        let client = TestBitcoinClient::new(1);
+        let config = WriterConfig {
+            fee_policy: FeePolicy::Mempool,
+            mempool_base_url: Some("not a url".to_string()),
+            ..WriterConfig::default()
+        };
+
+        let err = resolve_fee_rate(&client, &config)
+            .await
+            .expect_err("invalid mempool_base_url should error");
+
+        assert!(err.to_string().contains("invalid mempool_base_url"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_smart_uses_raw_estimate() {
+        let client = Arc::new(TestBitcoinClient::new(1));
+
+        let fee_rate = resolve_fee_rate(client.as_ref(), &WriterConfig::default())
+            .await
+            .expect("smart fee lookup should succeed");
+
+        assert_eq!(fee_rate, 3);
+    }
+}

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -263,8 +263,12 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_fee_rate_smart_uses_raw_estimate() {
         let client = Arc::new(TestBitcoinClient::new(1));
+        let config = WriterConfig {
+            fee_policy: FeePolicy::BitcoinD,
+            ..WriterConfig::default()
+        };
 
-        let fee_rate = resolve_fee_rate(client.as_ref(), &WriterConfig::default())
+        let fee_rate = resolve_fee_rate(client.as_ref(), &config)
             .await
             .expect("smart fee lookup should succeed");
 

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -9,6 +9,8 @@ use strata_config::btcio::{FeePolicy, WriterConfig};
 use tracing::warn;
 
 /// Represents the response from the mempool.space recommended fees endpoint.
+// TODO(STR-3038): once we update Alpen's mempool explorers we can use `api/v1/fees/precise`
+//                 for more granular sub-1 sat/vB fee rates if desired.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct MempoolRecommendedFees {
     #[serde(rename = "fastestFee")]

--- a/crates/btcio/src/writer/mod.rs
+++ b/crates/btcio/src/writer/mod.rs
@@ -2,6 +2,7 @@ pub mod builder;
 mod bundler;
 pub mod chunked_envelope;
 pub(crate) mod context;
+mod fees;
 mod signer;
 mod task;
 

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -33,7 +33,7 @@ pub struct WriterConfig {
 }
 
 /// Definition of how fees are determined while creating l1 transactions.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum FeePolicy {
     /// Use mempool explorer recommended fees endpoint.

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -22,6 +22,7 @@ pub struct WriterConfig {
     pub write_poll_dur_ms: u64,
     /// How the fees for are determined.
     // FIXME: This should actually be a part of signer.
+    #[serde(flatten)]
     pub fee_policy: FeePolicy,
     /// How much amount(in sats) to send to reveal address. Must be above dust amount or else
     /// reveal transaction won't be accepted.
@@ -40,11 +41,23 @@ pub enum FeePolicy {
     #[default]
     MempoolExplorer,
 
-    /// Use Bitcoin Core's `estimatesmartfee`.
-    BitcoinD,
+    /// Use Bitcoin Core's `estimatesmartfee` and the target confirmation parameter is the provided
+    /// value.
+    #[serde(rename = "bitcoind")]
+    BitcoinD {
+        #[serde(
+            default = "default_bitcoind_conf_target",
+            rename = "bitcoind_conf_target"
+        )]
+        conf_target: u16,
+    },
 
     /// Fixed fee in sat/vB.
-    Fixed(u64),
+    #[serde(rename = "fixed")]
+    Fixed {
+        #[serde(rename = "fixed_fee_rate")]
+        fee_rate: u64,
+    },
 }
 
 /// Configuration for btcio broadcaster.
@@ -64,6 +77,10 @@ impl Default for WriterConfig {
             mempool_base_url: None,
         }
     }
+}
+
+const fn default_bitcoind_conf_target() -> u16 {
+    1
 }
 
 impl Default for ReaderConfig {

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -34,12 +34,15 @@ pub struct WriterConfig {
 }
 
 /// Definition of how fees are determined while creating l1 transactions.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "fee_policy")]
 pub enum FeePolicy {
     /// Use mempool explorer recommended fees endpoint.
-    #[default]
-    MempoolExplorer,
+    #[serde(rename = "mempool")]
+    MempoolExplorer {
+        #[serde(default, rename = "mempool_fee_policy")]
+        policy: MempoolExplorerFeePolicy,
+    },
 
     /// Use Bitcoin Core's `estimatesmartfee` and the target confirmation parameter is the provided
     /// value.
@@ -60,6 +63,26 @@ pub enum FeePolicy {
     },
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MempoolExplorerFeePolicy {
+    /// Use the "fastest" fee estimate from mempool explorer.
+    #[default]
+    Fastest,
+
+    /// Use the "half hour" fee estimate from mempool explorer.
+    HalfHour,
+
+    /// Use the "hour" fee estimate from mempool explorer.
+    Hour,
+
+    /// Use the "economy" fee estimate from mempool explorer.
+    Economy,
+
+    /// Use the "minimum" fee estimate from mempool explorer.
+    Minimum,
+}
+
 /// Configuration for btcio broadcaster.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BroadcasterConfig {
@@ -71,10 +94,18 @@ impl Default for WriterConfig {
     fn default() -> Self {
         Self {
             write_poll_dur_ms: 5_000,
-            fee_policy: FeePolicy::MempoolExplorer,
+            fee_policy: FeePolicy::default(),
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
             mempool_base_url: None,
+        }
+    }
+}
+
+impl Default for FeePolicy {
+    fn default() -> Self {
+        Self::MempoolExplorer {
+            policy: MempoolExplorerFeePolicy::default(),
         }
     }
 }

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -28,15 +28,21 @@ pub struct WriterConfig {
     pub reveal_amount: u64,
     /// How often to bundle write intents.
     pub bundle_interval_ms: u64,
+    /// Base URL for mempool.space-compatible fee API.
+    pub mempool_base_url: Option<String>,
 }
 
 /// Definition of how fees are determined while creating l1 transactions.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum FeePolicy {
-    /// Use estimatesmartfee.
+    /// Use mempool.space explorer recommended fees endpoint.
     #[default]
-    Smart,
+    Mempool,
+
+    /// Use Bitcoin Core's `estimatesmartfee`.
+    BitcoinD,
+
     /// Fixed fee in sat/vB.
     Fixed(u64),
 }
@@ -52,9 +58,10 @@ impl Default for WriterConfig {
     fn default() -> Self {
         Self {
             write_poll_dur_ms: 5_000,
-            fee_policy: FeePolicy::Smart,
+            fee_policy: FeePolicy::Mempool,
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
+            mempool_base_url: None,
         }
     }
 }

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -104,8 +104,8 @@ impl Default for WriterConfig {
 
 impl Default for FeePolicy {
     fn default() -> Self {
-        Self::MempoolExplorer {
-            policy: MempoolExplorerFeePolicy::default(),
+        Self::BitcoinD {
+            conf_target: default_bitcoind_conf_target(),
         }
     }
 }

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -36,9 +36,9 @@ pub struct WriterConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum FeePolicy {
-    /// Use mempool.space explorer recommended fees endpoint.
+    /// Use mempool explorer recommended fees endpoint.
     #[default]
-    Mempool,
+    MempoolExplorer,
 
     /// Use Bitcoin Core's `estimatesmartfee`.
     BitcoinD,
@@ -58,7 +58,7 @@ impl Default for WriterConfig {
     fn default() -> Self {
         Self {
             write_poll_dur_ms: 5_000,
-            fee_policy: FeePolicy::Mempool,
+            fee_policy: FeePolicy::MempoolExplorer,
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
             mempool_base_url: None,

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -31,6 +31,10 @@ pub struct WriterConfig {
     pub bundle_interval_ms: u64,
     /// Base URL for mempool.space-compatible fee API.
     pub mempool_base_url: Option<String>,
+    /// Confirmation target passed to bitcoind's `estimatesmartfee` when the mempool explorer is
+    /// unreachable and the policy falls back to bitcoind.
+    #[serde(default = "default_bitcoind_conf_target")]
+    pub mempool_fallback_conf_target: u16,
 }
 
 /// Definition of how fees are determined while creating l1 transactions.
@@ -98,6 +102,7 @@ impl Default for WriterConfig {
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
             mempool_base_url: None,
+            mempool_fallback_conf_target: default_bitcoind_conf_target(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -561,4 +561,35 @@ mod test {
             Some("https://mempool.space/signet")
         );
     }
+    #[test]
+    fn test_writer_config_loads_bitcoind_conf_target() {
+        let config: WriterConfig = toml::from_str(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "bitcoind"
+            bitcoind_conf_target = 6
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+            "#,
+        )
+        .expect("writer config should parse");
+
+        assert_eq!(config.fee_policy, FeePolicy::BitcoinD { conf_target: 6 });
+    }
+
+    #[test]
+    fn test_writer_config_serializes_bitcoind_conf_target() {
+        let config = WriterConfig {
+            write_poll_dur_ms: 200,
+            fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
+            reveal_amount: 100,
+            bundle_interval_ms: 1_000,
+            mempool_base_url: None,
+        };
+
+        let toml = toml::to_string(&config).expect("writer config should serialize");
+
+        assert!(toml.contains("fee_policy = \"bitcoind\""));
+        assert!(toml.contains("bitcoind_conf_target = 6"));
+    }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -314,6 +314,7 @@ pub struct Config {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::btcio::{FeePolicy, WriterConfig};
 
     #[test]
     fn test_config_load() {
@@ -537,5 +538,25 @@ mod test {
                 assert_eq!(*slots_per_epoch, 10);
             }
         }
+    }
+
+    #[test]
+    fn test_writer_config_loads_mempool_policy() {
+        let config: WriterConfig = toml::from_str(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "mempool"
+            mempool_base_url = "https://mempool.space/signet"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+            "#,
+        )
+        .expect("writer config should parse");
+
+        assert_eq!(config.fee_policy, FeePolicy::Mempool);
+        assert_eq!(
+            config.mempool_base_url.as_deref(),
+            Some("https://mempool.space/signet")
+        );
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -608,11 +608,12 @@ mod test {
     #[test]
     fn test_writer_config_serializes_bitcoind_conf_target() {
         let config = WriterConfig {
-            write_poll_dur_ms: 200,
             fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
+            write_poll_dur_ms: 200,
             reveal_amount: 100,
             bundle_interval_ms: 1_000,
             mempool_base_url: None,
+            ..WriterConfig::default()
         };
 
         let toml = toml::to_string(&config).expect("writer config should serialize");

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -314,7 +314,7 @@ pub struct Config {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::btcio::{FeePolicy, WriterConfig};
+    use crate::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
 
     #[test]
     fn test_config_load() {
@@ -555,12 +555,40 @@ mod test {
         )
         .expect("writer config should parse");
 
-        assert_eq!(config.fee_policy, FeePolicy::MempoolExplorer);
+        assert_eq!(
+            config.fee_policy,
+            FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Fastest,
+            }
+        );
         assert_eq!(
             config.mempool_base_url.as_deref(),
             Some("https://mempool.space/signet")
         );
     }
+
+    #[test]
+    fn test_writer_config_loads_specific_mempool_policy() {
+        let config: WriterConfig = toml::from_str(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "mempool"
+            mempool_fee_policy = "economy"
+            mempool_base_url = "https://mempool.space/signet"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+            "#,
+        )
+        .expect("writer config should parse");
+
+        assert_eq!(
+            config.fee_policy,
+            FeePolicy::MempoolExplorer {
+                policy: MempoolExplorerFeePolicy::Economy,
+            }
+        );
+    }
+
     #[test]
     fn test_writer_config_loads_bitcoind_conf_target() {
         let config: WriterConfig = toml::from_str(

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -350,7 +350,8 @@ mod test {
 
             [btcio.writer]
             write_poll_dur_ms = 200
-            fee_policy = "smart"
+            fee_policy = "mempool"
+            mempool_base_url = "https://mempool.space/signet"
             reveal_amount = 100
             bundle_interval_ms = 1_000
 
@@ -441,7 +442,8 @@ mod test {
 
             [btcio.writer]
             write_poll_dur_ms = 200
-            fee_policy = "smart"
+            fee_policy = "mempool"
+            mempool_base_url = "https://mempool.space/signet"
             reveal_amount = 100
             bundle_interval_ms = 1_000
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -555,7 +555,7 @@ mod test {
         )
         .expect("writer config should parse");
 
-        assert_eq!(config.fee_policy, FeePolicy::Mempool);
+        assert_eq!(config.fee_policy, FeePolicy::MempoolExplorer);
         assert_eq!(
             config.mempool_base_url.as_deref(),
             Some("https://mempool.space/signet")

--- a/docker/configs/config.fn.toml
+++ b/docker/configs/config.fn.toml
@@ -22,7 +22,8 @@ client_poll_dur_ms = 200
 
 [btcio.writer]
 write_poll_dur_ms = 200
-fee_policy = "smart"
+fee_policy = "mempool"
+mempool_base_url = "https://mempool.space/signet"
 reveal_amount = 546
 bundle_interval_ms = 1000
 

--- a/docker/configs/config.fn.toml
+++ b/docker/configs/config.fn.toml
@@ -23,6 +23,8 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "mempool"
+# mempool_fee_policy = "economy"
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/config.fn.toml
+++ b/docker/configs/config.fn.toml
@@ -23,6 +23,10 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "bitcoind"
+# bitcoind_conf_target = 6
+# Required when fee_policy = "fixed"
+# fixed_fee_rate = 5
 mempool_base_url = "https://mempool.space/signet"
 reveal_amount = 546
 bundle_interval_ms = 1000

--- a/docker/configs/config.regtest.toml
+++ b/docker/configs/config.regtest.toml
@@ -27,14 +27,7 @@ client_poll_dur_ms = 200
 
 [btcio.writer]
 write_poll_dur_ms = 200
-fee_policy = "mempool"
-# Optional when fee_policy = "mempool"
-# mempool_fee_policy = "economy"
-# Optional when fee_policy = "bitcoind"
-# bitcoind_conf_target = 6
-# Required when fee_policy = "fixed"
-# fixed_fee_rate = 5
-mempool_base_url = "https://mempool.space"
+fee_policy = "bitcoind"
 reveal_amount = 100
 bundle_interval_ms = 1000
 

--- a/docker/configs/config.regtest.toml
+++ b/docker/configs/config.regtest.toml
@@ -28,6 +28,8 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "mempool"
+# mempool_fee_policy = "economy"
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/config.regtest.toml
+++ b/docker/configs/config.regtest.toml
@@ -27,7 +27,8 @@ client_poll_dur_ms = 200
 
 [btcio.writer]
 write_poll_dur_ms = 200
-fee_policy = "smart"
+fee_policy = "mempool"
+mempool_base_url = "https://mempool.space"
 reveal_amount = 100
 bundle_interval_ms = 1000
 

--- a/docker/configs/config.regtest.toml
+++ b/docker/configs/config.regtest.toml
@@ -28,6 +28,10 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "bitcoind"
+# bitcoind_conf_target = 6
+# Required when fee_policy = "fixed"
+# fixed_fee_rate = 5
 mempool_base_url = "https://mempool.space"
 reveal_amount = 100
 bundle_interval_ms = 1000

--- a/docker/configs/config.seq.toml
+++ b/docker/configs/config.seq.toml
@@ -20,6 +20,8 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "mempool"
+# mempool_fee_policy = "economy"
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/config.seq.toml
+++ b/docker/configs/config.seq.toml
@@ -20,6 +20,10 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "bitcoind"
+# bitcoind_conf_target = 6
+# Required when fee_policy = "fixed"
+# fixed_fee_rate = 5
 mempool_base_url = "https://mempool.space"
 reveal_amount = 100
 bundle_interval_ms = 1000

--- a/docker/configs/config.seq.toml
+++ b/docker/configs/config.seq.toml
@@ -19,7 +19,8 @@ client_poll_dur_ms = 200
 
 [btcio.writer]
 write_poll_dur_ms = 200
-fee_policy = "smart"
+fee_policy = "mempool"
+mempool_base_url = "https://mempool.space"
 reveal_amount = 100
 bundle_interval_ms = 1000
 

--- a/docker/configs/config.toml
+++ b/docker/configs/config.toml
@@ -23,6 +23,8 @@ client_poll_dur_ms = 10_000
 [btcio.writer]
 write_poll_dur_ms = 10_000
 fee_policy = "mempool"
+# Optional when fee_policy = "mempool"
+# mempool_fee_policy = "economy"
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/config.toml
+++ b/docker/configs/config.toml
@@ -23,6 +23,10 @@ client_poll_dur_ms = 10_000
 [btcio.writer]
 write_poll_dur_ms = 10_000
 fee_policy = "mempool"
+# Optional when fee_policy = "bitcoind"
+# bitcoind_conf_target = 6
+# Required when fee_policy = "fixed"
+# fixed_fee_rate = 5
 mempool_base_url = "https://mempool.space/signet"
 reveal_amount = 100
 bundle_interval_ms = 1_000

--- a/docker/configs/config.toml
+++ b/docker/configs/config.toml
@@ -22,7 +22,8 @@ client_poll_dur_ms = 10_000
 
 [btcio.writer]
 write_poll_dur_ms = 10_000
-fee_policy = "smart"
+fee_policy = "mempool"
+mempool_base_url = "https://mempool.space/signet"
 reveal_amount = 100
 bundle_interval_ms = 1_000
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -23,6 +23,8 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "mempool"
+# mempool_fee_policy = "economy"
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/example_config.toml
+++ b/example_config.toml
@@ -23,6 +23,10 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Optional when fee_policy = "bitcoind"
+# bitcoind_conf_target = 6
+# Required when fee_policy = "fixed"
+# fixed_fee_rate = 5
 mempool_base_url = "https://mempool.space"
 reveal_amount = 100
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -22,7 +22,8 @@ client_poll_dur_ms = 200
 
 [btcio.writer]
 write_poll_dur_ms = 200
-fee_policy = "smart"
+fee_policy = "mempool"
+mempool_base_url = "https://mempool.space"
 reveal_amount = 100
 
 [exec.reth]

--- a/functional-tests/common/config/config.py
+++ b/functional-tests/common/config/config.py
@@ -43,8 +43,9 @@ class ReaderConfig:
 class WriterConfig:
     write_poll_dur_ms: int = field(default=200)
     reveal_amount: int = field(default=546)  # The dust amount
-    fee_policy: str = field(default="smart")  # TODO: handle this as enum: Smart | Fixed(u64)
+    fee_policy: str = field(default="bitcoind")
     bundle_interval_ms: int = field(default=200)
+    mempool_base_url: str | None = field(default=None)
 
 
 @dataclass


### PR DESCRIPTION
## Description

This PR adds a new btcio writer fee policy, `mempool`, alongside the now-renamed existing `smart` (`BitcoinD`) and `fixed` modes.

When `fee_policy = "mempool"`, btcio fetches recommended fees from `{mempool_base_url}/api/v1/fees/recommended`, parses the JSON response, and uses `fastestFee` directly as the fee rate in sat/vB.

`BitcoinD` now uses the raw estimate directly. If the mempool fee lookup fails at runtime due to transport, HTTP status, or JSON parsing issues, btcio logs a `WARN` and falls back to `estimatesmartfee(1)`.

In addition, this PR exposes `mempool_base_url` in btcio writer config and updates examples/test config scaffolding accordingly.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The new config shape is:

```toml
[btcio.writer]
fee_policy = "mempool"
mempool_base_url = "https://mempool.space"
```

Supported mempool Esplora-compatible backends include:

- Official: https://mempool.space/docs/api/rest#get-recommended-fees
- Testnet Alpen: https://bitcoin.testnet.alpenlabs.io/docs/api/rest#get-recommended-fees
- Development Deployment: https://bitcoin.development.stratabtc.org/docs/api/rest#get-recommended-fees

The implementation treats `mempool_base_url` as a base URL and appends `/api/v1/fees/recommended`, so e.g. `https://mempool.space` resolves to `https://mempool.space/api/v1/fees/recommended`.

Behavioral points to review:

- mempool uses fastestFee directly
- runtime mempool lookup failures emit WARN and fall back to `estimatesmartfee(1)`
- missing or invalid mempool_base_url is treated as a config error

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- [STR-2997](https://alpenlabs.atlassian.net/browse/STR-2997)
- https://mempool.space/docs/api/rest#get-recommended-fees
- https://bitcoin.testnet.alpenlabs.io/docs/api/rest#get-recommended-fees
- https://bitcoin.development.stratabtc.org/docs/api/rest#get-recommended-fees
- [btcio Fee Estimation](https://www.notion.so/btcio-Fee-Estimation-335901ba000f8052a9c0da39b037f952)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-2997

[STR-2997]: https://alpenlabs.atlassian.net/browse/STR-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ