### PR TITLE
feat(alpen-client): serve alpen_getBlockStatus on fullnodes (STR-3076)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,8 @@ dependencies = [
  "alpen-ee-rpc-api",
  "async-trait",
  "jsonrpsee",
- "strata-acct-types",
+ "reth-node-builder",
+ "reth-provider",
  "tokio",
 ]
 

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -377,18 +377,15 @@ fn main() {
                 info!(target: "alpen-client", "installed StateDiffGenerator exex for DA");
             }
 
-            #[cfg(feature = "sequencer")]
-            if ext.sequencer {
-                node_builder = node_builder.extend_rpc_modules({
-                    let consensus_watcher = consensus_watcher.clone();
-                    move |ctx| {
-                        let provider = ctx.provider().clone();
-                        let ee_rpc_server = EeRpcServer::new(provider, consensus_watcher);
-                        ctx.modules.merge_configured(ee_rpc_server.into_rpc())?;
-                        Ok(())
-                    }
-                });
-            }
+            node_builder = node_builder.extend_rpc_modules({
+                let consensus_watcher = consensus_watcher.clone();
+                move |ctx| {
+                    let provider = ctx.provider().clone();
+                    let ee_rpc_server = EeRpcServer::new(provider, consensus_watcher);
+                    ctx.modules.merge_configured(ee_rpc_server.into_rpc())?;
+                    Ok(())
+                }
+            });
 
             let handle = node_builder.launch().await?;
 

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -380,10 +380,10 @@ fn main() {
             #[cfg(feature = "sequencer")]
             if ext.sequencer {
                 node_builder = node_builder.extend_rpc_modules({
-                    let storage = storage.clone();
                     let consensus_watcher = consensus_watcher.clone();
                     move |ctx| {
-                        let ee_rpc_server = EeRpcServer::new(storage, consensus_watcher);
+                        let provider = ctx.provider().clone();
+                        let ee_rpc_server = EeRpcServer::new(provider, consensus_watcher);
                         ctx.modules.merge_configured(ee_rpc_server.into_rpc())?;
                         Ok(())
                     }

--- a/crates/alpen-ee/rpc/api/src/lib.rs
+++ b/crates/alpen-ee/rpc/api/src/lib.rs
@@ -5,8 +5,8 @@ pub use alpen_ee_rpc_types::{BlockStatus, BlockStatusResponse};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// RPC methods exposed by Alpen EE nodes.
-#[cfg_attr(not(feature = "client"), rpc(server, namespace = "strataee"))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "strataee"))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "alpen"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "alpen"))]
 pub trait AlpenEeRpc {
     /// Returns the L1 finalization status for an EE block.
     #[method(name = "getBlockStatus")]

--- a/crates/alpen-ee/rpc/server/Cargo.toml
+++ b/crates/alpen-ee/rpc/server/Cargo.toml
@@ -9,9 +9,10 @@ workspace = true
 [dependencies]
 alpen-ee-common.workspace = true
 alpen-ee-rpc-api.workspace = true
-strata-acct-types.workspace = true
 
 alloy-primitives.workspace = true
 async-trait.workspace = true
 jsonrpsee = { workspace = true, features = ["server"] }
+reth-node-builder.workspace = true
+reth-provider.workspace = true
 tokio.workspace = true

--- a/crates/alpen-ee/rpc/server/src/block_status.rs
+++ b/crates/alpen-ee/rpc/server/src/block_status.rs
@@ -1,232 +1,116 @@
 //! Alpen EE RPC handler implementation for block-status methods.
 
-use std::{error::Error, fmt, num::NonZeroU64, sync::Arc};
-
 use alloy_primitives::B256;
-use alpen_ee_common::{BatchStorage, ConsensusHeads, ExecBlockStorage, StorageError};
+use alpen_ee_common::ConsensusHeads;
 use alpen_ee_rpc_api::{AlpenEeRpcServer, BlockStatus, BlockStatusResponse};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use strata_acct_types::Hash;
+use reth_node_builder::NodeTypesWithDB;
+use reth_provider::{
+    providers::{BlockchainProvider, ProviderNodeTypes},
+    BlockHashReader, BlockNumReader, ProviderResult,
+};
 use tokio::sync::watch;
 
-use crate::errors::{block_not_found_error, frontier_unavailable_error, internal_error};
+use crate::errors::{block_not_found_error, internal_error};
 
-/// RPC handler for [`AlpenEeRpcServer`].
-#[derive(Debug)]
-pub struct EeRpcServer<S> {
-    storage: Arc<S>,
-    consensus_rx: watch::Receiver<ConsensusHeads>,
-}
-
-/// Batch lookup result for an execution block hash.
-enum BlockBatchLookup {
-    /// Block hash does not exist in execution storage.
-    BlockNotFound,
-
-    /// Block exists but no batch covers it yet.
-    NoBatchCoverage,
-
-    /// Block is covered by the genesis marker batch (idx 0).
-    CoveredGenesis,
-
-    /// Block is covered by a non-genesis batch index.
-    Covered(NonZeroU64),
-}
-
-/// Errors while resolving a consensus frontier hash to batch coverage.
-#[derive(Debug)]
-enum FrontierResolveError {
-    /// Frontier block exists but no batch covers it yet.
-    NoBatchCoverage(Hash),
-
-    /// Frontier block hash does not exist in execution storage.
-    MissingExecBlock(Hash),
-
-    /// Storage failure while resolving frontier coverage.
-    Storage(StorageError),
-}
-
-impl fmt::Display for FrontierResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NoBatchCoverage(hash) => {
-                write!(f, "frontier block {hash} not covered by any batch")
-            }
-            Self::MissingExecBlock(hash) => {
-                write!(f, "frontier block {hash} missing in execution storage")
-            }
-            Self::Storage(err) => {
-                write!(f, "storage error while resolving frontier batch: {err}")
-            }
-        }
+/// Resolve `block_hash` to its canonical block number on `provider`.
+///
+/// Returns `Ok(Some(n))` only when `block_hash` is the canonical hash at
+/// height `n`. A hash that is known to the provider but belongs to an
+/// orphaned / non-canonical branch returns `Ok(None)`.
+fn canonical_block_number<N: NodeTypesWithDB + ProviderNodeTypes>(
+    provider: &BlockchainProvider<N>,
+    block_hash: B256,
+) -> ProviderResult<Option<u64>> {
+    let Some(block_number) = provider.block_number(block_hash)? else {
+        return Ok(None);
+    };
+    let Some(canonical_hash) = provider.block_hash(block_number)? else {
+        return Ok(None);
+    };
+    if canonical_hash == block_hash {
+        Ok(Some(block_number))
+    } else {
+        Ok(None)
     }
 }
 
-impl Error for FrontierResolveError {}
+/// RPC handler for [`AlpenEeRpcServer`].
+///
+/// Resolves block status by combining Reth's canonical-chain lookup with the
+/// `OLTracker`-derived [`ConsensusHeads`]. Works on both sequencer and fullnode
+/// because neither dependency is sequencer-specific.
+#[derive(Debug)]
+pub struct EeRpcServer<N: NodeTypesWithDB + ProviderNodeTypes> {
+    provider: BlockchainProvider<N>,
+    consensus_rx: watch::Receiver<ConsensusHeads>,
+}
 
-impl<S> EeRpcServer<S> {
-    pub fn new(storage: Arc<S>, consensus_rx: watch::Receiver<ConsensusHeads>) -> Self {
+impl<N: NodeTypesWithDB + ProviderNodeTypes> EeRpcServer<N> {
+    pub fn new(
+        provider: BlockchainProvider<N>,
+        consensus_rx: watch::Receiver<ConsensusHeads>,
+    ) -> Self {
         Self {
-            storage,
+            provider,
             consensus_rx,
         }
     }
 }
 
-impl<S: BatchStorage + ExecBlockStorage> EeRpcServer<S> {
-    /// Resolves a frontier head hash to its batch index.
-    ///
-    /// Returns `None` if the hash is zero (uninitialized frontier).
-    async fn resolve_frontier_batch_idx(
-        &self,
-        head_hash: Hash,
-    ) -> Result<Option<u64>, FrontierResolveError> {
-        if head_hash.is_zero() {
-            return Ok(None);
-        }
-
-        let lookup = self
-            .find_batch_for_block(head_hash)
-            .await
-            .map_err(FrontierResolveError::Storage)?;
-
-        match lookup {
-            BlockBatchLookup::CoveredGenesis => Ok(Some(0)),
-            BlockBatchLookup::Covered(idx) => Ok(Some(idx.get())),
-            BlockBatchLookup::NoBatchCoverage => {
-                Err(FrontierResolveError::NoBatchCoverage(head_hash))
-            }
-            BlockBatchLookup::BlockNotFound => {
-                Err(FrontierResolveError::MissingExecBlock(head_hash))
-            }
-        }
-    }
-
-    /// Resolves a block hash to its block number and finds the covering batch.
-    async fn find_batch_for_block(
-        &self,
-        target_hash: Hash,
-    ) -> Result<BlockBatchLookup, StorageError> {
-        let Some(target_record) = self.storage.get_exec_block(target_hash).await? else {
-            return Ok(BlockBatchLookup::BlockNotFound);
-        };
-
-        let batch_idx = self
-            .find_batch_by_number(target_record.blocknum(), target_hash)
-            .await?;
-
-        Ok(match batch_idx {
-            Some(0) => BlockBatchLookup::CoveredGenesis,
-            Some(idx) => BlockBatchLookup::Covered(
-                NonZeroU64::new(idx)
-                    .expect("batch index must be non-zero when mapped to Covered variant"),
-            ),
-            None => BlockBatchLookup::NoBatchCoverage,
-        })
-    }
-
-    /// Binary-searches `BatchStorage` for the batch containing `target_blocknum` and `target_hash`.
-    ///
-    /// Returns `None` if the block is not yet covered by any batch.
-    async fn find_batch_by_number(
-        &self,
-        target_blocknum: u64,
-        target_hash: Hash,
-    ) -> Result<Option<u64>, StorageError> {
-        let Some((latest_batch, _)) = self.storage.get_latest_batch().await? else {
-            return Ok(None);
-        };
-
-        let mut lo: u64 = 0;
-        let mut hi: u64 = latest_batch.idx();
-        let mut candidate_idx: Option<u64> = None;
-
-        while lo <= hi {
-            let mid = lo + (hi - lo) / 2;
-            let Some((batch, _)) = self.storage.get_batch_by_idx(mid).await? else {
-                break;
-            };
-
-            if batch.last_blocknum() >= target_blocknum {
-                candidate_idx = Some(mid);
-                if mid == 0 {
-                    break;
-                }
-                hi = mid - 1;
-            } else {
-                lo = mid + 1;
-            }
-        }
-
-        let Some(idx) = candidate_idx else {
-            return Ok(None);
-        };
-
-        let Some((batch, _)) = self.storage.get_batch_by_idx(idx).await? else {
-            return Ok(None);
-        };
-
-        if batch.last_block() == target_hash || batch.inner_blocks().contains(&target_hash) {
-            Ok(Some(idx))
-        } else {
-            Ok(None)
-        }
-    }
-}
-
 #[async_trait]
-impl<S> AlpenEeRpcServer for EeRpcServer<S>
+impl<N> AlpenEeRpcServer for EeRpcServer<N>
 where
-    S: BatchStorage + ExecBlockStorage + Send + Sync + 'static,
+    N: NodeTypesWithDB + ProviderNodeTypes + Send + Sync + 'static,
 {
     async fn get_block_status(&self, block_hash: B256) -> RpcResult<BlockStatusResponse> {
-        // This handler is registered only when running in sequencer mode (see `main.rs`).
-        let hash = Hash::from(block_hash.0);
-
-        let target_lookup = self
-            .find_batch_for_block(hash)
-            .await
-            .map_err(|e| internal_error(e.to_string()))?;
-
-        let target_batch_idx = match target_lookup {
-            BlockBatchLookup::BlockNotFound => return Err(block_not_found_error()),
-            BlockBatchLookup::NoBatchCoverage => {
-                return Ok(BlockStatusResponse {
-                    status: BlockStatus::Pending,
-                })
-            }
-            // Batch 0 is a storage marker, not a real update submitted to OL.
-            BlockBatchLookup::CoveredGenesis => {
-                return Ok(BlockStatusResponse {
-                    status: BlockStatus::Finalized,
-                })
-            }
-            BlockBatchLookup::Covered(idx) => idx.get(),
+        // Resolve target to a canonical block number. `block_number` alone
+        // does not distinguish canonical blocks from orphaned ones stored in
+        // the DB, so round-trip through `block_hash(number)` to verify.
+        let target_num = match canonical_block_number(&self.provider, block_hash) {
+            Ok(Some(n)) => n,
+            Ok(None) => return Err(block_not_found_error()),
+            Err(e) => return Err(internal_error(e.to_string())),
         };
 
-        let heads = self.consensus_rx.borrow().clone();
-
-        let finalized_batch_idx = self
-            .resolve_frontier_batch_idx(*heads.finalized())
-            .await
-            .map_err(frontier_unavailable_error)?;
-
-        if finalized_batch_idx.is_some_and(|idx| target_batch_idx <= idx) {
+        // Preserve genesis semantics: block 0 is always considered finalized.
+        if target_num == 0 {
             return Ok(BlockStatusResponse {
                 status: BlockStatus::Finalized,
             });
         }
 
-        let confirmed_batch_idx = self
-            .resolve_frontier_batch_idx(*heads.confirmed())
-            .await
-            .map_err(frontier_unavailable_error)?;
+        let heads = self.consensus_rx.borrow().clone();
 
-        if confirmed_batch_idx.is_some_and(|idx| target_batch_idx <= idx) {
-            return Ok(BlockStatusResponse {
-                status: BlockStatus::Confirmed,
-            });
+        // Finalized check: skip when the head is unset or not canonical on
+        // this node (transient during sync / reorg — OLTracker may still be
+        // tracking a fork that Reth hasn't reorged to).
+        let finalized_b256 = B256::from_slice(heads.finalized().as_slice());
+        if !finalized_b256.is_zero() {
+            match canonical_block_number(&self.provider, finalized_b256) {
+                Ok(Some(fin_num)) if target_num <= fin_num => {
+                    return Ok(BlockStatusResponse {
+                        status: BlockStatus::Finalized,
+                    });
+                }
+                Ok(_) => {}
+                Err(e) => return Err(internal_error(e.to_string())),
+            }
+        }
+
+        // Confirmed check.
+        let confirmed_b256 = B256::from_slice(heads.confirmed().as_slice());
+        if !confirmed_b256.is_zero() {
+            match canonical_block_number(&self.provider, confirmed_b256) {
+                Ok(Some(conf_num)) if target_num <= conf_num => {
+                    return Ok(BlockStatusResponse {
+                        status: BlockStatus::Confirmed,
+                    });
+                }
+                Ok(_) => {}
+                Err(e) => return Err(internal_error(e.to_string())),
+            }
         }
 
         Ok(BlockStatusResponse {

--- a/crates/alpen-ee/rpc/server/src/errors.rs
+++ b/crates/alpen-ee/rpc/server/src/errors.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use jsonrpsee::types::{
     error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE},
     ErrorObjectOwned,
@@ -13,9 +11,4 @@ pub(crate) fn internal_error(msg: impl Into<String>) -> ErrorObjectOwned {
 /// Creates an RPC error for missing block hash input.
 pub(crate) fn block_not_found_error() -> ErrorObjectOwned {
     ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "block not found", None::<()>)
-}
-
-/// Creates an RPC error for frontier resolution failures.
-pub(crate) fn frontier_unavailable_error(err: impl Display) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(INTERNAL_ERROR_CODE, err.to_string(), None::<()>)
 }

--- a/crates/alpen-ee/rpc/types/src/lib.rs
+++ b/crates/alpen-ee/rpc/types/src/lib.rs
@@ -16,7 +16,7 @@ pub enum BlockStatus {
     Finalized,
 }
 
-/// Response for `strataee_getBlockStatus`.
+/// Response for `alpen_getBlockStatus`.
 ///
 /// Reserved for forward-compatible expansion; additional fields may be added without changing the
 /// method signature.

--- a/functional-tests/common/services/alpen_client.py
+++ b/functional-tests/common/services/alpen_client.py
@@ -123,7 +123,7 @@ class AlpenClientService(RpcService):
         Returns one of: "pending", "confirmed", "finalized".
         """
         rpc = self.create_rpc()
-        result = rpc.strataee_getBlockStatus(block_hash)
+        result = rpc.alpen_getBlockStatus(block_hash)
         return result["status"]
 
     def get_peers(self) -> list[dict]:

--- a/functional-tests/tests/alpen_client/test_ee_block_status.py
+++ b/functional-tests/tests/alpen_client/test_ee_block_status.py
@@ -1,4 +1,4 @@
-"""Test strataee_getBlockStatus RPC for EE block finality progression."""
+"""Test alpen_getBlockStatus RPC for EE block finality progression."""
 
 import logging
 
@@ -109,7 +109,7 @@ class TestEeBlockStatus(BaseTest):
         # Non-existent block should error
         fake_hash = "0x" + "00" * 32
         try:
-            alpen_rpc.strataee_getBlockStatus(fake_hash)
+            alpen_rpc.alpen_getBlockStatus(fake_hash)
             raise AssertionError("Expected error for non-existent block hash")
         except RpcError as e:
             logger.info(
@@ -128,7 +128,7 @@ class TestEeBlockStatus(BaseTest):
         # Fullnode must also serve the method (STR-3076). Unknown hash still errors.
         fullnode_rpc = alpen_fullnode.create_rpc()
         try:
-            fullnode_rpc.strataee_getBlockStatus(fake_hash)
+            fullnode_rpc.alpen_getBlockStatus(fake_hash)
             raise AssertionError("Expected error for non-existent block hash on fullnode")
         except RpcError as e:
             logger.info(

--- a/functional-tests/tests/alpen_client/test_ee_block_status.py
+++ b/functional-tests/tests/alpen_client/test_ee_block_status.py
@@ -10,8 +10,13 @@ from common.rpc import RpcError
 from common.services.alpen_client import AlpenClientService
 from common.services.bitcoin import BitcoinService
 from common.services.strata import StrataService
+from common.wait import wait_until
 
 logger = logging.getLogger(__name__)
+
+# Fullnode OLTracker polls on an interval, so its consensus heads may lag the
+# sequencer by a few seconds. Wait this long for cross-node convergence.
+FULLNODE_SYNC_TIMEOUT = 15
 
 
 @flexitest.register
@@ -45,6 +50,43 @@ class TestEeBlockStatus(BaseTest):
             )
 
         return statuses
+
+    def wait_for_fullnode_match(
+        self,
+        alpen_fullnode: AlpenClientService,
+        block_hash: str,
+        expected_status: str,
+        timeout: int = FULLNODE_SYNC_TIMEOUT,
+    ) -> None:
+        """Poll the fullnode until its status for ``block_hash`` matches ``expected_status``.
+
+        Absorbs the OLTracker polling lag between sequencer and fullnode
+        without making the test flaky.
+        """
+        wait_until(
+            lambda: alpen_fullnode.get_block_status(block_hash) == expected_status,
+            error_with=(
+                f"Fullnode status for {block_hash} did not converge to "
+                f"{expected_status!r} within {timeout}s "
+                f"(last={alpen_fullnode.get_block_status(block_hash)!r})"
+            ),
+            timeout=timeout,
+        )
+
+    def assert_fullnode_matches_sequencer(
+        self,
+        alpen_seq: AlpenClientService,
+        alpen_fullnode: AlpenClientService,
+        alpen_rpc,
+        up_to_block: int,
+    ) -> None:
+        """Assert the fullnode converges to the sequencer's status for each block."""
+        for i in range(up_to_block + 1):
+            block = alpen_rpc.eth_getBlockByNumber(hex(i), False)
+            assert block is not None, f"Failed to get block {i}"
+            seq_status = alpen_seq.get_block_status(block["hash"])
+            self.wait_for_fullnode_match(alpen_fullnode, block["hash"], seq_status)
+            logger.info(f"  Block {i}: fullnode converged to {seq_status}")
 
     def main(self, ctx):
         alpen_seq: AlpenClientService = self.get_service(ServiceType.AlpenSequencer)
@@ -83,23 +125,24 @@ class TestEeBlockStatus(BaseTest):
         assert target_block is not None, f"Failed to get block {self.TARGET_BLOCK_NUMBER}"
         target_hash = target_block["hash"]
 
-        # Fullnode does not serve this method; expect JSON-RPC method-not-found.
+        # Fullnode must also serve the method (STR-3076). Unknown hash still errors.
         fullnode_rpc = alpen_fullnode.create_rpc()
         try:
-            fullnode_rpc.strataee_getBlockStatus(target_hash)
-            raise AssertionError(
-                f"Expected method-not-found on fullnode for block {self.TARGET_BLOCK_NUMBER}"
-            )
+            fullnode_rpc.strataee_getBlockStatus(fake_hash)
+            raise AssertionError("Expected error for non-existent block hash on fullnode")
         except RpcError as e:
             logger.info(
-                "Fullnode returned expected method-not-found: code=%s message=%s",
+                "Fullnode non-existent block returned expected error: code=%s message=%s",
                 e.code,
                 e.message,
             )
-            assert e.code == -32601, f"Expected method-not-found (-32601), got {e.code}"
+            assert e.code == -32602, f"Expected invalid params (-32602), got {e.code}"
 
         initial_status = alpen_seq.get_block_status(target_hash)
         logger.info(f"Block {self.TARGET_BLOCK_NUMBER} initial status: {initial_status}")
+
+        # Fullnode should converge to the same status for the target block.
+        self.wait_for_fullnode_match(alpen_fullnode, target_hash, initial_status)
 
         # Block 0 should be finalized.
         block_0 = alpen_rpc.eth_getBlockByNumber("0x0", False)
@@ -111,6 +154,10 @@ class TestEeBlockStatus(BaseTest):
             logger.info("Initial status consistency check:")
             self.assert_statuses_consistent(
                 alpen_seq, alpen_rpc, up_to_block=self.TARGET_BLOCK_NUMBER
+            )
+            logger.info("Initial fullnode parity check:")
+            self.assert_fullnode_matches_sequencer(
+                alpen_seq, alpen_fullnode, alpen_rpc, up_to_block=self.TARGET_BLOCK_NUMBER
             )
             logger.info(
                 "Block %s is already finalized at initial check; "
@@ -137,6 +184,11 @@ class TestEeBlockStatus(BaseTest):
                 f"Block {i} should be at least confirmed, got {statuses[i]}"
             )
 
+        logger.info("Post-confirmed fullnode parity check:")
+        self.assert_fullnode_matches_sequencer(
+            alpen_seq, alpen_fullnode, alpen_rpc, up_to_block=self.TARGET_BLOCK_NUMBER
+        )
+
         # Mine until target block is finalized.
         status = bitcoin.mine_until(
             check=lambda: alpen_seq.get_block_status(target_hash),
@@ -152,6 +204,11 @@ class TestEeBlockStatus(BaseTest):
         )
         for i in range(self.TARGET_BLOCK_NUMBER + 1):
             assert statuses[i] == "finalized", f"Block {i} should be finalized, got {statuses[i]}"
+
+        logger.info("Post-finalized fullnode parity check:")
+        self.assert_fullnode_matches_sequencer(
+            alpen_seq, alpen_fullnode, alpen_rpc, up_to_block=self.TARGET_BLOCK_NUMBER
+        )
 
         logger.info("Block status progression test passed")
         return True


### PR DESCRIPTION
## Description

On Alpen fullnodes, `alpen_getBlockStatus` was unavailable because the handler depended on sequencer-only state (`EeNodeStorage`/`BatchStorage`) and its registration was gated behind`#[cfg(feature = "sequencer")]` + `if ext.sequencer`.

The handler is rewritten to use two pieces of state that exist on every
Alpen node:

- Reth's canonical-chain lookup (`BlockchainProvider::block_number`) to resolve the target hash, the confirmed head, and the finalized head to canonical block numbers.
- The `OLTracker`-derived `ConsensusHeads` watcher (already injected into `EeRpcServer`) for the current confirmed / finalized EE block hashes.

Block status is derived by height comparison: target <= finalized -> `Finalized`; target <= confirmed -> `Confirmed`; else `Pending`.
Block `0` is special-cased to `Finalized` to preserve existing semantics. Non-canonical or unknown hashes return `-32602 block not found`, matching the previous error shape.

Registration is lifted to apply unconditionally, so the method is now served on both sequencer and fullnode.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Three independent commits for easier review:

1. `refactor(alpen-ee/rpc-server)` — rewrite the handler using `BlockchainProvider<N>` + `ConsensusHeads`; delete `BlockBatchLookup`, `FrontierResolveError`, and the `find_batch_*` / `resolve_frontier_batch_idx` helpers; swap `storage` for `ctx.provider().clone()` at the call site. Registration gate is preserved so sequencer behavior is unchanged.
2. `feat(alpen-client)` — lift the `#[cfg(feature = "sequencer")]` +  `if ext.sequencer` guard so the RPC is registered on every Alpen node.
3. `test(functional-tests)` — replace the "expect -32601 method-not-found on fullnode" assertion with positive parity checks; assert the fullnode converges to the sequencer's status for every block at each progression milestone, with a short poll-with-timeout to absorb `OLTracker` lag.

Reorg semantics are tightened: non-canonical known hashes now uniformly return `-32602` rather than relying on whether sequencer storage had seen the block.


This PR was written primarily by Claude Code (Opus 4.7) with human review and guidance on the design approach (the solution came from the ticket comments by myself and @sapinb).

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3076
