### PR TITLE
STR 2128 Expand testing coverage in OL block assembly

### DIFF
--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -1643,6 +1643,203 @@ mod tests {
         );
     }
 
+    /// Tests duplicate submission of the exact same tx (same txid, same seq_no).
+    /// First execution succeeds, duplicate replay in the same block is rejected.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_duplicate_seq_no_same_tx_second_rejected() {
+        let account_id = test_account_id(1);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let tx = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .build();
+        let txid = tx.compute_txid();
+
+        let mempool = env.mempool();
+        mempool.add_transaction(txid, tx.clone());
+        mempool.add_transaction(txid, tx);
+
+        let result = env
+            .generate_block_template()
+            .await
+            .expect("block generation should succeed");
+
+        let (template, failed_txs, _da) = result.into_parts();
+        let txs = template.body().tx_segment().expect("tx segment").txs();
+        assert_eq!(txs.len(), 1, "duplicate replay should not be included");
+        assert_eq!(
+            failed_txs.len(),
+            1,
+            "one duplicate should be reported failed"
+        );
+        assert_eq!(
+            failed_txs[0].0, txid,
+            "failed duplicate should reference replayed txid"
+        );
+    }
+
+    /// Tests same-account duplicate seq_no across two different txs.
+    /// First tx succeeds, second tx with same seq_no is rejected.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_duplicate_seq_no_different_tx_second_rejected() {
+        let account_id = test_account_id(1);
+        let receiver = test_account_id(2);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE))
+            .with_account(TestAccount::new(receiver, 0));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let tx1 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .build();
+        let tx1_id = tx1.compute_txid();
+        let tx2 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_outputs(vec![(receiver, 1)])
+            .build();
+        let tx2_id = tx2.compute_txid();
+
+        let mempool = env.mempool();
+        mempool.add_transaction(tx1_id, tx1);
+        mempool.add_transaction(tx2_id, tx2);
+
+        let result = env
+            .generate_block_template()
+            .await
+            .expect("block generation should succeed");
+
+        let (template, failed_txs, _da) = result.into_parts();
+        let txs = template.body().tx_segment().expect("tx segment").txs();
+        assert_eq!(txs.len(), 1, "only first seq_no=0 tx should be included");
+        assert_eq!(txs[0].compute_txid(), tx1_id);
+        assert_eq!(failed_txs.len(), 1, "second tx should be reported failed");
+        assert_eq!(failed_txs[0].0, tx2_id);
+    }
+
+    /// Tests reverse ordering: seq_no=1 before seq_no=0.
+    /// First tx fails, second tx succeeds against unchanged account state.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reverse_order_seq_one_then_zero() {
+        let account_id = test_account_id(1);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let tx_seq1 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(1)
+            .build();
+        let tx_seq1_id = tx_seq1.compute_txid();
+        let tx_seq0 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .build();
+        let tx_seq0_id = tx_seq0.compute_txid();
+
+        let mempool = env.mempool();
+        mempool.add_transaction(tx_seq1_id, tx_seq1);
+        mempool.add_transaction(tx_seq0_id, tx_seq0);
+
+        let result = env
+            .generate_block_template()
+            .await
+            .expect("block generation should succeed");
+
+        let (template, failed_txs, _da) = result.into_parts();
+        let txs = template.body().tx_segment().expect("tx segment").txs();
+        assert_eq!(txs.len(), 1, "only seq_no=0 tx should be included");
+        assert_eq!(txs[0].compute_txid(), tx_seq0_id);
+        assert_eq!(failed_txs.len(), 1, "seq_no=1 should be reported failed");
+        assert_eq!(failed_txs[0].0, tx_seq1_id);
+    }
+
+    /// Tests seq gap behavior: seq_no=0 then seq_no=2 in the same block.
+    /// The gap transaction must be rejected.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_seq_gap_zero_then_two_second_rejected() {
+        let account_id = test_account_id(1);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let tx_seq0 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .build();
+        let tx_seq0_id = tx_seq0.compute_txid();
+        let tx_seq2 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(2)
+            .build();
+        let tx_seq2_id = tx_seq2.compute_txid();
+
+        let mempool = env.mempool();
+        mempool.add_transaction(tx_seq0_id, tx_seq0);
+        mempool.add_transaction(tx_seq2_id, tx_seq2);
+
+        let result = env
+            .generate_block_template()
+            .await
+            .expect("block generation should succeed");
+
+        let (template, failed_txs, _da) = result.into_parts();
+        let txs = template.body().tx_segment().expect("tx segment").txs();
+        assert_eq!(txs.len(), 1, "gap tx should not be included");
+        assert_eq!(txs[0].compute_txid(), tx_seq0_id);
+        assert_eq!(failed_txs.len(), 1, "gap tx should be reported failed");
+        assert_eq!(failed_txs[0].0, tx_seq2_id);
+    }
+
+    /// Tests seq chain continuity across blocks when transactions are split one-per-block.
+    /// This models `max_txs_per_block=1` execution behavior.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_seq_chain_across_blocks_when_split_one_per_block() {
+        let account_id = test_account_id(1);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let tx_seq0 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .build();
+        let tx_seq0_id = tx_seq0.compute_txid();
+        let tx_seq1 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(1)
+            .build();
+        let tx_seq1_id = tx_seq1.compute_txid();
+
+        // Build block 1 with seq_no=0.
+        let output1 = env
+            .construct_block(vec![(tx_seq0_id, tx_seq0)])
+            .await
+            .expect("block 1 should construct");
+        let included1 = included_txids(&output1.template);
+        assert_eq!(included1.len(), 1);
+        let parent_da_2 = output1.accumulated_da.clone();
+        let _current_commitment = env.persist(&output1).await;
+
+        // Build block 2 with seq_no=1 against the state produced by block 1.
+        let output2 = env
+            .construct_block_with_da(vec![(tx_seq1_id, tx_seq1)], parent_da_2)
+            .await
+            .expect("block 2 should construct");
+        let included2 = included_txids(&output2.template);
+        assert_eq!(included2.len(), 1);
+    }
+
     /// Tests that tx with seq_no=1 fails if tx with seq_no=0 is not present.
     /// Only tx2 (seq_no=1) submitted - should fail during execution because account has seq_no=0.
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -2562,4 +2562,165 @@ mod tests {
             "hard verdict should mark checkpoint_size_limit_reached"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stress_1000_txs_100_accounts() {
+        const ACCOUNT_COUNT: usize = 100;
+        const TXS_PER_ACCOUNT: usize = 10;
+        const INITIAL_BALANCE: u64 = 1_000_000;
+
+        let account_ids: Vec<_> = (1..=ACCOUNT_COUNT)
+            .map(|i| test_account_id(i as u8))
+            .collect();
+
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_accounts(
+                account_ids
+                    .iter()
+                    .copied()
+                    .map(|account_id| TestAccount::new(account_id, INITIAL_BALANCE)),
+            );
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let mut txs = Vec::with_capacity(ACCOUNT_COUNT * TXS_PER_ACCOUNT);
+        for (idx, sender) in account_ids.iter().enumerate() {
+            let receiver = account_ids[(idx + 1) % ACCOUNT_COUNT];
+            for seq_no in 0..TXS_PER_ACCOUNT {
+                let tx = MempoolSnarkTxBuilder::new(*sender)
+                    .with_seq_no(seq_no as u64)
+                    .with_outputs(vec![(receiver, 1)])
+                    .build();
+                let txid = tx.compute_txid();
+                txs.push((txid, tx));
+            }
+        }
+
+        let output = env
+            .construct_block(txs)
+            .await
+            .expect("high-volume block should assemble");
+
+        let included = included_txids(&output.template);
+        assert_eq!(
+            included.len(),
+            ACCOUNT_COUNT * TXS_PER_ACCOUNT,
+            "all high-volume txs should be included"
+        );
+        assert!(
+            output.failed_txs.is_empty(),
+            "high-volume transfer set should not produce failed txs"
+        );
+
+        for account_id in &account_ids {
+            assert_eq!(
+                account_balance(&output.post_state, *account_id),
+                BitcoinAmount::from_sat(INITIAL_BALANCE),
+                "cyclic transfers should preserve per-account net balance for every account"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stress_50_l1_claims_with_duplicates() {
+        let account_id = test_account_id(50);
+        let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
+            .with_parent_slot(1)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE))
+            .with_l1_header_refs(1..=25)
+            .build_fixture()
+            .await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let mut claims: Vec<_> = env
+            .l1_header_refs()
+            .iter()
+            .map(|(_, claim)| claim.clone())
+            .collect();
+        claims.extend(claims.clone());
+        assert_eq!(claims.len(), 50, "stress setup should build 50 claims");
+
+        let tx = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_l1_claims(claims)
+            .build();
+        let txid = tx.compute_txid();
+
+        let output = env
+            .construct_block(vec![(txid, tx)])
+            .await
+            .expect("large-claim tx should assemble");
+
+        let included = included_txids(&output.template);
+        assert_eq!(included.len(), 1, "claim-heavy tx should be included");
+        let included_tx = &output
+            .template
+            .body()
+            .tx_segment()
+            .expect("tx segment")
+            .txs()[0];
+        let acc_proofs = included_tx
+            .proofs()
+            .accumulator_proofs()
+            .expect("claim-heavy tx should carry accumulator proofs");
+        assert_eq!(
+            acc_proofs.proofs().len(),
+            50,
+            "duplicate claims should currently produce duplicate accumulator proofs (no dedup)"
+        );
+        assert!(
+            output.failed_txs.is_empty(),
+            "claim-heavy tx should not be reported failed"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stress_100_inbox_messages_one_tx() {
+        // Stress value intentionally below SAU_MAX_PROCESSED_MESSAGES (1<<16),
+        // while still large enough to exercise message-heavy assembly/proof paths.
+        const MSG_COUNT: usize = 100;
+
+        let account_id = test_account_id(60);
+        let source_account = test_account_id(61);
+        let messages = generate_message_entries(MSG_COUNT, source_account);
+        let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(
+                TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE).with_inbox(messages.clone()),
+            )
+            .build_fixture()
+            .await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let tx = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_processed_messages(messages)
+            .build();
+        let txid = tx.compute_txid();
+
+        let output = env
+            .construct_block(vec![(txid, tx)])
+            .await
+            .expect("message-heavy tx should assemble");
+
+        let included = included_txids(&output.template);
+        assert_eq!(included.len(), 1, "message-heavy tx should be included");
+        assert!(
+            output.failed_txs.is_empty(),
+            "message-heavy tx should not be reported failed"
+        );
+        assert_eq!(
+            snark_account_next_inbox_msg_idx(&output.post_state, account_id),
+            MSG_COUNT as u64,
+            "processing should advance next_inbox_msg_idx by all messages"
+        );
+        assert_eq!(
+            snark_account_seqno(&output.post_state, account_id),
+            1,
+            "account seqno should advance after processing update"
+        );
+    }
 }

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -1458,6 +1458,121 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_no_new_manifests() {
+        // Parent already tracks manifests up to ASM tip height 3.
+        // Terminal fetch starts at 4, so L1 update must be present with an empty container.
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(1)
+            .with_l1_manifest_height_range(1..=3)
+            .with_l1_header_refs([1, 2, 3]);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("terminal block generation should succeed");
+
+        let template = output.into_template();
+        check_terminal_block_with_manifests(&template, &[]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_start_above_latest_asm_height() {
+        // Parent state claims a last_l1_height above ASM tip.
+        // Fetch should return an empty manifest set (not an error).
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(1)
+            .with_l1_manifest_height_range(1..=3)
+            .with_l1_header_refs([1, 2, 3, 4, 5]);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("terminal block generation should succeed");
+
+        let template = output.into_template();
+        check_terminal_block_with_manifests(&template, &[]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_missing_manifest_in_range_errors() {
+        // Parent last_l1_height = 1, ASM tip = 2, so terminal fetch expects manifest at height 2.
+        // Corrupt L1 canonical chain so height 2 points to a blockid with no manifest body.
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(1)
+            .with_l1_manifest_height_range(1..=2)
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let missing_manifest_blkid = L1BlockId::from(Buf32::from([0xAB; 32]));
+        env.storage()
+            .l1()
+            .revert_canonical_chain_async(1)
+            .await
+            .expect("revert L1 canonical chain to height 1");
+        env.storage()
+            .l1()
+            .extend_canonical_chain_async(&missing_manifest_blkid, 2)
+            .await
+            .expect("insert missing-manifest canonical entry at height 2");
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let err = env
+            .generate_block_template()
+            .await
+            .expect_err("missing manifest in expected terminal range should error");
+
+        assert!(
+            matches!(err, BlockAssemblyError::Db(DbError::Other(_))),
+            "expected Db(Other(_)) for missing manifest in expected range, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_empty_block_invariants() {
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("terminal block generation should succeed");
+
+        let template = output.into_template();
+        let body = template.body();
+        let tx_count = body.tx_segment().map(|seg| seg.txs().len()).unwrap_or(0);
+
+        assert_eq!(tx_count, 0, "terminal empty block should have zero txs");
+        assert!(
+            body.l1_update().is_some(),
+            "terminal block should include l1_update even when tx segment is empty"
+        );
+        assert!(
+            body.is_body_terminal(),
+            "terminal body must report terminal status"
+        );
+        assert!(
+            template.header().is_terminal(),
+            "terminal header flag must be set"
+        );
+        assert_eq!(
+            template.header().is_terminal(),
+            body.is_body_terminal(),
+            "header terminal flag must match body terminal status"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_non_terminal_block_at_slot_11() {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
@@ -1477,6 +1592,49 @@ mod tests {
         let block_template = result.unwrap().into_template();
         check_block_slot_epoch(&block_template, 11, 2);
         check_non_terminal_block(&block_template);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_non_terminal_empty_block_invariants() {
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("non-terminal block generation should succeed");
+
+        let template = output.into_template();
+        let body = template.body();
+        let tx_count = body.tx_segment().map(|seg| seg.txs().len()).unwrap_or(0);
+
+        assert_eq!(tx_count, 0, "non-terminal empty block should have zero txs");
+        assert!(
+            body.l1_update().is_none(),
+            "non-terminal empty block should not include l1_update"
+        );
+        assert!(
+            !body.is_body_terminal(),
+            "non-terminal body must not report terminal status"
+        );
+        assert!(
+            !template.header().is_terminal(),
+            "non-terminal header flag must not be set"
+        );
+        assert_eq!(
+            template.header().is_terminal(),
+            body.is_body_terminal(),
+            "header terminal flag must match body terminal status"
+        );
+        // Empty log sets must commit to the canonical zero logs root.
+        assert_eq!(
+            *template.header().logs_root(),
+            Buf32::zero(),
+            "non-terminal empty block should have zero logs root"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -110,6 +110,7 @@ fn block_assembly_error_to_mempool_reason(err: &BlockAssemblyError) -> MempoolTx
         | BlockAssemblyError::InvalidRange { .. }
         | BlockAssemblyError::InvalidSignature(_)
         | BlockAssemblyError::Mempool(_)
+        | BlockAssemblyError::StateProvider(_)
         | BlockAssemblyError::NoPendingTemplateForParent(_)
         | BlockAssemblyError::Other(_)
         | BlockAssemblyError::RequestChannelClosed
@@ -117,6 +118,7 @@ fn block_assembly_error_to_mempool_reason(err: &BlockAssemblyError) -> MempoolTx
         | BlockAssemblyError::UnknownTemplateId(_)
         | BlockAssemblyError::TimestampTooEarly(_)
         | BlockAssemblyError::BlockNotFound(_)
+        | BlockAssemblyError::ParentStateNotFound(_)
         | BlockAssemblyError::TooManyClaims
         | BlockAssemblyError::CannotBuildGenesis => MempoolTxInvalidReason::Failed,
     }
@@ -170,11 +172,7 @@ where
     let parent_state = ctx
         .fetch_state_for_tip(parent_commitment)
         .await?
-        .ok_or_else(|| {
-            BlockAssemblyError::Db(DbError::Other(format!(
-                "Parent state not found for commitment: {parent_commitment}"
-            )))
-        })?;
+        .ok_or(BlockAssemblyError::ParentStateNotFound(parent_commitment))?;
 
     // 2. Calculate next slot and epoch
     let (block_slot, block_epoch) =
@@ -1442,7 +1440,7 @@ mod tests {
             .build();
         let txid = valid_tx.compute_txid();
 
-        let mempool = env.mempool_arc();
+        let mempool = env.mempool();
 
         mempool.add_transaction(txid, valid_tx);
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -845,6 +845,67 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_add_accumulator_proofs_missing_target_account() {
+        let fixture_builder = TestStorageFixtureBuilder::new();
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let missing_account = test_account_id(99);
+        let mempool_tx = MempoolSnarkTxBuilder::new(missing_account)
+            .with_seq_no(0)
+            .build();
+
+        let ctx = create_test_context(fixture.storage().clone());
+        let err = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx)
+            .expect_err("missing target account should fail");
+        assert!(
+            matches!(err, BlockAssemblyError::AccountNotFound(id) if id == missing_account),
+            "expected AccountNotFound for missing account, got: {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_add_accumulator_proofs_gam_passthrough() {
+        let fixture_builder = TestStorageFixtureBuilder::new();
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let target = test_account_id(77);
+        let mempool_tx = MempoolGamTxBuilder::new(target)
+            .with_data(vec![1, 2, 3])
+            .build();
+        let proofs_before = mempool_tx.proofs().clone();
+
+        let ctx = create_test_context(fixture.storage().clone());
+        let out_tx = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx)
+            .expect("GAM tx should pass through unchanged");
+
+        // For GAM payloads this path should not inject accumulator proofs.
+        assert_eq!(
+            out_tx.proofs(),
+            &proofs_before,
+            "GAM tx proofs should remain unchanged"
+        );
+        assert!(
+            matches!(
+                out_tx.payload(),
+                TransactionPayload::GenericAccountMessage(_)
+            ),
+            "GAM tx payload should remain GenericAccountMessage"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_l1_header_claim_hash_mismatch() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -119,6 +119,9 @@ fn block_assembly_error_to_mempool_reason(err: &BlockAssemblyError) -> MempoolTx
         | BlockAssemblyError::TimestampTooEarly(_)
         | BlockAssemblyError::BlockNotFound(_)
         | BlockAssemblyError::ParentStateNotFound(_)
+        | BlockAssemblyError::GenesisEpochNoBoundary
+        | BlockAssemblyError::InvalidEpochBoundary { .. }
+        | BlockAssemblyError::EpochBoundaryStateNotFound(_)
         | BlockAssemblyError::TooManyClaims
         | BlockAssemblyError::CannotBuildGenesis => MempoolTxInvalidReason::Failed,
     }

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -740,51 +740,39 @@ fn add_accumulator_proofs<P: AccumulatorProofGenerator, S: IStateAccessor>(
 #[cfg(test)]
 mod tests {
     use strata_acct_types::*;
-    use strata_asm_manifest_types::AsmManifest;
-    use strata_codec::encode_to_vec;
-    use strata_identifiers::{Buf32, Buf64, L1BlockId, L1Height, OLBlockId, WtxidsRoot};
-    use strata_msg_fmt::{Msg, OwnedMsg};
-    use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, OLBlock, OLLog, SignedOLBlockHeader};
-    use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, WithdrawalMsgData};
-    use strata_ol_state_types::OLState;
-    use strata_ol_stf::BRIDGE_GATEWAY_ACCT_ID;
-    use strata_snark_acct_types::OutputMessage;
-    use strata_storage::NodeStorage;
+    use strata_identifiers::{Buf32, L1Height, OLBlockId};
+    use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, OLLog};
 
     use super::*;
     use crate::test_utils::*;
 
-    #[test]
-    fn test_l1_header_proof_gen_success() {
-        let storage = create_test_storage();
-
-        // Insert an ASM manifest hash into storage MMR and state MMR.
-        let manifest = AsmManifest::new(
-            1,
-            L1BlockId::from(Buf32::from([1u8; 32])),
-            WtxidsRoot::from(Buf32::zero()),
-            vec![],
-        )
-        .expect("test manifest should be valid");
-        let manifest_hash = manifest.compute_hash().into();
-        let mut asm_mmr = StorageAsmMmr::new(storage.as_ref());
-        asm_mmr.add_header(manifest_hash);
-
-        // Create state with snark account
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_proof_gen_success() {
         let account_id = test_account_id(1);
-        let mut state = create_test_genesis_state();
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-        state.append_manifest(manifest.height(), manifest);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let l1_claim = fixture
+            .l1_header_ref(1)
+            .expect("claim for L1 height 1 should exist");
 
         // Create tx with claims from the tracker using builder
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(asm_mmr.claims())
+            .with_l1_claims(vec![l1_claim])
             .build();
 
-        let ctx = create_test_context(storage.clone());
+        let ctx = create_test_context(fixture.storage().clone());
 
         // Convert transaction (generates accumulator proofs).
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
 
         assert!(
             result.is_ok(),
@@ -802,29 +790,29 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_inbox_proof_gen_success() {
-        let storage = create_test_storage();
-        let mut state = create_test_genesis_state();
-
-        // Create account
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_proof_gen_success() {
         let account_id = test_account_id(1);
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-
-        // Use StorageInboxMmr to populate inbox messages
         let source_account = test_account_id(2);
         let messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(storage.as_ref(), account_id);
-        inbox_mmr.add_messages(messages.clone());
-        insert_inbox_messages_into_state(&mut state, account_id, &messages);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(messages.clone()));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
 
         // Create tx using builder
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
             .with_processed_messages(messages.clone())
             .build();
 
-        let ctx = create_test_context(storage.clone());
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
 
         assert!(
             result.is_ok(),
@@ -844,43 +832,38 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_l1_header_claim_hash_mismatch() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_claim_hash_mismatch() {
+        let account_id = test_account_id(1);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let seeded_claim = fixture
+            .l1_header_ref(1)
+            .expect("claim for L1 height 1 should exist");
 
-        // Insert a deterministic ASM manifest hash into storage MMR and state MMR.
-        let manifest = AsmManifest::new(
-            1,
-            L1BlockId::from(Buf32::from([1u8; 32])),
-            WtxidsRoot::from(Buf32::zero()),
-            vec![],
-        )
-        .expect("test manifest should be valid");
-        let manifest_hash = manifest.compute_hash().into();
-        let mut asm_mmr = StorageAsmMmr::new(storage.as_ref());
-        asm_mmr.add_header(manifest_hash);
-
-        // Create claim with correct MMR index but WRONG hash (deterministic to guarantee mismatch)
+        // Create claim with correct MMR index but wrong hash.
         let wrong_hash = test_hash(99);
         assert_ne!(
             wrong_hash,
-            asm_mmr.hashes()[0],
-            "Test setup: wrong_hash should differ from actual hash"
+            seeded_claim.entry_hash(),
+            "test setup: wrong hash should differ from seeded claim hash"
         );
-
-        let mmr_idx = asm_mmr.indices()[0];
-        let invalid_claims = vec![AccumulatorClaim::new(mmr_idx, wrong_hash)];
-
-        let account_id = test_account_id(1);
-        let mut state = create_test_genesis_state();
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-        state.append_manifest(manifest.height(), manifest);
+        let invalid_claims = vec![AccumulatorClaim::new(seeded_claim.idx(), wrong_hash)];
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
             .with_l1_claims(invalid_claims)
             .build();
-        let ctx = create_test_context(storage.clone());
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
         assert!(result.is_err(), "Should fail with hash mismatch");
         let err = result.unwrap_err();
         assert!(
@@ -890,30 +873,37 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_l1_header_claim_missing_index() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_claim_missing_index() {
+        // Seed one L1 header so we can reuse its hash with a missing index.
+        let account_id = test_account_id(1);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let seeded_claim = fixture
+            .l1_header_ref(1)
+            .expect("claim for L1 height 1 should exist");
 
-        // Use StorageAsmMmr with random hashes
-        let mut asm_mmr = StorageAsmMmr::new(storage.as_ref());
-        asm_mmr.add_random_headers(1);
-
-        // Create claim with non-existent index (index 999 doesn't exist)
+        // Create claim with non-existent index.
         let nonexistent_index = 999u64;
         let invalid_claims = vec![AccumulatorClaim::new(
             nonexistent_index,
-            asm_mmr.hashes()[0],
+            seeded_claim.entry_hash(),
         )];
-
-        let account_id = test_account_id(1);
-        let mut state = create_test_genesis_state();
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
             .with_l1_claims(invalid_claims)
             .build();
-        let ctx = create_test_context(storage.clone());
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
 
         assert!(result.is_err(), "Should fail with nonexistent index");
         let err = result.unwrap_err();
@@ -928,27 +918,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_l1_header_claim_empty_mmr() {
-        // Setup storage WITHOUT any L1 headers in ASM MMR
-        let storage = create_test_storage();
-
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_claim_empty_mmr() {
         // Create claim for MMR index 0 with arbitrary hash (MMR is empty)
         let arbitrary_hash = test_hash(42);
         let invalid_claims = vec![AccumulatorClaim::new(0, arbitrary_hash)];
 
-        // Create state with snark account
         let account_id = test_account_id(1);
-        let mut state = create_test_genesis_state();
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
+        let fixture_builder =
+            TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
             .with_l1_claims(invalid_claims)
             .build();
 
-        let ctx = create_test_context(storage.clone());
+        let ctx = create_test_context(fixture.storage().clone());
         // Conversion should fail with an index/range DB error.
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
 
         assert!(result.is_err(), "Should fail when MMR is empty");
         let err = result.unwrap_err();
@@ -1025,20 +1019,21 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_inbox_claim_missing_index() {
-        let storage = create_test_storage();
-        let mut state = create_test_genesis_state();
-
-        // Create account
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_claim_missing_index() {
         let account_id = test_account_id(1);
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-
-        // Use StorageInboxMmr to add only 1 message
         let source_account = test_account_id(2);
         let messages = generate_message_entries(1, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(storage.as_ref(), account_id);
-        inbox_mmr.add_messages(messages.clone());
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(messages.clone()));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
 
         // Create transaction claiming to process messages at indices [5, 6]
         // which don't exist (only index 0 exists)
@@ -1048,10 +1043,8 @@ mod tests {
             .with_new_msg_idx(7) // Claims next_inbox_msg_idx = 7 after processing
             .build();
 
-        insert_inbox_messages_into_state(&mut state, account_id, &messages);
-
-        let ctx = create_test_context(storage.clone());
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
 
         assert!(
             result.is_err(),
@@ -1071,20 +1064,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_inbox_claim_invalid_msg_idx() {
-        let storage = create_test_storage();
-        let mut state = create_test_genesis_state();
-
-        // Create account
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_claim_invalid_msg_idx() {
         let account_id = test_account_id(1);
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-
-        // Use StorageInboxMmr to add 2 messages
         let source_account = test_account_id(2);
         let messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(storage.as_ref(), account_id);
-        inbox_mmr.add_messages(messages.clone());
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(messages.clone()));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
 
         // Account has next_inbox_msg_idx = 0 on-chain
         // Create transaction claiming WRONG new next_inbox_msg_idx
@@ -1094,10 +1088,8 @@ mod tests {
             .with_new_msg_idx(10) // Wrong! Should be 2
             .build();
 
-        insert_inbox_messages_into_state(&mut state, account_id, &messages);
-
-        let ctx = create_test_context(storage.clone());
-        let result = add_accumulator_proofs(&ctx, &state, mempool_tx);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx);
 
         assert!(
             result.is_err(),
@@ -1124,43 +1116,36 @@ mod tests {
     /// Verifies that when both inbox proofs and L1 header proofs are present,
     /// the accumulator proofs are ordered: L1 headers first, then inbox proofs.
     /// This must match the verification order in snark-acct-sys verification.rs.
-    #[test]
-    fn test_proof_ordering_l1_headers_before_inbox() {
-        let storage = create_test_storage();
-        let mut state = create_test_genesis_state();
-
-        // Create account
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_proof_ordering_l1_headers_before_inbox() {
         let account_id = test_account_id(1);
-        add_snark_account_to_state(&mut state, account_id, 1, 100_000);
-
-        // Add L1 header to storage and state MMRs
-        let manifest = AsmManifest::new(
-            1,
-            L1BlockId::from(Buf32::from([1u8; 32])),
-            WtxidsRoot::from(Buf32::zero()),
-            vec![],
-        )
-        .expect("test manifest should be valid");
-        let manifest_hash = manifest.compute_hash().into();
-        let mut asm_mmr = StorageAsmMmr::new(storage.as_ref());
-        asm_mmr.add_header(manifest_hash);
-        state.append_manifest(manifest.height(), manifest);
-
-        // Add inbox messages to storage and state
         let source_account = test_account_id(2);
         let messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(storage.as_ref(), account_id);
-        inbox_mmr.add_messages(messages.clone());
-        insert_inbox_messages_into_state(&mut state, account_id, &messages);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_l1_header_refs([1])
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(messages.clone()));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let l1_claims = vec![
+            fixture
+                .l1_header_ref(1)
+                .expect("claim for L1 height 1 should exist"),
+        ];
 
         // Create tx with BOTH L1 claims and inbox messages
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(asm_mmr.claims())
+            .with_l1_claims(l1_claims.clone())
             .with_processed_messages(messages.clone())
             .build();
 
-        let ctx = create_test_context(storage.clone());
-        let tx = add_accumulator_proofs(&ctx, &state, mempool_tx)
+        let ctx = create_test_context(fixture.storage().clone());
+        let tx = add_accumulator_proofs(&ctx, state.as_ref(), mempool_tx)
             .expect("proof generation should succeed");
         let tx_proofs = tx.proofs();
 
@@ -1168,7 +1153,7 @@ mod tests {
         let acc_proofs = tx_proofs
             .accumulator_proofs()
             .expect("should have accumulator proofs");
-        let n_l1 = asm_mmr.claims().len();
+        let n_l1 = l1_claims.len();
         let n_inbox = messages.len();
         assert_eq!(
             acc_proofs.proofs().len(),
@@ -1274,76 +1259,22 @@ mod tests {
 
     // Helper to build blocks from start_commitment up to (but not including) target_slot.
     // Stores blocks and states so subsequent blocks can find their parent.
-    async fn build_blocks_to_slot<C, E>(
-        start_commitment: OLBlockCommitment,
-        target_slot: u64,
-        ctx: &C,
-        storage: &NodeStorage,
-        epoch_sealing_policy: &E,
-    ) -> OLBlockCommitment
-    where
-        C: BlockAssemblyAnchorContext<State = OLState> + AccumulatorProofGenerator,
-        E: EpochSealingPolicy,
-    {
-        let mut current_commitment = start_commitment;
+    async fn build_blocks_to_slot(env: &mut TestEnv, target_slot: u64) -> OLBlockCommitment {
+        let mut current_commitment = env.parent_commitment();
 
         let start_slot = if current_commitment.is_null() {
             0
         } else {
-            start_commitment.slot() + 1
+            env.parent_commitment().slot() + 1
         };
 
         for slot in start_slot..target_slot {
-            let config = BlockGenerationConfig::new(current_commitment);
-
-            // Fetch parent state
-            let parent_state = ctx
-                .fetch_state_for_tip(config.parent_block_commitment())
+            let output = env
+                .construct_empty_block()
                 .await
-                .unwrap_or_else(|e| panic!("Failed to fetch parent state at slot {slot}: {e:?}"))
-                .unwrap_or_else(|| panic!("Missing parent state at slot {slot}"));
+                .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
 
-            // Calculate slot and epoch
-            let (block_slot, block_epoch) = calculate_block_slot_and_epoch(
-                &config.parent_block_commitment(),
-                parent_state.as_ref(),
-            );
-
-            // Construct block (no mempool txs for helper)
-            let output = construct_block(
-                ctx,
-                epoch_sealing_policy,
-                &config,
-                parent_state,
-                block_slot,
-                block_epoch,
-                vec![],
-                AccumulatedDaData::new_empty(),
-            )
-            .await
-            .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
-
-            // Create commitment from header
-            let header = output.template.header();
-            let new_commitment = OLBlockCommitment::new(header.slot(), header.compute_blkid());
-
-            // Store block (with dummy signature)
-            let signed_header = SignedOLBlockHeader::new(header.clone(), Buf64::zero());
-            let block = OLBlock::new(signed_header, output.template.body().clone());
-            storage
-                .ol_block()
-                .put_block_data_async(block)
-                .await
-                .unwrap_or_else(|e| panic!("Failed to store block at slot {slot}: {e:?}"));
-
-            // Store post-state at new commitment
-            storage
-                .ol_state()
-                .put_toplevel_ol_state_async(new_commitment, output.post_state)
-                .await
-                .unwrap_or_else(|e| panic!("Failed to store state at slot {slot}: {e:?}"));
-
-            current_commitment = new_commitment;
+            current_commitment = env.persist(&output).await;
         }
 
         current_commitment
@@ -1352,40 +1283,22 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[should_panic(expected = "generate_block_template_inner called with null parent")]
     async fn test_block_assembly_panics_on_null_parent() {
-        let env = TestEnvBuilder::new().build().await;
+        let env_builder = TestStorageFixtureBuilder::new();
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
-
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let _ = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await;
+        let _ = env.generate_block_template().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_non_terminal_block_at_slot_1() {
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .build()
-            .await;
+            .with_l1_manifest_height_range(1..=3);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(env.storage);
-
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let result = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await;
+        let result = env.generate_block_template().await;
         assert!(
             result.is_ok(),
             "Block generation should succeed: {:?}",
@@ -1399,28 +1312,21 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_block_template_fallback_timestamp_uses_milliseconds() {
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .build()
-            .await;
+            .with_l1_manifest_height_range(1..=3);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(env.storage);
-        let config = BlockGenerationConfig::new(env.parent_commitment);
         let before = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
 
-        let result = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("block generation should succeed");
+        let result = env
+            .generate_block_template()
+            .await
+            .expect("block generation should succeed");
 
         let after = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1436,32 +1342,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_terminal_block_at_slot_10() {
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .build()
-            .await;
+            .with_l1_manifest_height_range(1..=3);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
 
-        let current_commitment = build_blocks_to_slot(
-            env.parent_commitment,
-            10,
-            &ctx,
-            env.storage.as_ref(),
-            &env.epoch_sealing_policy,
-        )
-        .await;
-
-        let config = BlockGenerationConfig::new(current_commitment);
-        let result = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await;
+        let result = env.generate_block_template().await;
         assert!(
             result.is_ok(),
             "Block generation should succeed: {:?}",
@@ -1477,34 +1366,19 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_terminal_block_manifest_boundary_from_last_l1_height() {
         // Set last_l1_height to 2, but only provide manifests starting at 3.
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
-            .with_claim_manifests(2)
-            .with_asm_manifests(&[3, 4])
-            .build()
-            .await;
+            .with_l1_header_refs([1, 2])
+            .with_l1_manifest_height_range(3..=4);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
 
-        let current_commitment = build_blocks_to_slot(
-            env.parent_commitment,
-            10,
-            &ctx,
-            env.storage.as_ref(),
-            &env.epoch_sealing_policy,
-        )
-        .await;
-
-        let config = BlockGenerationConfig::new(current_commitment);
-        let result = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let result = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         let block_template = result.into_template();
         check_terminal_block_with_manifests(&block_template, &[3, 4]);
@@ -1512,32 +1386,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_non_terminal_block_at_slot_11() {
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .build()
-            .await;
+            .with_l1_manifest_height_range(1..=3);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+        let _current_commitment = build_blocks_to_slot(&mut env, 11).await;
 
-        let current_commitment = build_blocks_to_slot(
-            env.parent_commitment,
-            11,
-            &ctx,
-            env.storage.as_ref(),
-            &env.epoch_sealing_policy,
-        )
-        .await;
-
-        let config = BlockGenerationConfig::new(current_commitment);
-        let result = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await;
+        let result = env.generate_block_template().await;
         assert!(
             result.is_ok(),
             "Block generation should succeed: {:?}",
@@ -1553,18 +1410,16 @@ mod tests {
     async fn test_valid_tx_included_in_block() {
         // Setup env with snark account (seq_no=0 initially)
         let account_id = test_account_id(1);
-        let env = TestEnvBuilder::new()
-            .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .with_account(account_id, DEFAULT_ACCOUNT_BALANCE)
-            .build()
-            .await;
-
-        // Setup inbox MMR with real messages using StorageInboxMmr
         let source_account = test_account_id(2);
         let messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(&env.storage, account_id);
-        inbox_mmr.add_messages(messages.clone());
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(
+                TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE).with_inbox(messages.clone()),
+            );
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         // Create tx and add to mock provider
         let valid_tx = MempoolSnarkTxBuilder::new(account_id)
@@ -1573,40 +1428,22 @@ mod tests {
             .build();
         let txid = valid_tx.compute_txid();
 
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage.clone());
+        let mempool = env.mempool_arc();
 
-        insert_inbox_messages_into_storage_state(
-            env.storage.as_ref(),
-            env.parent_commitment,
-            account_id,
-            &messages,
-        )
-        .await;
         mempool.add_transaction(txid, valid_tx);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Assert: tx included in block
-        let txs = output
-            .template()
-            .body()
-            .tx_segment()
-            .expect("Should have tx segment")
-            .txs();
-        assert_eq!(txs.len(), 1, "Block should contain 1 transaction");
+        let included = included_txids(output.template());
+        assert_eq!(included.len(), 1, "Block should contain 1 transaction");
         assert_eq!(
-            txs[0].target(),
-            Some(account_id),
-            "Included tx should target the expected account"
+            included,
+            vec![txid],
+            "Included tx should be the submitted tx"
         );
     }
 
@@ -1638,19 +1475,25 @@ mod tests {
         // Setup env with two snark accounts
         let account1 = test_account_id(1);
         let account2 = test_account_id(2);
-        let env = TestEnvBuilder::new()
-            .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .with_account(account1, DEFAULT_ACCOUNT_BALANCE)
-            .with_account(account2, DEFAULT_ACCOUNT_BALANCE)
-            .build()
-            .await;
-
-        // Generate messages and insert into account1's inbox MMR using StorageInboxMmr
         let source_account = test_account_id(3);
         let real_messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(&env.storage, account1);
-        inbox_mmr.add_messages(real_messages.clone());
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(
+                TestAccount::new(account1, DEFAULT_ACCOUNT_BALANCE)
+                    .with_inbox(real_messages.clone()),
+            )
+            .with_account(TestAccount::new(account2, DEFAULT_ACCOUNT_BALANCE))
+            .with_expected_inbox_message_indices([(account1, vec![0, 1])]);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        assert_eq!(
+            env.inbox_message_claims_for_account(account1).len(),
+            real_messages.len(),
+            "fixture should expose inbox message claims for seeded messages"
+        );
 
         // Valid tx for account1: messages exist in MMR, proof generation succeeds
         let valid_tx = MempoolSnarkTxBuilder::new(account1)
@@ -1670,46 +1513,20 @@ mod tests {
         let invalid_txid = invalid_tx.compute_txid();
 
         // Build block
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage.clone());
-
-        insert_inbox_messages_into_storage_state(
-            env.storage.as_ref(),
-            env.parent_commitment,
-            account1,
-            &real_messages,
-        )
-        .await;
+        let mempool = env.mempool();
         mempool.add_transaction(valid_txid, valid_tx);
         mempool.add_transaction(invalid_txid, invalid_tx);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Assert: block has 1 transaction (valid included, invalid rejected)
-        let txs = output
-            .template()
-            .body()
-            .tx_segment()
-            .expect("Should have tx segment")
-            .txs();
         assert_eq!(
-            txs.len(),
-            1,
-            "Block should contain 1 tx (valid included, invalid rejected)"
-        );
-        // Verify the included tx is for account1 (the valid one)
-        assert_eq!(
-            txs[0].target(),
-            Some(account1),
-            "Included tx should be from account1 (valid tx)"
+            included_txids(output.template()),
+            vec![valid_txid],
+            "Block should contain only the valid tx"
         );
     }
 
@@ -1718,19 +1535,20 @@ mod tests {
         // Setup env with two snark accounts and manifests in both state and storage MMRs
         let account1 = test_account_id(1);
         let account2 = test_account_id(2);
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1) // Start from slot 1 instead of genesis to avoid genesis manifest conflicts
-            .with_account(account1, DEFAULT_ACCOUNT_BALANCE)
-            .with_account(account2, DEFAULT_ACCOUNT_BALANCE)
-            .with_claim_manifests(2)
-            .build()
-            .await;
+            .with_account(TestAccount::new(account1, DEFAULT_ACCOUNT_BALANCE))
+            .with_account(TestAccount::new(account2, DEFAULT_ACCOUNT_BALANCE))
+            .with_l1_header_refs([1, 2])
+            .with_expected_l1_header_ref_indices([(1, 0), (2, 1)]);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        // Valid tx for account1: L1 header claims exist in both MMRs (using MMR leaf index)
-        let valid_claims = vec![AccumulatorClaim::new(
-            env.manifests[0].mmr_idx,
-            env.manifests[0].hash,
-        )];
+        // Valid tx for account1: L1 header claims exist in both MMRs for the requested L1 height.
+        let valid_claims = vec![
+            env.l1_header_ref(1)
+                .expect("claim for L1 height 1 should exist"),
+        ];
         let valid_tx = MempoolSnarkTxBuilder::new(account1)
             .with_seq_no(0)
             .with_l1_claims(valid_claims)
@@ -1739,8 +1557,14 @@ mod tests {
 
         // Invalid tx for account2: non-existent MMR index (no corresponding MMR leaf)
         let fake_hash = test_hash(99);
-        let missing_height = env.manifests.last().unwrap().mmr_idx + 100;
-        let invalid_claims = vec![AccumulatorClaim::new(missing_height, fake_hash)];
+        let max_seeded_idx = env
+            .l1_header_refs()
+            .iter()
+            .map(|(_, claim)| claim.idx())
+            .max()
+            .expect("seeded claims");
+        let missing_idx = max_seeded_idx + 100;
+        let invalid_claims = vec![AccumulatorClaim::new(missing_idx, fake_hash)];
         let invalid_tx = MempoolSnarkTxBuilder::new(account2)
             .with_seq_no(0)
             .with_l1_claims(invalid_claims)
@@ -1748,38 +1572,20 @@ mod tests {
         let invalid_txid = invalid_tx.compute_txid();
 
         // Build block
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage.clone());
+        let mempool = env.mempool();
         mempool.add_transaction(valid_txid, valid_tx);
         mempool.add_transaction(invalid_txid, invalid_tx);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Assert: block has 1 transaction (valid included, invalid rejected)
-        let txs = output
-            .template()
-            .body()
-            .tx_segment()
-            .expect("Should have tx segment")
-            .txs();
         assert_eq!(
-            txs.len(),
-            1,
-            "Block should contain 1 tx (valid included, invalid rejected)"
-        );
-        // Verify the included tx is for account1 (the valid one)
-        assert_eq!(
-            txs[0].target(),
-            Some(account1),
-            "Included tx should be from account1 (valid tx)"
+            included_txids(output.template()),
+            vec![valid_txid],
+            "Block should contain only the valid tx"
         );
     }
 
@@ -1789,18 +1595,16 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sequential_seq_no_both_succeed() {
         let account_id = test_account_id(1);
-        let env = TestEnvBuilder::new()
-            .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .with_account(account_id, DEFAULT_ACCOUNT_BALANCE)
-            .build()
-            .await;
-
-        // Setup inbox MMR with messages for both txs using StorageInboxMmr
         let source_account = test_account_id(2);
         let messages = generate_message_entries(4, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(&env.storage, account_id);
-        inbox_mmr.add_messages(messages.clone());
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(
+                TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE).with_inbox(messages.clone()),
+            );
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         // tx1: seq_no=0, processes messages[0..2]
         let tx1_messages = messages[0..2].to_vec();
@@ -1820,38 +1624,20 @@ mod tests {
         let tx2_id = tx2.compute_txid();
 
         // Build block
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage.clone());
+        let mempool = env.mempool();
 
-        insert_inbox_messages_into_storage_state(
-            env.storage.as_ref(),
-            env.parent_commitment,
-            account_id,
-            &messages,
-        )
-        .await;
         mempool.add_transaction(tx1_id, tx1);
         mempool.add_transaction(tx2_id, tx2);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Assert: both txs included (tx2 succeeds because it sees tx1's seq_no increment)
-        let txs = output
-            .template()
-            .body()
-            .tx_segment()
-            .expect("Should have tx segment")
-            .txs();
+        let included = included_txids(output.template());
         assert_eq!(
-            txs.len(),
+            included.len(),
             2,
             "Block should contain both txs (tx2 sees tx1's state changes)"
         );
@@ -1862,18 +1648,16 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_dependent_tx_fails_without_predecessor() {
         let account_id = test_account_id(1);
-        let env = TestEnvBuilder::new()
-            .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .with_account(account_id, DEFAULT_ACCOUNT_BALANCE)
-            .build()
-            .await;
-
-        // Setup inbox MMR with messages using StorageInboxMmr
         let source_account = test_account_id(2);
         let messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr = StorageInboxMmr::new(&env.storage, account_id);
-        inbox_mmr.add_messages(messages.clone());
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(
+                TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE).with_inbox(messages.clone()),
+            );
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         // Only submit tx with seq_no=1 (no seq_no=0 predecessor)
         // Block assembly will reject during execution because account has seq_no=0
@@ -1883,33 +1667,20 @@ mod tests {
             .build();
         let txid = tx.compute_txid();
 
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage.clone());
+        let mempool = env.mempool();
 
-        insert_inbox_messages_into_storage_state(
-            env.storage.as_ref(),
-            env.parent_commitment,
-            account_id,
-            &messages,
-        )
-        .await;
         mempool.add_transaction(txid, tx);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Block should have no txs - the seq_no=1 tx is rejected during execution
-        let tx_segment = output.template().body().tx_segment();
-        let tx_count = tx_segment.map(|seg| seg.txs().len()).unwrap_or(0);
+        let included = included_txids(output.template());
         assert_eq!(
-            tx_count, 0,
+            included.len(),
+            0,
             "Block should be empty - tx with seq_no=1 rejected when account has seq_no=0"
         );
     }
@@ -1921,23 +1692,22 @@ mod tests {
     async fn test_independent_tx_succeeds_when_other_fails() {
         let account1 = test_account_id(1);
         let account2 = test_account_id(2);
-        let env = TestEnvBuilder::new()
-            .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .with_account(account1, DEFAULT_ACCOUNT_BALANCE)
-            .with_account(account2, DEFAULT_ACCOUNT_BALANCE)
-            .build()
-            .await;
-
-        // Setup inbox MMRs for both accounts using StorageInboxMmr
         let source_account = test_account_id(3);
         let account1_messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr1 = StorageInboxMmr::new(&env.storage, account1);
-        inbox_mmr1.add_messages(account1_messages.clone());
-
         let account2_messages = generate_message_entries(2, source_account);
-        let mut inbox_mmr2 = StorageInboxMmr::new(&env.storage, account2);
-        inbox_mmr2.add_messages(account2_messages.clone());
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(
+                TestAccount::new(account1, DEFAULT_ACCOUNT_BALANCE)
+                    .with_inbox(account1_messages.clone()),
+            )
+            .with_account(
+                TestAccount::new(account2, DEFAULT_ACCOUNT_BALANCE)
+                    .with_inbox(account2_messages.clone()),
+            );
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         // tx1: account1 claims fake message at index 100, but MMR only has indices 0-1
         let fake_message = generate_message_entries(1, test_account_id(99))
@@ -1958,40 +1728,22 @@ mod tests {
         let tx2_id = tx2.compute_txid();
 
         // Build block
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage.clone());
+        let mempool = env.mempool();
 
-        insert_inbox_messages_into_storage_state(
-            env.storage.as_ref(),
-            env.parent_commitment,
-            account1,
-            &account1_messages,
-        )
-        .await;
-        insert_inbox_messages_into_storage_state(
-            env.storage.as_ref(),
-            env.parent_commitment,
-            account2,
-            &account2_messages,
-        )
-        .await;
         mempool.add_transaction(tx1_id, tx1);
         mempool.add_transaction(tx2_id, tx2);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Assert: tx2 included, tx1 rejected
-        let tx_segment = output.template().body().tx_segment();
-        let tx_count = tx_segment.map(|seg| seg.txs().len()).unwrap_or(0);
-        assert_eq!(tx_count, 1, "Block should contain tx2 only");
+        assert_eq!(
+            included_txids(output.template()),
+            vec![tx2_id],
+            "Block should contain tx2 only"
+        );
 
         // Assert: tx1 removed (ConsensusInvalid), tx2 still in mempool (included txs not
         // auto-removed)
@@ -2014,14 +1766,14 @@ mod tests {
         let account3 = test_account_id(3);
 
         // Setup with custom balances: account1 has 10000 sats, account2 has 0 sats
-        let env = TestEnvBuilder::new()
+        let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
-            .with_asm_manifests(&[1, 2, 3])
-            .with_account(account1, 10000)
-            .with_account(account2, 0)
-            .with_account(account3, 0)
-            .build()
-            .await;
+            .with_l1_manifest_height_range(1..=3)
+            .with_account(TestAccount::new(account1, 10000))
+            .with_account(TestAccount::new(account2, 0))
+            .with_account(TestAccount::new(account3, 0));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         // tx1: account1 sends 1000 sats to account2
         let tx1 = MempoolSnarkTxBuilder::new(account1)
@@ -2038,32 +1790,21 @@ mod tests {
         let tx2_id = tx2.compute_txid();
 
         // Build block
-        let (ctx, mempool) = create_test_block_assembly_context(env.storage);
+        let mempool = env.mempool();
         mempool.add_transaction(tx1_id, tx1);
         mempool.add_transaction(tx2_id, tx2);
 
-        let config = BlockGenerationConfig::new(env.parent_commitment);
-        let output = generate_block_template_inner(
-            &ctx,
-            &env.epoch_sealing_policy,
-            &env.sequencer_config,
-            config,
-            AccumulatedDaData::new_empty(),
-        )
-        .await
-        .expect("Block generation should succeed");
+        let output = env
+            .generate_block_template()
+            .await
+            .expect("Block generation should succeed");
 
         // Assert: both txs included
         // tx1 executes first, transferring 1000 to account2
         // tx2 executes second, account2 now has 1000 and can send 500
-        let txs = output
-            .template()
-            .body()
-            .tx_segment()
-            .expect("Should have tx segment")
-            .txs();
+        let included = included_txids(output.template());
         assert_eq!(
-            txs.len(),
+            included.len(),
             2,
             "Block should contain both txs (tx2 sees tx1's balance transfer)"
         );
@@ -2078,44 +1819,38 @@ mod tests {
     /// pre-fill the block output buffer to near capacity and verify that even a
     /// small tx triggers the soft-break when it would push past the limit.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_tx_deferred_when_logs_would_overflow_remaining_budget() {
+    async fn test_log_overflow_defers_tx() {
         let account_id = test_account_id(1);
-        let storage = create_test_storage();
-        let mut parent_state = create_test_genesis_state();
-        add_snark_account_to_state(&mut parent_state, account_id, 1, DEFAULT_ACCOUNT_BALANCE);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(storage);
-        let parent_header = create_test_parent_header();
+        let parent_state = env
+            .ctx()
+            .fetch_state_for_tip(env.parent_commitment())
+            .await
+            .expect("fetch parent state")
+            .expect("parent state exists");
+        let parent_block = env
+            .ctx()
+            .fetch_ol_block(env.parent_commitment().blkid)
+            .await
+            .expect("fetch parent block")
+            .expect("parent block exists");
+        let parent_header = parent_block.header().clone();
         let block_info = BlockInfo::new(1_000_001, parent_header.slot() + 1, parent_header.epoch());
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
-        let accumulated_batch = WriteBatch::new_from_state(&parent_state);
-
-        let withdrawal_msg_data = WithdrawalMsgData::new(
-            DEFAULT_OPERATOR_FEE,
-            b"bc1qlogcapoverflow".to_vec(),
-            u32::MAX,
-        )
-        .expect("valid withdrawal data");
-        let encoded_withdrawal_body =
-            encode_to_vec(&withdrawal_msg_data).expect("encode withdrawal body");
-        let withdrawal_msg =
-            OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_withdrawal_body).expect("msg format");
-        let withdrawal_payload_data = withdrawal_msg.to_vec();
+        let accumulated_batch = WriteBatch::new_from_state(parent_state.as_ref());
 
         // Create a tx with 5 withdrawal messages (= 5 logs).
-        let output_messages: Vec<_> = (0..5)
-            .map(|_| {
-                let payload = MsgPayload::new(
-                    BitcoinAmount::from_sat(100_000_000),
-                    withdrawal_payload_data.clone(),
-                );
-                OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload)
-            })
-            .collect();
-
-        let tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_seq_no(0)
-            .with_output_messages(output_messages)
+        let withdrawal_dest = b"bc1qlogcapoverflow".to_vec();
+        let tx = (0..5)
+            .fold(
+                MempoolSnarkTxBuilder::new(account_id).with_seq_no(0),
+                |builder, _| builder.with_withdrawal(100_000_000, withdrawal_dest.clone()),
+            )
             .build();
         let txid = tx.compute_txid();
 
@@ -2128,10 +1863,10 @@ mod tests {
             .expect("pre-fill should succeed");
 
         let out = process_transactions(
-            &ctx,
+            env.ctx(),
             &block_context,
             &output_buffer,
-            &parent_state,
+            parent_state.as_ref(),
             accumulated_batch,
             vec![(txid, tx)],
             AccumulatedDaData::new_empty(),
@@ -2154,53 +1889,45 @@ mod tests {
     /// Uses `process_transactions` directly with a pre-filled output buffer so
     /// that realistic message counts (≤ 255 per tx) can trigger the overflow.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_block_full_log_overflow_tx_not_reported_invalid_and_kept_in_mempool() {
+    async fn test_log_overflow_tx_skipped_not_invalid() {
         let account_id = test_account_id(8);
-        let storage = create_test_storage();
-        let mut parent_state = create_test_genesis_state();
-        add_snark_account_to_state(&mut parent_state, account_id, 1, DEFAULT_ACCOUNT_BALANCE);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(storage);
-        let parent_header = create_test_parent_header();
+        let parent_state = env
+            .ctx()
+            .fetch_state_for_tip(env.parent_commitment())
+            .await
+            .expect("fetch parent state")
+            .expect("parent state exists");
+        let parent_block = env
+            .ctx()
+            .fetch_ol_block(env.parent_commitment().blkid)
+            .await
+            .expect("fetch parent block")
+            .expect("parent block exists");
+        let parent_header = parent_block.header().clone();
         let block_info = BlockInfo::new(1_000_001, parent_header.slot() + 1, parent_header.epoch());
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
-        let accumulated_batch = WriteBatch::new_from_state(&parent_state);
-
-        let withdrawal_msg_data =
-            WithdrawalMsgData::new(DEFAULT_OPERATOR_FEE, b"bc1qlogcapfull".to_vec(), u32::MAX)
-                .expect("valid withdrawal data");
-        let encoded_withdrawal_body =
-            encode_to_vec(&withdrawal_msg_data).expect("encode withdrawal body");
-        let withdrawal_msg =
-            OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_withdrawal_body).expect("msg format");
-        let withdrawal_payload_data = withdrawal_msg.to_vec();
+        let accumulated_batch = WriteBatch::new_from_state(parent_state.as_ref());
 
         // First tx: 10 withdrawal messages = 10 logs.
-        let fill_messages: Vec<_> = (0..10)
-            .map(|_| {
-                let payload = MsgPayload::new(
-                    BitcoinAmount::from_sat(100_000_000),
-                    withdrawal_payload_data.clone(),
-                );
-                OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload)
-            })
-            .collect();
-        let tx_fill = MempoolSnarkTxBuilder::new(account_id)
-            .with_seq_no(0)
-            .with_output_messages(fill_messages)
+        let withdrawal_dest = b"bc1qlogcapfull".to_vec();
+        let tx_fill = (0..10)
+            .fold(
+                MempoolSnarkTxBuilder::new(account_id).with_seq_no(0),
+                |builder, _| builder.with_withdrawal(100_000_000, withdrawal_dest.clone()),
+            )
             .build();
         let tx_fill_id = tx_fill.compute_txid();
 
         // Second tx: 1 withdrawal message = 1 log.
         let tx_overflow = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(1)
-            .with_output_messages(vec![{
-                let payload = MsgPayload::new(
-                    BitcoinAmount::from_sat(100_000_000),
-                    withdrawal_payload_data.clone(),
-                );
-                OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload)
-            }])
+            .with_withdrawal(100_000_000, withdrawal_dest)
             .build();
         let tx_overflow_id = tx_overflow.compute_txid();
 
@@ -2213,10 +1940,10 @@ mod tests {
             .expect("pre-fill should succeed");
 
         let out = process_transactions(
-            &ctx,
+            env.ctx(),
             &block_context,
             &output_buffer,
-            &parent_state,
+            parent_state.as_ref(),
             accumulated_batch,
             vec![(tx_fill_id, tx_fill), (tx_overflow_id, tx_overflow)],
             AccumulatedDaData::new_empty(),
@@ -2234,39 +1961,34 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_process_transactions_soft_breaks_when_log_cap_already_reached() {
+    async fn test_log_cap_soft_break() {
         let account_id = test_account_id(7);
-        let storage = create_test_storage();
-        let mut parent_state = create_test_genesis_state();
-        add_snark_account_to_state(&mut parent_state, account_id, 1, DEFAULT_ACCOUNT_BALANCE);
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let (ctx, _mempool) = create_test_block_assembly_context(storage);
-        let parent_header = create_test_parent_header();
+        let parent_state = env
+            .ctx()
+            .fetch_state_for_tip(env.parent_commitment())
+            .await
+            .expect("fetch parent state")
+            .expect("parent state exists");
+        let parent_block = env
+            .ctx()
+            .fetch_ol_block(env.parent_commitment().blkid)
+            .await
+            .expect("fetch parent block")
+            .expect("parent block exists");
+        let parent_header = parent_block.header().clone();
         let block_info = BlockInfo::new(1_000_001, parent_header.slot() + 1, parent_header.epoch());
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
-        let accumulated_batch = WriteBatch::new_from_state(&parent_state);
-
-        let withdrawal_msg_data = WithdrawalMsgData::new(
-            DEFAULT_OPERATOR_FEE,
-            b"bc1qlogcapreached".to_vec(),
-            u32::MAX,
-        )
-        .expect("valid withdrawal data");
-        let encoded_withdrawal_body =
-            encode_to_vec(&withdrawal_msg_data).expect("encode withdrawal body");
-        let withdrawal_msg =
-            OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_withdrawal_body).expect("msg format");
-        let withdrawal_payload_data = withdrawal_msg.to_vec();
+        let accumulated_batch = WriteBatch::new_from_state(parent_state.as_ref());
 
         let tx = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
-            .with_output_messages(vec![{
-                let payload = MsgPayload::new(
-                    BitcoinAmount::from_sat(100_000_000),
-                    withdrawal_payload_data.clone(),
-                );
-                OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload)
-            }])
+            .with_withdrawal(100_000_000, b"bc1qlogcapreached".to_vec())
             .build();
         let txid = tx.compute_txid();
 
@@ -2280,10 +2002,10 @@ mod tests {
             .expect("pre-filling up to the cap should succeed");
 
         let out = process_transactions(
-            &ctx,
+            env.ctx(),
             &block_context,
             &output_buffer,
-            &parent_state,
+            parent_state.as_ref(),
             accumulated_batch,
             vec![(txid, tx)],
             AccumulatedDaData::new_empty(),

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -143,7 +143,8 @@ pub(crate) struct ConstructBlockOutput<S> {
 /// Fetches transactions from the mempool, generates accumulator proofs, validates execution
 /// with per-transaction staging, and constructs a complete block template.
 ///
-/// Transactions that fail proof generation or execution are reported to the mempool.
+/// Transactions that fail proof generation or execution are returned in `failed_txs`.
+/// Reporting those failures to the mempool is handled by the service layer.
 ///
 /// Returns a [`BlockTemplateResult`] containing both the generated template and
 /// any transactions that failed validation during assembly.
@@ -193,16 +194,6 @@ where
         parent_da,
     )
     .await?;
-
-    // 5. Report failed transactions to mempool
-    if !output.failed_txs.is_empty() {
-        debug!(
-            component = "ol_block_assembly",
-            count = output.failed_txs.len(),
-            "Reporting failed transactions to mempool"
-        );
-        MempoolProvider::report_invalid_transactions(ctx, &output.failed_txs).await?;
-    }
 
     Ok(BlockTemplateResult::new(
         output.template,
@@ -2173,13 +2164,13 @@ mod tests {
             "Block should contain tx2 only"
         );
 
-        // Assert: tx1 removed (ConsensusInvalid), tx2 still in mempool (included txs not
-        // auto-removed)
+        // Inner generation no longer reports invalid txs to mempool; both txs remain until
+        // service-level reporting and block-application handling.
         let remaining = mempool.get_transactions(10).await.unwrap();
         assert_eq!(
             remaining.len(),
-            1,
-            "tx1 removed as invalid, tx2 still in mempool until block applied"
+            2,
+            "inner generation should not mutate mempool membership"
         );
     }
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -739,12 +739,26 @@ fn add_accumulator_proofs<P: AccumulatorProofGenerator, S: IStateAccessor>(
 
 #[cfg(test)]
 mod tests {
+    const CHECKPOINT_MSG_VALUE_SATS: u64 = 100_000_000;
+
     use strata_acct_types::*;
+    use strata_checkpoint_types_ssz::MAX_OL_LOGS_PER_CHECKPOINT;
     use strata_identifiers::{Buf32, L1Height, OLBlockId};
     use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, OLLog};
+    use strata_ol_state_types::OLState;
 
     use super::*;
     use crate::test_utils::*;
+
+    type OlWriteBatch = WriteBatch<<OLState as IStateAccessor>::AccountState>;
+
+    async fn build_process_tx_env(account_id: AccountId) -> TestEnv {
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        TestEnv::from_fixture(fixture, parent_commitment)
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_l1_header_proof_gen_success() {
@@ -2015,15 +2029,17 @@ mod tests {
     /// a single tx can never overflow the per-tx log buffer on its own. So we
     /// pre-fill the block output buffer to near capacity and verify that even a
     /// small tx triggers the soft-break when it would push past the limit.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_log_overflow_defers_tx() {
-        let account_id = test_account_id(1);
-        let env_builder = TestStorageFixtureBuilder::new()
-            .with_parent_slot(0)
-            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
-        let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let env = TestEnv::from_fixture(fixture, parent_commitment);
-
+    async fn build_process_transactions_preamble(
+        env: &TestEnv,
+        timestamp: u64,
+        slot_offset: u64,
+    ) -> (
+        Arc<OLState>,
+        OLBlockHeader,
+        BlockInfo,
+        OlWriteBatch,
+        ExecOutputBuffer,
+    ) {
         let parent_state = env
             .ctx()
             .fetch_state_for_tip(env.parent_commitment())
@@ -2037,23 +2053,41 @@ mod tests {
             .expect("fetch parent block")
             .expect("parent block exists");
         let parent_header = parent_block.header().clone();
-        let block_info = BlockInfo::new(1_000_001, parent_header.slot() + 1, parent_header.epoch());
-        let block_context = BlockContext::new(&block_info, Some(&parent_header));
+        let block_info = BlockInfo::new(
+            timestamp,
+            parent_header.slot() + slot_offset,
+            parent_header.epoch(),
+        );
         let accumulated_batch = WriteBatch::new_from_state(parent_state.as_ref());
+        let output_buffer = ExecOutputBuffer::new_empty();
+        (
+            parent_state,
+            parent_header,
+            block_info,
+            accumulated_batch,
+            output_buffer,
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_log_overflow_defers_tx() {
+        let account_id = test_account_id(1);
+        let env = build_process_tx_env(account_id).await;
+
+        let (parent_state, parent_header, block_info, accumulated_batch, output_buffer) =
+            build_process_transactions_preamble(&env, 1_000_001, 1).await;
+        let block_context = BlockContext::new(&block_info, Some(&parent_header));
 
         // Create a tx with 5 withdrawal messages (= 5 logs).
         let withdrawal_dest = b"bc1qlogcapoverflow".to_vec();
-        let tx = (0..5)
-            .fold(
-                MempoolSnarkTxBuilder::new(account_id).with_seq_no(0),
-                |builder, _| builder.with_withdrawal(100_000_000, withdrawal_dest.clone()),
-            )
+        let tx = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_withdrawals(5, 100_000_000, withdrawal_dest)
             .build();
         let txid = tx.compute_txid();
 
         // Pre-fill output buffer so only 3 logs remain before the cap.
         // The tx produces 5 logs, so 5 > 3 remaining → soft-break.
-        let output_buffer = ExecOutputBuffer::new_empty();
         let prefill = MAX_LOGS_PER_BLOCK as usize - 3;
         output_buffer
             .emit_logs((0..prefill).map(|i| OLLog::new(AccountSerial::from(i as u32), vec![])))
@@ -2088,36 +2122,17 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_log_overflow_tx_skipped_not_invalid() {
         let account_id = test_account_id(8);
-        let env_builder = TestStorageFixtureBuilder::new()
-            .with_parent_slot(0)
-            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
-        let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = build_process_tx_env(account_id).await;
 
-        let parent_state = env
-            .ctx()
-            .fetch_state_for_tip(env.parent_commitment())
-            .await
-            .expect("fetch parent state")
-            .expect("parent state exists");
-        let parent_block = env
-            .ctx()
-            .fetch_ol_block(env.parent_commitment().blkid)
-            .await
-            .expect("fetch parent block")
-            .expect("parent block exists");
-        let parent_header = parent_block.header().clone();
-        let block_info = BlockInfo::new(1_000_001, parent_header.slot() + 1, parent_header.epoch());
+        let (parent_state, parent_header, block_info, accumulated_batch, output_buffer) =
+            build_process_transactions_preamble(&env, 1_000_001, 1).await;
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
-        let accumulated_batch = WriteBatch::new_from_state(parent_state.as_ref());
 
         // First tx: 10 withdrawal messages = 10 logs.
         let withdrawal_dest = b"bc1qlogcapfull".to_vec();
-        let tx_fill = (0..10)
-            .fold(
-                MempoolSnarkTxBuilder::new(account_id).with_seq_no(0),
-                |builder, _| builder.with_withdrawal(100_000_000, withdrawal_dest.clone()),
-            )
+        let tx_fill = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_withdrawals(10, 100_000_000, withdrawal_dest.clone())
             .build();
         let tx_fill_id = tx_fill.compute_txid();
 
@@ -2130,7 +2145,6 @@ mod tests {
 
         // Pre-fill the buffer so that tx_fill's 10 logs exactly reach the cap,
         // leaving no room for tx_overflow's 1 log.
-        let output_buffer = ExecOutputBuffer::new_empty();
         let prefill = MAX_LOGS_PER_BLOCK as usize - 10;
         output_buffer
             .emit_logs((0..prefill).map(|i| OLLog::new(AccountSerial::from(i as u32), vec![])))
@@ -2160,28 +2174,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_log_cap_soft_break() {
         let account_id = test_account_id(7);
-        let env_builder = TestStorageFixtureBuilder::new()
-            .with_parent_slot(0)
-            .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE));
-        let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = build_process_tx_env(account_id).await;
 
-        let parent_state = env
-            .ctx()
-            .fetch_state_for_tip(env.parent_commitment())
-            .await
-            .expect("fetch parent state")
-            .expect("parent state exists");
-        let parent_block = env
-            .ctx()
-            .fetch_ol_block(env.parent_commitment().blkid)
-            .await
-            .expect("fetch parent block")
-            .expect("parent block exists");
-        let parent_header = parent_block.header().clone();
-        let block_info = BlockInfo::new(1_000_001, parent_header.slot() + 1, parent_header.epoch());
+        let (parent_state, parent_header, block_info, accumulated_batch, output_buffer) =
+            build_process_transactions_preamble(&env, 1_000_001, 1).await;
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
-        let accumulated_batch = WriteBatch::new_from_state(parent_state.as_ref());
 
         let tx = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
@@ -2191,7 +2188,6 @@ mod tests {
 
         // Pre-fill the block output buffer to exactly the cap so the next tx that emits logs
         // hits the soft-break branch without being marked invalid.
-        let output_buffer = ExecOutputBuffer::new_empty();
         output_buffer
             .emit_logs(
                 (0..MAX_LOGS_PER_BLOCK).map(|i| OLLog::new(AccountSerial::from(i as u32), vec![])),
@@ -2215,6 +2211,138 @@ mod tests {
         assert!(
             out.successful_txs.is_empty(),
             "overflowing tx should not be included"
+        );
+    }
+
+    async fn run_process_transactions_with_seeded_checkpoint_logs(
+        account_id: AccountId,
+        seeded_log_count: usize,
+        mempool_txs: Vec<(OLTxId, OLTransaction)>,
+    ) -> ProcessTransactionsOutput<OLState> {
+        const CHECKPOINT_TEST_TIMESTAMP: u64 = 1_000_003;
+        const CHECKPOINT_TEST_SLOT_OFFSET: u64 = 3;
+
+        let env = build_process_tx_env(account_id).await;
+        let (parent_state, parent_header, block_info, accumulated_batch, output_buffer) =
+            build_process_transactions_preamble(
+                &env,
+                CHECKPOINT_TEST_TIMESTAMP,
+                CHECKPOINT_TEST_SLOT_OFFSET,
+            )
+            .await;
+        let block_context = BlockContext::new(&block_info, Some(&parent_header));
+        let seeded_da = seeded_da(seeded_log_count);
+
+        process_transactions(
+            env.ctx(),
+            &block_context,
+            &output_buffer,
+            parent_state.as_ref(),
+            accumulated_batch,
+            mempool_txs,
+            seeded_da,
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_checkpoint_soft_commits_then_stops() {
+        const CHECKPOINT_WITHDRAWAL_DEST: &[u8] = b"bc1qcheckpointlimit";
+        let account_id = test_account_id(9);
+        let withdrawal_dest = CHECKPOINT_WITHDRAWAL_DEST.to_vec();
+        let tx1 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_withdrawal(CHECKPOINT_MSG_VALUE_SATS, withdrawal_dest.clone())
+            .build();
+        let tx2 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(1)
+            .with_withdrawal(CHECKPOINT_MSG_VALUE_SATS, withdrawal_dest)
+            .build();
+        let tx1_id = tx1.compute_txid();
+        let tx2_id = tx2.compute_txid();
+
+        // Seed one below soft threshold so tx1's single log tips verdict to
+        // SoftLimitReached (commit current tx, then stop).
+        let soft_threshold = MAX_OL_LOGS_PER_CHECKPOINT as usize * 9 / 10;
+        let out = run_process_transactions_with_seeded_checkpoint_logs(
+            account_id,
+            soft_threshold - 1,
+            vec![(tx1_id, tx1), (tx2_id, tx2)],
+        )
+        .await;
+
+        assert_eq!(
+            out.successful_txs.len(),
+            1,
+            "soft limit should commit current tx and defer remaining txs"
+        );
+        assert_eq!(
+            out.successful_txs[0].compute_txid(),
+            tx1_id,
+            "first tx should be committed before soft-break"
+        );
+        assert!(
+            out.failed_txs.is_empty(),
+            "deferred tx should not be marked invalid"
+        );
+        assert!(
+            out.checkpoint_size_limit_reached,
+            "soft verdict should mark checkpoint_size_limit_reached"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_checkpoint_hard_rolls_back_then_stops() {
+        const CHECKPOINT_WITHDRAWAL_DEST: &[u8] = b"bc1qcheckpointlimit";
+        let account_id = test_account_id(10);
+        let withdrawal_dest = CHECKPOINT_WITHDRAWAL_DEST.to_vec();
+        let tx1 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(0)
+            .with_withdrawal(CHECKPOINT_MSG_VALUE_SATS, withdrawal_dest.clone())
+            .build();
+        let tx2 = MempoolSnarkTxBuilder::new(account_id)
+            .with_seq_no(1)
+            .with_withdrawal(CHECKPOINT_MSG_VALUE_SATS, withdrawal_dest)
+            .build();
+        let tx1_id = tx1.compute_txid();
+        let tx2_id = tx2.compute_txid();
+
+        // Control case: one below hard-1 (i.e. hard-2) should still accept tx1.
+        let control = run_process_transactions_with_seeded_checkpoint_logs(
+            account_id,
+            (MAX_OL_LOGS_PER_CHECKPOINT as usize) - 2,
+            vec![(tx1_id, tx1.clone())],
+        )
+        .await;
+        assert_eq!(
+            control
+                .successful_txs
+                .iter()
+                .map(OLTransaction::compute_txid)
+                .collect::<Vec<_>>(),
+            vec![tx1_id],
+            "tx1 should be accepted just below the hard threshold"
+        );
+
+        // Seed one below hard limit so tx1's single log tips verdict to
+        // HardLimitExceeded (roll back current tx, then stop).
+        let out = run_process_transactions_with_seeded_checkpoint_logs(
+            account_id,
+            (MAX_OL_LOGS_PER_CHECKPOINT as usize) - 1,
+            vec![(tx1_id, tx1), (tx2_id, tx2)],
+        )
+        .await;
+
+        assert!(
+            out.successful_txs.is_empty(),
+            "hard limit should roll back current tx"
+        );
+        assert!(
+            out.failed_txs.is_empty(),
+            "hard-limit rollback should not mark tx invalid"
+        );
+        assert!(
+            out.checkpoint_size_limit_reached,
+            "hard verdict should mark checkpoint_size_limit_reached"
         );
     }
 }

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -165,8 +165,7 @@ where
         self.state_provider
             .get_state_for_tip_async(tip)
             .await
-            // keep current logic: stringified provider error
-            .map_err(|e| BlockAssemblyError::Other(e.to_string()))
+            .map_err(|e| BlockAssemblyError::StateProvider(Box::new(e)))
     }
 
     async fn fetch_asm_manifests_from(

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -368,109 +368,99 @@ where
 #[cfg(test)]
 mod tests {
     use strata_acct_types::AccumulatorClaim;
-    use strata_asm_manifest_types::AsmManifest;
-    use strata_identifiers::{Buf32, L1BlockId, WtxidsRoot};
-    use strata_ledger_types::IStateAccessor;
 
     use super::*;
     use crate::test_utils::{
-        StorageAsmMmr, StorageInboxMmr, create_test_context, create_test_genesis_state,
-        create_test_message, create_test_storage, test_account_id, test_hash,
+        TestAccount, TestStorageFixtureBuilder, create_test_context, create_test_message,
+        test_account_id, test_hash,
     };
 
     // =========================================================================
     // L1 Header Proof Generation Tests
     // =========================================================================
 
-    fn create_test_manifest(height: L1Height, seed: u8) -> AsmManifest {
-        let mut blkid_bytes = [0u8; 32];
-        blkid_bytes[0] = seed;
-        AsmManifest::new(
-            height,
-            L1BlockId::from(Buf32::from(blkid_bytes)),
-            WtxidsRoot::from(Buf32::zero()),
-            vec![],
-        )
-        .expect("test manifest should be valid")
-    }
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_proof_gen_success() {
+        let account_id = test_account_id(1);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let claims = vec![
+            fixture
+                .l1_header_ref(1)
+                .expect("claim for L1 height 1 should exist"),
+        ];
 
-    #[test]
-    fn test_l1_header_proof_gen_success() {
-        let storage = create_test_storage();
-        let manifest = create_test_manifest(1, 1);
-        let manifest_hash = manifest.compute_hash().into();
-
-        // Add a header hash to the ASM MMR
-        let mut asm_mmr = StorageAsmMmr::new(&storage);
-        asm_mmr.add_header(manifest_hash);
-
-        // Collect claims before creating context
-        let claims = asm_mmr.claims();
-        let mut state = create_test_genesis_state();
-        state.append_manifest(manifest.height(), manifest);
-
-        let ctx = create_test_context(storage);
-
-        let result = ctx.generate_l1_header_proofs(&claims, &state);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = ctx.generate_l1_header_proofs(&claims, state.as_ref());
 
         assert!(result.is_ok(), "Should succeed with valid claim");
         let proofs = result.unwrap();
         assert_eq!(proofs.l1_headers_proofs().len(), 1);
     }
 
-    #[test]
-    fn test_l1_header_proof_gen_multiple_claims() {
-        let storage = create_test_storage();
-        let manifests = vec![
-            create_test_manifest(1, 1),
-            create_test_manifest(2, 2),
-            create_test_manifest(3, 3),
-        ];
-        let manifest_hashes: Vec<Hash> = manifests
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_proof_gen_multiple_claims() {
+        let account_id = test_account_id(1);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1, 2, 3]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let claims = fixture
+            .l1_header_refs()
             .iter()
-            .map(|mf| mf.compute_hash().into())
-            .collect();
+            .map(|(_, claim)| claim.clone())
+            .collect::<Vec<_>>();
 
-        // Add multiple header hashes
-        let mut asm_mmr = StorageAsmMmr::new(&storage);
-        asm_mmr.add_headers(manifest_hashes.iter().copied());
-
-        let claims = asm_mmr.claims();
-        let mut state = create_test_genesis_state();
-        for manifest in manifests {
-            state.append_manifest(manifest.height(), manifest);
-        }
-
-        let ctx = create_test_context(storage);
-
-        let result = ctx.generate_l1_header_proofs(&claims, &state);
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = ctx.generate_l1_header_proofs(&claims, state.as_ref());
 
         assert!(result.is_ok(), "Should succeed with multiple valid claims");
         let proofs = result.unwrap();
         assert_eq!(proofs.l1_headers_proofs().len(), 3);
     }
 
-    #[test]
-    fn test_l1_header_proof_gen_hash_mismatch() {
-        let storage = create_test_storage();
-        let manifest = create_test_manifest(1, 1);
-        let manifest_hash = manifest.compute_hash().into();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_proof_gen_hash_mismatch() {
+        let account_id = test_account_id(1);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let seeded_claim = fixture
+            .l1_header_ref(1)
+            .expect("claim for L1 height 1 should exist");
 
-        // Add a header hash to the ASM MMR
-        let mut asm_mmr = StorageAsmMmr::new(&storage);
-        asm_mmr.add_header(manifest_hash);
-
-        // Create claim with correct MMR index but wrong hash
-        let mmr_idx = asm_mmr.indices()[0];
+        // Create claim with correct MMR index but wrong hash.
         let wrong_hash = test_hash(99);
-        let claim = AccumulatorClaim::new(mmr_idx, wrong_hash);
-        let expected_hash = asm_mmr.hashes()[0];
-        let mut state = create_test_genesis_state();
-        state.append_manifest(manifest.height(), manifest);
+        let claim = AccumulatorClaim::new(seeded_claim.idx(), wrong_hash);
+        let expected_hash = seeded_claim.entry_hash();
 
-        let ctx = create_test_context(storage);
+        let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(&[claim], &state);
+        let result = ctx.generate_l1_header_proofs(&[claim], state.as_ref());
 
         assert!(
             result.is_err(),
@@ -491,25 +481,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_l1_header_proof_gen_missing_index() {
-        let storage = create_test_storage();
-        let manifest = create_test_manifest(1, 1);
-        let manifest_hash = manifest.compute_hash().into();
-
-        // Add one header but request a different index
-        let mut asm_mmr = StorageAsmMmr::new(&storage);
-        asm_mmr.add_header(manifest_hash);
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_proof_gen_missing_index() {
+        let account_id = test_account_id(1);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000))
+            .with_l1_header_refs([1]);
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let seeded_claim = fixture
+            .l1_header_ref(1)
+            .expect("claim for L1 height 1 should exist");
 
         // Create claim with non-existent MMR index (999 doesn't exist, MMR has 1 entry)
         let nonexistent_idx = 999u64;
-        let claim = AccumulatorClaim::new(nonexistent_idx, asm_mmr.hashes()[0]);
-        let mut state = create_test_genesis_state();
-        state.append_manifest(manifest.height(), manifest);
+        let claim = AccumulatorClaim::new(nonexistent_idx, seeded_claim.entry_hash());
 
-        let ctx = create_test_context(storage);
+        let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(&[claim], &state);
+        let result = ctx.generate_l1_header_proofs(&[claim], state.as_ref());
 
         assert!(result.is_err(), "Should fail with missing index");
         let err = result.unwrap_err();
@@ -524,15 +520,25 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_l1_header_claim_empty_mmr() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_claim_empty_mmr() {
+        let account_id = test_account_id(1);
+        let fixture_builder =
+            TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+
         // MMR index 0 is valid but the MMR is empty
         let claim = AccumulatorClaim::new(0, test_hash(42));
-        let state = create_test_genesis_state();
-        let ctx = create_test_context(storage);
+        let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(&[claim], &state);
+        let result = ctx.generate_l1_header_proofs(&[claim], state.as_ref());
 
         assert!(result.is_err(), "Should fail when MMR is empty");
         let err = result.unwrap_err();
@@ -549,13 +555,22 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_l1_header_proof_gen_empty_claims() {
-        let storage = create_test_storage();
-        let state = create_test_genesis_state();
-        let ctx = create_test_context(storage);
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_l1_header_proof_gen_empty_claims() {
+        let account_id = test_account_id(1);
+        let fixture_builder =
+            TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
+        let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+        let state = fixture
+            .storage()
+            .ol_state()
+            .get_toplevel_ol_state_async(parent_commitment)
+            .await
+            .expect("fetch stored state")
+            .expect("stored state missing");
+        let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(&[], &state);
+        let result = ctx.generate_l1_header_proofs(&[], state.as_ref());
 
         assert!(result.is_ok(), "Should succeed with empty claims");
         let proofs = result.unwrap();
@@ -566,24 +581,17 @@ mod tests {
     // Inbox Proof Generation Tests
     // =========================================================================
 
-    #[test]
-    fn test_inbox_proof_gen_success() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_proof_gen_success() {
         let account_id = test_account_id(1);
-
-        // Add messages to the inbox MMR using the tracker
-        let mut inbox_mmr = StorageInboxMmr::new(&storage, account_id);
         let messages: Vec<_> = (1..=2)
             .map(|i| create_test_message(i, i as u32, 1000 * i as u64))
             .collect();
-        inbox_mmr.add_messages(messages);
-
-        // Collect entries before creating context
-        let entries: Vec<_> = inbox_mmr.entries().to_vec();
-
-        let ctx = create_test_context(storage);
-
-        let result = ctx.generate_inbox_proofs_at(account_id, &entries, 0, entries.len() as u64);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(messages.clone()));
+        let (fixture, _parent_commitment) = fixture_builder.build_fixture().await;
+        let ctx = create_test_context(fixture.storage().clone());
+        let result = ctx.generate_inbox_proofs_at(account_id, &messages, 0, messages.len() as u64);
 
         assert!(
             result.is_ok(),
@@ -594,12 +602,13 @@ mod tests {
         assert_eq!(proofs.len(), 2);
     }
 
-    #[test]
-    fn test_inbox_proof_gen_empty_messages() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_proof_gen_empty_messages() {
         let account_id = test_account_id(1);
-
-        let ctx = create_test_context(storage);
+        let fixture_builder =
+            TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
+        let (fixture, _parent_commitment) = fixture_builder.build_fixture().await;
+        let ctx = create_test_context(fixture.storage().clone());
 
         let result = ctx.generate_inbox_proofs_at(account_id, &[], 0, 0);
 
@@ -608,27 +617,25 @@ mod tests {
         assert!(proofs.is_empty());
     }
 
-    #[test]
-    fn test_inbox_proof_gen_with_offset() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_proof_gen_with_offset() {
         let account_id = test_account_id(1);
-
-        // Add 4 messages to the inbox MMR using the tracker
-        let mut inbox_mmr = StorageInboxMmr::new(&storage, account_id);
         let all_messages: Vec<_> = (1..=4)
             .map(|i| create_test_message(i, i as u32, 1000 * i as u64))
             .collect();
-        inbox_mmr.add_messages(all_messages);
-
-        // Collect entries before creating context
-        let entries: Vec<_> = inbox_mmr.entries().to_vec();
-
-        let ctx = create_test_context(storage);
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(all_messages.clone()));
+        let (fixture, _parent_commitment) = fixture_builder.build_fixture().await;
+        let ctx = create_test_context(fixture.storage().clone());
 
         // Request proofs starting at index 2 for last 2 messages
-        let messages_to_prove = &entries[2..];
-        let result =
-            ctx.generate_inbox_proofs_at(account_id, messages_to_prove, 2, entries.len() as u64);
+        let messages_to_prove = &all_messages[2..];
+        let result = ctx.generate_inbox_proofs_at(
+            account_id,
+            messages_to_prove,
+            2,
+            all_messages.len() as u64,
+        );
 
         assert!(
             result.is_ok(),
@@ -639,34 +646,28 @@ mod tests {
         assert_eq!(proofs.len(), 2);
     }
 
-    #[test]
-    fn test_inbox_proof_gen_missing_messages() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_proof_gen_missing_messages() {
         let account_id = test_account_id(1);
-
-        // Don't add any messages to MMR, but try to generate proofs
-        let ctx = create_test_context(storage);
-
+        let fixture_builder =
+            TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
+        let (fixture, _parent_commitment) = fixture_builder.build_fixture().await;
+        let ctx = create_test_context(fixture.storage().clone());
         let messages = vec![create_test_message(1, 1, 1000)];
         let result = ctx.generate_inbox_proofs_at(account_id, &messages, 0, 0);
 
         assert!(result.is_err(), "Should fail when MMR has no messages");
     }
 
-    #[test]
-    fn test_inbox_claim_missing_index() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_claim_missing_index() {
         let account_id = test_account_id(1);
-
-        // Add one message at index 0
-        let mut inbox_mmr = StorageInboxMmr::new(&storage, account_id);
         let stored_message = create_test_message(1, 1, 1000);
-        inbox_mmr.add_message(stored_message);
-
-        // Claim messages starting at a non-existent index
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(vec![stored_message]));
+        let (fixture, _parent_commitment) = fixture_builder.build_fixture().await;
+        let ctx = create_test_context(fixture.storage().clone());
         let claimed_messages = vec![create_test_message(2, 2, 2000)];
-        let ctx = create_test_context(storage);
-
         let result = ctx.generate_inbox_proofs_at(account_id, &claimed_messages, 5, 1);
 
         assert!(result.is_err(), "Should fail for missing inbox index");
@@ -682,20 +683,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_inbox_claim_hash_mismatch() {
-        let storage = create_test_storage();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbox_claim_hash_mismatch() {
         let account_id = test_account_id(1);
-
-        // Add one message at index 0
-        let mut inbox_mmr = StorageInboxMmr::new(&storage, account_id);
         let stored_message = create_test_message(1, 1, 1000);
-        inbox_mmr.add_message(stored_message);
-
-        // Claim different message for the same index
+        let fixture_builder = TestStorageFixtureBuilder::new()
+            .with_account(TestAccount::new(account_id, 100_000).with_inbox(vec![stored_message]));
+        let (fixture, _parent_commitment) = fixture_builder.build_fixture().await;
+        let ctx = create_test_context(fixture.storage().clone());
         let claimed_messages = vec![create_test_message(2, 2, 2000)];
-        let ctx = create_test_context(storage);
-
         let result = ctx.generate_inbox_proofs_at(account_id, &claimed_messages, 0, 1);
 
         assert!(

--- a/crates/ol/block-assembly/src/da_tests.rs
+++ b/crates/ol/block-assembly/src/da_tests.rs
@@ -3,24 +3,21 @@
 //! Tests that verify DA is correctly accumulated during block assembly,
 //! reset at epoch boundaries, and rolled back on failed transactions.
 
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 use strata_identifiers::{Buf64, OLBlockCommitment};
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, SignedOLBlockHeader};
 use strata_ol_state_support_types::{DaAccumulatingState, EpochDaAccumulator};
 use strata_ol_state_types::OLState;
 use strata_ol_stf::execute_block_batch;
-use strata_storage::NodeStorage;
 
 use crate::{
-    AccumulatorProofGenerator, EpochSealingPolicy,
-    block_assembly::{calculate_block_slot_and_epoch, construct_block},
     context::BlockAssemblyAnchorContext,
     da_tracker::{AccumulatedDaData, rebuild_accumulated_da_upto},
     test_utils::{
-        DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, StorageInboxMmr, TestEnvBuilder,
-        create_test_block_assembly_context, generate_message_entries,
-        insert_inbox_messages_into_storage_state, test_account_id,
+        DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
+        TestStorageFixtureBuilder, assemble_block_with_txs, generate_message_entries,
+        included_txids, test_account_id,
     },
     types::BlockGenerationConfig,
 };
@@ -34,79 +31,39 @@ fn finalize_da_to_bytes(accumulator: EpochDaAccumulator, state: OLState) -> Vec<
         .expect("should produce a blob")
 }
 
-/// Builds blocks from `start_commitment` up to (not including) `target_slot`, threading DA.
+/// Builds blocks from the env parent commitment up to (not including) `target_slot`, threading DA.
 /// Returns `(final_commitment, accumulated_da, Vec<(block, post_state)>)`.
-async fn build_blocks_with_da_and_artifacts<C, E>(
-    start_commitment: OLBlockCommitment,
+async fn build_blocks_with_da_and_artifacts(
+    env: &mut TestEnv,
     target_slot: u64,
-    ctx: &C,
-    storage: &NodeStorage,
-    epoch_sealing_policy: &E,
 ) -> (
     OLBlockCommitment,
     AccumulatedDaData,
     Vec<(OLBlock, OLState)>,
-)
-where
-    C: BlockAssemblyAnchorContext<State = OLState> + AccumulatorProofGenerator,
-    E: EpochSealingPolicy,
-{
-    let mut current_commitment = start_commitment;
+) {
+    let mut current_commitment = env.parent_commitment();
     let mut accumulated_da = AccumulatedDaData::new_empty();
     let mut artifacts = Vec::new();
 
     let start_slot = if current_commitment.is_null() {
         0
     } else {
-        start_commitment.slot() + 1
+        current_commitment.slot() + 1
     };
 
     for slot in start_slot..target_slot {
-        let config = BlockGenerationConfig::new(current_commitment);
-
-        let parent_state = ctx
-            .fetch_state_for_tip(config.parent_block_commitment())
+        let output = env
+            .construct_block_with_da(iter::empty(), accumulated_da)
             .await
-            .unwrap_or_else(|e| panic!("Failed to fetch parent state at slot {slot}: {e:?}"))
-            .unwrap_or_else(|| panic!("Missing parent state at slot {slot}"));
-
-        let (block_slot, block_epoch) = calculate_block_slot_and_epoch(
-            &config.parent_block_commitment(),
-            parent_state.as_ref(),
-        );
-
-        let output = construct_block(
-            ctx,
-            epoch_sealing_policy,
-            &config,
-            parent_state,
-            block_slot,
-            block_epoch,
-            vec![],
-            accumulated_da,
-        )
-        .await
-        .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
+            .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
 
         let header = output.template.header();
-        let new_commitment = OLBlockCommitment::new(header.slot(), header.compute_blkid());
-
         let signed_header = SignedOLBlockHeader::new(header.clone(), Buf64::zero());
         let block = OLBlock::new(signed_header, output.template.body().clone());
+        let post_state = output.post_state.clone();
+        let new_commitment = env.persist(&output).await;
 
-        storage
-            .ol_block()
-            .put_block_data_async(block.clone())
-            .await
-            .unwrap_or_else(|e| panic!("Failed to store block at slot {slot}: {e:?}"));
-
-        storage
-            .ol_state()
-            .put_toplevel_ol_state_async(new_commitment, output.post_state.clone())
-            .await
-            .unwrap_or_else(|e| panic!("Failed to store state at slot {slot}: {e:?}"));
-
-        artifacts.push((block, output.post_state));
+        artifacts.push((block, post_state));
         accumulated_da = output.accumulated_da;
         current_commitment = new_commitment;
     }
@@ -114,32 +71,20 @@ where
     (current_commitment, accumulated_da, artifacts)
 }
 
-/// Collects stored blocks for an epoch by walking forward from start_slot to end_slot (exclusive).
-fn collect_blocks_from_artifacts(artifacts: &[(OLBlock, OLState)]) -> Vec<&OLBlock> {
-    artifacts.iter().map(|(block, _)| block).collect()
-}
-
 /// Core correctness: DA accumulated incrementally during block assembly must produce
 /// the same encoded blob as DA rebuilt by replaying those same blocks.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_da_incremental_matches_replay() {
-    let env = TestEnvBuilder::new()
+    let env_builder = TestStorageFixtureBuilder::new()
         .with_parent_slot(0)
-        .with_asm_manifests(&[1, 2, 3])
-        .build()
-        .await;
-
-    let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+        .with_l1_manifest_height_range(1..=3);
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
     // Build blocks 1..5, threading DA through each.
-    let (_final_commitment, incremental_da, artifacts) = build_blocks_with_da_and_artifacts(
-        env.parent_commitment,
-        5,
-        &ctx,
-        env.storage.as_ref(),
-        &env.epoch_sealing_policy,
-    )
-    .await;
+    let start_commitment = env.parent_commitment();
+    let (_final_commitment, incremental_da, artifacts) =
+        build_blocks_with_da_and_artifacts(&mut env, 5).await;
 
     // Get the post-state of the last block for finalization.
     let (_, last_post_state) = artifacts.last().unwrap();
@@ -150,18 +95,24 @@ async fn test_da_incremental_matches_replay() {
 
     // Replay: use DaAccumulatingState to re-execute all blocks.
     // Get parent state of first block (genesis post-state).
-    let genesis_state = ctx
-        .fetch_state_for_tip(env.parent_commitment)
+    let genesis_state = env
+        .ctx()
+        .fetch_state_for_tip(start_commitment)
         .await
         .unwrap()
         .unwrap();
 
-    let blocks: Vec<&OLBlock> = collect_blocks_from_artifacts(&artifacts);
+    let blocks: Vec<&OLBlock> = artifacts.iter().map(|(block, _)| block).collect();
     let first_parent_header = artifacts[0].0.header();
 
     // Get the parent header (genesis header) from storage.
     let parent_blkid = *first_parent_header.parent_blkid();
-    let parent_block = ctx.fetch_ol_block(parent_blkid).await.unwrap().unwrap();
+    let parent_block = env
+        .ctx()
+        .fetch_ol_block(parent_blkid)
+        .await
+        .unwrap()
+        .unwrap();
     let parent_header: &OLBlockHeader = parent_block.header();
 
     let owned_blocks: Vec<OLBlock> = blocks.into_iter().cloned().collect();
@@ -190,47 +141,33 @@ async fn test_da_incremental_matches_replay() {
 /// accumulated data, proving that epoch DA is scoped correctly.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_da_resets_at_epoch_boundary() {
-    let env = TestEnvBuilder::new()
+    let env_builder = TestStorageFixtureBuilder::new()
         .with_parent_slot(0)
-        .with_asm_manifests(&[1, 2, 3])
-        .build()
-        .await;
-
-    let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+        .with_l1_manifest_height_range(1..=3);
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
     // Build blocks 1..10 (slots before the terminal block), threading DA.
     let (pre_terminal_commitment, epoch1_da, _epoch1_artifacts) =
-        build_blocks_with_da_and_artifacts(
-            env.parent_commitment,
-            10,
-            &ctx,
-            env.storage.as_ref(),
-            &env.epoch_sealing_policy,
-        )
-        .await;
+        build_blocks_with_da_and_artifacts(&mut env, 10).await;
 
     // Epoch 1 DA accumulator should have slot changes from blocks 1-9.
     let (epoch1_acc, _) = epoch1_da.clone().into_parts();
-    let epoch1_pre_terminal_state = ctx
+    let epoch1_pre_terminal_state = env
+        .ctx()
         .fetch_state_for_tip(pre_terminal_commitment)
         .await
         .unwrap()
         .unwrap();
-    let epoch1_blob = finalize_da_to_bytes(epoch1_acc, (*epoch1_pre_terminal_state).clone());
+    let epoch1_blob =
+        finalize_da_to_bytes(epoch1_acc, Arc::unwrap_or_clone(epoch1_pre_terminal_state));
 
     // Build terminal block (slot 10) with epoch 1 DA.
     let config = BlockGenerationConfig::new(pre_terminal_commitment);
-    let (block_slot, block_epoch) = calculate_block_slot_and_epoch(
-        &pre_terminal_commitment,
-        epoch1_pre_terminal_state.as_ref(),
-    );
-    let terminal_output = construct_block(
-        &ctx,
-        &env.epoch_sealing_policy,
+    let terminal_output = assemble_block_with_txs(
+        env.ctx(),
+        env.epoch_sealing_policy(),
         &config,
-        epoch1_pre_terminal_state,
-        block_slot,
-        block_epoch,
         vec![],
         epoch1_da,
     )
@@ -238,38 +175,14 @@ async fn test_da_resets_at_epoch_boundary() {
     .expect("terminal block construction should succeed");
 
     // Store terminal block so we can build on it.
-    let terminal_header = terminal_output.template.header();
-    let terminal_commitment =
-        OLBlockCommitment::new(terminal_header.slot(), terminal_header.compute_blkid());
-    let signed = SignedOLBlockHeader::new(terminal_header.clone(), Buf64::zero());
-    let terminal_block = OLBlock::new(signed, terminal_output.template.body().clone());
-    env.storage
-        .ol_block()
-        .put_block_data_async(terminal_block)
-        .await
-        .unwrap();
-    env.storage
-        .ol_state()
-        .put_toplevel_ol_state_async(terminal_commitment, terminal_output.post_state.clone())
-        .await
-        .unwrap();
+    env.persist(&terminal_output).await;
 
     // Build slot 11 (first block of epoch 2) with FRESH empty DA.
-    let config_11 = BlockGenerationConfig::new(terminal_commitment);
-    let parent_state_11 = ctx
-        .fetch_state_for_tip(terminal_commitment)
-        .await
-        .unwrap()
-        .unwrap();
-    let (slot_11, epoch_11) =
-        calculate_block_slot_and_epoch(&terminal_commitment, parent_state_11.as_ref());
-    let epoch2_output = construct_block(
-        &ctx,
-        &env.epoch_sealing_policy,
+    let config_11 = BlockGenerationConfig::new(env.parent_commitment());
+    let epoch2_output = assemble_block_with_txs(
+        env.ctx(),
+        env.epoch_sealing_policy(),
         &config_11,
-        parent_state_11,
-        slot_11,
-        epoch_11,
         vec![],
         AccumulatedDaData::new_empty(),
     )
@@ -299,30 +212,18 @@ async fn test_da_resets_at_epoch_boundary() {
 async fn test_da_rollback_on_failed_tx() {
     let valid_account = test_account_id(1);
     let invalid_account = test_account_id(2);
-
-    let env = TestEnvBuilder::new()
-        .with_parent_slot(0)
-        .with_asm_manifests(&[1, 2, 3])
-        .with_account(valid_account, DEFAULT_ACCOUNT_BALANCE)
-        .with_account(invalid_account, DEFAULT_ACCOUNT_BALANCE)
-        .build()
-        .await;
-
-    // Setup inbox messages for valid account only.
     let source_account = test_account_id(3);
     let messages = generate_message_entries(2, source_account);
-    let mut inbox_mmr = StorageInboxMmr::new(&env.storage, valid_account);
-    inbox_mmr.add_messages(messages.clone());
 
-    insert_inbox_messages_into_storage_state(
-        env.storage.as_ref(),
-        env.parent_commitment,
-        valid_account,
-        &messages,
-    )
-    .await;
-
-    let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+    let env_builder = TestStorageFixtureBuilder::new()
+        .with_parent_slot(0)
+        .with_l1_manifest_height_range(1..=3)
+        .with_account(
+            TestAccount::new(valid_account, DEFAULT_ACCOUNT_BALANCE).with_inbox(messages.clone()),
+        )
+        .with_account(TestAccount::new(invalid_account, DEFAULT_ACCOUNT_BALANCE));
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    let env = TestEnv::from_fixture(fixture, parent_commitment);
 
     // Build the valid tx once and clone for reuse.
     let valid_tx = MempoolSnarkTxBuilder::new(valid_account)
@@ -338,57 +239,27 @@ async fn test_da_rollback_on_failed_tx() {
         .build();
     let invalid_txid = invalid_tx.compute_txid();
 
-    let parent_state = ctx
-        .fetch_state_for_tip(env.parent_commitment)
+    let output_both = env
+        .construct_block_with_da(
+            vec![(valid_txid, valid_tx), (invalid_txid, invalid_tx)],
+            AccumulatedDaData::new_empty(),
+        )
         .await
-        .unwrap()
-        .unwrap();
-
-    let config = BlockGenerationConfig::new(env.parent_commitment);
-    let (block_slot, block_epoch) =
-        calculate_block_slot_and_epoch(&env.parent_commitment, parent_state.as_ref());
-
-    // Build block with both valid + invalid txs.
-    let output_both = construct_block(
-        &ctx,
-        &env.epoch_sealing_policy,
-        &config,
-        parent_state.clone(),
-        block_slot,
-        block_epoch,
-        vec![(valid_txid, valid_tx), (invalid_txid, invalid_tx)],
-        AccumulatedDaData::new_empty(),
-    )
-    .await
-    .expect("block construction should succeed");
+        .expect("block construction should succeed");
 
     // Verify only valid tx was included.
-    let txs = output_both
-        .template
-        .body()
-        .tx_segment()
-        .expect("should have txs")
-        .txs();
-    assert_eq!(txs.len(), 1, "only valid tx should be included");
+    let included = included_txids(&output_both.template);
     assert_eq!(
-        txs[0].target(),
-        Some(valid_account),
-        "included tx should target valid account"
+        included,
+        vec![valid_txid],
+        "only valid tx should be included"
     );
 
     // Build a reference block with only the valid tx (same tx object via clone).
-    let output_valid_only = construct_block(
-        &ctx,
-        &env.epoch_sealing_policy,
-        &config,
-        parent_state,
-        block_slot,
-        block_epoch,
-        vec![(valid_txid, valid_tx_clone)],
-        AccumulatedDaData::new_empty(),
-    )
-    .await
-    .expect("valid-only block construction should succeed");
+    let output_valid_only = env
+        .construct_block(vec![(valid_txid, valid_tx_clone)])
+        .await
+        .expect("valid-only block construction should succeed");
 
     // Finalize both DA accumulators and compare.
     let (acc_both, _) = output_both.accumulated_da.into_parts();
@@ -410,23 +281,15 @@ async fn test_da_rollback_on_failed_tx() {
 /// parent header instead of the actual epoch boundary block's header.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rebuild_da_matches_incremental() {
-    let env = TestEnvBuilder::new()
+    let env_builder = TestStorageFixtureBuilder::new()
         .with_parent_slot(0)
-        .with_asm_manifests(&[1, 2, 3])
-        .build()
-        .await;
-
-    let (ctx, _mempool) = create_test_block_assembly_context(env.storage.clone());
+        .with_l1_manifest_height_range(1..=3);
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
     // Build blocks 1..5, threading DA incrementally.
-    let (final_commitment, incremental_da, artifacts) = build_blocks_with_da_and_artifacts(
-        env.parent_commitment,
-        5,
-        &ctx,
-        env.storage.as_ref(),
-        &env.epoch_sealing_policy,
-    )
-    .await;
+    let (final_commitment, incremental_da, artifacts) =
+        build_blocks_with_da_and_artifacts(&mut env, 5).await;
 
     let (_, last_post_state) = artifacts.last().unwrap();
 
@@ -436,7 +299,7 @@ async fn test_rebuild_da_matches_incremental() {
 
     // Rebuild DA from scratch using the production code path.
     let epoch = artifacts[0].0.header().epoch();
-    let rebuilt_da = rebuild_accumulated_da_upto(final_commitment, epoch, &ctx)
+    let rebuilt_da = rebuild_accumulated_da_upto(final_commitment, epoch, env.ctx())
         .await
         .expect("rebuild_accumulated_da_upto should succeed");
 

--- a/crates/ol/block-assembly/src/da_tracker.rs
+++ b/crates/ol/block-assembly/src/da_tracker.rs
@@ -31,6 +31,11 @@ impl EpochDaTracker {
         self.block_da_map.insert(blkid, da);
     }
 
+    /// Removes accumulated DA for a block id, if present.
+    pub(crate) fn remove_accumulated_da(&mut self, blkid: OLBlockId) {
+        self.block_da_map.remove(&blkid);
+    }
+
     /// Inserts the entry for given block id and also removes the entry for parent if exists. This
     /// method is used to optimize memory usage because in the next assembly we would require
     /// accumulation upto the current block and not the parent block.

--- a/crates/ol/block-assembly/src/da_tracker.rs
+++ b/crates/ol/block-assembly/src/da_tracker.rs
@@ -61,9 +61,7 @@ async fn collect_epoch_blocks_until<C: BlockAssemblyAnchorContext>(
     ctx: &C,
 ) -> Result<EpochBlocks, BlockAssemblyError> {
     if epoch == 0 {
-        return Err(BlockAssemblyError::Other(
-            "epoch 0 has no collectable blocks (genesis only)".to_string(),
-        ));
+        return Err(BlockAssemblyError::GenesisEpochNoBoundary);
     }
 
     let mut blocks = Vec::new();
@@ -78,12 +76,12 @@ async fn collect_epoch_blocks_until<C: BlockAssemblyAnchorContext>(
         // Block doesn't belong to our epoch — must be the boundary.
         if block.header().epoch() != epoch {
             if !block.header().is_terminal() || block.header().epoch() != epoch - 1 {
-                return Err(BlockAssemblyError::Other(format!(
-                    "expected terminal of epoch {}, got epoch {} (terminal={})",
-                    epoch - 1,
-                    block.header().epoch(),
-                    block.header().is_terminal()
-                )));
+                return Err(BlockAssemblyError::InvalidEpochBoundary {
+                    blkid: block.header().compute_blkid(),
+                    expected_prev_epoch: epoch - 1,
+                    got_epoch: block.header().epoch(),
+                    is_terminal: block.header().is_terminal(),
+                });
             }
             break block.header().clone();
         }
@@ -140,9 +138,10 @@ async fn fetch_state<C: BlockAssemblyAnchorContext>(
     ctx: &C,
 ) -> Result<Arc<C::State>, BlockAssemblyError> {
     let blkid = blk_header.compute_block_commitment();
-    let ol_state = ctx.fetch_state_for_tip(blkid).await?.ok_or_else(|| {
-        BlockAssemblyError::Other(format!("missing OL state at epoch boundary {blkid}"))
-    })?;
+    let ol_state = ctx
+        .fetch_state_for_tip(blkid)
+        .await?
+        .ok_or(BlockAssemblyError::EpochBoundaryStateNotFound(blkid))?;
     Ok(ol_state)
 }
 
@@ -172,5 +171,141 @@ impl AccumulatedDaData {
 
     pub(crate) fn append_logs(&mut self, new_logs: &[OLLog]) {
         self.logs.extend_from_slice(new_logs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_identifiers::{Buf32, Buf64, OLBlockId};
+    use strata_ol_chain_types_new::{
+        BlockFlags, OLBlock, OLBlockBody, OLBlockHeader, OLTxSegment, SignedOLBlockHeader,
+    };
+
+    use super::*;
+    use crate::test_utils::{TestEnv, TestStorageFixtureBuilder};
+
+    async fn build_test_env() -> TestEnv {
+        let (fixture, parent_commitment) = TestStorageFixtureBuilder::new().build_fixture().await;
+        TestEnv::from_fixture(fixture, parent_commitment)
+    }
+
+    fn make_block(
+        slot: u64,
+        epoch: Epoch,
+        is_terminal: bool,
+        parent_blkid: OLBlockId,
+        timestamp: u64,
+    ) -> OLBlock {
+        let body = OLBlockBody::new_common(OLTxSegment::new(vec![]).expect("empty tx segment"));
+        let mut flags = BlockFlags::zero();
+        flags.set_is_terminal(is_terminal);
+        let header = OLBlockHeader::new(
+            timestamp,
+            flags,
+            slot,
+            epoch,
+            parent_blkid,
+            body.compute_hash_commitment(),
+            Buf32::zero(),
+            Buf32::zero(),
+        );
+        let signed_header = SignedOLBlockHeader::new(header, Buf64::zero());
+        OLBlock::new(signed_header, body)
+    }
+
+    fn test_blkid(seed: u8) -> OLBlockId {
+        OLBlockId::from(Buf32::from([seed; 32]))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_collect_epoch_blocks_epoch_zero() {
+        let env = build_test_env().await;
+
+        let err = collect_epoch_blocks_until(test_blkid(1), 0, env.ctx())
+            .await
+            .expect_err("epoch 0 should be rejected");
+        assert!(
+            matches!(err, BlockAssemblyError::GenesisEpochNoBoundary),
+            "expected GenesisEpochNoBoundary, got: {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_collect_epoch_blocks_invalid_boundary() {
+        let env = build_test_env().await;
+
+        // epoch-2 target points to an epoch-1 non-terminal block, which is an invalid boundary.
+        let boundary = make_block(1, 1, false, OLBlockId::null(), 1_000_001);
+        let target = make_block(2, 2, false, boundary.header().compute_blkid(), 1_000_002);
+
+        env.put_block(boundary).await;
+        env.put_block(target.clone()).await;
+
+        let err = collect_epoch_blocks_until(target.header().compute_blkid(), 2, env.ctx())
+            .await
+            .expect_err("invalid boundary should fail");
+        assert!(
+            matches!(
+                err,
+                BlockAssemblyError::InvalidEpochBoundary {
+                    expected_prev_epoch: 1,
+                    got_epoch: 1,
+                    is_terminal: false,
+                    ..
+                }
+            ),
+            "expected InvalidEpochBoundary, got: {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rebuild_da_missing_boundary_state() {
+        let env = build_test_env().await;
+
+        // Valid boundary shape (terminal epoch-1), but boundary OL state is intentionally absent.
+        let boundary = make_block(10, 1, true, OLBlockId::null(), 1_000_010);
+        let target = make_block(11, 2, false, boundary.header().compute_blkid(), 1_000_011);
+        let target_commitment =
+            OLBlockCommitment::new(target.header().slot(), target.header().compute_blkid());
+
+        env.put_block(boundary).await;
+        env.put_block(target).await;
+
+        let err = rebuild_accumulated_da_upto(target_commitment, 2, env.ctx())
+            .await
+            .expect_err("missing boundary state should fail rebuild");
+        assert!(
+            matches!(err, BlockAssemblyError::EpochBoundaryStateNotFound(_)),
+            "expected EpochBoundaryStateNotFound(_), got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_tracker_set_remove_parent_entry() {
+        let parent = test_blkid(10);
+        let child = test_blkid(11);
+        let unrelated = test_blkid(12);
+
+        let mut tracker = EpochDaTracker::new_empty();
+        tracker.set_accumulated_da(parent, AccumulatedDaData::new_empty());
+        tracker.set_accumulated_da(unrelated, AccumulatedDaData::new_empty());
+        tracker.set_accumulated_da_and_remove_parent_entry(
+            child,
+            parent,
+            AccumulatedDaData::new_empty(),
+        );
+
+        assert!(
+            tracker.get_accumulated_da(parent).is_none(),
+            "parent entry must be removed"
+        );
+        assert!(
+            tracker.get_accumulated_da(child).is_some(),
+            "child entry must be inserted"
+        );
+        assert!(
+            tracker.get_accumulated_da(unrelated).is_some(),
+            "unrelated entries must remain"
+        );
     }
 }

--- a/crates/ol/block-assembly/src/error.rs
+++ b/crates/ol/block-assembly/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types for block assembly operations.
 
+use std::error::Error;
+
 use strata_acct_types::AcctError;
 use strata_db_types::errors::DbError;
-use strata_identifiers::{AccountId, Hash, OLBlockId};
+use strata_identifiers::{AccountId, Hash, OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::ChainTypesError;
 use strata_ol_mempool::OLMempoolError;
 use strata_ol_stf::ExecError;
@@ -48,6 +50,10 @@ pub enum BlockAssemblyError {
     /// Block not found in db.
     #[error("block not found in db: {0}")]
     BlockNotFound(OLBlockId),
+
+    /// Parent state not found in db.
+    #[error("parent state not found in db: {0}")]
+    ParentStateNotFound(OLBlockCommitment),
 
     /// No mapping found in parent block ID -> template ID cache.
     #[error("no pending template found for parent id: {0}")]
@@ -96,6 +102,10 @@ pub enum BlockAssemblyError {
     /// Mempool operation failed.
     #[error("mempool: {0}")]
     Mempool(#[from] OLMempoolError),
+
+    /// State provider operation failed.
+    #[error("state provider: {0}")]
+    StateProvider(#[source] Box<dyn Error + Send + Sync>),
 
     /// Block construction/execution failed.
     #[error("block construction: {0}")]

--- a/crates/ol/block-assembly/src/error.rs
+++ b/crates/ol/block-assembly/src/error.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 use strata_acct_types::AcctError;
 use strata_db_types::errors::DbError;
-use strata_identifiers::{AccountId, Hash, OLBlockCommitment, OLBlockId};
+use strata_identifiers::{AccountId, Epoch, Hash, OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::ChainTypesError;
 use strata_ol_mempool::OLMempoolError;
 use strata_ol_stf::ExecError;
@@ -78,6 +78,25 @@ pub enum BlockAssemblyError {
     /// Genesis must be created via `init_ol_genesis` at node startup.
     #[error("cannot build genesis block via block assembly")]
     CannotBuildGenesis,
+
+    /// Genesis epoch has no boundary.
+    #[error("genesis epoch has no boundary")]
+    GenesisEpochNoBoundary,
+
+    /// Epoch boundary block does not satisfy expected terminal/epoch properties.
+    #[error(
+        "invalid epoch boundary at {blkid}: expected prev epoch {expected_prev_epoch}, got {got_epoch}, terminal={is_terminal}"
+    )]
+    InvalidEpochBoundary {
+        blkid: OLBlockId,
+        expected_prev_epoch: Epoch,
+        got_epoch: Epoch,
+        is_terminal: bool,
+    },
+
+    /// Epoch boundary state not found in db.
+    #[error("epoch boundary state not found in db: {0}")]
+    EpochBoundaryStateNotFound(OLBlockCommitment),
 
     /// Request channel closed (service shutdown).
     #[error("request channel closed")]

--- a/crates/ol/block-assembly/src/lib.rs
+++ b/crates/ol/block-assembly/src/lib.rs
@@ -5,8 +5,6 @@ mod builder;
 mod checkpoint_size;
 mod command;
 mod context;
-#[cfg(test)]
-mod da_tests;
 mod da_tracker;
 mod epoch_sealing;
 mod error;
@@ -16,6 +14,8 @@ mod service;
 mod state;
 #[cfg(test)]
 mod test_utils;
+#[cfg(test)]
+mod tests;
 mod types;
 
 pub use builder::BlockasmBuilder;

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -11,6 +11,7 @@ use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
 use strata_ol_state_types::StateProvider;
 use strata_params::RollupParams;
 use strata_service::{AsyncService, Response, Service};
+use tracing::debug;
 
 use crate::{
     BlockAssemblyStateAccess, EpochSealingPolicy, FullBlockTemplate, MempoolProvider,
@@ -134,8 +135,12 @@ where
 
     let (full_template, failed_txs, accumulated_da) = result.into_parts();
 
-    // Report failed transactions back to mempool
+    // Report failed transactions back to mempool.
     if !failed_txs.is_empty() {
+        debug!(
+            count = failed_txs.len(),
+            "Reporting failed transactions to mempool"
+        );
         MempoolProvider::report_invalid_transactions(state.context(), &failed_txs).await?;
     }
 
@@ -223,7 +228,7 @@ mod tests {
     use strata_config::BlockAssemblyConfig;
     use strata_crypto::{hash::raw, sign_schnorr_sig};
     use strata_identifiers::{Buf32, Buf64};
-    use strata_ol_mempool::MempoolTxInvalidReason;
+    use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
     use strata_params::CredRule;
     use strata_primitives::utils::get_test_schnorr_keys;
     use strata_test_utils_l2::gen_params;
@@ -374,7 +379,11 @@ mod tests {
         let first = generate_block_template(&mut state, config.clone())
             .await
             .expect("first generation should succeed despite invalid tx");
-        let reports_after_first = mempool.report_call_count();
+        assert_eq!(
+            mempool.report_call_count(),
+            1,
+            "first generation should report failed txs exactly once"
+        );
         assert_eq!(
             mempool.last_reported_invalid_txs(),
             vec![(invalid_txid, MempoolTxInvalidReason::Invalid)],
@@ -389,8 +398,37 @@ mod tests {
         assert_eq!(second.get_blockid(), first.get_blockid());
         assert_eq!(
             mempool.report_call_count(),
-            reports_after_first,
-            "cached template reuse should not increase report call count"
+            1,
+            "cached template reuse should not add extra report calls"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_generate_propagates_report_invalid_transactions_failure() {
+        let (mut state, mempool, env, _sk) = build_service_state(false).await;
+        let missing_account = test_account_id(78);
+        let invalid_tx = MempoolSnarkTxBuilder::new(missing_account)
+            .with_seq_no(0)
+            .build();
+        let invalid_txid = invalid_tx.compute_txid();
+        mempool.add_transaction(invalid_txid, invalid_tx);
+        mempool.set_fail_mode(MockMempoolFailMode::ReportInvalidTransactions);
+
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let err = generate_block_template(&mut state, config)
+            .await
+            .expect_err("report_invalid_transactions failure should fail generation");
+        assert!(
+            matches!(
+                err,
+                BlockAssemblyError::Mempool(OLMempoolError::ServiceClosed(_))
+            ),
+            "expected mempool service-closed error, got: {err:?}"
+        );
+        assert_eq!(
+            mempool.report_call_count(),
+            1,
+            "failed tx report should be attempted exactly once at service layer"
         );
     }
 

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -217,12 +217,15 @@ pub(crate) struct BlockasmServiceStatus;
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::Arc,
-        time::{Duration, Instant},
-    };
+    use std::{sync::Arc, time::Instant};
 
-    use strata_config::{BlockAssemblyConfig, SequencerConfig};
+    use ssz::Encode;
+    use strata_config::BlockAssemblyConfig;
+    use strata_crypto::{hash::raw, sign_schnorr_sig};
+    use strata_identifiers::{Buf32, Buf64};
+    use strata_ol_mempool::MempoolTxInvalidReason;
+    use strata_params::CredRule;
+    use strata_primitives::utils::get_test_schnorr_keys;
     use strata_test_utils_l2::gen_params;
 
     use super::*;
@@ -231,29 +234,65 @@ mod tests {
         epoch_sealing::FixedSlotSealing,
         state::BlockasmServiceState,
         test_utils::{
-            TEST_BLOCK_TEMPLATE_TTL, TEST_SLOTS_PER_EPOCH, create_test_block_assembly_context,
-            create_test_block_generation_config, create_test_storage, create_test_template,
+            MempoolSnarkTxBuilder, MockMempoolFailMode, MockMempoolProvider, StateProviderHandle,
+            TEST_BLOCK_TEMPLATE_TTL, TestEnv, TestStorageFixtureBuilder, create_test_template,
+            test_account_id,
         },
+        types::BlockCompletionData,
     };
+
+    type TestServiceState =
+        BlockasmServiceState<Arc<MockMempoolProvider>, FixedSlotSealing, StateProviderHandle>;
+
+    async fn build_service_state(
+        use_schnorr_cred_rule: bool,
+    ) -> (
+        TestServiceState,
+        Arc<MockMempoolProvider>,
+        TestEnv,
+        Option<Buf32>,
+    ) {
+        let mut params = gen_params();
+        let signing_key = if use_schnorr_cred_rule {
+            let keypair = get_test_schnorr_keys()[0].clone();
+            params.rollup.cred_rule = CredRule::SchnorrKey(keypair.pk);
+            Some(keypair.sk)
+        } else {
+            None
+        };
+
+        let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .build_fixture()
+            .await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+        let mempool = env.mempool_arc();
+
+        let state = BlockasmServiceState::new(
+            Arc::new(params),
+            Arc::new(BlockAssemblyConfig::new(TEST_BLOCK_TEMPLATE_TTL)),
+            env.sequencer_config().clone(),
+            env.ctx_arc(),
+            env.epoch_sealing_policy().clone(),
+        );
+
+        (state, mempool, env, signing_key)
+    }
+
+    fn valid_completion_data(
+        template: &FullBlockTemplate,
+        signing_key: Buf32,
+    ) -> BlockCompletionData {
+        let sighash = raw(&template.header().as_ssz_bytes());
+        let signature = sign_schnorr_sig(&sighash, &signing_key);
+        BlockCompletionData::from_signature(signature)
+    }
 
     /// Verifies that `process_input` lazily cleans up expired templates
     /// before handling the incoming command.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_process_input_cleans_up_expired_templates() {
-        let storage = create_test_storage();
-        let (ctx, _) = create_test_block_assembly_context(storage.clone());
-        let params = gen_params();
-        let blockasm_config = Arc::new(BlockAssemblyConfig::new(Duration::from_millis(5_000)));
-        let epoch_sealing_policy = FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH);
-        let sequencer_config = SequencerConfig::default();
-
-        let mut state = BlockasmServiceState::new(
-            Arc::new(params),
-            blockasm_config,
-            sequencer_config,
-            Arc::new(ctx),
-            epoch_sealing_policy,
-        );
+        let (mut state, _mempool, env, _sk) = build_service_state(false).await;
 
         // Insert a template and backdate it to simulate expiration.
         let template = create_test_template();
@@ -261,16 +300,13 @@ mod tests {
         let parent = *template.header().parent_blkid();
 
         state.state_mut().insert_template(template_id, template);
-
         state
             .state_mut()
-            .pending_templates
-            .get_mut(&template_id)
-            .unwrap()
-            .created_at = Instant::now() - TEST_BLOCK_TEMPLATE_TTL;
+            .set_template_created_at_for_test(template_id, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
+            .expect("template should be present before backdating");
 
         // Send any command — the lazy cleanup in process_input runs before handling it.
-        let config = create_test_block_generation_config();
+        let config = BlockGenerationConfig::new(env.parent_commitment());
         let (completion, _rx) = create_completion();
         let cmd = BlockasmCommand::GenerateBlockTemplate { config, completion };
         BlockasmService::<_, _, _>::process_input(&mut state, cmd)
@@ -290,5 +326,158 @@ mod tests {
                 .get_pending_block_template_by_parent(parent),
             Err(BlockAssemblyError::NoPendingTemplateForParent(p)) if p == parent
         ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_generate_reuses_cached_template() {
+        let (mut state, mempool, env, _sk) = build_service_state(false).await;
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+
+        let first = generate_block_template(&mut state, config.clone())
+            .await
+            .expect("first generation should succeed");
+        let template_id = first.get_blockid();
+        let tracked_da = state
+            .epoch_da_tracker()
+            .get_accumulated_da(template_id)
+            .expect("first generation should store accumulated DA for template id");
+        assert_eq!(
+            tracked_da.logs().len(),
+            0,
+            "empty mempool generation should store zero DA logs"
+        );
+
+        // If generation ran again, this would fail. Cached reuse must short-circuit before mempool
+        // fetch.
+        mempool.set_fail_mode(MockMempoolFailMode::GetTransactions);
+        let second = generate_block_template(&mut state, config)
+            .await
+            .expect("second generation should return cached template");
+        assert_eq!(
+            second.get_blockid(),
+            template_id,
+            "same parent should return exact cached template id"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cached_template_does_not_report() {
+        let (mut state, mempool, env, _sk) = build_service_state(false).await;
+        let missing_account = test_account_id(77);
+        let invalid_tx = MempoolSnarkTxBuilder::new(missing_account)
+            .with_seq_no(0)
+            .build();
+        let invalid_txid = invalid_tx.compute_txid();
+        mempool.add_transaction(invalid_txid, invalid_tx);
+
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let first = generate_block_template(&mut state, config.clone())
+            .await
+            .expect("first generation should succeed despite invalid tx");
+        let reports_after_first = mempool.report_call_count();
+        assert_eq!(
+            mempool.last_reported_invalid_txs(),
+            vec![(invalid_txid, MempoolTxInvalidReason::Invalid)],
+            "first generation should report missing-account tx as Invalid"
+        );
+
+        // Reuse path must not call report_invalid_transactions again.
+        mempool.set_fail_mode(MockMempoolFailMode::ReportInvalidTransactions);
+        let second = generate_block_template(&mut state, config)
+            .await
+            .expect("cached template reuse should not hit report path");
+        assert_eq!(second.get_blockid(), first.get_blockid());
+        assert_eq!(
+            mempool.report_call_count(),
+            reports_after_first,
+            "cached template reuse should not increase report call count"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_invalid_signature_keeps_template_cached() {
+        let (mut state, _mempool, env, _sk) = build_service_state(true).await;
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+
+        let bad_completion = BlockCompletionData::from_signature(Buf64::zero());
+        let err = complete_block_template(&mut state, template_id, bad_completion)
+            .expect_err("invalid signature should fail completion");
+        assert!(
+            matches!(err, BlockAssemblyError::InvalidSignature(id) if id == template_id),
+            "expected InvalidSignature({template_id}), got {err:?}"
+        );
+        let cached_template = state
+            .state_mut()
+            .get_pending_block_template(template_id)
+            .expect("template should remain cached after invalid signature");
+        assert_eq!(
+            cached_template.get_blockid(),
+            template_id,
+            "cached template id should remain unchanged after invalid signature"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_second_template_completion_rejected() {
+        let (mut state, _mempool, env, sk) = build_service_state(true).await;
+        let signing_key = sk.expect("schnorr signing key should be present");
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+
+        let completion_data = valid_completion_data(&template, signing_key);
+        let completed = complete_block_template(&mut state, template_id, completion_data.clone())
+            .expect("valid signature should complete template");
+        assert_eq!(
+            completed.header().compute_blkid(),
+            template_id,
+            "completed block id should match template id"
+        );
+        assert!(
+            matches!(
+                state.state_mut().get_pending_block_template(template_id),
+                Err(BlockAssemblyError::UnknownTemplateId(id)) if id == template_id
+            ),
+            "template should be removed after successful completion"
+        );
+
+        let err = complete_block_template(&mut state, template_id, completion_data)
+            .expect_err("second completion should fail");
+        assert!(
+            matches!(err, BlockAssemblyError::UnknownTemplateId(id) if id == template_id),
+            "second completion should return UnknownTemplateId, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_expired_template_completion_rejected() {
+        let (mut state, _mempool, env, _sk) = build_service_state(false).await;
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+
+        state
+            .state_mut()
+            .set_template_created_at_for_test(template_id, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
+            .expect("template should be present before backdating");
+
+        let err = complete_block_template(
+            &mut state,
+            template_id,
+            BlockCompletionData::from_signature(Buf64::zero()),
+        )
+        .expect_err("expired template completion should fail");
+        assert!(
+            matches!(err, BlockAssemblyError::UnknownTemplateId(id) if id == template_id),
+            "expired completion should return UnknownTemplateId, got {err:?}"
+        );
     }
 }

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -63,7 +63,12 @@ where
 
     async fn process_input(state: &mut Self::State, input: Self::Msg) -> anyhow::Result<Response> {
         // Lazily clean up expired templates on every command.
-        state.state_mut().cleanup_expired_templates();
+        let expired_template_ids = state.state_mut().cleanup_expired_templates();
+        for template_id in expired_template_ids {
+            state
+                .epoch_da_tracker_mut()
+                .remove_accumulated_da(template_id);
+        }
 
         match input {
             BlockasmCommand::GenerateBlockTemplate { config, completion } => {
@@ -151,9 +156,14 @@ where
         .epoch_da_tracker_mut()
         .set_accumulated_da_and_remove_parent_entry(template_id, parent_blkid, accumulated_da);
 
-    state
+    let evicted_template_ids = state
         .state_mut()
         .insert_template(template_id, full_template.clone());
+    for evicted_template_id in evicted_template_ids {
+        state
+            .epoch_da_tracker_mut()
+            .remove_accumulated_da(evicted_template_id);
+    }
 
     Ok(full_template)
 }
@@ -197,6 +207,9 @@ fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
 
     // Signature valid - now remove template from cache
     let template = state.state_mut().remove_template(template_id)?;
+    state
+        .epoch_da_tracker_mut()
+        .remove_accumulated_da(template_id);
 
     // Complete the template
     Ok(template.complete_block_template(completion_data))
@@ -236,12 +249,13 @@ mod tests {
     use super::*;
     use crate::{
         command::create_completion,
+        da_tracker::AccumulatedDaData,
         epoch_sealing::FixedSlotSealing,
         state::BlockasmServiceState,
         test_utils::{
             MempoolSnarkTxBuilder, MockMempoolFailMode, MockMempoolProvider, StateProviderHandle,
-            TEST_BLOCK_TEMPLATE_TTL, TestEnv, TestStorageFixtureBuilder, create_test_template,
-            test_account_id,
+            TEST_BLOCK_TEMPLATE_TTL, TestAccount, TestEnv, TestStorageFixtureBuilder,
+            create_test_template, create_test_template_with_parent, test_account_id,
         },
         types::BlockCompletionData,
     };
@@ -249,8 +263,9 @@ mod tests {
     type TestServiceState =
         BlockasmServiceState<Arc<MockMempoolProvider>, FixedSlotSealing, StateProviderHandle>;
 
-    async fn build_service_state(
+    async fn build_service_state_with_accounts(
         use_schnorr_cred_rule: bool,
+        accounts: impl IntoIterator<Item = TestAccount>,
     ) -> (
         TestServiceState,
         Arc<MockMempoolProvider>,
@@ -268,6 +283,7 @@ mod tests {
 
         let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
+            .with_accounts(accounts)
             .build_fixture()
             .await;
         let env = TestEnv::from_fixture(fixture, parent_commitment);
@@ -282,6 +298,17 @@ mod tests {
         );
 
         (state, mempool, env, signing_key)
+    }
+
+    async fn build_service_state(
+        use_schnorr_cred_rule: bool,
+    ) -> (
+        TestServiceState,
+        Arc<MockMempoolProvider>,
+        TestEnv,
+        Option<Buf32>,
+    ) {
+        build_service_state_with_accounts(use_schnorr_cred_rule, Vec::<TestAccount>::new()).await
     }
 
     fn valid_completion_data(
@@ -334,6 +361,53 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_process_input_cleanup_evicts_expired_da_tracker_entry() {
+        let (mut state, _mempool, env, _sk) = build_service_state(false).await;
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(template_id)
+                .is_some(),
+            "generated template should have tracked DA entry"
+        );
+
+        state
+            .state_mut()
+            .set_template_created_at_for_test(template_id, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
+            .expect("template should be present before backdating");
+
+        let (completion, rx) = create_completion();
+        let cmd = BlockasmCommand::GetBlockTemplate {
+            parent_block_id: parent,
+            completion,
+        };
+        BlockasmService::<_, _, _>::process_input(&mut state, cmd)
+            .await
+            .expect("process_input should succeed");
+        let lookup_result = rx.await.expect("lookup completion should be delivered");
+        assert!(
+            matches!(
+                lookup_result,
+                Err(BlockAssemblyError::NoPendingTemplateForParent(p)) if p == parent
+            ),
+            "lookup should fail after expired template cleanup"
+        );
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(template_id)
+                .is_none(),
+            "expired template cleanup should evict DA tracker entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_generate_reuses_cached_template() {
         let (mut state, mempool, env, _sk) = build_service_state(false).await;
         let config = BlockGenerationConfig::new(env.parent_commitment());
@@ -362,6 +436,102 @@ mod tests {
             second.get_blockid(),
             template_id,
             "same parent should return exact cached template id"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_new_template_for_same_parent_evicts_expired_template_da_entry() {
+        let sender = test_account_id(91);
+        let (mut state, mempool, env, _sk) =
+            build_service_state_with_accounts(false, [TestAccount::new(sender, 10_000)]).await;
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+
+        let first = generate_block_template(&mut state, config.clone())
+            .await
+            .expect("first generation should succeed");
+        let first_template_id = first.get_blockid();
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(first_template_id)
+                .is_some(),
+            "first generation should store accumulated DA entry"
+        );
+        state
+            .state_mut()
+            .set_template_created_at_for_test(
+                first_template_id,
+                Instant::now() - TEST_BLOCK_TEMPLATE_TTL,
+            )
+            .expect("first template should be present before backdating");
+
+        // Make regenerated template content differ so block ID replacement path is deterministic.
+        let tx = MempoolSnarkTxBuilder::new(sender).with_seq_no(0).build();
+        mempool.add_transaction(tx.compute_txid(), tx);
+
+        let second = generate_block_template(&mut state, config)
+            .await
+            .expect("regeneration after expiry should succeed");
+        let second_template_id = second.get_blockid();
+        assert_ne!(
+            second_template_id, first_template_id,
+            "regeneration should produce a distinct template id"
+        );
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(first_template_id)
+                .is_none(),
+            "same-parent replacement should evict old DA tracker entry"
+        );
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(second_template_id)
+                .is_some(),
+            "new template should retain DA tracker entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_insert_cleans_expired_da_entry_for_different_parent() {
+        let (mut state, _mempool, env, _sk) = build_service_state(false).await;
+
+        let stale_parent = OLBlockId::from(Buf32::from([0xAB; 32]));
+        let stale_template = create_test_template_with_parent(stale_parent);
+        let stale_template_id = stale_template.get_blockid();
+        state
+            .state_mut()
+            .insert_template(stale_template_id, stale_template);
+        state
+            .epoch_da_tracker_mut()
+            .set_accumulated_da(stale_template_id, AccumulatedDaData::new_empty());
+        state
+            .state_mut()
+            .set_template_created_at_for_test(
+                stale_template_id,
+                Instant::now() - TEST_BLOCK_TEMPLATE_TTL,
+            )
+            .expect("stale template should be present before backdating");
+
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let _new_template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed while cleaning unrelated stale entry");
+
+        assert!(
+            matches!(
+                state.state_mut().get_pending_block_template(stale_template_id),
+                Err(BlockAssemblyError::UnknownTemplateId(id)) if id == stale_template_id
+            ),
+            "unrelated expired template should be removed during insert-time cleanup"
+        );
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(stale_template_id)
+                .is_none(),
+            "insert-time cleanup should evict stale DA tracker entry"
         );
     }
 
@@ -483,6 +653,13 @@ mod tests {
                 Err(BlockAssemblyError::UnknownTemplateId(id)) if id == template_id
             ),
             "template should be removed after successful completion"
+        );
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(template_id)
+                .is_none(),
+            "successful completion should evict DA tracker entry"
         );
 
         let err = complete_block_template(&mut state, template_id, completion_data)

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -68,7 +68,14 @@ impl BlockAssemblyState {
     /// Insert a new pending template.
     ///
     /// Invariant: at most one pending template per parent.
-    pub(crate) fn insert_template(&mut self, template_id: OLBlockId, template: FullBlockTemplate) {
+    ///
+    /// Returns template IDs evicted while inserting (same-parent replacement and TTL cleanup).
+    pub(crate) fn insert_template(
+        &mut self,
+        template_id: OLBlockId,
+        template: FullBlockTemplate,
+    ) -> Vec<OLBlockId> {
+        let mut evicted_template_ids = Vec::new();
         let parent = *template.header().parent_blkid();
 
         // If we already have a template cached for this parent, evict it to avoid orphans.
@@ -76,6 +83,7 @@ impl BlockAssemblyState {
             && old_id != template_id
         {
             self.pending_templates.remove(&old_id);
+            evicted_template_ids.push(old_id);
         }
 
         // Insert/overwrite the template itself.
@@ -91,7 +99,8 @@ impl BlockAssemblyState {
             );
         }
 
-        self.cleanup_expired_templates();
+        evicted_template_ids.extend(self.cleanup_expired_templates());
+        evicted_template_ids
     }
 
     /// Gets a pending template by template ID.
@@ -147,8 +156,8 @@ impl BlockAssemblyState {
         Ok(cached.template)
     }
 
-    /// Removes expired entries from both maps.
-    pub(crate) fn cleanup_expired_templates(&mut self) {
+    /// Removes expired entries from both maps and returns removed template IDs.
+    pub(crate) fn cleanup_expired_templates(&mut self) -> Vec<OLBlockId> {
         let now = Instant::now();
         let ttl = self.ttl;
         let expired_ids: Vec<OLBlockId> = self
@@ -166,6 +175,7 @@ impl BlockAssemblyState {
                 }
             }
         }
+        expired_ids
     }
 
     /// Sets a cached template creation time for expiry tests.

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -309,10 +309,54 @@ impl<M: MempoolProvider, E: EpochSealingPolicy, S: Send + Sync + 'static> Servic
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use strata_config::BlockAssemblyConfig;
+    use strata_identifiers::{AccountSerial, Buf32, Buf64};
+    use strata_ol_chain_types_new::{OLBlock, OLLog, SignedOLBlockHeader};
+    use strata_ol_state_support_types::EpochDaAccumulator;
+    use strata_test_utils_l2::gen_params;
+
     use super::*;
-    use crate::test_utils::{
-        TEST_BLOCK_TEMPLATE_TTL, create_test_template, create_test_template_with_parent,
+    use crate::{
+        FixedSlotSealing,
+        block_assembly::generate_block_template_inner,
+        da_tracker::AccumulatedDaData,
+        test_utils::{
+            MockMempoolProvider, StateProviderHandle, TEST_BLOCK_TEMPLATE_TTL, TestEnv,
+            TestStorageFixtureBuilder, create_test_template, create_test_template_with_parent,
+        },
+        types::BlockGenerationConfig,
     };
+
+    type TestServiceState =
+        BlockasmServiceState<Arc<MockMempoolProvider>, FixedSlotSealing, StateProviderHandle>;
+
+    fn sample_accumulated_da() -> AccumulatedDaData {
+        AccumulatedDaData::new(
+            EpochDaAccumulator::default(),
+            vec![OLLog::new(AccountSerial::from(4242_u32), vec![1, 2, 3])],
+        )
+    }
+
+    async fn build_service_state_with_env(parent_slot: u64) -> (TestServiceState, TestEnv) {
+        let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
+            .with_parent_slot(parent_slot)
+            .with_l1_manifest_height_range(1..=3)
+            .build_fixture()
+            .await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let state = BlockasmServiceState::new(
+            Arc::new(gen_params()),
+            Arc::new(BlockAssemblyConfig::new(TEST_BLOCK_TEMPLATE_TTL)),
+            env.sequencer_config().clone(),
+            env.ctx_arc(),
+            env.epoch_sealing_policy().clone(),
+        );
+
+        (state, env)
+    }
 
     #[test]
     fn insert_and_get_by_id() {
@@ -364,6 +408,10 @@ mod tests {
 
         // Verify parent lookup also fails (proves both maps cleaned up).
         assert!(state.get_pending_block_template_by_parent(parent).is_err());
+        assert!(
+            !state.pending_by_parent.contains_key(&parent),
+            "parent index must be cleared when template is removed"
+        );
     }
 
     #[test]
@@ -403,6 +451,11 @@ mod tests {
         assert!(state.get_pending_block_template(id1).is_err());
         // New template should be present.
         assert!(state.get_pending_block_template(id2).is_ok());
+        assert_eq!(
+            state.pending_by_parent.get(&parent),
+            Some(&id2),
+            "parent index must point to the newest template id"
+        );
     }
 
     #[test]
@@ -436,5 +489,124 @@ mod tests {
         // Fresh template should still be present.
         assert!(state.pending_templates.contains_key(&id2));
         assert!(state.pending_by_parent.contains_key(&parent2));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_fetch_da_terminal_parent_empty() {
+        let (mut state, env) = build_service_state_with_env(0).await;
+
+        // Even if tracker has an entry, terminal-parent path must return fresh empty DA.
+        state
+            .epoch_da_tracker_mut()
+            .set_accumulated_da(*env.parent_commitment().blkid(), sample_accumulated_da());
+
+        let parent_block = state
+            .context()
+            .fetch_ol_block(*env.parent_commitment().blkid())
+            .await
+            .expect("fetch should succeed")
+            .expect("parent block should exist");
+        assert!(
+            parent_block.header().is_terminal(),
+            "test setup requires terminal parent"
+        );
+
+        let da = state
+            .fetch_epoch_da_until_parent(env.parent_commitment())
+            .await
+            .expect("terminal parent should return empty DA");
+        assert!(
+            da.logs().is_empty(),
+            "terminal-parent path must reset accumulated DA"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_fetch_da_cache_hit() {
+        let (mut state, env) = build_service_state_with_env(1).await;
+
+        let parent_block = state
+            .context()
+            .fetch_ol_block(*env.parent_commitment().blkid())
+            .await
+            .expect("fetch should succeed")
+            .expect("parent block should exist");
+        assert!(
+            !parent_block.header().is_terminal(),
+            "test setup requires non-terminal parent"
+        );
+
+        let cached_da = sample_accumulated_da();
+        let expected_logs = cached_da.logs().to_vec();
+        state
+            .epoch_da_tracker_mut()
+            .set_accumulated_da(*env.parent_commitment().blkid(), cached_da);
+
+        let da = state
+            .fetch_epoch_da_until_parent(env.parent_commitment())
+            .await
+            .expect("cache-hit path should succeed");
+        assert_eq!(
+            da.logs(),
+            expected_logs.as_slice(),
+            "cache-hit path should return tracker data without rebuild"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_fetch_da_cache_miss_rebuild() {
+        let (state, env) = build_service_state_with_env(0).await;
+
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let result = generate_block_template_inner(
+            state.context(),
+            env.epoch_sealing_policy(),
+            env.sequencer_config(),
+            config,
+            AccumulatedDaData::new_empty(),
+        )
+        .await
+        .expect("child block generation should succeed");
+        let child_template = result.into_template();
+        assert!(
+            !child_template.header().is_terminal(),
+            "test setup requires non-terminal child for cache-miss rebuild"
+        );
+
+        let child_commitment = OLBlockCommitment::new(
+            child_template.header().slot(),
+            child_template.header().compute_blkid(),
+        );
+        let signed_header =
+            SignedOLBlockHeader::new(child_template.header().clone(), Buf64::zero());
+        let child_block = OLBlock::new(signed_header, child_template.body().clone());
+        env.put_block(child_block).await;
+
+        let da = state
+            .fetch_epoch_da_until_parent(child_commitment)
+            .await
+            .expect("cache-miss rebuild should succeed");
+        assert!(
+            da.logs().is_empty(),
+            "empty-child rebuild should produce empty logs"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_fetch_da_missing_parent_not_found() {
+        let (state, env) = build_service_state_with_env(0).await;
+        let missing = OLBlockCommitment::new(
+            env.parent_commitment().slot() + 100,
+            OLBlockId::from(Buf32::from([0xff_u8; 32])),
+        );
+
+        let err = state
+            .fetch_epoch_da_until_parent(missing)
+            .await
+            .expect_err("missing parent should fail");
+        assert!(
+            matches!(err, BlockAssemblyError::BlockNotFound(_)),
+            "expected BlockNotFound(_), got: {err:?}"
+        );
     }
 }

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -167,6 +167,21 @@ impl BlockAssemblyState {
             }
         }
     }
+
+    /// Sets a cached template creation time for expiry tests.
+    #[cfg(test)]
+    pub(crate) fn set_template_created_at_for_test(
+        &mut self,
+        template_id: OLBlockId,
+        created_at: Instant,
+    ) -> Result<(), BlockAssemblyError> {
+        let cached = self
+            .pending_templates
+            .get_mut(&template_id)
+            .ok_or(BlockAssemblyError::UnknownTemplateId(template_id))?;
+        cached.created_at = created_at;
+        Ok(())
+    }
 }
 
 /// Combined state for the service (context + mutable state).
@@ -361,8 +376,9 @@ mod tests {
         state.insert_template(id, template);
 
         // Backdate the entry so it appears expired.
-        state.pending_templates.get_mut(&id).unwrap().created_at =
-            Instant::now() - TEST_BLOCK_TEMPLATE_TTL;
+        state
+            .set_template_created_at_for_test(id, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
+            .unwrap();
 
         assert!(state.get_pending_block_template(id).is_err());
         assert!(state.get_pending_block_template_by_parent(parent).is_err());
@@ -406,8 +422,9 @@ mod tests {
         state.insert_template(id2, t2);
 
         // Backdate the first template to make it expired.
-        state.pending_templates.get_mut(&id1).unwrap().created_at =
-            Instant::now() - TEST_BLOCK_TEMPLATE_TTL;
+        state
+            .set_template_created_at_for_test(id1, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
+            .unwrap();
 
         // Explicitly call cleanup to remove expired templates.
         state.cleanup_expired_templates();

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -29,7 +29,7 @@ use strata_db_store_sled::test_utils::get_test_sled_backend;
 use strata_db_types::{MmrId, errors::DbError};
 use strata_identifiers::{
     Buf32, Buf64, L1BlockCommitment, L1BlockId, L1Height, OLBlockCommitment, OLBlockId, OLTxId,
-    WtxidsRoot, test_utils::ol_block_commitment_strategy,
+    WtxidsRoot,
 };
 use strata_l1_txfmt::MagicBytes;
 use strata_ledger_types::{
@@ -670,16 +670,6 @@ pub(crate) fn create_test_template_with_parent(parent: OLBlockId) -> FullBlockTe
     FullBlockTemplate::new(header, body)
 }
 
-/// Creates a random [`BlockGenerationConfig`] using proptest strategies.
-pub(crate) fn create_test_block_generation_config() -> BlockGenerationConfig {
-    let mut runner = TestRunner::default();
-    let commitment = ol_block_commitment_strategy()
-        .new_tree(&mut runner)
-        .unwrap()
-        .current();
-    BlockGenerationConfig::new(commitment)
-}
-
 /// Create test storage instance.
 pub(crate) fn create_test_storage() -> Arc<NodeStorage> {
     let pool = ThreadPool::new(1);
@@ -917,11 +907,7 @@ impl TestEnv {
         self.ctx.as_ref()
     }
 
-    /// Returns an owned block assembly context handle when ownership is required.
-    #[expect(
-        dead_code,
-        reason = "Added for downstream helper migrations in follow-up commits."
-    )]
+    /// Returns shared block assembly context handle.
     pub(crate) fn ctx_arc(&self) -> Arc<BlockAssemblyContextImpl> {
         self.ctx.clone()
     }
@@ -929,6 +915,11 @@ impl TestEnv {
     /// Returns mock mempool handle for injection/inspection tests.
     pub(crate) fn mempool(&self) -> &MockMempoolProvider {
         self.mempool.as_ref()
+    }
+
+    /// Returns shared mock mempool handle.
+    pub(crate) fn mempool_arc(&self) -> Arc<MockMempoolProvider> {
+        self.mempool.clone()
     }
 
     /// Appends inbox messages to the storage MMR for a given account and returns MMR indices.

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -92,10 +92,6 @@ pub(crate) fn test_hash(seed: u8) -> Hash {
 // Keep account/snark assertions concise in tests that inspect post-state.
 
 /// Returns account balance from post-state.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) fn account_balance(state: &OLState, account_id: AccountId) -> BitcoinAmount {
     state
         .get_account_state(account_id)
@@ -115,28 +111,16 @@ pub(crate) fn snark_account_state(state: &OLState, account_id: AccountId) -> &OL
 }
 
 /// Returns snark account sequence number from post-state.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) fn snark_account_seqno(state: &OLState, account_id: AccountId) -> u64 {
     *snark_account_state(state, account_id).seqno().inner()
 }
 
 /// Returns snark account next inbox message index from post-state.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) fn snark_account_next_inbox_msg_idx(state: &OLState, account_id: AccountId) -> u64 {
     snark_account_state(state, account_id).next_inbox_msg_idx()
 }
 
 /// Returns snark account inbox MMR entry count from post-state.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) fn snark_account_inbox_len(state: &OLState, account_id: AccountId) -> u64 {
     snark_account_state(state, account_id)
         .inbox_mmr()
@@ -959,6 +943,19 @@ impl TestEnv {
     /// Returns an owned mock mempool handle when ownership is required.
     pub(crate) fn mempool_arc(&self) -> Arc<MockMempoolProvider> {
         self.mempool.clone()
+    }
+
+    /// Appends inbox messages to the storage MMR for a given account and returns MMR indices.
+    ///
+    /// This is a runtime storage update helper for multi-block tests where
+    /// proofs in a later block must reference newly-added inbox entries.
+    pub(crate) fn append_inbox_messages(
+        &self,
+        account_id: AccountId,
+        messages: impl IntoIterator<Item = MessageEntry>,
+    ) -> Vec<u64> {
+        let mut inbox_mmr = StorageInboxMmr::new(self.storage().as_ref(), account_id);
+        inbox_mmr.add_messages(messages)
     }
 
     /// Returns configured L1 header refs keyed by L1 height.

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -529,6 +529,23 @@ impl MempoolSnarkTxBuilder {
         self
     }
 
+    /// Appends `count` withdrawal messages routed to the bridge-gateway account.
+    pub(crate) fn with_withdrawals(
+        mut self,
+        count: usize,
+        amount_sats: u64,
+        destination_desc: Vec<u8>,
+    ) -> Self {
+        for _ in 0..count {
+            self.output_messages.push(withdrawal_output_message(
+                amount_sats,
+                destination_desc.clone(),
+                DEFAULT_OPERATOR_FEE,
+            ));
+        }
+        self
+    }
+
     /// Builds the mempool transaction.
     pub(crate) fn build(self) -> OLTransaction {
         // Use a random inner state from proptest
@@ -1457,10 +1474,6 @@ pub(crate) fn withdrawal_intents(
 }
 
 /// Returns accumulated DA with `n` seeded dummy logs.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) fn seeded_da(n: usize) -> AccumulatedDaData {
     let logs = (0..n)
         .map(|i| OLLog::new(AccountSerial::from(i as u32), vec![]))

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1126,6 +1126,12 @@ impl TestStorageFixtureBuilder {
         self
     }
 
+    /// Adds multiple configured account fixtures.
+    pub(crate) fn with_accounts(mut self, accounts: impl IntoIterator<Item = TestAccount>) -> Self {
+        self.accounts.extend(accounts);
+        self
+    }
+
     /// Stores L1 manifests in ASM storage for block's L1 update fetching.
     pub(crate) fn with_l1_manifest_height_range(mut self, range: RangeInclusive<L1Height>) -> Self {
         self.l1_manifest_height_range = Some(range);
@@ -1429,6 +1435,11 @@ pub(crate) fn included_txids(template: &FullBlockTemplate) -> Vec<OLTxId> {
         .iter()
         .map(OLTransaction::compute_txid)
         .collect()
+}
+
+/// Returns post-state root committed in the block template header.
+pub(crate) fn template_state_root(template: &FullBlockTemplate) -> Hash {
+    *template.header().state_root()
 }
 
 /// Returns decoded withdrawal intent logs from accumulated DA logs.

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -182,19 +182,11 @@ impl MockMempoolProvider {
     }
 
     /// Configures a failure injection mode.
-    #[expect(
-        dead_code,
-        reason = "Commit 1 adds test infra before the follow-up tests consume it."
-    )]
     pub(crate) fn set_fail_mode(&self, fail_mode: MockMempoolFailMode) {
         *self.fail_mode.lock().unwrap() = fail_mode;
     }
 
     /// Returns the number of times `report_invalid_transactions` was called.
-    #[expect(
-        dead_code,
-        reason = "Commit 1 adds test infra before the follow-up tests consume it."
-    )]
     pub(crate) fn report_call_count(&self) -> usize {
         self.report_call_count.load(Ordering::Relaxed)
     }
@@ -268,10 +260,6 @@ impl MempoolProvider for Arc<MockMempoolProvider> {
 }
 
 /// State provider test double that always fails state lookup.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) struct FailingStateProvider;
 
 impl StateProvider for FailingStateProvider {
@@ -513,7 +501,9 @@ impl MempoolSnarkTxBuilder {
         self
     }
 
-    /// Sets output messages (balance transfers to other accounts).
+    /// Sets simple output transfers as `(destination_account, value_sats)`.
+    ///
+    /// These are encoded as output messages with empty payload data.
     pub(crate) fn with_outputs(mut self, outputs: Vec<(AccountId, u64)>) -> Self {
         self.outputs = outputs;
         self
@@ -955,11 +945,6 @@ impl TestEnv {
     /// Returns mock mempool handle for injection/inspection tests.
     pub(crate) fn mempool(&self) -> &MockMempoolProvider {
         self.mempool.as_ref()
-    }
-
-    /// Returns an owned mock mempool handle when ownership is required.
-    pub(crate) fn mempool_arc(&self) -> Arc<MockMempoolProvider> {
-        self.mempool.clone()
     }
 
     /// Appends inbox messages to the storage MMR for a given account and returns MMR indices.

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1426,10 +1426,6 @@ pub(crate) fn template_state_root(template: &FullBlockTemplate) -> Hash {
 }
 
 /// Returns decoded withdrawal intent logs from accumulated DA logs.
-#[expect(
-    dead_code,
-    reason = "Added for downstream helper migrations in follow-up commits."
-)]
 pub(crate) fn withdrawal_intents(
     output: &ConstructBlockOutput<OLState>,
 ) -> Vec<SimpleWithdrawalIntentLogData> {

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1058,6 +1058,18 @@ impl TestEnv {
         self.parent_commitment = commitment;
         commitment
     }
+
+    /// Stores an OL block in runtime storage.
+    ///
+    /// Use this for tests that need runtime block injection without reaching into
+    /// raw storage plumbing from test bodies.
+    pub(crate) async fn put_block(&self, block: OLBlock) {
+        self.storage()
+            .ol_block()
+            .put_block_data_async(block)
+            .await
+            .expect("store block");
+    }
 }
 
 /// Converts assembled output into persisted artifacts: `(OLBlock, post_state)`.

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1035,6 +1035,15 @@ impl TestEnv {
             .await
     }
 
+    /// Constructs an empty block using current parent commitment and explicit parent DA.
+    pub(crate) async fn construct_empty_block_with_da(
+        &self,
+        parent_da: AccumulatedDaData,
+    ) -> BlockAssemblyResult<ConstructBlockOutput<OLState>> {
+        self.construct_block_with_da(iter::empty::<(OLTxId, OLTransaction)>(), parent_da)
+            .await
+    }
+
     /// Constructs a block directly from explicit txs and parent DA using current parent commitment.
     pub(crate) async fn construct_block_with_da(
         &self,
@@ -1059,8 +1068,7 @@ impl TestEnv {
     ) -> OLBlockCommitment {
         let header = output.template.header().clone();
         let commitment = OLBlockCommitment::new(header.slot(), header.compute_blkid());
-        let signed_header = SignedOLBlockHeader::new(header, Buf64::zero());
-        let block = OLBlock::new(signed_header, output.template.body().clone());
+        let (block, post_state) = block_and_post_state_from_output(output);
 
         self.storage()
             .ol_block()
@@ -1069,13 +1077,23 @@ impl TestEnv {
             .expect("store assembled block");
         self.storage()
             .ol_state()
-            .put_toplevel_ol_state_async(commitment, output.post_state.clone())
+            .put_toplevel_ol_state_async(commitment, post_state)
             .await
             .expect("store assembled post-state");
 
         self.parent_commitment = commitment;
         commitment
     }
+}
+
+/// Converts assembled output into persisted artifacts: `(OLBlock, post_state)`.
+pub(crate) fn block_and_post_state_from_output(
+    output: &ConstructBlockOutput<OLState>,
+) -> (OLBlock, OLState) {
+    let header = output.template.header().clone();
+    let signed_header = SignedOLBlockHeader::new(header, Buf64::zero());
+    let block = OLBlock::new(signed_header, output.template.body().clone());
+    (block, output.post_state.clone())
 }
 
 /// Builder for seeded storage fixtures used by block assembly tests.

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -192,10 +192,6 @@ impl MockMempoolProvider {
     }
 
     /// Returns the most recent invalid-tx payload passed to `report_invalid_transactions`.
-    #[expect(
-        dead_code,
-        reason = "Added for downstream helper migrations in follow-up commits."
-    )]
     pub(crate) fn last_reported_invalid_txs(&self) -> Vec<(OLTxId, MempoolTxInvalidReason)> {
         self.last_reported_invalid_txs.lock().unwrap().clone()
     }

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -2,7 +2,12 @@
 
 use std::{
     future::Future,
-    sync::{Arc, Mutex},
+    iter,
+    ops::RangeInclusive,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -10,13 +15,15 @@ use async_trait::async_trait;
 use bitcoin::Network;
 use proptest::{arbitrary, prelude::*, strategy::ValueTree, test_runner::TestRunner};
 use strata_acct_types::{
-    AccountId, AccumulatorClaim, BitcoinAmount, Hash, MessageEntry, MsgPayload, tree_hash::TreeHash,
+    AccountId, AccountSerial, AccumulatorClaim, BitcoinAmount, Hash, MessageEntry, MsgPayload,
+    tree_hash::TreeHash,
 };
 use strata_asm_common::{
     AnchorState, AsmHistoryAccumulatorState, ChainViewState, HeaderVerificationState,
 };
 use strata_asm_manifest_types::AsmManifest;
 use strata_btc_verification::L1Anchor;
+use strata_codec::{decode_buf_exact, encode_to_vec};
 use strata_config::SequencerConfig;
 use strata_db_store_sled::test_utils::get_test_sled_backend;
 use strata_db_types::{MmrId, errors::DbError};
@@ -26,18 +33,25 @@ use strata_identifiers::{
 };
 use strata_l1_txfmt::MagicBytes;
 use strata_ledger_types::{
-    AccountTypeState, IAccountStateMut, ISnarkAccountStateMut, IStateAccessor, NewAccountData,
+    AccountTypeState, IAccountState, IAccountStateMut, ISnarkAccountState, ISnarkAccountStateMut,
+    IStateAccessor, NewAccountData,
 };
+use strata_msg_fmt::{Msg, OwnedMsg};
 use strata_ol_chain_types_new::{
-    ClaimList, OLBlock, OLBlockBody, OLTransaction, OLTransactionData, OLTxSegment,
+    ClaimList, OLBlock, OLBlockBody, OLLog, OLTransaction, OLTransactionData, OLTxSegment,
     ProofSatisfierList, SauTxLedgerRefs, SauTxOperationData, SauTxPayload, SauTxProofState,
-    SauTxUpdateData, SignedOLBlockHeader, TransactionPayload, TxProofs,
-    test_utils as ol_test_utils,
+    SauTxUpdateData, SignedOLBlockHeader, SimpleWithdrawalIntentLogData, TransactionPayload,
+    TxProofs, test_utils as ol_test_utils,
 };
-use strata_ol_mempool::MempoolTxInvalidReason;
+use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
+use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, WithdrawalMsgData};
 use strata_ol_params::OLParams;
+use strata_ol_state_support_types::EpochDaAccumulator;
 use strata_ol_state_types::{OLSnarkAccountState, OLState, StateProvider};
-use strata_ol_stf::{BlockComponents, BlockContext, BlockInfo, construct_block};
+use strata_ol_stf::{
+    BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BlockComponents, BlockContext, BlockInfo,
+    construct_block as stf_construct_block,
+};
 use strata_predicate::PredicateKey;
 use strata_snark_acct_types::*;
 use strata_state::asm_state::AsmState;
@@ -52,8 +66,13 @@ pub(crate) fn create_test_genesis_state() -> OLState {
 
 use crate::{
     BlockAssemblyResult, FixedSlotSealing, MempoolProvider,
-    context::BlockAssemblyContext,
-    types::{BlockGenerationConfig, FullBlockTemplate},
+    block_assembly::{
+        ConstructBlockOutput, calculate_block_slot_and_epoch, construct_block,
+        generate_block_template_inner,
+    },
+    context::{BlockAssemblyAnchorContext, BlockAssemblyContext},
+    da_tracker::AccumulatedDaData,
+    types::{BlockGenerationConfig, BlockTemplateResult, FullBlockTemplate},
 };
 
 /// Creates a test account ID with the given seed byte.
@@ -66,6 +85,62 @@ pub(crate) fn test_account_id(id: u8) -> AccountId {
 /// Creates a test hash with all bytes set to the given seed.
 pub(crate) fn test_hash(seed: u8) -> Hash {
     Hash::from([seed; 32])
+}
+
+// ===== Post-State Query Helpers =====
+//
+// Keep account/snark assertions concise in tests that inspect post-state.
+
+/// Returns account balance from post-state.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) fn account_balance(state: &OLState, account_id: AccountId) -> BitcoinAmount {
+    state
+        .get_account_state(account_id)
+        .expect("lookup account")
+        .expect("account exists")
+        .balance()
+}
+
+/// Returns snark account state from post-state.
+pub(crate) fn snark_account_state(state: &OLState, account_id: AccountId) -> &OLSnarkAccountState {
+    state
+        .get_account_state(account_id)
+        .expect("lookup account")
+        .expect("account exists")
+        .as_snark_account()
+        .expect("account should be snark")
+}
+
+/// Returns snark account sequence number from post-state.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) fn snark_account_seqno(state: &OLState, account_id: AccountId) -> u64 {
+    *snark_account_state(state, account_id).seqno().inner()
+}
+
+/// Returns snark account next inbox message index from post-state.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) fn snark_account_next_inbox_msg_idx(state: &OLState, account_id: AccountId) -> u64 {
+    snark_account_state(state, account_id).next_inbox_msg_idx()
+}
+
+/// Returns snark account inbox MMR entry count from post-state.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) fn snark_account_inbox_len(state: &OLState, account_id: AccountId) -> u64 {
+    snark_account_state(state, account_id)
+        .inbox_mmr()
+        .num_entries()
 }
 
 /// Creates a test message entry.
@@ -92,6 +167,18 @@ pub(crate) fn create_test_context(storage: Arc<NodeStorage>) -> BlockAssemblyCon
 /// Mock mempool provider for tests that stores transactions in memory.
 pub(crate) struct MockMempoolProvider {
     transactions: Mutex<Vec<(OLTxId, OLTransaction)>>,
+    report_call_count: AtomicUsize,
+    last_reported_invalid_txs: Mutex<Vec<(OLTxId, MempoolTxInvalidReason)>>,
+    fail_mode: Mutex<MockMempoolFailMode>,
+}
+
+/// Failure injection mode for [`MockMempoolProvider`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum MockMempoolFailMode {
+    #[default]
+    None,
+    GetTransactions,
+    ReportInvalidTransactions,
 }
 
 impl MockMempoolProvider {
@@ -99,12 +186,42 @@ impl MockMempoolProvider {
     pub(crate) fn new() -> Self {
         Self {
             transactions: Mutex::new(Vec::new()),
+            report_call_count: AtomicUsize::new(0),
+            last_reported_invalid_txs: Mutex::new(Vec::new()),
+            fail_mode: Mutex::new(MockMempoolFailMode::None),
         }
     }
 
     /// Add a transaction to the mock mempool.
     pub(crate) fn add_transaction(&self, txid: OLTxId, tx: OLTransaction) {
         self.transactions.lock().unwrap().push((txid, tx));
+    }
+
+    /// Configures a failure injection mode.
+    #[expect(
+        dead_code,
+        reason = "Commit 1 adds test infra before the follow-up tests consume it."
+    )]
+    pub(crate) fn set_fail_mode(&self, fail_mode: MockMempoolFailMode) {
+        *self.fail_mode.lock().unwrap() = fail_mode;
+    }
+
+    /// Returns the number of times `report_invalid_transactions` was called.
+    #[expect(
+        dead_code,
+        reason = "Commit 1 adds test infra before the follow-up tests consume it."
+    )]
+    pub(crate) fn report_call_count(&self) -> usize {
+        self.report_call_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the most recent invalid-tx payload passed to `report_invalid_transactions`.
+    #[expect(
+        dead_code,
+        reason = "Added for downstream helper migrations in follow-up commits."
+    )]
+    pub(crate) fn last_reported_invalid_txs(&self) -> Vec<(OLTxId, MempoolTxInvalidReason)> {
+        self.last_reported_invalid_txs.lock().unwrap().clone()
     }
 }
 
@@ -114,6 +231,14 @@ impl MempoolProvider for MockMempoolProvider {
         &self,
         limit: usize,
     ) -> BlockAssemblyResult<Vec<(OLTxId, OLTransaction)>> {
+        if *self.fail_mode.lock().unwrap() == MockMempoolFailMode::GetTransactions {
+            return Err(crate::BlockAssemblyError::Mempool(
+                OLMempoolError::ServiceClosed(
+                    "mock mempool: get_transactions injected failure".to_string(),
+                ),
+            ));
+        }
+
         let txs = self.transactions.lock().unwrap();
         Ok(txs.iter().take(limit).cloned().collect())
     }
@@ -122,6 +247,17 @@ impl MempoolProvider for MockMempoolProvider {
         &self,
         txs: &[(OLTxId, MempoolTxInvalidReason)],
     ) -> BlockAssemblyResult<()> {
+        self.report_call_count.fetch_add(1, Ordering::Relaxed);
+        *self.last_reported_invalid_txs.lock().unwrap() = txs.to_vec();
+
+        if *self.fail_mode.lock().unwrap() == MockMempoolFailMode::ReportInvalidTransactions {
+            return Err(crate::BlockAssemblyError::Mempool(
+                OLMempoolError::ServiceClosed(
+                    "mock mempool: report_invalid_transactions injected failure".to_string(),
+                ),
+            ));
+        }
+
         let mut stored = self.transactions.lock().unwrap();
         for (txid, _reason) in txs {
             stored.retain(|(id, _)| id != txid);
@@ -144,6 +280,42 @@ impl MempoolProvider for Arc<MockMempoolProvider> {
         txs: &[(OLTxId, MempoolTxInvalidReason)],
     ) -> BlockAssemblyResult<()> {
         MempoolProvider::report_invalid_transactions(self.as_ref(), txs).await
+    }
+}
+
+/// State provider test double that always fails state lookup.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) struct FailingStateProvider;
+
+impl StateProvider for FailingStateProvider {
+    type State = OLState;
+    type Error = DbError;
+
+    #[expect(
+        clippy::manual_async_fn,
+        reason = "Keep explicit Future return shape in this test double implementation."
+    )]
+    fn get_state_for_tip_async(
+        &self,
+        _tip: OLBlockCommitment,
+    ) -> impl Future<Output = Result<Option<Arc<Self::State>>, Self::Error>> + Send {
+        async {
+            Err(DbError::Other(
+                "injected state provider failure".to_string(),
+            ))
+        }
+    }
+
+    fn get_state_for_tip_blocking(
+        &self,
+        _tip: OLBlockCommitment,
+    ) -> Result<Option<Arc<Self::State>>, Self::Error> {
+        Err(DbError::Other(
+            "injected state provider failure".to_string(),
+        ))
     }
 }
 
@@ -234,69 +406,6 @@ impl<'a> StorageInboxMmr<'a> {
             .map(|msg| self.add_message(msg))
             .collect()
     }
-
-    pub(crate) fn entries(&self) -> &[MessageEntry] {
-        &self.entries
-    }
-}
-
-/// Tracks ASM MMR entries (L1 header hashes) in storage.
-///
-/// Use this to populate the storage MMR with L1 header hashes for claim validation tests.
-pub(crate) struct StorageAsmMmr<'a> {
-    storage: &'a NodeStorage,
-    entries: Vec<Hash>,
-    indices: Vec<u64>,
-}
-
-impl<'a> StorageAsmMmr<'a> {
-    /// Creates a new tracker bound to storage.
-    pub(crate) fn new(storage: &'a NodeStorage) -> Self {
-        Self {
-            storage,
-            entries: Vec::new(),
-            indices: Vec::new(),
-        }
-    }
-
-    /// Adds a header hash to the storage MMR and tracks it.
-    pub(crate) fn add_header(&mut self, hash: Hash) -> u64 {
-        let mmr_handle = self.storage.mmr_index().as_ref().get_handle(MmrId::Asm);
-        let idx = mmr_handle.append_leaf_blocking(hash).unwrap();
-        self.entries.push(hash);
-        self.indices.push(idx);
-        idx
-    }
-
-    /// Adds multiple header hashes and returns their indices.
-    pub(crate) fn add_headers(&mut self, hashes: impl IntoIterator<Item = Hash>) -> Vec<u64> {
-        hashes.into_iter().map(|h| self.add_header(h)).collect()
-    }
-
-    /// Adds random header hashes using proptest.
-    pub(crate) fn add_random_headers(&mut self, count: usize) -> Vec<u64> {
-        let hashes = generate_header_hashes(count);
-        hashes.into_iter().map(|h| self.add_header(h)).collect()
-    }
-
-    /// Returns the tracked header hashes.
-    pub(crate) fn hashes(&self) -> &[Hash] {
-        &self.entries
-    }
-
-    /// Returns the MMR leaf indices.
-    pub(crate) fn indices(&self) -> &[u64] {
-        &self.indices
-    }
-
-    /// Returns all claims as AccumulatorClaim objects with MMR leaf indices.
-    pub(crate) fn claims(&self) -> Vec<AccumulatorClaim> {
-        self.indices
-            .iter()
-            .zip(self.entries.iter())
-            .map(|(&idx, &hash)| AccumulatorClaim::new(idx, hash))
-            .collect()
-    }
 }
 
 // ===== Mempool Transaction Builder =====
@@ -313,6 +422,72 @@ pub(crate) struct MempoolSnarkTxBuilder {
     l1_claims: Vec<AccumulatorClaim>,
     outputs: Vec<(AccountId, u64)>,
     output_messages: Vec<OutputMessage>,
+}
+
+/// Builder for creating mempool OL transactions for generic account messages.
+///
+/// Produces a valid GAM transaction shape:
+/// - payload target matches message destination
+/// - exactly one message in effects
+/// - zero message value
+/// - no transfers
+/// - no sequence-number field (GAM payloads are non-sequenced)
+pub(crate) struct MempoolGamTxBuilder {
+    target: AccountId,
+    data: Vec<u8>,
+}
+
+impl MempoolGamTxBuilder {
+    /// Creates a new GAM builder targeting the given account.
+    #[expect(
+        dead_code,
+        reason = "Commit 1 adds test infra before the follow-up tests consume it."
+    )]
+    pub(crate) fn new(target: AccountId) -> Self {
+        Self {
+            target,
+            data: Vec::new(),
+        }
+    }
+
+    /// Sets message payload bytes.
+    #[expect(
+        dead_code,
+        reason = "Commit 1 adds test infra before the follow-up tests consume it."
+    )]
+    pub(crate) fn with_data(mut self, data: Vec<u8>) -> Self {
+        self.data = data;
+        self
+    }
+
+    /// Builds the mempool transaction.
+    #[expect(
+        dead_code,
+        reason = "Commit 1 adds test infra before the follow-up tests consume it."
+    )]
+    pub(crate) fn build(self) -> OLTransaction {
+        OLTransaction::new(
+            OLTransactionData::new_gam(self.target, self.data),
+            TxProofs::new_empty(),
+        )
+    }
+}
+
+/// Constructs a bridge-gateway withdrawal output message.
+pub(crate) fn withdrawal_output_message(
+    amount_sats: u64,
+    destination_desc: Vec<u8>,
+    withdrawal_fee_sats: u32,
+) -> OutputMessage {
+    let withdrawal_data = WithdrawalMsgData::new(withdrawal_fee_sats, destination_desc, u32::MAX)
+        .expect("valid withdrawal data");
+    let encoded_body = encode_to_vec(&withdrawal_data).expect("encode withdrawal body");
+    let withdrawal_msg = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).expect("msg format");
+    let payload = MsgPayload::new(
+        BitcoinAmount::from_sat(amount_sats),
+        withdrawal_msg.to_vec(),
+    );
+    OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload)
 }
 
 impl MempoolSnarkTxBuilder {
@@ -360,9 +535,13 @@ impl MempoolSnarkTxBuilder {
         self
     }
 
-    /// Sets fully-formed output messages, including payload bytes.
-    pub(crate) fn with_output_messages(mut self, output_messages: Vec<OutputMessage>) -> Self {
-        self.output_messages = output_messages;
+    /// Appends a withdrawal message routed to the bridge-gateway account.
+    pub(crate) fn with_withdrawal(mut self, amount_sats: u64, destination_desc: Vec<u8>) -> Self {
+        self.output_messages.push(withdrawal_output_message(
+            amount_sats,
+            destination_desc,
+            DEFAULT_OPERATOR_FEE,
+        ));
         self
     }
 
@@ -398,7 +577,8 @@ impl MempoolSnarkTxBuilder {
             operation_data,
         ));
 
-        // Build effects: empty by default, or explicit if with_outputs() was called.
+        // Build effects: empty by default. `output_messages()` take precedence;
+        // otherwise we synthesize plain value outputs from `with_outputs()`.
         let output_messages = if !self.output_messages.is_empty() {
             self.output_messages
         } else if self.outputs.is_empty() {
@@ -465,30 +645,6 @@ pub(crate) fn insert_inbox_messages_into_state(
     }
 }
 
-/// Inserts inbox messages into the stored OL state at `commitment`.
-pub(crate) async fn insert_inbox_messages_into_storage_state(
-    storage: &NodeStorage,
-    commitment: OLBlockCommitment,
-    account_id: AccountId,
-    messages: &[MessageEntry],
-) {
-    let state = storage
-        .ol_state()
-        .get_toplevel_ol_state_async(commitment)
-        .await
-        .expect("fetch stored state")
-        .expect("stored state missing");
-    let mut state = (*state).clone();
-
-    insert_inbox_messages_into_state(&mut state, account_id, messages);
-
-    storage
-        .ol_state()
-        .put_toplevel_ol_state_async(commitment, state)
-        .await
-        .expect("store updated state");
-}
-
 /// Create test parent header by executing genesis block.
 pub(crate) fn create_test_parent_header() -> strata_ol_chain_types_new::OLBlockHeader {
     let mut runner = TestRunner::default();
@@ -502,7 +658,7 @@ pub(crate) fn create_test_parent_header() -> strata_ol_chain_types_new::OLBlockH
     let genesis_context = BlockContext::new(&genesis_info, None);
     let genesis_components = BlockComponents::new_empty();
     let genesis_output =
-        construct_block(&mut temp_state, genesis_context, genesis_components).unwrap();
+        stf_construct_block(&mut temp_state, genesis_context, genesis_components).unwrap();
     genesis_output.completed_block().header().clone()
 }
 
@@ -582,20 +738,6 @@ pub(crate) fn generate_message_entries(
         .collect()
 }
 
-/// Generate random L1 header hashes using proptest.
-pub(crate) fn generate_header_hashes(count: usize) -> Vec<Hash> {
-    let mut runner = TestRunner::default();
-    (0..count)
-        .map(|_| {
-            arbitrary::any::<[u8; 32]>()
-                .new_tree(&mut runner)
-                .unwrap()
-                .current()
-                .into()
-        })
-        .collect()
-}
-
 // ===== Test Environment Builder (Commit 2) =====
 
 /// Setup ASM state with L1 manifests in storage.
@@ -671,31 +813,283 @@ pub(crate) async fn setup_asm_state_with_l1_manifests(
 /// Default balance for test accounts (100 billion sats).
 pub(crate) const DEFAULT_ACCOUNT_BALANCE: u64 = 100_000_000_000;
 
-/// Manifest commitment metadata for tests (MMR leaf index + committed manifest hash).
-pub(crate) struct ManifestCommitment {
-    pub mmr_idx: u64,
-    pub hash: Hash,
+/// Typed account setup used by test environment builders.
+#[derive(Clone)]
+pub(crate) struct TestAccount {
+    id: AccountId,
+    balance: u64,
+    inbox: Vec<MessageEntry>,
 }
 
-/// Output from TestEnvBuilder - all fields public for direct access.
+impl TestAccount {
+    /// Creates a test account with a balance and empty inbox.
+    pub(crate) fn new(id: AccountId, balance: u64) -> Self {
+        Self {
+            id,
+            balance,
+            inbox: Vec::new(),
+        }
+    }
+
+    /// Adds pre-seeded inbox messages for this account.
+    pub(crate) fn with_inbox(mut self, messages: Vec<MessageEntry>) -> Self {
+        self.inbox = messages;
+        self
+    }
+}
+
+/// Storage fixture layer for block assembly tests.
+pub(crate) struct TestStorageFixture {
+    storage: Arc<NodeStorage>,
+    l1_header_refs: Vec<(L1Height, AccumulatorClaim)>,
+    inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
+}
+
+impl TestStorageFixture {
+    /// Creates a new fixture from storage.
+    pub(crate) fn new(storage: Arc<NodeStorage>) -> Self {
+        Self {
+            storage,
+            l1_header_refs: Vec::new(),
+            inbox_message_claims: Vec::new(),
+        }
+    }
+
+    /// Sets seeded L1 header refs and inbox message claims produced during fixture setup.
+    pub(crate) fn with_seeded_claims(
+        mut self,
+        l1_header_refs: Vec<(L1Height, AccumulatorClaim)>,
+        inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
+    ) -> Self {
+        self.l1_header_refs = l1_header_refs;
+        self.inbox_message_claims = inbox_message_claims;
+        self
+    }
+
+    /// Returns storage handle for lower-level tests.
+    pub(crate) fn storage(&self) -> &Arc<NodeStorage> {
+        &self.storage
+    }
+
+    /// Returns configured L1 header refs keyed by L1 height.
+    pub(crate) fn l1_header_refs(&self) -> &[(L1Height, AccumulatorClaim)] {
+        &self.l1_header_refs
+    }
+
+    /// Returns an L1 header ref for a specific L1 height.
+    pub(crate) fn l1_header_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
+        self.l1_header_refs
+            .iter()
+            .find(|(h, _)| *h == height)
+            .map(|(_, claim)| claim.clone())
+    }
+
+    /// Returns inbox message claims for a specific account.
+    pub(crate) fn inbox_message_claims_for_account(
+        &self,
+        account_id: AccountId,
+    ) -> &[AccumulatorClaim] {
+        self.inbox_message_claims
+            .iter()
+            .find(|(id, _)| *id == account_id)
+            .map(|(_, claims)| claims.as_slice())
+            .unwrap_or(&[])
+    }
+}
+
+/// Behavior-level test environment for block assembly.
 pub(crate) struct TestEnv {
-    pub storage: Arc<NodeStorage>,
-    pub parent_commitment: OLBlockCommitment,
-    pub sequencer_config: SequencerConfig,
-    pub epoch_sealing_policy: FixedSlotSealing,
-    pub manifests: Vec<ManifestCommitment>,
+    fixture: Arc<TestStorageFixture>,
+    ctx: Arc<BlockAssemblyContextImpl>,
+    mempool: Arc<MockMempoolProvider>,
+    sequencer_config: SequencerConfig,
+    epoch_sealing_policy: FixedSlotSealing,
+    parent_commitment: OLBlockCommitment,
 }
 
-/// Builder for block assembly test environments.
+impl TestEnv {
+    /// Creates a behavior-level env from a seeded fixture and parent commitment.
+    pub(crate) fn from_fixture(
+        fixture: Arc<TestStorageFixture>,
+        parent_commitment: OLBlockCommitment,
+    ) -> Self {
+        let (ctx, mempool) = create_test_block_assembly_context(fixture.storage().clone());
+        Self {
+            fixture,
+            ctx: Arc::new(ctx),
+            mempool,
+            sequencer_config: SequencerConfig::default(),
+            epoch_sealing_policy: FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH),
+            parent_commitment,
+        }
+    }
+
+    /// Returns parent commitment used by default assembly entrypoints.
+    pub(crate) fn parent_commitment(&self) -> OLBlockCommitment {
+        self.parent_commitment
+    }
+
+    /// Returns storage handle for storage-backed test setup helpers.
+    pub(crate) fn storage(&self) -> &Arc<NodeStorage> {
+        self.fixture.storage()
+    }
+
+    /// Returns the block assembly context bound to this environment.
+    ///
+    /// Prefer behavior-level helpers (`generate_block_template` /
+    /// `construct_block`) unless a test needs direct context APIs.
+    pub(crate) fn ctx(&self) -> &BlockAssemblyContextImpl {
+        self.ctx.as_ref()
+    }
+
+    /// Returns an owned block assembly context handle when ownership is required.
+    #[expect(
+        dead_code,
+        reason = "Added for downstream helper migrations in follow-up commits."
+    )]
+    pub(crate) fn ctx_arc(&self) -> Arc<BlockAssemblyContextImpl> {
+        self.ctx.clone()
+    }
+
+    /// Returns mock mempool handle for injection/inspection tests.
+    pub(crate) fn mempool(&self) -> &MockMempoolProvider {
+        self.mempool.as_ref()
+    }
+
+    /// Returns an owned mock mempool handle when ownership is required.
+    pub(crate) fn mempool_arc(&self) -> Arc<MockMempoolProvider> {
+        self.mempool.clone()
+    }
+
+    /// Returns configured L1 header refs keyed by L1 height.
+    pub(crate) fn l1_header_refs(&self) -> &[(L1Height, AccumulatorClaim)] {
+        self.fixture.l1_header_refs()
+    }
+
+    /// Returns an L1 header ref for a specific L1 height.
+    pub(crate) fn l1_header_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
+        self.fixture.l1_header_ref(height)
+    }
+
+    /// Returns inbox message claims for a specific account.
+    pub(crate) fn inbox_message_claims_for_account(
+        &self,
+        account_id: AccountId,
+    ) -> &[AccumulatorClaim] {
+        self.fixture.inbox_message_claims_for_account(account_id)
+    }
+
+    /// Returns sequencer config.
+    pub(crate) fn sequencer_config(&self) -> &SequencerConfig {
+        &self.sequencer_config
+    }
+
+    /// Returns epoch sealing policy.
+    pub(crate) fn epoch_sealing_policy(&self) -> &FixedSlotSealing {
+        &self.epoch_sealing_policy
+    }
+
+    /// Returns a block-generation config rooted at this environment's parent commitment.
+    fn parent_config(&self) -> BlockGenerationConfig {
+        BlockGenerationConfig::new(self.parent_commitment())
+    }
+
+    /// Generates block template from mempool using current parent commitment and empty parent DA.
+    pub(crate) async fn generate_block_template(&self) -> BlockAssemblyResult<BlockTemplateResult> {
+        self.generate_block_template_with_da(AccumulatedDaData::new_empty())
+            .await
+    }
+
+    /// Generates block template from mempool using current parent commitment and explicit parent
+    /// DA.
+    pub(crate) async fn generate_block_template_with_da(
+        &self,
+        parent_da: AccumulatedDaData,
+    ) -> BlockAssemblyResult<BlockTemplateResult> {
+        let config = self.parent_config();
+        generate_block_template_inner(
+            self.ctx(),
+            self.epoch_sealing_policy(),
+            self.sequencer_config(),
+            config,
+            parent_da,
+        )
+        .await
+    }
+
+    /// Constructs a block directly from explicit txs using current parent commitment and empty
+    /// parent DA.
+    pub(crate) async fn construct_block(
+        &self,
+        txs: impl IntoIterator<Item = (OLTxId, OLTransaction)>,
+    ) -> BlockAssemblyResult<ConstructBlockOutput<OLState>> {
+        self.construct_block_with_da(txs, AccumulatedDaData::new_empty())
+            .await
+    }
+
+    /// Constructs an empty block using current parent commitment and empty parent DA.
+    pub(crate) async fn construct_empty_block(
+        &self,
+    ) -> BlockAssemblyResult<ConstructBlockOutput<OLState>> {
+        self.construct_block(iter::empty::<(OLTxId, OLTransaction)>())
+            .await
+    }
+
+    /// Constructs a block directly from explicit txs and parent DA using current parent commitment.
+    pub(crate) async fn construct_block_with_da(
+        &self,
+        txs: impl IntoIterator<Item = (OLTxId, OLTransaction)>,
+        parent_da: AccumulatedDaData,
+    ) -> BlockAssemblyResult<ConstructBlockOutput<OLState>> {
+        let config = self.parent_config();
+        assemble_block_with_txs(
+            self.ctx(),
+            self.epoch_sealing_policy(),
+            &config,
+            txs.into_iter().collect(),
+            parent_da,
+        )
+        .await
+    }
+
+    /// Persists assembled output as the next parent block/state and advances parent commitment.
+    pub(crate) async fn persist(
+        &mut self,
+        output: &ConstructBlockOutput<OLState>,
+    ) -> OLBlockCommitment {
+        let header = output.template.header().clone();
+        let commitment = OLBlockCommitment::new(header.slot(), header.compute_blkid());
+        let signed_header = SignedOLBlockHeader::new(header, Buf64::zero());
+        let block = OLBlock::new(signed_header, output.template.body().clone());
+
+        self.storage()
+            .ol_block()
+            .put_block_data_async(block)
+            .await
+            .expect("store assembled block");
+        self.storage()
+            .ol_state()
+            .put_toplevel_ol_state_async(commitment, output.post_state.clone())
+            .await
+            .expect("store assembled post-state");
+
+        self.parent_commitment = commitment;
+        commitment
+    }
+}
+
+/// Builder for seeded storage fixtures used by block assembly tests.
 #[derive(Default)]
-pub(crate) struct TestEnvBuilder {
+pub(crate) struct TestStorageFixtureBuilder {
     parent_slot: Option<u64>,
-    asm_manifest_heights: Vec<L1Height>,
-    claim_manifest_count: Option<usize>,
-    accounts: Vec<(AccountId, u64)>,
+    l1_manifest_height_range: Option<RangeInclusive<L1Height>>,
+    l1_header_ref_heights: Vec<L1Height>,
+    expected_l1_header_ref_indices: Vec<(L1Height, u64)>,
+    expected_inbox_message_indices: Vec<(AccountId, Vec<u64>)>,
+    accounts: Vec<TestAccount>,
 }
 
-impl TestEnvBuilder {
+impl TestStorageFixtureBuilder {
     /// Creates a new builder with default values.
     pub(crate) fn new() -> Self {
         Self::default()
@@ -708,64 +1102,141 @@ impl TestEnvBuilder {
         self
     }
 
-    /// Adds a snark account with the specified balance.
-    pub(crate) fn with_account(mut self, id: AccountId, balance: u64) -> Self {
-        self.accounts.push((id, balance));
+    /// Adds a configured account fixture.
+    pub(crate) fn with_account(mut self, account: TestAccount) -> Self {
+        self.accounts.push(account);
         self
     }
 
     /// Stores L1 manifests in ASM storage for block's L1 update fetching.
-    /// Used by tests that build terminal blocks with L1 manifests.
-    pub(crate) fn with_asm_manifests(mut self, heights: &[L1Height]) -> Self {
-        self.asm_manifest_heights = heights.to_vec();
+    pub(crate) fn with_l1_manifest_height_range(mut self, range: RangeInclusive<L1Height>) -> Self {
+        self.l1_manifest_height_range = Some(range);
         self
     }
 
-    /// Sets up manifests in BOTH storage MMR AND state MMR for claim testing.
-    /// The manifests field in [`TestEnv`] will be populated with [`ManifestCommitment`]s.
-    pub(crate) fn with_claim_manifests(mut self, count: usize) -> Self {
-        self.claim_manifest_count = Some(count);
+    /// Seeds L1 header refs for the provided L1 heights.
+    pub(crate) fn with_l1_header_refs(
+        mut self,
+        heights: impl IntoIterator<Item = L1Height>,
+    ) -> Self {
+        self.l1_header_ref_heights = heights.into_iter().collect();
         self
     }
 
-    /// Builds the test environment.
-    pub(crate) async fn build(self) -> TestEnv {
-        let storage = create_test_storage();
+    /// Asserts exact seeded L1 header ref indices as `(l1_height, expected_mmr_index)` entries.
+    pub(crate) fn with_expected_l1_header_ref_indices(
+        mut self,
+        expected: impl IntoIterator<Item = (L1Height, u64)>,
+    ) -> Self {
+        self.expected_l1_header_ref_indices = expected.into_iter().collect();
+        self
+    }
 
-        // Setup ASM state with L1 manifests if heights provided
-        if let (Some(&min_height), Some(&max_height)) = (
-            self.asm_manifest_heights.iter().min(),
-            self.asm_manifest_heights.iter().max(),
-        ) {
-            setup_asm_state_with_l1_manifests(&storage, min_height, max_height).await;
+    /// Asserts exact seeded inbox message indices as `(account_id, [expected_mmr_index])` entries.
+    ///
+    /// Inbox messages come from account fixtures (`TestAccount::with_inbox`).
+    pub(crate) fn with_expected_inbox_message_indices(
+        mut self,
+        indices: impl IntoIterator<Item = (AccountId, Vec<u64>)>,
+    ) -> Self {
+        self.expected_inbox_message_indices = indices.into_iter().collect();
+        self
+    }
+
+    /// Builds and seeds the storage fixture.
+    ///
+    /// Returns `(fixture, parent_commitment)` for advanced tests that need lower layers directly.
+    pub(crate) async fn build_fixture(self) -> (Arc<TestStorageFixture>, OLBlockCommitment) {
+        let fixture = TestStorageFixture::new(create_test_storage());
+
+        // Setup ASM state with L1 manifests if configured.
+        if let Some(range) = &self.l1_manifest_height_range {
+            let min_height = *range.start();
+            let max_height = *range.end();
+            setup_asm_state_with_l1_manifests(fixture.storage().as_ref(), min_height, max_height)
+                .await;
         }
 
         // Create genesis state
         let mut state = create_test_genesis_state();
 
         // Add snark accounts
-        for (i, (account_id, balance)) in self.accounts.iter().enumerate() {
-            add_snark_account_to_state(&mut state, *account_id, i as u8 + 1, *balance);
+        let mut inbox_message_claims = Vec::new();
+        for (i, account) in self.accounts.iter().enumerate() {
+            add_snark_account_to_state(&mut state, account.id, i as u8 + 1, account.balance);
+            if !account.inbox.is_empty() {
+                insert_inbox_messages_into_state(&mut state, account.id, &account.inbox);
+
+                let mut inbox_mmr = StorageInboxMmr::new(fixture.storage().as_ref(), account.id);
+                let indices = inbox_mmr.add_messages(account.inbox.clone());
+                if let Some((_, expected_indices)) = self
+                    .expected_inbox_message_indices
+                    .iter()
+                    .find(|(account_id, _)| *account_id == account.id)
+                {
+                    assert_eq!(
+                        expected_indices.len(),
+                        indices.len(),
+                        "expected inbox ref count mismatch for account {:?}",
+                        account.id
+                    );
+                    for (position, (expected_idx, actual_idx)) in
+                        expected_indices.iter().zip(indices.iter()).enumerate()
+                    {
+                        assert_eq!(
+                            *expected_idx, *actual_idx,
+                            "seeded inbox ref index mismatch for account {:?} at position {}",
+                            account.id, position
+                        );
+                    }
+                }
+                let claims = build_inbox_claims_for_messages(&account.inbox, &indices);
+                inbox_message_claims.push((account.id, claims));
+            }
         }
 
-        // Setup claim manifests if requested (populates both state and storage MMRs)
-        let manifests = if let Some(count) = self.claim_manifest_count {
-            let test_manifests = create_deterministic_manifests(count);
-            let (hashes, _indices) =
-                setup_manifests_in_state_and_storage(&storage, &mut state, test_manifests.clone());
-
-            test_manifests
+        for (account_id, _) in &self.expected_inbox_message_indices {
+            let is_seeded = inbox_message_claims
                 .iter()
-                .enumerate()
-                .map(|(i, m)| {
-                    // Test genesis has last_l1_height=0, so mmr_offset=1
-                    let mmr_idx = m.height() as u64 - 1;
-                    ManifestCommitment {
-                        mmr_idx,
-                        hash: hashes[i],
-                    }
-                })
-                .collect()
+                .any(|(seeded_account_id, _)| seeded_account_id == account_id);
+            assert!(
+                is_seeded,
+                "inbox message indices configured for account {:?}, but no inbox messages were seeded for that account",
+                account_id
+            );
+        }
+
+        // Seed requested L1 header refs into both state claims and the ASM MMR.
+        let mut l1_heights = self.l1_header_ref_heights.clone();
+        l1_heights.extend(
+            self.expected_l1_header_ref_indices
+                .iter()
+                .map(|(height, _)| *height),
+        );
+        l1_heights.sort_unstable();
+        l1_heights.dedup();
+
+        let seeded_l1_header_refs = if !l1_heights.is_empty() {
+            let asm_manifests = create_test_manifests_for_heights(&l1_heights);
+            let claims_by_height = setup_manifests_in_state_and_storage(
+                fixture.storage().as_ref(),
+                &mut state,
+                asm_manifests,
+            );
+
+            for (height, expected_idx) in &self.expected_l1_header_ref_indices {
+                let (_, claim) = claims_by_height
+                    .iter()
+                    .find(|(h, _)| h == height)
+                    .unwrap_or_else(|| panic!("missing seeded claim for l1 height {height}"));
+                assert_eq!(
+                    claim.idx(),
+                    *expected_idx,
+                    "seeded claim index mismatch for l1 height {height}"
+                );
+            }
+
+            claims_by_height
         } else {
             vec![]
         };
@@ -791,7 +1262,7 @@ impl TestEnvBuilder {
                 let components = BlockComponents::new_manifests(vec![genesis_manifest]);
 
                 let block_context = BlockContext::new(&block_info, None);
-                let construct_output = construct_block(&mut state, block_context, components)
+                let construct_output = stf_construct_block(&mut state, block_context, components)
                     .expect("Genesis block execution should succeed");
 
                 let completed_block = construct_output.completed_block();
@@ -809,13 +1280,15 @@ impl TestEnvBuilder {
                 SignedOLBlockHeader::new(parent_header.clone(), Buf64::zero());
             let parent_block = OLBlock::new(parent_signed_header, parent_block_body);
 
-            storage
+            fixture
+                .storage()
                 .ol_state()
                 .put_toplevel_ol_state_async(commitment, parent_state)
                 .await
                 .expect("Failed to store parent OL state");
 
-            storage
+            fixture
+                .storage()
                 .ol_block()
                 .put_block_data_async(parent_block)
                 .await
@@ -825,7 +1298,8 @@ impl TestEnvBuilder {
         } else {
             // No parent slot - return null commitment for genesis testing
             let null_commitment = OLBlockCommitment::null();
-            storage
+            fixture
+                .storage()
                 .ol_state()
                 .put_toplevel_ol_state_async(null_commitment, state)
                 .await
@@ -833,30 +1307,25 @@ impl TestEnvBuilder {
             null_commitment
         };
 
-        let sequencer_config = SequencerConfig::default();
-
-        let epoch_sealing_policy = FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH);
-
-        TestEnv {
-            storage,
-            parent_commitment,
-            sequencer_config,
-            epoch_sealing_policy,
-            manifests,
-        }
+        let fixture =
+            Arc::new(fixture.with_seeded_claims(seeded_l1_header_refs, inbox_message_claims));
+        (fixture, parent_commitment)
     }
 }
 
-/// Create deterministic test manifests with unique block IDs.
+/// Create deterministic test manifests for specific L1 heights.
 ///
 /// Returns manifests that can be used to populate both state and storage MMRs.
-fn create_deterministic_manifests(count: usize) -> Vec<AsmManifest> {
-    (0..count)
-        .map(|i| {
+fn create_test_manifests_for_heights(heights: &[L1Height]) -> Vec<AsmManifest> {
+    heights
+        .iter()
+        .copied()
+        .map(|height| {
             let mut blkid_bytes = [0u8; 32];
-            blkid_bytes[0] = (i + 1) as u8; // Unique block ID for each manifest
+            blkid_bytes[0] = height as u8;
+            blkid_bytes[1] = (height >> 8) as u8;
             AsmManifest::new(
-                (i + 1) as L1Height, // height
+                height,
                 L1BlockId::from(Buf32::from(blkid_bytes)),
                 WtxidsRoot::from(Buf32::zero()),
                 vec![],
@@ -871,32 +1340,51 @@ fn create_deterministic_manifests(count: usize) -> Vec<AsmManifest> {
 /// This ensures consistency between proof generation (uses storage MMR) and
 /// verification (uses state's manifest MMR).
 ///
-/// Returns the manifest hashes and their leaf indices.
+/// Returns `(l1_height, claim)` pairs for each inserted manifest.
 fn setup_manifests_in_state_and_storage(
     storage: &NodeStorage,
     state: &mut OLState,
     manifests: Vec<AsmManifest>,
-) -> (Vec<Hash>, Vec<u64>) {
+) -> Vec<(L1Height, AccumulatorClaim)> {
     let mmr_handle = storage.mmr_index().as_ref().get_handle(MmrId::Asm);
 
-    let mut hashes = Vec::with_capacity(manifests.len());
-    let mut indices = Vec::with_capacity(manifests.len());
+    let mut claims_by_l1_height = Vec::with_capacity(manifests.len());
 
     for manifest in manifests {
         // Compute manifest hash
         let manifest_hash: Hash = manifest.compute_hash().into();
-        hashes.push(manifest_hash);
 
         // Add to storage MMR (for proof generation)
         let leaf_idx = mmr_handle.append_leaf_blocking(manifest_hash).unwrap();
-        indices.push(leaf_idx);
+        let claim = AccumulatorClaim::new(leaf_idx, manifest_hash);
 
         // Add to state's manifest MMR (for verification)
         let height = manifest.height();
         state.append_manifest(height, manifest);
+        claims_by_l1_height.push((height, claim));
     }
 
-    (hashes, indices)
+    claims_by_l1_height.sort_by_key(|(height, _)| *height);
+    claims_by_l1_height
+}
+
+fn build_inbox_claims_for_messages(
+    messages: &[MessageEntry],
+    indices: &[u64],
+) -> Vec<AccumulatorClaim> {
+    assert_eq!(
+        messages.len(),
+        indices.len(),
+        "messages/indices length mismatch while building inbox claims"
+    );
+    indices
+        .iter()
+        .zip(messages.iter())
+        .map(|(&idx, msg)| {
+            let hash = <MessageEntry as TreeHash>::tree_hash_root(msg).into_inner();
+            AccumulatorClaim::new(idx, hash)
+        })
+        .collect()
 }
 
 /// Create test BlockAssemblyContext with mock providers.
@@ -909,4 +1397,78 @@ pub(crate) fn create_test_block_assembly_context(
     let state_provider = StateProviderHandle(storage.ol_state().clone());
     let ctx = BlockAssemblyContext::new(storage, mempool_provider.clone(), state_provider, 0);
     (ctx, mempool_provider)
+}
+
+// ===== Result Inspection Helpers =====
+
+/// Returns included txids in block order.
+pub(crate) fn included_txids(template: &FullBlockTemplate) -> Vec<OLTxId> {
+    template
+        .body()
+        .tx_segment()
+        .expect("tx segment")
+        .txs()
+        .iter()
+        .map(OLTransaction::compute_txid)
+        .collect()
+}
+
+/// Returns decoded withdrawal intent logs from accumulated DA logs.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) fn withdrawal_intents(
+    output: &ConstructBlockOutput<OLState>,
+) -> Vec<SimpleWithdrawalIntentLogData> {
+    output
+        .accumulated_da
+        .logs()
+        .iter()
+        .filter(|log| log.account_serial() == BRIDGE_GATEWAY_ACCT_SERIAL)
+        .filter_map(|log| decode_buf_exact::<SimpleWithdrawalIntentLogData>(log.payload()).ok())
+        .collect()
+}
+
+/// Returns accumulated DA with `n` seeded dummy logs.
+#[expect(
+    dead_code,
+    reason = "Added for downstream helper migrations in follow-up commits."
+)]
+pub(crate) fn seeded_da(n: usize) -> AccumulatedDaData {
+    let logs = (0..n)
+        .map(|i| OLLog::new(AccountSerial::from(i as u32), vec![]))
+        .collect();
+    AccumulatedDaData::new(EpochDaAccumulator::default(), logs)
+}
+
+// ===== Assembly Pipeline Helper =====
+
+/// Assembles a block for `config` using tx list and parent DA snapshot.
+pub(crate) async fn assemble_block_with_txs(
+    ctx: &BlockAssemblyContextImpl,
+    epoch_sealing_policy: &FixedSlotSealing,
+    config: &BlockGenerationConfig,
+    txs: Vec<(OLTxId, OLTransaction)>,
+    parent_da: AccumulatedDaData,
+) -> BlockAssemblyResult<ConstructBlockOutput<OLState>> {
+    let parent_state = ctx
+        .fetch_state_for_tip(config.parent_block_commitment())
+        .await?
+        .expect("parent state should exist");
+
+    let (block_slot, block_epoch) =
+        calculate_block_slot_and_epoch(&config.parent_block_commitment(), parent_state.as_ref());
+
+    construct_block(
+        ctx,
+        epoch_sealing_policy,
+        config,
+        parent_state,
+        block_slot,
+        block_epoch,
+        txs,
+        parent_da,
+    )
+    .await
 }

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -407,10 +407,6 @@ pub(crate) struct MempoolGamTxBuilder {
 
 impl MempoolGamTxBuilder {
     /// Creates a new GAM builder targeting the given account.
-    #[expect(
-        dead_code,
-        reason = "Commit 1 adds test infra before the follow-up tests consume it."
-    )]
     pub(crate) fn new(target: AccountId) -> Self {
         Self {
             target,
@@ -419,20 +415,12 @@ impl MempoolGamTxBuilder {
     }
 
     /// Sets message payload bytes.
-    #[expect(
-        dead_code,
-        reason = "Commit 1 adds test infra before the follow-up tests consume it."
-    )]
     pub(crate) fn with_data(mut self, data: Vec<u8>) -> Self {
         self.data = data;
         self
     }
 
     /// Builds the mempool transaction.
-    #[expect(
-        dead_code,
-        reason = "Commit 1 adds test infra before the follow-up tests consume it."
-    )]
     pub(crate) fn build(self) -> OLTransaction {
         OLTransaction::new(
             OLTransactionData::new_gam(self.target, self.data),

--- a/crates/ol/block-assembly/src/tests/da.rs
+++ b/crates/ol/block-assembly/src/tests/da.rs
@@ -3,10 +3,10 @@
 //! Tests that verify DA is correctly accumulated during block assembly,
 //! reset at epoch boundaries, and rolled back on failed transactions.
 
-use std::{iter, sync::Arc};
+use std::sync::Arc;
 
-use strata_identifiers::{Buf64, OLBlockCommitment};
-use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, SignedOLBlockHeader};
+use strata_identifiers::OLBlockCommitment;
+use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
 use strata_ol_state_support_types::{DaAccumulatingState, EpochDaAccumulator};
 use strata_ol_state_types::OLState;
 use strata_ol_stf::execute_block_batch;
@@ -16,10 +16,9 @@ use crate::{
     da_tracker::{AccumulatedDaData, rebuild_accumulated_da_upto},
     test_utils::{
         DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
-        TestStorageFixtureBuilder, assemble_block_with_txs, generate_message_entries,
+        TestStorageFixtureBuilder, block_and_post_state_from_output, generate_message_entries,
         included_txids, test_account_id,
     },
-    types::BlockGenerationConfig,
 };
 
 /// Finalizes an accumulator against the given state and returns the encoded DA blob bytes.
@@ -53,14 +52,10 @@ async fn build_blocks_with_da_and_artifacts(
 
     for slot in start_slot..target_slot {
         let output = env
-            .construct_block_with_da(iter::empty(), accumulated_da)
+            .construct_empty_block_with_da(accumulated_da)
             .await
             .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
-
-        let header = output.template.header();
-        let signed_header = SignedOLBlockHeader::new(header.clone(), Buf64::zero());
-        let block = OLBlock::new(signed_header, output.template.body().clone());
-        let post_state = output.post_state.clone();
+        let (block, post_state) = block_and_post_state_from_output(&output);
         let new_commitment = env.persist(&output).await;
 
         artifacts.push((block, post_state));
@@ -163,31 +158,19 @@ async fn test_da_resets_at_epoch_boundary() {
         finalize_da_to_bytes(epoch1_acc, Arc::unwrap_or_clone(epoch1_pre_terminal_state));
 
     // Build terminal block (slot 10) with epoch 1 DA.
-    let config = BlockGenerationConfig::new(pre_terminal_commitment);
-    let terminal_output = assemble_block_with_txs(
-        env.ctx(),
-        env.epoch_sealing_policy(),
-        &config,
-        vec![],
-        epoch1_da,
-    )
-    .await
-    .expect("terminal block construction should succeed");
+    let terminal_output = env
+        .construct_empty_block_with_da(epoch1_da)
+        .await
+        .expect("terminal block construction should succeed");
 
     // Store terminal block so we can build on it.
     env.persist(&terminal_output).await;
 
     // Build slot 11 (first block of epoch 2) with FRESH empty DA.
-    let config_11 = BlockGenerationConfig::new(env.parent_commitment());
-    let epoch2_output = assemble_block_with_txs(
-        env.ctx(),
-        env.epoch_sealing_policy(),
-        &config_11,
-        vec![],
-        AccumulatedDaData::new_empty(),
-    )
-    .await
-    .expect("epoch 2 block construction should succeed");
+    let epoch2_output = env
+        .construct_empty_block_with_da(AccumulatedDaData::new_empty())
+        .await
+        .expect("epoch 2 block construction should succeed");
 
     // Epoch 2 DA should only contain slot 11's changes, not epoch 1's.
     let (epoch2_acc, epoch2_logs) = epoch2_output.accumulated_da.into_parts();

--- a/crates/ol/block-assembly/src/tests/effects.rs
+++ b/crates/ol/block-assembly/src/tests/effects.rs
@@ -1,0 +1,276 @@
+//! Post-state effects and rollback-focused block assembly tests.
+
+use strata_acct_types::{AccountSerial, BitcoinAmount};
+use strata_checkpoint_types_ssz::MAX_OL_LOGS_PER_CHECKPOINT;
+use strata_ol_chain_types_new::OLLog;
+use strata_ol_mempool::MempoolTxInvalidReason;
+use strata_ol_state_support_types::EpochDaAccumulator;
+
+use crate::{
+    da_tracker::AccumulatedDaData,
+    test_utils::{
+        DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
+        TestStorageFixtureBuilder, account_balance, included_txids, test_account_id,
+        withdrawal_intents,
+    },
+};
+
+async fn build_effects_env(accounts: impl IntoIterator<Item = TestAccount>) -> TestEnv {
+    let env_builder = accounts.into_iter().fold(
+        TestStorageFixtureBuilder::new()
+            .with_parent_slot(0)
+            .with_l1_manifest_height_range(1..=3),
+        |builder, account| builder.with_account(account),
+    );
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    TestEnv::from_fixture(fixture, parent_commitment)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transfer_balances_update() {
+    let sender = test_account_id(1);
+    let receiver = test_account_id(2);
+    let transfer_sats = 7_000u64;
+
+    let env = build_effects_env([
+        TestAccount::new(sender, DEFAULT_ACCOUNT_BALANCE),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let tx = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, transfer_sats)])
+        .build();
+    let txid = tx.compute_txid();
+
+    let output = env
+        .construct_block(vec![(txid, tx)])
+        .await
+        .expect("transfer block should assemble");
+    assert!(output.failed_txs.is_empty(), "transfer should succeed");
+
+    let included = included_txids(&output.template);
+    assert_eq!(included.len(), 1, "block should include one transfer");
+
+    assert_eq!(
+        account_balance(&output.post_state, sender),
+        BitcoinAmount::from_sat(DEFAULT_ACCOUNT_BALANCE - transfer_sats),
+        "sender balance should be debited by transfer amount"
+    );
+    assert_eq!(
+        account_balance(&output.post_state, receiver),
+        BitcoinAmount::from_sat(transfer_sats),
+        "receiver balance should be credited by transfer amount"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_withdrawal_log_content() {
+    let sender = test_account_id(3);
+    let withdrawal_sats = 100_000_000u64;
+    let withdrawal_dest = b"bc1qeffectswithdrawal".to_vec();
+
+    let env = build_effects_env([TestAccount::new(sender, DEFAULT_ACCOUNT_BALANCE)]).await;
+
+    let tx = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(0)
+        .with_withdrawal(withdrawal_sats, withdrawal_dest.clone())
+        .build();
+    let txid = tx.compute_txid();
+
+    let output = env
+        .construct_block(vec![(txid, tx)])
+        .await
+        .expect("withdrawal block should assemble");
+    assert!(output.failed_txs.is_empty(), "withdrawal tx should succeed");
+
+    let decoded_withdrawal_logs = withdrawal_intents(&output);
+    assert_eq!(
+        decoded_withdrawal_logs.len(),
+        1,
+        "expected exactly one decodable withdrawal intent log"
+    );
+
+    let withdrawal_log = &decoded_withdrawal_logs[0];
+    assert_eq!(
+        withdrawal_log.amt, withdrawal_sats,
+        "withdrawal amount should match"
+    );
+    assert_eq!(
+        withdrawal_log.dest.as_slice(),
+        withdrawal_dest.as_slice(),
+        "withdrawal destination should match"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rollback_preserves_first_tx_effects() {
+    let sender = test_account_id(4);
+    let receiver = test_account_id(5);
+    let first_transfer_sats = 5_000u64;
+
+    let env = build_effects_env([
+        TestAccount::new(sender, DEFAULT_ACCOUNT_BALANCE),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let tx1 = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, first_transfer_sats)])
+        .build();
+    let tx1_id = tx1.compute_txid();
+
+    // Force deterministic failure via seq gap: account seq_no should be 1 after tx1.
+    let tx2 = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(2)
+        .with_outputs(vec![(receiver, 1_000)])
+        .build();
+    let tx2_id = tx2.compute_txid();
+
+    let output = env
+        .construct_block(vec![(tx1_id, tx1), (tx2_id, tx2)])
+        .await
+        .expect("rollback block should assemble");
+
+    let included = included_txids(&output.template);
+    assert_eq!(included.len(), 1, "only first tx should be included");
+    assert_eq!(output.failed_txs.len(), 1, "second tx should fail");
+    assert_eq!(
+        output.failed_txs[0].0, tx2_id,
+        "failed entry should correspond to the second tx"
+    );
+
+    assert_eq!(
+        account_balance(&output.post_state, sender),
+        BitcoinAmount::from_sat(DEFAULT_ACCOUNT_BALANCE - first_transfer_sats),
+        "sender should reflect only first tx debit"
+    );
+    assert_eq!(
+        account_balance(&output.post_state, receiver),
+        BitcoinAmount::from_sat(first_transfer_sats),
+        "receiver should reflect only first tx credit"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_hard_limit_rollback_discards_tx2_log() {
+    let account = test_account_id(6);
+    let receiver = test_account_id(7);
+    let withdrawal_sats = 100_000_000u64;
+
+    let env = build_effects_env([
+        TestAccount::new(account, DEFAULT_ACCOUNT_BALANCE),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let tx1 = MempoolSnarkTxBuilder::new(account)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 1_000)])
+        .build();
+    let tx1_id = tx1.compute_txid();
+
+    // This tx would emit a bridge-gateway withdrawal log if committed.
+    let tx2 = MempoolSnarkTxBuilder::new(account)
+        .with_seq_no(1)
+        .with_withdrawal(withdrawal_sats, b"bc1qhardlimitrollback".to_vec())
+        .build();
+    let tx2_id = tx2.compute_txid();
+
+    let seeded_count = (MAX_OL_LOGS_PER_CHECKPOINT as usize) - 1;
+    // Offset seeded log source serials away from test account serials (1..10)
+    // so seeded checkpoint logs cannot collide with real tx-emitted sources.
+    let seeded_logs: Vec<_> = (0..seeded_count)
+        .map(|i| OLLog::new(AccountSerial::from((1_000 + i) as u32), vec![]))
+        .collect();
+    let parent_da = AccumulatedDaData::new(EpochDaAccumulator::default(), seeded_logs);
+
+    let output = env
+        .construct_block_with_da(vec![(tx1_id, tx1), (tx2_id, tx2)], parent_da)
+        .await
+        .expect("hard-limit rollback scenario should assemble");
+
+    let included = included_txids(&output.template);
+    assert_eq!(
+        included.len(),
+        1,
+        "tx1 should be kept, tx2 should be rolled back"
+    );
+    assert!(
+        output.failed_txs.is_empty(),
+        "hard-limit rollback should defer/stop, not mark tx invalid"
+    );
+
+    assert_eq!(
+        output.accumulated_da.logs().len(),
+        seeded_count,
+        "rolled-back tx2 log must not be appended to accumulated DA logs"
+    );
+    assert_eq!(
+        withdrawal_intents(&output).len(),
+        0,
+        "rolled-back tx2 must not leave bridge-gateway withdrawal logs"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rollback_on_insufficient_balance_preserves_prior_effects() {
+    let rich = test_account_id(8);
+    let poor = test_account_id(9);
+    let receiver = test_account_id(10);
+    let tx1_amount = 5_000u64;
+    let tx2_amount = 1_000u64;
+
+    let env = build_effects_env([
+        TestAccount::new(rich, DEFAULT_ACCOUNT_BALANCE),
+        TestAccount::new(poor, 0),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let tx1 = MempoolSnarkTxBuilder::new(rich)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, tx1_amount)])
+        .build();
+    let tx1_id = tx1.compute_txid();
+
+    // Non-seq-gap deterministic failure path: insufficient balance.
+    let tx2 = MempoolSnarkTxBuilder::new(poor)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, tx2_amount)])
+        .build();
+    let tx2_id = tx2.compute_txid();
+
+    let output = env
+        .construct_block(vec![(tx1_id, tx1), (tx2_id, tx2)])
+        .await
+        .expect("mixed success/failure block should assemble");
+
+    let included = included_txids(&output.template);
+    assert_eq!(included.len(), 1, "only tx1 should be included");
+    assert_eq!(output.failed_txs.len(), 1, "tx2 should fail");
+    assert_eq!(output.failed_txs[0].0, tx2_id, "failed tx should be tx2");
+    assert_eq!(
+        output.failed_txs[0].1,
+        MempoolTxInvalidReason::Failed,
+        "insufficient-balance path should map to Failed"
+    );
+
+    assert_eq!(
+        account_balance(&output.post_state, rich),
+        BitcoinAmount::from_sat(DEFAULT_ACCOUNT_BALANCE - tx1_amount),
+        "rich account should reflect only tx1 debit"
+    );
+    assert_eq!(
+        account_balance(&output.post_state, receiver),
+        BitcoinAmount::from_sat(tx1_amount),
+        "receiver should reflect only tx1 credit"
+    );
+    assert_eq!(
+        account_balance(&output.post_state, poor),
+        BitcoinAmount::from_sat(0),
+        "failing tx2 should not mutate poor account balance"
+    );
+}

--- a/crates/ol/block-assembly/src/tests/mempool.rs
+++ b/crates/ol/block-assembly/src/tests/mempool.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use strata_config::SequencerConfig;
 use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
-use strata_ol_mempool::OLMempoolError;
+use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
 
 use crate::{
     BlockAssemblyError, FixedSlotSealing,
@@ -182,5 +182,248 @@ async fn test_no_report_when_all_txs_valid() {
         env.mempool().report_call_count(),
         0,
         "report_invalid_transactions must not be called when failed_txs is empty"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_exact_invalid_report_payload() {
+    let missing_account = test_account_id(11);
+    let env = build_mempool_env([]).await;
+
+    let invalid_tx = MempoolSnarkTxBuilder::new(missing_account)
+        .with_seq_no(0)
+        .build();
+    let invalid_txid = invalid_tx.compute_txid();
+    env.mempool().add_transaction(invalid_txid, invalid_tx);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("assembly should succeed with invalid tx filtered");
+
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![(invalid_txid, MempoolTxInvalidReason::Invalid)];
+    assert_eq!(
+        failed_txs, expected,
+        "failed_txs should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().last_reported_invalid_txs(),
+        expected,
+        "reported invalid payload should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().report_call_count(),
+        1,
+        "invalid payload should be reported once"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mixed_failures_keep_order_and_reason() {
+    let missing_account = test_account_id(12);
+    let low_balance_account = test_account_id(1);
+    let receiver = test_account_id(2);
+    let env = build_mempool_env([
+        TestAccount::new(low_balance_account, 0),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let invalid_tx = MempoolSnarkTxBuilder::new(missing_account)
+        .with_seq_no(0)
+        .build();
+    let invalid_txid = invalid_tx.compute_txid();
+
+    let failed_tx = MempoolSnarkTxBuilder::new(low_balance_account)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 1)])
+        .build();
+    let failed_txid = failed_tx.compute_txid();
+
+    env.mempool().add_transaction(invalid_txid, invalid_tx);
+    env.mempool().add_transaction(failed_txid, failed_tx);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("assembly should succeed with failed tx filtering");
+
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![
+        (invalid_txid, MempoolTxInvalidReason::Invalid),
+        (failed_txid, MempoolTxInvalidReason::Failed),
+    ];
+    assert_eq!(
+        failed_txs, expected,
+        "failed_txs should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().last_reported_invalid_txs(),
+        expected,
+        "reported invalid payload should match expected invalid payload"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_max_txs_reports_only_fetched_failures() {
+    let missing_a = test_account_id(13);
+    let missing_b = test_account_id(14);
+    let env = build_mempool_env([]).await;
+
+    let tx_a = MempoolSnarkTxBuilder::new(missing_a).with_seq_no(0).build();
+    let tx_a_id = tx_a.compute_txid();
+    let tx_b = MempoolSnarkTxBuilder::new(missing_b).with_seq_no(0).build();
+    let tx_b_id = tx_b.compute_txid();
+    env.mempool().add_transaction(tx_a_id, tx_a);
+    env.mempool().add_transaction(tx_b_id, tx_b);
+
+    let mut sequencer_config = env.sequencer_config().clone();
+    sequencer_config.max_txs_per_block = 1;
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        &sequencer_config,
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("assembly should succeed with limited tx fetch");
+
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![(tx_a_id, MempoolTxInvalidReason::Invalid)];
+    assert_eq!(
+        failed_txs, expected,
+        "failed_txs should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().last_reported_invalid_txs(),
+        expected,
+        "reported invalid payload should match expected invalid payload"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_exec_failure_reports_failed() {
+    let sender = test_account_id(1);
+    let receiver = test_account_id(2);
+    let env = build_mempool_env([TestAccount::new(sender, 0), TestAccount::new(receiver, 0)]).await;
+
+    let tx = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 1)])
+        .build();
+    let txid = tx.compute_txid();
+    env.mempool().add_transaction(txid, tx);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("assembly should succeed with failed execution filtered");
+
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![(txid, MempoolTxInvalidReason::Failed)];
+    assert_eq!(
+        failed_txs, expected,
+        "failed_txs should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().last_reported_invalid_txs(),
+        expected,
+        "reported invalid payload should match expected invalid payload"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_duplicate_txid_one_fails() {
+    let account = test_account_id(1);
+    let env = build_mempool_env([TestAccount::new(account, 10_000)]).await;
+
+    let tx = MempoolSnarkTxBuilder::new(account).with_seq_no(0).build();
+    let txid = tx.compute_txid();
+    env.mempool().add_transaction(txid, tx.clone());
+    env.mempool().add_transaction(txid, tx);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("assembly should succeed");
+
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![(txid, MempoolTxInvalidReason::Invalid)];
+    assert_eq!(
+        failed_txs, expected,
+        "failed_txs should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().last_reported_invalid_txs(),
+        expected,
+        "reported invalid payload should match expected invalid payload"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_duplicate_txid_both_fail() {
+    let missing_account = test_account_id(15);
+    let env = build_mempool_env([]).await;
+
+    // Both copies of the same txid fail in the same way (missing account).
+    let tx = MempoolSnarkTxBuilder::new(missing_account)
+        .with_seq_no(0)
+        .build();
+    let txid = tx.compute_txid();
+    env.mempool().add_transaction(txid, tx.clone());
+    env.mempool().add_transaction(txid, tx);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("assembly should succeed with both txs filtered");
+
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![
+        (txid, MempoolTxInvalidReason::Invalid),
+        (txid, MempoolTxInvalidReason::Invalid),
+    ];
+    assert_eq!(
+        failed_txs, expected,
+        "failed_txs should match expected invalid payload"
+    );
+    assert_eq!(
+        env.mempool().last_reported_invalid_txs(),
+        expected,
+        "reported invalid payload should match expected invalid payload"
     );
 }

--- a/crates/ol/block-assembly/src/tests/mempool.rs
+++ b/crates/ol/block-assembly/src/tests/mempool.rs
@@ -1,0 +1,186 @@
+//! Mempool-facing block assembly failure/report tests.
+
+use std::sync::Arc;
+
+use strata_config::SequencerConfig;
+use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
+use strata_ol_mempool::OLMempoolError;
+
+use crate::{
+    BlockAssemblyError, FixedSlotSealing,
+    block_assembly::generate_block_template_inner,
+    context::BlockAssemblyContext,
+    da_tracker::AccumulatedDaData,
+    test_utils::{
+        FailingStateProvider, MempoolSnarkTxBuilder, MockMempoolFailMode, MockMempoolProvider,
+        TEST_SLOTS_PER_EPOCH, TestAccount, TestEnv, TestStorageFixtureBuilder, create_test_storage,
+        included_txids, test_account_id,
+    },
+    types::BlockGenerationConfig,
+};
+
+async fn build_mempool_env(accounts: impl IntoIterator<Item = TestAccount>) -> TestEnv {
+    let fixture_builder = TestStorageFixtureBuilder::new()
+        .with_parent_slot(0)
+        .with_accounts(accounts);
+    let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
+    TestEnv::from_fixture(fixture, parent_commitment)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_missing_parent_fails() {
+    let env = build_mempool_env([]).await;
+
+    let missing_parent = OLBlockCommitment::new(999, OLBlockId::from(Buf32::from([7u8; 32])));
+    let config = BlockGenerationConfig::new(missing_parent);
+
+    let err = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect_err("missing parent state should fail");
+
+    assert!(
+        matches!(err, BlockAssemblyError::ParentStateNotFound(_)),
+        "expected ParentStateNotFound(_), got: {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_state_provider_failure_propagates() {
+    let storage = create_test_storage();
+    let mempool = Arc::new(MockMempoolProvider::new());
+    let ctx = BlockAssemblyContext::new(storage, mempool, FailingStateProvider, 0);
+    let config = BlockGenerationConfig::new(OLBlockCommitment::new(
+        1,
+        OLBlockId::from(Buf32::from([7; 32])),
+    ));
+    let epoch_sealing_policy = FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH);
+    let sequencer_config = SequencerConfig::default();
+
+    let err = generate_block_template_inner(
+        &ctx,
+        &epoch_sealing_policy,
+        &sequencer_config,
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect_err("state provider error should fail");
+
+    assert!(
+        matches!(err, BlockAssemblyError::StateProvider(_)),
+        "expected StateProvider(_), got: {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_transactions_failure_propagates() {
+    let env = build_mempool_env([]).await;
+    env.mempool()
+        .set_fail_mode(MockMempoolFailMode::GetTransactions);
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+
+    let err = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect_err("mempool get failure should fail");
+
+    assert!(
+        matches!(
+            err,
+            BlockAssemblyError::Mempool(OLMempoolError::ServiceClosed(_))
+        ),
+        "expected mempool service-closed error, got: {err:?}"
+    );
+    assert_eq!(
+        env.mempool().report_call_count(),
+        0,
+        "report_invalid_transactions must not be called when get_transactions fails"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_report_failure_propagates() {
+    let missing_account = test_account_id(9);
+    let env = build_mempool_env([]).await;
+
+    // Target an uncreated account so this tx lands in failed_txs and triggers reporting.
+    let invalid_tx = MempoolSnarkTxBuilder::new(missing_account)
+        .with_seq_no(0)
+        .build();
+    let invalid_txid = invalid_tx.compute_txid();
+    env.mempool().add_transaction(invalid_txid, invalid_tx);
+    env.mempool()
+        .set_fail_mode(MockMempoolFailMode::ReportInvalidTransactions);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let err = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect_err("report_invalid_transactions failure should fail");
+
+    assert!(
+        matches!(
+            err,
+            BlockAssemblyError::Mempool(OLMempoolError::ServiceClosed(_))
+        ),
+        "expected mempool service-closed error, got: {err:?}"
+    );
+    assert_eq!(
+        env.mempool().report_call_count(),
+        1,
+        "failed tx report should be attempted exactly once"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_no_report_when_all_txs_valid() {
+    let account = test_account_id(1);
+    let env = build_mempool_env([TestAccount::new(account, 10_000)]).await;
+
+    let valid_tx = MempoolSnarkTxBuilder::new(account).with_seq_no(0).build();
+    let valid_txid = valid_tx.compute_txid();
+    env.mempool().add_transaction(valid_txid, valid_tx);
+
+    let config = BlockGenerationConfig::new(env.parent_commitment());
+    let result = generate_block_template_inner(
+        env.ctx(),
+        env.epoch_sealing_policy(),
+        env.sequencer_config(),
+        config,
+        AccumulatedDaData::new_empty(),
+    )
+    .await
+    .expect("valid tx block assembly should succeed");
+
+    let (template, failed_txs, _da) = result.into_parts();
+    assert!(
+        failed_txs.is_empty(),
+        "valid tx path should not produce failed_txs"
+    );
+    assert_eq!(
+        included_txids(&template),
+        vec![valid_txid],
+        "valid tx should be included in output template"
+    );
+    assert_eq!(
+        env.mempool().report_call_count(),
+        0,
+        "report_invalid_transactions must not be called when failed_txs is empty"
+    );
+}

--- a/crates/ol/block-assembly/src/tests/mempool.rs
+++ b/crates/ol/block-assembly/src/tests/mempool.rs
@@ -110,11 +110,11 @@ async fn test_get_transactions_failure_propagates() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_report_failure_propagates() {
+async fn test_generation_stage_does_not_report_invalid_txs() {
     let missing_account = test_account_id(9);
     let env = build_mempool_env([]).await;
 
-    // Target an uncreated account so this tx lands in failed_txs and triggers reporting.
+    // Target an uncreated account so this tx lands in failed_txs.
     let invalid_tx = MempoolSnarkTxBuilder::new(missing_account)
         .with_seq_no(0)
         .build();
@@ -124,7 +124,7 @@ async fn test_report_failure_propagates() {
         .set_fail_mode(MockMempoolFailMode::ReportInvalidTransactions);
 
     let config = BlockGenerationConfig::new(env.parent_commitment());
-    let err = generate_block_template_inner(
+    let result = generate_block_template_inner(
         env.ctx(),
         env.epoch_sealing_policy(),
         env.sequencer_config(),
@@ -132,19 +132,17 @@ async fn test_report_failure_propagates() {
         AccumulatedDaData::new_empty(),
     )
     .await
-    .expect_err("report_invalid_transactions failure should fail");
-
-    assert!(
-        matches!(
-            err,
-            BlockAssemblyError::Mempool(OLMempoolError::ServiceClosed(_))
-        ),
-        "expected mempool service-closed error, got: {err:?}"
+    .expect("inner assembly should not call report_invalid_transactions");
+    let (_template, failed_txs, _da) = result.into_parts();
+    let expected = vec![(invalid_txid, MempoolTxInvalidReason::Invalid)];
+    assert_eq!(
+        failed_txs, expected,
+        "inner assembly should still return failed_txs payload"
     );
     assert_eq!(
         env.mempool().report_call_count(),
-        1,
-        "failed tx report should be attempted exactly once"
+        0,
+        "inner assembly should not call report_invalid_transactions"
     );
 }
 
@@ -186,7 +184,7 @@ async fn test_no_report_when_all_txs_valid() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_exact_invalid_report_payload() {
+async fn test_exact_failed_txs_payload() {
     let missing_account = test_account_id(11);
     let env = build_mempool_env([]).await;
 
@@ -213,15 +211,9 @@ async fn test_exact_invalid_report_payload() {
         failed_txs, expected,
         "failed_txs should match expected invalid payload"
     );
-    assert_eq!(
-        env.mempool().last_reported_invalid_txs(),
-        expected,
-        "reported invalid payload should match expected invalid payload"
-    );
-    assert_eq!(
-        env.mempool().report_call_count(),
-        1,
-        "invalid payload should be reported once"
+    assert!(
+        env.mempool().last_reported_invalid_txs().is_empty(),
+        "inner assembly should not report invalid txs to mempool"
     );
 }
 
@@ -270,15 +262,14 @@ async fn test_mixed_failures_keep_order_and_reason() {
         failed_txs, expected,
         "failed_txs should match expected invalid payload"
     );
-    assert_eq!(
-        env.mempool().last_reported_invalid_txs(),
-        expected,
-        "reported invalid payload should match expected invalid payload"
+    assert!(
+        env.mempool().last_reported_invalid_txs().is_empty(),
+        "inner assembly should not report invalid txs to mempool"
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_max_txs_reports_only_fetched_failures() {
+async fn test_max_txs_returns_only_fetched_failures() {
     let missing_a = test_account_id(13);
     let missing_b = test_account_id(14);
     let env = build_mempool_env([]).await;
@@ -310,15 +301,14 @@ async fn test_max_txs_reports_only_fetched_failures() {
         failed_txs, expected,
         "failed_txs should match expected invalid payload"
     );
-    assert_eq!(
-        env.mempool().last_reported_invalid_txs(),
-        expected,
-        "reported invalid payload should match expected invalid payload"
+    assert!(
+        env.mempool().last_reported_invalid_txs().is_empty(),
+        "inner assembly should not report invalid txs to mempool"
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_exec_failure_reports_failed() {
+async fn test_exec_failure_maps_to_failed() {
     let sender = test_account_id(1);
     let receiver = test_account_id(2);
     let env = build_mempool_env([TestAccount::new(sender, 0), TestAccount::new(receiver, 0)]).await;
@@ -347,10 +337,9 @@ async fn test_exec_failure_reports_failed() {
         failed_txs, expected,
         "failed_txs should match expected invalid payload"
     );
-    assert_eq!(
-        env.mempool().last_reported_invalid_txs(),
-        expected,
-        "reported invalid payload should match expected invalid payload"
+    assert!(
+        env.mempool().last_reported_invalid_txs().is_empty(),
+        "inner assembly should not report invalid txs to mempool"
     );
 }
 
@@ -381,10 +370,9 @@ async fn test_duplicate_txid_one_fails() {
         failed_txs, expected,
         "failed_txs should match expected invalid payload"
     );
-    assert_eq!(
-        env.mempool().last_reported_invalid_txs(),
-        expected,
-        "reported invalid payload should match expected invalid payload"
+    assert!(
+        env.mempool().last_reported_invalid_txs().is_empty(),
+        "inner assembly should not report invalid txs to mempool"
     );
 }
 
@@ -421,9 +409,8 @@ async fn test_duplicate_txid_both_fail() {
         failed_txs, expected,
         "failed_txs should match expected invalid payload"
     );
-    assert_eq!(
-        env.mempool().last_reported_invalid_txs(),
-        expected,
-        "reported invalid payload should match expected invalid payload"
+    assert!(
+        env.mempool().last_reported_invalid_txs().is_empty(),
+        "inner assembly should not report invalid txs to mempool"
     );
 }

--- a/crates/ol/block-assembly/src/tests/messaging.rs
+++ b/crates/ol/block-assembly/src/tests/messaging.rs
@@ -61,7 +61,6 @@ async fn test_multi_sender_attribution() {
         epoch,
         MsgPayload::new(BitcoinAmount::from_sat(250), vec![]),
     );
-
     let included_block1 = included_txids(&output_block1.template);
     assert_eq!(
         included_block1,
@@ -96,7 +95,6 @@ async fn test_multi_sender_attribution() {
         .construct_block_with_da(vec![(tx_receiver_id, tx_receiver)], parent_da_2)
         .await
         .expect("block 2 should construct and process attributed messages");
-
     let included_block2 = included_txids(&output_block2.template);
     assert_eq!(
         included_block2,
@@ -153,7 +151,6 @@ async fn test_single_account_inbox_index_progression() {
         .construct_block(vec![(tx1_id, tx1), (tx2_id, tx2)])
         .await
         .expect("block should construct");
-
     let included = included_txids(&output.template);
     assert_eq!(
         included,

--- a/crates/ol/block-assembly/src/tests/messaging.rs
+++ b/crates/ol/block-assembly/src/tests/messaging.rs
@@ -1,0 +1,224 @@
+//! Messaging-focused block assembly tests.
+
+use strata_acct_types::{BitcoinAmount, MessageEntry, MsgPayload};
+
+use crate::test_utils::{
+    DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
+    TestStorageFixtureBuilder, account_balance, create_test_message, included_txids,
+    snark_account_inbox_len, snark_account_next_inbox_msg_idx, snark_account_seqno,
+    test_account_id,
+};
+
+async fn build_messaging_env(accounts: impl IntoIterator<Item = TestAccount>) -> TestEnv {
+    let env_builder = TestStorageFixtureBuilder::new()
+        .with_parent_slot(0)
+        .with_accounts(accounts);
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    TestEnv::from_fixture(fixture, parent_commitment)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multi_sender_attribution() {
+    let sender_a = test_account_id(1);
+    let sender_b = test_account_id(2);
+    let receiver = test_account_id(3);
+
+    let mut env = build_messaging_env([
+        TestAccount::new(sender_a, DEFAULT_ACCOUNT_BALANCE),
+        TestAccount::new(sender_b, DEFAULT_ACCOUNT_BALANCE),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let tx_a = MempoolSnarkTxBuilder::new(sender_a)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 100)])
+        .build();
+    let tx_a_id = tx_a.compute_txid();
+
+    let tx_b = MempoolSnarkTxBuilder::new(sender_b)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 250)])
+        .build();
+    let tx_b_id = tx_b.compute_txid();
+
+    let output_block1 = env
+        .construct_block(vec![(tx_a_id, tx_a), (tx_b_id, tx_b)])
+        .await
+        .expect("block 1 should construct");
+
+    // Receiver update explicitly processes the two expected inbox messages,
+    // including source-account attribution. If attribution is wrong, this tx
+    // fails during proof generation/execution.
+    let epoch = output_block1.template.header().epoch();
+    let expected_msg_from_a = MessageEntry::new(
+        sender_a,
+        epoch,
+        MsgPayload::new(BitcoinAmount::from_sat(100), vec![]),
+    );
+    let expected_msg_from_b = MessageEntry::new(
+        sender_b,
+        epoch,
+        MsgPayload::new(BitcoinAmount::from_sat(250), vec![]),
+    );
+
+    let included_block1 = included_txids(&output_block1.template);
+    assert_eq!(
+        included_block1,
+        vec![tx_a_id, tx_b_id],
+        "both sender txs should be included in block 1"
+    );
+    assert!(
+        output_block1.failed_txs.is_empty(),
+        "no sender tx should fail in block 1"
+    );
+
+    // Persist block 1 + post-state as parent for block 2.
+    let parent_da_2 = output_block1.accumulated_da.clone();
+    let _current_commitment = env.persist(&output_block1).await;
+
+    // Mirror expected entries into storage MMR for block-2 proof generation.
+    // If block-1 sender attribution is wrong, block-2 processing below fails
+    // because these expected proofs will not match block-1 state MMR.
+    env.append_inbox_messages(
+        receiver,
+        vec![expected_msg_from_a.clone(), expected_msg_from_b.clone()],
+    );
+
+    let tx_receiver = MempoolSnarkTxBuilder::new(receiver)
+        .with_seq_no(0)
+        .with_processed_messages(vec![expected_msg_from_a, expected_msg_from_b])
+        .with_new_msg_idx(2)
+        .build();
+    let tx_receiver_id = tx_receiver.compute_txid();
+
+    let output_block2 = env
+        .construct_block_with_da(vec![(tx_receiver_id, tx_receiver)], parent_da_2)
+        .await
+        .expect("block 2 should construct and process attributed messages");
+
+    let included_block2 = included_txids(&output_block2.template);
+    assert_eq!(
+        included_block2,
+        vec![tx_receiver_id],
+        "receiver processing tx should be included in block 2"
+    );
+    assert!(
+        output_block2.failed_txs.is_empty(),
+        "receiver processing tx should not fail when sender attribution is correct"
+    );
+
+    assert_eq!(
+        snark_account_inbox_len(&output_block2.post_state, receiver),
+        2,
+        "receiver inbox should contain both messages"
+    );
+    assert_eq!(
+        snark_account_next_inbox_msg_idx(&output_block2.post_state, receiver),
+        2,
+        "receiver processing tx should consume both attributed messages in block 2"
+    );
+    assert_eq!(
+        snark_account_seqno(&output_block2.post_state, receiver),
+        1,
+        "receiver seqno should advance after processing tx in block 2"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_single_account_inbox_index_progression() {
+    let receiver = test_account_id(1);
+    let msg0 = create_test_message(2, 1, 100);
+    let msg1 = create_test_message(3, 1, 200);
+    let inbox_messages = vec![msg0.clone(), msg1.clone()];
+    let env = build_messaging_env([
+        TestAccount::new(receiver, DEFAULT_ACCOUNT_BALANCE).with_inbox(inbox_messages.clone())
+    ])
+    .await;
+
+    let tx1 = MempoolSnarkTxBuilder::new(receiver)
+        .with_seq_no(0)
+        .with_processed_messages(vec![msg0])
+        .build();
+    let tx1_id = tx1.compute_txid();
+
+    let tx2 = MempoolSnarkTxBuilder::new(receiver)
+        .with_seq_no(1)
+        .with_processed_messages(vec![msg1])
+        .with_new_msg_idx(2)
+        .build();
+    let tx2_id = tx2.compute_txid();
+
+    let output = env
+        .construct_block(vec![(tx1_id, tx1), (tx2_id, tx2)])
+        .await
+        .expect("block should construct");
+
+    let included = included_txids(&output.template);
+    assert_eq!(
+        included,
+        vec![tx1_id, tx2_id],
+        "both processing transactions should be included"
+    );
+    assert!(
+        output.failed_txs.is_empty(),
+        "no processing transaction should fail"
+    );
+
+    assert_eq!(
+        snark_account_next_inbox_msg_idx(&output.post_state, receiver),
+        2,
+        "sequential processing should advance next_inbox_msg_idx to 2"
+    );
+    assert_eq!(
+        snark_account_seqno(&output.post_state, receiver),
+        2,
+        "receiver seqno should advance across both updates"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_message_value_flow_balance_updates() {
+    let sender = test_account_id(1);
+    let receiver = test_account_id(2);
+
+    let env = build_messaging_env([
+        TestAccount::new(sender, 1_000),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    let tx = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 400)])
+        .build();
+    let tx_id = tx.compute_txid();
+
+    let output = env
+        .construct_block(vec![(tx_id, tx)])
+        .await
+        .expect("block should construct");
+
+    let included = included_txids(&output.template);
+    assert_eq!(included, vec![tx_id], "message-value tx should be included");
+    assert!(
+        output.failed_txs.is_empty(),
+        "message-value tx should not fail"
+    );
+
+    assert_eq!(
+        account_balance(&output.post_state, sender),
+        BitcoinAmount::from_sat(600),
+        "sender balance should be debited by message value"
+    );
+    assert_eq!(
+        account_balance(&output.post_state, receiver),
+        BitcoinAmount::from_sat(400),
+        "receiver balance should be credited by message value"
+    );
+    assert_eq!(
+        snark_account_inbox_len(&output.post_state, receiver),
+        1,
+        "receiver inbox should contain the delivered message"
+    );
+}

--- a/crates/ol/block-assembly/src/tests/mod.rs
+++ b/crates/ol/block-assembly/src/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Crate test modules.
 
 mod da;
+mod messaging;
 mod reorder;

--- a/crates/ol/block-assembly/src/tests/mod.rs
+++ b/crates/ol/block-assembly/src/tests/mod.rs
@@ -1,0 +1,3 @@
+//! Crate test modules.
+
+mod da;

--- a/crates/ol/block-assembly/src/tests/mod.rs
+++ b/crates/ol/block-assembly/src/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Crate test modules.
 
 mod da;
+mod mempool;
 mod messaging;
 mod reorder;

--- a/crates/ol/block-assembly/src/tests/mod.rs
+++ b/crates/ol/block-assembly/src/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Crate test modules.
 
 mod da;
+mod effects;
 mod mempool;
 mod messaging;
 mod reorder;

--- a/crates/ol/block-assembly/src/tests/mod.rs
+++ b/crates/ol/block-assembly/src/tests/mod.rs
@@ -1,3 +1,4 @@
 //! Crate test modules.
 
 mod da;
+mod reorder;

--- a/crates/ol/block-assembly/src/tests/reorder.rs
+++ b/crates/ol/block-assembly/src/tests/reorder.rs
@@ -1,0 +1,148 @@
+//! Transaction reorder-focused block assembly tests.
+
+use crate::test_utils::{
+    MempoolSnarkTxBuilder, TestAccount, TestEnv, TestStorageFixtureBuilder, included_txids,
+    template_state_root, test_account_id,
+};
+
+async fn build_reorder_env(accounts: impl IntoIterator<Item = TestAccount>) -> TestEnv {
+    let env_builder = TestStorageFixtureBuilder::new()
+        .with_parent_slot(0)
+        .with_accounts(accounts);
+    let (fixture, parent_commitment) = env_builder.build_fixture().await;
+    TestEnv::from_fixture(fixture, parent_commitment)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_independent_reorder_same_state_root() {
+    let account_a = test_account_id(1);
+    let account_b = test_account_id(2);
+    let receiver_a = test_account_id(3);
+    let receiver_b = test_account_id(4);
+
+    let env = build_reorder_env([
+        TestAccount::new(account_a, 10_000),
+        TestAccount::new(account_b, 10_000),
+        TestAccount::new(receiver_a, 0),
+        TestAccount::new(receiver_b, 0),
+    ])
+    .await;
+
+    let tx_a = MempoolSnarkTxBuilder::new(account_a)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver_a, 1_000)])
+        .build();
+    let tx_b = MempoolSnarkTxBuilder::new(account_b)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver_b, 2_000)])
+        .build();
+
+    let tx_a_id = tx_a.compute_txid();
+    let tx_b_id = tx_b.compute_txid();
+
+    let txs_ab = vec![(tx_a_id, tx_a.clone()), (tx_b_id, tx_b.clone())];
+    let txs_ba = vec![(tx_b_id, tx_b), (tx_a_id, tx_a)];
+
+    let output_ab = env
+        .construct_block(txs_ab)
+        .await
+        .expect("AB order should construct");
+
+    let output_ba = env
+        .construct_block(txs_ba)
+        .await
+        .expect("BA order should construct");
+
+    let included_ab = included_txids(&output_ab.template);
+    let included_ba = included_txids(&output_ba.template);
+    assert_eq!(
+        included_ab.len(),
+        2,
+        "AB order should include both transactions"
+    );
+    assert!(
+        included_ab.contains(&tx_a_id) && included_ab.contains(&tx_b_id),
+        "AB order should include tx_a and tx_b"
+    );
+    assert_eq!(
+        included_ba.len(),
+        2,
+        "BA order should include both transactions"
+    );
+    assert!(
+        included_ba.contains(&tx_a_id) && included_ba.contains(&tx_b_id),
+        "BA order should include tx_a and tx_b"
+    );
+
+    let root_ab = template_state_root(&output_ab.template);
+    let root_ba = template_state_root(&output_ba.template);
+    assert_eq!(
+        root_ab, root_ba,
+        "Independent-account transaction reorder should preserve post-state root"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_value_flow_reorder_changes_state_root() {
+    let sender = test_account_id(1);
+    let relay = test_account_id(2);
+    let receiver = test_account_id(3);
+
+    let env = build_reorder_env([
+        TestAccount::new(sender, 10_000),
+        TestAccount::new(relay, 0),
+        TestAccount::new(receiver, 0),
+    ])
+    .await;
+
+    // tx_fund sends value from sender -> relay.
+    let tx_fund = MempoolSnarkTxBuilder::new(sender)
+        .with_seq_no(0)
+        .with_outputs(vec![(relay, 1_000)])
+        .build();
+    // tx_spend spends from relay -> receiver, requiring relay to be funded first.
+    let tx_spend = MempoolSnarkTxBuilder::new(relay)
+        .with_seq_no(0)
+        .with_outputs(vec![(receiver, 500)])
+        .build();
+
+    let tx_fund_id = tx_fund.compute_txid();
+    let tx_spend_id = tx_spend.compute_txid();
+
+    // Cross-account dependency reorder:
+    // [fund, spend] keeps both txs eligible, while [spend, fund] makes the
+    // first tx ineligible (relay has no funds yet). Different eligibility
+    // outcomes must produce a different block/state root.
+    let output_fund_then_spend = env
+        .construct_block(vec![
+            (tx_fund_id, tx_fund.clone()),
+            (tx_spend_id, tx_spend.clone()),
+        ])
+        .await
+        .expect("fund->spend order should construct");
+
+    let output_spend_then_fund = env
+        .construct_block(vec![(tx_spend_id, tx_spend), (tx_fund_id, tx_fund)])
+        .await
+        .expect("spend->fund order should construct");
+
+    let included_fund_then_spend = included_txids(&output_fund_then_spend.template);
+    let included_spend_then_fund = included_txids(&output_spend_then_fund.template);
+    assert_eq!(
+        included_fund_then_spend,
+        vec![tx_fund_id, tx_spend_id],
+        "fund->spend order should include both transactions"
+    );
+    assert_eq!(
+        included_spend_then_fund,
+        vec![tx_fund_id],
+        "spend->fund order should reject spend and include fund only"
+    );
+
+    let root_fund_then_spend = template_state_root(&output_fund_then_spend.template);
+    let root_spend_then_fund = template_state_root(&output_spend_then_fund.template);
+    assert_ne!(
+        root_fund_then_spend, root_spend_then_fund,
+        "Cross-account dependency reorder should change post-state root"
+    );
+}


### PR DESCRIPTION
## Description

### Expanded `ol/block-assembly` unit coverage across:
- seq-number replay/order handling
- tx reorder behavior and state-root invariants
- snark-account messaging flows
- checkpoint-size integration behavior
- mempool failure/reporting paths
- `add_accumulator_proofs` branch gaps
- terminal-manifest and empty-block invariants
- post-state effects and rollback semantics
- high-volume stress scenarios
- service template-cache and completion lifecycle
- state `fetch_epoch_da` branches and cache/index consistency
- `da_tracker` epoch-walk error paths

### Production Refactors Included

- Centralized invalid-tx reporting at the service layer (removed reporting from `generate_block_template_inner`).
- Replaced stringly error paths with typed errors for:
  - state fetch: `ParentStateNotFound`, `StateProvider`
  - epoch walk: `GenesisEpochNoBoundary`, `InvalidEpochBoundary`, `EpochBoundaryStateNotFound`

### Test Infrastructure Updates
- `MockMempoolProvider`:
  - gains fail-mode injection, report call counter, and last-reported payload capture. It also admits transactions that the mempool in production would reject (replays, seq-no gaps, reverse order).
- `MempoolGamTxBuilder` for GAM transaction construction.

### Test Placement
Tests are placed inline or under `src/tests/` based on visibility and cohesion rules.

This PR was created with help from Claude Code and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
