### PR TITLE
feat(ee-da): add `block_hash` to `EvmHeaderSummary` (STR-2320)

### DIFF
--- a/bin/alpen-client/src/header_summary.rs
+++ b/bin/alpen-client/src/header_summary.rs
@@ -2,7 +2,7 @@
 //!
 //! The DA blob pipeline needs an [`EvmHeaderSummary`] for each batch so that
 //! verifiers can reconstruct EVM chain metadata (block number, timestamp,
-//! base fee, gas used/limit). [`RethHeaderSummaryProvider`]
+//! base fee, gas used/limit, block hash, state root). [`RethHeaderSummaryProvider`]
 //! satisfies the [`HeaderSummaryProvider`] trait by reading headers directly
 //! from the Reth [`HeaderProvider`](reth_provider::HeaderProvider).
 //!
@@ -12,6 +12,7 @@
 //! [`alpen_ee_da`].
 
 use alpen_ee_common::{EvmHeaderSummary, HeaderSummaryProvider};
+use strata_acct_types::Hash;
 
 /// [`HeaderSummaryProvider`] backed by a Reth [`HeaderProvider`](reth_provider::HeaderProvider).
 pub(crate) struct RethHeaderSummaryProvider<P> {
@@ -44,6 +45,8 @@ where
             })?,
             gas_used: header.gas_used,
             gas_limit: header.gas_limit,
+            block_hash: Hash::from(header.hash_slow().0),
+            state_root: Hash::from(header.state_root.0),
         })
     }
 }

--- a/bin/alpen-client/src/header_summary.rs
+++ b/bin/alpen-client/src/header_summary.rs
@@ -2,7 +2,7 @@
 //!
 //! The DA blob pipeline needs an [`EvmHeaderSummary`] for each batch so that
 //! verifiers can reconstruct EVM chain metadata (block number, timestamp,
-//! base fee, gas used/limit, block hash, state root). [`RethHeaderSummaryProvider`]
+//! base fee, gas used/limit, state root). [`RethHeaderSummaryProvider`]
 //! satisfies the [`HeaderSummaryProvider`] trait by reading headers directly
 //! from the Reth [`HeaderProvider`](reth_provider::HeaderProvider).
 //!
@@ -55,7 +55,6 @@ fn summarize_header(header: &reth_primitives::Header) -> eyre::Result<EvmHeaderS
         })?,
         gas_used: header.gas_used,
         gas_limit: header.gas_limit,
-        block_hash: Hash::from(header.hash_slow().0),
         state_root: Hash::from(header.state_root.0),
     })
 }
@@ -68,8 +67,7 @@ mod tests {
     use super::*;
 
     /// Header → EvmHeaderSummary mapping: verifies each field comes from the
-    /// right source on the reth header, catching swaps (e.g. `block_hash`
-    /// vs `state_root`) that would compile but corrupt DA blobs.
+    /// right source on the reth header.
     #[test]
     fn summarize_header_maps_fields_correctly() {
         let state_root = B256::repeat_byte(0xAA);
@@ -84,8 +82,6 @@ mod tests {
             state_root,
             ..Default::default()
         };
-        let expected_block_hash_bytes = header.hash_slow().0;
-
         let summary = summarize_header(&header).expect("mapping must succeed");
 
         assert_eq!(summary.block_num, 12345);
@@ -94,18 +90,9 @@ mod tests {
         assert_eq!(summary.gas_used, 15_000_000);
         assert_eq!(summary.gas_limit, 30_000_000);
         assert_eq!(
-            summary.block_hash,
-            Hash::from(expected_block_hash_bytes),
-            "block_hash must come from header.hash_slow(), not state_root"
-        );
-        assert_eq!(
             summary.state_root,
             Hash::from(expected_state_root_bytes),
-            "state_root must come from header.state_root, not hash_slow()"
-        );
-        assert_ne!(
-            summary.block_hash, summary.state_root,
-            "distinct sources must produce distinct values — guards against field-swap regressions"
+            "state_root must come from header.state_root"
         );
     }
 

--- a/bin/alpen-client/src/header_summary.rs
+++ b/bin/alpen-client/src/header_summary.rs
@@ -2,7 +2,7 @@
 //!
 //! The DA blob pipeline needs an [`EvmHeaderSummary`] for each batch so that
 //! verifiers can reconstruct EVM chain metadata (block number, timestamp,
-//! base fee, gas used/limit, state root). [`RethHeaderSummaryProvider`]
+//! base fee, gas used/limit). [`RethHeaderSummaryProvider`]
 //! satisfies the [`HeaderSummaryProvider`] trait by reading headers directly
 //! from the Reth [`HeaderProvider`](reth_provider::HeaderProvider).
 //!
@@ -12,7 +12,6 @@
 //! [`alpen_ee_da`].
 
 use alpen_ee_common::{EvmHeaderSummary, HeaderSummaryProvider};
-use strata_acct_types::Hash;
 
 /// [`HeaderSummaryProvider`] backed by a Reth [`HeaderProvider`](reth_provider::HeaderProvider).
 pub(crate) struct RethHeaderSummaryProvider<P> {
@@ -55,13 +54,11 @@ fn summarize_header(header: &reth_primitives::Header) -> eyre::Result<EvmHeaderS
         })?,
         gas_used: header.gas_used,
         gas_limit: header.gas_limit,
-        state_root: Hash::from(header.state_root.0),
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
     use reth_primitives::Header;
 
     use super::*;
@@ -70,16 +67,12 @@ mod tests {
     /// right source on the reth header.
     #[test]
     fn summarize_header_maps_fields_correctly() {
-        let state_root = B256::repeat_byte(0xAA);
-        let expected_state_root_bytes = state_root.0;
-
         let header = Header {
             number: 12345,
             timestamp: 1_700_000_000,
             base_fee_per_gas: Some(1_000_000_000),
             gas_used: 15_000_000,
             gas_limit: 30_000_000,
-            state_root,
             ..Default::default()
         };
         let summary = summarize_header(&header).expect("mapping must succeed");
@@ -89,11 +82,6 @@ mod tests {
         assert_eq!(summary.base_fee, 1_000_000_000);
         assert_eq!(summary.gas_used, 15_000_000);
         assert_eq!(summary.gas_limit, 30_000_000);
-        assert_eq!(
-            summary.state_root,
-            Hash::from(expected_state_root_bytes),
-            "state_root must come from header.state_root"
-        );
     }
 
     #[test]

--- a/bin/alpen-client/src/header_summary.rs
+++ b/bin/alpen-client/src/header_summary.rs
@@ -34,19 +34,93 @@ where
             .provider
             .header_by_number(block_num)?
             .ok_or_else(|| eyre::eyre!("no header for block {block_num}"))?;
-        Ok(EvmHeaderSummary {
-            block_num: header.number,
-            timestamp: header.timestamp,
-            base_fee: header.base_fee_per_gas.ok_or_else(|| {
-                eyre::eyre!(
-                    "block {block_num} missing base_fee_per_gas; \
-                     Alpen is post-London from genesis so this should always be present"
-                )
-            })?,
-            gas_used: header.gas_used,
-            gas_limit: header.gas_limit,
-            block_hash: Hash::from(header.hash_slow().0),
-            state_root: Hash::from(header.state_root.0),
-        })
+        summarize_header(&header)
+    }
+}
+
+/// Extracts the [`EvmHeaderSummary`] fields from a reth header.
+///
+/// Split out from the trait impl so the reth → DA mapping can be unit-tested
+/// without constructing a full [`reth_provider::HeaderProvider`].
+fn summarize_header(header: &reth_primitives::Header) -> eyre::Result<EvmHeaderSummary> {
+    Ok(EvmHeaderSummary {
+        block_num: header.number,
+        timestamp: header.timestamp,
+        base_fee: header.base_fee_per_gas.ok_or_else(|| {
+            eyre::eyre!(
+                "block {} missing base_fee_per_gas; \
+                 Alpen is post-London from genesis so this should always be present",
+                header.number
+            )
+        })?,
+        gas_used: header.gas_used,
+        gas_limit: header.gas_limit,
+        block_hash: Hash::from(header.hash_slow().0),
+        state_root: Hash::from(header.state_root.0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use reth_primitives::Header;
+
+    use super::*;
+
+    /// Header → EvmHeaderSummary mapping: verifies each field comes from the
+    /// right source on the reth header, catching swaps (e.g. `block_hash`
+    /// vs `state_root`) that would compile but corrupt DA blobs.
+    #[test]
+    fn summarize_header_maps_fields_correctly() {
+        let state_root = B256::repeat_byte(0xAA);
+        let expected_state_root_bytes = state_root.0;
+
+        let header = Header {
+            number: 12345,
+            timestamp: 1_700_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            gas_used: 15_000_000,
+            gas_limit: 30_000_000,
+            state_root,
+            ..Default::default()
+        };
+        let expected_block_hash_bytes = header.hash_slow().0;
+
+        let summary = summarize_header(&header).expect("mapping must succeed");
+
+        assert_eq!(summary.block_num, 12345);
+        assert_eq!(summary.timestamp, 1_700_000_000);
+        assert_eq!(summary.base_fee, 1_000_000_000);
+        assert_eq!(summary.gas_used, 15_000_000);
+        assert_eq!(summary.gas_limit, 30_000_000);
+        assert_eq!(
+            summary.block_hash,
+            Hash::from(expected_block_hash_bytes),
+            "block_hash must come from header.hash_slow(), not state_root"
+        );
+        assert_eq!(
+            summary.state_root,
+            Hash::from(expected_state_root_bytes),
+            "state_root must come from header.state_root, not hash_slow()"
+        );
+        assert_ne!(
+            summary.block_hash, summary.state_root,
+            "distinct sources must produce distinct values — guards against field-swap regressions"
+        );
+    }
+
+    #[test]
+    fn summarize_header_errors_when_base_fee_missing() {
+        let header = Header {
+            number: 7,
+            base_fee_per_gas: None,
+            ..Default::default()
+        };
+        let err = summarize_header(&header).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("base_fee_per_gas") && msg.contains("block 7"),
+            "error must identify missing field and block number, got: {msg}"
+        );
     }
 }

--- a/crates/alpen-ee/common/src/types/da.rs
+++ b/crates/alpen-ee/common/src/types/da.rs
@@ -4,6 +4,7 @@
 //! into Bitcoin envelope chunks for inscription.
 
 use alpen_reth_statediff::BatchStateDiff;
+use strata_acct_types::Hash;
 use strata_codec::{decode_buf_exact, encode_to_vec, BufDecoder, Codec, CodecError};
 use strata_crypto::hash;
 use strata_identifiers::Buf32;
@@ -12,15 +13,19 @@ use crate::BatchId;
 
 /// Compact summary of the last EVM block header in a batch.
 ///
-/// Captures the subset of the EVM block header needed to build the next
-/// block during DA-only chain reconstruction. A new sequencer recovering
-/// from L1 DA has the [`BatchStateDiff`] (account/storage changes) but
-/// **not** the block headers themselves — these fields fill that gap.
+/// Captures the subset of the EVM block header a sequencer recovering
+/// purely from L1 DA needs to (a) build the next EVM block and (b) feed
+/// the EE proof statement. A fresh sequencer has the [`BatchStateDiff`]
+/// (account/storage changes) but **not** the block headers themselves —
+/// these fields fill that gap.
 ///
 /// - `base_fee`, `gas_used`, `gas_limit` feed the EIP-1559 base-fee calculation and gas-limit
 ///   adjustment for the next block.
 /// - `timestamp` enforces monotonicity (`next > parent`).
 /// - `block_num` identifies where the chain continues.
+/// - `block_hash` becomes the `parent_hash` of the next block and anchors chain-continuity checks
+///   in the EE proof.
+/// - `state_root` pins the pre-state root the next block's EE proof opens against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Codec)]
 pub struct EvmHeaderSummary {
     /// Block number of the last EVM block in this batch.
@@ -33,6 +38,16 @@ pub struct EvmHeaderSummary {
     pub gas_used: u64,
     /// Gas limit of the last EVM block.
     pub gas_limit: u64,
+    /// Block hash of the last EVM block in this batch.
+    ///
+    /// Becomes the `parent_hash` of the next block; required by the EE
+    /// proof for chain-continuity verification.
+    pub block_hash: Hash,
+    /// Post-state root of the last EVM block.
+    ///
+    /// Required by the EE proof so the next block's pre-state root can
+    /// be pinned to DA.
+    pub state_root: Hash,
 }
 
 /// DA blob containing batch metadata and state diff.
@@ -308,6 +323,8 @@ mod tests {
                 base_fee: 1_000_000_000,
                 gas_used: 15_000_000,
                 gas_limit: 30_000_000,
+                block_hash: Hash::from([0x33; 32]),
+                state_root: Hash::from([0x44; 32]),
             },
             state_diff: BatchStateDiff::default(),
         }

--- a/crates/alpen-ee/common/src/types/da.rs
+++ b/crates/alpen-ee/common/src/types/da.rs
@@ -4,7 +4,6 @@
 //! into Bitcoin envelope chunks for inscription.
 
 use alpen_reth_statediff::BatchStateDiff;
-use strata_acct_types::Hash;
 use strata_codec::{decode_buf_exact, encode_to_vec, BufDecoder, Codec, CodecError};
 use strata_crypto::hash;
 use strata_identifiers::Buf32;
@@ -14,18 +13,16 @@ use crate::BatchId;
 /// Compact summary of the last EVM block header in a batch.
 ///
 /// Captures the subset of the terminal EVM block header a sequencer recovering
-/// purely from L1 DA needs to (a) build the next EVM block and (b) feed
-/// the EE proof statement. A fresh sequencer has the [`BatchStateDiff`]
-/// (account/storage changes) but **not** the block headers themselves —
-/// these fields fill that gap. The terminal block hash is carried separately
-/// by [`DaBlob::batch_id`].
+/// purely from L1 DA needs to build the next EVM block. A fresh sequencer has
+/// the [`BatchStateDiff`] for account/storage changes but **not** the block
+/// headers themselves, so these non-derivable header fields fill that gap. The
+/// terminal block hash is carried separately by [`DaBlob::batch_id`], and the
+/// terminal post-state root is reconstructible by applying the DA state diffs.
 ///
 /// - `base_fee`, `gas_used`, `gas_limit` feed the EIP-1559 base-fee calculation and gas-limit
 ///   adjustment for the next block.
 /// - `timestamp` enforces monotonicity (`next > parent`).
 /// - `block_num` identifies where the chain continues.
-/// - `state_root` is the terminal post-state root, which pins the pre-state root the next block's
-///   EE proof opens against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Codec)]
 pub struct EvmHeaderSummary {
     /// Block number of the last EVM block in this batch.
@@ -38,11 +35,6 @@ pub struct EvmHeaderSummary {
     pub gas_used: u64,
     /// Gas limit of the last EVM block.
     pub gas_limit: u64,
-    /// Post-state root of the last EVM block.
-    ///
-    /// Required by the EE proof so the next block's pre-state root can
-    /// be pinned to DA.
-    pub state_root: Hash,
 }
 
 /// DA blob containing batch metadata and state diff.
@@ -318,7 +310,6 @@ mod tests {
                 base_fee: 1_000_000_000,
                 gas_used: 15_000_000,
                 gas_limit: 30_000_000,
-                state_root: Hash::from([0x44; 32]),
             },
             state_diff: BatchStateDiff::default(),
         }

--- a/crates/alpen-ee/common/src/types/da.rs
+++ b/crates/alpen-ee/common/src/types/da.rs
@@ -13,19 +13,19 @@ use crate::BatchId;
 
 /// Compact summary of the last EVM block header in a batch.
 ///
-/// Captures the subset of the EVM block header a sequencer recovering
+/// Captures the subset of the terminal EVM block header a sequencer recovering
 /// purely from L1 DA needs to (a) build the next EVM block and (b) feed
 /// the EE proof statement. A fresh sequencer has the [`BatchStateDiff`]
 /// (account/storage changes) but **not** the block headers themselves —
-/// these fields fill that gap.
+/// these fields fill that gap. The terminal block hash is carried separately
+/// by [`DaBlob::batch_id`].
 ///
 /// - `base_fee`, `gas_used`, `gas_limit` feed the EIP-1559 base-fee calculation and gas-limit
 ///   adjustment for the next block.
 /// - `timestamp` enforces monotonicity (`next > parent`).
 /// - `block_num` identifies where the chain continues.
-/// - `block_hash` becomes the `parent_hash` of the next block and anchors chain-continuity checks
-///   in the EE proof.
-/// - `state_root` pins the pre-state root the next block's EE proof opens against.
+/// - `state_root` is the terminal post-state root, which pins the pre-state root the next block's
+///   EE proof opens against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Codec)]
 pub struct EvmHeaderSummary {
     /// Block number of the last EVM block in this batch.
@@ -38,11 +38,6 @@ pub struct EvmHeaderSummary {
     pub gas_used: u64,
     /// Gas limit of the last EVM block.
     pub gas_limit: u64,
-    /// Block hash of the last EVM block in this batch.
-    ///
-    /// Becomes the `parent_hash` of the next block; required by the EE
-    /// proof for chain-continuity verification.
-    pub block_hash: Hash,
     /// Post-state root of the last EVM block.
     ///
     /// Required by the EE proof so the next block's pre-state root can
@@ -323,7 +318,6 @@ mod tests {
                 base_fee: 1_000_000_000,
                 gas_used: 15_000_000,
                 gas_limit: 30_000_000,
-                block_hash: Hash::from([0x33; 32]),
                 state_root: Hash::from([0x44; 32]),
             },
             state_diff: BatchStateDiff::default(),

--- a/functional-tests/tests/alpen_client/ee_da/codec.py
+++ b/functional-tests/tests/alpen_client/ee_da/codec.py
@@ -46,7 +46,6 @@ class EvmHeaderDigest:
     base_fee: int
     gas_used: int
     gas_limit: int
-    block_hash: bytes
     state_root: bytes
 
 
@@ -127,16 +126,15 @@ def parse_evm_header_digest(data: bytes) -> EvmHeaderDigest | None:
     """
     Parse EvmHeaderDigest from strata-codec encoded bytes.
 
-    Layout (104 bytes):
+    Layout (72 bytes):
     - block_num: 8 bytes
     - timestamp: 8 bytes
     - base_fee: 8 bytes
     - gas_used: 8 bytes
     - gas_limit: 8 bytes
-    - block_hash: 32 bytes
     - state_root: 32 bytes
     """
-    if len(data) < 104:
+    if len(data) < 72:
         return None
 
     return EvmHeaderDigest(
@@ -145,8 +143,7 @@ def parse_evm_header_digest(data: bytes) -> EvmHeaderDigest | None:
         base_fee=int.from_bytes(data[16:24], "big"),
         gas_used=int.from_bytes(data[24:32], "big"),
         gas_limit=int.from_bytes(data[32:40], "big"),
-        block_hash=data[40:72],
-        state_root=data[72:104],
+        state_root=data[40:72],
     )
 
 
@@ -157,17 +154,16 @@ def parse_da_blob(data: bytes) -> DaBlob | None:
     Layout:
     - batch_id.prev_block: 32 bytes (raw)
     - batch_id.last_block: 32 bytes (raw)
-    - evm_header: 104 bytes
+    - evm_header: 72 bytes
       - 5 x u64 BE
-      - block_hash: 32 bytes
       - state_root: 32 bytes
     - state_diff: remaining bytes (BatchStateDiff encoding)
     """
-    # Minimum: 32 + 32 + 104 = 168
-    if len(data) < 168:
+    # Minimum: 32 + 32 + 72 = 136
+    if len(data) < 136:
         return None
 
-    evm_header = parse_evm_header_digest(data[64:168])
+    evm_header = parse_evm_header_digest(data[64:136])
     if evm_header is None:
         return None
 
@@ -175,7 +171,7 @@ def parse_da_blob(data: bytes) -> DaBlob | None:
         batch_id_prev_block=data[0:32],
         batch_id_last_block=data[32:64],
         evm_header=evm_header,
-        state_diff=data[168:],
+        state_diff=data[136:],
     )
 
 

--- a/functional-tests/tests/alpen_client/ee_da/codec.py
+++ b/functional-tests/tests/alpen_client/ee_da/codec.py
@@ -46,7 +46,6 @@ class EvmHeaderDigest:
     base_fee: int
     gas_used: int
     gas_limit: int
-    state_root: bytes
 
 
 @dataclass
@@ -126,15 +125,14 @@ def parse_evm_header_digest(data: bytes) -> EvmHeaderDigest | None:
     """
     Parse EvmHeaderDigest from strata-codec encoded bytes.
 
-    Layout (72 bytes):
+    Layout (40 bytes):
     - block_num: 8 bytes
     - timestamp: 8 bytes
     - base_fee: 8 bytes
     - gas_used: 8 bytes
     - gas_limit: 8 bytes
-    - state_root: 32 bytes
     """
-    if len(data) < 72:
+    if len(data) < 40:
         return None
 
     return EvmHeaderDigest(
@@ -143,7 +141,6 @@ def parse_evm_header_digest(data: bytes) -> EvmHeaderDigest | None:
         base_fee=int.from_bytes(data[16:24], "big"),
         gas_used=int.from_bytes(data[24:32], "big"),
         gas_limit=int.from_bytes(data[32:40], "big"),
-        state_root=data[40:72],
     )
 
 
@@ -154,16 +151,15 @@ def parse_da_blob(data: bytes) -> DaBlob | None:
     Layout:
     - batch_id.prev_block: 32 bytes (raw)
     - batch_id.last_block: 32 bytes (raw)
-    - evm_header: 72 bytes
+    - evm_header: 40 bytes
       - 5 x u64 BE
-      - state_root: 32 bytes
     - state_diff: remaining bytes (BatchStateDiff encoding)
     """
-    # Minimum: 32 + 32 + 72 = 136
-    if len(data) < 136:
+    # Minimum: 32 + 32 + 40 = 104
+    if len(data) < 104:
         return None
 
-    evm_header = parse_evm_header_digest(data[64:136])
+    evm_header = parse_evm_header_digest(data[64:104])
     if evm_header is None:
         return None
 
@@ -171,7 +167,7 @@ def parse_da_blob(data: bytes) -> DaBlob | None:
         batch_id_prev_block=data[0:32],
         batch_id_last_block=data[32:64],
         evm_header=evm_header,
-        state_diff=data[136:],
+        state_diff=data[104:],
     )
 
 

--- a/functional-tests/tests/alpen_client/ee_da/codec.py
+++ b/functional-tests/tests/alpen_client/ee_da/codec.py
@@ -39,13 +39,15 @@ class DaChunkHeader:
 
 @dataclass
 class EvmHeaderDigest:
-    """Parsed EVM header digest (5 x u64 = 40 bytes)."""
+    """Parsed EVM header digest from the DA blob."""
 
     block_num: int
     timestamp: int
     base_fee: int
     gas_used: int
     gas_limit: int
+    block_hash: bytes
+    state_root: bytes
 
 
 @dataclass
@@ -125,14 +127,16 @@ def parse_evm_header_digest(data: bytes) -> EvmHeaderDigest | None:
     """
     Parse EvmHeaderDigest from strata-codec encoded bytes.
 
-    Layout (40 bytes, 5 x u64 big-endian):
+    Layout (104 bytes):
     - block_num: 8 bytes
     - timestamp: 8 bytes
     - base_fee: 8 bytes
     - gas_used: 8 bytes
     - gas_limit: 8 bytes
+    - block_hash: 32 bytes
+    - state_root: 32 bytes
     """
-    if len(data) < 40:
+    if len(data) < 104:
         return None
 
     return EvmHeaderDigest(
@@ -141,6 +145,8 @@ def parse_evm_header_digest(data: bytes) -> EvmHeaderDigest | None:
         base_fee=int.from_bytes(data[16:24], "big"),
         gas_used=int.from_bytes(data[24:32], "big"),
         gas_limit=int.from_bytes(data[32:40], "big"),
+        block_hash=data[40:72],
+        state_root=data[72:104],
     )
 
 
@@ -151,14 +157,17 @@ def parse_da_blob(data: bytes) -> DaBlob | None:
     Layout:
     - batch_id.prev_block: 32 bytes (raw)
     - batch_id.last_block: 32 bytes (raw)
-    - evm_header: 40 bytes (EvmHeaderDigest: 5 x u64 BE)
+    - evm_header: 104 bytes
+      - 5 x u64 BE
+      - block_hash: 32 bytes
+      - state_root: 32 bytes
     - state_diff: remaining bytes (BatchStateDiff encoding)
     """
-    # Minimum: 32 + 32 + 40 = 104
-    if len(data) < 104:
+    # Minimum: 32 + 32 + 104 = 168
+    if len(data) < 168:
         return None
 
-    evm_header = parse_evm_header_digest(data[64:104])
+    evm_header = parse_evm_header_digest(data[64:168])
     if evm_header is None:
         return None
 
@@ -166,7 +175,7 @@ def parse_da_blob(data: bytes) -> DaBlob | None:
         batch_id_prev_block=data[0:32],
         batch_id_last_block=data[32:64],
         evm_header=evm_header,
-        state_diff=data[104:],
+        state_diff=data[168:],
     )
 
 


### PR DESCRIPTION
## Description

Extends `EvmHeaderSummary` — the compact EVM header we pin inside each
`DaBlob` posted to L1 — with one new fields: `block_hash` (the last
block's own hash, which becomes `parent_hash` of the next block).
`state_root` can be reconstructible, if the recovery path indexes DA from the trusted base and applies each `BatchStateDiff` in order, and does not need to be carried in EvmHeaderSummary. The original shape shipped in #1340 was designed around
block-assembly needs only (EIP-1559 base-fee calc, gas-limit adjust,
timestamp monotonicity). With the EE proof statement now finalized, a
sequencer recovering purely from L1 DA also needs this field to
verify chain continuity.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- **DA wire format:** adding fields to a `#[derive(Codec)]` struct
  changes the on-wire layout of `DaBlob`. Blobs written with the
  previous layout will not decode into the new struct. This is
  considered safe because the chunked-envelope DA format is still
  pre-production — if that assumption is wrong, we should land a
  `DaBlob` version byte first.
- **Test strategy:** the trait impl is thin, so the reth `Header →
  EvmHeaderSummary` mapping was extracted into a free function
  `summarize_header` and unit-tested directly. The test asserts every
  field maps from the correct source and includes a `block_hash !=
  state_root` sanity check specifically designed to catch a
  field-swap regression (verified locally by introducing and then
  reverting a swap).
- **AI assistance:** this PR was drafted with AI assistance per
  [CONTRIBUTING.md](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice).

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-2320