### PR TITLE
fix(ci): use guest-checkpoint.elf instead of stale guest-checkpoint-new

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -148,14 +148,14 @@ jobs:
           mkdir -p docker/strata/artifacts/elfs/sp1
           install -m 0755 target/release/strata-datatool docker/strata/artifacts/strata-datatool
 
-          # strata only reads guest-checkpoint-new.elf at runtime. The other
+          # strata only reads guest-checkpoint.elf at runtime. The other
           # guest ELFs are embedded inside the datatool binary (via
           # strata-sp1-guest-builder's build script) and re-emitted by
           # `datatool genparams --elf-dir` during params generation.
           #
           # strata-sp1-guest-builder writes compiled ELFs to
           # provers/sp1/guest-*/cache/*.elf.
-          cp -v provers/sp1/guest-checkpoint-new/cache/guest-checkpoint-new.elf \
+          cp -v provers/sp1/guest-checkpoint/cache/guest-checkpoint.elf \
             docker/strata/artifacts/elfs/sp1/
 
           ls -la docker/strata/artifacts/ docker/strata/artifacts/elfs/sp1/


### PR DESCRIPTION
## Description
Recently `guest-checkpoint-new` was replaced with `guest-checkpoint` which was missed in ci workflow hence breaking it.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers
Error in ci:
```
warning: strata-sp1-guest-builder@0.3.0-alpha.1: rustc +succinct --version: "rustc 1.93.0-dev\n"
warning: strata-sp1-guest-builder@0.3.0-alpha.1: guest-sp1-alpen-acct built at 2026-05-01 10:17:25
   Compiling strata-datatool v0.3.0-alpha.1 (/home/runner/work/alpen/alpen/bin/datatool)
    Finished `release` profile [optimized] target(s) in 26m 04s
cp: cannot stat 'provers/sp1/guest-checkpoint-new/cache/guest-checkpoint-new.elf': No such file or directory
Error: Process completed with exit code 1.
```
<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
