### PR TITLE
feat(config): add v1 L2 fee-model config and reusable fee-quote types (STR-2977)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,9 @@ name = "alpen-ee-config"
 version = "0.3.0-alpha.1"
 dependencies = [
  "alloy-primitives",
+ "alpen-ee-common",
  "strata-acct-types",
+ "strata-config",
  "strata-predicate",
 ]
 

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -568,7 +568,9 @@ fn main() {
                 // config file. For now, we hardcode to `BitcoinD` so that functional-tests can
                 // pass.
                 let writer_config = Arc::new(WriterConfig {
-                    l1_fee_policy: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 1 }),
+                    l1_fee_policy_config: L1FeePolicyConfig::new(FeePolicy::BitcoinD {
+                        conf_target: 1,
+                    }),
                     ..WriterConfig::default()
                 });
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -568,11 +568,7 @@ fn main() {
                 // config file. For now, we hardcode to `BitcoinD` so that functional-tests can
                 // pass.
                 let writer_config = Arc::new(WriterConfig {
-                    l1_fee_policy: L1FeePolicyConfig {
-                        fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
-                        mempool_base_url: None,
-                        ..L1FeePolicyConfig::default()
-                    },
+                    l1_fee_policy: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 1 }),
                     ..WriterConfig::default()
                 });
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -62,7 +62,7 @@ use strata_btcio::{
     BtcioParams,
 };
 #[cfg(feature = "sequencer")]
-use strata_config::btcio::{FeePolicy, WriterConfig};
+use strata_config::btcio::{FeePolicy, L1FeePolicyConfig, WriterConfig};
 use strata_identifiers::{EpochCommitment, OLBlockId};
 use strata_l1_txfmt::MagicBytes;
 use strata_predicate::PredicateKey;
@@ -568,7 +568,11 @@ fn main() {
                 // config file. For now, we hardcode to `BitcoinD` so that functional-tests can
                 // pass.
                 let writer_config = Arc::new(WriterConfig {
-                    fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
+                    l1_fee_policy: L1FeePolicyConfig {
+                        fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
+                        mempool_base_url: None,
+                        ..L1FeePolicyConfig::default()
+                    },
                     ..WriterConfig::default()
                 });
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(

--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -503,7 +503,12 @@ mod tests {
             &sequencer_config_path,
             r#"
                 [sequencer]
-                ol_block_time_ms = 5000
+                ol_block_time_ms = 5_000
+
+                [fee_model]
+                prover_fee_per_gas_wei = 15
+                da_overhead_multiplier_bps = 10_000
+                ol_overhead_wei = 0
             "#,
         )
         .unwrap();

--- a/crates/alpen-ee/common/src/lib.rs
+++ b/crates/alpen-ee/common/src/lib.rs
@@ -39,6 +39,10 @@ pub use types::{
     da::{prepare_da_chunks, reassemble_da_blob, DaBlob, EvmHeaderSummary, ReassemblyError},
     ee_account_state::EeAccountStateAtEpoch,
     exec_record::{ExecBlockPayload, ExecBlockRecord},
+    fees::{
+        FeeBreakdown, FeeModelConfig, FeeModelError, FeeQuoteInputs, GasEquivalentQuote,
+        L1FeeRateSource, DA_OVERHEAD_MULTIPLIER_SCALE_BPS,
+    },
     ol_account_epoch_summary::OLEpochSummary,
     ol_chain_status::{OLChainStatus, OLFinalizedStatus},
     payload_builder::{DepositInfo, PayloadBuildAttributes},

--- a/crates/alpen-ee/common/src/types/fees.rs
+++ b/crates/alpen-ee/common/src/types/fees.rs
@@ -1,0 +1,383 @@
+//! Shared fee-model types and helpers for Alpen v1 fee quoting.
+//!
+//! This module defines the internal representation of fee-model inputs
+//! ([`FeeQuoteInputs`]), the configurable parameters that drive the formula
+//! ([`FeeModelConfig`]), the computed fee breakdown ([`FeeBreakdown`]), and
+//! a budgeting-only gas-equivalent view ([`GasEquivalentQuote`]). It
+//! intentionally does not perform any RPC handling or execution-time
+//! charging; those layers consume these types so the v1 formula lives in a
+//! single place.
+
+use alloy_primitives::U256;
+use serde::{Deserialize, Serialize};
+
+/// Basis-points scaling factor for DA fee multipliers.
+pub const DA_OVERHEAD_MULTIPLIER_SCALE_BPS: u32 = 10_000;
+
+/// Source for the L1 fee rate used by the fee model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum L1FeeRateSource {
+    /// Reuse the btcio writer policy used for publication.
+    BtcioWriter,
+}
+
+/// Runtime configuration for the v1 fee model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeeModelConfig {
+    /// Static proving fee charged per unit of raw EVM gas.
+    pub prover_fee_per_gas_wei: U256,
+
+    /// Basis-points multiplier applied to estimated DA cost.
+    pub da_overhead_multiplier_bps: u32,
+
+    /// Small additive fee charged for OL and infrastructure overhead.
+    pub ol_overhead_wei: U256,
+
+    /// Source used to resolve the L1 fee rate.
+    pub l1_fee_rate_source: L1FeeRateSource,
+}
+
+/// Inputs required to quote fees for a transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeeQuoteInputs {
+    /// Estimated raw EVM gas for the transaction.
+    pub raw_evm_gas: u64,
+
+    /// Current base fee per gas in wei.
+    pub base_fee_per_gas: U256,
+
+    /// Current priority fee per gas in wei.
+    pub priority_fee_per_gas: U256,
+
+    /// Resolved L1 fee rate in wei per byte of DA payload.
+    pub l1_fee_rate_wei_per_byte: U256,
+
+    /// Estimated diff size in bytes for the transaction.
+    pub diff_size_bytes: u64,
+}
+
+impl FeeQuoteInputs {
+    /// Returns the total execution gas price in wei.
+    pub fn execution_gas_price(&self) -> Result<U256, FeeModelError> {
+        fee_add(
+            self.base_fee_per_gas,
+            self.priority_fee_per_gas,
+            "execution_gas_price",
+        )
+    }
+}
+
+/// Quoted fee breakdown for a single transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeeBreakdown {
+    /// Raw EVM gas used for execution and block accounting.
+    pub raw_evm_gas: u64,
+
+    /// Total execution gas price in wei.
+    pub execution_gas_price: U256,
+
+    /// EVM execution fee in wei.
+    pub execution_fee: U256,
+
+    /// Proving fee in wei.
+    pub prover_fee: U256,
+
+    /// DA fee in wei.
+    pub da_fee: U256,
+
+    /// OL overhead fee in wei.
+    pub ol_overhead_fee: U256,
+
+    /// Sum of all non-execution fees in wei.
+    pub non_execution_fee: U256,
+
+    /// Total quoted fee in wei.
+    pub total_fee: U256,
+}
+
+impl FeeBreakdown {
+    /// Converts fee amounts into a [`GasEquivalentQuote`] for budgeting.
+    ///
+    /// Uses ceiling division when converting non-execution wei into gas
+    /// units so the budgeting view never undercharges relative to the
+    /// quoted [`FeeBreakdown::total_fee`].
+    pub fn gas_equivalent_quote(&self) -> Result<GasEquivalentQuote, FeeModelError> {
+        let non_execution_gas = if self.non_execution_fee.is_zero() {
+            0
+        } else if self.execution_gas_price.is_zero() {
+            return Err(FeeModelError::ZeroExecutionGasPrice);
+        } else {
+            let gas = self.non_execution_fee.div_ceil(self.execution_gas_price);
+            u64::try_from(gas)
+                .map_err(|_| FeeModelError::GasEquivalentOverflow("non_execution_gas"))?
+        };
+
+        let total_gas = self
+            .raw_evm_gas
+            .checked_add(non_execution_gas)
+            .ok_or(FeeModelError::GasEquivalentOverflow("total_gas"))?;
+
+        Ok(GasEquivalentQuote {
+            execution_gas: self.raw_evm_gas,
+            non_execution_gas,
+            total_gas,
+        })
+    }
+}
+
+/// Gas-equivalent budgeting view of a quote.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GasEquivalentQuote {
+    /// Raw EVM execution gas.
+    pub execution_gas: u64,
+
+    /// Additional budgeting gas equivalent for non-execution fees.
+    pub non_execution_gas: u64,
+
+    /// Total budgeting gas.
+    pub total_gas: u64,
+}
+
+/// Errors returned while computing fee quotes.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum FeeModelError {
+    #[error("{0} overflowed during fee computation")]
+    Overflow(&'static str),
+
+    #[error("cannot convert non-execution fee into gas units when execution gas price is zero")]
+    ZeroExecutionGasPrice,
+
+    #[error("{0} does not fit in u64 gas units")]
+    GasEquivalentOverflow(&'static str),
+}
+
+impl FeeModelConfig {
+    /// Computes the v1 fee-model breakdown for the provided inputs.
+    ///
+    /// Returns a [`FeeBreakdown`] on success. The DA component rounds up
+    /// when applying [`FeeModelConfig::da_overhead_multiplier_bps`] so the
+    /// operator never silently undercharges due to integer truncation.
+    pub fn quote(&self, inputs: &FeeQuoteInputs) -> Result<FeeBreakdown, FeeModelError> {
+        let raw_evm_gas = U256::from(inputs.raw_evm_gas);
+        let execution_gas_price = inputs.execution_gas_price()?;
+        let execution_fee = fee_mul(execution_gas_price, raw_evm_gas, "execution_fee")?;
+        let prover_fee = fee_mul(self.prover_fee_per_gas_wei, raw_evm_gas, "prover_fee")?;
+
+        let raw_da_fee = fee_mul(
+            inputs.l1_fee_rate_wei_per_byte,
+            U256::from(inputs.diff_size_bytes),
+            "raw_da_fee",
+        )?;
+        let da_fee_numerator = fee_mul(
+            raw_da_fee,
+            U256::from(self.da_overhead_multiplier_bps),
+            "da_fee_numerator",
+        )?;
+        // Ceil so a fractional bps multiplier never rounds a non-zero DA
+        // cost down to a lower wei value than the raw input.
+        let da_fee = da_fee_numerator.div_ceil(U256::from(DA_OVERHEAD_MULTIPLIER_SCALE_BPS));
+
+        let non_execution_fee = fee_add(
+            fee_add(prover_fee, da_fee, "non_execution_fee")?,
+            self.ol_overhead_wei,
+            "non_execution_fee",
+        )?;
+        let total_fee = fee_add(execution_fee, non_execution_fee, "total_fee")?;
+
+        Ok(FeeBreakdown {
+            raw_evm_gas: inputs.raw_evm_gas,
+            execution_gas_price,
+            execution_fee,
+            prover_fee,
+            da_fee,
+            ol_overhead_fee: self.ol_overhead_wei,
+            non_execution_fee,
+            total_fee,
+        })
+    }
+}
+
+/// Checked `U256` addition that returns a [`FeeModelError::Overflow`] tagged
+/// with the calling field name on overflow.
+fn fee_add(lhs: U256, rhs: U256, field: &'static str) -> Result<U256, FeeModelError> {
+    lhs.checked_add(rhs).ok_or(FeeModelError::Overflow(field))
+}
+
+/// Checked `U256` multiplication that returns a [`FeeModelError::Overflow`]
+/// tagged with the calling field name on overflow.
+fn fee_mul(lhs: U256, rhs: U256, field: &'static str) -> Result<U256, FeeModelError> {
+    lhs.checked_mul(rhs).ok_or(FeeModelError::Overflow(field))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::U256;
+
+    use super::{
+        FeeModelConfig, FeeModelError, FeeQuoteInputs, GasEquivalentQuote, L1FeeRateSource,
+    };
+
+    #[test]
+    fn test_quote_computes_v1_fee_breakdown() {
+        let config = FeeModelConfig {
+            prover_fee_per_gas_wei: U256::from(3u8),
+            da_overhead_multiplier_bps: 12_500,
+            ol_overhead_wei: U256::from(7u8),
+            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
+        };
+        let inputs = FeeQuoteInputs {
+            raw_evm_gas: 100,
+            base_fee_per_gas: U256::from(10u8),
+            priority_fee_per_gas: U256::from(2u8),
+            l1_fee_rate_wei_per_byte: U256::from(5u8),
+            diff_size_bytes: 4,
+        };
+
+        let quote = config.quote(&inputs).expect("quote should compute");
+
+        assert_eq!(quote.execution_gas_price, U256::from(12u8));
+        assert_eq!(quote.execution_fee, U256::from(1_200u64));
+        assert_eq!(quote.prover_fee, U256::from(300u64));
+        assert_eq!(quote.da_fee, U256::from(25u8));
+        assert_eq!(quote.ol_overhead_fee, U256::from(7u8));
+        assert_eq!(quote.non_execution_fee, U256::from(332u64));
+        assert_eq!(quote.total_fee, U256::from(1_532u64));
+    }
+
+    #[test]
+    fn test_quote_supports_undercharge_and_overcharge_multipliers() {
+        let inputs = FeeQuoteInputs {
+            raw_evm_gas: 1,
+            base_fee_per_gas: U256::from(1u8),
+            priority_fee_per_gas: U256::ZERO,
+            l1_fee_rate_wei_per_byte: U256::from(4u8),
+            diff_size_bytes: 5,
+        };
+
+        let undercharge = FeeModelConfig {
+            prover_fee_per_gas_wei: U256::ZERO,
+            da_overhead_multiplier_bps: 5_000,
+            ol_overhead_wei: U256::ZERO,
+            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
+        };
+        let overcharge = FeeModelConfig {
+            da_overhead_multiplier_bps: 15_000,
+            ..undercharge.clone()
+        };
+
+        assert_eq!(
+            undercharge
+                .quote(&inputs)
+                .expect("undercharge quote")
+                .da_fee,
+            U256::from(10u8)
+        );
+        assert_eq!(
+            overcharge.quote(&inputs).expect("overcharge quote").da_fee,
+            U256::from(30u8)
+        );
+    }
+
+    #[test]
+    fn test_quote_rounds_da_fee_up_on_fractional_multiplier() {
+        // raw_da_fee = 3 * 7 = 21
+        // numerator  = 21 * 12_345 = 259_245
+        // 259_245 / 10_000 = 25.9245 -> ceil 26.
+        let config = FeeModelConfig {
+            prover_fee_per_gas_wei: U256::ZERO,
+            da_overhead_multiplier_bps: 12_345,
+            ol_overhead_wei: U256::ZERO,
+            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
+        };
+        let inputs = FeeQuoteInputs {
+            raw_evm_gas: 1,
+            base_fee_per_gas: U256::from(1u8),
+            priority_fee_per_gas: U256::ZERO,
+            l1_fee_rate_wei_per_byte: U256::from(3u8),
+            diff_size_bytes: 7,
+        };
+
+        let quote = config.quote(&inputs).expect("quote should compute");
+
+        assert_eq!(quote.da_fee, U256::from(26u8));
+    }
+
+    #[test]
+    fn test_gas_equivalent_quote_uses_ceil_division() {
+        let config = FeeModelConfig {
+            prover_fee_per_gas_wei: U256::from(3u8),
+            da_overhead_multiplier_bps: 12_500,
+            ol_overhead_wei: U256::from(7u8),
+            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
+        };
+        let inputs = FeeQuoteInputs {
+            raw_evm_gas: 100,
+            base_fee_per_gas: U256::from(10u8),
+            priority_fee_per_gas: U256::from(2u8),
+            l1_fee_rate_wei_per_byte: U256::from(5u8),
+            diff_size_bytes: 4,
+        };
+
+        let gas_quote = config
+            .quote(&inputs)
+            .and_then(|quote| quote.gas_equivalent_quote())
+            .expect("gas-equivalent quote should compute");
+
+        assert_eq!(
+            gas_quote,
+            GasEquivalentQuote {
+                execution_gas: 100,
+                non_execution_gas: 28,
+                total_gas: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn test_gas_equivalent_quote_rejects_non_zero_fee_with_zero_execution_price() {
+        let config = FeeModelConfig {
+            prover_fee_per_gas_wei: U256::ZERO,
+            da_overhead_multiplier_bps: 10_000,
+            ol_overhead_wei: U256::from(1u8),
+            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
+        };
+        let inputs = FeeQuoteInputs {
+            raw_evm_gas: 1,
+            base_fee_per_gas: U256::ZERO,
+            priority_fee_per_gas: U256::ZERO,
+            l1_fee_rate_wei_per_byte: U256::ZERO,
+            diff_size_bytes: 0,
+        };
+
+        let error = config
+            .quote(&inputs)
+            .expect("quote should compute")
+            .gas_equivalent_quote()
+            .expect_err("non-zero non-execution fee with zero price must fail");
+
+        assert_eq!(error, FeeModelError::ZeroExecutionGasPrice);
+    }
+
+    #[test]
+    fn test_quote_reports_overflow() {
+        let config = FeeModelConfig {
+            prover_fee_per_gas_wei: U256::MAX,
+            da_overhead_multiplier_bps: 10_000,
+            ol_overhead_wei: U256::ZERO,
+            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
+        };
+        let inputs = FeeQuoteInputs {
+            raw_evm_gas: 2,
+            base_fee_per_gas: U256::ZERO,
+            priority_fee_per_gas: U256::ZERO,
+            l1_fee_rate_wei_per_byte: U256::ZERO,
+            diff_size_bytes: 0,
+        };
+
+        let error = config
+            .quote(&inputs)
+            .expect_err("overflowing prover fee must fail");
+
+        assert_eq!(error, FeeModelError::Overflow("prover_fee"));
+    }
+}

--- a/crates/alpen-ee/common/src/types/fees.rs
+++ b/crates/alpen-ee/common/src/types/fees.rs
@@ -22,6 +22,9 @@ pub enum L1FeeRateSource {
 }
 
 /// Runtime configuration for the v1 fee model.
+// NOTE: Gas and byte counts stay in their native bounded `u64` representation.
+//       Wei-denominated rates and fee totals use `U256` because fee arithmetic can
+//       exceed 64 bits.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FeeModelConfig {
     /// Static proving fee charged per unit of raw EVM gas.

--- a/crates/alpen-ee/common/src/types/fees.rs
+++ b/crates/alpen-ee/common/src/types/fees.rs
@@ -25,38 +25,80 @@ pub enum L1FeeRateSource {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FeeModelConfig {
     /// Static proving fee charged per unit of raw EVM gas.
-    pub prover_fee_per_gas_wei: U256,
+    pub(crate) prover_fee_per_gas_wei: U256,
 
     /// Basis-points multiplier applied to estimated DA cost.
-    pub da_overhead_multiplier_bps: u32,
+    pub(crate) da_overhead_multiplier_bps: u32,
 
     /// Small additive fee charged for OL and infrastructure overhead.
-    pub ol_overhead_wei: U256,
+    pub(crate) ol_overhead_wei: U256,
 
     /// Source used to resolve the L1 fee rate.
-    pub l1_fee_rate_source: L1FeeRateSource,
+    pub(crate) l1_fee_rate_source: L1FeeRateSource,
 }
 
 /// Inputs required to quote fees for a transaction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FeeQuoteInputs {
     /// Estimated raw EVM gas for the transaction.
-    pub raw_evm_gas: u64,
+    pub(crate) raw_evm_gas: u64,
 
     /// Current base fee per gas in wei.
-    pub base_fee_per_gas: U256,
+    pub(crate) base_fee_per_gas: U256,
 
     /// Current priority fee per gas in wei.
-    pub priority_fee_per_gas: U256,
+    pub(crate) priority_fee_per_gas: U256,
 
     /// Resolved L1 fee rate in wei per byte of DA payload.
-    pub l1_fee_rate_wei_per_byte: U256,
+    pub(crate) l1_fee_rate_wei_per_byte: U256,
 
     /// Estimated diff size in bytes for the transaction.
-    pub diff_size_bytes: u64,
+    pub(crate) diff_size_bytes: u64,
 }
 
 impl FeeQuoteInputs {
+    /// Creates fee-quote inputs for a single transaction.
+    pub fn new(
+        raw_evm_gas: u64,
+        base_fee_per_gas: U256,
+        priority_fee_per_gas: U256,
+        l1_fee_rate_wei_per_byte: U256,
+        diff_size_bytes: u64,
+    ) -> Self {
+        Self {
+            raw_evm_gas,
+            base_fee_per_gas,
+            priority_fee_per_gas,
+            l1_fee_rate_wei_per_byte,
+            diff_size_bytes,
+        }
+    }
+
+    /// Returns the estimated raw EVM gas for the transaction.
+    pub fn raw_evm_gas(&self) -> u64 {
+        self.raw_evm_gas
+    }
+
+    /// Returns the current base fee per gas in wei.
+    pub fn base_fee_per_gas(&self) -> U256 {
+        self.base_fee_per_gas
+    }
+
+    /// Returns the current priority fee per gas in wei.
+    pub fn priority_fee_per_gas(&self) -> U256 {
+        self.priority_fee_per_gas
+    }
+
+    /// Returns the resolved L1 fee rate in wei per byte of DA payload.
+    pub fn l1_fee_rate_wei_per_byte(&self) -> U256 {
+        self.l1_fee_rate_wei_per_byte
+    }
+
+    /// Returns the estimated diff size in bytes for the transaction.
+    pub fn diff_size_bytes(&self) -> u64 {
+        self.diff_size_bytes
+    }
+
     /// Returns the total execution gas price in wei.
     pub fn execution_gas_price(&self) -> Result<U256, FeeModelError> {
         fee_add(
@@ -71,31 +113,71 @@ impl FeeQuoteInputs {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FeeBreakdown {
     /// Raw EVM gas used for execution and block accounting.
-    pub raw_evm_gas: u64,
+    pub(crate) raw_evm_gas: u64,
 
     /// Total execution gas price in wei.
-    pub execution_gas_price: U256,
+    pub(crate) execution_gas_price: U256,
 
     /// EVM execution fee in wei.
-    pub execution_fee: U256,
+    pub(crate) execution_fee: U256,
 
     /// Proving fee in wei.
-    pub prover_fee: U256,
+    pub(crate) prover_fee: U256,
 
     /// DA fee in wei.
-    pub da_fee: U256,
+    pub(crate) da_fee: U256,
 
     /// OL overhead fee in wei.
-    pub ol_overhead_fee: U256,
+    pub(crate) ol_overhead_fee: U256,
 
     /// Sum of all non-execution fees in wei.
-    pub non_execution_fee: U256,
+    pub(crate) non_execution_fee: U256,
 
     /// Total quoted fee in wei.
-    pub total_fee: U256,
+    pub(crate) total_fee: U256,
 }
 
 impl FeeBreakdown {
+    /// Returns the raw EVM gas used for execution and block accounting.
+    pub fn raw_evm_gas(&self) -> u64 {
+        self.raw_evm_gas
+    }
+
+    /// Returns the total execution gas price in wei.
+    pub fn execution_gas_price(&self) -> U256 {
+        self.execution_gas_price
+    }
+
+    /// Returns the EVM execution fee in wei.
+    pub fn execution_fee(&self) -> U256 {
+        self.execution_fee
+    }
+
+    /// Returns the proving fee in wei.
+    pub fn prover_fee(&self) -> U256 {
+        self.prover_fee
+    }
+
+    /// Returns the DA fee in wei.
+    pub fn da_fee(&self) -> U256 {
+        self.da_fee
+    }
+
+    /// Returns the OL overhead fee in wei.
+    pub fn ol_overhead_fee(&self) -> U256 {
+        self.ol_overhead_fee
+    }
+
+    /// Returns the sum of all non-execution fees in wei.
+    pub fn non_execution_fee(&self) -> U256 {
+        self.non_execution_fee
+    }
+
+    /// Returns the total quoted fee in wei.
+    pub fn total_fee(&self) -> U256 {
+        self.total_fee
+    }
+
     /// Converts fee amounts into a [`GasEquivalentQuote`] for budgeting.
     ///
     /// Uses ceiling division when converting non-execution wei into gas
@@ -117,11 +199,11 @@ impl FeeBreakdown {
             .checked_add(non_execution_gas)
             .ok_or(FeeModelError::GasEquivalentOverflow("total_gas"))?;
 
-        Ok(GasEquivalentQuote {
-            execution_gas: self.raw_evm_gas,
+        Ok(GasEquivalentQuote::new(
+            self.raw_evm_gas,
             non_execution_gas,
             total_gas,
-        })
+        ))
     }
 }
 
@@ -129,13 +211,13 @@ impl FeeBreakdown {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GasEquivalentQuote {
     /// Raw EVM execution gas.
-    pub execution_gas: u64,
+    pub(crate) execution_gas: u64,
 
     /// Additional budgeting gas equivalent for non-execution fees.
-    pub non_execution_gas: u64,
+    pub(crate) non_execution_gas: u64,
 
     /// Total budgeting gas.
-    pub total_gas: u64,
+    pub(crate) total_gas: u64,
 }
 
 /// Errors returned while computing fee quotes.
@@ -152,6 +234,41 @@ pub enum FeeModelError {
 }
 
 impl FeeModelConfig {
+    /// Creates a runtime configuration for the v1 fee model.
+    pub fn new(
+        prover_fee_per_gas_wei: U256,
+        da_overhead_multiplier_bps: u32,
+        ol_overhead_wei: U256,
+        l1_fee_rate_source: L1FeeRateSource,
+    ) -> Self {
+        Self {
+            prover_fee_per_gas_wei,
+            da_overhead_multiplier_bps,
+            ol_overhead_wei,
+            l1_fee_rate_source,
+        }
+    }
+
+    /// Returns the proving fee charged per unit of raw EVM gas.
+    pub fn prover_fee_per_gas_wei(&self) -> U256 {
+        self.prover_fee_per_gas_wei
+    }
+
+    /// Returns the basis-points multiplier applied to estimated DA cost.
+    pub fn da_overhead_multiplier_bps(&self) -> u32 {
+        self.da_overhead_multiplier_bps
+    }
+
+    /// Returns the additive OL and infrastructure overhead fee.
+    pub fn ol_overhead_wei(&self) -> U256 {
+        self.ol_overhead_wei
+    }
+
+    /// Returns the source used to resolve the L1 fee rate.
+    pub fn l1_fee_rate_source(&self) -> L1FeeRateSource {
+        self.l1_fee_rate_source
+    }
+
     /// Computes the v1 fee-model breakdown for the provided inputs.
     ///
     /// Returns a [`FeeBreakdown`] on success. The DA component rounds up
@@ -197,6 +314,31 @@ impl FeeModelConfig {
     }
 }
 
+impl GasEquivalentQuote {
+    fn new(execution_gas: u64, non_execution_gas: u64, total_gas: u64) -> Self {
+        Self {
+            execution_gas,
+            non_execution_gas,
+            total_gas,
+        }
+    }
+
+    /// Returns the raw EVM execution gas.
+    pub fn execution_gas(&self) -> u64 {
+        self.execution_gas
+    }
+
+    /// Returns the budgeting gas equivalent for non-execution fees.
+    pub fn non_execution_gas(&self) -> u64 {
+        self.non_execution_gas
+    }
+
+    /// Returns the total budgeting gas.
+    pub fn total_gas(&self) -> u64 {
+        self.total_gas
+    }
+}
+
 /// Checked `U256` addition that returns a [`FeeModelError::Overflow`] tagged
 /// with the calling field name on overflow.
 fn fee_add(lhs: U256, rhs: U256, field: &'static str) -> Result<U256, FeeModelError> {
@@ -219,61 +361,51 @@ mod tests {
 
     #[test]
     fn test_quote_computes_v1_fee_breakdown() {
-        let config = FeeModelConfig {
-            prover_fee_per_gas_wei: U256::from(3u8),
-            da_overhead_multiplier_bps: 12_500,
-            ol_overhead_wei: U256::from(7u8),
-            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
-        };
-        let inputs = FeeQuoteInputs {
-            raw_evm_gas: 100,
-            base_fee_per_gas: U256::from(10u8),
-            priority_fee_per_gas: U256::from(2u8),
-            l1_fee_rate_wei_per_byte: U256::from(5u8),
-            diff_size_bytes: 4,
-        };
+        let config = FeeModelConfig::new(
+            U256::from(3u8),
+            12_500,
+            U256::from(7u8),
+            L1FeeRateSource::BtcioWriter,
+        );
+        let inputs =
+            FeeQuoteInputs::new(100, U256::from(10u8), U256::from(2u8), U256::from(5u8), 4);
 
         let quote = config.quote(&inputs).expect("quote should compute");
 
-        assert_eq!(quote.execution_gas_price, U256::from(12u8));
-        assert_eq!(quote.execution_fee, U256::from(1_200u64));
-        assert_eq!(quote.prover_fee, U256::from(300u64));
-        assert_eq!(quote.da_fee, U256::from(25u8));
-        assert_eq!(quote.ol_overhead_fee, U256::from(7u8));
-        assert_eq!(quote.non_execution_fee, U256::from(332u64));
-        assert_eq!(quote.total_fee, U256::from(1_532u64));
+        assert_eq!(quote.execution_gas_price(), U256::from(12u8));
+        assert_eq!(quote.execution_fee(), U256::from(1_200u64));
+        assert_eq!(quote.prover_fee(), U256::from(300u64));
+        assert_eq!(quote.da_fee(), U256::from(25u8));
+        assert_eq!(quote.ol_overhead_fee(), U256::from(7u8));
+        assert_eq!(quote.non_execution_fee(), U256::from(332u64));
+        assert_eq!(quote.total_fee(), U256::from(1_532u64));
     }
 
     #[test]
     fn test_quote_supports_undercharge_and_overcharge_multipliers() {
-        let inputs = FeeQuoteInputs {
-            raw_evm_gas: 1,
-            base_fee_per_gas: U256::from(1u8),
-            priority_fee_per_gas: U256::ZERO,
-            l1_fee_rate_wei_per_byte: U256::from(4u8),
-            diff_size_bytes: 5,
-        };
+        let inputs = FeeQuoteInputs::new(1, U256::from(1u8), U256::ZERO, U256::from(4u8), 5);
 
-        let undercharge = FeeModelConfig {
-            prover_fee_per_gas_wei: U256::ZERO,
-            da_overhead_multiplier_bps: 5_000,
-            ol_overhead_wei: U256::ZERO,
-            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
-        };
-        let overcharge = FeeModelConfig {
-            da_overhead_multiplier_bps: 15_000,
-            ..undercharge.clone()
-        };
+        let undercharge =
+            FeeModelConfig::new(U256::ZERO, 5_000, U256::ZERO, L1FeeRateSource::BtcioWriter);
+        let overcharge = FeeModelConfig::new(
+            undercharge.prover_fee_per_gas_wei(),
+            15_000,
+            undercharge.ol_overhead_wei(),
+            undercharge.l1_fee_rate_source(),
+        );
 
         assert_eq!(
             undercharge
                 .quote(&inputs)
                 .expect("undercharge quote")
-                .da_fee,
+                .da_fee(),
             U256::from(10u8)
         );
         assert_eq!(
-            overcharge.quote(&inputs).expect("overcharge quote").da_fee,
+            overcharge
+                .quote(&inputs)
+                .expect("overcharge quote")
+                .da_fee(),
             U256::from(30u8)
         );
     }
@@ -283,71 +415,43 @@ mod tests {
         // raw_da_fee = 3 * 7 = 21
         // numerator  = 21 * 12_345 = 259_245
         // 259_245 / 10_000 = 25.9245 -> ceil 26.
-        let config = FeeModelConfig {
-            prover_fee_per_gas_wei: U256::ZERO,
-            da_overhead_multiplier_bps: 12_345,
-            ol_overhead_wei: U256::ZERO,
-            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
-        };
-        let inputs = FeeQuoteInputs {
-            raw_evm_gas: 1,
-            base_fee_per_gas: U256::from(1u8),
-            priority_fee_per_gas: U256::ZERO,
-            l1_fee_rate_wei_per_byte: U256::from(3u8),
-            diff_size_bytes: 7,
-        };
+        let config =
+            FeeModelConfig::new(U256::ZERO, 12_345, U256::ZERO, L1FeeRateSource::BtcioWriter);
+        let inputs = FeeQuoteInputs::new(1, U256::from(1u8), U256::ZERO, U256::from(3u8), 7);
 
         let quote = config.quote(&inputs).expect("quote should compute");
 
-        assert_eq!(quote.da_fee, U256::from(26u8));
+        assert_eq!(quote.da_fee(), U256::from(26u8));
     }
 
     #[test]
     fn test_gas_equivalent_quote_uses_ceil_division() {
-        let config = FeeModelConfig {
-            prover_fee_per_gas_wei: U256::from(3u8),
-            da_overhead_multiplier_bps: 12_500,
-            ol_overhead_wei: U256::from(7u8),
-            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
-        };
-        let inputs = FeeQuoteInputs {
-            raw_evm_gas: 100,
-            base_fee_per_gas: U256::from(10u8),
-            priority_fee_per_gas: U256::from(2u8),
-            l1_fee_rate_wei_per_byte: U256::from(5u8),
-            diff_size_bytes: 4,
-        };
+        let config = FeeModelConfig::new(
+            U256::from(3u8),
+            12_500,
+            U256::from(7u8),
+            L1FeeRateSource::BtcioWriter,
+        );
+        let inputs =
+            FeeQuoteInputs::new(100, U256::from(10u8), U256::from(2u8), U256::from(5u8), 4);
 
         let gas_quote = config
             .quote(&inputs)
             .and_then(|quote| quote.gas_equivalent_quote())
             .expect("gas-equivalent quote should compute");
 
-        assert_eq!(
-            gas_quote,
-            GasEquivalentQuote {
-                execution_gas: 100,
-                non_execution_gas: 28,
-                total_gas: 128,
-            }
-        );
+        assert_eq!(gas_quote, GasEquivalentQuote::new(100, 28, 128));
     }
 
     #[test]
     fn test_gas_equivalent_quote_rejects_non_zero_fee_with_zero_execution_price() {
-        let config = FeeModelConfig {
-            prover_fee_per_gas_wei: U256::ZERO,
-            da_overhead_multiplier_bps: 10_000,
-            ol_overhead_wei: U256::from(1u8),
-            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
-        };
-        let inputs = FeeQuoteInputs {
-            raw_evm_gas: 1,
-            base_fee_per_gas: U256::ZERO,
-            priority_fee_per_gas: U256::ZERO,
-            l1_fee_rate_wei_per_byte: U256::ZERO,
-            diff_size_bytes: 0,
-        };
+        let config = FeeModelConfig::new(
+            U256::ZERO,
+            10_000,
+            U256::from(1u8),
+            L1FeeRateSource::BtcioWriter,
+        );
+        let inputs = FeeQuoteInputs::new(1, U256::ZERO, U256::ZERO, U256::ZERO, 0);
 
         let error = config
             .quote(&inputs)
@@ -360,19 +464,9 @@ mod tests {
 
     #[test]
     fn test_quote_reports_overflow() {
-        let config = FeeModelConfig {
-            prover_fee_per_gas_wei: U256::MAX,
-            da_overhead_multiplier_bps: 10_000,
-            ol_overhead_wei: U256::ZERO,
-            l1_fee_rate_source: L1FeeRateSource::BtcioWriter,
-        };
-        let inputs = FeeQuoteInputs {
-            raw_evm_gas: 2,
-            base_fee_per_gas: U256::ZERO,
-            priority_fee_per_gas: U256::ZERO,
-            l1_fee_rate_wei_per_byte: U256::ZERO,
-            diff_size_bytes: 0,
-        };
+        let config =
+            FeeModelConfig::new(U256::MAX, 10_000, U256::ZERO, L1FeeRateSource::BtcioWriter);
+        let inputs = FeeQuoteInputs::new(2, U256::ZERO, U256::ZERO, U256::ZERO, 0);
 
         let error = config
             .quote(&inputs)

--- a/crates/alpen-ee/common/src/types/fees.rs
+++ b/crates/alpen-ee/common/src/types/fees.rs
@@ -199,11 +199,10 @@ impl FeeBreakdown {
             .checked_add(non_execution_gas)
             .ok_or(FeeModelError::GasEquivalentOverflow("total_gas"))?;
 
-        Ok(GasEquivalentQuote::new(
-            self.raw_evm_gas,
-            non_execution_gas,
-            total_gas,
-        ))
+        let gas_quote = GasEquivalentQuote::new(self.raw_evm_gas, non_execution_gas);
+        debug_assert_eq!(gas_quote.total_gas(), total_gas);
+
+        Ok(gas_quote)
     }
 }
 
@@ -215,9 +214,6 @@ pub struct GasEquivalentQuote {
 
     /// Additional budgeting gas equivalent for non-execution fees.
     pub(crate) non_execution_gas: u64,
-
-    /// Total budgeting gas.
-    pub(crate) total_gas: u64,
 }
 
 /// Errors returned while computing fee quotes.
@@ -315,11 +311,13 @@ impl FeeModelConfig {
 }
 
 impl GasEquivalentQuote {
-    fn new(execution_gas: u64, non_execution_gas: u64, total_gas: u64) -> Self {
+    fn new(execution_gas: u64, non_execution_gas: u64) -> Self {
+        execution_gas
+            .checked_add(non_execution_gas)
+            .expect("gas-equivalent quote must fit in u64");
         Self {
             execution_gas,
             non_execution_gas,
-            total_gas,
         }
     }
 
@@ -335,7 +333,9 @@ impl GasEquivalentQuote {
 
     /// Returns the total budgeting gas.
     pub fn total_gas(&self) -> u64 {
-        self.total_gas
+        self.execution_gas
+            .checked_add(self.non_execution_gas)
+            .expect("gas-equivalent quote must fit in u64")
     }
 }
 
@@ -440,7 +440,7 @@ mod tests {
             .and_then(|quote| quote.gas_equivalent_quote())
             .expect("gas-equivalent quote should compute");
 
-        assert_eq!(gas_quote, GasEquivalentQuote::new(100, 28, 128));
+        assert_eq!(gas_quote, GasEquivalentQuote::new(100, 28));
     }
 
     #[test]

--- a/crates/alpen-ee/common/src/types/mod.rs
+++ b/crates/alpen-ee/common/src/types/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod consensus_heads;
 pub(crate) mod da;
 pub(crate) mod ee_account_state;
 pub(crate) mod exec_record;
+pub(crate) mod fees;
 pub(crate) mod ol_account_epoch_summary;
 pub(crate) mod ol_chain_status;
 pub(crate) mod payload_builder;

--- a/crates/alpen-ee/config/Cargo.toml
+++ b/crates/alpen-ee/config/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+alpen-ee-common.workspace = true
+strata-config.workspace = true
 strata-acct-types.workspace = true
 strata-predicate.workspace = true
 

--- a/crates/alpen-ee/config/src/config.rs
+++ b/crates/alpen-ee/config/src/config.rs
@@ -1,5 +1,8 @@
 use std::sync::Arc;
 
+use alloy_primitives::U256;
+use alpen_ee_common::{FeeModelConfig, L1FeeRateSource};
+use strata_config::{btcio::L1FeePolicyConfig, L1FeeRateSourceConfig, SequencerFeeModelConfig};
 use strata_predicate::PredicateKey;
 
 use crate::{defaults::DEFAULT_DB_RETRY_COUNT, AlpenEeParams};
@@ -21,6 +24,12 @@ pub struct AlpenEeConfig {
 
     /// Number of retries for db connections
     db_retry_count: u16,
+
+    /// Optional v1 fee-model configuration for quoting and charging.
+    fee_model: Option<SequencerFeeModelConfig>,
+
+    /// Optional L1 fee-policy config reused for DA pricing.
+    l1_fee_policy: Option<L1FeePolicyConfig>,
 }
 
 impl AlpenEeConfig {
@@ -38,7 +47,20 @@ impl AlpenEeConfig {
             ol_client_http,
             ee_sequencer_http,
             db_retry_count: db_retry_count.unwrap_or(DEFAULT_DB_RETRY_COUNT),
+            fee_model: None,
+            l1_fee_policy: None,
         }
+    }
+
+    /// Attaches the fee-model configuration used by quote-time RPC and execution-time charging.
+    pub fn with_fee_model_config(
+        mut self,
+        fee_model: SequencerFeeModelConfig,
+        l1_fee_policy: L1FeePolicyConfig,
+    ) -> Self {
+        self.fee_model = Some(fee_model);
+        self.l1_fee_policy = Some(l1_fee_policy);
+        self
     }
 
     /// Returns the chain parameters.
@@ -64,5 +86,86 @@ impl AlpenEeConfig {
     /// Returns the number of database retries attempted for any transaction.
     pub fn db_retry_count(&self) -> u16 {
         self.db_retry_count
+    }
+
+    /// Returns the resolved fee-model configuration, if one has been attached.
+    pub fn fee_model(&self) -> Option<FeeModelConfig> {
+        self.fee_model.as_ref().map(|fee_model| FeeModelConfig {
+            prover_fee_per_gas_wei: u256_from_u64(fee_model.prover_fee_per_gas_wei),
+            da_overhead_multiplier_bps: fee_model.da_overhead_multiplier_bps,
+            ol_overhead_wei: u256_from_u64(fee_model.ol_overhead_wei),
+            l1_fee_rate_source: match fee_model.l1_fee_rate_source {
+                L1FeeRateSourceConfig::BtcioWriter => L1FeeRateSource::BtcioWriter,
+            },
+        })
+    }
+
+    /// Returns the attached L1 fee-policy config, if one has been attached.
+    pub fn l1_fee_policy(&self) -> Option<&L1FeePolicyConfig> {
+        self.l1_fee_policy.as_ref()
+    }
+}
+
+fn u256_from_u64(value: u64) -> U256 {
+    U256::from_limbs([value, 0, 0, 0])
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_ee_common::L1FeeRateSource;
+    use strata_acct_types::AccountId;
+    use strata_config::{
+        btcio::{FeePolicy, L1FeePolicyConfig},
+        L1FeeRateSourceConfig, SequencerFeeModelConfig,
+    };
+    use strata_predicate::PredicateKey;
+
+    use super::{u256_from_u64, AlpenEeConfig};
+    use crate::AlpenEeParams;
+
+    #[test]
+    fn test_fee_model_config_can_be_attached_and_read_back() {
+        let params = AlpenEeParams::new(
+            AccountId::new([1u8; 32]),
+            [2u8; 32].into(),
+            [3u8; 32].into(),
+            0,
+        );
+
+        let config = AlpenEeConfig::new(
+            params,
+            PredicateKey::always_accept(),
+            "http://localhost:8542".to_string(),
+            Some("http://localhost:8543".to_string()),
+            Some(7),
+        )
+        .with_fee_model_config(
+            SequencerFeeModelConfig {
+                prover_fee_per_gas_wei: 15,
+                da_overhead_multiplier_bps: 12_500,
+                ol_overhead_wei: 42,
+                l1_fee_rate_source: L1FeeRateSourceConfig::BtcioWriter,
+            },
+            L1FeePolicyConfig {
+                fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
+                mempool_base_url: None,
+                ..L1FeePolicyConfig::default()
+            },
+        );
+
+        let fee_model = config.fee_model().expect("fee model must be attached");
+        let l1_fee_policy = config
+            .l1_fee_policy()
+            .expect("l1 fee policy must be attached");
+
+        assert_eq!(config.db_retry_count(), 7);
+        assert_eq!(fee_model.prover_fee_per_gas_wei, u256_from_u64(15));
+        assert_eq!(fee_model.da_overhead_multiplier_bps, 12_500);
+        assert_eq!(fee_model.ol_overhead_wei, u256_from_u64(42));
+        assert_eq!(fee_model.l1_fee_rate_source, L1FeeRateSource::BtcioWriter);
+        assert_eq!(
+            l1_fee_policy.fee_policy,
+            FeePolicy::BitcoinD { conf_target: 6 }
+        );
     }
 }

--- a/crates/alpen-ee/config/src/config.rs
+++ b/crates/alpen-ee/config/src/config.rs
@@ -90,13 +90,15 @@ impl AlpenEeConfig {
 
     /// Returns the resolved fee-model configuration, if one has been attached.
     pub fn fee_model(&self) -> Option<FeeModelConfig> {
-        self.fee_model.as_ref().map(|fee_model| FeeModelConfig {
-            prover_fee_per_gas_wei: u256_from_u64(fee_model.prover_fee_per_gas_wei),
-            da_overhead_multiplier_bps: fee_model.da_overhead_multiplier_bps,
-            ol_overhead_wei: u256_from_u64(fee_model.ol_overhead_wei),
-            l1_fee_rate_source: match fee_model.l1_fee_rate_source {
-                L1FeeRateSourceConfig::BtcioWriter => L1FeeRateSource::BtcioWriter,
-            },
+        self.fee_model.as_ref().map(|fee_model| {
+            FeeModelConfig::new(
+                u256_from_u64(fee_model.prover_fee_per_gas_wei()),
+                fee_model.da_overhead_multiplier_bps(),
+                u256_from_u64(fee_model.ol_overhead_wei()),
+                match fee_model.l1_fee_rate_source() {
+                    L1FeeRateSourceConfig::BtcioWriter => L1FeeRateSource::BtcioWriter,
+                },
+            )
         })
     }
 
@@ -140,17 +142,8 @@ mod tests {
             Some(7),
         )
         .with_fee_model_config(
-            SequencerFeeModelConfig {
-                prover_fee_per_gas_wei: 15,
-                da_overhead_multiplier_bps: 12_500,
-                ol_overhead_wei: 42,
-                l1_fee_rate_source: L1FeeRateSourceConfig::BtcioWriter,
-            },
-            L1FeePolicyConfig {
-                fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
-                mempool_base_url: None,
-                ..L1FeePolicyConfig::default()
-            },
+            SequencerFeeModelConfig::new(15, 12_500, 42, L1FeeRateSourceConfig::BtcioWriter),
+            L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 6 }),
         );
 
         let fee_model = config.fee_model().expect("fee model must be attached");
@@ -159,13 +152,13 @@ mod tests {
             .expect("l1 fee policy must be attached");
 
         assert_eq!(config.db_retry_count(), 7);
-        assert_eq!(fee_model.prover_fee_per_gas_wei, u256_from_u64(15));
-        assert_eq!(fee_model.da_overhead_multiplier_bps, 12_500);
-        assert_eq!(fee_model.ol_overhead_wei, u256_from_u64(42));
-        assert_eq!(fee_model.l1_fee_rate_source, L1FeeRateSource::BtcioWriter);
+        assert_eq!(fee_model.prover_fee_per_gas_wei(), u256_from_u64(15));
+        assert_eq!(fee_model.da_overhead_multiplier_bps(), 12_500);
+        assert_eq!(fee_model.ol_overhead_wei(), u256_from_u64(42));
+        assert_eq!(fee_model.l1_fee_rate_source(), L1FeeRateSource::BtcioWriter);
         assert_eq!(
-            l1_fee_policy.fee_policy,
-            FeePolicy::BitcoinD { conf_target: 6 }
+            l1_fee_policy.fee_policy(),
+            &FeePolicy::BitcoinD { conf_target: 6 }
         );
     }
 }

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -574,8 +574,8 @@ pub fn create_checkpoint_envelope_tx(address: &str, l1_payload: L1Payload) -> Tr
 pub(crate) mod test_context {
     use std::sync::Arc;
 
-    use bitcoin::{secp256k1::SecretKey, Address, Network};
-    use strata_config::btcio::{FeePolicy, WriterConfig};
+    use bitcoin::{Address, Network};
+    use strata_config::btcio::{FeePolicy, L1FeePolicyConfig, WriterConfig};
     use strata_l1_txfmt::MagicBytes;
     use strata_status::StatusChannel;
     use strata_test_utils::ArbitraryGenerator;
@@ -590,7 +590,11 @@ pub(crate) mod test_context {
             .require_network(Network::Regtest)
             .unwrap();
         let cfg = Arc::new(WriterConfig {
-            fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
+                mempool_base_url: None,
+                ..L1FeePolicyConfig::default()
+            },
             ..WriterConfig::default()
         });
         let status_channel = StatusChannel::new(

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -574,7 +574,7 @@ pub fn create_checkpoint_envelope_tx(address: &str, l1_payload: L1Payload) -> Tr
 pub(crate) mod test_context {
     use std::sync::Arc;
 
-    use bitcoin::{Address, Network};
+    use bitcoin::{secp256k1::SecretKey, Address, Network};
     use strata_config::btcio::{FeePolicy, L1FeePolicyConfig, WriterConfig};
     use strata_l1_txfmt::MagicBytes;
     use strata_status::StatusChannel;
@@ -590,11 +590,7 @@ pub(crate) mod test_context {
             .require_network(Network::Regtest)
             .unwrap();
         let cfg = Arc::new(WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
-                mempool_base_url: None,
-                ..L1FeePolicyConfig::default()
-            },
+            l1_fee_policy: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 1 }),
             ..WriterConfig::default()
         });
         let status_channel = StatusChannel::new(

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -590,7 +590,7 @@ pub(crate) mod test_context {
             .require_network(Network::Regtest)
             .unwrap();
         let cfg = Arc::new(WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 1 }),
+            l1_fee_policy_config: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 1 }),
             ..WriterConfig::default()
         });
         let status_channel = StatusChannel::new(

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -121,7 +121,7 @@ async fn resolve_mempool_fee_rate<R: Reader>(
         .ok_or_else(|| anyhow!("mempool_base_url must be set when fee_policy = \"mempool\""))?;
 
     let explorer = MempoolExplorerClient::new(base_url)?;
-    let fallback_conf_target = config.l1_fee_policy.mempool_fallback_conf_target;
+    let fallback_conf_target = config.mempool_fallback_conf_target();
 
     match explorer.fetch_recommended_fees().await {
         Ok(fees) => Ok(fees.select(mempool_fee_policy)),

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -3,7 +3,7 @@
 
 use std::sync::LazyLock;
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use bitcoind_async_client::traits::Reader;
 use reqwest::Url;
 use serde::Deserialize;
@@ -94,8 +94,12 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
             .estimate_smart_fee(*conf_target)
             .await
             .context("failed to estimate smart fee"),
-        FeePolicy::MempoolExplorer { policy } => {
-            resolve_mempool_fee_rate(client, config, *policy).await
+        FeePolicy::MempoolExplorer {
+            policy,
+            mempool_base_url,
+            fallback_conf_target,
+        } => {
+            resolve_mempool_fee_rate(client, mempool_base_url, *fallback_conf_target, *policy).await
         }
         FeePolicy::Fixed { fee_rate } => Ok(*fee_rate),
     }?;
@@ -113,15 +117,11 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
 /// Bitcoin Core's `estimatesmartfee` on failure.
 async fn resolve_mempool_fee_rate<R: Reader>(
     client: &R,
-    config: &WriterConfig,
+    base_url: &str,
+    fallback_conf_target: u16,
     mempool_fee_policy: MempoolExplorerFeePolicy,
 ) -> anyhow::Result<u64> {
-    let base_url = config
-        .mempool_base_url()
-        .ok_or_else(|| anyhow!("mempool_base_url must be set when fee_policy = \"mempool\""))?;
-
     let explorer = MempoolExplorerClient::new(base_url)?;
-    let fallback_conf_target = config.mempool_fallback_conf_target();
 
     match explorer.fetch_recommended_fees().await {
         Ok(fees) => Ok(fees.select(mempool_fee_policy)),
@@ -157,21 +157,17 @@ mod tests {
 
     fn writer_config(l1_fee_policy: L1FeePolicyConfig) -> WriterConfig {
         WriterConfig {
-            l1_fee_policy,
+            l1_fee_policy_config: l1_fee_policy,
             ..WriterConfig::default()
         }
     }
 
-    fn mempool_writer_config(
-        policy: MempoolExplorerFeePolicy,
-        base_url: Option<String>,
-    ) -> WriterConfig {
-        let mut l1_fee_policy = L1FeePolicyConfig::new(FeePolicy::MempoolExplorer { policy });
-        if let Some(base_url) = base_url {
-            l1_fee_policy = l1_fee_policy.with_mempool_base_url(base_url);
-        }
-
-        writer_config(l1_fee_policy)
+    fn mempool_writer_config(policy: MempoolExplorerFeePolicy, base_url: String) -> WriterConfig {
+        writer_config(L1FeePolicyConfig::new(FeePolicy::MempoolExplorer {
+            policy,
+            mempool_base_url: base_url,
+            fallback_conf_target: 1,
+        }))
     }
 
     fn bitcoind_writer_config(conf_target: u16) -> WriterConfig {
@@ -254,7 +250,7 @@ mod tests {
         )
         .await;
         let client = TestBitcoinClient::new(1);
-        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, Some(server));
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, server);
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -272,7 +268,7 @@ mod tests {
         )
         .await;
         let client = TestBitcoinClient::new(1);
-        let config = mempool_writer_config(MempoolExplorerFeePolicy::Economy, Some(server));
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Economy, server);
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -286,7 +282,7 @@ mod tests {
     async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_invalid_json() {
         let server = spawn_single_response_server("200 OK", "not-json").await;
         let client = TestBitcoinClient::new(1);
-        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, Some(server));
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, server);
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -300,7 +296,7 @@ mod tests {
     async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_http_error() {
         let server = spawn_single_response_server("500 Internal Server Error", "").await;
         let client = TestBitcoinClient::new(1);
-        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, Some(server));
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, server);
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -311,26 +307,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_missing() {
-        let client = TestBitcoinClient::new(1);
-        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, None);
-
-        let err = resolve_fee_rate(&client, &config)
-            .await
-            .expect_err("missing mempool_base_url should error");
-
-        assert!(err
-            .to_string()
-            .contains("mempool_base_url must be set when fee_policy = \"mempool\""));
-    }
-
-    #[tokio::test]
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_invalid() {
         let client = TestBitcoinClient::new(1);
-        let config = mempool_writer_config(
-            MempoolExplorerFeePolicy::Fastest,
-            Some("not a url".to_string()),
-        );
+        let config =
+            mempool_writer_config(MempoolExplorerFeePolicy::Fastest, "not a url".to_string());
 
         let err = resolve_fee_rate(&client, &config)
             .await

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -89,7 +89,7 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
     client: &R,
     config: &WriterConfig,
 ) -> anyhow::Result<u64> {
-    let fee_rate = match &config.fee_policy {
+    let fee_rate = match config.fee_policy() {
         FeePolicy::BitcoinD { conf_target } => client
             .estimate_smart_fee(*conf_target)
             .await
@@ -117,12 +117,11 @@ async fn resolve_mempool_fee_rate<R: Reader>(
     mempool_fee_policy: MempoolExplorerFeePolicy,
 ) -> anyhow::Result<u64> {
     let base_url = config
-        .mempool_base_url
-        .as_deref()
+        .mempool_base_url()
         .ok_or_else(|| anyhow!("mempool_base_url must be set when fee_policy = \"mempool\""))?;
 
     let explorer = MempoolExplorerClient::new(base_url)?;
-    let fallback_conf_target = config.mempool_fallback_conf_target;
+    let fallback_conf_target = config.l1_fee_policy.mempool_fallback_conf_target;
 
     match explorer.fetch_recommended_fees().await {
         Ok(fees) => Ok(fees.select(mempool_fee_policy)),
@@ -145,7 +144,9 @@ async fn resolve_mempool_fee_rate<R: Reader>(
 mod tests {
     use std::sync::Arc;
 
-    use strata_config::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
+    use strata_config::btcio::{
+        FeePolicy, L1FeePolicyConfig, MempoolExplorerFeePolicy, WriterConfig,
+    };
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
@@ -231,10 +232,13 @@ mod tests {
         .await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer {
-                policy: MempoolExplorerFeePolicy::Fastest,
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::MempoolExplorer {
+                    policy: MempoolExplorerFeePolicy::Fastest,
+                },
+                mempool_base_url: Some(server),
+                ..L1FeePolicyConfig::default()
             },
-            mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
 
@@ -255,10 +259,13 @@ mod tests {
         .await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer {
-                policy: MempoolExplorerFeePolicy::Economy,
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::MempoolExplorer {
+                    policy: MempoolExplorerFeePolicy::Economy,
+                },
+                mempool_base_url: Some(server),
+                ..L1FeePolicyConfig::default()
             },
-            mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
 
@@ -275,10 +282,13 @@ mod tests {
         let server = spawn_single_response_server("200 OK", "not-json").await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer {
-                policy: MempoolExplorerFeePolicy::Fastest,
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::MempoolExplorer {
+                    policy: MempoolExplorerFeePolicy::Fastest,
+                },
+                mempool_base_url: Some(server),
+                ..L1FeePolicyConfig::default()
             },
-            mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
 
@@ -295,10 +305,13 @@ mod tests {
         let server = spawn_single_response_server("500 Internal Server Error", "").await;
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer {
-                policy: MempoolExplorerFeePolicy::Fastest,
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::MempoolExplorer {
+                    policy: MempoolExplorerFeePolicy::Fastest,
+                },
+                mempool_base_url: Some(server),
+                ..L1FeePolicyConfig::default()
             },
-            mempool_base_url: Some(server),
             ..WriterConfig::default()
         };
 
@@ -314,10 +327,13 @@ mod tests {
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_missing() {
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer {
-                policy: MempoolExplorerFeePolicy::Fastest,
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::MempoolExplorer {
+                    policy: MempoolExplorerFeePolicy::Fastest,
+                },
+                mempool_base_url: None,
+                ..L1FeePolicyConfig::default()
             },
-            mempool_base_url: None,
             ..WriterConfig::default()
         };
 
@@ -334,10 +350,13 @@ mod tests {
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_invalid() {
         let client = TestBitcoinClient::new(1);
         let config = WriterConfig {
-            fee_policy: FeePolicy::MempoolExplorer {
-                policy: MempoolExplorerFeePolicy::Fastest,
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::MempoolExplorer {
+                    policy: MempoolExplorerFeePolicy::Fastest,
+                },
+                mempool_base_url: Some("not a url".to_string()),
+                ..L1FeePolicyConfig::default()
             },
-            mempool_base_url: Some("not a url".to_string()),
             ..WriterConfig::default()
         };
 
@@ -352,7 +371,11 @@ mod tests {
     async fn test_resolve_fee_rate_smart_uses_raw_estimate() {
         let client = Arc::new(TestBitcoinClient::new(1));
         let config = WriterConfig {
-            fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
+                mempool_base_url: None,
+                ..L1FeePolicyConfig::default()
+            },
             ..WriterConfig::default()
         };
 

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -155,6 +155,29 @@ mod tests {
     use super::{resolve_fee_rate, MempoolExplorerClient, MempoolRecommendedFees};
     use crate::test_utils::TestBitcoinClient;
 
+    fn writer_config(l1_fee_policy: L1FeePolicyConfig) -> WriterConfig {
+        WriterConfig {
+            l1_fee_policy,
+            ..WriterConfig::default()
+        }
+    }
+
+    fn mempool_writer_config(
+        policy: MempoolExplorerFeePolicy,
+        base_url: Option<String>,
+    ) -> WriterConfig {
+        let mut l1_fee_policy = L1FeePolicyConfig::new(FeePolicy::MempoolExplorer { policy });
+        if let Some(base_url) = base_url {
+            l1_fee_policy = l1_fee_policy.with_mempool_base_url(base_url);
+        }
+
+        writer_config(l1_fee_policy)
+    }
+
+    fn bitcoind_writer_config(conf_target: u16) -> WriterConfig {
+        writer_config(L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target }))
+    }
+
     async fn spawn_single_response_server(status_line: &'static str, body: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -231,16 +254,7 @@ mod tests {
         )
         .await;
         let client = TestBitcoinClient::new(1);
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::MempoolExplorer {
-                    policy: MempoolExplorerFeePolicy::Fastest,
-                },
-                mempool_base_url: Some(server),
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, Some(server));
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -258,16 +272,7 @@ mod tests {
         )
         .await;
         let client = TestBitcoinClient::new(1);
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::MempoolExplorer {
-                    policy: MempoolExplorerFeePolicy::Economy,
-                },
-                mempool_base_url: Some(server),
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Economy, Some(server));
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -281,16 +286,7 @@ mod tests {
     async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_invalid_json() {
         let server = spawn_single_response_server("200 OK", "not-json").await;
         let client = TestBitcoinClient::new(1);
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::MempoolExplorer {
-                    policy: MempoolExplorerFeePolicy::Fastest,
-                },
-                mempool_base_url: Some(server),
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, Some(server));
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -304,16 +300,7 @@ mod tests {
     async fn test_resolve_fee_rate_falls_back_to_smart_fee_on_http_error() {
         let server = spawn_single_response_server("500 Internal Server Error", "").await;
         let client = TestBitcoinClient::new(1);
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::MempoolExplorer {
-                    policy: MempoolExplorerFeePolicy::Fastest,
-                },
-                mempool_base_url: Some(server),
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, Some(server));
 
         let fee_rate = resolve_fee_rate(&client, &config)
             .await
@@ -326,16 +313,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_missing() {
         let client = TestBitcoinClient::new(1);
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::MempoolExplorer {
-                    policy: MempoolExplorerFeePolicy::Fastest,
-                },
-                mempool_base_url: None,
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = mempool_writer_config(MempoolExplorerFeePolicy::Fastest, None);
 
         let err = resolve_fee_rate(&client, &config)
             .await
@@ -349,16 +327,10 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_fee_rate_errors_when_mempool_base_url_is_invalid() {
         let client = TestBitcoinClient::new(1);
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::MempoolExplorer {
-                    policy: MempoolExplorerFeePolicy::Fastest,
-                },
-                mempool_base_url: Some("not a url".to_string()),
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = mempool_writer_config(
+            MempoolExplorerFeePolicy::Fastest,
+            Some("not a url".to_string()),
+        );
 
         let err = resolve_fee_rate(&client, &config)
             .await
@@ -370,14 +342,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_fee_rate_smart_uses_raw_estimate() {
         let client = Arc::new(TestBitcoinClient::new(1));
-        let config = WriterConfig {
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::BitcoinD { conf_target: 1 },
-                mempool_base_url: None,
-                ..L1FeePolicyConfig::default()
-            },
-            ..WriterConfig::default()
-        };
+        let config = bitcoind_writer_config(1);
 
         let fee_rate = resolve_fee_rate(client.as_ref(), &config)
             .await

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -22,7 +22,7 @@ pub struct WriterConfig {
     pub write_poll_dur_ms: u64,
     /// How the fees are determined.
     #[serde(flatten)]
-    pub l1_fee_policy: L1FeePolicyConfig,
+    pub l1_fee_policy_config: L1FeePolicyConfig,
     /// How much amount(in sats) to send to reveal address. Must be above dust amount or else
     /// reveal transaction won't be accepted.
     pub reveal_amount: u64,
@@ -32,23 +32,13 @@ pub struct WriterConfig {
 
 impl WriterConfig {
     /// Returns the configured L1 fee-policy configuration.
-    pub fn l1_fee_policy(&self) -> &L1FeePolicyConfig {
-        &self.l1_fee_policy
+    pub fn l1_fee_policy_config(&self) -> &L1FeePolicyConfig {
+        &self.l1_fee_policy_config
     }
 
     /// Returns the configured L1 fee policy.
     pub fn fee_policy(&self) -> &FeePolicy {
-        self.l1_fee_policy.fee_policy()
-    }
-
-    /// Returns the configured mempool explorer base URL, if any.
-    pub fn mempool_base_url(&self) -> Option<&str> {
-        self.l1_fee_policy.mempool_base_url()
-    }
-
-    /// Returns the bitcoind fallback confirmation target used for mempool failures.
-    pub fn mempool_fallback_conf_target(&self) -> u16 {
-        self.l1_fee_policy.mempool_fallback_conf_target()
+        self.l1_fee_policy_config.fee_policy()
     }
 }
 
@@ -58,48 +48,17 @@ pub struct L1FeePolicyConfig {
     /// How fees are determined while creating L1 transactions.
     #[serde(flatten)]
     pub(crate) fee_policy: FeePolicy,
-    /// Base URL for mempool.space-compatible fee API.
-    pub(crate) mempool_base_url: Option<String>,
-    /// Confirmation target passed to bitcoind's `estimatesmartfee` when the mempool explorer is
-    /// unreachable and the policy falls back to bitcoind.
-    #[serde(default = "default_bitcoind_conf_target")]
-    pub(crate) mempool_fallback_conf_target: u16,
 }
 
 impl L1FeePolicyConfig {
     /// Creates an L1 fee-policy configuration for the provided fee policy.
     pub fn new(fee_policy: FeePolicy) -> Self {
-        Self {
-            fee_policy,
-            ..Self::default()
-        }
+        Self { fee_policy }
     }
 
     /// Returns how fees are determined while creating L1 transactions.
     pub fn fee_policy(&self) -> &FeePolicy {
         &self.fee_policy
-    }
-
-    /// Returns the configured mempool explorer base URL, if any.
-    pub fn mempool_base_url(&self) -> Option<&str> {
-        self.mempool_base_url.as_deref()
-    }
-
-    /// Returns the bitcoind fallback confirmation target used for mempool failures.
-    pub fn mempool_fallback_conf_target(&self) -> u16 {
-        self.mempool_fallback_conf_target
-    }
-
-    /// Sets the mempool explorer base URL.
-    pub fn with_mempool_base_url(mut self, mempool_base_url: impl Into<String>) -> Self {
-        self.mempool_base_url = Some(mempool_base_url.into());
-        self
-    }
-
-    /// Sets the bitcoind fallback confirmation target used for mempool failures.
-    pub fn with_mempool_fallback_conf_target(mut self, conf_target: u16) -> Self {
-        self.mempool_fallback_conf_target = conf_target;
-        self
     }
 }
 
@@ -112,6 +71,15 @@ pub enum FeePolicy {
     MempoolExplorer {
         #[serde(default, rename = "mempool_fee_policy")]
         policy: MempoolExplorerFeePolicy,
+        /// Base URL for a mempool.space-compatible fee API.
+        mempool_base_url: String,
+        /// Confirmation target passed to bitcoind's `estimatesmartfee` when the mempool explorer
+        /// is unreachable.
+        #[serde(
+            default = "default_bitcoind_conf_target",
+            rename = "mempool_fallback_conf_target"
+        )]
+        fallback_conf_target: u16,
     },
 
     /// Use Bitcoin Core's `estimatesmartfee` and the target confirmation parameter is the provided
@@ -153,6 +121,18 @@ pub enum MempoolExplorerFeePolicy {
     Minimum,
 }
 
+impl FeePolicy {
+    /// Returns the configured mempool explorer base URL, if any.
+    pub fn mempool_base_url(&self) -> Option<&str> {
+        match self {
+            Self::MempoolExplorer {
+                mempool_base_url, ..
+            } => Some(mempool_base_url.as_str()),
+            Self::BitcoinD { .. } | Self::Fixed { .. } => None,
+        }
+    }
+}
+
 /// Configuration for btcio broadcaster.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BroadcasterConfig {
@@ -166,7 +146,7 @@ impl Default for WriterConfig {
             write_poll_dur_ms: 5_000,
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
-            l1_fee_policy: L1FeePolicyConfig::default(),
+            l1_fee_policy_config: L1FeePolicyConfig::default(),
         }
     }
 }

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -31,14 +31,24 @@ pub struct WriterConfig {
 }
 
 impl WriterConfig {
+    /// Returns the configured L1 fee-policy configuration.
+    pub fn l1_fee_policy(&self) -> &L1FeePolicyConfig {
+        &self.l1_fee_policy
+    }
+
     /// Returns the configured L1 fee policy.
     pub fn fee_policy(&self) -> &FeePolicy {
-        &self.l1_fee_policy.fee_policy
+        self.l1_fee_policy.fee_policy()
     }
 
     /// Returns the configured mempool explorer base URL, if any.
     pub fn mempool_base_url(&self) -> Option<&str> {
-        self.l1_fee_policy.mempool_base_url.as_deref()
+        self.l1_fee_policy.mempool_base_url()
+    }
+
+    /// Returns the bitcoind fallback confirmation target used for mempool failures.
+    pub fn mempool_fallback_conf_target(&self) -> u16 {
+        self.l1_fee_policy.mempool_fallback_conf_target()
     }
 }
 
@@ -47,13 +57,50 @@ impl WriterConfig {
 pub struct L1FeePolicyConfig {
     /// How fees are determined while creating L1 transactions.
     #[serde(flatten)]
-    pub fee_policy: FeePolicy,
+    pub(crate) fee_policy: FeePolicy,
     /// Base URL for mempool.space-compatible fee API.
-    pub mempool_base_url: Option<String>,
+    pub(crate) mempool_base_url: Option<String>,
     /// Confirmation target passed to bitcoind's `estimatesmartfee` when the mempool explorer is
     /// unreachable and the policy falls back to bitcoind.
     #[serde(default = "default_bitcoind_conf_target")]
-    pub mempool_fallback_conf_target: u16,
+    pub(crate) mempool_fallback_conf_target: u16,
+}
+
+impl L1FeePolicyConfig {
+    /// Creates an L1 fee-policy configuration for the provided fee policy.
+    pub fn new(fee_policy: FeePolicy) -> Self {
+        Self {
+            fee_policy,
+            ..Self::default()
+        }
+    }
+
+    /// Returns how fees are determined while creating L1 transactions.
+    pub fn fee_policy(&self) -> &FeePolicy {
+        &self.fee_policy
+    }
+
+    /// Returns the configured mempool explorer base URL, if any.
+    pub fn mempool_base_url(&self) -> Option<&str> {
+        self.mempool_base_url.as_deref()
+    }
+
+    /// Returns the bitcoind fallback confirmation target used for mempool failures.
+    pub fn mempool_fallback_conf_target(&self) -> u16 {
+        self.mempool_fallback_conf_target
+    }
+
+    /// Sets the mempool explorer base URL.
+    pub fn with_mempool_base_url(mut self, mempool_base_url: impl Into<String>) -> Self {
+        self.mempool_base_url = Some(mempool_base_url.into());
+        self
+    }
+
+    /// Sets the bitcoind fallback confirmation target used for mempool failures.
+    pub fn with_mempool_fallback_conf_target(mut self, conf_target: u16) -> Self {
+        self.mempool_fallback_conf_target = conf_target;
+        self
+    }
 }
 
 /// Definition of how fees are determined while creating l1 transactions.

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -20,15 +20,34 @@ pub struct ReaderConfig {
 pub struct WriterConfig {
     /// How often to invoke the writer.
     pub write_poll_dur_ms: u64,
-    /// How the fees for are determined.
-    // FIXME: This should actually be a part of signer.
+    /// How the fees are determined.
     #[serde(flatten)]
-    pub fee_policy: FeePolicy,
+    pub l1_fee_policy: L1FeePolicyConfig,
     /// How much amount(in sats) to send to reveal address. Must be above dust amount or else
     /// reveal transaction won't be accepted.
     pub reveal_amount: u64,
     /// How often to bundle write intents.
     pub bundle_interval_ms: u64,
+}
+
+impl WriterConfig {
+    /// Returns the configured L1 fee policy.
+    pub fn fee_policy(&self) -> &FeePolicy {
+        &self.l1_fee_policy.fee_policy
+    }
+
+    /// Returns the configured mempool explorer base URL, if any.
+    pub fn mempool_base_url(&self) -> Option<&str> {
+        self.l1_fee_policy.mempool_base_url.as_deref()
+    }
+}
+
+/// Reusable configuration for resolving Bitcoin fee rates.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct L1FeePolicyConfig {
+    /// How fees are determined while creating L1 transactions.
+    #[serde(flatten)]
+    pub fee_policy: FeePolicy,
     /// Base URL for mempool.space-compatible fee API.
     pub mempool_base_url: Option<String>,
     /// Confirmation target passed to bitcoind's `estimatesmartfee` when the mempool explorer is
@@ -98,11 +117,9 @@ impl Default for WriterConfig {
     fn default() -> Self {
         Self {
             write_poll_dur_ms: 5_000,
-            fee_policy: FeePolicy::default(),
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
-            mempool_base_url: None,
-            mempool_fallback_conf_target: default_bitcoind_conf_target(),
+            l1_fee_policy: L1FeePolicyConfig::default(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -326,7 +326,7 @@ pub struct Config {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::btcio::{FeePolicy, MempoolExplorerFeePolicy, WriterConfig};
+    use crate::btcio::{FeePolicy, L1FeePolicyConfig, MempoolExplorerFeePolicy, WriterConfig};
 
     #[test]
     fn test_config_load() {
@@ -574,13 +574,13 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.fee_policy,
+            config.l1_fee_policy.fee_policy,
             FeePolicy::MempoolExplorer {
                 policy: MempoolExplorerFeePolicy::Fastest,
             }
         );
         assert_eq!(
-            config.mempool_base_url.as_deref(),
+            config.l1_fee_policy.mempool_base_url.as_deref(),
             Some("https://mempool.space/signet")
         );
     }
@@ -600,7 +600,7 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.fee_policy,
+            config.l1_fee_policy.fee_policy,
             FeePolicy::MempoolExplorer {
                 policy: MempoolExplorerFeePolicy::Economy,
             }
@@ -620,18 +620,23 @@ mod test {
         )
         .expect("writer config should parse");
 
-        assert_eq!(config.fee_policy, FeePolicy::BitcoinD { conf_target: 6 });
+        assert_eq!(
+            config.l1_fee_policy.fee_policy,
+            FeePolicy::BitcoinD { conf_target: 6 }
+        );
     }
 
     #[test]
     fn test_writer_config_serializes_bitcoind_conf_target() {
         let config = WriterConfig {
-            fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
             write_poll_dur_ms: 200,
             reveal_amount: 100,
             bundle_interval_ms: 1_000,
-            mempool_base_url: None,
-            ..WriterConfig::default()
+            l1_fee_policy: L1FeePolicyConfig {
+                fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
+                mempool_base_url: None,
+                ..L1FeePolicyConfig::default()
+            },
         };
 
         let toml = toml::to_string(&config).expect("writer config should serialize");

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -173,17 +173,54 @@ fn default_l1_fee_rate_source() -> L1FeeRateSourceConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SequencerFeeModelConfig {
     /// Static proving fee charged per unit of raw EVM gas.
-    pub prover_fee_per_gas_wei: u64,
+    pub(crate) prover_fee_per_gas_wei: u64,
 
     /// Basis-points multiplier applied to the estimated DA fee.
-    pub da_overhead_multiplier_bps: u32,
+    pub(crate) da_overhead_multiplier_bps: u32,
 
     /// Small additive fee charged for OL and infrastructure overhead.
-    pub ol_overhead_wei: u64,
+    pub(crate) ol_overhead_wei: u64,
 
     /// Source used to resolve the current L1 fee rate.
     #[serde(default = "default_l1_fee_rate_source")]
-    pub l1_fee_rate_source: L1FeeRateSourceConfig,
+    pub(crate) l1_fee_rate_source: L1FeeRateSourceConfig,
+}
+
+impl SequencerFeeModelConfig {
+    /// Creates a v1 L2 fee-model configuration.
+    pub fn new(
+        prover_fee_per_gas_wei: u64,
+        da_overhead_multiplier_bps: u32,
+        ol_overhead_wei: u64,
+        l1_fee_rate_source: L1FeeRateSourceConfig,
+    ) -> Self {
+        Self {
+            prover_fee_per_gas_wei,
+            da_overhead_multiplier_bps,
+            ol_overhead_wei,
+            l1_fee_rate_source,
+        }
+    }
+
+    /// Returns the proving fee charged per unit of raw EVM gas.
+    pub fn prover_fee_per_gas_wei(&self) -> u64 {
+        self.prover_fee_per_gas_wei
+    }
+
+    /// Returns the basis-points multiplier applied to the estimated DA fee.
+    pub fn da_overhead_multiplier_bps(&self) -> u32 {
+        self.da_overhead_multiplier_bps
+    }
+
+    /// Returns the additive OL and infrastructure overhead fee.
+    pub fn ol_overhead_wei(&self) -> u64 {
+        self.ol_overhead_wei
+    }
+
+    /// Returns the source used to resolve the current L1 fee rate.
+    pub fn l1_fee_rate_source(&self) -> L1FeeRateSourceConfig {
+        self.l1_fee_rate_source
+    }
 }
 
 /// Source for the L1 fee rate used by the fee model.
@@ -588,11 +625,11 @@ mod test {
         assert_eq!(config.sequencer.ol_block_time_ms, 3_000);
         assert_eq!(config.sequencer.max_txs_per_block, 500);
         assert_eq!(config.sequencer.block_template_ttl_secs, 120);
-        assert_eq!(config.fee_model.prover_fee_per_gas_wei, 15);
-        assert_eq!(config.fee_model.da_overhead_multiplier_bps, 12_500);
-        assert_eq!(config.fee_model.ol_overhead_wei, 42);
+        assert_eq!(config.fee_model.prover_fee_per_gas_wei(), 15);
+        assert_eq!(config.fee_model.da_overhead_multiplier_bps(), 12_500);
+        assert_eq!(config.fee_model.ol_overhead_wei(), 42);
         assert_eq!(
-            config.fee_model.l1_fee_rate_source,
+            config.fee_model.l1_fee_rate_source(),
             L1FeeRateSourceConfig::BtcioWriter
         );
 
@@ -619,7 +656,7 @@ mod test {
         .expect("sequencer runtime config should parse");
 
         assert_eq!(
-            config.fee_model.l1_fee_rate_source,
+            config.fee_model.l1_fee_rate_source(),
             L1FeeRateSourceConfig::BtcioWriter
         );
     }
@@ -658,13 +695,13 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.l1_fee_policy.fee_policy,
-            FeePolicy::MempoolExplorer {
+            config.l1_fee_policy.fee_policy(),
+            &FeePolicy::MempoolExplorer {
                 policy: MempoolExplorerFeePolicy::Fastest,
             }
         );
         assert_eq!(
-            config.l1_fee_policy.mempool_base_url.as_deref(),
+            config.l1_fee_policy.mempool_base_url(),
             Some("https://mempool.space/signet")
         );
     }
@@ -684,8 +721,8 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.l1_fee_policy.fee_policy,
-            FeePolicy::MempoolExplorer {
+            config.l1_fee_policy.fee_policy(),
+            &FeePolicy::MempoolExplorer {
                 policy: MempoolExplorerFeePolicy::Economy,
             }
         );
@@ -705,8 +742,8 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.l1_fee_policy.fee_policy,
-            FeePolicy::BitcoinD { conf_target: 6 }
+            config.l1_fee_policy.fee_policy(),
+            &FeePolicy::BitcoinD { conf_target: 6 }
         );
     }
 
@@ -716,11 +753,7 @@ mod test {
             write_poll_dur_ms: 200,
             reveal_amount: 100,
             bundle_interval_ms: 1_000,
-            l1_fee_policy: L1FeePolicyConfig {
-                fee_policy: FeePolicy::BitcoinD { conf_target: 6 },
-                mempool_base_url: None,
-                ..L1FeePolicyConfig::default()
-            },
+            l1_fee_policy: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 6 }),
         };
 
         let toml = toml::to_string(&config).expect("writer config should serialize");

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -695,14 +695,12 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.l1_fee_policy.fee_policy(),
+            config.l1_fee_policy_config.fee_policy(),
             &FeePolicy::MempoolExplorer {
                 policy: MempoolExplorerFeePolicy::Fastest,
+                mempool_base_url: "https://mempool.space/signet".to_string(),
+                fallback_conf_target: 1,
             }
-        );
-        assert_eq!(
-            config.l1_fee_policy.mempool_base_url(),
-            Some("https://mempool.space/signet")
         );
     }
 
@@ -721,10 +719,30 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.l1_fee_policy.fee_policy(),
+            config.l1_fee_policy_config.fee_policy(),
             &FeePolicy::MempoolExplorer {
                 policy: MempoolExplorerFeePolicy::Economy,
+                mempool_base_url: "https://mempool.space/signet".to_string(),
+                fallback_conf_target: 1,
             }
+        );
+    }
+
+    #[test]
+    fn test_writer_config_rejects_mempool_policy_without_base_url() {
+        let error = toml::from_str::<WriterConfig>(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "mempool"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+            "#,
+        )
+        .expect_err("writer config should reject mempool policy without base URL");
+
+        assert!(
+            error.to_string().contains("mempool_base_url"),
+            "unexpected error: {error}"
         );
     }
 
@@ -742,7 +760,7 @@ mod test {
         .expect("writer config should parse");
 
         assert_eq!(
-            config.l1_fee_policy.fee_policy(),
+            config.l1_fee_policy_config.fee_policy(),
             &FeePolicy::BitcoinD { conf_target: 6 }
         );
     }
@@ -753,7 +771,7 @@ mod test {
             write_poll_dur_ms: 200,
             reveal_amount: 100,
             bundle_interval_ms: 1_000,
-            l1_fee_policy: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 6 }),
+            l1_fee_policy_config: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 6 }),
         };
 
         let toml = toml::to_string(&config).expect("writer config should serialize");

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -159,8 +159,39 @@ impl Default for SequencerConfig {
 pub struct SequencerRuntimeConfig {
     pub sequencer: SequencerConfig,
 
+    pub fee_model: SequencerFeeModelConfig,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub epoch_sealing: Option<EpochSealingConfig>,
+}
+
+fn default_l1_fee_rate_source() -> L1FeeRateSourceConfig {
+    L1FeeRateSourceConfig::BtcioWriter
+}
+
+/// Configuration for the v1 L2 fee model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequencerFeeModelConfig {
+    /// Static proving fee charged per unit of raw EVM gas.
+    pub prover_fee_per_gas_wei: u64,
+
+    /// Basis-points multiplier applied to the estimated DA fee.
+    pub da_overhead_multiplier_bps: u32,
+
+    /// Small additive fee charged for OL and infrastructure overhead.
+    pub ol_overhead_wei: u64,
+
+    /// Source used to resolve the current L1 fee rate.
+    #[serde(default = "default_l1_fee_rate_source")]
+    pub l1_fee_rate_source: L1FeeRateSourceConfig,
+}
+
+/// Source for the L1 fee rate used by the fee model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum L1FeeRateSourceConfig {
+    /// Reuse the btcio writer policy used for actual Bitcoin publication.
+    BtcioWriter,
 }
 
 /// Default slots per epoch for epoch sealing.
@@ -543,6 +574,11 @@ mod test {
             max_txs_per_block = 500
             block_template_ttl_secs = 120
 
+            [fee_model]
+            prover_fee_per_gas_wei = 15
+            da_overhead_multiplier_bps = 12_500
+            ol_overhead_wei = 42
+
             [epoch_sealing]
             policy = "FixedSlot"
             slots_per_epoch = 10
@@ -552,12 +588,60 @@ mod test {
         assert_eq!(config.sequencer.ol_block_time_ms, 3_000);
         assert_eq!(config.sequencer.max_txs_per_block, 500);
         assert_eq!(config.sequencer.block_template_ttl_secs, 120);
+        assert_eq!(config.fee_model.prover_fee_per_gas_wei, 15);
+        assert_eq!(config.fee_model.da_overhead_multiplier_bps, 12_500);
+        assert_eq!(config.fee_model.ol_overhead_wei, 42);
+        assert_eq!(
+            config.fee_model.l1_fee_rate_source,
+            L1FeeRateSourceConfig::BtcioWriter
+        );
 
         match config.epoch_sealing.as_ref().unwrap() {
             EpochSealingConfig::FixedSlot { slots_per_epoch } => {
                 assert_eq!(*slots_per_epoch, 10);
             }
         }
+    }
+
+    #[test]
+    fn test_sequencer_runtime_config_defaults_l1_fee_rate_source() {
+        let config: SequencerRuntimeConfig = toml::from_str(
+            r#"
+            [sequencer]
+            ol_block_time_ms = 3_000
+
+            [fee_model]
+            prover_fee_per_gas_wei = 15
+            da_overhead_multiplier_bps = 10_000
+            ol_overhead_wei = 0
+            "#,
+        )
+        .expect("sequencer runtime config should parse");
+
+        assert_eq!(
+            config.fee_model.l1_fee_rate_source,
+            L1FeeRateSourceConfig::BtcioWriter
+        );
+    }
+
+    #[test]
+    fn test_sequencer_runtime_config_requires_fee_model_fields() {
+        let error = toml::from_str::<SequencerRuntimeConfig>(
+            r#"
+            [sequencer]
+            ol_block_time_ms = 3_000
+
+            [fee_model]
+            da_overhead_multiplier_bps = 10_000
+            ol_overhead_wei = 0
+            "#,
+        )
+        .expect_err("missing prover fee must fail");
+
+        assert!(
+            error.to_string().contains("prover_fee_per_gas_wei"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/docker/configs/config.fn.toml
+++ b/docker/configs/config.fn.toml
@@ -23,8 +23,12 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Required when fee_policy = "mempool"
+# mempool_base_url = "https://mempool.space/signet"
 # Optional when fee_policy = "mempool"
 # mempool_fee_policy = "economy"
+# Optional when fee_policy = "mempool"
+# mempool_fallback_conf_target = 6
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/config.regtest.toml
+++ b/docker/configs/config.regtest.toml
@@ -28,6 +28,8 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "bitcoind"
+# Optional when fee_policy = "bitcoind"
+# bitcoind_conf_target = 6
 reveal_amount = 100
 bundle_interval_ms = 1000
 

--- a/docker/configs/config.seq.toml
+++ b/docker/configs/config.seq.toml
@@ -20,8 +20,12 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Required when fee_policy = "mempool"
+# mempool_base_url = "https://mempool.space"
 # Optional when fee_policy = "mempool"
 # mempool_fee_policy = "economy"
+# Optional when fee_policy = "mempool"
+# mempool_fallback_conf_target = 6
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/config.toml
+++ b/docker/configs/config.toml
@@ -23,8 +23,12 @@ client_poll_dur_ms = 10_000
 [btcio.writer]
 write_poll_dur_ms = 10_000
 fee_policy = "mempool"
+# Required when fee_policy = "mempool"
+# mempool_base_url = "https://mempool.space/signet"
 # Optional when fee_policy = "mempool"
 # mempool_fee_policy = "economy"
+# Optional when fee_policy = "mempool"
+# mempool_fallback_conf_target = 6
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/docker/configs/sequencer.toml
+++ b/docker/configs/sequencer.toml
@@ -1,2 +1,11 @@
 [sequencer]
 ol_block_time_ms = 5_000
+
+[fee_model]
+prover_fee_per_gas_wei = 15
+da_overhead_multiplier_bps = 10_000
+ol_overhead_wei = 0
+
+[epoch_sealing]
+policy = "FixedSlot"
+slots_per_epoch = 64

--- a/docker/init-keys.sh
+++ b/docker/init-keys.sh
@@ -103,4 +103,9 @@ fi
 cat > "$SEQUENCER_CONFIG_FILE" <<EOF
 [sequencer]
 ol_block_time_ms = $OL_BLOCK_TIME_MS
+
+[fee_model]
+prover_fee_per_gas_wei = 15
+da_overhead_multiplier_bps = 10000
+ol_overhead_wei = 0
 EOF

--- a/example_config.toml
+++ b/example_config.toml
@@ -23,8 +23,12 @@ client_poll_dur_ms = 200
 [btcio.writer]
 write_poll_dur_ms = 200
 fee_policy = "mempool"
+# Required when fee_policy = "mempool"
+# mempool_base_url = "https://mempool.space"
 # Optional when fee_policy = "mempool"
 # mempool_fee_policy = "economy"
+# Optional when fee_policy = "mempool"
+# mempool_fallback_conf_target = 6
 # Optional when fee_policy = "bitcoind"
 # bitcoind_conf_target = 6
 # Required when fee_policy = "fixed"

--- a/functional-tests/common/config/config.py
+++ b/functional-tests/common/config/config.py
@@ -86,6 +86,20 @@ class SequencerConfig:
 
 
 @dataclass
+class FeeModelConfig:
+    """v1 L2 fee-model configuration mirroring ``SequencerFeeModelConfig``.
+
+    Defaults match ``docker/configs/sequencer.toml`` so functional-test
+    environments deserialize cleanly on the Rust side.
+    """
+
+    prover_fee_per_gas_wei: int = field(default=15)
+    da_overhead_multiplier_bps: int = field(default=10_000)
+    ol_overhead_wei: int = field(default=0)
+    l1_fee_rate_source: str = field(default="btcio_writer")
+
+
+@dataclass
 class EeDaConfig:
     """DA pipeline configuration for alpen-client sequencer.
 
@@ -135,6 +149,7 @@ class StrataConfig:
 @dataclass
 class SequencerRuntimeConfig:
     sequencer: SequencerConfig = field(default_factory=SequencerConfig)
+    fee_model: FeeModelConfig = field(default_factory=FeeModelConfig)
     epoch_sealing: EpochSealingConfig | None = field(default=None)
 
     def as_toml_string(self) -> str:


### PR DESCRIPTION
## Description

Introduces the sequencer fee-model configuration and shared internal types needed by the Alpen v1 fee model, prior to wiring up RPC behavior or execution-time charging.

### What changed

- **`L1FeePolicyConfig`** — extracted as a reusable struct wrapping `FeePolicy` + `mempool_base_url` + `mempool_fallback_conf_target`, shared between btcio writer config
  and EE config.
- **`SequencerFeeModelConfig`** — new TOML-deserializable config with `prover_fee_per_gas_wei`, `da_overhead_multiplier_bps`, `ol_overhead_wei`, and `l1_fee_rate_source`.
 All three fee params are mandatory; `l1_fee_rate_source` defaults to `btcio_writer`.
- **`FeeModelConfig` / `FeeQuoteInputs` / `FeeBreakdown` / `GasEquivalentQuote`** — runtime types in `alpen-ee-common` implementing the v1 formula with checked U256
arithmetic.
- **`AlpenEeConfig`** — gains `with_fee_model_config()` to carry the resolved fee model + L1 fee policy into the EE layer.
- Docker `sequencer.toml` and `init-keys.sh` updated with default `[fee_model]` section.

### v1 formula implemented

```py
execution_fee    = (base_fee + priority_fee) × gas_used
prover_fee       = prover_fee_per_gas × gas_used
da_fee           = ⌈ l1_fee_rate × diff_size × da_overhead_multiplier_bps / 10_000 ⌉

non_execution_fee = prover_fee + da_fee + ol_overhead

total_fee        = execution_fee + non_execution_fee
```

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- No RPC behavior changes — this is config + types only.
- `da_overhead_multiplier_bps` uses basis points (10 000 = 1×) to allow both undercharging and overcharging, as the design doc requires.
- `FeeQuoteInputs::l1_fee_rate_wei_per_byte` will need a sat/vB → wei/byte conversion when the fee-quote RPC is wired up (not in scope here).
- `SequencerFeeModelConfig` stores values as `u64`, converted to `U256` at resolution time in `AlpenEeConfig::fee_model()`. This caps configurable values at ~18.4 ETH in wei, which is practically fine for v1.
- `da_fee` uses ceiling division when applying `da_overhead_multiplier_bps` so the
  operator never silently undercharges from integer truncation. `GasEquivalentQuote`
  uses the same rounding direction when converting non-execution wei → gas units.
- Public types (`FeeModelConfig`, `FeeQuoteInputs`, `FeeBreakdown`, `GasEquivalentQuote`,
  `L1FeeRateSource`) derive `Serialize`/`Deserialize` so STR-2979 can reuse
  `FeeBreakdown` directly as the `eth_estimateDiffSize` response body without a
  parallel wire type.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- [Alpen L2 Fee Model (Notion)](https://www.notion.so/Alpen-L2-Fee-Model-333901ba000f80d899b7c628cf0469d9)
- [STR-2977 (Jira)](https://alpenlabs.atlassian.net/browse/STR-2977)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

**AI disclosure:** Initial implementation was done mostly manually with GPT-5.4 assistance. Then, Opus 4.6 was used to review this branch against the Jira ticket and design doc, implement review fixes, and assist with rebasing.

## Related Issues

STR-2977