### PR TITLE
(alpen-ee): Use correct bridge gateway account in sequencer config

### DIFF
--- a/crates/alpen-ee/sequencer/src/block_builder/config.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/config.rs
@@ -7,7 +7,8 @@ const DEFAULT_BLOCKTIME_MS: u64 = 5_000;
 /// Default number of deposits to process per ee block.
 const DEFAULT_DEPOSITS_PER_BLOCK: NonZeroU8 = NonZeroU8::new(16).expect("16 is always NonZero");
 /// Default bridge gateway account on OL.
-const DEFAULT_BRIDGE_GATEWAY_ACCOUNT: AccountId = AccountId::special(1); // TODO: correct account id
+// TODO(STR-3358): Don't hardcode here
+const DEFAULT_BRIDGE_GATEWAY_ACCOUNT: AccountId = AccountId::special(0x10);
 /// Default time to wait on errors during block building.
 const DEFAULT_ERROR_BACKOFF_MS: u64 = 100;
 


### PR DESCRIPTION
## Description

Use correct bridge gateway account(`0x10`) instead of incorrect value (`1`) being used.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
