### PR TITLE
fix(btcio,alpen-ee): broadcaster -25 disambiguation + block-builder inbox-fetch off-by-one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14423,6 +14423,7 @@ dependencies = [
  "anyhow",
  "serde",
  "ssz",
+ "strata-acct-types",
  "strata-checkpoint-types",
  "strata-db-types",
  "strata-identifiers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2973,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2cbde433d230760d71ccf2bc2eef53ca98b2cd7b31d67a19ad3d466cee67a3"
+checksum = "e6092f4da3f6e25a5c452dc387c13972f03a53c414e4999f9beff555af305e52"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14422,9 +14422,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
+ "sled",
  "ssz",
  "strata-acct-types",
  "strata-checkpoint-types",
+ "strata-db-store-sled",
  "strata-db-types",
  "strata-identifiers",
  "strata-node-context",
@@ -14438,8 +14440,10 @@ dependencies = [
  "strata-status",
  "strata-storage",
  "thiserror 2.0.18",
+ "threadpool",
  "tokio",
  "tracing",
+ "typed-sled",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -414,7 +414,7 @@ bitcoin = { version = "0.32.6", features = ["serde"] }
 bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", version = "0.10.0", tag = "v0.10.0", features = [
   "ssz",
 ] }
-bitcoind-async-client = { version = "0.10.2", features = ["29_0"] }
+bitcoind-async-client = { version = "0.10.5", features = ["29_0"] }
 bitvec = { version = "1.0.1", features = ["serde"] }
 borsh = { version = "1.6.1", features = ["derive"] }
 bytes = "1.11.1"

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -271,7 +271,13 @@ impl ProofSpec for AcctSpec {
             })?;
         let new_tip_blkid = last_record.package().exec_blkid();
         let new_inbox_idx = last_record.next_inbox_msg_idx();
-        let pre_inbox_idx = new_inbox_idx - messages.len() as u64;
+        let message_count = messages.len() as u64;
+        let pre_inbox_idx = new_inbox_idx.checked_sub(message_count).ok_or_else(|| {
+            PaasError::TransientFailure(format!(
+                "inconsistent inbox indices for batch {batch_id}: \
+                 new_inbox_idx={new_inbox_idx}, message_count={message_count}"
+            ))
+        })?;
 
         // Derive pre/post state roots. We advance `pre_ee_state` the same
         // way the EE program's `pre_finalize_state` does (set tip blkid)

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -400,13 +400,13 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
             return Ok(None);
         };
 
-        // Snark-only fields are zeroed for non-snark accounts. `RpcAccountBlockSummary`
-        // exposes `next_inbox_msg_idx` directly rather than a full `ProofState`, since
-        // per-block summaries focus on changes rather than full proof state.
+        // Snark-only fields are zeroed for non-snark accounts. For block
+        // summaries, `next_inbox_msg_idx` tracks the inbox accumulator leaf
+        // count after this block, not the snark proof-state read cursor.
         let (next_seq_no, next_inbox_msg_idx) = match account_state.as_snark_account() {
             Ok(snark_state) => (
                 *snark_state.seqno().inner(),
-                snark_state.next_inbox_msg_idx(),
+                snark_state.inbox_mmr().num_entries(),
             ),
             Err(_) => (0, 0),
         };

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    slice,
     sync::{Arc, Mutex},
 };
 
@@ -397,6 +398,16 @@ fn ol_state_with_snark_account(
     seq_no: u64,
     next_inbox_msg_idx: u64,
 ) -> OLState {
+    ol_state_with_snark_account_and_inbox_entries(account_id, slot, seq_no, next_inbox_msg_idx, &[])
+}
+
+fn ol_state_with_snark_account_and_inbox_entries(
+    account_id: AccountId,
+    slot: Slot,
+    seq_no: u64,
+    next_inbox_msg_idx: u64,
+    inbox_messages: &[MessageEntry],
+) -> OLState {
     let base = genesis_ol_state();
     let mut state = MemoryStateBaseLayer::new(base);
     state.set_cur_slot(slot);
@@ -412,6 +423,9 @@ fn ol_state_with_snark_account(
         .update_account(account_id, |acct| {
             let s = acct.as_snark_account_mut().unwrap();
             s.set_proof_state_directly(Hash::zero(), next_inbox_msg_idx, Seqno::from(seq_no));
+            for message in inbox_messages {
+                s.insert_inbox_message(message.clone()).unwrap();
+            }
         })
         .unwrap();
     state.into_inner()
@@ -1233,6 +1247,49 @@ async fn blocks_summaries_snark_vs_non_snark() {
     assert_eq!(empty.len(), 1);
     assert_eq!(empty[0].next_seq_no(), 0);
     assert_eq!(empty[0].next_inbox_msg_idx(), 0);
+}
+
+#[tokio::test]
+async fn blocks_summaries_reports_inbox_accumulator_count() {
+    let account_id = test_account_id(3);
+
+    let block0 = make_block(0, 0, null_blkid());
+    let blkid0 = block0.header().compute_blkid();
+    let block1 = make_block(1, 0, blkid0);
+    let blkid1 = block1.header().compute_blkid();
+
+    let tip = OLBlockCommitment::new(1, blkid1);
+    let deposit_message = make_message_entry(test_account_id(50), 0, 1_000, vec![0x02, 0xaa]);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block0, ol_state_with_snark_account(account_id, 0, 0, 0))
+        .with_block_and_state(
+            &block1,
+            ol_state_with_snark_account_and_inbox_entries(
+                account_id,
+                1,
+                0,
+                0,
+                slice::from_ref(&deposit_message),
+            ),
+        );
+    let rpc = make_rpc(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 1)
+        .await
+        .expect("summaries");
+
+    assert_eq!(summaries.len(), 2);
+    assert_eq!(summaries[0].next_inbox_msg_idx(), 0);
+    assert_eq!(summaries[1].next_inbox_msg_idx(), 1);
 }
 
 // ── get_blocks_summaries: indexed activity ──

--- a/crates/alpen-ee/sequencer/src/block_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/task.rs
@@ -56,6 +56,50 @@ fn should_fetch_inbox_messages(last_local_ol_blkid: &OLBlockId, best_ol_blkid: &
     last_local_ol_blkid != best_ol_blkid
 }
 
+/// Picks the OL block commitment to record on the next exec block.
+///
+/// During restart catch-up, finalization lag, or reorg handling, the OL
+/// tracker can report a block behind the local EE tip. Returning
+/// `last_local_ol_block` in that case keeps the OL slot recorded on the EE
+/// chain monotonic; using the older `best_ol_block` would cause inbox
+/// fetching to re-include slots already reflected in account state.
+fn effective_ol_block(
+    best_ol_block: OLBlockCommitment,
+    last_local_ol_block: OLBlockCommitment,
+) -> OLBlockCommitment {
+    if best_ol_block.slot() < last_local_ol_block.slot() {
+        last_local_ol_block
+    } else {
+        best_ol_block
+    }
+}
+
+/// Computes the inbox-fetch slot range for the next exec block.
+///
+/// Returns `None` when no fetch is needed: either the OL tip is unchanged
+/// from what's already in account state, or the slot delta is empty.
+/// Otherwise returns `Some((from_slot, to_slot))` with both ends inclusive.
+///
+/// `from_slot = last_local_ol_slot + 1` is the off-by-one fix: the previously
+/// recorded slot's messages are already drained, so re-fetching it produces a
+/// SAU whose `processed_messages` does not match `new_next_inbox_msg_idx` and
+/// OL rejects it with "invalid next msg index".
+fn compute_inbox_fetch_range(
+    last_local_ol_slot: u64,
+    last_local_ol_blkid: &OLBlockId,
+    effective_ol_slot: u64,
+    effective_ol_blkid: &OLBlockId,
+) -> Option<(u64, u64)> {
+    if !should_fetch_inbox_messages(last_local_ol_blkid, effective_ol_blkid) {
+        return None;
+    }
+    let from_slot = last_local_ol_slot.saturating_add(1);
+    if from_slot > effective_ol_slot {
+        return None;
+    }
+    Some((from_slot, effective_ol_slot))
+}
+
 /// Constructs BlockAssemblyInputs from the current state.
 fn create_block_assembly_inputs<'a>(
     last_local_block: &ExecBlockRecord,
@@ -241,37 +285,20 @@ async fn build_next_block(
         .await
         .context("build_next_block: failed to get finalized OL block")?;
 
-    // Record a monotonic OL commitment on the new exec block. During restart
-    // catch-up, finalization lag, or reorg handling, the OL tracker can report
-    // a block behind the local EE tip. Writing that lower slot makes inbox
-    // fetching include slots already reflected in account state.
-    let effective_ol_block: OLBlockCommitment =
-        if best_ol_block.slot() < last_local_block.ol_block().slot() {
-            *last_local_block.ol_block()
-        } else {
-            best_ol_block
-        };
+    let effective_ol_block = effective_ol_block(best_ol_block, *last_local_block.ol_block());
 
-    let (inbox_messages, next_inbox_msg_idx) = if should_fetch_inbox_messages(
+    let (inbox_messages, next_inbox_msg_idx) = match compute_inbox_fetch_range(
+        last_local_block.ol_block().slot(),
         last_local_block.ol_block().blkid(),
+        effective_ol_block.slot(),
         effective_ol_block.blkid(),
     ) {
-        // Fetch only slots newer than the last OL slot reflected in account
-        // state. Re-including a drained slot produces a SAU whose
-        // processed_messages do not match new_next_inbox_msg_idx, and OL
-        // rejects it with "invalid next msg index".
-        let from_slot = last_local_block.ol_block().slot().saturating_add(1);
-        if from_slot > effective_ol_block.slot() {
-            (vec![], last_local_block.next_inbox_msg_idx())
-        } else {
-            ol_chain_handle
-                .get_inbox_messages(from_slot, effective_ol_block.slot())
-                .await
-                .context("build_next_block: failed to get inbox messages")?
-                .into_parts()
-        }
-    } else {
-        (vec![], last_local_block.next_inbox_msg_idx())
+        Some((from_slot, to_slot)) => ol_chain_handle
+            .get_inbox_messages(from_slot, to_slot)
+            .await
+            .context("build_next_block: failed to get inbox messages")?
+            .into_parts(),
+        None => (vec![], last_local_block.next_inbox_msg_idx()),
     };
 
     // build next block
@@ -396,6 +423,85 @@ mod tests {
             assert_eq!(inputs.inbox_messages.len(), 2);
             assert_eq!(inputs.inbox_messages[0].source(), msg1.source());
             assert_eq!(inputs.inbox_messages[1].source(), msg2.source());
+        }
+    }
+
+    mod effective_ol_block_tests {
+        use super::*;
+
+        #[test]
+        fn picks_best_when_best_is_ahead() {
+            let last = make_ol_block(5);
+            let best = make_ol_block(10);
+            assert_eq!(effective_ol_block(best, last), best);
+        }
+
+        #[test]
+        fn picks_best_when_slots_equal() {
+            // Equal slots: best wins. Different blkid at the same slot still
+            // means the OL tracker advanced (e.g. reorg sibling).
+            let last = make_ol_block(5);
+            let best = make_ol_block(5);
+            assert_eq!(effective_ol_block(best, last), best);
+        }
+
+        #[test]
+        fn falls_back_to_last_when_best_is_behind() {
+            // Restart catch-up / finalization lag: tracker behind the local
+            // tip. Falling back to `last` keeps the recorded OL slot
+            // monotonic; using `best` here would re-include drained slots.
+            let last = make_ol_block(10);
+            let best = make_ol_block(5);
+            assert_eq!(effective_ol_block(best, last), last);
+        }
+    }
+
+    mod compute_inbox_fetch_range_tests {
+        use super::*;
+
+        fn blkid(byte: u8) -> OLBlockId {
+            let mut bytes = [0u8; 32];
+            bytes[31] = byte;
+            OLBlockId::from(Buf32::from(bytes))
+        }
+
+        #[test]
+        fn returns_none_when_blkids_match() {
+            // OL tip unchanged: nothing new to fetch even if slots happened
+            // to differ (would mean a slot was rewritten in place).
+            let id = blkid(1);
+            assert_eq!(compute_inbox_fetch_range(5, &id, 5, &id), None);
+        }
+
+        #[test]
+        fn returns_none_when_range_is_empty() {
+            // Different blkids but `from > to` — can happen if `effective_ol`
+            // falls back to `last_local` after a behind-tracker case and the
+            // siblings carry the same slot but different ids. No slots to
+            // pull.
+            assert_eq!(compute_inbox_fetch_range(5, &blkid(1), 5, &blkid(2)), None);
+        }
+
+        #[test]
+        fn fetches_only_new_slots_off_by_one_regression() {
+            // Last local OL block at slot 5, new effective at slot 7.
+            // The fetch must start at slot 6, NOT slot 5: re-including slot 5
+            // would re-process messages already drained into account state
+            // and OL would reject the resulting SAU with "invalid next msg
+            // index".
+            assert_eq!(
+                compute_inbox_fetch_range(5, &blkid(1), 7, &blkid(2)),
+                Some((6, 7)),
+            );
+        }
+
+        #[test]
+        fn single_slot_advance_returns_singleton_range() {
+            // Slot 5 -> slot 6: fetch [6, 6].
+            assert_eq!(
+                compute_inbox_fetch_range(5, &blkid(1), 6, &blkid(2)),
+                Some((6, 6)),
+            );
         }
     }
 }

--- a/crates/alpen-ee/sequencer/src/block_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/task.rs
@@ -217,8 +217,8 @@ async fn build_next_block(
         .await
         .context("build_next_block: failed to get best exec block")?;
 
-    // Check if last local block is not as expected from previous block building cycle
-    // This shouldn't happen in a single sequencer case, but checking for sanity anyway.
+    // Check the parent expected by the block target. A mismatch means another
+    // builder advanced the local EE tip.
     if last_local_block.blockhash() != expected_block_target.parent {
         warn!(
             expected = %expected_block_target.parent,
@@ -227,8 +227,7 @@ async fn build_next_block(
         )
     }
 
-    // Ensure blocktime >= configured blocktime
-    // This shouldn't happen in a single sequencer case, but checking for sanity anyway.
+    // Enforce the configured blocktime against the current local tip.
     let timestamp_ms = clock.current_timestamp();
     validate_blocktime_constraint(
         timestamp_ms,
@@ -241,15 +240,36 @@ async fn build_next_block(
         .get_finalized_block()
         .await
         .context("build_next_block: failed to get finalized OL block")?;
+
+    // Record a monotonic OL commitment on the new exec block. During restart
+    // catch-up, finalization lag, or reorg handling, the OL tracker can report
+    // a block behind the local EE tip. Writing that lower slot makes inbox
+    // fetching include slots already reflected in account state.
+    let effective_ol_block: OLBlockCommitment =
+        if best_ol_block.slot() < last_local_block.ol_block().slot() {
+            *last_local_block.ol_block()
+        } else {
+            best_ol_block
+        };
+
     let (inbox_messages, next_inbox_msg_idx) = if should_fetch_inbox_messages(
         last_local_block.ol_block().blkid(),
-        best_ol_block.blkid(),
+        effective_ol_block.blkid(),
     ) {
-        ol_chain_handle
-            .get_inbox_messages(last_local_block.ol_block().slot(), best_ol_block.slot())
-            .await
-            .context("build_next_block: failed to get inbox messages")?
-            .into_parts()
+        // Fetch only slots newer than the last OL slot reflected in account
+        // state. Re-including a drained slot produces a SAU whose
+        // processed_messages do not match new_next_inbox_msg_idx, and OL
+        // rejects it with "invalid next msg index".
+        let from_slot = last_local_block.ol_block().slot().saturating_add(1);
+        if from_slot > effective_ol_block.slot() {
+            (vec![], last_local_block.next_inbox_msg_idx())
+        } else {
+            ol_chain_handle
+                .get_inbox_messages(from_slot, effective_ol_block.slot())
+                .await
+                .context("build_next_block: failed to get inbox messages")?
+                .into_parts()
+        }
     } else {
         (vec![], last_local_block.next_inbox_msg_idx())
     };
@@ -272,7 +292,7 @@ async fn build_next_block(
         package,
         account_state,
         last_local_block.blocknum(),
-        best_ol_block,
+        effective_ol_block,
         timestamp_ms,
         parent_blockhash,
         next_inbox_msg_idx,

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/state.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/state.rs
@@ -139,6 +139,11 @@ impl OLChainTrackerState {
             return Err(eyre!("unknown block: {next_base:?}"));
         };
 
+        self.base_block_next_inbox_msg_idx = self
+            .data
+            .get(next_base.blkid())
+            .expect("tracked block must have inbox data")
+            .next_inbox_msg_idx;
         self.base_block = next_base;
         for _ in 0..=prune_idx {
             let block = self.blocks.pop_front().expect("should exist");
@@ -362,19 +367,20 @@ mod tests {
             let block13 = make_block(13);
 
             state
-                .append_block(block11, vec![make_message(1)], 0)
+                .append_block(block11, vec![make_message(1)], 1)
                 .unwrap();
             state
-                .append_block(block12, vec![make_message(2)], 0)
+                .append_block(block12, vec![make_message(2)], 2)
                 .unwrap();
             state
-                .append_block(block13, vec![make_message(3)], 0)
+                .append_block(block13, vec![make_message(3)], 3)
                 .unwrap();
 
             state.prune_blocks(block12).unwrap();
 
             // block12 becomes new base, blocks 11 and 12 are removed
             assert_eq!(state.base_block, block12);
+            assert_eq!(state.base_block_next_inbox_msg_idx, 2);
             assert_eq!(state.blocks.len(), 1);
             assert_eq!(state.blocks.front().unwrap().slot(), 13);
             // Data for pruned blocks should be removed
@@ -391,12 +397,13 @@ mod tests {
             let block11 = make_block(11);
             let block12 = make_block(12);
 
-            state.append_block(block11, vec![], 0).unwrap();
-            state.append_block(block12, vec![], 0).unwrap();
+            state.append_block(block11, vec![], 1).unwrap();
+            state.append_block(block12, vec![], 2).unwrap();
 
             state.prune_blocks(block11).unwrap();
 
             assert_eq!(state.base_block, block11);
+            assert_eq!(state.base_block_next_inbox_msg_idx, 1);
             assert_eq!(state.blocks.len(), 1);
             assert_eq!(state.blocks.front().unwrap().slot(), 12);
         }
@@ -409,13 +416,31 @@ mod tests {
             let block11 = make_block(11);
             let block12 = make_block(12);
 
-            state.append_block(block11, vec![], 0).unwrap();
-            state.append_block(block12, vec![], 0).unwrap();
+            state.append_block(block11, vec![], 1).unwrap();
+            state.append_block(block12, vec![], 2).unwrap();
 
             state.prune_blocks(block12).unwrap();
 
             assert_eq!(state.base_block, block12);
+            assert_eq!(state.base_block_next_inbox_msg_idx, 2);
             assert!(state.blocks.is_empty());
+        }
+
+        #[test]
+        fn empty_after_prune_returns_new_base_inbox_idx() {
+            let base = make_block(10);
+            let mut state = OLChainTrackerState::new_empty(base, 0);
+
+            let block11 = make_block(11);
+            state
+                .append_block(block11, vec![make_message(100)], 1)
+                .unwrap();
+
+            state.prune_blocks(block11).unwrap();
+
+            let messages = state.get_inbox_messages(11, 11).unwrap();
+            assert!(messages.messages.is_empty());
+            assert_eq!(messages.next_inbox_msg_idx(), 1);
         }
 
         #[test]

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -10,8 +10,21 @@ use strata_btc_types::BlockHashExt;
 use strata_db_types::types::L1TxEntry;
 use strata_primitives::{buf::Buf32, L1Height};
 use strata_storage::BroadcastDbOps;
+use tracing::{info, warn};
 
 use super::error::{BroadcasterError, BroadcasterResult};
+
+/// Classifies a bitcoind `-25` reject reason as benign (already accepted) or
+/// not. Bitcoind's reject strings use hyphenated tokens (see
+/// `validation.cpp`/`policy/policy.cpp`): `txn-already-in-mempool`,
+/// `txn-already-known`, `txn-already-in-block-chain`. A space-separated check
+/// like `"already in mempool"` does not match any of these and would route
+/// every benign `-25` to `InvalidInputs`, causing spurious envelope rebuilds.
+fn is_benign_minus25_message(msg: &str) -> bool {
+    msg.contains("already-in-mempool")
+        || msg.contains("already-known")
+        || msg.contains("already-in-block-chain")
+}
 
 /// IO context abstraction for broadcaster service internals.
 pub(crate) trait BroadcasterIoContext: Send + Sync + 'static {
@@ -58,7 +71,7 @@ pub(crate) enum PublishTxOutcome {
     /// Transaction was accepted for broadcast.
     Published,
 
-    /// Transaction was already accepted earlier and is already in mempool.
+    /// Transaction is already accepted and present in mempool.
     AlreadyInMempool,
 
     /// Transaction has invalid/missing inputs and should be marked invalid.
@@ -117,19 +130,94 @@ where
         &'a self,
         tx: &'a Transaction,
     ) -> BroadcasterResult<PublishTxOutcome> {
+        let txid = tx.compute_txid();
         match self.rpc_client.send_raw_transaction(tx).await {
-            Ok(_) => Ok(PublishTxOutcome::Published),
-            Err(ClientError::Server(-25, _)) => Ok(PublishTxOutcome::AlreadyInMempool),
-            Err(err)
-                if err.is_missing_or_invalid_input()
-                    || matches!(err, ClientError::Server(-22, _)) =>
-            {
+            Ok(_) => {
+                info!(%txid, "sendrawtransaction accepted (Published)");
+                Ok(PublishTxOutcome::Published)
+            }
+            Err(ClientError::Server(-25, msg)) => {
+                // Bitcoind reuses code -25 for several distinct reject reasons.
+                // "txn-already-in-mempool" / "txn-already-known" mean the tx is
+                // already accepted; fold to AlreadyInMempool.
+                // "bad-txns-inputs-missingorspent" means the chosen UTXO has
+                // already been spent or evicted; the entry must be re-signed
+                // against a fresh listunspent snapshot. Mapping it blindly to
+                // AlreadyInMempool pins the entry at Published forever and
+                // stalls the watcher's curr_payloadidx.
+                if is_benign_minus25_message(&msg) {
+                    warn!(%txid, %msg, "sendrawtransaction reports tx already accepted (AlreadyInMempool)");
+                    Ok(PublishTxOutcome::AlreadyInMempool)
+                } else {
+                    warn!(%txid, %msg, "sendrawtransaction -25 with non-benign message (treated as InvalidInputs)");
+                    Ok(PublishTxOutcome::InvalidInputs)
+                }
+            }
+            Err(ClientError::Server(-22, msg)) => {
+                warn!(%txid, %msg, "sendrawtransaction returned -22 (treated as InvalidInputs)");
                 Ok(PublishTxOutcome::InvalidInputs)
             }
-            Err(err @ ClientError::Status(500, _)) => Ok(PublishTxOutcome::RetryLater {
-                reason: err.to_string(),
-            }),
-            Err(err) => Err(BroadcasterError::Rpc(anyhow!(err))),
+            Err(err) if err.is_missing_or_invalid_input() => {
+                warn!(%txid, %err, "sendrawtransaction missing/invalid input (treated as InvalidInputs)");
+                Ok(PublishTxOutcome::InvalidInputs)
+            }
+            Err(err @ ClientError::Status(500, _)) => {
+                warn!(%txid, %err, "sendrawtransaction HTTP 500 (treated as RetryLater)");
+                Ok(PublishTxOutcome::RetryLater {
+                    reason: err.to_string(),
+                })
+            }
+            Err(ClientError::Server(code, msg)) => {
+                warn!(%txid, %code, %msg, "sendrawtransaction returned unhandled bitcoin server error");
+                Err(BroadcasterError::Rpc(anyhow!(
+                    "bitcoin server error {code}: {msg}"
+                )))
+            }
+            Err(err) => {
+                warn!(%txid, %err, "sendrawtransaction returned unexpected error");
+                Err(BroadcasterError::Rpc(anyhow!(err)))
+            }
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::is_benign_minus25_message;
+
+    #[test]
+    fn benign_minus25_strings_match() {
+        // Bitcoind reject reasons that mean "the tx is already accepted",
+        // safe to fold to AlreadyInMempool. Strings come from bitcoind's
+        // validation.cpp / policy.cpp.
+        assert!(is_benign_minus25_message("txn-already-in-mempool"));
+        assert!(is_benign_minus25_message("txn-already-known"));
+        assert!(is_benign_minus25_message("txn-already-in-block-chain"));
+    }
+
+    #[test]
+    fn missing_input_minus25_is_not_benign() {
+        // The case that motivated this disambiguation: input UTXO is gone,
+        // entry must be re-signed against a fresh listunspent.
+        assert!(!is_benign_minus25_message("bad-txns-inputs-missingorspent"));
+    }
+
+    #[test]
+    fn other_minus25_reasons_are_not_benign() {
+        // Catch-all: anything we have not explicitly classified as benign
+        // (e.g. RBF / fee policy violations) routes to InvalidInputs so the
+        // watcher rebuilds rather than pinning at Published.
+        assert!(!is_benign_minus25_message("txn-mempool-conflict"));
+        assert!(!is_benign_minus25_message("min relay fee not met"));
+    }
+
+    #[test]
+    fn space_separated_does_not_match_hyphenated() {
+        // Space-separated forms do not appear in bitcoind reject strings.
+        // Keep them non-benign so only real `already-*` tokens map to
+        // AlreadyInMempool.
+        assert!(!is_benign_minus25_message("already in mempool"));
+        assert!(!is_benign_minus25_message("already known"));
     }
 }

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -157,8 +157,8 @@ where
                 warn!(%txid, %msg, "sendrawtransaction returned -22 (treated as InvalidInputs)");
                 Ok(PublishTxOutcome::InvalidInputs)
             }
-            Err(err) if err.is_missing_or_invalid_input() => {
-                warn!(%txid, %err, "sendrawtransaction missing/invalid input (treated as InvalidInputs)");
+            Err(err) if err.is_rpc_verify_rejected() => {
+                warn!(%txid, %err, "sendrawtransaction verify-rejected (treated as InvalidInputs)");
                 Ok(PublishTxOutcome::InvalidInputs)
             }
             Err(err @ ClientError::Status(500, _)) => {

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -181,7 +181,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::is_benign_minus25_message;

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -58,12 +58,11 @@ where
 {
     let result = match txentry.status {
         L1TxStatus::Unpublished => publish_tx(io, txentry).await.map(Some),
-        L1TxStatus::Published => probe_published_entry(io, txentry, txid, params)
-            .await
-            .map(Some),
-        L1TxStatus::Confirmed { .. } => check_tx_confirmations(io, txentry, txid, params)
-            .await
-            .map(Some),
+        L1TxStatus::Published | L1TxStatus::Confirmed { .. } => {
+            resolve_broadcast_entry_status(io, txentry, txid, params)
+                .await
+                .map(Some)
+        }
         L1TxStatus::Finalized { .. } => Ok(None),
         L1TxStatus::InvalidInputs => Ok(None),
     };
@@ -73,10 +72,10 @@ where
     result
 }
 
-/// Resolves a `Published` entry from a confirmation lookup, falling back to a
-/// re-publish probe only when the lookup actually misses.
+/// Resolves a broadcast entry from a confirmation lookup, falling back to a
+/// re-publish probe when the lookup misses.
 ///
-/// `gettransaction` returns three distinguishable shapes for a Published entry:
+/// `gettransaction` returns three distinguishable shapes for a broadcast entry:
 ///
 /// 1. `Some(info)` with `confirmations >= 1`: tx mined, derive Confirmed/Finalized.
 /// 2. `Some(info)` with `confirmations == 0`: tx alive in mempool. Hold at Published. Re-publishing
@@ -85,7 +84,7 @@ where
 ///    tx, or a genuinely dropped tx (mempool eviction, RBF). Re-publish to disambiguate: benign
 ///    mempool messages fold back to Published, `bad-txns-inputs-missingorspent` routes to
 ///    InvalidInputs so the watcher rebuilds the envelope.
-async fn probe_published_entry<C>(
+async fn resolve_broadcast_entry_status<C>(
     io: &C,
     txentry: &L1TxEntry,
     txid: &Txid,
@@ -99,8 +98,6 @@ where
     let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
 
     match txinfo_res? {
-        // `confirmation_status` returns `Published` for 0-conf, which is the
-        // correct sighting for an already-Published entry still in mempool.
         Some(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
         None => match publish_tx(io, txentry).await? {
             L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
@@ -136,40 +133,6 @@ fn confirmation_status(info: &TxConfirmationInfo, reorg_safe_depth: i64) -> L1Tx
             block_height,
         }
     }
-}
-
-/// Resolves a `Confirmed` entry to its next confirmation-derived status. A
-/// confirmed tx that disappears regresses to `Unpublished` so the broadcaster
-/// re-publishes (typical reorg recovery).
-///
-/// Callers in `Published` state must use `probe_published_entry` instead; that
-/// path probes not-found transactions before deciding whether they were dropped.
-async fn check_tx_confirmations<C>(
-    io: &C,
-    txentry: &L1TxEntry,
-    txid: &Txid,
-    params: &BtcioParams,
-) -> BroadcasterResult<L1TxStatus>
-where
-    C: BroadcasterIoContext,
-{
-    async {
-        let txinfo_res = io.get_transaction(txid).await;
-        debug!(?txinfo_res, "checked transaction status");
-        let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
-
-        Ok(txinfo_res?
-            .as_ref()
-            .map(|info| confirmation_status(info, reorg_safe_depth))
-            .unwrap_or(L1TxStatus::Unpublished))
-    }
-    .instrument(debug_span!(
-        "check_tx_confirmations",
-        component = "btcio_broadcaster",
-        %txid,
-        current_status = ?txentry.status
-    ))
-    .await
 }
 
 /// Attempts to broadcast an unpublished entry and maps publication outcomes to statuses.
@@ -723,10 +686,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_handle_confirmed_entry_missing_tx_regresses_to_unpublished() {
-        // Confirmed entries that go missing on lookup should still regress to
-        // Unpublished so the broadcaster re-publishes (e.g. after a reorg
-        // dropped them from the wallet view).
+    async fn test_handle_confirmed_entry_missing_tx_probes_before_regressing() {
         let (e, txid) = entry_with_txid(confirmed_status(1, 1, Buf32::zero()));
         let btcio_params = get_test_btcio_params();
 
@@ -734,8 +694,24 @@ mod test {
         let res = process_status(&io, &e, &txid, &btcio_params).await;
         assert_eq!(
             res,
-            Some(L1TxStatus::Unpublished),
-            "Confirmed entry that disappears should regress to Unpublished"
+            Some(L1TxStatus::Published),
+            "Confirmed entry that disappears should probe before changing status"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_confirmed_entry_missing_tx_with_invalid_inputs_marks_invalid_inputs() {
+        let (e, txid) = entry_with_txid(confirmed_status(1, 1, Buf32::zero()));
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default()
+            .with_tx_lookup(txid, MockTxLookupResult::Missing)
+            .with_broadcast_result(txid, MockBroadcastResult::InvalidInputs);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::InvalidInputs),
+            "Confirmed entry with invalid inputs should trigger envelope rebuild"
         );
     }
 

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -113,9 +113,7 @@ where
 ///
 /// `confirmations <= 0` means the tx is visible to bitcoind but not anchored
 /// to the canonical chain (mempool-only, or on a side branch after reorg);
-/// returns [`L1TxStatus::Published`]. Callers that need different 0-conf
-/// semantics — e.g. regressing a `Confirmed` entry to `Unpublished` on
-/// reorg drop — must override the result themselves.
+/// returns [`L1TxStatus::Published`].
 fn confirmation_status(info: &TxConfirmationInfo, reorg_safe_depth: i64) -> L1TxStatus {
     if info.confirmations <= 0 {
         return L1TxStatus::Published;
@@ -141,12 +139,11 @@ fn confirmation_status(info: &TxConfirmationInfo, reorg_safe_depth: i64) -> L1Tx
 }
 
 /// Resolves a `Confirmed` entry to its next confirmation-derived status. A
-/// confirmed tx that disappears or drops to 0 confirmations regresses to
-/// `Unpublished` so the broadcaster re-publishes (typical reorg recovery).
+/// confirmed tx that disappears regresses to `Unpublished` so the broadcaster
+/// re-publishes (typical reorg recovery).
 ///
 /// Callers in `Published` state must use `probe_published_entry` instead; that
-/// path holds 0-conf and not-found differently to avoid publish/revert
-/// oscillation and unnecessary re-broadcasts.
+/// path probes not-found transactions before deciding whether they were dropped.
 async fn check_tx_confirmations<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -161,11 +158,10 @@ where
         debug!(?txinfo_res, "checked transaction status");
         let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
 
-        match txinfo_res? {
-            Some(info) if info.confirmations == 0 => Ok(L1TxStatus::Unpublished),
-            Some(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
-            None => Ok(L1TxStatus::Unpublished),
-        }
+        Ok(txinfo_res?
+            .as_ref()
+            .map(|info| confirmation_status(info, reorg_safe_depth))
+            .unwrap_or(L1TxStatus::Unpublished))
     }
     .instrument(debug_span!(
         "check_tx_confirmations",
@@ -611,8 +607,8 @@ mod test {
                 let res = process_status(&io, &e, &txid, &btcio_params).await;
                 assert_eq!(
                     res,
-                    Some(L1TxStatus::Unpublished),
-                    "Status should revert to unpublished if confirmed tx now has 0 confirmations"
+                    Some(L1TxStatus::Published),
+                    "Status should revert to published if confirmed tx is visible at 0 confirmations"
                 );
 
                 let io = MockIoContext::default().with_tx_lookup(
@@ -673,14 +669,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_published_entry_dropped_from_mempool_advances_to_invalid_inputs() {
-        // A `Published` entry whose lookup says "not found" AND whose
-        // re-publish probe returns `InvalidInputs` (e.g. its inputs were
-        // spent or evicted) must transition to `InvalidInputs` so the
-        // watcher's `determine_payload_next_status` flips the bundle to
-        // `NeedsResign` and the envelope is rebuilt against fresh UTXOs.
-        // Without the publish-probe in `probe_published_entry`, the entry
-        // would stay `Published` forever and the watcher's
-        // `curr_payloadidx` would stall.
         let (e, txid) = entry_with_txid(L1TxStatus::Published);
         let btcio_params = get_test_btcio_params();
 
@@ -717,13 +705,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_published_entry_at_zero_conf_does_not_republish() {
-        // A `Published` entry that `gettransaction` reports as 0-conf in the
-        // wallet is alive in mempool and waiting to be mined. Re-publishing
-        // every poll for the entire pre-confirmation window would only spam
-        // bitcoind and the broadcaster logs. The probe must hold at Published
-        // without calling `send_raw_transaction`. We poison the broadcast path
-        // so any re-publish would surface as `InvalidInputs`; the assertion
-        // proves the probe never went down that road.
         let (e, txid) = entry_with_txid(L1TxStatus::Published);
         let btcio_params = get_test_btcio_params();
 

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -99,8 +99,9 @@ where
     let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
 
     match txinfo_res? {
-        Some(info) if info.confirmations >= 1 => Ok(confirmation_status(&info, reorg_safe_depth)),
-        Some(_) => Ok(L1TxStatus::Published),
+        // `confirmation_status` returns `Published` for 0-conf, which is the
+        // correct sighting for an already-Published entry still in mempool.
+        Some(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
         None => match publish_tx(io, txentry).await? {
             L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
             _ => Ok(L1TxStatus::Published),
@@ -108,11 +109,17 @@ where
     }
 }
 
-/// Maps a confirmed `TxConfirmationInfo` (`info.confirmations >= 1`) to the
-/// corresponding `Confirmed` or `Finalized` status. Caller must ensure the
-/// `confirmations >= 1` precondition; the block_hash/block_height fields are
-/// only populated by bitcoind once a tx is mined.
+/// Maps `TxConfirmationInfo` to the natural confirmation-derived status.
+///
+/// `confirmations <= 0` means the tx is visible to bitcoind but not anchored
+/// to the canonical chain (mempool-only, or on a side branch after reorg);
+/// returns [`L1TxStatus::Published`]. Callers that need different 0-conf
+/// semantics — e.g. regressing a `Confirmed` entry to `Unpublished` on
+/// reorg drop — must override the result themselves.
 fn confirmation_status(info: &TxConfirmationInfo, reorg_safe_depth: i64) -> L1TxStatus {
+    if info.confirmations <= 0 {
+        return L1TxStatus::Published;
+    }
     let block_hash = info.block_hash.expect("confirmed tx must have block_hash");
     let block_height = info
         .block_height
@@ -838,5 +845,53 @@ mod test {
                 );
             });
         }
+    }
+
+    // ── confirmation_status ──
+
+    #[test]
+    fn confirmation_status_zero_confirmations_returns_published() {
+        // 0-conf means the tx is in the mempool but not anchored to a block;
+        // bitcoind leaves block_hash/block_height as None in that case.
+        let info = TxConfirmationInfo {
+            confirmations: 0,
+            block_hash: None,
+            block_height: None,
+        };
+        assert_eq!(confirmation_status(&info, 6), L1TxStatus::Published);
+    }
+
+    #[test]
+    fn confirmation_status_negative_confirmations_returns_published() {
+        // Negative confirmations mean the tx is on a side branch after a reorg;
+        // treat it like 0-conf rather than synthesising a phantom Confirmed entry.
+        let info = TxConfirmationInfo {
+            confirmations: -2,
+            block_hash: None,
+            block_height: None,
+        };
+        assert_eq!(confirmation_status(&info, 6), L1TxStatus::Published);
+    }
+
+    #[test]
+    fn confirmation_status_below_reorg_depth_is_confirmed() {
+        let block_hash = Buf32::new([7u8; 32]);
+        let block_height: L1Height = 100;
+        let info = confirmation_info(3, block_height, block_hash);
+        assert_eq!(
+            confirmation_status(&info, 6),
+            confirmed_status(3, block_height, block_hash),
+        );
+    }
+
+    #[test]
+    fn confirmation_status_at_or_above_reorg_depth_is_finalized() {
+        let block_hash = Buf32::new([7u8; 32]);
+        let block_height: L1Height = 100;
+        let info = confirmation_info(6, block_height, block_hash);
+        assert_eq!(
+            confirmation_status(&info, 6),
+            finalized_status(6, block_height, block_hash),
+        );
     }
 }

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -4,7 +4,7 @@ use tracing::*;
 
 use super::{
     error::{BroadcasterError, BroadcasterResult},
-    io::{BroadcasterIoContext, PublishTxOutcome},
+    io::{BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo},
     state::{BroadcasterState, IndexedEntry},
 };
 use crate::BtcioParams;
@@ -58,7 +58,9 @@ where
 {
     let result = match txentry.status {
         L1TxStatus::Unpublished => publish_tx(io, txentry).await.map(Some),
-        L1TxStatus::Published => probe_published_entry(io, txentry, txid, params).await.map(Some),
+        L1TxStatus::Published => probe_published_entry(io, txentry, txid, params)
+            .await
+            .map(Some),
         L1TxStatus::Confirmed { .. } => check_tx_confirmations(io, txentry, txid, params)
             .await
             .map(Some),
@@ -71,23 +73,18 @@ where
     result
 }
 
-/// Resolves a `Published` entry by combining a confirmation lookup with a
-/// re-publish probe.
+/// Resolves a `Published` entry from a confirmation lookup, falling back to a
+/// re-publish probe only when the lookup actually misses.
 ///
-/// A `Published` entry that gets `Ok(None)` from `gettransaction` could be in
-/// one of two states:
-/// 1. Transient miss: the tx is in mempool but the wallet's chain syncer
-///    hasn't observed it yet. Holding `Published` lets it advance once the
-///    syncer catches up.
-/// 2. Genuinely dropped: the tx was evicted from mempool (fee policy, RBF
-///    conflict, etc.) or never relayed. If we keep holding `Published` the
-///    watcher's `curr_payloadidx` stalls forever.
+/// `gettransaction` returns three distinguishable shapes for a Published entry:
 ///
-/// `gettransaction` alone cannot distinguish these. Re-attempting publication
-/// can: bitcoind responds with `txn-already-in-mempool` (benign, fold to
-/// `Published`) when case 1 holds, and with `bad-txns-inputs-missingorspent`
-/// (mapped to `InvalidInputs`) when the inputs are gone, which lets the
-/// watcher rebuild the envelope.
+/// 1. `Some(info)` with `confirmations >= 1`: tx mined, derive Confirmed/Finalized.
+/// 2. `Some(info)` with `confirmations == 0`: tx alive in mempool. Hold at Published. Re-publishing
+///    here would only spam bitcoind and the logs every poll for the entire pre-confirmation window.
+/// 3. `Ok(None)`: not found at all. Could be a transient wallet-syncer miss for a freshly broadcast
+///    tx, or a genuinely dropped tx (mempool eviction, RBF). Re-publish to disambiguate: benign
+///    mempool messages fold back to Published, `bad-txns-inputs-missingorspent` routes to
+///    InvalidInputs so the watcher rebuilds the envelope.
 async fn probe_published_entry<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -97,22 +94,52 @@ async fn probe_published_entry<C>(
 where
     C: BroadcasterIoContext,
 {
-    let conf_status = check_tx_confirmations(io, txentry, txid, params).await?;
-    // Confirmed/Finalized: lookup found the tx with a block. Done.
-    if !matches!(conf_status, L1TxStatus::Published) {
-        return Ok(conf_status);
-    }
-    // Held at `Published` because lookup returned not-found. Probe via
-    // re-publish. `publish_tx` returns `InvalidInputs` if the inputs are
-    // genuinely gone, which exits the stuck state. Anything else (already in
-    // mempool, freshly accepted, retry-later) keeps us at `Published`.
-    match publish_tx(io, txentry).await? {
-        L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
-        _ => Ok(L1TxStatus::Published),
+    let txinfo_res = io.get_transaction(txid).await;
+    debug!(?txinfo_res, "checked transaction status");
+    let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
+
+    match txinfo_res? {
+        Some(info) if info.confirmations >= 1 => Ok(confirmation_status(&info, reorg_safe_depth)),
+        Some(_) => Ok(L1TxStatus::Published),
+        None => match publish_tx(io, txentry).await? {
+            L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
+            _ => Ok(L1TxStatus::Published),
+        },
     }
 }
 
-/// Resolves `Published`/`Confirmed` entries to their next confirmation-derived status.
+/// Maps a confirmed `TxConfirmationInfo` (`info.confirmations >= 1`) to the
+/// corresponding `Confirmed` or `Finalized` status. Caller must ensure the
+/// `confirmations >= 1` precondition; the block_hash/block_height fields are
+/// only populated by bitcoind once a tx is mined.
+fn confirmation_status(info: &TxConfirmationInfo, reorg_safe_depth: i64) -> L1TxStatus {
+    let block_hash = info.block_hash.expect("confirmed tx must have block_hash");
+    let block_height = info
+        .block_height
+        .expect("confirmed tx must have block_height");
+    let confirmations = info.confirmations as u64;
+    if info.confirmations >= reorg_safe_depth {
+        L1TxStatus::Finalized {
+            confirmations,
+            block_hash,
+            block_height,
+        }
+    } else {
+        L1TxStatus::Confirmed {
+            confirmations,
+            block_hash,
+            block_height,
+        }
+    }
+}
+
+/// Resolves a `Confirmed` entry to its next confirmation-derived status. A
+/// confirmed tx that disappears or drops to 0 confirmations regresses to
+/// `Unpublished` so the broadcaster re-publishes (typical reorg recovery).
+///
+/// Callers in `Published` state must use `probe_published_entry` instead; that
+/// path holds 0-conf and not-found differently to avoid publish/revert
+/// oscillation and unnecessary re-broadcasts.
 async fn check_tx_confirmations<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -125,50 +152,12 @@ where
     async {
         let txinfo_res = io.get_transaction(txid).await;
         debug!(?txinfo_res, "checked transaction status");
+        let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
 
-        let reorg_safe_depth = params.l1_reorg_safe_depth();
-        let reorg_safe_depth: i64 = reorg_safe_depth.into();
-
-        match txinfo_res {
-            Ok(Some(info)) => match (info.confirmations, &txentry.status) {
-                // A `Published` tx with 0 confirmations remains published.
-                (0, L1TxStatus::Published) => Ok(L1TxStatus::Published),
-                // A confirmed tx with 0 confirmations regresses to unpublished.
-                (0, _) => Ok(L1TxStatus::Unpublished),
-                (confirmations, _) => {
-                    let block_hash = info.block_hash.expect("confirmed tx must have block_hash");
-                    let block_height = info
-                        .block_height
-                        .expect("confirmed tx must have block_height");
-
-                    if confirmations >= reorg_safe_depth {
-                        Ok(L1TxStatus::Finalized {
-                            confirmations: confirmations as u64,
-                            block_hash,
-                            block_height,
-                        })
-                    } else {
-                        Ok(L1TxStatus::Confirmed {
-                            confirmations: confirmations as u64,
-                            block_hash,
-                            block_height,
-                        })
-                    }
-                }
-            },
-            // A `gettransaction`-style lookup returns "tx not found" both for
-            // unknown txs and for newly-broadcast txs that the wallet's chain
-            // syncer has not yet observed. Reverting an already-Published entry
-            // to Unpublished on this transient miss creates a publish/revert
-            // oscillation that prevents the entry from ever advancing to
-            // Confirmed (the watcher's curr_payloadidx then stalls). For
-            // entries we know we already published, hold the Published status
-            // and re-check on the next tick.
-            Ok(None) => match &txentry.status {
-                L1TxStatus::Published => Ok(L1TxStatus::Published),
-                _ => Ok(L1TxStatus::Unpublished),
-            },
-            Err(e) => Err(e),
+        match txinfo_res? {
+            Some(info) if info.confirmations == 0 => Ok(L1TxStatus::Unpublished),
+            Some(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
+            None => Ok(L1TxStatus::Unpublished),
         }
     }
     .instrument(debug_span!(
@@ -716,6 +705,32 @@ mod test {
             res,
             Some(L1TxStatus::Published),
             "Published entry whose probe says already-in-mempool must hold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_published_entry_at_zero_conf_does_not_republish() {
+        // A `Published` entry that `gettransaction` reports as 0-conf in the
+        // wallet is alive in mempool and waiting to be mined. Re-publishing
+        // every poll for the entire pre-confirmation window would only spam
+        // bitcoind and the broadcaster logs. The probe must hold at Published
+        // without calling `send_raw_transaction`. We poison the broadcast path
+        // so any re-publish would surface as `InvalidInputs`; the assertion
+        // proves the probe never went down that road.
+        let (e, txid) = entry_with_txid(L1TxStatus::Published);
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default()
+            .with_tx_lookup(
+                txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            )
+            .with_broadcast_result(txid, MockBroadcastResult::InvalidInputs);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::Published),
+            "Published entry found at 0-conf in wallet must hold without re-publishing"
         );
     }
 

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -58,11 +58,10 @@ where
 {
     let result = match txentry.status {
         L1TxStatus::Unpublished => publish_tx(io, txentry).await.map(Some),
-        L1TxStatus::Published | L1TxStatus::Confirmed { .. } => {
-            check_tx_confirmations(io, txentry, txid, params)
-                .await
-                .map(Some)
-        }
+        L1TxStatus::Published => probe_published_entry(io, txentry, txid, params).await.map(Some),
+        L1TxStatus::Confirmed { .. } => check_tx_confirmations(io, txentry, txid, params)
+            .await
+            .map(Some),
         L1TxStatus::Finalized { .. } => Ok(None),
         L1TxStatus::InvalidInputs => Ok(None),
     };
@@ -70,6 +69,47 @@ where
         debug!(?updated_status);
     }
     result
+}
+
+/// Resolves a `Published` entry by combining a confirmation lookup with a
+/// re-publish probe.
+///
+/// A `Published` entry that gets `Ok(None)` from `gettransaction` could be in
+/// one of two states:
+/// 1. Transient miss: the tx is in mempool but the wallet's chain syncer
+///    hasn't observed it yet. Holding `Published` lets it advance once the
+///    syncer catches up.
+/// 2. Genuinely dropped: the tx was evicted from mempool (fee policy, RBF
+///    conflict, etc.) or never relayed. If we keep holding `Published` the
+///    watcher's `curr_payloadidx` stalls forever.
+///
+/// `gettransaction` alone cannot distinguish these. Re-attempting publication
+/// can: bitcoind responds with `txn-already-in-mempool` (benign, fold to
+/// `Published`) when case 1 holds, and with `bad-txns-inputs-missingorspent`
+/// (mapped to `InvalidInputs`) when the inputs are gone, which lets the
+/// watcher rebuild the envelope.
+async fn probe_published_entry<C>(
+    io: &C,
+    txentry: &L1TxEntry,
+    txid: &Txid,
+    params: &BtcioParams,
+) -> BroadcasterResult<L1TxStatus>
+where
+    C: BroadcasterIoContext,
+{
+    let conf_status = check_tx_confirmations(io, txentry, txid, params).await?;
+    // Confirmed/Finalized: lookup found the tx with a block. Done.
+    if !matches!(conf_status, L1TxStatus::Published) {
+        return Ok(conf_status);
+    }
+    // Held at `Published` because lookup returned not-found. Probe via
+    // re-publish. `publish_tx` returns `InvalidInputs` if the inputs are
+    // genuinely gone, which exits the stuck state. Anything else (already in
+    // mempool, freshly accepted, retry-later) keeps us at `Published`.
+    match publish_tx(io, txentry).await? {
+        L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
+        _ => Ok(L1TxStatus::Published),
+    }
 }
 
 /// Resolves `Published`/`Confirmed` entries to their next confirmation-derived status.
@@ -91,9 +131,9 @@ where
 
         match txinfo_res {
             Ok(Some(info)) => match (info.confirmations, &txentry.status) {
-                // A previously published tx with 0 confirmations remains published.
+                // A `Published` tx with 0 confirmations remains published.
                 (0, L1TxStatus::Published) => Ok(L1TxStatus::Published),
-                // A previously confirmed tx with 0 confirmations regresses to unpublished.
+                // A confirmed tx with 0 confirmations regresses to unpublished.
                 (0, _) => Ok(L1TxStatus::Unpublished),
                 (confirmations, _) => {
                     let block_hash = info.block_hash.expect("confirmed tx must have block_hash");
@@ -116,7 +156,18 @@ where
                     }
                 }
             },
-            Ok(None) => Ok(L1TxStatus::Unpublished),
+            // A `gettransaction`-style lookup returns "tx not found" both for
+            // unknown txs and for newly-broadcast txs that the wallet's chain
+            // syncer has not yet observed. Reverting an already-Published entry
+            // to Unpublished on this transient miss creates a publish/revert
+            // oscillation that prevents the entry from ever advancing to
+            // Confirmed (the watcher's curr_payloadidx then stalls). For
+            // entries we know we already published, hold the Published status
+            // and re-check on the next tick.
+            Ok(None) => match &txentry.status {
+                L1TxStatus::Published => Ok(L1TxStatus::Published),
+                _ => Ok(L1TxStatus::Unpublished),
+            },
             Err(e) => Err(e),
         }
     }
@@ -603,6 +654,86 @@ mod test {
                 );
             });
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_handle_published_entry_missing_tx_holds_published() {
+        // Bitcoind's `gettransaction` can briefly report a freshly broadcast
+        // tx as missing before the wallet's chain syncer catches up. A
+        // `Published` entry must not regress to `Unpublished` on that
+        // transient miss; otherwise the broadcaster oscillates and the
+        // watcher's curr_payloadidx never advances past it.
+        let (e, txid) = entry_with_txid(L1TxStatus::Published);
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default().with_tx_lookup(txid, MockTxLookupResult::Missing);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::Published),
+            "Published entry must hold its status when get_transaction returns NotFound"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_published_entry_dropped_from_mempool_advances_to_invalid_inputs() {
+        // A `Published` entry whose lookup says "not found" AND whose
+        // re-publish probe returns `InvalidInputs` (e.g. its inputs were
+        // spent or evicted) must transition to `InvalidInputs` so the
+        // watcher's `determine_payload_next_status` flips the bundle to
+        // `NeedsResign` and the envelope is rebuilt against fresh UTXOs.
+        // Without the publish-probe in `probe_published_entry`, the entry
+        // would stay `Published` forever and the watcher's
+        // `curr_payloadidx` would stall.
+        let (e, txid) = entry_with_txid(L1TxStatus::Published);
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default()
+            .with_tx_lookup(txid, MockTxLookupResult::Missing)
+            .with_broadcast_result(txid, MockBroadcastResult::InvalidInputs);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::InvalidInputs),
+            "Published entry whose re-publish probe returns InvalidInputs must \
+             transition to InvalidInputs so the watcher rebuilds the envelope"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_published_entry_already_in_mempool_holds_published() {
+        // A `Published` entry whose lookup says "not found" but whose
+        // re-publish probe returns `AlreadyInMempool` is in the transient
+        // wallet-syncer-lag state. Stay `Published`; do not regress.
+        let (e, txid) = entry_with_txid(L1TxStatus::Published);
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default()
+            .with_tx_lookup(txid, MockTxLookupResult::Missing)
+            .with_broadcast_result(txid, MockBroadcastResult::AlreadyInMempool);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::Published),
+            "Published entry whose probe says already-in-mempool must hold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_handle_confirmed_entry_missing_tx_regresses_to_unpublished() {
+        // Confirmed entries that go missing on lookup should still regress to
+        // Unpublished so the broadcaster re-publishes (e.g. after a reorg
+        // dropped them from the wallet view).
+        let (e, txid) = entry_with_txid(confirmed_status(1, 1, Buf32::zero()));
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default().with_tx_lookup(txid, MockTxLookupResult::Missing);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::Unpublished),
+            "Confirmed entry that disappears should regress to Unpublished"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -596,7 +596,9 @@ async fn check_commit_and_broadcast_reveals(
                 );
             }
             Err(e)
-                if e.is_missing_or_invalid_input() || matches!(e, ClientError::Server(-22, _)) =>
+                if e.is_rpc_verify_error()
+                    || e.is_rpc_verify_rejected()
+                    || matches!(e, ClientError::Server(-22, _)) =>
             {
                 warn!(
                     envelope_idx,

--- a/crates/chain-worker-new/Cargo.toml
+++ b/crates/chain-worker-new/Cargo.toml
@@ -8,6 +8,7 @@ description = "New chain worker implementation using OL STF and new OL types"
 workspace = true
 
 [dependencies]
+strata-acct-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-db-types.workspace = true
 strata-identifiers.workspace = true

--- a/crates/chain-worker-new/Cargo.toml
+++ b/crates/chain-worker-new/Cargo.toml
@@ -31,4 +31,8 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+strata-db-store-sled.workspace = true
 strata-ol-state-types = { workspace = true, features = ["test-utils"] }
+sled.workspace = true
+threadpool.workspace = true
+typed-sled.workspace = true

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -186,12 +186,7 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
                 ..
             }) if attempted == commitment && last_applied == commitment => {
                 index_inbox_mmr_writes(&self.mmr_index_mgr, output)?;
-                return Err(DbError::BlockIndexingConflict {
-                    epoch,
-                    attempted,
-                    last_applied,
-                }
-                .into());
+                debug!(%commitment, "block indexing already applied; treating as retry");
             }
             Err(e) => return Err(e.into()),
         }
@@ -430,4 +425,110 @@ fn index_inbox_mmr_writes(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use strata_acct_types::{BitcoinAmount, MsgPayload};
+    use strata_db_store_sled::{MmrIndexDb, SledDbConfig};
+    use strata_identifiers::Buf32;
+    use strata_ol_state_support_types::{InboxMessageWrite, IndexerWrites};
+
+    use super::*;
+
+    fn setup_mmr_index_manager() -> MmrIndexManager {
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let sled_db = Arc::new(typed_sled::SledDb::new(db).unwrap());
+        let mmr_db = Arc::new(MmrIndexDb::new(sled_db, SledDbConfig::test()).unwrap());
+        MmrIndexManager::new(threadpool::ThreadPool::new(1), mmr_db)
+    }
+
+    fn message_entry(source_seed: u8, value_sats: u64) -> MessageEntry {
+        let payload = MsgPayload::new(BitcoinAmount::from_sat(value_sats), vec![source_seed]);
+        MessageEntry::new(AccountId::from([source_seed; 32]), 0, payload)
+    }
+
+    fn output_with_inbox_messages(
+        writes: impl IntoIterator<Item = (AccountId, MessageEntry, u64)>,
+    ) -> OLBlockExecutionOutput {
+        let mut indexer_writes = IndexerWrites::new();
+        for (account_id, entry, index) in writes {
+            indexer_writes.push_inbox_message(InboxMessageWrite::new(account_id, entry, index));
+        }
+
+        OLBlockExecutionOutput::new(Buf32::zero(), WriteBatch::default(), indexer_writes)
+    }
+
+    fn assert_mmr_entry(
+        mmr_index_mgr: &MmrIndexManager,
+        account_id: AccountId,
+        index: u64,
+        entry: &MessageEntry,
+    ) {
+        let handle = mmr_index_mgr.get_handle(MmrId::SnarkMsgInbox(account_id));
+        let expected_hash: Hash = <MessageEntry as TreeHash>::tree_hash_root(entry).into();
+
+        assert_eq!(
+            handle.get_leaf_blocking(index).unwrap(),
+            Some(expected_hash)
+        );
+        assert_eq!(handle.get_blocking(index).unwrap(), entry.as_ssz_bytes());
+    }
+
+    #[test]
+    fn index_inbox_mmr_writes_stores_expected_leaves_and_preimages() {
+        let mmr_index_mgr = setup_mmr_index_manager();
+        let account_one = AccountId::from([1u8; 32]);
+        let account_two = AccountId::from([2u8; 32]);
+        let entry_one = message_entry(10, 100);
+        let entry_two = message_entry(11, 200);
+        let entry_three = message_entry(12, 300);
+        let output = output_with_inbox_messages([
+            (account_one, entry_one.clone(), 0),
+            (account_one, entry_two.clone(), 1),
+            (account_two, entry_three.clone(), 0),
+        ]);
+
+        index_inbox_mmr_writes(&mmr_index_mgr, &output).unwrap();
+
+        assert_eq!(
+            mmr_index_mgr
+                .get_handle(MmrId::SnarkMsgInbox(account_one))
+                .get_num_leaves_blocking()
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            mmr_index_mgr
+                .get_handle(MmrId::SnarkMsgInbox(account_two))
+                .get_num_leaves_blocking()
+                .unwrap(),
+            1
+        );
+        assert_mmr_entry(&mmr_index_mgr, account_one, 0, &entry_one);
+        assert_mmr_entry(&mmr_index_mgr, account_one, 1, &entry_two);
+        assert_mmr_entry(&mmr_index_mgr, account_two, 0, &entry_three);
+    }
+
+    #[test]
+    fn index_inbox_mmr_writes_is_idempotent() {
+        let mmr_index_mgr = setup_mmr_index_manager();
+        let account_id = AccountId::from([3u8; 32]);
+        let entry_one = message_entry(13, 400);
+        let entry_two = message_entry(14, 500);
+        let output = output_with_inbox_messages([
+            (account_id, entry_one.clone(), 0),
+            (account_id, entry_two.clone(), 1),
+        ]);
+
+        index_inbox_mmr_writes(&mmr_index_mgr, &output).unwrap();
+        index_inbox_mmr_writes(&mmr_index_mgr, &output).unwrap();
+
+        let handle = mmr_index_mgr.get_handle(MmrId::SnarkMsgInbox(account_id));
+        assert_eq!(handle.get_num_leaves_blocking().unwrap(), 2);
+        assert_mmr_entry(&mmr_index_mgr, account_id, 0, &entry_one);
+        assert_mmr_entry(&mmr_index_mgr, account_id, 1, &entry_two);
+    }
 }

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -6,19 +6,23 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use ssz::Encode;
+use strata_acct_types::{MessageEntry, tree_hash::TreeHash};
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::{
     errors::DbError,
     ol_state_index::{AccountUpdateMeta, AccountUpdateRecord, InboxMessageRecord, IndexingWrites},
 };
-use strata_identifiers::{AccountId, OLBlockCommitment, OLBlockId};
+use strata_identifiers::{AccountId, Hash, OLBlockCommitment, OLBlockId};
 use strata_node_context::NodeContext;
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
 use strata_ol_state_types::{OLAccountState, OLState, WriteBatch};
 use strata_params::Params;
 use strata_primitives::epoch::EpochCommitment;
 use strata_status::StatusChannel;
-use strata_storage::{OLBlockManager, OLCheckpointManager, OLStateIndexingManager, OLStateManager};
+use strata_storage::{
+    MmrId, MmrIndexManager, OLBlockManager, OLCheckpointManager, OLStateIndexingManager,
+    OLStateManager,
+};
 use tokio::{runtime::Handle, sync::watch};
 use tracing::debug;
 
@@ -50,6 +54,9 @@ pub struct ChainWorkerContextImpl {
     /// Manager for OL state indexing data (per-block writes, epoch finalization).
     ol_state_indexing_mgr: Arc<OLStateIndexingManager>,
 
+    /// Manager for append-only MMR proof indices.
+    mmr_index_mgr: Arc<MmrIndexManager>,
+
     /// Status channel to send/receive messages.
     status_channel: Arc<StatusChannel>,
 
@@ -72,6 +79,7 @@ impl ChainWorkerContextImpl {
             ol_state_mgr: nodectx.storage().ol_state().clone(),
             ol_checkpoint_mgr: nodectx.storage().ol_checkpoint().clone(),
             ol_state_indexing_mgr: nodectx.storage().ol_state_indexing().clone(),
+            mmr_index_mgr: nodectx.storage().mmr_index().clone(),
             status_channel: nodectx.status_channel().clone(),
             epoch_summary_tx,
             params: nodectx.params().clone(),
@@ -165,8 +173,28 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
             .put_write_batch_blocking(commitment, wb.clone())?;
 
         let writes = build_indexing_writes(commitment, output);
-        self.ol_state_indexing_mgr
-            .apply_block_indexing_blocking(epoch, commitment, writes)?;
+        match self
+            .ol_state_indexing_mgr
+            .apply_block_indexing_blocking(epoch, commitment, writes)
+        {
+            Ok(()) => {
+                index_inbox_mmr_writes(&self.mmr_index_mgr, output)?;
+            }
+            Err(DbError::BlockIndexingConflict {
+                attempted,
+                last_applied,
+                ..
+            }) if attempted == commitment && last_applied == commitment => {
+                index_inbox_mmr_writes(&self.mmr_index_mgr, output)?;
+                return Err(DbError::BlockIndexingConflict {
+                    epoch,
+                    attempted,
+                    last_applied,
+                }
+                .into());
+            }
+            Err(e) => return Err(e.into()),
+        }
 
         Ok(())
     }
@@ -345,4 +373,61 @@ fn build_indexing_writes(
     }
 
     IndexingWrites::new(created_accounts, account_updates, account_inbox_writes)
+}
+
+/// Applies snark inbox writes to the MMR proof index.
+///
+/// The OL state itself stores the compact MMR root/peaks. Block assembly needs
+/// historical nodes from [`MmrIndexManager`] to generate proofs for later snark
+/// account updates, so the chain worker mirrors each accepted inbox append into
+/// the proof index. The operation is idempotent for crash-restart retries.
+fn index_inbox_mmr_writes(
+    mmr_index_mgr: &MmrIndexManager,
+    output: &OLBlockExecutionOutput,
+) -> WorkerResult<()> {
+    for write in output.indexer_writes().inbox_messages() {
+        let expected_hash: Hash = <MessageEntry as TreeHash>::tree_hash_root(write.entry()).into();
+        let entry_bytes = write.entry().as_ssz_bytes();
+        let handle = mmr_index_mgr.get_handle(MmrId::SnarkMsgInbox(write.account_id()));
+        let leaf_count = handle.get_num_leaves_blocking()?;
+
+        if write.index() < leaf_count {
+            let Some(existing_hash) = handle.get_leaf_blocking(write.index())? else {
+                return Err(
+                    DbError::MmrLeafNotFoundForAccount(write.index(), write.account_id()).into(),
+                );
+            };
+
+            if existing_hash != expected_hash {
+                return Err(DbError::MmrLeafHashMismatch {
+                    idx: write.index(),
+                    expected: expected_hash,
+                    got: existing_hash,
+                }
+                .into());
+            }
+
+            continue;
+        }
+
+        if write.index() > leaf_count {
+            return Err(DbError::MmrIndexOutOfRange {
+                requested: write.index(),
+                cur: leaf_count,
+            }
+            .into());
+        }
+
+        let appended_idx = handle.append_leaf_with_preimage_blocking(expected_hash, entry_bytes)?;
+        if appended_idx != write.index() {
+            return Err(WorkerError::Unexpected(format!(
+                "snark inbox MMR append index mismatch for account {}: expected {}, got {}",
+                write.account_id(),
+                write.index(),
+                appended_idx
+            )));
+        }
+    }
+
+    Ok(())
 }

--- a/crates/db/store-sled/src/asm/db.rs
+++ b/crates/db/store-sled/src/asm/db.rs
@@ -44,17 +44,8 @@ impl AsmDatabase for AsmDBSled {
 
     fn get_latest_asm_state(&self) -> DbResult<Option<(L1BlockCommitment, AsmState)>> {
         // Relying on the lexicographical order of L1BlockCommitment.
-        let state = self.asm_state_tree.last()?;
-        let logs = self.asm_log_tree.last()?;
-
-        match (state, logs) {
-            (Some((state_block, state)), Some((logs_block, logs))) if state_block == logs_block => {
-                Ok(Some((state_block, AsmState::new(state, logs))))
-            }
+        match (self.asm_state_tree.last()?, self.asm_log_tree.last()?) {
             (Some((state_block, _)), Some((logs_block, _))) => {
-                // The state and log entries are written in one transaction, but this method reads
-                // the two trees separately. A concurrent append can commit between those reads, so
-                // fall back to the latest block that both trees had to contain when observed.
                 let latest_common_block = state_block.min(logs_block);
                 Ok(self
                     .get_asm_state(latest_common_block)?

--- a/crates/db/store-sled/src/asm/db.rs
+++ b/crates/db/store-sled/src/asm/db.rs
@@ -47,14 +47,21 @@ impl AsmDatabase for AsmDBSled {
         let state = self.asm_state_tree.last()?;
         let logs = self.asm_log_tree.last()?;
 
-        // Assert that the block for the state and for the logs is the same.
-        // It should be because we are putting it within transaction.
-        Ok(state.and_then(|s| {
-            logs.map(|l| {
-                assert_eq!(s.0, l.0);
-                (s.0, AsmState::new(s.1, l.1))
-            })
-        }))
+        match (state, logs) {
+            (Some((state_block, state)), Some((logs_block, logs))) if state_block == logs_block => {
+                Ok(Some((state_block, AsmState::new(state, logs))))
+            }
+            (Some((state_block, _)), Some((logs_block, _))) => {
+                // The state and log entries are written in one transaction, but this method reads
+                // the two trees separately. A concurrent append can commit between those reads, so
+                // fall back to the latest block that both trees had to contain when observed.
+                let latest_common_block = state_block.min(logs_block);
+                Ok(self
+                    .get_asm_state(latest_common_block)?
+                    .map(|state| (latest_common_block, state)))
+            }
+            _ => Ok(None),
+        }
     }
 
     fn get_asm_states_from(

--- a/crates/storage/src/managers/mmr_index.rs
+++ b/crates/storage/src/managers/mmr_index.rs
@@ -308,6 +308,25 @@ impl MmrIndexHandle {
         })
     }
 
+    /// Appends a caller-provided leaf hash and stores its preimage bytes.
+    pub fn append_leaf_with_preimage_blocking(
+        &self,
+        hash: Hash,
+        preimage: Vec<u8>,
+    ) -> DbResult<u64> {
+        run_with_precondition_retries(self.max_retries, || {
+            self.append_leaf_once_blocking(hash, Some(preimage.clone()))
+        })
+    }
+
+    /// Appends a caller-provided leaf hash and stores its preimage bytes.
+    pub async fn append_leaf_with_preimage(&self, hash: Hash, preimage: Vec<u8>) -> DbResult<u64> {
+        let this = self.clone();
+        spawn_blocking(move || this.append_leaf_with_preimage_blocking(hash, preimage))
+            .await
+            .map_err(|_| DbError::WorkerFailedStrangely)?
+    }
+
     /// Appends a preimage and stores it as bytes in the preimage table.
     pub fn append_blocking(&self, preimage: Vec<u8>) -> DbResult<u64> {
         self.append_with_hasher_blocking::<Sha256Hasher>(preimage)


### PR DESCRIPTION
Three production-code fixes that surfaced building the real-bridge E2E test ([#1699](https://github.com/alpenlabs/alpen/pull/1699)), plus the bridge indexing fixes needed for the full deposit -> withdrawal path. Each is independently load-bearing: revert any one and the test stalls in a different place.

| File | Bug | Fix |
|---|---|---|
| `alpen-ee/sequencer/src/block_builder/task.rs` | `get_inbox_messages` was called with `from_slot = last_local_block.ol_block().slot()`, range inclusive on both ends. Successive EE batches re-included the OL inbox slot the previous batch already drained. SAU shipped with `processed_messages.len() = 1` and unchanged `next_inbox_msg_idx`; block-assembly rejected with `expected 2, got 1`. seq_no=0 applied, every later SAU starved. | Start at `last_consumed_slot + 1`. Pick a monotonic `effective_ol_block` for the exec record so the OL commitment never regresses during restart catch-up, finalization lag, or reorg. |
| `btcio/src/broadcaster/io.rs` | Every `Server(-25, _)` was folded to `AlreadyInMempool`. Bitcoind reuses -25 for several reject reasons; `bad-txns-inputs-missingorspent` (input UTXO gone) was being treated as benign and entries pinned at `Published`. ASM checkpoint validation stalled at epoch 4 of ~160. | `is_benign_minus25_message` matches the hyphenated tokens bitcoind emits (`already-in-mempool`, `already-known`, `already-in-block-chain`). Everything else under -25 routes to `InvalidInputs`. |
| `btcio/src/broadcaster/processor.rs` | `Published` entries had two failure modes: `Ok(None)` from `gettransaction` regressed them to `Unpublished` (publish/revert oscillation pinning the watcher), and the broadcaster never re-called `send_raw_transaction` on stuck-Published, so genuinely-dropped txs stayed `Published` forever. | Hold `Published` across a transient lookup miss. New `probe_published_entry` runs the confirmation lookup and re-attempts publication only on actual not-found; `Some(info)` at 0-conf holds without re-publishing. `InvalidInputs` from the probe routes the entry so the watcher rebuilds. |
| `chain-worker-new`, `storage/mmr_index`, `strata RPC block summaries`, `alpen-client/prover/spec_acct.rs` | Snark inbox messages were present in OL state, but their MMR preimages were not indexed for the prover path. The block-summary RPC also reported proof-state `next_inbox_msg_idx`, which can lag the inbox accumulator count after new inbox inserts. That lets the prover assemble an inconsistent deposit-processing input. | Index snark inbox MMR writes when storing block output, add MMR leaf preimage append helpers, report the inbox accumulator entry count from block summaries, and guard the client prover against inconsistent pre-inbox indices with a transient retryable failure. |
| `alpen-ee/sequencer/src/ol_chain_tracker/state.rs` | Pruning tracked OL blocks could drop the base block's `next_inbox_msg_idx`, causing later inbox fetch ranges to restart from the wrong base. | Preserve `base_block_next_inbox_msg_idx` across prune cases, including the empty-after-prune path. |
| `db/store-sled/src/asm/db.rs` | `get_latest_asm_state` asserted when a concurrent read saw latest state metadata before the matching state row. | Fall back through common-block state lookups instead of asserting. |

Covered by focused unit tests in `broadcaster::{io,processor}`, Strata RPC block summaries, storage, chain-worker, ASM sled DB, and EE sequencer OL tracker state.

## Local verification

- [x] `git diff --check HEAD`
- [x] `cargo test -p strata --bin strata blocks_summaries_reports_inbox_accumulator_count`
- [x] `cargo test -p strata-storage`
- [x] `cargo test -p strata-chain-worker-new`
- [x] `cargo test -p strata-db-store-sled asm::db::tests::test_get_asm`
- [x] `cargo test -p alpen-ee-sequencer ol_chain_tracker::state`

## AI Assistance

Bug-chain debugging, code review, implementation, and this description.
