### PR TITLE
refactor: ensure syncStatus channel is updated in fresh start (genesis) and in restarts

### DIFF
--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -19,16 +19,17 @@ use strata_config::{
     BitcoindConfig, BlockAssemblyConfig, Config, SequencerConfig, SequencerRuntimeConfig,
 };
 use strata_csm_types::{ClientState, ClientUpdateOutput, L1Status};
+use strata_identifiers::Epoch;
 use strata_node_context::NodeContext;
 use strata_ol_params::OLParams;
 use strata_params::{Params, RollupParams, SyncParams};
 #[cfg(feature = "prover")]
 use strata_predicate::PredicateTypeId;
-use strata_primitives::L1BlockCommitment;
-use strata_status::StatusChannel;
+use strata_primitives::{L1BlockCommitment, OLBlockCommitment};
+use strata_status::{OLSyncStatus, OLSyncStatusUpdate, StatusChannel};
 use strata_storage::{NodeStorage, create_node_storage};
 use tokio::runtime::Handle;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{args::*, config::*, errors::*, genesis::init_ol_genesis, init_db};
 
@@ -363,10 +364,36 @@ fn init_status_channel(
     Ok(StatusChannel::new(cur_state, cur_block, l1_status, None, None).into())
 }
 
-pub(crate) fn check_and_init_genesis(
+/// Ensures client state and OL genesis, updates status channel.
+pub(crate) fn ensure_genesis(
+    storage: &NodeStorage,
+    ol_params: &OLParams,
+    status_channel: &StatusChannel,
+) -> Result<(), InitError> {
+    let olgen_out = ensure_ol_genesis(storage, ol_params)?;
+    let (l1blk, client_state) = ensure_client_state_genesis(storage, ol_params)?;
+
+    // Create sync status and update status channel
+    let sync_status = OLSyncStatus::new(
+        olgen_out.tip_blk,
+        olgen_out.epoch,
+        olgen_out.is_terminal,
+        client_state.get_last_epoch().unwrap_or_default(),
+        client_state.get_last_epoch().unwrap_or_default(),
+        client_state.get_declared_final_epoch().unwrap_or_default(),
+        l1blk,
+    );
+    status_channel.update_ol_sync_status(OLSyncStatusUpdate::new(sync_status));
+
+    Ok(())
+}
+
+/// Ensures client state genesis.
+fn ensure_client_state_genesis(
     storage: &NodeStorage,
     ol_params: &OLParams,
 ) -> Result<(L1BlockCommitment, ClientState), InitError> {
+    // Check for client state genesis
     let csman = storage.client_state();
     let recent_state = csman
         .fetch_most_recent_state()
@@ -374,18 +401,59 @@ pub(crate) fn check_and_init_genesis(
 
     match recent_state {
         None => {
-            // Initialize OL genesis block and state
-            init_ol_genesis(ol_params, storage)
-                .map_err(|e| InitError::StorageCreation(e.to_string()))?;
-
             // Create and insert init client state into db.
             let init_state = ClientState::default();
             let l1blk = ol_params.last_l1_block;
             let update = ClientUpdateOutput::new_state(init_state.clone());
             csman.put_update_blocking(&l1blk, update.clone())?;
-            Ok((l1blk, init_state))
+            Ok((l1blk, update.state().clone()))
         }
-        Some(recent_state) => Ok(recent_state),
+        Some(s) => Ok(s),
+    }
+}
+
+/// OL Chain tip information after ensuring genesis.
+#[derive(Clone, Debug)]
+pub(crate) struct EnsureOLGenesisOutput {
+    pub(crate) epoch: Epoch,
+    pub(crate) tip_blk: OLBlockCommitment,
+    pub(crate) is_terminal: bool,
+}
+
+/// Ensures OL genesis. Returns the tip block commitment and a boolean indicating if it is terminal.
+fn ensure_ol_genesis(
+    storage: &NodeStorage,
+    ol_params: &OLParams,
+) -> Result<EnsureOLGenesisOutput, InitError> {
+    match storage.ol_block().get_canonical_block_at_blocking(0)? {
+        None => {
+            info!("No canonical block found at slot 0, doing OL genesis");
+            let commitment = init_ol_genesis(ol_params, storage)
+                .inspect(|blkid| info!(%blkid, "Done genesis with block"))
+                .map_err(|e| InitError::StorageCreation(e.to_string()))?;
+            Ok(EnsureOLGenesisOutput {
+                epoch: 0,
+                tip_blk: commitment,
+                is_terminal: true,
+            })
+        }
+        Some(commitment) => {
+            info!(%commitment, "Genesis block found, no need to do OL genesis");
+            // Get tip
+            let tip = storage
+                .ol_block()
+                .get_canonical_tip_blocking()?
+                .expect("tip commitment is expected after genesis");
+            let blk = storage
+                .ol_block()
+                .get_block_data_blocking(*tip.blkid())?
+                .expect("tip block expected after genesis");
+            Ok(EnsureOLGenesisOutput {
+                epoch: blk.header().epoch(),
+                tip_blk: tip,
+                is_terminal: blk.header().is_terminal(),
+            })
+        }
     }
 }
 

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -2,20 +2,19 @@
 
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use strata_btcio::reader::query::bitcoin_data_reader_task;
 use strata_chain_worker_new::start_chain_worker_service_from_ctx;
 use strata_consensus_logic::{
     AsmBlockSubmitter, FcmContext, start_fcm_service,
     sync_manager::{spawn_asm_worker_with_ctx, spawn_csm_listener_with_ctx},
 };
-use strata_identifiers::OLBlockCommitment;
 use strata_node_context::NodeContext;
 use strata_ol_checkpoint::OLCheckpointBuilder;
 use strata_ol_mempool::{MempoolBuilder, MempoolHandle, OLMempoolConfig};
 
 use crate::{
-    context::check_and_init_genesis,
+    context::ensure_genesis,
     helpers::rollup_to_btcio_params,
     run_context::{RunContext, ServiceHandles},
 };
@@ -245,7 +244,11 @@ pub(crate) fn start_strata_services(
     // Check and do genesis if not yet. This should be done after asm/csm/btcio and before mempool
     // because genesis requires asm to be working and mempool and other services expect genesis to
     // have happened.
-    check_and_init_genesis(nodectx.storage().as_ref(), nodectx.ol_params())?;
+    ensure_genesis(
+        nodectx.storage().as_ref(),
+        nodectx.ol_params(),
+        nodectx.status_channel().as_ref(),
+    )?;
 
     // Start mempool service
     let mempool_handle = Arc::new(start_mempool(&nodectx)?);
@@ -336,22 +339,11 @@ fn start_btcio_reader(nodectx: &NodeContext, asm_handle: Arc<strata_asm_worker::
 fn start_mempool(nodectx: &NodeContext) -> Result<MempoolHandle> {
     let config = OLMempoolConfig::default();
 
-    // Get current chain tip - try status channel first, fall back to genesis from storage
-    let current_tip = match nodectx.status_channel().get_ol_sync_status() {
-        Some(status) => status.tip,
-        None => {
-            // No chain sync status yet - get genesis block from OL storage
-            let genesis_blocks = nodectx
-                .storage()
-                .ol_block()
-                .get_blocks_at_height_blocking(0)
-                .map_err(|e| anyhow!("Failed to get genesis block: {e}"))?;
-            let genesis_blkid = genesis_blocks
-                .first()
-                .ok_or_else(|| anyhow!("Genesis block not found, cannot start mempool"))?;
-            OLBlockCommitment::new(0, *genesis_blkid)
-        }
-    };
+    let current_tip = nodectx
+        .status_channel()
+        .get_ol_sync_status()
+        .expect("OL sync status must be set before starting mempool")
+        .tip;
 
     let storage = nodectx.storage().clone();
     let status_channel = nodectx.status_channel().as_ref().clone();

--- a/functional-tests/tests/dbtool/revert_ol_state_delete_blocks.py
+++ b/functional-tests/tests/dbtool/revert_ol_state_delete_blocks.py
@@ -41,7 +41,7 @@ class RevertOLStateDeleteBlocksTest(StrataNodeTest):
         seq_rpc = setup["rpc"]
 
         # Wait for extra blocks beyond checkpoint terminal.
-        seq_service.wait_for_additional_blocks(5, seq_rpc, timeout_per_block=10)
+        seq_service.wait_for_additional_blocks(6, seq_rpc, timeout_per_block=10)
 
         live_sync = seq_service.get_sync_status(seq_rpc)
         old_live_tip_slot = live_sync["tip"]["slot"]

--- a/functional-tests/tests/dbtool/revert_ol_state_seq.py
+++ b/functional-tests/tests/dbtool/revert_ol_state_seq.py
@@ -38,7 +38,7 @@ class RevertOLStateSeqTest(StrataNodeTest):
         seq_rpc = setup["rpc"]
 
         # Wait for extra blocks beyond checkpoint terminal.
-        seq_service.wait_for_additional_blocks(5, seq_rpc, timeout_per_block=10)
+        seq_service.wait_for_additional_blocks(6, seq_rpc, timeout_per_block=10)
 
         live_sync = seq_service.get_sync_status(seq_rpc)
         old_live_tip_slot = live_sync["tip"]["slot"]


### PR DESCRIPTION
## Description
This pr ensures that status channel is updated after genesis or after any restarts after that. Due to lack of this behavior some of the works downstream had to depend on db to make sure of genesis, this is explained well in this [ticket](https://alpenlabs.atlassian.net/browse/STR-3105).
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers
This pr is mostly copy paste of @bewakes 's [solution](https://github.com/alpenlabs/alpen/pull/1536) to ensuring genesis and updating that in status channel.
<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
STR-2397
<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
