### PR TITLE
ci: build strata image with --features sp1 (prover enabled)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -133,7 +133,16 @@ jobs:
           ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}/${PROGRAM}"
           FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:${SHORT_TAG}"
 
+          # Bake prover features into the strata image. Other programs build
+          # with default features. Relies on docker/strata/Dockerfile accepting
+          # the CARGO_FEATURES build arg (#1663).
+          BUILD_ARGS=()
+          if [ "$PROGRAM" = "strata" ]; then
+            BUILD_ARGS+=( --build-arg "CARGO_FEATURES=sp1" )
+          fi
+
           docker buildx build \
+            "${BUILD_ARGS[@]}" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
             --label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -138,7 +138,7 @@ jobs:
           # the CARGO_FEATURES build arg (#1663).
           BUILD_ARGS=()
           if [ "$PROGRAM" = "strata" ]; then
-            BUILD_ARGS+=( --build-arg "CARGO_FEATURES=sp1" )
+            BUILD_ARGS+=( --build-arg "CARGO_FEATURES=sp1,prover" )
           fi
 
           docker buildx build \


### PR DESCRIPTION
## Summary

Pass \`--build-arg CARGO_FEATURES=sp1\` when building the \`strata\` image so the published \`strata:<sha>\` artifact has the SP1 network prover SDK linked in. Other programs in the matrix (\`alpen-client\`) keep building with default features.

## Why

Deployments need a strata binary capable of submitting proofs to the SP1 Network. With this change there is **one** strata image — same tag, same consumers, no separate \`-prover\` variant — and the prover code path is gated at runtime by env vars (\`SP1_PROVER\`, \`SP1_PROOF_STRATEGY\`, \`NETWORK_PRIVATE_KEY\`). When those env vars are unset, the prover code is dormant and there's no behavioral change.

## Dependency

Blocked on **#1663** (adds \`ARG CARGO_FEATURES\` to \`docker/strata/Dockerfile\`). Once #1663 merges, this change becomes effective. Until then, \`docker buildx\` will warn \"unknown build arg\" but proceed without it (no behavioral change).

## Notes

- The \`sp1\` feature in \`bin/strata/Cargo.toml\` pulls in \`zkaleido-sp1-host\` (client SDK for talking to the remote prover) but **not** \`sp1-builder\` (guest ELF compiler). So no SP1 toolchain install is needed inside the Docker build — same runner setup as today.
- First build with the new feature flag will invalidate the cargo-chef cache (~40 min one-time). Subsequent builds with the same features are cached.
- Image size grows by ~50–100 MB from the SP1 SDK deps.

## Test plan

- [ ] Wait for #1663 to merge
- [ ] Trigger this workflow via \`workflow_dispatch\` with \`programs: strata\` and verify the published image runs and accepts the prover env vars
- [ ] Smoke-test in dev cluster by bumping \`strata-ol\` image tag and confirming \`sp1_sdk::network::prover\` activity in logs

## Related

- alpen #1663 — Add CARGO_FEATURES to Dockerfile
- deployments #260 — Stage SP1 prover env vars on strata-ol (dev)