### PR TITLE
test(da-framework): add proptests for DA primitive round-trips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14750,6 +14750,7 @@ dependencies = [
 name = "strata-da-framework"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "sha2",
  "strata-codec",
  "strata-merkle",

--- a/crates/da-framework/Cargo.toml
+++ b/crates/da-framework/Cargo.toml
@@ -10,4 +10,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 strata-merkle.workspace = true
+
+proptest.workspace = true
 sha2.workspace = true

--- a/crates/da-framework/src/compound.rs
+++ b/crates/da-framework/src/compound.rs
@@ -445,7 +445,14 @@ pub trait CompoundMember: Sized {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ContextlessDaWrite, DaRegister, encode_to_vec};
+    use proptest::prelude::*;
+    use strata_codec::decode_buf_exact;
+
+    use crate::{
+        ContextlessDaWrite, DaCounter, DaRegister,
+        counter_schemes::{CtrI64ByI8, CtrU64ByU8},
+        encode_to_vec,
+    };
 
     #[derive(Copy, Clone, Eq, PartialEq, Debug)]
     pub struct Point {
@@ -463,6 +470,28 @@ mod tests {
         DaPointDiff u16 => Point {
             x: register (i32),
             y: register (i32),
+        }
+    }
+
+    #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+    struct Metrics {
+        label: u16,
+        nonce: u64,
+        score: i64,
+    }
+
+    #[derive(Debug, Default)]
+    struct MetricsDiff {
+        label: DaRegister<u16>,
+        nonce: DaCounter<CtrU64ByU8>,
+        score: DaCounter<CtrI64ByI8>,
+    }
+
+    make_compound_impl! {
+        MetricsDiff u8 => Metrics {
+            label: register (u16),
+            nonce: counter (CtrU64ByU8),
+            score: counter (CtrI64ByI8),
         }
     }
 
@@ -532,6 +561,8 @@ mod tests {
 
     // Test type coercion feature
     mod coercion {
+        use strata_codec::{Codec, CodecError, Decoder, Encoder};
+
         use crate::{
             ContextlessDaWrite, DaCounter, DaRegister, counter_schemes::CtrU64ByU8,
             decode_buf_exact, encode_to_vec,
@@ -547,12 +578,12 @@ mod tests {
             }
         }
 
-        impl crate::Codec for WrappedI32 {
-            fn encode(&self, enc: &mut impl crate::Encoder) -> Result<(), crate::CodecError> {
+        impl Codec for WrappedI32 {
+            fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
                 self.0.encode(enc)
             }
 
-            fn decode(dec: &mut impl crate::Decoder) -> Result<Self, crate::CodecError> {
+            fn decode(dec: &mut impl Decoder) -> Result<Self, CodecError> {
                 Ok(Self(i32::decode(dec)?))
             }
         }
@@ -770,6 +801,58 @@ mod tests {
             assert_eq!(transfer.from, alice_id);
             assert_eq!(transfer.to, bob_id);
             assert_eq!(transfer.amount, 1000);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_compound_codec_roundtrip(
+            label in proptest::option::of(any::<u16>()),
+            nonce_delta in any::<u8>(),
+            score_delta in any::<i8>(),
+        ) {
+            let diff = MetricsDiff {
+                label: label.map_or_else(DaRegister::new_unset, DaRegister::new_set),
+                nonce: DaCounter::new_changed(nonce_delta),
+                score: DaCounter::new_changed(score_delta),
+            };
+
+            let encoded = encode_to_vec(&diff).expect("test: encode compound diff");
+            let decoded: MetricsDiff = decode_buf_exact(&encoded).expect("test: decode compound diff");
+
+            prop_assert_eq!(decoded.label.new_value().copied(), diff.label.new_value().copied());
+            prop_assert_eq!(decoded.nonce.diff().copied(), diff.nonce.diff().copied());
+            prop_assert_eq!(decoded.score.diff().copied(), diff.score.diff().copied());
+        }
+
+        #[test]
+        fn proptest_compound_apply_matches_after_decode(
+            start in (any::<u16>(), any::<u64>(), any::<i64>()),
+            label in proptest::option::of(any::<u16>()),
+            nonce_delta in any::<u8>(),
+            score_delta in any::<i8>(),
+        ) {
+            let diff = MetricsDiff {
+                label: label.map_or_else(DaRegister::new_unset, DaRegister::new_set),
+                nonce: DaCounter::new_changed(nonce_delta),
+                score: DaCounter::new_changed(score_delta),
+            };
+
+            let encoded = encode_to_vec(&diff).expect("test: encode compound diff");
+            let decoded: MetricsDiff = decode_buf_exact(&encoded).expect("test: decode compound diff");
+
+            let initial = Metrics {
+                label: start.0,
+                nonce: start.1,
+                score: start.2,
+            };
+            let mut applied_original = initial;
+            let mut applied_decoded = initial;
+
+            diff.apply(&mut applied_original).expect("test: apply original compound diff");
+            decoded.apply(&mut applied_decoded).expect("test: apply decoded compound diff");
+
+            prop_assert_eq!(applied_decoded, applied_original);
         }
     }
 }

--- a/crates/da-framework/src/counter.rs
+++ b/crates/da-framework/src/counter.rs
@@ -336,14 +336,33 @@ pub mod counter_schemes {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+    use strata_codec::BufDecoder;
+
     use super::{
-        DaCounter,
+        DaCounter, DaCounterBuilder,
         counter_schemes::{CtrU64ByI16, CtrU64BySignedVarInt, CtrU64ByUnsignedVarInt},
     };
     use crate::{
-        ContextlessDaWrite, CounterScheme, SignedVarInt, UnsignedVarInt, decode_buf_exact,
-        encode_to_vec,
+        CompoundMember, ContextlessDaWrite, CounterScheme, DaBuilder, SignedVarInt, UnsignedVarInt,
+        boundary_u64_strategy, decode_buf_exact, encode_to_vec,
     };
+
+    fn signed_varint_strategy() -> impl Strategy<Value = SignedVarInt> {
+        (
+            prop_oneof![Just(true), Just(false)],
+            boundary_u64_strategy(),
+        )
+            .prop_map(|(positive, magnitude)| SignedVarInt::new(positive, magnitude))
+    }
+
+    fn encode_set_counter<S: CounterScheme>(counter: &DaCounter<S>) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        counter
+            .encode_set(&mut encoded)
+            .expect("test: encode counter via CompoundMember");
+        encoded
+    }
 
     #[test]
     fn test_counter_simple() {
@@ -461,5 +480,156 @@ mod tests {
         let d = ctr.diff().unwrap();
         assert!(d.is_positive());
         assert_eq!(d.magnitude(), 1_000_000_000_000u64);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_counter_new_changed_normalizes_signed_zero(positive in any::<bool>()) {
+            let counter = DaCounter::<CtrU64BySignedVarInt>::new_changed(SignedVarInt::new(positive, 0));
+
+            prop_assert!(!counter.is_changed());
+            prop_assert_eq!(counter.diff(), None);
+        }
+
+        #[test]
+        fn proptest_counter_new_changed_normalizes_unsigned_zero(base in any::<u64>()) {
+            let mut counter = DaCounter::<CtrU64ByUnsignedVarInt>::new_changed(UnsignedVarInt::ZERO);
+            counter.set_diff(UnsignedVarInt::new(base.saturating_sub(base)));
+
+            prop_assert!(!counter.is_changed());
+            prop_assert_eq!(counter.diff(), None);
+        }
+
+        #[test]
+        fn proptest_counter_signed_compound_member_roundtrip(incr in signed_varint_strategy()) {
+            prop_assume!(!incr.is_zero());
+            let counter = DaCounter::<CtrU64BySignedVarInt>::new_changed(incr);
+
+            let encoded = encode_set_counter(&counter);
+            let mut decoder = BufDecoder::new(&encoded);
+            let decoded = DaCounter::<CtrU64BySignedVarInt>::decode_set(&mut decoder)
+                .expect("test: decode counter via CompoundMember");
+
+            prop_assert_eq!(
+                decoded.diff().copied().map(|diff| (diff.is_positive(), diff.magnitude())),
+                counter.diff().copied().map(|diff| (diff.is_positive(), diff.magnitude()))
+            );
+        }
+
+        #[test]
+        fn proptest_counter_unsigned_compound_member_roundtrip(incr in boundary_u64_strategy()) {
+            prop_assume!(incr != 0);
+            let counter = DaCounter::<CtrU64ByUnsignedVarInt>::new_changed(UnsignedVarInt::new(incr));
+
+            let encoded = encode_set_counter(&counter);
+            let mut decoder = BufDecoder::new(&encoded);
+            let decoded = DaCounter::<CtrU64ByUnsignedVarInt>::decode_set(&mut decoder)
+                .expect("test: decode counter via CompoundMember");
+
+            prop_assert_eq!(
+                decoded.diff().copied().map(UnsignedVarInt::inner),
+                counter.diff().copied().map(UnsignedVarInt::inner)
+            );
+        }
+
+        #[test]
+        fn proptest_counter_signed_compare_apply_reconstructs_target(
+            original in boundary_u64_strategy(),
+            next in boundary_u64_strategy(),
+        ) {
+            let incr = CtrU64BySignedVarInt::compare(original, next)
+                .expect("test: signed scheme compare is total");
+            let counter = DaCounter::<CtrU64BySignedVarInt>::new_changed(incr);
+            let mut applied = original;
+
+            counter.apply(&mut applied).expect("test: apply signed counter");
+
+            prop_assert_eq!(applied, next);
+        }
+
+        #[test]
+        fn proptest_counter_unsigned_compare_apply_reconstructs_target(
+            original in boundary_u64_strategy(),
+            next in boundary_u64_strategy(),
+        ) {
+            if next < original {
+                prop_assert!(CtrU64ByUnsignedVarInt::compare(original, next).is_none());
+            } else {
+                let incr = CtrU64ByUnsignedVarInt::compare(original, next)
+                    .expect("test: non-decreasing pair must produce an increment");
+                let counter = DaCounter::<CtrU64ByUnsignedVarInt>::new_changed(incr);
+                let mut applied = original;
+
+                counter.apply(&mut applied).expect("test: apply unsigned counter");
+
+                prop_assert_eq!(applied, next);
+            }
+        }
+
+        #[test]
+        fn proptest_counter_signed_saturation_matches_update(
+            base in boundary_u64_strategy(),
+            incr in signed_varint_strategy(),
+        ) {
+            let counter = DaCounter::<CtrU64BySignedVarInt>::new_changed(incr);
+            let mut applied = base;
+            counter.apply(&mut applied).expect("test: apply signed counter");
+
+            let expected = if incr.is_positive() {
+                base.saturating_add(incr.magnitude())
+            } else {
+                base.saturating_sub(incr.magnitude())
+            };
+
+            prop_assert_eq!(applied, expected);
+        }
+
+        #[test]
+        fn proptest_counter_unsigned_saturation_matches_update(
+            base in boundary_u64_strategy(),
+            incr in boundary_u64_strategy(),
+        ) {
+            let counter = DaCounter::<CtrU64ByUnsignedVarInt>::new_changed(UnsignedVarInt::new(incr));
+            let mut applied = base;
+            counter.apply(&mut applied).expect("test: apply unsigned counter");
+
+            prop_assert_eq!(applied, base.saturating_add(incr));
+        }
+
+        #[test]
+        fn proptest_counter_builder_signed_roundtrip(
+            original in boundary_u64_strategy(),
+            next in boundary_u64_strategy(),
+        ) {
+            let mut builder = DaCounterBuilder::<CtrU64BySignedVarInt>::from_source(original);
+            builder.set(next).expect("test: signed builder set");
+
+            let counter = builder.into_write().expect("test: build signed counter");
+            let mut applied = original;
+            counter.apply(&mut applied).expect("test: apply built counter");
+
+            prop_assert_eq!(applied, next);
+            prop_assert_eq!(counter.is_changed(), original != next);
+        }
+
+        #[test]
+        fn proptest_counter_builder_unsigned_respects_bounds(
+            original in boundary_u64_strategy(),
+            next in boundary_u64_strategy(),
+        ) {
+            let mut builder = DaCounterBuilder::<CtrU64ByUnsignedVarInt>::from_source(original);
+            let set_result = builder.set(next);
+
+            if next < original {
+                prop_assert!(set_result.is_err());
+            } else {
+                set_result.expect("test: unsigned builder set");
+                let counter = builder.into_write().expect("test: build unsigned counter");
+                let mut applied = original;
+                counter.apply(&mut applied).expect("test: apply built counter");
+
+                prop_assert_eq!(applied, next);
+            }
+        }
     }
 }

--- a/crates/da-framework/src/lib.rs
+++ b/crates/da-framework/src/lib.rs
@@ -21,3 +21,36 @@ pub use queue::{DaQueue, DaQueueBuilder, DaQueueTarget, QueueView};
 pub use register::DaRegister;
 pub use traits::{ContextlessDaWrite, DaBuilder, DaWrite};
 pub use varint64::{SignedVarInt, UnsignedVarInt};
+
+#[cfg(test)]
+/// Returns a boundary-heavy [`u64`] strategy shared by DA framework proptests.
+///
+/// The fixed values are chosen to hit the codec thresholds we care about:
+/// zero and one for degenerate cases; `63`/`64`, `127`/`128`, `255`/`256`,
+/// `8191`/`8192`, and `16383`/`16384` for signed and unsigned varint byte-width
+/// transitions; [`u32::MAX`] for a large but common boundary; and `u64::MAX - 1`
+/// plus [`u64::MAX`] for full-range overflow and saturation paths. Arbitrary
+/// [`u64`] values are still included so the strategy keeps broad coverage beyond
+/// the hand-picked edges.
+pub(crate) fn boundary_u64_strategy() -> impl proptest::strategy::Strategy<Value = u64> {
+    use proptest::prelude::*;
+
+    prop_oneof![
+        Just(0),
+        Just(1),
+        Just(63),
+        Just(64),
+        Just(127),
+        Just(128),
+        Just(255),
+        Just(256),
+        Just(8191),
+        Just(8192),
+        Just(16383),
+        Just(16384),
+        Just(u32::MAX as u64),
+        Just(u64::MAX - 1),
+        Just(u64::MAX),
+        any::<u64>(),
+    ]
+}

--- a/crates/da-framework/src/linear_acc.rs
+++ b/crates/da-framework/src/linear_acc.rs
@@ -146,6 +146,7 @@ impl<A: LinearAccumulator> CompoundMember for DaLinacc<A> {
 
 #[cfg(test)]
 mod tests {
+    use proptest::{collection::vec, prelude::*};
     use strata_codec::BufDecoder;
     use strata_merkle::{CompactMmr64, MerkleHasher, Mmr, MmrState, Sha256Hasher};
 
@@ -169,6 +170,21 @@ mod tests {
         fn insert(&mut self, entry: &Self::EntryData) {
             let hash = Sha256Hasher::hash_leaf(entry);
             Mmr::<Sha256Hasher>::add_leaf(&mut self.0, hash).expect("test: insert should succeed");
+        }
+    }
+
+    #[derive(Debug, Default, Clone, PartialEq, Eq)]
+    struct RecordingAccumulator {
+        entries: Vec<u32>,
+    }
+
+    impl LinearAccumulator for RecordingAccumulator {
+        type InsertCnt = u8;
+        type EntryData = u32;
+        const MAX_INSERT: Self::InsertCnt = 8;
+
+        fn insert(&mut self, entry: &Self::EntryData) {
+            self.entries.push(*entry);
         }
     }
 
@@ -340,5 +356,63 @@ mod tests {
             peaks1, peaks2,
             "test: MMR peaks should be identical after sequential diffs"
         );
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_linear_acc_roundtrip(entries in vec(any::<u32>(), 0..=8)) {
+            let mut diff = DaLinacc::<RecordingAccumulator>::new();
+            for entry in &entries {
+                prop_assert!(diff.append_entry(*entry));
+            }
+
+            let mut encoded = Vec::new();
+            diff.encode_set(&mut encoded).expect("test: encode linear accumulator");
+            let mut decoder = BufDecoder::new(&encoded);
+            let decoded = DaLinacc::<RecordingAccumulator>::decode_set(&mut decoder)
+                .expect("test: decode linear accumulator");
+
+            prop_assert_eq!(decoded.new_entries(), entries.as_slice());
+        }
+
+        #[test]
+        fn proptest_linear_acc_apply_matches_after_decode(entries in vec(any::<u32>(), 0..=8)) {
+            let mut diff = DaLinacc::<RecordingAccumulator>::new();
+            for entry in &entries {
+                prop_assert!(diff.append_entry(*entry));
+            }
+
+            let mut encoded = Vec::new();
+            diff.encode_set(&mut encoded).expect("test: encode linear accumulator");
+            let mut decoder = BufDecoder::new(&encoded);
+            let decoded = DaLinacc::<RecordingAccumulator>::decode_set(&mut decoder)
+                .expect("test: decode linear accumulator");
+
+            let mut original_target = RecordingAccumulator::default();
+            let mut decoded_target = RecordingAccumulator::default();
+
+            diff.apply(&mut original_target, &()).expect("test: apply original linacc");
+            decoded.apply(&mut decoded_target, &()).expect("test: apply decoded linacc");
+
+            prop_assert_eq!(&decoded_target, &original_target);
+            prop_assert_eq!(decoded_target.entries, entries);
+        }
+
+        #[test]
+        fn proptest_linear_acc_respects_max_insert(
+            first_entries in vec(any::<u32>(), 0..=8),
+            extra_entry in any::<u32>(),
+        ) {
+            let mut diff = DaLinacc::<RecordingAccumulator>::new();
+            for entry in &first_entries {
+                prop_assert!(diff.append_entry(*entry));
+            }
+
+            prop_assert_eq!(diff.is_write_full(), first_entries.len() == RecordingAccumulator::MAX_INSERT as usize);
+            prop_assert_eq!(
+                diff.append_entry(extra_entry),
+                first_entries.len() < RecordingAccumulator::MAX_INSERT as usize
+            );
+        }
     }
 }

--- a/crates/da-framework/src/queue.rs
+++ b/crates/da-framework/src/queue.rs
@@ -365,6 +365,7 @@ impl<'a, Q: DaQueueTarget> QueueView<'a, Q> {
 
 #[cfg(test)]
 mod tests {
+    use proptest::{collection::vec, prelude::*};
     use strata_codec::BufDecoder;
 
     use super::*;
@@ -384,7 +385,7 @@ mod tests {
     }
 
     /// Mock queue target for testing.
-    #[derive(Debug, Clone, Default)]
+    #[derive(Debug, Clone, Default, PartialEq, Eq)]
     struct MockQueue {
         front: IncrTy,
         next: IncrTy,
@@ -424,6 +425,36 @@ mod tests {
         fn increment_front(&mut self, incr: IncrTy) {
             self.front += incr;
         }
+    }
+
+    fn base_queue_strategy() -> impl Strategy<Value = MockQueue> {
+        (
+            0u16..=(u16::MAX - 64),
+            0usize..=32,
+            vec(any::<u32>(), 0..=32),
+        )
+            .prop_flat_map(|(front, len, mut entries)| {
+                entries.truncate(len);
+                Just(MockQueue {
+                    front,
+                    next: front + (entries.len() as IncrTy),
+                    entries,
+                })
+            })
+    }
+
+    fn tail_strategy() -> impl Strategy<Value = Vec<u32>> {
+        vec(any::<u32>(), 0..=16)
+    }
+
+    fn valid_queue_write_strategy() -> impl Strategy<Value = (MockQueue, Vec<u32>, IncrTy)> {
+        (base_queue_strategy(), tail_strategy(), 0usize..=48).prop_flat_map(
+            |(base, tail, consume_hint)| {
+                let available = base.entries.len() + tail.len();
+                let consume = consume_hint.min(available) as IncrTy;
+                Just((base, tail, consume))
+            },
+        )
     }
 
     #[test]
@@ -920,5 +951,65 @@ mod tests {
         assert_eq!(view.len(), 1);
         assert_eq!(view.get(2), None);
         assert_eq!(view.get(3), Some(&40)); // only new entry visible
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_queue_compound_member_roundtrip(
+            tail in tail_strategy(),
+            incr_front in 0u16..=HEAD_WORD_INCR_MASK,
+        ) {
+            let queue = DaQueue::<MockQueue> { tail, incr_front };
+
+            let encoded = encode_set_cm_to_vec(&queue).expect("test: encode queue");
+            let decoded: DaQueue<MockQueue> = decode_set_cm_from_vec(&encoded).expect("test: decode queue");
+
+            prop_assert_eq!(decoded.tail, queue.tail);
+            prop_assert_eq!(decoded.incr_front, queue.incr_front);
+        }
+
+        #[test]
+        fn proptest_queue_builder_roundtrip_preserves_apply(
+            (base, appended, consume_total) in valid_queue_write_strategy(),
+        ) {
+            let mut builder = DaQueueBuilder::from_source(base.clone());
+            for entry in &appended {
+                prop_assert!(builder.append_entry(*entry));
+            }
+            prop_assert_eq!(builder.add_front_incr(consume_total), (consume_total as usize) <= (base.entries.len() + appended.len()));
+
+            let write = builder.into_write().expect("test: builder into_write");
+            let encoded = encode_set_cm_to_vec(&write).expect("test: encode queue write");
+            let decoded: DaQueue<MockQueue> = decode_set_cm_from_vec(&encoded).expect("test: decode queue write");
+
+            let mut applied_original = base.clone();
+            let mut applied_decoded = base;
+            write.apply(&mut applied_original, &()).expect("test: apply original write");
+            decoded.apply(&mut applied_decoded, &()).expect("test: apply decoded write");
+
+            prop_assert_eq!(applied_decoded, applied_original);
+        }
+
+        #[test]
+        fn proptest_queue_builder_into_write_drops_consumed_new_entries(
+            base in base_queue_strategy(),
+            appended in tail_strategy(),
+            consume_hint in 0usize..=48,
+        ) {
+            let base_len = base.entries.len();
+            let consumed_total = consume_hint.min(base_len + appended.len());
+            let consumed_new = consumed_total.saturating_sub(base_len);
+
+            let mut builder = DaQueueBuilder::from_source(base.clone());
+            for entry in &appended {
+                prop_assert!(builder.append_entry(*entry));
+            }
+            prop_assert!(builder.add_front_incr(consumed_total as IncrTy));
+
+            let write = builder.into_write().expect("test: builder into_write");
+
+            prop_assert_eq!(write.incr_front, consumed_total as IncrTy);
+            prop_assert_eq!(write.tail, appended[consumed_new..].to_vec());
+        }
     }
 }

--- a/crates/da-framework/src/register.rs
+++ b/crates/da-framework/src/register.rs
@@ -153,3 +153,83 @@ impl<T: Codec + Clone> CompoundMember for DaRegister<T> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::DaRegister;
+    use crate::{ContextlessDaWrite, DaWrite, decode_buf_exact, encode_to_vec};
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Wrapper(u64);
+
+    impl From<Wrapper> for u128 {
+        fn from(value: Wrapper) -> Self {
+            value.0.into()
+        }
+    }
+
+    impl crate::Codec for Wrapper {
+        fn encode(&self, enc: &mut impl crate::Encoder) -> Result<(), crate::CodecError> {
+            self.0.encode(enc)
+        }
+
+        fn decode(dec: &mut impl crate::Decoder) -> Result<Self, crate::CodecError> {
+            Ok(Self(u64::decode(dec)?))
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_register_codec_roundtrip(new_value in proptest::option::of(any::<u64>())) {
+            let register = DaRegister::new(new_value);
+
+            let encoded = encode_to_vec(&register).expect("test: encode register");
+            let decoded: DaRegister<u64> = decode_buf_exact(&encoded).expect("test: decode register");
+
+            prop_assert_eq!(decoded.new_value().copied(), register.new_value().copied());
+            prop_assert_eq!(DaWrite::is_default(&decoded), DaWrite::is_default(&register));
+        }
+
+        #[test]
+        fn proptest_register_compare(orig in any::<u64>(), new in any::<u64>()) {
+            let register = DaRegister::compare(&orig, &new);
+
+            if orig == new {
+                prop_assert!(DaWrite::is_default(&register));
+                prop_assert_eq!(register.new_value(), None);
+            } else {
+                prop_assert!(!DaWrite::is_default(&register));
+                prop_assert_eq!(register.new_value(), Some(&new));
+            }
+        }
+
+        #[test]
+        fn proptest_register_apply(orig in any::<u64>(), new_value in proptest::option::of(any::<u64>())) {
+            let register = DaRegister::new(new_value);
+            let mut target = orig;
+
+            ContextlessDaWrite::apply(&register, &mut target).expect("test: apply register");
+
+            prop_assert_eq!(target, register.new_value().copied().unwrap_or(orig));
+        }
+
+        #[test]
+        fn proptest_register_apply_into(target in any::<u128>(), new_value in proptest::option::of(any::<u64>())) {
+            let register = DaRegister::new(new_value.map(Wrapper));
+            let mut applied = target;
+
+            register.apply_into(&mut applied);
+
+            prop_assert_eq!(
+                applied,
+                register
+                    .new_value()
+                    .copied()
+                    .map(u128::from)
+                    .unwrap_or(target)
+            );
+        }
+    }
+}

--- a/crates/da-framework/src/varint64.rs
+++ b/crates/da-framework/src/varint64.rs
@@ -241,10 +241,20 @@ impl Codec for SignedVarInt {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
-    use crate::{decode_buf_exact, encode_to_vec};
+    use crate::{boundary_u64_strategy, decode_buf_exact, encode_to_vec};
 
     const MAX_VARINT_BYTES: usize = 10;
+
+    fn signed_varint_strategy() -> impl Strategy<Value = SignedVarInt> {
+        (
+            prop_oneof![Just(true), Just(false)],
+            boundary_u64_strategy(),
+        )
+            .prop_map(|(positive, magnitude)| SignedVarInt::new(positive, magnitude))
+    }
 
     // UnsignedVarInt tests
 
@@ -503,6 +513,37 @@ mod tests {
                 mag,
                 expected_len
             );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_unsigned_varint_codec_roundtrip(value in boundary_u64_strategy()) {
+            let varint = UnsignedVarInt::new(value);
+
+            let encoded = encode_to_vec(&varint).expect("test: encode unsigned varint");
+            let decoded: UnsignedVarInt = decode_buf_exact(&encoded).expect("test: decode unsigned varint");
+
+            prop_assert_eq!(decoded, varint);
+        }
+
+        #[test]
+        fn proptest_signed_varint_codec_roundtrip(value in signed_varint_strategy()) {
+            let encoded = encode_to_vec(&value).expect("test: encode signed varint");
+            let decoded: SignedVarInt = decode_buf_exact(&encoded).expect("test: decode signed varint");
+
+            prop_assert_eq!(decoded, value);
+            if decoded.is_zero() {
+                prop_assert!(decoded.is_positive());
+            }
+        }
+
+        #[test]
+        fn proptest_signed_varint_zero_is_normalized(positive in any::<bool>()) {
+            let value = SignedVarInt::new(positive, 0);
+
+            prop_assert_eq!(value, SignedVarInt::ZERO);
+            prop_assert!(value.is_positive());
         }
     }
 }


### PR DESCRIPTION
## Description

Add property-test coverage to `strata-da-framework` for the core DA primitives and their round-trip/apply behavior.

This focuses on the gap called out in STR-2147: exercising absurd-but-valid values, especially around `counter` and `varint` boundaries, so `codec` and state-application paths get stressed beyond the existing example-based unit tests.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This PR stays scoped to `crates/da-framework` and does not add downstream OL/EE integration property tests.

Added proptests cover:
- `UnsignedVarInt` and `SignedVarInt` codec round-trips and signed-zero normalization
- `DaCounter` / `DaCounterBuilder` normalization, compare/apply reconstruction, saturation behavior, and full-range signed/unsigned varint counter paths
- `DaRegister` codec/apply semantics
- `DaQueue` round-trips and builder invariants using the existing mock queue fixture
- `DaLinacc` round-trips and max-insert behavior using a simple recording accumulator
- A synthetic compound diff to verify mixed primitive encoding and apply equivalence

Also added a shared crate-level `boundary_u64_strategy()` test helper with a docstring describing why those thresholds were chosen.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-2147
