### PR TITLE
STR 3025  Properly populate updates and inbox messages in `RpcAccountBlockSummary`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13855,6 +13855,7 @@ dependencies = [
  "bitcoind-async-client",
  "format_serde_error",
  "jsonrpsee",
+ "proptest",
  "serde",
  "serde_json",
  "ssz",

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -26,7 +26,6 @@ debug-utils = [
 prover = [
   "dep:serde",
   "dep:strata-ol-state-support-types",
-  "dep:strata-ol-stf",
   "dep:strata-paas",
   "dep:strata-predicate",
   "dep:strata-proofimpl-checkpoint-new",
@@ -77,7 +76,7 @@ strata-ol-rpc-types.workspace = true
 strata-ol-sequencer = { workspace = true, optional = true }
 strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
-strata-ol-stf = { workspace = true, optional = true }
+strata-ol-stf.workspace = true
 strata-paas = { workspace = true, optional = true }
 strata-params.workspace = true
 strata-predicate = { workspace = true, optional = true }

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -111,6 +111,8 @@ zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1
 ], optional = true }
 
 [dev-dependencies]
+proptest.workspace = true
+strata-ol-chain-types-new = { workspace = true, features = ["test-utils"] }
 strata-ol-params.workspace = true
 strata-ol-state-types = { workspace = true, features = ["test-utils"] }
 strata-predicate.workspace = true

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -1,4 +1,6 @@
 //! OL RPC server implementation for a strata node.
+use std::collections::{HashMap, hash_map::Entry};
+
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use ssz::Encode;
@@ -9,16 +11,21 @@ use strata_identifiers::{
     OLBlockCommitment, OLBlockId, OLTxId,
 };
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
-use strata_ol_chain_types_new::{OLBlock, OLTransaction, TransactionPayload};
+use strata_ol_chain_types_new::{
+    OLBlock, OLBlockHeader, OLTransaction, OLTxSegment, TransactionPayload,
+};
 use strata_ol_rpc_api::{OLClientRpcServer, OLFullNodeRpcServer};
 use strata_ol_rpc_types::{
-    OLBlockOrTag, OLRpcProvider, RpcAccountBlockSummary, RpcAccountEpochSummary, RpcBlockEntry,
-    RpcBlockHeaderEntry, RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref,
-    RpcOLBlockInfo, RpcOLChainStatus, RpcOLTransaction, RpcSnarkAccountState, RpcUpdateInputData,
+    AccountExtraData, OLBlockOrTag, OLRpcProvider, RpcAccountBlockSummary, RpcAccountEpochSummary,
+    RpcBlockEntry, RpcBlockHeaderEntry, RpcCheckpointConfStatus, RpcCheckpointInfo,
+    RpcCheckpointL1Ref, RpcOLBlockInfo, RpcOLChainStatus, RpcOLTransaction, RpcSnarkAccountState,
+    RpcUpdateInputData,
 };
+use strata_ol_state_types::OLAccountState;
+use strata_ol_stf::SEQUENCER_ACCT_ID;
 use strata_primitives::{HexBytes, HexBytes32};
-use strata_snark_acct_types::ProofState;
-use tracing::{error, info};
+use strata_snark_acct_types::{ProofState, UpdateInputData, UpdateStateData};
+use tracing::{error, info, warn, warn_span};
 
 use crate::rpc::errors::{
     db_error, internal_error, invalid_params_error, map_mempool_error_to_rpc, not_found_error,
@@ -29,6 +36,122 @@ pub(crate) struct OLRpcServer<P: OLRpcProvider> {
     provider: P,
     genesis_l1_height: L1Height,
     max_headers_range: usize,
+}
+
+pub(crate) fn extract_account_activity_from_block(
+    account_id: AccountId,
+    block_epoch: Epoch,
+    tx_segment: Option<&OLTxSegment>,
+    account_state: &OLAccountState,
+) -> (Vec<UpdateInputData>, Vec<MessageEntry>) {
+    let mut updates = Vec::new();
+    let mut new_inbox_messages = Vec::new();
+    let account_is_snark = account_state.as_snark_account().is_ok();
+
+    let Some(tx_segment) = tx_segment else {
+        return (updates, new_inbox_messages);
+    };
+
+    for tx in tx_segment.txs() {
+        let sender = match tx.payload() {
+            TransactionPayload::GenericAccountMessage(_) => SEQUENCER_ACCT_ID,
+            TransactionPayload::SnarkAccountUpdate(payload) => {
+                if *payload.target() == account_id {
+                    let op = payload.operation();
+                    let update_state = UpdateStateData::new(
+                        ProofState::new(
+                            op.update().proof_state().inner_state_root(),
+                            op.update().proof_state().new_next_msg_idx(),
+                        ),
+                        op.update().extra_data().to_vec(),
+                    );
+                    updates.push(UpdateInputData::new(
+                        op.update().seq_no(),
+                        op.messages_iter().cloned().collect(),
+                        update_state,
+                    ));
+                }
+                *payload.target()
+            }
+        };
+
+        if account_is_snark {
+            // `new_inbox_messages` reflects snark inbox appends (not all messages/effects).
+            for msg in tx.data().effects().messages_iter() {
+                if msg.dest() == account_id {
+                    new_inbox_messages.push(MessageEntry::new(
+                        sender,
+                        block_epoch,
+                        msg.payload().clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    (updates, new_inbox_messages)
+}
+
+pub(crate) fn resolve_update_extra_data_for_block(
+    account_id: AccountId,
+    epoch: Epoch,
+    block_commitment: OLBlockCommitment,
+    updates: &mut [UpdateInputData],
+    extra_data_entries: Option<&AccountExtraData>,
+) {
+    if updates.is_empty() {
+        return;
+    }
+
+    let _warn_span = warn_span!(
+        "resolve_update_extra_data_for_block",
+        %account_id,
+        epoch,
+        %block_commitment,
+        update_count = updates.len()
+    )
+    .entered();
+
+    let Some(extra_data_entries) = extra_data_entries else {
+        warn!("missing account extra-data index; using tx payload extra_data");
+        return;
+    };
+
+    // NOTE: We pair block-level index entries to SAU updates positionally. This assumes
+    // index insertion order for a block matches SAU tx order in the block tx segment.
+    // Current flow reference:
+    // - STF applies txs in tx-segment order in `process_block_tx_segment`.
+    // - SAU updates are appended to index writes in `update_inner_state`.
+    // - Chain worker persists those updates in iteration order in `store_block_output`.
+    // If any of that ordering changes, pairing can drift.
+    let mut matching_index_entries_iter = extra_data_entries
+        .iter()
+        .filter(|entry| entry.block() == &block_commitment);
+    let mut applied_updates_count = 0usize;
+    for update in updates.iter_mut() {
+        let Some(entry) = matching_index_entries_iter.next() else {
+            break;
+        };
+        // Index data is authoritative for update extra data.
+        update.set_extra_data(entry.extra_data().to_vec());
+        applied_updates_count = applied_updates_count.saturating_add(1);
+    }
+    // `matching_index_entries_iter` has been advanced by the loop above. Counting what's left
+    // and adding `applied_updates_count` gives the total number of index entries for this block.
+    let matching_index_entries_count =
+        applied_updates_count.saturating_add(matching_index_entries_iter.count());
+
+    if matching_index_entries_count == 0 {
+        warn!("no indexed extra-data entries for block; using tx payload extra_data");
+        return;
+    }
+
+    if matching_index_entries_count != updates.len() {
+        warn!(
+            matching_index_entries_count,
+            "extra-data index/update count mismatch; unmatched updates use tx payload extra_data"
+        );
+    }
 }
 
 impl<P: OLRpcProvider> OLRpcServer<P> {
@@ -439,9 +562,9 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .unwrap_or(0);
 
         // Walk backwards from end_slot via parent references to ensure blocks are chained.
-        // This guarantees all returned blocks are from the same chain, not different forks.
         // Once we reach a finalized block, we can fetch remaining blocks directly by slot.
-        let mut chain_blocks: Vec<(u64, OLBlockId)> = Vec::new();
+        // We cache only the fields needed for summaries: block id, header, and tx segment.
+        let mut chain_blocks: Vec<(OLBlockId, OLBlockHeader, Option<OLTxSegment>)> = Vec::new();
 
         // Get the block at end_slot (we'll walk backwards from here)
         let end_block_id = self.get_canonical_block_at_height(end_slot).await?;
@@ -457,13 +580,14 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         loop {
             // Get the block data to access parent
             let block = self.get_block(current_id).await?;
-
-            let header = block.header();
+            let header = block.header().clone();
             let current_slot = header.slot();
+            let parent_id = *header.parent_blkid();
+            let tx_segment = block.body().tx_segment().cloned();
 
             // Add this block if it's within our range
             if current_slot >= start_slot && current_slot <= end_slot {
-                chain_blocks.push((current_slot, current_id));
+                chain_blocks.push((current_id, header, tx_segment));
             }
 
             // Stop if we've reached or passed start_slot
@@ -478,14 +602,19 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                 for slot in (start_slot..current_slot).rev() {
                     let blkid = self.get_canonical_block_at_height(slot).await?;
                     if let Some(blkid) = blkid {
-                        chain_blocks.push((slot, blkid));
+                        let block = self.get_block(blkid).await?;
+                        chain_blocks.push((
+                            blkid,
+                            block.header().clone(),
+                            block.body().tx_segment().cloned(),
+                        ));
                     }
                 }
                 break;
             }
 
             // Move to parent block
-            current_id = *header.parent_blkid();
+            current_id = parent_id;
         }
 
         // Reverse to get ascending slot order
@@ -493,9 +622,12 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
 
         // Now build summaries for each block in the chain
         let mut summaries = Vec::with_capacity(chain_blocks.len());
+        let mut extra_data_cache: HashMap<Epoch, Option<AccountExtraData>> = HashMap::new();
 
-        for (slot, block_id) in chain_blocks {
+        for (block_id, header, tx_segment) in chain_blocks {
+            let slot = header.slot();
             let block_commitment = OLBlockCommitment::new(slot, block_id);
+            let epoch = header.epoch();
 
             // Get OL state at this block
             let ol_state = self
@@ -538,13 +670,39 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                 Err(_) => (0, 0), // Non-snark account
             };
 
+            let (mut updates, new_inbox_messages) = extract_account_activity_from_block(
+                account_id,
+                epoch,
+                tx_segment.as_ref(),
+                account_state,
+            );
+            let epoch_extra_data = match extra_data_cache.entry(epoch) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    let fetched = self
+                        .provider
+                        .get_account_extra_data((account_id, epoch))
+                        .await
+                        .map_err(db_error)?;
+                    entry.insert(fetched)
+                }
+            }
+            .as_ref();
+            resolve_update_extra_data_for_block(
+                account_id,
+                epoch,
+                block_commitment,
+                &mut updates,
+                epoch_extra_data,
+            );
+
             summaries.push(RpcAccountBlockSummary::new(
                 account_id,
                 block_commitment,
                 account_state.balance(),
                 next_seq_no,
-                vec![], // updates - requires write batch analysis
-                vec![], // new_inbox_messages - requires write batch analysis
+                updates,
+                new_inbox_messages,
                 next_inbox_msg_idx,
             ));
         }

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -1,14 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use strata_acct_types::{MessageEntry, MsgPayload};
+use proptest::prelude::*;
+use strata_acct_types::{MessageEntry, MsgPayload, TxEffects};
 use strata_asm_common::AsmManifest;
 use strata_checkpoint_types::EpochSummary;
 use strata_csm_types::CheckpointL1Ref;
 use strata_db_types::{DbError, DbResult, types::AccountExtraDataEntry};
 use strata_identifiers::*;
 use strata_ledger_types::*;
-use strata_ol_chain_types_new::*;
+use strata_ol_chain_types_new::{test_utils::transaction_payload_strategy, *};
 use strata_ol_mempool::{OLMempoolError, OLMempoolResult};
 use strata_ol_params::OLParams;
 use strata_ol_rpc_api::{OLClientRpcServer, OLFullNodeRpcServer};
@@ -18,10 +19,13 @@ use strata_predicate::PredicateKey;
 use strata_primitives::{
     HexBytes, HexBytes32, OLBlockCommitment, epoch::EpochCommitment, prelude::BitcoinAmount,
 };
-use strata_snark_acct_types::Seqno;
+use strata_snark_acct_types::{ProofState, Seqno, UpdateInputData, UpdateStateData};
 use strata_status::OLSyncStatus;
+use tokio::runtime::Builder;
 
-use super::OLRpcServer;
+use super::{
+    OLRpcServer, extract_account_activity_from_block, resolve_update_extra_data_for_block,
+};
 use crate::rpc::errors::{
     INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, MEMPOOL_CAPACITY_ERROR_CODE, map_mempool_error_to_rpc,
 };
@@ -146,8 +150,13 @@ impl MockProvider {
         block: OLBlockCommitment,
     ) -> Self {
         let entry = AccountExtraDataEntry::new(extra_data, block);
-        self.account_extra_data
-            .insert((account_id, epoch), AccountExtraData::new(entry));
+        let key = (account_id, epoch);
+        if let Some(entries) = self.account_extra_data.get_mut(&key) {
+            entries.push(entry);
+        } else {
+            self.account_extra_data
+                .insert(key, AccountExtraData::new(entry));
+        }
         self
     }
 
@@ -334,6 +343,28 @@ fn make_block(slot: u64, epoch: u32, parent: OLBlockId) -> OLBlock {
     OLBlock::new(signed, body)
 }
 
+fn make_block_with_txs(
+    slot: u64,
+    epoch: Epoch,
+    parent: OLBlockId,
+    txs: Vec<OLTransaction>,
+) -> OLBlock {
+    let header = OLBlockHeader::new(
+        0,
+        0.into(),
+        slot,
+        epoch,
+        parent,
+        Buf32::zero(),
+        Buf32::zero(),
+        Buf32::zero(),
+    );
+    let signed = SignedOLBlockHeader::new(header, Buf64::zero());
+    let tx_segment = OLTxSegment::new(txs).expect("tx segment");
+    let body = OLBlockBody::new_common(tx_segment);
+    OLBlock::new(signed, body)
+}
+
 fn genesis_ol_state() -> OLState {
     let params = OLParams::new_empty(test_l1_commitment());
     OLState::from_genesis_params(&params).expect("genesis state")
@@ -379,6 +410,78 @@ fn make_rpc(provider: MockProvider) -> OLRpcServer<MockProvider> {
 fn make_gam_rpc_tx(target: AccountId, payload: Vec<u8>) -> RpcOLTransaction {
     let gam = RpcGenericAccountMessage::new(HexBytes32::from(*target.inner()), HexBytes(payload));
     RpcOLTransaction::new_payload(RpcTransactionPayload::GenericAccountMessage(gam))
+}
+
+fn make_sau_tx(
+    target: AccountId,
+    seq_no: u64,
+    next_inbox_msg_idx: u64,
+    inner_state_tag: u8,
+    extra_data: Vec<u8>,
+    processed_messages: Vec<MessageEntry>,
+    effects: TxEffects,
+) -> OLTransaction {
+    let proof_state = SauTxProofState::new(next_inbox_msg_idx, fixed_buf32(inner_state_tag));
+    let update_data = SauTxUpdateData::new(seq_no, proof_state, extra_data);
+    let operation_data = SauTxOperationData::new(
+        update_data,
+        processed_messages,
+        SauTxLedgerRefs::new_empty(),
+    );
+    let payload = TransactionPayload::SnarkAccountUpdate(SauTxPayload::new(target, operation_data));
+    let tx_data = OLTransactionData::new(payload, effects);
+    OLTransaction::new(tx_data, TxProofs::new_empty())
+}
+
+/// Retargets a generated payload to the given account.
+fn retarget_payload(payload: TransactionPayload, target: AccountId) -> TransactionPayload {
+    match payload {
+        TransactionPayload::GenericAccountMessage(_) => {
+            TransactionPayload::GenericAccountMessage(GamTxPayload::new(target).expect("gam"))
+        }
+        TransactionPayload::SnarkAccountUpdate(sau) => TransactionPayload::SnarkAccountUpdate(
+            SauTxPayload::new(target, sau.operation().clone()),
+        ),
+    }
+}
+
+/// Generates an arbitrary OL transaction targeting either `account_id` or `other_account`,
+/// with a single effect message aimed at one of the two. Uses chain-types strategies for
+/// payload/constraint generation.
+fn arbitrary_tx_strategy(
+    account_id: AccountId,
+    other_account: AccountId,
+) -> impl Strategy<Value = OLTransaction> {
+    (
+        transaction_payload_strategy(),
+        any::<bool>(),
+        any::<bool>(),
+        any::<u64>(),
+        prop::collection::vec(any::<u8>(), 0..8),
+    )
+        .prop_map(
+            move |(payload, to_target, effect_to_target, effect_val, effect_data)| {
+                let target = if to_target { account_id } else { other_account };
+                let payload = retarget_payload(payload, target);
+                let effect_dest = if effect_to_target {
+                    account_id
+                } else {
+                    other_account
+                };
+                let mut effects = TxEffects::default();
+                effects.push_message(effect_dest, effect_val, effect_data);
+                let data = OLTransactionData::new(payload, effects);
+                OLTransaction::new(data, TxProofs::new_empty())
+            },
+        )
+}
+
+/// Returns the sender that `extract_account_activity_from_block` would derive for a tx.
+fn expected_sender(tx: &OLTransaction) -> AccountId {
+    match tx.payload() {
+        TransactionPayload::GenericAccountMessage(_) => strata_ol_stf::SEQUENCER_ACCT_ID,
+        TransactionPayload::SnarkAccountUpdate(p) => *p.target(),
+    }
 }
 
 fn test_epoch_commitment(epoch: Epoch, slot: u64, blkid_tag: u8) -> EpochCommitment {
@@ -1126,6 +1229,443 @@ async fn blocks_summaries_snark_vs_non_snark() {
     assert_eq!(empty.len(), 1);
     assert_eq!(empty[0].next_seq_no(), 0);
     assert_eq!(empty[0].next_inbox_msg_idx(), 0);
+}
+
+// ── get_blocks_summaries: activity extraction edge cases ──
+
+#[tokio::test]
+async fn blocks_summaries_empty_tx_segment_produces_no_activity() {
+    let account_id = test_account_id(1);
+    let block = make_block(0, 0, null_blkid());
+    let tip = OLBlockCommitment::new(0, block.header().compute_blkid());
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 5, 3));
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect("summaries");
+    assert_eq!(summaries.len(), 1);
+    assert!(summaries[0].updates().is_empty());
+    assert!(summaries[0].new_inbox_messages().is_empty());
+}
+
+#[test]
+fn extract_activity_none_tx_segment() {
+    let account_id = test_account_id(1);
+    let state = ol_state_with_snark_account(account_id, 0, 5, 3);
+    let account_state = state.get_account_state(account_id).unwrap().unwrap();
+
+    let (updates, inbox) = extract_account_activity_from_block(account_id, 0, None, account_state);
+    assert!(updates.is_empty());
+    assert!(inbox.is_empty());
+}
+
+// ── get_blocks_summaries: extra data resolution edge cases ──
+
+#[tokio::test]
+async fn blocks_summaries_extra_data_uses_tx_payload_when_no_index() {
+    let account_id = test_account_id(1);
+    let tx = make_sau_tx(
+        account_id,
+        3,
+        1,
+        0x63,
+        vec![0xDE, 0xAD],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let block = make_block_with_txs(0, 0, null_blkid(), vec![tx.clone()]);
+    let tip = OLBlockCommitment::new(0, block.header().compute_blkid());
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 4, 1));
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect("summaries");
+    let update: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let expected = match tx.payload() {
+        TransactionPayload::SnarkAccountUpdate(p) => p.operation().update().extra_data(),
+        _ => unreachable!(),
+    };
+    assert_eq!(update.extra_data(), expected);
+}
+
+#[tokio::test]
+async fn blocks_summaries_extra_data_prefers_index_over_tx_payload() {
+    let account_id = test_account_id(1);
+    let indexed = vec![0xF0, 0x0D];
+    let tx = make_sau_tx(
+        account_id,
+        6,
+        2,
+        0x66,
+        vec![0x01, 0x02],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let block = make_block_with_txs(0, 0, null_blkid(), vec![tx]);
+    let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            commitment,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 7, 2))
+        .with_account_extra_data(account_id, 0, indexed.clone(), commitment);
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect("summaries");
+    let update: UpdateInputData = summaries[0].updates()[0].clone().into();
+    assert_eq!(update.extra_data(), indexed.as_slice());
+}
+
+#[tokio::test]
+async fn blocks_summaries_extra_data_falls_back_for_non_matching_block() {
+    let account_id = test_account_id(1);
+    let tx = make_sau_tx(
+        account_id,
+        9,
+        2,
+        0x90,
+        vec![0xCA, 0xFE],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let block = make_block_with_txs(0, 0, null_blkid(), vec![tx.clone()]);
+    let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
+    let wrong_block = OLBlockCommitment::new(99, fixed_ol_block_id(0x99));
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            commitment,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 10, 2))
+        .with_account_extra_data(account_id, 0, vec![0xF0, 0x0D], wrong_block);
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect("summaries");
+    let update: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let expected = match tx.payload() {
+        TransactionPayload::SnarkAccountUpdate(p) => p.operation().update().extra_data(),
+        _ => unreachable!(),
+    };
+    assert_eq!(update.extra_data(), expected);
+}
+
+#[tokio::test]
+async fn blocks_summaries_extra_data_partial_mismatch_applies_available_entries() {
+    let account_id = test_account_id(1);
+    let tx1 = make_sau_tx(
+        account_id,
+        1,
+        1,
+        0xA1,
+        vec![0x01],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let tx2 = make_sau_tx(
+        account_id,
+        2,
+        2,
+        0xA2,
+        vec![0x02],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let block = make_block_with_txs(0, 0, null_blkid(), vec![tx1, tx2]);
+    let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            commitment,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 3, 2))
+        .with_account_extra_data(account_id, 0, vec![0xFE], commitment);
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect("summaries");
+    let u0: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let u1: UpdateInputData = summaries[0].updates()[1].clone().into();
+    assert_eq!(u0.extra_data(), [0xFE].as_slice());
+    assert_eq!(u1.extra_data(), [0x02].as_slice());
+}
+
+#[tokio::test]
+async fn blocks_summaries_extra_data_cache_across_epoch_blocks() {
+    let account_id = test_account_id(1);
+    let epoch: Epoch = 7;
+    let b0_tx = make_sau_tx(
+        account_id,
+        21,
+        1,
+        0x21,
+        vec![0x11],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let b0 = make_block_with_txs(0, epoch, null_blkid(), vec![b0_tx]);
+    let b0c = OLBlockCommitment::new(0, b0.header().compute_blkid());
+
+    let b1_tx = make_sau_tx(
+        account_id,
+        22,
+        2,
+        0x22,
+        vec![0x22],
+        Vec::new(),
+        TxEffects::default(),
+    );
+    let b1 = make_block_with_txs(1, epoch, b0.header().compute_blkid(), vec![b1_tx]);
+    let b1c = OLBlockCommitment::new(1, b1.header().compute_blkid());
+
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            b1c,
+            epoch,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&b0, ol_state_with_snark_account(account_id, 0, 21, 1))
+        .with_block_and_state(&b1, ol_state_with_snark_account(account_id, 1, 22, 2))
+        .with_account_extra_data(account_id, epoch, vec![0xA0], b0c)
+        .with_account_extra_data(account_id, epoch, vec![0xA1], b1c);
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 1)
+        .await
+        .expect("summaries");
+    assert_eq!(summaries.len(), 2);
+    let u0: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let u1: UpdateInputData = summaries[1].updates()[0].clone().into();
+    assert_eq!(u0.extra_data(), [0xA0].as_slice());
+    assert_eq!(u1.extra_data(), [0xA1].as_slice());
+}
+
+// ── get_blocks_summaries: property tests ──
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, .. ProptestConfig::default() })]
+
+    /// Update count matches SAU txs targeting this account. Each update reflects its
+    /// source SAU fields. Inbox messages match effect messages destined for this account
+    /// with correct sender derivation (sequencer for GAM, target for SAU).
+    #[test]
+    fn blocks_summaries_reflects_block_txs_for_snark_account(
+        txs in prop::collection::vec(
+            arbitrary_tx_strategy(test_account_id(1), test_account_id(2)),
+            0..12
+        )
+    ) {
+        let account_id = test_account_id(1);
+        let block_epoch: Epoch = 5;
+        let block = make_block_with_txs(0, block_epoch, null_blkid(), txs.clone());
+        let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
+        let provider = MockProvider::new()
+            .with_sync_status(make_sync_status(commitment, block_epoch, false, EpochCommitment::null(), EpochCommitment::null(), EpochCommitment::null()))
+            .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 99, 99));
+        let rpc = make_rpc(provider);
+
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        let summaries = rt
+            .block_on(async { rpc.get_blocks_summaries(account_id, 0, 0).await })
+            .expect("summaries");
+        prop_assert_eq!(summaries.len(), 1);
+        let summary = &summaries[0];
+
+        // Collect SAU txs targeting this account from the input.
+        let target_saus: Vec<&SauTxPayload> = txs.iter().filter_map(|tx| match tx.payload() {
+            TransactionPayload::SnarkAccountUpdate(p) if *p.target() == account_id => Some(p),
+            _ => None,
+        }).collect();
+
+        // Update count matches SAU count targeting this account.
+        prop_assert_eq!(summary.updates().len(), target_saus.len());
+
+        // Each update reflects its source SAU fields.
+        for (rpc_update, sau) in summary.updates().iter().zip(target_saus.iter()) {
+            let update: UpdateInputData = rpc_update.clone().into();
+            let op = sau.operation();
+            prop_assert_eq!(update.seq_no(), op.update().seq_no());
+            prop_assert_eq!(update.extra_data(), op.update().extra_data());
+            prop_assert_eq!(
+                update.new_state().inner_state(),
+                op.update().proof_state().inner_state_root()
+            );
+            prop_assert_eq!(
+                update.new_state().next_inbox_msg_idx(),
+                op.update().proof_state().new_next_msg_idx()
+            );
+            let expected_msgs: Vec<_> = op.messages_iter().cloned().collect();
+            prop_assert_eq!(update.processed_messages(), expected_msgs.as_slice());
+        }
+
+        // Inbox messages match effect messages destined for this account.
+        let expected_inbox: Vec<_> = txs.iter()
+            .flat_map(|tx| {
+                let sender = expected_sender(tx);
+                tx.data().effects().messages_iter()
+                    .filter(|msg| msg.dest() == account_id)
+                    .map(move |msg| (sender, msg.payload().clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        let actual_inbox = rpc_messages_to_entries(summary.new_inbox_messages());
+        prop_assert_eq!(actual_inbox.len(), expected_inbox.len());
+
+        for (actual, (exp_sender, exp_payload)) in actual_inbox.iter().zip(expected_inbox.iter()) {
+            prop_assert_eq!(actual.source, *exp_sender);
+            prop_assert_eq!(actual.incl_epoch(), block_epoch);
+            prop_assert_eq!(&actual.payload, exp_payload);
+        }
+    }
+
+    /// Non-snark accounts never collect inbox messages, regardless of what effect
+    /// messages target them. SAU updates targeting the account are still reported.
+    #[test]
+    fn blocks_summaries_non_snark_never_collects_inbox_but_reports_updates(
+        txs in prop::collection::vec(
+            arbitrary_tx_strategy(test_account_id(1), test_account_id(2)),
+            0..12
+        )
+    ) {
+        let account_id = test_account_id(1);
+        let block_epoch: Epoch = 12;
+        let block = make_block_with_txs(0, block_epoch, null_blkid(), txs.clone());
+        let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
+        let provider = MockProvider::new()
+            .with_sync_status(make_sync_status(commitment, block_epoch, false, EpochCommitment::null(), EpochCommitment::null(), EpochCommitment::null()))
+            .with_block_and_state(&block, ol_state_with_empty_account(account_id, 0));
+        let rpc = make_rpc(provider);
+
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        let summaries = rt
+            .block_on(async { rpc.get_blocks_summaries(account_id, 0, 0).await })
+            .expect("summaries");
+
+        prop_assert_eq!(summaries.len(), 1);
+        prop_assert!(summaries[0].new_inbox_messages().is_empty());
+
+        // SAU updates targeting this account are still collected even for non-snark.
+        let expected_update_count = txs.iter().filter(|tx| matches!(
+            tx.payload(),
+            TransactionPayload::SnarkAccountUpdate(p) if *p.target() == account_id
+        )).count();
+        prop_assert_eq!(summaries[0].updates().len(), expected_update_count);
+    }
+
+    /// When index entries match the block commitment, `resolve_update_extra_data_for_block`
+    /// overwrites each update's extra_data with the index value. When entries don't match,
+    /// the original tx payload extra_data is preserved.
+    #[test]
+    fn extra_data_resolved_from_matching_block(
+        sau_payloads in prop::collection::vec(
+            transaction_payload_strategy().prop_filter_map("SAU only", |p| match p {
+                TransactionPayload::SnarkAccountUpdate(sau) => Some(sau),
+                _ => None,
+            }),
+            1..6
+        ),
+        indexed_extra_datas in prop::collection::vec(
+            prop::collection::vec(any::<u8>(), 1..16),
+            0..8
+        ),
+        matching in any::<bool>(),
+    ) {
+        let commitment = OLBlockCommitment::new(0, fixed_ol_block_id(1));
+        let other_commitment = OLBlockCommitment::new(99, fixed_ol_block_id(99));
+
+        // Build updates from the generated SAU payloads (same way production code does).
+        let mut updates: Vec<UpdateInputData> = sau_payloads.iter().map(|sau| {
+            let op = sau.operation();
+            UpdateInputData::new(
+                op.update().seq_no(),
+                op.messages_iter().cloned().collect(),
+                UpdateStateData::new(
+                    ProofState::new(
+                        op.update().proof_state().inner_state_root(),
+                        op.update().proof_state().new_next_msg_idx(),
+                    ),
+                    op.update().extra_data().to_vec(),
+                ),
+            )
+        }).collect();
+        let original_extra_datas: Vec<Vec<u8>> = updates.iter()
+            .map(|u| u.extra_data().to_vec())
+            .collect();
+
+        // Build index entries — either matching or non-matching block commitment.
+        let entry_commitment = if matching { commitment } else { other_commitment };
+        let entries: Option<AccountExtraData> = if indexed_extra_datas.is_empty() {
+            None
+        } else {
+            let mut entries = AccountExtraData::new(
+                AccountExtraDataEntry::new(indexed_extra_datas[0].clone(), entry_commitment),
+            );
+            for ed in &indexed_extra_datas[1..] {
+                entries.push(AccountExtraDataEntry::new(ed.clone(), entry_commitment));
+            }
+            Some(entries)
+        };
+
+        resolve_update_extra_data_for_block(
+            test_account_id(1), 0, commitment, &mut updates, entries.as_ref(),
+        );
+
+        for (i, update) in updates.iter().enumerate() {
+            if matching && i < indexed_extra_datas.len() {
+                // Index was applied.
+                prop_assert_eq!(update.extra_data(), indexed_extra_datas[i].as_slice());
+            } else {
+                // Original tx payload preserved.
+                prop_assert_eq!(update.extra_data(), original_extra_datas[i].as_slice());
+            }
+        }
+    }
 }
 
 // ── get_acct_epoch_summary ──

--- a/crates/db/types/src/types.rs
+++ b/crates/db/types/src/types.rs
@@ -528,6 +528,14 @@ impl AccountExtraDataEntry {
         Self { extra_data, block }
     }
 
+    pub fn extra_data(&self) -> &[u8] {
+        &self.extra_data
+    }
+
+    pub fn block(&self) -> &OLBlockCommitment {
+        &self.block
+    }
+
     pub fn into_parts(self) -> (Vec<u8>, OLBlockCommitment) {
         (self.extra_data, self.block)
     }

--- a/crates/snark-acct-types/src/update.rs
+++ b/crates/snark-acct-types/src/update.rs
@@ -25,6 +25,13 @@ impl UpdateStateData {
     pub fn extra_data(&self) -> &[u8] {
         self.extra_data.as_ref()
     }
+
+    /// Replaces the update state's extra data in-place.
+    pub fn set_extra_data(&mut self, extra_data: Vec<u8>) {
+        self.extra_data = extra_data
+            .try_into()
+            .expect("snark account extra data must fit within SSZ max length");
+    }
 }
 
 impl UpdateInputData {
@@ -53,6 +60,11 @@ impl UpdateInputData {
 
     pub fn extra_data(&self) -> &[u8] {
         self.update_state.extra_data()
+    }
+
+    /// Replaces the update's extra data in-place.
+    pub fn set_extra_data(&mut self, extra_data: Vec<u8>) {
+        self.update_state.set_extra_data(extra_data);
     }
 }
 


### PR DESCRIPTION
## Description

The returned `RpcAccountBlockSummary` from `strata_getBlocksSummaries` did not have its `updates` and `new_inbox_messages` fields populated; they were set to empty vectors. They are now properly populated.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Includes commits from #1587. Need to rebase after that is merged.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
