### PR TITLE
fix(ol): accept special-account inbox sources in DA accumulator

### DIFF
--- a/crates/ol/state-support-types/src/da_accumulating_layer.rs
+++ b/crates/ol/state-support-types/src/da_accumulating_layer.rs
@@ -281,14 +281,17 @@ impl EpochDaAccumulator {
             }
 
             let source_id = entry.source();
-            if source_id.is_special() {
-                return Err(DaAccumulationError::MessageSourceMissing(source_id));
-            }
-            let exists = state
-                .check_account_exists(source_id)
-                .map_err(|_| DaAccumulationError::MessageSourceMissing(source_id))?;
-            if !exists {
-                return Err(DaAccumulationError::MessageSourceMissing(source_id));
+            // Special account IDs (e.g. the bridge gateway) have no ledger
+            // record, so skip the existence check for them and trust the
+            // well-known constant. This matches the destination-side
+            // convention in `transaction_processing::check_outputs`.
+            if !source_id.is_special() {
+                let exists = state
+                    .check_account_exists(source_id)
+                    .map_err(|_| DaAccumulationError::MessageSourceMissing(source_id))?;
+                if !exists {
+                    return Err(DaAccumulationError::MessageSourceMissing(source_id));
+                }
             }
 
             let entry = DaMessageEntry::new(source_id, entry.incl_epoch(), entry.payload().clone());

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -1031,6 +1031,32 @@ fn test_message_source_missing_is_rejected() {
 }
 
 #[test]
+fn test_special_message_source_is_accepted() {
+    // Special account IDs (e.g. the bridge gateway used for deposits) have
+    // no ledger record. The DA accumulator must accept inbox messages from
+    // them without consulting state, otherwise every epoch that includes a
+    // deposit fails to produce a DA diff.
+    let account_id = test_account_id(1);
+    let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let mut da_state = DaAccumulatingState::new(layer);
+
+    let bridge_gateway = AccountId::special(0x10);
+    let payload = MsgPayload::new(BitcoinAmount::from_sat(0), vec![0u8; 4]);
+    let msg = MessageEntry::new(bridge_gateway, 0, payload);
+    da_state
+        .update_account(account_id, |acct| {
+            acct.as_snark_account_mut()
+                .unwrap()
+                .insert_inbox_message(msg)
+        })
+        .unwrap()
+        .unwrap();
+
+    let result = da_state.take_completed_epoch_da_blob();
+    assert!(matches!(result, Ok(Some(_))));
+}
+
+#[test]
 fn test_message_payload_size_limit() {
     let account_id = test_account_id(1);
     let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));


### PR DESCRIPTION
## Description

Bridge deposits in the OL STF deliver inbox messages from
`BRIDGE_GATEWAY_ACCT_ID`, which is a special account
(`AccountId::special(0x10)`) and intentionally has no ledger record.
The DA accumulator rejected any inbox source where `is_special()` was
true, so every epoch containing a deposit failed proof input
computation with:

```
da accumulator missing message source 0000…0010
```

Skip the existence check for special sources, mirroring the
destination-side convention in
`transaction_processing::check_outputs` (`crates/ol/stf/src/transaction_processing.rs:229`).
Special account IDs are well-known constants the verifier can trust
without consulting state, and the verifier-side `apply_snark_diff`
(`crates/ol/da/src/types/payload.rs:280-285`) already constructs inbox
entries without checking the source — so accumulator and verifier are
now consistent.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The failure log that motivated this fix:

```
strata::prover: checkpoint proof failed, will retry
epoch=292
error=permanent: DA state diff computation failed:
da accumulator missing message source
0000000000000000000000000000000000000000000000000000000000000010
```

The trailing `10` in the source ID is `BRIDGE_GATEWAY_REF` — the
special-account byte for the bridge gateway, set in
`crates/ol/stf/src/constants.rs`.
Path audit (no other guards on the inbox-source path):
- `manifest_processing::process_deposit_log` emits the message with
  `BRIDGE_GATEWAY_ACCT_ID` as source (unchanged).
- `da_accumulating_layer::record_account_update` — patched here.
- `apply_snark_diff` on the verifier side already accepts any source.

Debuged and fixed with the help of claude code.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3307