### PR TITLE
STR-3310: Add bookkeeping for funds in limbo

### DIFF
--- a/bin/prover-perf/src/programs/checkpoint.rs
+++ b/bin/prover-perf/src/programs/checkpoint.rs
@@ -54,7 +54,10 @@ fn prepare_checkpoint_input() -> CheckpointProverInput {
     let slot_delta_u16 =
         u16::try_from(slot_delta).expect("slot delta exceeds u16::MAX; epoch too long");
     let da_diff = StateDiff::new(
-        GlobalStateDiff::new(DaCounter::new_changed(slot_delta_u16)),
+        GlobalStateDiff::new(
+            DaCounter::new_changed(slot_delta_u16),
+            DaCounter::new_unchanged(),
+        ),
         LedgerDiff::default(),
     );
     let da_state_diff_bytes =

--- a/crates/alpen-ee/config/Cargo.toml
+++ b/crates/alpen-ee/config/Cargo.toml
@@ -8,8 +8,8 @@ workspace = true
 
 [dependencies]
 alpen-ee-common.workspace = true
-strata-config.workspace = true
 strata-acct-types.workspace = true
+strata-config.workspace = true
 strata-predicate.workspace = true
 
 alloy-primitives.workspace = true

--- a/crates/ledger-types/src/errors.rs
+++ b/crates/ledger-types/src/errors.rs
@@ -41,6 +41,18 @@ pub enum StateError {
         have: BitcoinAmount,
     },
 
+    #[error("insufficient limbo funds to take (need {need}, have {have})")]
+    InsufficientLimboFunds {
+        need: BitcoinAmount,
+        have: BitcoinAmount,
+    },
+
+    #[error("limbo funds overflow (cur {cur}, add {add})")]
+    LimboFundsOverflow {
+        cur: BitcoinAmount,
+        add: BitcoinAmount,
+    },
+
     #[error("out-of-order seqno change (cur {cur:?}, new {new:?})")]
     OooSeqnoChange { cur: Seqno, new: Seqno },
 

--- a/crates/ledger-types/src/state_accessor.rs
+++ b/crates/ledger-types/src/state_accessor.rs
@@ -3,6 +3,7 @@ use strata_asm_manifest_types::AsmManifest;
 use strata_identifiers::{Buf32, EpochCommitment, L1BlockId, L1Height};
 
 use crate::{
+    Coin,
     account::{IAccountState, IAccountStateMut, NewAccountData},
     errors::StateResult,
 };
@@ -20,6 +21,9 @@ pub trait IStateAccessor {
 
     /// Gets the current slot.
     fn cur_slot(&self) -> u64;
+
+    /// Gets the current amount of funds in limbo.
+    fn limbo_funds(&self) -> BitcoinAmount;
 
     // ===== Epochal state methods =====
 
@@ -72,6 +76,16 @@ pub trait IStateAccessorMut: IStateAccessor {
     /// Sets the current slot.
     fn set_cur_slot(&mut self, slot: u64);
 
+    /// Adds a coin to the funds in limbo.
+    ///
+    /// This uses the [`Coin`] abstraction since it represents a credit.
+    fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()>;
+
+    /// Takes a coin from the funds in limbo.
+    ///
+    /// This uses the [`Coin`] abstraction since it represents a credit.
+    fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin>;
+
     // ===== Epochal state methods =====
 
     /// Sets the current epoch.
@@ -88,6 +102,9 @@ pub trait IStateAccessorMut: IStateAccessor {
     fn set_asm_recorded_epoch(&mut self, epoch: EpochCommitment);
 
     /// Sets the total OL ledger balance.
+    ///
+    /// This does not use the [`Coin`] abstraction since it represents an
+    /// obligation to fulfill, not a credit.
     fn set_total_ledger_balance(&mut self, amt: BitcoinAmount);
 
     // ===== Account methods =====

--- a/crates/ol/da/src/scheme.rs
+++ b/crates/ol/da/src/scheme.rs
@@ -44,7 +44,7 @@ mod tests {
         let start_slot = state.cur_slot();
 
         let diff = StateDiff::new(
-            GlobalStateDiff::new(DaCounter::new_changed(1u16)),
+            GlobalStateDiff::new(DaCounter::new_changed(1u16), DaCounter::new_unchanged()),
             LedgerDiff::default(),
         );
         let payload = OLDaPayloadV1::new(diff);

--- a/crates/ol/da/src/types/global.rs
+++ b/crates/ol/da/src/types/global.rs
@@ -2,7 +2,7 @@
 
 use strata_da_framework::{
     DaCounter,
-    counter_schemes::{self, CtrU64ByU16},
+    counter_schemes::{CtrU64BySignedVarInt, CtrU64ByU16},
     make_compound_impl,
 };
 
@@ -11,26 +11,37 @@ use strata_da_framework::{
 pub struct GlobalStateDiff {
     /// Slot counter diff.
     pub cur_slot: DaCounter<CtrU64ByU16>,
+
+    /// Limbo funds counter diff.
+    pub limbo_funds_sats: DaCounter<CtrU64BySignedVarInt>,
 }
 
 impl Default for GlobalStateDiff {
     fn default() -> Self {
         Self {
             cur_slot: DaCounter::new_unchanged(),
+            limbo_funds_sats: DaCounter::default(),
         }
     }
 }
 
 impl GlobalStateDiff {
     /// Creates a new [`GlobalStateDiff`] from a slot counter.
-    pub fn new(cur_slot: DaCounter<counter_schemes::CtrU64ByU16>) -> Self {
-        Self { cur_slot }
+    pub fn new(
+        cur_slot: DaCounter<CtrU64ByU16>,
+        limbo_funds_sats: DaCounter<CtrU64BySignedVarInt>,
+    ) -> Self {
+        Self {
+            cur_slot,
+            limbo_funds_sats,
+        }
     }
 }
 
 make_compound_impl! {
     GlobalStateDiff < (), crate::DaError > u8 => GlobalStateTarget {
-        cur_slot: counter (counter_schemes::CtrU64ByU16),
+        cur_slot: counter (CtrU64ByU16),
+        limbo_funds_sats: counter (CtrU64BySignedVarInt)
     }
 }
 
@@ -39,4 +50,7 @@ make_compound_impl! {
 pub struct GlobalStateTarget {
     /// Current slot value.
     pub cur_slot: u64,
+
+    /// Limbo funds value.
+    pub limbo_funds_sats: u64,
 }

--- a/crates/ol/da/src/types/payload.rs
+++ b/crates/ol/da/src/types/payload.rs
@@ -128,6 +128,21 @@ impl<S: IStateAccessorMut> DaWrite for OLStateDiff<S> {
         self.diff.global.cur_slot.apply(&mut cur_slot, &())?;
         target.set_cur_slot(cur_slot);
 
+        if let Some(d) = self.diff.global.limbo_funds_sats.diff() {
+            let amt = BitcoinAmount::from_sat(d.magnitude());
+            if d.is_positive() {
+                let coin = Coin::new_unchecked(amt);
+                target
+                    .add_limbo_funds_coin(coin)
+                    .map_err(|_| DaError::InvalidStateDiff("failed to apply limbo funds diff"))?;
+            } else {
+                let coin = target
+                    .take_limbo_funds_coin(amt)
+                    .map_err(|_| DaError::InvalidStateDiff("insufficient limbo funds for diff"))?;
+                coin.safely_consume_unchecked();
+            }
+        }
+
         let pre_state_next_serial = target.next_account_serial();
         // NOTE: `validate_ledger_entries` is intentionally not called here;
         // it was already called in `poll_context` which runs before `apply`.
@@ -415,6 +430,34 @@ mod tests {
             .expect("read account")
             .expect("account exists");
         assert_eq!(account.balance(), BitcoinAmount::from_sat(2_000));
+    }
+
+    #[test]
+    fn test_ol_state_diff_apply_updates_limbo_funds() {
+        let mut state = create_test_genesis_state();
+        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(0));
+
+        let global_diff = GlobalStateDiff::new(
+            DaCounter::new_unchanged(),
+            DaCounter::new_changed(SignedVarInt::positive(1_500)),
+        );
+        let diff = StateDiff::new(global_diff, LedgerDiff::default());
+
+        let ol_diff = OLStateDiff::<MemoryStateBaseLayer>::new(diff);
+        DaWrite::apply(&ol_diff, &mut state, &()).expect("apply limbo add diff");
+
+        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(1_500));
+
+        let global_diff = GlobalStateDiff::new(
+            DaCounter::new_unchanged(),
+            DaCounter::new_changed(SignedVarInt::negative(400)),
+        );
+        let diff = StateDiff::new(global_diff, LedgerDiff::default());
+
+        let ol_diff = OLStateDiff::<MemoryStateBaseLayer>::new(diff);
+        DaWrite::apply(&ol_diff, &mut state, &()).expect("apply limbo take diff");
+
+        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(1_100));
     }
 
     #[test]

--- a/crates/ol/state-support-types/src/batch_diff_layer.rs
+++ b/crates/ol/state-support-types/src/batch_diff_layer.rs
@@ -108,6 +108,17 @@ impl<'batches, 'base, S: IStateAccessor + IComputeStateRootWithWrites> IStateAcc
         self.resolve(|b| b.global_writes().cur_slot, || self.base.cur_slot())
     }
 
+    fn limbo_funds(&self) -> BitcoinAmount {
+        self.resolve(
+            |b| {
+                b.global_writes()
+                    .limbo_funds_sats
+                    .map(BitcoinAmount::from_sat)
+            },
+            || self.base.limbo_funds(),
+        )
+    }
+
     // ===== Epochal state methods =====
 
     fn cur_epoch(&self) -> u32 {

--- a/crates/ol/state-support-types/src/da_accumulating_layer.rs
+++ b/crates/ol/state-support-types/src/da_accumulating_layer.rs
@@ -350,8 +350,11 @@ impl EpochDaAccumulator {
     /// adding more transactions would risk exceeding `OL_DA_DIFF_MAX_SIZE`.
     /// Overestimates are acceptable; underestimates are not.
     pub fn estimated_encoded_size(&self) -> usize {
-        // Global diff: 1 byte mask + up to 2 bytes slot counter.
-        let global_size = 3;
+        // Global diff:
+        // * 1 byte mask
+        // * up to 2 bytes for slot counter
+        // * up to 9 bytes for limbo funds counter
+        let global_size = 1 + 2 + 9;
 
         // New accounts list: 2-byte u16 length prefix + per-entry overhead.
         // Per new account: 32 (AccountId) + 8 (balance) + 1 (type disc)

--- a/crates/ol/state-support-types/src/da_accumulating_layer.rs
+++ b/crates/ol/state-support-types/src/da_accumulating_layer.rs
@@ -191,6 +191,9 @@ pub struct EpochDaAccumulator {
     /// Slot counter builder for the epoch.
     slot_builder: Option<DaCounterBuilder<CtrU64ByU16>>,
 
+    /// Limbo funds counter builder for the epoch.
+    limbo_funds_builder: Option<DaCounterBuilder<CtrU64BySignedVarInt>>,
+
     /// Expected first serial based on the pre-state next_account_serial.
     expected_first_serial: Option<AccountSerial>,
 
@@ -208,6 +211,10 @@ impl fmt::Debug for EpochDaAccumulator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EpochDaAccumulator")
             .field("slot_builder_set", &self.slot_builder.is_some())
+            .field(
+                "limbo_funds_builder_set",
+                &self.limbo_funds_builder.is_some(),
+            )
             .field("expected_first_serial", &self.expected_first_serial)
             .field("new_account_records", &self.new_account_records)
             .field("new_account_ids", &self.new_account_ids)
@@ -222,6 +229,19 @@ impl EpochDaAccumulator {
         let builder = self
             .slot_builder
             .get_or_insert_with(|| DaCounterBuilder::<CtrU64ByU16>::from_source(prior));
+        builder.set(new)?;
+        Ok(())
+    }
+
+    /// Records a limbo funds change event.
+    fn record_limbo_funds_change(
+        &mut self,
+        prior: u64,
+        new: u64,
+    ) -> Result<(), DaAccumulationError> {
+        let builder = self
+            .limbo_funds_builder
+            .get_or_insert_with(|| DaCounterBuilder::<CtrU64BySignedVarInt>::from_source(prior));
         builder.set(new)?;
         Ok(())
     }
@@ -387,7 +407,13 @@ impl EpochDaAccumulator {
             DaCounter::new_unchanged()
         };
 
-        Ok(GlobalStateDiff::new(cur_slot))
+        let limbo_funds_sats = if let Some(builder) = self.limbo_funds_builder.take() {
+            builder.into_write()?
+        } else {
+            DaCounter::new_unchanged()
+        };
+
+        Ok(GlobalStateDiff::new(cur_slot, limbo_funds_sats))
     }
 
     /// Builds the ledger diff for the epoch.
@@ -606,6 +632,10 @@ impl<S: IStateAccessor> IStateAccessor for DaAccumulatingState<S> {
         self.inner.cur_slot()
     }
 
+    fn limbo_funds(&self) -> BitcoinAmount {
+        self.inner.limbo_funds()
+    }
+
     // ===== Epochal state methods =====
 
     fn cur_epoch(&self) -> u32 {
@@ -670,6 +700,30 @@ where
             self.pending_epoch_error = Some(err);
         }
         self.inner.set_cur_slot(slot);
+    }
+
+    fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
+        let prior = self.inner.limbo_funds().to_sat();
+        self.inner.add_limbo_funds_coin(coin)?;
+        let new = self.inner.limbo_funds().to_sat();
+        if let Err(err) = self.epoch_acc.record_limbo_funds_change(prior, new)
+            && self.pending_epoch_error.is_none()
+        {
+            self.pending_epoch_error = Some(err);
+        }
+        Ok(())
+    }
+
+    fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
+        let prior = self.inner.limbo_funds().to_sat();
+        let coin = self.inner.take_limbo_funds_coin(amt)?;
+        let new = self.inner.limbo_funds().to_sat();
+        if let Err(err) = self.epoch_acc.record_limbo_funds_change(prior, new)
+            && self.pending_epoch_error.is_none()
+        {
+            self.pending_epoch_error = Some(err);
+        }
+        Ok(coin)
     }
 
     fn set_cur_epoch(&mut self, epoch: u32) {

--- a/crates/ol/state-support-types/src/indexer_layer.rs
+++ b/crates/ol/state-support-types/src/indexer_layer.rs
@@ -392,6 +392,10 @@ impl<S: IStateAccessor> IStateAccessor for IndexerState<S> {
     fn cur_slot(&self) -> u64 {
         self.inner.cur_slot()
     }
+
+    fn limbo_funds(&self) -> BitcoinAmount {
+        self.inner.limbo_funds()
+    }
     // ===== Epochal state methods =====
 
     fn cur_epoch(&self) -> u32 {
@@ -450,6 +454,14 @@ where
 
     fn set_cur_slot(&mut self, slot: u64) {
         self.inner.set_cur_slot(slot);
+    }
+
+    fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
+        self.inner.add_limbo_funds_coin(coin)
+    }
+
+    fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
+        self.inner.take_limbo_funds_coin(amt)
     }
 
     fn set_cur_epoch(&mut self, epoch: u32) {

--- a/crates/ol/state-support-types/src/memory_state_layer.rs
+++ b/crates/ol/state-support-types/src/memory_state_layer.rs
@@ -71,6 +71,10 @@ impl IStateAccessor for MemoryStateBaseLayer {
         self.state.global.get_cur_slot()
     }
 
+    fn limbo_funds(&self) -> BitcoinAmount {
+        self.state.global.limbo_funds()
+    }
+
     // ===== Epochal state methods =====
 
     fn cur_epoch(&self) -> u32 {
@@ -125,6 +129,26 @@ impl IStateAccessorMut for MemoryStateBaseLayer {
 
     fn set_cur_slot(&mut self, slot: u64) {
         self.state.global.set_cur_slot(slot);
+    }
+
+    fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
+        let cur = self.state.global.limbo_funds();
+        let amt = coin.amt();
+        if cur.checked_add(amt).is_none() {
+            return Err(StateError::LimboFundsOverflow { cur, add: amt });
+        }
+        self.state.global.add_limbo_funds_coin(coin);
+        Ok(())
+    }
+
+    fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
+        self.state
+            .global
+            .take_limbo_funds_coin(amt)
+            .ok_or(StateError::InsufficientLimboFunds {
+                need: amt,
+                have: self.state.global.limbo_funds(),
+            })
     }
 
     fn set_cur_epoch(&mut self, epoch: u32) {

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -624,6 +624,7 @@ struct TestState {
     next_serial: AccountSerial,
     serial_overrides: VecDeque<AccountSerial>,
     cur_slot: u64,
+    limbo_funds: BitcoinAmount,
     cur_epoch: u32,
     last_l1_blkid: L1BlockId,
     last_l1_height: L1Height,
@@ -638,6 +639,7 @@ impl TestState {
             next_serial: AccountSerial::one(),
             serial_overrides: VecDeque::from(serials),
             cur_slot: 0,
+            limbo_funds: BitcoinAmount::ZERO,
             cur_epoch: 0,
             last_l1_blkid: L1BlockId::from(Buf32::zero()),
             last_l1_height: L1Height::from(0u32),
@@ -652,6 +654,10 @@ impl IStateAccessor for TestState {
 
     fn cur_slot(&self) -> u64 {
         self.cur_slot
+    }
+
+    fn limbo_funds(&self) -> BitcoinAmount {
+        self.limbo_funds
     }
 
     fn cur_epoch(&self) -> u32 {
@@ -707,6 +713,32 @@ impl IStateAccessorMut for TestState {
 
     fn set_cur_slot(&mut self, slot: u64) {
         self.cur_slot = slot;
+    }
+
+    fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
+        let amt = coin.amt();
+        let new = self
+            .limbo_funds
+            .checked_add(amt)
+            .ok_or(StateError::LimboFundsOverflow {
+                cur: self.limbo_funds,
+                add: amt,
+            })?;
+        self.limbo_funds = new;
+        coin.safely_consume_unchecked();
+        Ok(())
+    }
+
+    fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
+        let new = self
+            .limbo_funds
+            .checked_sub(amt)
+            .ok_or(StateError::InsufficientLimboFunds {
+                need: amt,
+                have: self.limbo_funds,
+            })?;
+        self.limbo_funds = new;
+        Ok(Coin::new_unchecked(amt))
     }
 
     fn set_cur_epoch(&mut self, epoch: u32) {

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -92,6 +92,14 @@ where
             .unwrap_or_else(|| self.base.cur_slot())
     }
 
+    fn limbo_funds(&self) -> BitcoinAmount {
+        self.batch
+            .global_writes()
+            .limbo_funds_sats
+            .map(BitcoinAmount::from_sat)
+            .unwrap_or_else(|| self.base.limbo_funds())
+    }
+
     // ===== Epochal state methods =====
 
     fn cur_epoch(&self) -> u32 {
@@ -191,6 +199,29 @@ where
 
     fn set_cur_slot(&mut self, slot: u64) {
         self.batch.global_writes_mut().cur_slot = Some(slot);
+    }
+
+    fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
+        let cur = self.limbo_funds();
+        let amt = coin.amt();
+        let new = cur
+            .checked_add(amt)
+            .ok_or(StateError::LimboFundsOverflow { cur, add: amt })?;
+        self.batch.global_writes_mut().limbo_funds_sats = Some(new.to_sat());
+        coin.safely_consume_unchecked();
+        Ok(())
+    }
+
+    fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
+        let cur = self.limbo_funds();
+        let new = cur
+            .checked_sub(amt)
+            .ok_or(StateError::InsufficientLimboFunds {
+                need: amt,
+                have: cur,
+            })?;
+        self.batch.global_writes_mut().limbo_funds_sats = Some(new.to_sat());
+        Ok(Coin::new_unchecked(amt))
     }
 
     fn set_cur_epoch(&mut self, epoch: u32) {

--- a/crates/ol/state-types/src/global.rs
+++ b/crates/ol/state-types/src/global.rs
@@ -1,7 +1,8 @@
 //! Global state variables that are always accessible.
 
-use strata_acct_types::AccountSerial;
+use strata_acct_types::{AccountSerial, BitcoinAmount};
 use strata_identifiers::Slot;
+use strata_ledger_types::Coin;
 
 use crate::ssz_generated::ssz::state::GlobalState;
 
@@ -12,6 +13,7 @@ impl GlobalState {
             cur_slot,
             // FIXME(STR-3227): fix this conversion
             next_avail_serial: next_avail_serial.into_inner() as u64,
+            limbo_funds_sats: 0,
         }
     }
 
@@ -35,6 +37,53 @@ impl GlobalState {
     pub fn set_next_avail_serial(&mut self, serial: AccountSerial) {
         // FIXME(STR-3227): fix this conversion
         self.next_avail_serial = serial.into_inner() as u64;
+    }
+
+    /// Gets the amount of funds in limbo.
+    pub fn limbo_funds(&self) -> BitcoinAmount {
+        BitcoinAmount::from_sat(self.limbo_funds_sats)
+    }
+
+    /// Attempts to add limbo funds.
+    pub fn add_limbo_funds(&mut self, amt: BitcoinAmount) -> bool {
+        let Some(new_lf) = self.limbo_funds().checked_add(amt) else {
+            return false;
+        };
+        self.limbo_funds_sats = new_lf.to_sat();
+        true
+    }
+
+    /// Adds a [`Coin`] to limbo funds, consuming it.
+    ///
+    /// # Panics
+    ///
+    /// If there's balance overflow.
+    pub fn add_limbo_funds_coin(&mut self, coin: Coin) {
+        assert!(
+            self.add_limbo_funds(coin.amt()),
+            "ol/state: limbo funds overflow"
+        );
+        coin.safely_consume_unchecked();
+    }
+
+    /// Takes some limbo funds as a [`Coin`], if possible.
+    pub fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> Option<Coin> {
+        let lf = self.limbo_funds();
+
+        let Some(new_lf) = lf.checked_sub(amt) else {
+            return None;
+        };
+
+        // This sanity check should be optimized out.
+        assert_eq!(
+            new_lf.checked_add(amt),
+            Some(lf),
+            "ol/state: inconsistent limbo funds change"
+        );
+
+        let coin = Coin::new_unchecked(amt);
+        self.limbo_funds_sats = new_lf.to_sat();
+        Some(coin)
     }
 }
 

--- a/crates/ol/state-types/src/global.rs
+++ b/crates/ol/state-types/src/global.rs
@@ -70,9 +70,7 @@ impl GlobalState {
     pub fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> Option<Coin> {
         let lf = self.limbo_funds();
 
-        let Some(new_lf) = lf.checked_sub(amt) else {
-            return None;
-        };
+        let new_lf = lf.checked_sub(amt)?;
 
         // This sanity check should be optimized out.
         assert_eq!(

--- a/crates/ol/state-types/src/test_utils.rs
+++ b/crates/ol/state-types/src/test_utils.rs
@@ -27,9 +27,12 @@ pub fn bitcoin_amount_strategy() -> impl Strategy<Value = BitcoinAmount> {
 }
 
 pub fn global_state_strategy() -> impl Strategy<Value = GlobalState> {
-    any::<(u64, u64)>().prop_map(|(cur_slot, next_avail_serial)| GlobalState {
-        cur_slot,
-        next_avail_serial,
+    any::<(u64, u64, u64)>().prop_map(|(cur_slot, next_avail_serial, limbo_funds_sats)| {
+        GlobalState {
+            cur_slot,
+            next_avail_serial,
+            limbo_funds_sats,
+        }
     })
 }
 

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -175,6 +175,10 @@ impl OLState {
             self.global.set_cur_slot(slot);
         }
 
+        if let Some(limbo_funds_sats) = global_writes.limbo_funds_sats {
+            self.global.limbo_funds_sats = limbo_funds_sats;
+        }
+
         // Apply epochal state writes.
         if let Some(epoch) = epochal_writes.cur_epoch {
             self.epoch.set_cur_epoch(epoch);

--- a/crates/ol/state-types/src/write_batch.rs
+++ b/crates/ol/state-types/src/write_batch.rs
@@ -16,6 +16,9 @@ use crate::SerialMap;
 pub struct GlobalStateWrites {
     /// New slot value, if changed.
     pub cur_slot: Option<Slot>,
+
+    /// New limbo funds value (in satoshis), if changed.
+    pub limbo_funds_sats: Option<u64>,
 }
 
 /// Tracked writes to the epochal state.
@@ -219,12 +222,14 @@ impl<A> Default for LedgerWriteBatch<A> {
 impl Codec for GlobalStateWrites {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         CodecSsz::new(self.cur_slot).encode(enc)?;
+        CodecSsz::new(self.limbo_funds_sats).encode(enc)?;
         Ok(())
     }
 
     fn decode(dec: &mut impl Decoder) -> Result<Self, CodecError> {
         Ok(Self {
             cur_slot: CodecSsz::<Option<Slot>>::decode(dec)?.into_inner(),
+            limbo_funds_sats: CodecSsz::<Option<u64>>::decode(dec)?.into_inner(),
         })
     }
 }

--- a/crates/ol/state-types/ssz/state.ssz
+++ b/crates/ol/state-types/ssz/state.ssz
@@ -105,3 +105,6 @@ class GlobalState(Container):
 
     ### Next available serial we can assign to an account.
     next_avail_serial: uint64
+
+    ### Funds in limbo, measured in satoshis.
+    limbo_funds_sats: uint64

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -6,6 +6,7 @@ use strata_msg_fmt::MsgRef;
 use strata_ol_chain_types_new::SimpleWithdrawalIntentLogData;
 use strata_ol_msg_types::OLMessageExt;
 use strata_snark_acct_sys as snark_sys;
+use tracing::*;
 
 use crate::{
     constants::{BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL},
@@ -36,7 +37,8 @@ pub(crate) fn process_message<S: IStateAccessorMut>(
             // Check if the account exists first.
             if !state.check_account_exists(target)? {
                 // If we don't find it then we can sweep it into limbo.
-                state.add_limbo_funds_coin(coin)?;
+                warn!(%target, "target account does not exist");
+                handle_misplaced_funds(state, coin)?;
                 return Ok(());
             }
 
@@ -74,7 +76,8 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
         // Bridge gateway transfer, not permitted.
         BRIDGE_GATEWAY_ACCT_ID => {
             // Just sweep to limbo unconditionally.
-            state.add_limbo_funds_coin(coin)?;
+            warn!("limboing transfer to bridge gateway acct");
+            handle_misplaced_funds(state, coin)?;
         }
 
         // Any other address we assume is a ledger account, so we have to look it up.
@@ -82,7 +85,8 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
             // Check if the account exists first.
             if !state.check_account_exists(target)? {
                 // If we don't find it then we can sweep it into limbo.
-                state.add_limbo_funds_coin(coin)?;
+                warn!(%target, "limboing transfer to non-existent account");
+                handle_misplaced_funds(state, coin)?;
                 return Ok(());
             }
 
@@ -100,7 +104,7 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
 
 fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     state: &mut S,
-    _sender: AccountId,
+    sender: AccountId,
     payload: MsgPayload,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
@@ -109,13 +113,15 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     // 1. Parse the message from the payload data.
     let Ok(msg) = MsgRef::try_from(payload.data()) else {
         // Invalid message format, sweep to limbo.
-        state.add_limbo_funds_coin(coin)?;
+        warn!(%sender, "limboing malformed message sent to bridge gateway acct");
+        handle_misplaced_funds(state, coin)?;
         return Ok(());
     };
 
     let Some(withdrawal_data) = msg.try_as_withdrawal() else {
         // Not a withdrawal message, or malformed, sweep to limbo.
-        state.add_limbo_funds_coin(coin)?;
+        warn!(%sender, "limboing non-withdrawal message sent to bridge gateway acct");
+        handle_misplaced_funds(state, coin)?;
         return Ok(());
     };
 
@@ -129,7 +135,8 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     let amt_raw: u64 = withdrawal_amt.into();
     if amt_raw == 0 || !amt_raw.is_multiple_of(withdrawal_denom) {
         // Sweep to limbo.
-        state.add_limbo_funds_coin(coin)?;
+        warn!(%sender, %amt_raw, "limboing bad amount sent to bridge gateway acct");
+        handle_misplaced_funds(state, coin)?;
         return Ok(());
     }
 
@@ -153,5 +160,17 @@ fn handle_snark_account_message<S: ISnarkAccountStateMut>(
 ) -> ExecResult<()> {
     let cur_epoch = context.epoch();
     snark_sys::handle_snark_msg(cur_epoch, sastate, sender, payload)?;
+    Ok(())
+}
+
+/// Handles misplaced funds.
+///
+/// This currently just sends funds to limbo.  It's broken out so that we can
+/// maintain the same code path when we change this behavior.
+pub(crate) fn handle_misplaced_funds(
+    state: &mut impl IStateAccessorMut,
+    coin: Coin,
+) -> ExecResult<()> {
+    state.add_limbo_funds_coin(coin)?;
     Ok(())
 }

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -6,7 +6,6 @@ use strata_msg_fmt::MsgRef;
 use strata_ol_chain_types_new::SimpleWithdrawalIntentLogData;
 use strata_ol_msg_types::OLMessageExt;
 use strata_snark_acct_sys as snark_sys;
-use tracing::warn;
 
 use crate::{
     constants::{BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL},
@@ -32,17 +31,18 @@ pub(crate) fn process_message<S: IStateAccessorMut>(
 
         // Any other address we assume is a ledger account, so we have to look it up.
         _ => {
+            let coin = Coin::new_unchecked(msg.value());
+
             // Check if the account exists first.
             if !state.check_account_exists(target)? {
-                // If we don't find it then we can just ignore it.
-                // TODO do something with the funds we're throwing away by doing this
+                // If we don't find it then we can sweep it into limbo.
+                state.add_limbo_funds_coin(coin)?;
                 return Ok(());
             }
 
             // Update the account within a closure.
             state.update_account(target, |acct_state| -> ExecResult<()> {
                 // First, just increase the balance right now.
-                let coin = Coin::new_unchecked(msg.value());
                 acct_state.add_balance(coin);
 
                 // Then depending on the type we call a different handler function
@@ -68,25 +68,27 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
     value: BitcoinAmount,
     _context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
+    let coin = Coin::new_unchecked(value);
+
     match target {
-        // Bridge gateway transfer.
+        // Bridge gateway transfer, not permitted.
         BRIDGE_GATEWAY_ACCT_ID => {
-            // TODO: what do we do with direct transfers to bridge accounts? Emit log?
+            // Just sweep to limbo unconditionally.
+            state.add_limbo_funds_coin(coin)?;
         }
 
         // Any other address we assume is a ledger account, so we have to look it up.
         _ => {
             // Check if the account exists first.
             if !state.check_account_exists(target)? {
-                // If we don't find it then we can just ignore it.
-                // TODO: do something with the funds we're throwing away by doing this
+                // If we don't find it then we can sweep it into limbo.
+                state.add_limbo_funds_coin(coin)?;
                 return Ok(());
             }
 
             // Update the account within a closure.
             state.update_account(target, |acct_state| -> ExecResult<()> {
                 // Just increase the balance right now.
-                let coin = Coin::new_unchecked(value);
                 acct_state.add_balance(coin);
                 Ok(())
             })??;
@@ -97,21 +99,23 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
 }
 
 fn handle_bridge_gateway_message<S: IStateAccessorMut>(
-    _state: &mut S,
+    state: &mut S,
     _sender: AccountId,
     payload: MsgPayload,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
+    let coin = Coin::new_unchecked(payload.value());
+
     // 1. Parse the message from the payload data.
     let Ok(msg) = MsgRef::try_from(payload.data()) else {
-        // Invalid message format, just ignore.
+        // Invalid message format, sweep to limbo.
+        state.add_limbo_funds_coin(coin)?;
         return Ok(());
     };
 
     let Some(withdrawal_data) = msg.try_as_withdrawal() else {
-        // Not a withdrawal message, or malformed, just ignore.
-        //
-        // TODO maybe reroute this to a different thing?
+        // Not a withdrawal message, or malformed, sweep to limbo.
+        state.add_limbo_funds_coin(coin)?;
         return Ok(());
     };
 
@@ -124,7 +128,8 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     // 3. Verify the amount is a positive exact multiple of the denomination.
     let amt_raw: u64 = withdrawal_amt.into();
     if amt_raw == 0 || !amt_raw.is_multiple_of(withdrawal_denom) {
-        warn!(%amt_raw, "ignoring withdrawal with invalid amount");
+        // Sweep to limbo.
+        state.add_limbo_funds_coin(coin)?;
         return Ok(());
     }
 
@@ -135,6 +140,7 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
         dest: withdrawal_data.into_dest_desc(),
     };
     context.emit_typed_log(BRIDGE_GATEWAY_ACCT_SERIAL, &log_data)?;
+    coin.safely_consume_unchecked();
 
     Ok(())
 }

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -18,7 +18,7 @@ use strata_ol_msg_types::DepositMsgData;
 use tracing::warn;
 
 use crate::{
-    account_processing,
+    account_processing::{self, handle_misplaced_funds},
     constants::BRIDGE_GATEWAY_ACCT_ID,
     context::BasicExecContext,
     errors::{ExecError, ExecResult},
@@ -133,8 +133,9 @@ fn process_deposit_log<S: IStateAccessorMut>(
     // Parse the raw destination bytes into account serial + subject.
     let Ok(descriptor) = DepositDescriptor::decode_from_slice(&deposit.destination) else {
         // Malformed destination descriptor, sweep to limbo.
+        let coin = Coin::new_unchecked(amt_btc);
         warn!(amount = %deposit.amount, "limboing deposit with malformed destination descriptor");
-        state.add_limbo_funds_coin(Coin::new_unchecked(amt_btc))?;
+        handle_misplaced_funds(state, coin)?;
         return Ok(());
     };
 
@@ -144,8 +145,9 @@ fn process_deposit_log<S: IStateAccessorMut>(
     // Convert the account serial to account ID.
     let Some(dest_id) = state.find_account_id_by_serial(acct_serial)? else {
         // Account serial not found, sweep to limbo.
+        let coin = Coin::new_unchecked(amt_btc);
         warn!(?acct_serial, amount = %deposit.amount, "limboing deposit for unknown account serial");
-        state.add_limbo_funds_coin(Coin::new_unchecked(amt_btc))?;
+        handle_misplaced_funds(state, coin)?;
         return Ok(());
     };
 

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -1,6 +1,6 @@
 //! ASM manifest processing.
 
-use strata_acct_types::MsgPayload;
+use strata_acct_types::{BitcoinAmount, MsgPayload};
 use strata_asm_common::{AsmLogEntry, AsmManifest};
 use strata_asm_logs::{
     CheckpointTipUpdate, DepositLog, EePredicateKeyUpdate,
@@ -128,10 +128,13 @@ fn process_deposit_log<S: IStateAccessorMut>(
     deposit: &DepositLog,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
+    let amt_btc = BitcoinAmount::from_sat(deposit.amount);
+
     // Parse the raw destination bytes into account serial + subject.
     let Ok(descriptor) = DepositDescriptor::decode_from_slice(&deposit.destination) else {
-        // Malformed destination descriptor, skip this deposit.
-        warn!(amount = %deposit.amount, "dropping deposit with malformed destination descriptor");
+        // Malformed destination descriptor, sweep to limbo.
+        warn!(amount = %deposit.amount, "limboing deposit with malformed destination descriptor");
+        state.add_limbo_funds_coin(Coin::new_unchecked(amt_btc))?;
         return Ok(());
     };
 
@@ -140,11 +143,9 @@ fn process_deposit_log<S: IStateAccessorMut>(
 
     // Convert the account serial to account ID.
     let Some(dest_id) = state.find_account_id_by_serial(acct_serial)? else {
-        // Account serial not found, skip this deposit.
-        //
-        // TODO make this actually do something more sophisticated to make loss
-        // of funds less likely
-        warn!(?acct_serial, amount = %deposit.amount, "dropping deposit for unknown account serial");
+        // Account serial not found, sweep to limbo.
+        warn!(?acct_serial, amount = %deposit.amount, "limboing deposit for unknown account serial");
+        state.add_limbo_funds_coin(Coin::new_unchecked(amt_btc))?;
         return Ok(());
     };
 

--- a/crates/ol/stf/src/tests/limbo.rs
+++ b/crates/ol/stf/src/tests/limbo.rs
@@ -1,0 +1,316 @@
+//! Tests covering the paths that route misplaced funds into limbo via
+//! [`crate::account_processing::handle_misplaced_funds`].
+//!
+//! Sites covered here:
+//! - A: `process_message` to a non-existent ledger account
+//! - B: `process_transfer` to `BRIDGE_GATEWAY_ACCT_ID`
+//! - C: `process_transfer` to a non-existent ledger account
+//! - E: bridge-gateway message that parses as `MsgRef` but is not a withdrawal
+//! - F: bridge-gateway withdrawal message with a bad amount
+//! - G: manifest deposit log with a destination that does not decode as a `DepositDescriptor`
+//! - H: manifest deposit log referencing an account serial that does not exist
+//!
+//! Sites D (bridge-gateway message with un-parseable payload) is exercised by
+//! existing tests in `tests/multi_operations.rs`, which now also assert the
+//! limbo balance grew.
+
+use strata_acct_types::{BitcoinAmount, MsgPayload};
+use strata_asm_common::{AsmLogEntry, AsmManifest};
+use strata_asm_logs::DepositLog;
+use strata_codec::{VarVec, encode_to_vec};
+use strata_identifiers::{AccountSerial, Buf32, SubjectId, SubjectIdBytes, WtxidsRoot};
+use strata_ledger_types::{IAccountState, IStateAccessor};
+use strata_msg_fmt::{Msg, OwnedMsg};
+use strata_ol_bridge_types::DepositDescriptor;
+use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, WithdrawalMsgData};
+
+use crate::{
+    BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, account_processing,
+    assembly::BlockComponents,
+    context::{BasicExecContext, BlockInfo},
+    output::ExecOutputBuffer,
+    test_utils::*,
+};
+
+/// Site A: `process_message` to a non-existent ledger account.
+///
+/// In practice the SAU validator (`verify_effects_safe`) rejects unknown
+/// non-special destinations before this code runs, so we exercise the
+/// branch directly through the internal entry point.
+#[test]
+fn limbo_message_to_nonexistent_account() {
+    let mut state = create_test_genesis_state();
+    let nonexistent = test_account_id(TEST_NONEXISTENT_ID);
+    let limbo_before = state.limbo_funds();
+
+    let block_info = BlockInfo::new(1, 0, 0);
+    let outputs = ExecOutputBuffer::new_empty();
+    let context = BasicExecContext::new(block_info, &outputs);
+
+    let value = BitcoinAmount::from_sat(2_500_000);
+    let payload = MsgPayload::new(value, vec![]);
+
+    account_processing::process_message(
+        &mut state,
+        BRIDGE_GATEWAY_ACCT_ID,
+        nonexistent,
+        payload,
+        &context,
+    )
+    .expect("process_message should not error");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        2_500_000,
+        "Message to non-existent account should sweep value into limbo"
+    );
+}
+
+/// Site C: `process_transfer` to a non-existent ledger account.
+///
+/// Same dispatch consideration as site A — direct call to the internal
+/// entry point since the SAU validator rejects this in normal flow.
+#[test]
+fn limbo_transfer_to_nonexistent_account() {
+    let mut state = create_test_genesis_state();
+    let snark_id = get_test_snark_account_id();
+    let nonexistent = test_account_id(TEST_NONEXISTENT_ID);
+    let limbo_before = state.limbo_funds();
+
+    let block_info = BlockInfo::new(1, 0, 0);
+    let outputs = ExecOutputBuffer::new_empty();
+    let context = BasicExecContext::new(block_info, &outputs);
+
+    let value = BitcoinAmount::from_sat(4_000_000);
+    account_processing::process_transfer(&mut state, snark_id, nonexistent, value, &context)
+        .expect("process_transfer should not error");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        4_000_000,
+        "Transfer to non-existent account should sweep value into limbo"
+    );
+}
+
+/// Site B: `process_transfer` to `BRIDGE_GATEWAY_ACCT_ID`.
+///
+/// Drives the path through a SAU transaction, since `BRIDGE_GATEWAY_ACCT_ID`
+/// is special and passes `verify_effects_safe` without an existence check.
+#[test]
+fn limbo_transfer_to_bridge_gateway() {
+    let mut state = create_test_genesis_state();
+    let snark_id = get_test_snark_account_id();
+    let genesis_block = setup_genesis_with_snark_account(&mut state, snark_id, 100_000_000);
+    let limbo_before = state.limbo_funds();
+
+    let snark_state = state
+        .get_account_state(snark_id)
+        .unwrap()
+        .unwrap()
+        .as_snark_account()
+        .unwrap()
+        .clone();
+    let tx = SnarkUpdateBuilder::from_snark_state(snark_state)
+        .with_transfer(BRIDGE_GATEWAY_ACCT_ID, 7_000_000)
+        .build(snark_id, get_test_state_root(2), get_test_proof(1));
+
+    execute_tx_in_block(&mut state, genesis_block.header(), tx, 1, 0)
+        .expect("transfer to bridge gateway should succeed");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        7_000_000,
+        "Transfer to bridge gateway should sweep value into limbo"
+    );
+
+    let snark_acct = state.get_account_state(snark_id).unwrap().unwrap();
+    assert_eq!(
+        snark_acct.balance().to_sat(),
+        100_000_000 - 7_000_000,
+        "Sender should have been debited by the transfer amount"
+    );
+}
+
+/// Site E: bridge-gateway message that parses as `MsgRef` but isn't a
+/// withdrawal.
+#[test]
+fn limbo_non_withdrawal_message_to_bridge_gateway() {
+    let mut state = create_test_genesis_state();
+    let snark_id = get_test_snark_account_id();
+    let genesis_block = setup_genesis_with_snark_account(&mut state, snark_id, 200_000_000);
+    let limbo_before = state.limbo_funds();
+
+    // A well-formed `OwnedMsg` whose type id is not the withdrawal type id.
+    let bogus_type_id: u16 = 0x99;
+    assert_ne!(bogus_type_id, WITHDRAWAL_MSG_TYPE_ID);
+    let owned = OwnedMsg::new(bogus_type_id, vec![1, 2, 3, 4]).expect("valid OwnedMsg");
+    let msg_bytes = owned.to_vec();
+
+    let snark_state = state
+        .get_account_state(snark_id)
+        .unwrap()
+        .unwrap()
+        .as_snark_account()
+        .unwrap()
+        .clone();
+    let tx = SnarkUpdateBuilder::from_snark_state(snark_state)
+        .with_output_message(BRIDGE_GATEWAY_ACCT_ID, 100_000_000, msg_bytes)
+        .build(snark_id, get_test_state_root(2), get_test_proof(1));
+
+    let output = execute_block_with_outputs(
+        &mut state,
+        &BlockInfo::new(1_001_000, 1, 0),
+        Some(genesis_block.header()),
+        BlockComponents::new_txs_from_ol_transactions(vec![tx]),
+    )
+    .expect("non-withdrawal message to bridge gateway should succeed");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        100_000_000,
+        "Non-withdrawal bridge-gateway message should sweep value into limbo"
+    );
+
+    // No withdrawal intent log should have been emitted.
+    for log in output.outputs().logs() {
+        assert!(
+            log.account_serial() != BRIDGE_GATEWAY_ACCT_SERIAL,
+            "no bridge-gateway log expected, got {log:?}"
+        );
+    }
+}
+
+/// Site F: bridge-gateway withdrawal message with an amount that is not a
+/// multiple of the 100_000_000 sat denomination.
+#[test]
+fn limbo_bad_withdrawal_amount_to_bridge_gateway() {
+    let mut state = create_test_genesis_state();
+    let snark_id = get_test_snark_account_id();
+    let genesis_block = setup_genesis_with_snark_account(&mut state, snark_id, 100_000_000);
+    let limbo_before = state.limbo_funds();
+
+    // A real, decode-able withdrawal body, but the outer payload value is 1
+    // sat — not a multiple of 100_000_000.
+    let withdrawal_body =
+        WithdrawalMsgData::new(DEFAULT_OPERATOR_FEE, b"bc1qexample".to_vec(), u32::MAX)
+            .expect("valid withdrawal body");
+    let encoded_body = encode_to_vec(&withdrawal_body).expect("encode withdrawal body");
+    let owned = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).expect("valid OwnedMsg");
+    let msg_bytes = owned.to_vec();
+
+    let snark_state = state
+        .get_account_state(snark_id)
+        .unwrap()
+        .unwrap()
+        .as_snark_account()
+        .unwrap()
+        .clone();
+    let tx = SnarkUpdateBuilder::from_snark_state(snark_state)
+        .with_output_message(BRIDGE_GATEWAY_ACCT_ID, 1, msg_bytes)
+        .build(snark_id, get_test_state_root(2), get_test_proof(1));
+
+    let output = execute_block_with_outputs(
+        &mut state,
+        &BlockInfo::new(1_001_000, 1, 0),
+        Some(genesis_block.header()),
+        BlockComponents::new_txs_from_ol_transactions(vec![tx]),
+    )
+    .expect("bad-amount withdrawal should not error block");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        1,
+        "Bad withdrawal amount should sweep value into limbo"
+    );
+
+    for log in output.outputs().logs() {
+        assert!(
+            log.account_serial() != BRIDGE_GATEWAY_ACCT_SERIAL,
+            "no withdrawal intent log expected, got {log:?}"
+        );
+    }
+}
+
+/// Site G: manifest deposit log whose destination bytes do not decode as a
+/// [`DepositDescriptor`].
+#[test]
+fn limbo_deposit_with_malformed_descriptor() {
+    let mut state = create_test_genesis_state();
+    let limbo_before = state.limbo_funds();
+    let deposit_amount = 75_000_000u64;
+
+    // Empty destination — `DepositDescriptor::decode_from_slice` returns
+    // `EmptyDescriptor` for this.
+    let bogus_destination = VarVec::from_vec(Vec::<u8>::new()).expect("varvec");
+    let deposit_log_data = DepositLog::new(bogus_destination, deposit_amount);
+    let deposit_log = AsmLogEntry::from_log(&deposit_log_data).expect("log entry");
+
+    let manifest = AsmManifest::new(
+        1,
+        test_l1_block_id(1),
+        WtxidsRoot::from(Buf32::from([0u8; 32])),
+        vec![deposit_log],
+    )
+    .expect("valid manifest");
+
+    execute_block(
+        &mut state,
+        &BlockInfo::new_genesis(1_000_000),
+        None,
+        BlockComponents::new_manifests(vec![manifest]),
+    )
+    .expect("genesis manifest with bad descriptor should still execute");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        deposit_amount,
+        "Deposit with malformed descriptor should sweep amount into limbo"
+    );
+}
+
+/// Site H: manifest deposit log referencing an account serial that does not
+/// exist in state.
+#[test]
+fn limbo_deposit_to_unknown_account_serial() {
+    let mut state = create_test_genesis_state();
+    let limbo_before = state.limbo_funds();
+    let deposit_amount = 50_000_000u64;
+
+    // No accounts have been created, so any non-reserved serial is unknown.
+    let unknown_serial = AccountSerial::new(12345);
+    let subject =
+        SubjectIdBytes::try_new(SubjectId::from([7u8; 32]).inner().to_vec()).expect("subject");
+    let descriptor = DepositDescriptor::new(unknown_serial, subject).expect("valid descriptor");
+    let destination = descriptor.encode_to_varvec();
+    let deposit_log_data = DepositLog::new(destination, deposit_amount);
+    let deposit_log = AsmLogEntry::from_log(&deposit_log_data).expect("log entry");
+
+    let manifest = AsmManifest::new(
+        1,
+        test_l1_block_id(1),
+        WtxidsRoot::from(Buf32::from([0u8; 32])),
+        vec![deposit_log],
+    )
+    .expect("valid manifest");
+
+    execute_block(
+        &mut state,
+        &BlockInfo::new_genesis(1_000_000),
+        None,
+        BlockComponents::new_manifests(vec![manifest]),
+    )
+    .expect("genesis manifest with unknown serial should still execute");
+
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        deposit_amount,
+        "Deposit for unknown account serial should sweep amount into limbo"
+    );
+}

--- a/crates/ol/stf/src/tests/mod.rs
+++ b/crates/ol/stf/src/tests/mod.rs
@@ -26,3 +26,6 @@ mod ledger_references;
 
 #[cfg(test)]
 mod stf;
+
+#[cfg(test)]
+mod limbo;

--- a/crates/ol/stf/src/tests/multi_operations.rs
+++ b/crates/ol/stf/src/tests/multi_operations.rs
@@ -82,6 +82,8 @@ fn test_snark_update_multiple_output_messages() {
     // Setup: genesis with snark account
     let genesis_block = setup_genesis_with_snark_account(&mut state, snark_id, 100_000_000);
 
+    let limbo_before = state.limbo_funds();
+
     // Create update with multiple output messages using SnarkUpdateBuilder
     let tx = SnarkUpdateBuilder::from_snark_state(
         state
@@ -112,6 +114,17 @@ fn test_snark_update_multiple_output_messages() {
         BitcoinAmount::from_sat(85_000_000),
         "Balance should be reduced by total message value"
     );
+
+    // All three output messages target the bridge gateway account
+    // (SEQUENCER_ACCT_ID aliases BRIDGE_GATEWAY_ACCT_ID) with payload data
+    // that does not parse as a valid MsgRef, so all three sweep their
+    // values into limbo (10M + 5M + 0).
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        15_000_000,
+        "Limbo should grow by total of malformed bridge-gateway message values"
+    );
 }
 
 #[test]
@@ -125,6 +138,8 @@ fn test_snark_update_transfers_and_messages_combined() {
 
     // Create recipient account
     create_empty_account(&mut state, recipient_id);
+
+    let limbo_before = state.limbo_funds();
 
     // Create update with both transfers and messages using SnarkUpdateBuilder
     let tx = SnarkUpdateBuilder::from_snark_state(
@@ -161,6 +176,16 @@ fn test_snark_update_transfers_and_messages_combined() {
         recipient.balance(),
         BitcoinAmount::from_sat(25_000_000),
         "Recipient should receive 25M"
+    );
+
+    // The output message to the bridge gateway carries payload data
+    // (`vec![42, 43, 44]`) that does not parse as a valid MsgRef, so its
+    // 15M value is swept into limbo.
+    let limbo_after = state.limbo_funds();
+    assert_eq!(
+        limbo_after.to_sat() - limbo_before.to_sat(),
+        15_000_000,
+        "Limbo should grow by malformed bridge-gateway message value"
     );
 }
 

--- a/crates/proof-impl/checkpoint/src/program.rs
+++ b/crates/proof-impl/checkpoint/src/program.rs
@@ -109,7 +109,10 @@ mod tests {
         let slot_delta_u16 =
             u16::try_from(slot_delta).expect("slot delta exceeds u16::MAX; epoch too long");
         let da_diff = StateDiff::new(
-            GlobalStateDiff::new(DaCounter::new_changed(slot_delta_u16)),
+            GlobalStateDiff::new(
+                DaCounter::new_changed(slot_delta_u16),
+                DaCounter::new_unchanged(),
+            ),
             LedgerDiff::default(),
         );
         let da_state_diff_bytes =
@@ -177,7 +180,10 @@ mod tests {
         let bad_delta = u16::try_from(slot_delta.saturating_sub(1))
             .expect("slot delta exceeds u16::MAX; epoch too long");
         let bad_da_diff = StateDiff::new(
-            GlobalStateDiff::new(DaCounter::new_changed(bad_delta)),
+            GlobalStateDiff::new(
+                DaCounter::new_changed(bad_delta),
+                DaCounter::new_unchanged(),
+            ),
             LedgerDiff::default(),
         );
         input.da_state_diff_bytes =


### PR DESCRIPTION
## Description

This PR adds bookkeeping to track funds that have been put into "limbo".  We can't access these funds, but the ledger will keep track of them so we can do something with them later when we decide on a plan.

Claude was used for some basic refactoring downstream of the human changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
