### PR TITLE
STR 2751 Investigate flaky OL block timings

### DIFF
--- a/bin/strata/src/rpc/mod.rs
+++ b/bin/strata/src/rpc/mod.rs
@@ -184,6 +184,7 @@ async fn spawn_rpc(deps: RpcDeps) -> Result<()> {
     if let Some(sequencer_deps) = deps.seq_deps {
         let ol_seq_listener = OLSeqRpcServer::new(
             deps.storage.clone(),
+            deps.status_channel.clone(),
             sequencer_deps.blockasm_handle().clone(),
             sequencer_deps.envelope_handle().clone(),
             deps.fcm_handle.clone(),

--- a/bin/strata/src/sequencer/mod.rs
+++ b/bin/strata/src/sequencer/mod.rs
@@ -3,6 +3,7 @@
 mod block_producer;
 mod node_context;
 mod rpc;
+mod tip;
 
 pub(crate) use block_producer::start_block_producer;
 pub(crate) use rpc::OLSeqRpcServer;

--- a/bin/strata/src/sequencer/node_context.rs
+++ b/bin/strata/src/sequencer/node_context.rs
@@ -1,14 +1,23 @@
 //! Concrete [`SequencerContext`] implementation for the Strata node.
 
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use async_trait::async_trait;
+use strata_identifiers::OLBlockId;
 use strata_ol_block_assembly::{BlockAssemblyError, BlockasmHandle};
 use strata_ol_sequencer::{BlockGenerationConfig, SequencerContext, SequencerContextError};
-use strata_primitives::{OLBlockCommitment, OLBlockId};
 use strata_status::StatusChannel;
 use strata_storage::NodeStorage;
 use tracing::{debug, warn};
+
+use crate::sequencer::tip::resolve_canonical_tip;
+
+/// Percentage drift of block wall-clock spacing above the configured
+/// `ol_block_time_ms` that triggers a cadence warning.
+const BLOCK_TS_DRIFT_TOLERANCE_PCT: u64 = 20;
 
 /// Node-level context providing concrete infrastructure for the sequencer service.
 pub(crate) struct NodeSequencerContext {
@@ -32,36 +41,19 @@ impl NodeSequencerContext {
             ol_block_time_ms,
         }
     }
-
-    /// Resolve the current chain tip block ID.
-    async fn resolve_tip(&self) -> Result<OLBlockId, SequencerContextError> {
-        if let Some(tip) = self
-            .status_channel
-            .get_ol_sync_status()
-            .map(|s| *s.tip_blkid())
-        {
-            return Ok(tip);
-        }
-
-        match self.storage.ol_block().get_canonical_tip_async().await {
-            Ok(Some(commitment)) => Ok(*commitment.blkid()),
-            Ok(None) => {
-                warn!("canonical tip not found yet");
-                Ok(OLBlockId::default())
-            }
-            Err(e) => Err(SequencerContextError::Db(e)),
-        }
-    }
 }
 
 #[async_trait]
 impl SequencerContext for NodeSequencerContext {
     async fn generate_template_for_tip(&self) -> Result<Option<OLBlockId>, SequencerContextError> {
-        let tip_blkid = self.resolve_tip().await?;
-        if tip_blkid == OLBlockId::default() {
+        let Some(parent_commitment) = resolve_canonical_tip(&self.status_channel, &self.storage)
+            .await
+            .map_err(SequencerContextError::Db)?
+        else {
             debug!("template generation skipped: canonical tip unavailable");
             return Ok(None);
-        }
+        };
+        let tip_blkid = *parent_commitment.blkid();
 
         debug!(tip_blkid = ?tip_blkid, "template generation attempt");
 
@@ -77,16 +69,31 @@ impl SequencerContext for NodeSequencerContext {
             })?;
         let parent_header = parent_block.header();
 
-        let parent_commitment = OLBlockCommitment::new(parent_header.slot(), tip_blkid);
-        let target_ts = parent_header
-            .timestamp()
-            .saturating_add(self.ol_block_time_ms);
+        let parent_ts = parent_header.timestamp();
+        let target_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_millis() as u64;
+
+        let time_since_parent = target_ts.saturating_sub(parent_ts);
+        let threshold_ms = self.ol_block_time_ms * (100 + BLOCK_TS_DRIFT_TOLERANCE_PCT) / 100;
+        if time_since_parent > threshold_ms {
+            warn!(
+                time_since_parent,
+                block_time_ms = self.ol_block_time_ms,
+                threshold_ms,
+                parent_ts,
+                target_ts,
+                "block wall-clock interval exceeds block_time by more than {BLOCK_TS_DRIFT_TOLERANCE_PCT}%",
+            );
+        }
+
         let config = BlockGenerationConfig::new(parent_commitment).with_ts(target_ts);
 
         debug!(
             tip_blkid = ?tip_blkid,
             parent_slot = parent_header.slot(),
-            parent_ts = parent_header.timestamp(),
+            parent_ts,
             target_ts,
             "submitting template generation request"
         );

--- a/bin/strata/src/sequencer/rpc.rs
+++ b/bin/strata/src/sequencer/rpc.rs
@@ -22,15 +22,22 @@ use strata_primitives::{
     HexBytes32, HexBytes64,
     buf::{Buf32, Buf64},
 };
+use strata_status::StatusChannel;
 use strata_storage::NodeStorage;
 use tracing::{info, warn};
 
-use crate::rpc::errors::{db_error, internal_error, not_found_error};
+use crate::{
+    rpc::errors::{db_error, internal_error, not_found_error},
+    sequencer::tip::resolve_canonical_tip,
+};
 
 /// Rpc handler for sequencer.
 pub(crate) struct OLSeqRpcServer {
     /// Storage backend.
     storage: Arc<NodeStorage>,
+
+    /// Status channel for resolving the current canonical tip.
+    status_channel: Arc<StatusChannel>,
 
     /// Block assembly handle.
     blockasm_handle: Arc<BlockasmHandle>,
@@ -51,6 +58,7 @@ impl OLSeqRpcServer {
     /// Creates a new [`OLSeqRpcServer`] instance.
     pub(crate) fn new(
         storage: Arc<NodeStorage>,
+        status_channel: Arc<StatusChannel>,
         blockasm_handle: Arc<BlockasmHandle>,
         envelope_handle: Arc<EnvelopeHandle>,
         fcm_handle: Arc<FcmServiceHandle>,
@@ -58,6 +66,7 @@ impl OLSeqRpcServer {
     ) -> Self {
         Self {
             storage,
+            status_channel,
             blockasm_handle,
             envelope_handle,
             fcm_handle,
@@ -69,19 +78,15 @@ impl OLSeqRpcServer {
 #[async_trait]
 impl OLSequencerRpcServer for OLSeqRpcServer {
     async fn get_sequencer_duties(&self) -> RpcResult<Vec<RpcDuty>> {
-        let Some(tip_blkid) = self
-            .storage
-            .ol_block()
-            .get_canonical_tip_async()
+        let Some(tip_commitment) = resolve_canonical_tip(&self.status_channel, &self.storage)
             .await
             .map_err(db_error)?
-            .map(|c| *c.blkid())
         else {
             return Ok(vec![]);
         };
         let duties = extract_duties(
             self.blockasm_handle.as_ref(),
-            tip_blkid,
+            *tip_commitment.blkid(),
             self.storage.as_ref(),
         )
         .await

--- a/bin/strata/src/sequencer/tip.rs
+++ b/bin/strata/src/sequencer/tip.rs
@@ -1,0 +1,22 @@
+//! Shared canonical tip resolution.
+
+use strata_db_types::DbResult;
+use strata_identifiers::OLBlockCommitment;
+use strata_status::StatusChannel;
+use strata_storage::NodeStorage;
+
+/// Resolves the current canonical tip.
+///
+/// Prefers the in-memory [`StatusChannel`] (published by FCM before the new
+/// block's status is written to storage), falling back to
+/// `storage.ol_block().get_canonical_tip_async()` when the channel has not
+/// been initialized yet.
+pub(crate) async fn resolve_canonical_tip(
+    status_channel: &StatusChannel,
+    storage: &NodeStorage,
+) -> DbResult<Option<OLBlockCommitment>> {
+    if let Some(tip) = status_channel.get_ol_sync_status().map(|s| s.tip) {
+        return Ok(Some(tip));
+    }
+    storage.ol_block().get_canonical_tip_async().await
+}


### PR DESCRIPTION
## Description

Investigated flaky block time issue from [STR-2751](https://alpenlabs.atlassian.net/browse/STR-2751). Found that his is related to OL canonical chain tip resolution.

- Align sequencer tip-resolution across `GenerationTick` (template generation) and the duty-extraction RPC so both read from the same source. Before this change, GenerationTick preferred `status_channel` while `get_sequencer_duties` read directly from storage — so during the FCM window between publishing a new tip to the status channel and writing the block's `Valid` status to storage, the two paths disagreed: GenerationTick cached a template for the new tip while the signer's RPC was still asking for a template keyed on the old tip (whose template had just been consumed). The signer saw empty duties for a slot that was otherwise ready.
- Stamp the block's `timestamp` with `SystemTime::now()` instead of the deterministic `parent_ts + ol_block_time_ms`. Chain time now reflects real production cadence, which surfaces cadence anomalies in the block headers themselves.
- Warn when the wall-clock interval from the parent block exceeds `ol_block_time_ms * (1 + BLOCK_TS_DRIFT_TOLERANCE_PCT / 100)` (default 20%). Silent in a healthy chain; fires on the production race symptom.


Reproduced the issue in a functional test (without the fix) and tested the fix using two approaches. Sampled 80 block times from block headers and block duties (by adding explicit timestamp to duty struct).
1. Removed the status channel based tip resolution so both template generation and rpc get tip from db.
2. Adding status channel based tip resolution to rpc path so both template generation and rpc first check status channeld and fall back to db.

In both cases, block times are consistent after making both parties use shared tip resolution.

This PR was created with help from Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This fix is related to [STR-3105](https://alpenlabs.atlassian.net/browse/STR-3105). Just addressing the block time issue here. Let me know if STR-3105 needs to go in first.

We could add a functional test that was used to test the fix. But that requires changing the defaults for block time and duty poll interval if we want to sample ample number of block times. Also need explicit timestamp in duty struct. Hence run locally, but not committed.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-2751](https://alpenlabs.atlassian.net/browse/STR-2751)

[STR-2751]: https://alpenlabs.atlassian.net/browse/STR-2751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STR-3105]: https://alpenlabs.atlassian.net/browse/STR-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ