### PR TITLE
STR 3075 extend finalized chain atomically for multi-block OL updates

### DIFF
--- a/crates/alpen-ee/common/src/traits/storage/exec_block.rs
+++ b/crates/alpen-ee/common/src/traits/storage/exec_block.rs
@@ -28,12 +28,14 @@ pub trait ExecBlockStorage: Send + Sync {
     /// calling multiple times with the same hash should succeed. Fails if block doesn't exist.
     async fn init_finalized_chain(&self, hash: Hash) -> Result<(), StorageError>;
 
-    /// Extend the finalized chain by one block.
+    /// Extend the finalized chain up to and including `new_tip`.
     ///
-    /// The block must have been saved via `save_exec_block` and its parent hash must match the
-    /// current best finalized block. Fails if chain is empty, block doesn't exist, or parent
-    /// hash doesn't match.
-    async fn extend_finalized_chain(&self, hash: Hash) -> Result<(), StorageError>;
+    /// Walks parent links from `new_tip` back to the current best finalized block and inserts
+    /// each missing canonical block in order. Atomic: either all intermediate finalized entries
+    /// are inserted or none are. Works for both single-block and multi-block extensions.
+    /// Fails if chain is empty, `new_tip` is unknown, an intermediate parent is missing, or
+    /// `new_tip` does not descend from the current finalized tip.
+    async fn extend_finalized_chain(&self, new_tip: Hash) -> Result<(), StorageError>;
 
     /// Revert the finalized chain to a specified height.
     ///
@@ -148,6 +150,56 @@ macro_rules! exec_block_storage_tests {
         async fn test_extend_finalized_chain() {
             let storage = $setup_expr;
             $crate::exec_block_storage_test_fns::test_extend_finalized_chain(&storage).await;
+        }
+
+        #[tokio::test]
+        async fn test_extend_finalized_chain_multi_block() {
+            let storage = $setup_expr;
+            $crate::exec_block_storage_test_fns::test_extend_finalized_chain_multi_block(&storage)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_extend_finalized_chain_single_step() {
+            let storage = $setup_expr;
+            $crate::exec_block_storage_test_fns::test_extend_finalized_chain_single_step(&storage)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_extend_finalized_chain_is_noop_at_tip() {
+            let storage = $setup_expr;
+            $crate::exec_block_storage_test_fns::test_extend_finalized_chain_is_noop_at_tip(
+                &storage,
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn test_extend_finalized_chain_non_descendant_tip() {
+            let storage = $setup_expr;
+            $crate::exec_block_storage_test_fns::test_extend_finalized_chain_non_descendant_tip(
+                &storage,
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn test_extend_finalized_chain_missing_parent() {
+            let storage = $setup_expr;
+            $crate::exec_block_storage_test_fns::test_extend_finalized_chain_missing_parent(
+                &storage,
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn test_extend_finalized_chain_cycle_rejected() {
+            let storage = $setup_expr;
+            $crate::exec_block_storage_test_fns::test_extend_finalized_chain_cycle_rejected(
+                &storage,
+            )
+            .await;
         }
 
         #[tokio::test]
@@ -543,6 +595,142 @@ pub mod exec_block_storage_test_fns {
         let best = storage.best_finalized_block().await.unwrap().unwrap();
         assert_eq!(best.blockhash(), hash1);
         assert_eq!(best.blocknum(), 1);
+    }
+
+    /// Save a block and its (empty) payload to storage.
+    async fn save_block(storage: &impl ExecBlockStorage, block: ExecBlockRecord) {
+        storage
+            .save_exec_block(block, ExecBlockPayload::from_bytes(vec![]))
+            .await
+            .unwrap();
+    }
+
+    /// Build and save a contiguous chain of `len` blocks starting at genesis, returning
+    /// the sequence of block hashes. Block `i` has `blocknum = i` and parent = `hashes[i - 1]`
+    /// (or `Hash::default()` for genesis). The finalized chain is also initialized at
+    /// `hashes[0]`.
+    async fn save_linear_chain(storage: &impl ExecBlockStorage, len: u64) -> Vec<Hash> {
+        let mut hashes = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let hash = hash_from_u8(i as u8);
+            let parent = if i == 0 {
+                Hash::default()
+            } else {
+                hashes[(i - 1) as usize]
+            };
+            save_block(storage, create_exec_block(i, parent, hash, i)).await;
+            hashes.push(hash);
+        }
+        storage.init_finalized_chain(hashes[0]).await.unwrap();
+        hashes
+    }
+
+    /// Assert `best_finalized_block()` matches the expected hash and blocknum.
+    async fn assert_best_finalized(
+        storage: &impl ExecBlockStorage,
+        expected_hash: Hash,
+        expected_blocknum: u64,
+    ) {
+        let best = storage.best_finalized_block().await.unwrap().unwrap();
+        assert_eq!(best.blockhash(), expected_hash);
+        assert_eq!(best.blocknum(), expected_blocknum);
+    }
+
+    /// Test extending finalized chain to a tip with multiple intermediate blocks.
+    pub async fn test_extend_finalized_chain_multi_block(storage: &impl ExecBlockStorage) {
+        let hashes = save_linear_chain(storage, 4).await;
+
+        storage.extend_finalized_chain(hashes[3]).await.unwrap();
+
+        assert_best_finalized(storage, hashes[3], 3).await;
+        for (i, h) in hashes.iter().enumerate().skip(1) {
+            assert_eq!(
+                storage.get_finalized_height(*h).await.unwrap().unwrap(),
+                i as u64
+            );
+        }
+    }
+
+    /// Test single-step extension through `extend_finalized_chain`.
+    pub async fn test_extend_finalized_chain_single_step(storage: &impl ExecBlockStorage) {
+        let hashes = save_linear_chain(storage, 2).await;
+
+        storage.extend_finalized_chain(hashes[1]).await.unwrap();
+
+        assert_best_finalized(storage, hashes[1], 1).await;
+    }
+
+    /// Test idempotent no-op when extending to current finalized tip.
+    pub async fn test_extend_finalized_chain_is_noop_at_tip(storage: &impl ExecBlockStorage) {
+        let hashes = save_linear_chain(storage, 3).await;
+
+        storage.extend_finalized_chain(hashes[2]).await.unwrap();
+        // Calling again with the current tip should be a no-op success.
+        storage.extend_finalized_chain(hashes[2]).await.unwrap();
+
+        assert_best_finalized(storage, hashes[2], 2).await;
+    }
+
+    /// Test extending finalized chain to a tip that does not descend from current finalized tip.
+    pub async fn test_extend_finalized_chain_non_descendant_tip(storage: &impl ExecBlockStorage) {
+        let hashes = save_linear_chain(storage, 2).await;
+
+        // Build a sibling fork branching from genesis.
+        let fork1 = hash_from_u8(11);
+        let fork2 = hash_from_u8(12);
+        save_block(storage, create_exec_block(1, hashes[0], fork1, 10)).await;
+        save_block(storage, create_exec_block(2, fork1, fork2, 11)).await;
+
+        storage.extend_finalized_chain(hashes[1]).await.unwrap();
+
+        let result = storage.extend_finalized_chain(fork2).await;
+        assert!(result.is_err());
+
+        assert_best_finalized(storage, hashes[1], 1).await;
+    }
+
+    /// Test extending finalized chain to a tip when an intermediate parent record is missing.
+    pub async fn test_extend_finalized_chain_missing_parent(storage: &impl ExecBlockStorage) {
+        let genesis_hash = hash_from_u8(0);
+        save_block(
+            storage,
+            create_exec_block(0, Hash::default(), genesis_hash, 0),
+        )
+        .await;
+        storage.init_finalized_chain(genesis_hash).await.unwrap();
+
+        // Block at height 2 whose parent (height 1) was never saved.
+        let missing_parent = hash_from_u8(1);
+        let tip_hash = hash_from_u8(2);
+        save_block(storage, create_exec_block(2, missing_parent, tip_hash, 1)).await;
+
+        let result = storage.extend_finalized_chain(tip_hash).await;
+        assert!(result.is_err());
+
+        assert_best_finalized(storage, genesis_hash, 0).await;
+    }
+
+    /// Test extending finalized chain to a cyclic parent graph is rejected.
+    pub async fn test_extend_finalized_chain_cycle_rejected(storage: &impl ExecBlockStorage) {
+        let genesis_hash = hash_from_u8(0);
+        save_block(
+            storage,
+            create_exec_block(0, Hash::default(), genesis_hash, 0),
+        )
+        .await;
+        storage.init_finalized_chain(genesis_hash).await.unwrap();
+
+        // Corrupt graph above finalized tip:
+        // h3 -> h2 and h2 -> h3 (cycle), never descending to finalized tip.
+        let h2 = hash_from_u8(2);
+        let h3 = hash_from_u8(3);
+        save_block(storage, create_exec_block(2, h3, h2, 2)).await;
+        save_block(storage, create_exec_block(3, h2, h3, 3)).await;
+
+        let result = storage.extend_finalized_chain(h3).await;
+        assert!(result.is_err());
+
+        assert_best_finalized(storage, genesis_hash, 0).await;
     }
 
     /// Test extending before initializing

--- a/crates/alpen-ee/database/src/database.rs
+++ b/crates/alpen-ee/database/src/database.rs
@@ -36,8 +36,8 @@ pub(crate) trait EeNodeDb: Send + Sync + 'static {
     /// Insert first block to local view of canonical finalized chain (ie. genesis block)
     fn init_finalized_chain(&self, hash: Hash) -> DbResult<()>;
 
-    /// Extend local view of canonical chain with specified block hash
-    fn extend_finalized_chain(&self, hash: Hash) -> DbResult<()>;
+    /// Extend local view of canonical chain up to and including the specified block hash.
+    fn extend_finalized_chain(&self, new_tip: Hash) -> DbResult<()>;
 
     /// Revert local view of canonical chain to specified height
     fn revert_finalized_chain(&self, to_height: u64) -> DbResult<()>;
@@ -127,7 +127,7 @@ pub(crate) mod ops {
 
             save_exec_block(block: ExecBlockRecord, payload: Vec<u8>) => ();
             init_finalized_chain(hash: Hash) => ();
-            extend_finalized_chain(hash: Hash) => ();
+            extend_finalized_chain(new_tip: Hash) => ();
             revert_finalized_chain(to_height: u64) => ();
             prune_block_data(to_height: u64) => ();
             best_finalized_block() => Option<ExecBlockRecord>;

--- a/crates/alpen-ee/database/src/error.rs
+++ b/crates/alpen-ee/database/src/error.rs
@@ -16,51 +16,76 @@ pub enum DbError {
     NullOLBlock,
 
     /// OL slot was skipped in sequential persistence.
-    #[error("OL entries must be persisted sequentially; next: {expected}; got: {got}")]
+    #[error("OL entries must be persisted sequentially but provided nonsequentially (exp next {expected}, got {got})")]
     SkippedOLSlot { expected: u64, got: u64 },
 
     /// Transaction conflict: slot is already filled.
-    #[error("Txn conflict: OL slot {0} already filled")]
+    #[error("likely db txn conflict, OL slot {0} already filled")]
     TxnFilledOLSlot(u64),
 
     /// Transaction conflict: expected slot to be empty.
-    #[error("Txn conflict: OL slot {0} should be empty")]
+    #[error("likely db txn conflict, OL slot {0} should be empty")]
     TxnExpectEmptyOLSlot(u64),
 
     /// Account state is missing for the given block.
-    #[error("Account state expected to be present; block_id = {0}")]
+    #[error("account state missing (at blkid {0})")]
     MissingAccountState(OLBlockId),
 
     /// Finalized chain is empty.
-    #[error("Finalized exec block expected to be present")]
+    #[error("finalized exec block expected to be present")]
     FinalizedExecChainEmpty,
 
     /// Exec block is missing.
-    #[error("Exec block expected to be present; blockhahs = {0:?}")]
+    #[error("missing expected exec blkid {0}")]
     MissingExecBlock(Hash),
 
-    #[error("Expected exec block finalized chain to be empty")]
+    #[error("expected exec block finalized chain to be empty")]
     FinalizedExecChainGenesisBlockMismatch,
 
-    #[error("Provided block does not extend chain; {0:?}")]
+    #[error("provided blkid {0} does not extend chain")]
     ExecBlockDoesNotExtendChain(Hash),
 
-    #[error("Txn conflict: expected finalized height {0} to be empty")]
+    /// Walk from `new_tip` failed to reach the current finalized tip.
+    ///
+    /// This indicates one of:
+    /// - `new_tip` is non-canonical (does not descend from finalized tip),
+    /// - storage inconsistency (parent links / block numbers disagree), or
+    /// - walk exceeded the expected height-difference budget without reaching the tip (e.g.
+    ///   cyclic/corrupt parent links above finalized height).
+    #[error("walk failed to reach finalized tip (new tip {new_tip}, finalized height {finalized_height})")]
+    FinalizedWalkNotDescending {
+        new_tip: Hash,
+        finalized_height: u64,
+    },
+
+    /// Walk from `new_tip` did not reach finalized tip within expected height-difference budget.
+    ///
+    /// This usually indicates cyclic/corrupt parent links above finalized height, or severe
+    /// block-number/parent inconsistency that prevented convergence.
+    #[error("walk exhausted step budget before reaching tip (new tip {new_tip}, finalized height {finalized_height}, max steps {max_steps})")]
+    FinalizedWalkStepBudgetExceeded {
+        new_tip: Hash,
+        finalized_height: u64,
+        max_steps: u64,
+    },
+
+    #[error("likely db txn conflict, expected finalized height {0} to be empty")]
     TxnExpectEmptyFinalized(u64),
 
-    #[error("Txn conflict: expected finalized height {0} to be {1:?}")]
+    #[error("likely db txn conflict, expected finalized height {0} to be {1}")]
     TxnExpectFinalized(u64, Hash),
 
     /// Attempted to delete a finalized block.
-    #[error("Cannot delete finalized block: {0:?}")]
+    #[error("tried to delete finalized block {0}")]
     CannotDeleteFinalizedBlock(Hash),
 
     /// Batch not found when trying to update status.
-    #[error("Batch not found: {0:?}")]
+    #[error("batch {0} not found")]
     BatchNotFound(BatchId),
 
     /// Chunk not found when trying to update status.
-    #[error("Chunk not found: {0:?}")]
+    // NOTE: `ChunkId` doesn't implement `Display`, so use `Debug` here.
+    #[error("chunk {0:?} not found")]
     ChunkNotFound(ChunkId),
 
     /// Batch deserialization error.
@@ -68,7 +93,7 @@ pub enum DbError {
     BatchDeserialize(String),
 
     /// Database operation error.
-    #[error("Database: {0}")]
+    #[error("db ops: {0}")]
     DbOpsError(#[from] OpsError),
 
     /// Sled database error.

--- a/crates/alpen-ee/database/src/sleddb/db.rs
+++ b/crates/alpen-ee/database/src/sleddb/db.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, sync::Arc};
+use std::{error::Error, sync::Arc, thread, time::Duration};
 
 use alpen_ee_common::{
     Batch, BatchId, BatchStatus, Chunk, ChunkId, ChunkStatus, EeAccountStateAtEpoch,
@@ -8,7 +8,7 @@ use strata_acct_types::Hash;
 use strata_db_store_sled::SledDbConfig;
 use strata_ee_acct_types::EeAccountState;
 use strata_identifiers::{EpochCommitment, OLBlockId};
-use tracing::{error, warn};
+use tracing::{error, trace, warn};
 use typed_sled::{error::Error as TSledError, transaction::SledTransactional, SledDb, SledTree};
 
 use super::{AccountStateAtOLEpochSchema, OLBlockAtEpochSchema};
@@ -27,6 +27,49 @@ use crate::{
 
 fn abort<T>(reason: impl Error + Send + Sync + 'static) -> Result<T, TSledError> {
     Err(TSledError::abort(reason))
+}
+
+/// Retries a finalized-tip operation when tip-shift conflicts are detected.
+///
+/// Calls `op` up to `retry_count + 1` times with configured backoff between retries.
+/// Retries only [`DbError::TxnExpectFinalized`] and [`DbError::TxnExpectEmptyFinalized`];
+/// all other errors fail fast.
+fn retry_on_tip_shift<T, F>(config: &SledDbConfig, new_tip: Hash, mut op: F) -> DbResult<T>
+where
+    F: FnMut() -> DbResult<T>,
+{
+    let mut delay_ms = config.backoff.base_delay_ms();
+
+    for attempt in 0..=config.retry_count {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(err @ DbError::TxnExpectFinalized(_, _))
+            | Err(err @ DbError::TxnExpectEmptyFinalized(_)) => {
+                let retries_left = config.retry_count - attempt;
+                if retries_left == 0 {
+                    return Err(err);
+                }
+
+                warn!(
+                    ?new_tip,
+                    %attempt,
+                    retries_left,
+                    delay_ms,
+                    %err,
+                    "finalized tip shifted while extending chain; retrying whole operation"
+                );
+                // NOTE: blocking sleep is safe here because EE DB ops are dispatched on a
+                // dedicated threadpool via `inst_ops_generic!`, so this blocks a worker
+                // thread rather than the async runtime. If this helper is ever invoked
+                // directly from async context, switch to a non-blocking sleep.
+                thread::sleep(Duration::from_millis(delay_ms));
+                delay_ms = config.backoff.next_delay_ms(delay_ms);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("loop exits via return");
 }
 
 #[derive(Debug)]
@@ -62,6 +105,123 @@ impl EeNodeDBSled {
             batch_chunks_tree: db.get_tree()?,
             config,
         })
+    }
+
+    fn extend_finalized_chain_once(&self, new_tip: Hash) -> DbResult<()> {
+        let (last_finalized_height, last_finalized_blockhash) = self
+            .exec_block_finalized_tree
+            .last()?
+            .ok_or(DbError::FinalizedExecChainEmpty)?;
+
+        if new_tip == last_finalized_blockhash {
+            return Ok(());
+        }
+
+        let tip_block = self
+            .get_exec_block(new_tip)?
+            .ok_or(DbError::MissingExecBlock(new_tip))?;
+        if tip_block.blocknum() <= last_finalized_height {
+            // Another writer may have finalized this tip (or beyond) concurrently.
+            // In that case, extending to `new_tip` is already satisfied.
+            if self.get_finalized_height(new_tip)?.is_some() {
+                trace!(
+                    ?new_tip,
+                    tip_blocknum = tip_block.blocknum(),
+                    last_finalized_height,
+                    "new_tip already finalized by concurrent writer; no-op"
+                );
+                return Ok(());
+            }
+            return Err(DbError::ExecBlockDoesNotExtendChain(new_tip));
+        }
+
+        // Walk parent links from `new_tip` backward until we reach the current finalized tip.
+        // On a well-formed chain the walk terminates naturally at `last_finalized_blockhash`.
+        // If the walk crosses below the current finalized height without matching the tip,
+        // `new_tip` is not a descendant and we reject the request.
+        //
+        // Reads are sequential (one `get_exec_block` per height). The walk length is bounded
+        // by the L1 follow distance during normal operation (tens of blocks), so sequential
+        // reads are acceptable. A batched bulk-get would be worth adding if catch-up windows
+        // grow significantly.
+        let max_steps = tip_block.blocknum() - last_finalized_height;
+        let mut pending_entries_rev = Vec::new();
+        let mut current_hash = new_tip;
+        let mut current_block = tip_block;
+        let mut found_child_of_tip = false;
+
+        for _ in 0..max_steps {
+            if current_block.blocknum() <= last_finalized_height {
+                return Err(DbError::FinalizedWalkNotDescending {
+                    new_tip,
+                    finalized_height: last_finalized_height,
+                });
+            }
+            pending_entries_rev.push((current_block.blocknum(), current_hash));
+
+            if current_block.parent_blockhash() == last_finalized_blockhash {
+                found_child_of_tip = true;
+                break;
+            }
+
+            current_hash = current_block.parent_blockhash();
+            current_block = self
+                .get_exec_block(current_hash)?
+                .ok_or(DbError::MissingExecBlock(current_hash))?;
+        }
+        if !found_child_of_tip {
+            return Err(DbError::FinalizedWalkStepBudgetExceeded {
+                new_tip,
+                finalized_height: last_finalized_height,
+                max_steps,
+            });
+        }
+
+        pending_entries_rev.reverse();
+
+        // Defense in depth: parent-link walk alone is not enough if block number metadata
+        // is corrupted (parent links valid but blocknums non-contiguous). Verify the walked
+        // range has contiguous heights starting at `last_finalized_height + 1` before
+        // inserting, so we never leave gaps in the finalized tree.
+        for (offset, (height, _)) in pending_entries_rev.iter().enumerate() {
+            let expected_height = last_finalized_height + offset as u64 + 1;
+            if *height != expected_height {
+                return Err(DbError::FinalizedWalkNotDescending {
+                    new_tip,
+                    finalized_height: last_finalized_height,
+                });
+            }
+        }
+
+        // Retry storage conflicts inside the transaction body, but do not retry user aborts.
+        // Tip-shift aborts invalidate precomputed `pending_entries_rev`, so those must be
+        // retried by re-running the whole operation in `extend_finalized_chain`.
+        (&self.exec_block_finalized_tree,)
+            .transaction_with_retry(
+                self.config.backoff.as_ref(),
+                self.config.retry_count.into(),
+                |(finalized_tree,)| {
+                    if finalized_tree.get(&last_finalized_height)? != Some(last_finalized_blockhash)
+                    {
+                        abort(DbError::TxnExpectFinalized(
+                            last_finalized_height,
+                            last_finalized_blockhash,
+                        ))?;
+                    }
+
+                    for (height, hash) in &pending_entries_rev {
+                        if finalized_tree.get(height)?.is_some() {
+                            abort(DbError::TxnExpectEmptyFinalized(*height))?;
+                        }
+                        finalized_tree.insert(height, hash)?;
+                    }
+
+                    Ok(())
+                },
+            )
+            .map_err(DbError::from)?;
+
+        Ok(())
     }
 }
 
@@ -273,49 +433,10 @@ impl EeNodeDb for EeNodeDBSled {
         Ok(())
     }
 
-    fn extend_finalized_chain(&self, hash: Hash) -> DbResult<()> {
-        let block = self
-            .get_exec_block(hash)?
-            .ok_or(DbError::MissingExecBlock(hash))?;
-
-        let (last_finalized_height, last_finalized_blockhash) = self
-            .exec_block_finalized_tree
-            .last()?
-            .ok_or(DbError::FinalizedExecChainEmpty)?;
-
-        if block.parent_blockhash() != last_finalized_blockhash {
-            // does not extend chain
-            return Err(DbError::ExecBlockDoesNotExtendChain(hash));
-        }
-
-        (&self.exec_block_finalized_tree,).transaction_with_retry(
-            self.config.backoff.as_ref(),
-            self.config.retry_count.into(),
-            |(finalized_tree,)| {
-                // NOTE: Cannot check for last entry inside txn, so have to do this. CANNOT retry if
-                // finalized block has changed in a race.
-
-                // ensure finalized block has not changed
-                if finalized_tree.get(&last_finalized_height)? != Some(last_finalized_blockhash) {
-                    abort(DbError::TxnExpectFinalized(
-                        last_finalized_height,
-                        last_finalized_blockhash,
-                    ))?;
-                }
-                let next_height = last_finalized_height + 1;
-                // ensure next block height is empty
-                if finalized_tree.get(&next_height)?.is_some() {
-                    abort(DbError::TxnExpectEmptyFinalized(last_finalized_height + 1))?;
-                }
-
-                // las finalized block has not changed and can extend
-                finalized_tree.insert(&next_height, &hash)?;
-
-                Ok(())
-            },
-        )?;
-
-        Ok(())
+    fn extend_finalized_chain(&self, new_tip: Hash) -> DbResult<()> {
+        retry_on_tip_shift(&self.config, new_tip, || {
+            self.extend_finalized_chain_once(new_tip)
+        })
     }
 
     fn revert_finalized_chain(&self, to_height: u64) -> DbResult<()> {
@@ -825,5 +946,132 @@ impl EeNodeDb for EeNodeDBSled {
         self.batch_chunks_tree.insert(&db_batch_id, &db_chunks)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alpen_ee_common::exec_block_storage_test_fns::create_exec_block;
+    use strata_db_store_sled::SledDbConfig;
+    use typed_sled::SledDb;
+
+    use super::*;
+
+    fn hash_from_u8(value: u8) -> Hash {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 1;
+        bytes[31] = value;
+        Hash::from(bytes)
+    }
+
+    fn setup_db(retry_count: u16) -> EeNodeDBSled {
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let sled_db = SledDb::new(db).unwrap();
+        let config = SledDbConfig::new_with_constant_backoff(retry_count, 0);
+        EeNodeDBSled::new(Arc::new(sled_db), config).unwrap()
+    }
+
+    fn save_block(db: &EeNodeDBSled, block: ExecBlockRecord) {
+        db.save_exec_block(block, vec![]).unwrap();
+    }
+
+    #[test]
+    fn retry_on_tip_shift_retries_then_succeeds() {
+        let config = SledDbConfig::new_with_constant_backoff(2, 0);
+        let mut attempts = 0usize;
+
+        let out = retry_on_tip_shift(&config, hash_from_u8(9), || {
+            attempts += 1;
+            if attempts == 1 {
+                return Err(DbError::TxnExpectFinalized(0, hash_from_u8(0)));
+            }
+            Ok(())
+        });
+
+        assert!(out.is_ok());
+        assert_eq!(attempts, 2);
+    }
+
+    #[test]
+    fn retry_on_tip_shift_exhausts_retry_budget() {
+        let config = SledDbConfig::new_with_constant_backoff(1, 0); // 2 attempts total
+        let mut attempts = 0usize;
+
+        let err = retry_on_tip_shift(&config, hash_from_u8(9), || {
+            attempts += 1;
+            Err::<(), DbError>(DbError::TxnExpectEmptyFinalized(42))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, DbError::TxnExpectEmptyFinalized(42)));
+        assert_eq!(attempts, 2);
+    }
+
+    #[test]
+    fn retry_on_tip_shift_does_not_retry_non_retryable_errors() {
+        let config = SledDbConfig::new_with_constant_backoff(10, 0);
+        let mut attempts = 0usize;
+        let missing = hash_from_u8(7);
+
+        let err = retry_on_tip_shift(&config, hash_from_u8(9), || {
+            attempts += 1;
+            Err::<(), DbError>(DbError::MissingExecBlock(missing))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, DbError::MissingExecBlock(h) if h == missing));
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn extend_finalized_chain_ok_if_tip_already_finalized() {
+        let db = setup_db(2);
+        let h0 = hash_from_u8(0);
+        let h1 = hash_from_u8(1);
+        let h2 = hash_from_u8(2);
+
+        save_block(&db, create_exec_block(0, Hash::default(), h0, 0));
+        save_block(&db, create_exec_block(1, h0, h1, 1));
+        save_block(&db, create_exec_block(2, h1, h2, 2));
+
+        db.init_finalized_chain(h0).unwrap();
+        db.extend_finalized_chain(h2).unwrap();
+
+        // Simulates "caller behind" after another writer already finalized beyond h1.
+        db.extend_finalized_chain(h1).unwrap();
+
+        assert_eq!(db.get_finalized_height(h1).unwrap(), Some(1));
+        assert_eq!(db.get_finalized_height(h2).unwrap(), Some(2));
+        let best = db.best_finalized_block().unwrap().unwrap();
+        assert_eq!(best.blockhash(), h2);
+        assert_eq!(best.blocknum(), 2);
+    }
+
+    #[test]
+    fn extend_finalized_chain_cycle_errors_with_step_budget_exceeded() {
+        let db = setup_db(2);
+        let h0 = hash_from_u8(0);
+        let h2 = hash_from_u8(2);
+        let h3 = hash_from_u8(3);
+
+        save_block(&db, create_exec_block(0, Hash::default(), h0, 0));
+        db.init_finalized_chain(h0).unwrap();
+
+        // Corrupt graph above finalized tip:
+        // h3 -> h2 and h2 -> h3 (cycle).
+        save_block(&db, create_exec_block(2, h3, h2, 2));
+        save_block(&db, create_exec_block(3, h2, h3, 3));
+
+        let err = db.extend_finalized_chain(h3).unwrap_err();
+        assert!(matches!(
+            err,
+            DbError::FinalizedWalkStepBudgetExceeded {
+                new_tip,
+                finalized_height: 0,
+                max_steps: 3,
+            } if new_tip == h3
+        ));
     }
 }

--- a/crates/alpen-ee/database/src/storage.rs
+++ b/crates/alpen-ee/database/src/storage.rs
@@ -130,10 +130,10 @@ impl ExecBlockStorage for EeNodeStorage {
             .map_err(Into::into)
     }
 
-    /// Extend local view of canonical chain with specified block hash
-    async fn extend_finalized_chain(&self, hash: Hash) -> Result<(), StorageError> {
+    /// Extend local view of canonical chain up to and including the specified block hash.
+    async fn extend_finalized_chain(&self, new_tip: Hash) -> Result<(), StorageError> {
         self.ops
-            .extend_finalized_chain_async(hash)
+            .extend_finalized_chain_async(new_tip)
             .await
             .map_err(Into::into)
     }

--- a/crates/alpen-ee/exec-chain/src/task.rs
+++ b/crates/alpen-ee/exec-chain/src/task.rs
@@ -217,3 +217,62 @@ async fn handle_ol_update<TStorage: ExecBlockStorage>(
     // TODO: we have a deep reorg beyond what we consider finalized.
     unimplemented!("deep reorg");
 }
+
+#[cfg(test)]
+mod tests {
+    use alpen_ee_common::{
+        exec_block_storage_test_fns::create_exec_block, ConsensusHeads, MockExecBlockStorage,
+    };
+    use strata_acct_types::Hash;
+
+    use super::*;
+
+    fn hash_from_u8(value: u8) -> Hash {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 1;
+        bytes[31] = value;
+        Hash::from(bytes)
+    }
+
+    #[tokio::test]
+    async fn handle_ol_update_uses_multi_block_finalized_extension() {
+        let hash0 = hash_from_u8(0);
+        let hash1 = hash_from_u8(1);
+        let hash2 = hash_from_u8(2);
+        let hash3 = hash_from_u8(3);
+
+        let block0 = create_exec_block(0, Hash::default(), hash0, 0);
+        let block1 = create_exec_block(1, hash0, hash1, 1);
+        let block2 = create_exec_block(2, hash1, hash2, 2);
+        let block3 = create_exec_block(3, hash2, hash3, 3);
+
+        let mut state = ExecChainState::new_empty(block0);
+        state.append_block(block1).unwrap();
+        state.append_block(block2).unwrap();
+        state.append_block(block3).unwrap();
+
+        let (preconf_tx, _preconf_rx) = watch::channel(state.tip_blocknumhash());
+
+        let mut storage = MockExecBlockStorage::new();
+        storage
+            .expect_extend_finalized_chain()
+            .withf(move |hash| *hash == hash3)
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let heads = ConsensusHeads {
+            confirmed: hash3,
+            confirmed_epoch: 1,
+            finalized: hash3,
+            finalized_epoch: 1,
+        };
+
+        handle_ol_update(&mut state, heads, &storage, &preconf_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(state.finalized_blockhash(), hash3);
+        assert_eq!(state.finalized_blocknum(), 3);
+        assert_eq!(state.tip_blockhash(), hash3);
+    }
+}


### PR DESCRIPTION
## Description

Fix sequencer `ExecBlockStorage` finalized-chain extension to handle multi-block advances from the OL tracker.

Before this change, `handle_ol_update` called `extend_finalized_chain(finalized)` assuming one-block appends, while the sled implementation effectively required direct parent continuity at the current tip. As a result, normal multi-block finalized jumps were rejected, the sequencer finalized EE chain could stall at genesis, and `get_finalized_height` could remain `None` for non-genesis blocks.

## Changes
- `ExecBlockStorage::extend_finalized_chain(new_tip)` now supports extending to arbitrary canonical descendants of the current finalized tip.
- The sled implementation walks parent links from `new_tip` back to the current finalized tip, collects intermediate entries, and inserts them atomically.
- Added contiguous-height validation for the walked range as a defense against inconsistent block-number metadata.
- Added `DbError::FinalizedWalkNotDescending` to distinguish non-descendant / inconsistent-chain walk failures.
- Preserved transaction-level retry for storage conflicts inside a single attempt.
- Added operation-level retry (`retry_on_tip_shift`) for tip-shift conflicts (`TxnExpectFinalized`, `TxnExpectEmptyFinalized`), with configured backoff.
- `handle_ol_update` continues using `extend_finalized_chain(finalized)` with no caller-side walk logic.

## Tests
- Added storage contract coverage in `exec_block_storage_test_fns` for:
  - multi-block extension
  - single-step extension through the same path
  - idempotent no-op at tip
  - non-descendant fork rejection
  - missing intermediate parent rejection
- Added deterministic unit tests for retry wrapper behavior in sled DB:
  - retries then succeeds on retryable conflict
  - exhausts retry budget on persistent retryable conflict
  - does not retry non-retryable errors
- Functional log-grep test was used during validation but not
  committed (slow and log-format brittle).

## Out of Scope
- `handle_ol_update` orphan/deep-reorg handling remains unchanged.
- Bulk/batched walk reads are not introduced.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3075](https://alpenlabs.atlassian.net/browse/STR-3075)

[STR-3075]: https://alpenlabs.atlassian.net/browse/STR-3075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ