### PR TITLE
feat(btcio): add RBF fee bumping for writer transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15652,6 +15652,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2",
  "strata-asm-checkpoint-types",
  "strata-asm-common",
  "strata-checkpoint-types",

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -26,12 +26,13 @@ mod service_executor;
 mod services;
 
 #[cfg(feature = "sequencer")]
-use std::time::Duration;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::{
     env, fs,
     path::{Path, PathBuf},
     process,
     sync::Arc,
+    time::Duration,
 };
 
 use alpen_chainspec::{
@@ -73,6 +74,8 @@ use bitcoind_async_client::{
     Auth, Client as BtcClient,
 };
 use clap::{ArgAction, Parser};
+#[cfg(feature = "sequencer")]
+use eyre::eyre;
 use eyre::Context;
 use reth_chainspec::ChainSpec;
 use reth_cli_commands::{launcher::FnLauncher, node::NodeCommand};
@@ -89,8 +92,8 @@ use strata_btcio::{
 use strata_common::healthz::{start_health_check_server, HealthCheckState};
 #[cfg(feature = "sequencer")]
 use strata_config::btcio::{
-    fee_rate_from_sat_per_vb, fee_rate_to_sat_per_vb, FeePolicy, L1FeePolicyConfig,
-    MempoolExplorerFeePolicy, WriterConfig,
+    fee_rate_from_sat_per_vb, fee_rate_to_sat_per_vb, FeeBumpingConfig, FeePolicy,
+    L1FeePolicyConfig, MempoolExplorerFeePolicy, WriterConfig,
 };
 use strata_identifiers::{EpochCommitment, OLBlockId};
 use strata_l1_txfmt::MagicBytes;
@@ -679,15 +682,14 @@ fn main() {
                 })?;
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(
                     btc_client.clone(),
-                    writer_config,
+                    writer_config.clone(),
                     btcio_params,
-                    sequencer_address,
+                    sequencer_address.clone(),
                     sequencer_keypair,
-                    envelope_ops,
+                    envelope_ops.clone(),
                     broadcast_handle.clone(),
                 )
                 .map_err(|e| eyre::eyre!("creating chunked envelope task: {e}"))?;
-
                 let header_summary =
                     Arc::new(RethHeaderSummaryProvider::new(node.provider.clone()));
 
@@ -712,7 +714,6 @@ fn main() {
                     envelope_watcher_task
                         .instrument(info_span!("chunked_envelope_watcher", component = "alpen")),
                 );
-
                 info!(target: "alpen-client", component = "alpen", "btcio DA pipeline started");
 
                 // EE chunk + acct paas provers. Both use SP1 remote
@@ -1093,6 +1094,36 @@ pub struct AdditionalConfig {
     #[arg(long, required = false)]
     pub batch_event_channel_capacity: Option<usize>,
 
+    /// Minimum time between BTCIO replacement passes, in ms.
+    #[arg(long, default_value_t = NonZeroU64::new(30_000).expect("nonzero default"))]
+    pub btcio_fee_bumping_check_interval_ms: NonZeroU64,
+
+    /// L1 block age before a published BTCIO transaction is considered stale.
+    #[arg(long, default_value_t = NonZeroU32::new(2).expect("nonzero default"))]
+    pub btcio_fee_bumping_min_age_blocks: NonZeroU32,
+
+    /// Maximum broadcast attempts for one BTCIO fee-bump node.
+    #[arg(long, default_value_t = NonZeroU32::new(5).expect("nonzero default"))]
+    pub btcio_fee_bumping_max_attempts: NonZeroU32,
+
+    /// Minimum multiplicative BTCIO fee bump in basis points.
+    ///
+    /// Not a `NonZero`: the meaningful floor is 10_000, which `FeeBumpingConfig::validate` checks.
+    #[arg(long, default_value_t = 12_500)]
+    pub btcio_fee_bumping_multiplier_bps: u32,
+
+    /// Minimum additive BTCIO fee-rate bump in sat/vB.
+    #[arg(long, default_value_t = NonZeroU64::new(1).expect("nonzero default"))]
+    pub btcio_fee_bumping_min_delta_sat_vb: NonZeroU64,
+
+    /// Maximum BTCIO replacement fee rate in sat/vB.
+    #[arg(long, default_value_t = NonZeroU64::new(1_000).expect("nonzero default"))]
+    pub btcio_fee_bumping_max_fee_rate_sat_vb: NonZeroU64,
+
+    /// Maximum absolute fee headroom funded into each BTCIO reveal transaction.
+    #[arg(long, default_value_t = NonZeroU64::new(10_000_000).expect("nonzero default"))]
+    pub btcio_fee_bumping_max_reveal_fee_headroom_sats: NonZeroU64,
+
     /// Use the zkaleido `NativeHost` for the EE chunk + acct provers
     /// instead of the SP1 remote host.
     ///
@@ -1173,6 +1204,53 @@ impl AdditionalConfig {
             _ => Some("trace"),
         }
     }
+
+    /// Builds the BTCIO fee-bumping config from CLI flags.
+    #[cfg(feature = "sequencer")]
+    fn btcio_fee_bumping_config(&self) -> eyre::Result<FeeBumpingConfig> {
+        // Zero is rejected by clap at parse time, which names the offending flag. Only the
+        // cross-field rule is left to check here.
+        let config = FeeBumpingConfig {
+            check_interval_ms: self.btcio_fee_bumping_check_interval_ms,
+            min_age_blocks: self.btcio_fee_bumping_min_age_blocks,
+            max_attempts: self.btcio_fee_bumping_max_attempts,
+            multiplier_bps: self.btcio_fee_bumping_multiplier_bps,
+            min_fee_rate_delta_sat_vb: self.btcio_fee_bumping_min_delta_sat_vb,
+            max_fee_rate_sat_vb: self.btcio_fee_bumping_max_fee_rate_sat_vb,
+            max_reveal_fee_headroom_sats: self.btcio_fee_bumping_max_reveal_fee_headroom_sats,
+        };
+        config
+            .validate()
+            .map_err(|err| eyre!("invalid BTCIO fee bumping config: {err}"))?;
+        Ok(config)
+    }
+}
+
+#[cfg(feature = "sequencer")]
+fn sequencer_privkey_from_env(sequencer_enabled: bool) -> eyre::Result<Option<Buf32>> {
+    if !sequencer_enabled {
+        return Ok(None);
+    }
+
+    let privkey_str = env::var("SEQUENCER_PRIVATE_KEY").map_err(|_| {
+        eyre::eyre!(
+            "SEQUENCER_PRIVATE_KEY environment variable is required when running with --sequencer"
+        )
+    })?;
+
+    let privkey = privkey_str
+        .parse::<Buf32>()
+        .map_err(|e| eyre::eyre!("Failed to parse SEQUENCER_PRIVATE_KEY as hex: {e}"))?;
+
+    Ok(Some(privkey))
+}
+
+#[cfg(feature = "sequencer")]
+fn sequencer_bitcoin_keypair(privkey: &Buf32) -> eyre::Result<Keypair> {
+    let secret_key =
+        SecretKey::from_slice(privkey.as_ref()).context("invalid sequencer private key")?;
+    let secp = Secp256k1::signing_only();
+    Ok(Keypair::from_secret_key(&secp, &secret_key))
 }
 
 /// Loads Alpen EE chain params from a JSON file.
@@ -1484,32 +1562,6 @@ fn parse_magic_bytes(s: &str) -> eyre::Result<MagicBytes> {
         .map_err(|e| eyre::eyre!("Failed to parse magic bytes: {e}"))
 }
 
-#[cfg(feature = "sequencer")]
-fn sequencer_privkey_from_env(sequencer_enabled: bool) -> eyre::Result<Option<Buf32>> {
-    if !sequencer_enabled {
-        return Ok(None);
-    }
-
-    let privkey_str = env::var("SEQUENCER_PRIVATE_KEY").map_err(|_| {
-        eyre::eyre!(
-            "SEQUENCER_PRIVATE_KEY environment variable is required when running with --sequencer"
-        )
-    })?;
-
-    let privkey = privkey_str
-        .parse::<Buf32>()
-        .map_err(|e| eyre::eyre!("Failed to parse SEQUENCER_PRIVATE_KEY as hex: {e}"))?;
-
-    Ok(Some(privkey))
-}
-
-#[cfg(feature = "sequencer")]
-fn sequencer_bitcoin_keypair(privkey: &Buf32) -> eyre::Result<Keypair> {
-    let sk = SecretKey::from_slice(privkey.as_ref()).context("invalid sequencer private key")?;
-    let secp = Secp256k1::signing_only();
-    Ok(Keypair::from_secret_key(&secp, &sk))
-}
-
 // Mirrors `bitcoind-async-client`'s upstream defaults.
 #[cfg(feature = "sequencer")]
 const DEFAULT_BTCIO_RETRY_COUNT: u16 = 3;
@@ -1584,6 +1636,7 @@ fn resolve_writer_config(ext: &AdditionalConfig) -> eyre::Result<WriterConfig> {
     };
     Ok(WriterConfig {
         l1_fee_policy_config: L1FeePolicyConfig::new(fee_policy),
+        fee_bumping: ext.btcio_fee_bumping_config()?,
         ..WriterConfig::default()
     })
 }

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -26,12 +26,13 @@ mod service_executor;
 mod services;
 
 #[cfg(feature = "sequencer")]
-use std::time::Duration;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::{
     env, fs,
     path::{Path, PathBuf},
     process,
     sync::Arc,
+    time::Duration,
 };
 
 use alpen_chainspec::{
@@ -73,6 +74,8 @@ use bitcoind_async_client::{
     Auth, Client as BtcClient,
 };
 use clap::{ArgAction, Parser};
+#[cfg(feature = "sequencer")]
+use eyre::eyre;
 use eyre::Context;
 use reth_chainspec::ChainSpec;
 use reth_cli_commands::{launcher::FnLauncher, node::NodeCommand};
@@ -89,8 +92,8 @@ use strata_btcio::{
 use strata_common::healthz::{start_health_check_server, HealthCheckState};
 #[cfg(feature = "sequencer")]
 use strata_config::btcio::{
-    fee_rate_from_sat_per_vb, fee_rate_to_sat_per_vb, FeePolicy, L1FeePolicyConfig,
-    MempoolExplorerFeePolicy, WriterConfig,
+    fee_rate_from_sat_per_vb, fee_rate_to_sat_per_vb, FeeBumpingConfig, FeePolicy,
+    L1FeePolicyConfig, MempoolExplorerFeePolicy, WriterConfig,
 };
 use strata_identifiers::{EpochCommitment, OLBlockId};
 use strata_l1_txfmt::MagicBytes;
@@ -679,15 +682,14 @@ fn main() {
                 })?;
                 let (envelope_handle, envelope_watcher_task) = create_chunked_envelope_task(
                     btc_client.clone(),
-                    writer_config,
+                    writer_config.clone(),
                     btcio_params,
-                    sequencer_address,
+                    sequencer_address.clone(),
                     sequencer_keypair,
-                    envelope_ops,
+                    envelope_ops.clone(),
                     broadcast_handle.clone(),
                 )
                 .map_err(|e| eyre::eyre!("creating chunked envelope task: {e}"))?;
-
                 let header_summary =
                     Arc::new(RethHeaderSummaryProvider::new(node.provider.clone()));
 
@@ -712,7 +714,6 @@ fn main() {
                     envelope_watcher_task
                         .instrument(info_span!("chunked_envelope_watcher", component = "alpen")),
                 );
-
                 info!(target: "alpen-client", component = "alpen", "btcio DA pipeline started");
 
                 // EE chunk + acct paas provers. Both use SP1 remote
@@ -1093,6 +1094,43 @@ pub struct AdditionalConfig {
     #[arg(long, required = false)]
     pub batch_event_channel_capacity: Option<usize>,
 
+    /// Minimum time between BTCIO replacement passes, in ms.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = NonZeroU64::new(30_000).expect("nonzero default"))]
+    pub btcio_fee_bumping_check_interval_ms: NonZeroU64,
+
+    /// L1 block age before a published BTCIO transaction is considered stale.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = NonZeroU32::new(2).expect("nonzero default"))]
+    pub btcio_fee_bumping_min_age_blocks: NonZeroU32,
+
+    /// Maximum broadcast attempts for one BTCIO fee-bump node.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = NonZeroU32::new(5).expect("nonzero default"))]
+    pub btcio_fee_bumping_max_attempts: NonZeroU32,
+
+    /// Minimum multiplicative BTCIO fee bump in basis points.
+    ///
+    /// Not a `NonZero`: the meaningful floor is 10_000, which `FeeBumpingConfig::validate` checks.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = 12_500)]
+    pub btcio_fee_bumping_multiplier_bps: u32,
+
+    /// Minimum additive BTCIO fee-rate bump in sat/vB.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = NonZeroU64::new(1).expect("nonzero default"))]
+    pub btcio_fee_bumping_min_delta_sat_vb: NonZeroU64,
+
+    /// Maximum BTCIO replacement fee rate in sat/vB.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = NonZeroU64::new(1_000).expect("nonzero default"))]
+    pub btcio_fee_bumping_max_fee_rate_sat_vb: NonZeroU64,
+
+    /// Maximum absolute fee headroom funded into each BTCIO reveal transaction.
+    #[cfg(feature = "sequencer")]
+    #[arg(long, default_value_t = NonZeroU64::new(10_000_000).expect("nonzero default"))]
+    pub btcio_fee_bumping_max_reveal_fee_headroom_sats: NonZeroU64,
+
     /// Use the zkaleido `NativeHost` for the EE chunk + acct provers
     /// instead of the SP1 remote host.
     ///
@@ -1173,6 +1211,53 @@ impl AdditionalConfig {
             _ => Some("trace"),
         }
     }
+
+    /// Builds the BTCIO fee-bumping config from CLI flags.
+    #[cfg(feature = "sequencer")]
+    fn btcio_fee_bumping_config(&self) -> eyre::Result<FeeBumpingConfig> {
+        // Zero is rejected by clap at parse time, which names the offending flag. Only the
+        // cross-field rule is left to check here.
+        let config = FeeBumpingConfig {
+            check_interval_ms: self.btcio_fee_bumping_check_interval_ms,
+            min_age_blocks: self.btcio_fee_bumping_min_age_blocks,
+            max_attempts: self.btcio_fee_bumping_max_attempts,
+            multiplier_bps: self.btcio_fee_bumping_multiplier_bps,
+            min_fee_rate_delta_sat_vb: self.btcio_fee_bumping_min_delta_sat_vb,
+            max_fee_rate_sat_vb: self.btcio_fee_bumping_max_fee_rate_sat_vb,
+            max_reveal_fee_headroom_sats: self.btcio_fee_bumping_max_reveal_fee_headroom_sats,
+        };
+        config
+            .validate()
+            .map_err(|err| eyre!("invalid BTCIO fee bumping config: {err}"))?;
+        Ok(config)
+    }
+}
+
+#[cfg(feature = "sequencer")]
+fn sequencer_privkey_from_env(sequencer_enabled: bool) -> eyre::Result<Option<Buf32>> {
+    if !sequencer_enabled {
+        return Ok(None);
+    }
+
+    let privkey_str = env::var("SEQUENCER_PRIVATE_KEY").map_err(|_| {
+        eyre::eyre!(
+            "SEQUENCER_PRIVATE_KEY environment variable is required when running with --sequencer"
+        )
+    })?;
+
+    let privkey = privkey_str
+        .parse::<Buf32>()
+        .map_err(|e| eyre::eyre!("Failed to parse SEQUENCER_PRIVATE_KEY as hex: {e}"))?;
+
+    Ok(Some(privkey))
+}
+
+#[cfg(feature = "sequencer")]
+fn sequencer_bitcoin_keypair(privkey: &Buf32) -> eyre::Result<Keypair> {
+    let secret_key =
+        SecretKey::from_slice(privkey.as_ref()).context("invalid sequencer private key")?;
+    let secp = Secp256k1::signing_only();
+    Ok(Keypair::from_secret_key(&secp, &secret_key))
 }
 
 /// Loads Alpen EE chain params from a JSON file.
@@ -1484,32 +1569,6 @@ fn parse_magic_bytes(s: &str) -> eyre::Result<MagicBytes> {
         .map_err(|e| eyre::eyre!("Failed to parse magic bytes: {e}"))
 }
 
-#[cfg(feature = "sequencer")]
-fn sequencer_privkey_from_env(sequencer_enabled: bool) -> eyre::Result<Option<Buf32>> {
-    if !sequencer_enabled {
-        return Ok(None);
-    }
-
-    let privkey_str = env::var("SEQUENCER_PRIVATE_KEY").map_err(|_| {
-        eyre::eyre!(
-            "SEQUENCER_PRIVATE_KEY environment variable is required when running with --sequencer"
-        )
-    })?;
-
-    let privkey = privkey_str
-        .parse::<Buf32>()
-        .map_err(|e| eyre::eyre!("Failed to parse SEQUENCER_PRIVATE_KEY as hex: {e}"))?;
-
-    Ok(Some(privkey))
-}
-
-#[cfg(feature = "sequencer")]
-fn sequencer_bitcoin_keypair(privkey: &Buf32) -> eyre::Result<Keypair> {
-    let sk = SecretKey::from_slice(privkey.as_ref()).context("invalid sequencer private key")?;
-    let secp = Secp256k1::signing_only();
-    Ok(Keypair::from_secret_key(&secp, &sk))
-}
-
 // Mirrors `bitcoind-async-client`'s upstream defaults.
 #[cfg(feature = "sequencer")]
 const DEFAULT_BTCIO_RETRY_COUNT: u16 = 3;
@@ -1584,6 +1643,7 @@ fn resolve_writer_config(ext: &AdditionalConfig) -> eyre::Result<WriterConfig> {
     };
     Ok(WriterConfig {
         l1_fee_policy_config: L1FeePolicyConfig::new(fee_policy),
+        fee_bumping: ext.btcio_fee_bumping_config()?,
         ..WriterConfig::default()
     })
 }

--- a/bin/strata-dbtool/src/cmd/broadcaster.rs
+++ b/bin/strata-dbtool/src/cmd/broadcaster.rs
@@ -64,6 +64,7 @@ pub(crate) fn get_broadcaster_summary(
                 L1TxStatus::Confirmed { .. } => confirmed_count += 1,
                 L1TxStatus::Finalized { .. } => finalized_count += 1,
                 L1TxStatus::InvalidInputs => invalid_inputs_count += 1,
+                L1TxStatus::Replaced { .. } => {}
             }
         }
     }

--- a/bin/strata-test-cli/src/cmd/post_ee_da_envelope.rs
+++ b/bin/strata-test-cli/src/cmd/post_ee_da_envelope.rs
@@ -145,6 +145,7 @@ fn build_and_post_ee_da_envelope(args: PostEeDaEnvelopeArgs) -> anyhow::Result<S
         NETWORK,
         fee_rate,
         DEFAULT_REVEAL_AMOUNT_SATS,
+        Default::default(),
         None,
     );
 

--- a/crates/alpen-ee/da/provider/src/envelope_provider.rs
+++ b/crates/alpen-ee/da/provider/src/envelope_provider.rs
@@ -6,7 +6,7 @@ use alpen_ee_common::{BatchDaProvider, BatchId, DaStatus, L1DaBlockInfo, L1DaBlo
 use alpen_ee_da_types::{wtxids_root_from_txs, DA_BLOB_VERSION, EE_DA_MAGIC_BYTES};
 use alpen_ee_database::BroadcastDbOps;
 use async_trait::async_trait;
-use bitcoin::{Block, BlockHash, Txid, Wtxid};
+use bitcoin::{hashes::Hash, Block, BlockHash, Txid, Wtxid};
 use bitcoind_async_client::{traits::Reader, Client as BtcClient};
 use eyre::{bail, ensure};
 use strata_btc_types::{BlockHashExt, Buf32BitcoinExt};
@@ -263,7 +263,7 @@ impl ChunkedEnvelopeDaProvider {
         // first; reveals follow in ascending vout order.
         let mut refs: Vec<L1DaBlockRef> = Vec::with_capacity(block_map.len());
         for ((hash, height), mut txs) in block_map {
-            let block_hash = hash.to_block_hash();
+            let block_hash = BlockHash::from_byte_array(hash.0);
             let block = self.l1_blocks.get_l1_block(&block_hash).await?;
             let wtxids_root = compute_wtxids_root(&block)?;
 

--- a/crates/alpen-ee/da/provider/src/envelope_provider.rs
+++ b/crates/alpen-ee/da/provider/src/envelope_provider.rs
@@ -6,7 +6,7 @@ use alpen_ee_common::{BatchDaProvider, BatchId, DaStatus, L1DaBlockInfo, L1DaBlo
 use alpen_ee_da_types::{wtxids_root_from_txs, DA_BLOB_VERSION, EE_DA_MAGIC_BYTES};
 use alpen_ee_database::BroadcastDbOps;
 use async_trait::async_trait;
-use bitcoin::{Block, BlockHash, Txid, Wtxid};
+use bitcoin::{hashes::Hash, Block, BlockHash, Txid, Wtxid};
 use bitcoind_async_client::{traits::Reader, Client as BtcClient};
 use eyre::{bail, ensure};
 use strata_btc_types::{BlockHashExt, Buf32BitcoinExt};
@@ -261,7 +261,7 @@ impl ChunkedEnvelopeDaProvider {
         // first; reveals follow in ascending vout order.
         let mut refs: Vec<L1DaBlockRef> = Vec::with_capacity(block_map.len());
         for ((hash, height), mut txs) in block_map {
-            let block_hash = hash.to_block_hash();
+            let block_hash = BlockHash::from_byte_array(hash.0);
             let block = self.l1_blocks.get_l1_block(&block_hash).await?;
             let wtxids_root = compute_wtxids_root(&block)?;
 

--- a/crates/btcio/src/broadcaster/error.rs
+++ b/crates/btcio/src/broadcaster/error.rs
@@ -1,5 +1,5 @@
-use strata_db_types::errors::DbError;
-use strata_primitives::buf::Buf32;
+use bitcoin::consensus::encode::Error as ConsensusEncodeError;
+use strata_db_types::{common::L1TxId, errors::DbError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,7 +11,7 @@ pub enum BroadcasterError {
     Rpc(#[from] anyhow::Error),
 
     #[error("missing transaction entry index for txid {0}")]
-    MissingEntryIndex(Buf32),
+    MissingEntryIndex(L1TxId),
 
     #[error("transaction not found in db at index {0}")]
     TxNotFound(u64),
@@ -19,8 +19,11 @@ pub enum BroadcasterError {
     #[error("inconsistent next idx (expected {expected}, got {got})")]
     InconsistentNextIdx { expected: u64, got: u64 },
 
-    #[error("{0}")]
-    Other(String),
+    #[error("invalid serialized Bitcoin transaction: {0}")]
+    InvalidTransaction(#[from] ConsensusEncodeError),
+
+    #[error("replacement chain from {txid} exceeded {max_hops} hops")]
+    ReplacementChainTooLong { txid: L1TxId, max_hops: usize },
 }
 
 pub(crate) type BroadcasterResult<T> = Result<T, BroadcasterError>;

--- a/crates/btcio/src/broadcaster/error.rs
+++ b/crates/btcio/src/broadcaster/error.rs
@@ -1,5 +1,4 @@
-use strata_db_types::errors::DbError;
-use strata_primitives::buf::Buf32;
+use strata_db_types::{common::L1TxId, errors::DbError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,7 +10,7 @@ pub enum BroadcasterError {
     Rpc(#[from] anyhow::Error),
 
     #[error("missing transaction entry index for txid {0}")]
-    MissingEntryIndex(Buf32),
+    MissingEntryIndex(L1TxId),
 
     #[error("transaction not found in db at index {0}")]
     TxNotFound(u64),

--- a/crates/btcio/src/broadcaster/fee_bump.rs
+++ b/crates/btcio/src/broadcaster/fee_bump.rs
@@ -1,0 +1,571 @@
+//! Fee bumping policy calculation.
+
+use bitcoin::{Amount, FeeRate};
+use strata_config::btcio::FeeBumpingConfig;
+use strata_db_types::fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeRecord};
+use strata_primitives::L1Height;
+
+/// A concrete fee-bump request for one active transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FeeBumpRequest {
+    /// Replacement fee rate.
+    pub target_fee_rate: FeeRate,
+    /// Attempt number to assign to the replacement.
+    pub attempt_no: u32,
+}
+
+/// Policy decision for one transaction node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FeeBumpDecision {
+    /// The transaction is not eligible for replacement yet.
+    Wait,
+    /// The transaction should be replaced.
+    Replace(FeeBumpRequest),
+    /// The current fee estimate is above the effective ceiling.
+    ///
+    /// Deliberately not [`Self::Terminal`]. The estimate is the one input to the target that
+    /// recovers on its own, so a fee-market spike must leave the chain bumpable once the market
+    /// settles. Reported rather than silently folded into [`Self::Wait`] so an operator whose
+    /// ceiling is holding back every bump can see it.
+    BlockedByCeiling {
+        /// The estimate that exceeded the ceiling.
+        estimate: FeeRate,
+        /// The lower of the configured ceiling and a reveal's fundable ceiling.
+        ceiling: FeeRate,
+    },
+    /// The replacement chain cannot advance further.
+    Terminal(TerminalError),
+}
+
+/// Runtime inputs used to evaluate one replacement candidate.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FeeBumpEvaluation {
+    pub current_l1_tip: L1Height,
+    pub estimate_fee_rate: FeeRate,
+    pub incremental_relay_fee_rate: FeeRate,
+    pub replacement_vsize: usize,
+    /// Maximum absolute replacement fee a reveal can fund while preserving its dust output.
+    pub reveal_fee_budget: Option<Amount>,
+}
+
+/// Evaluates whether an active published transaction should be replaced.
+pub(crate) fn evaluate_fee_bump(
+    config: &FeeBumpingConfig,
+    record: &TxNodeRecord,
+    active_attempt: &TxAttempt,
+    evaluation: FeeBumpEvaluation,
+) -> FeeBumpDecision {
+    let FeeBumpEvaluation {
+        current_l1_tip,
+        estimate_fee_rate,
+        incremental_relay_fee_rate,
+        replacement_vsize,
+        reveal_fee_budget,
+    } = evaluation;
+    let Some(first_published_height) = active_attempt.first_published_l1_height else {
+        return FeeBumpDecision::Wait;
+    };
+
+    let age = current_l1_tip.saturating_sub(first_published_height);
+    if age < config.min_age_blocks.get() {
+        return FeeBumpDecision::Wait;
+    }
+
+    // Discarded attempts were never broadcast, so they must not consume the budget.
+    let broadcast_attempts = record
+        .attempts
+        .iter()
+        .filter(|attempt| attempt.status != TxAttemptStatus::Discarded)
+        .count();
+    if broadcast_attempts >= config.max_attempts.get() as usize {
+        return FeeBumpDecision::Terminal(TerminalError::MaxAttemptsReached);
+    }
+
+    let FeeFloors {
+        additive,
+        multiplicative,
+        bip125_min,
+        max_fee_rate,
+    } = match replacement_fee_floors(
+        config,
+        active_attempt,
+        incremental_relay_fee_rate,
+        replacement_vsize,
+    ) {
+        Ok(floors) => floors,
+        Err(error) => return FeeBumpDecision::Terminal(error),
+    };
+
+    // Split the ceiling check by whether the constraint that breached it can ever ease.
+    //
+    // The floors below are all derived from the active attempt, and within a replacement chain the
+    // active fee rate only ever rises, so a floor above the ceiling stays above it for good. Those
+    // are genuinely terminal. The market estimate is re-read on every pass and falls back on its
+    // own, so terminating on it would let one fee spike disable bumping for this transaction
+    // permanently, which is precisely the situation the bumper exists for.
+    let policy_floor = additive.max(multiplicative).max(bip125_min);
+    let (effective_ceiling, reveal_headroom_binds) = match reveal_fee_budget {
+        Some(budget) => {
+            let replacement_vsize_sat = u64::try_from(replacement_vsize).unwrap_or(u64::MAX);
+            let fundable_rate_sat_vb = budget
+                .to_sat()
+                .checked_div(replacement_vsize_sat)
+                .unwrap_or(0);
+            let fundable_rate =
+                FeeRate::from_sat_per_vb(fundable_rate_sat_vb).unwrap_or(max_fee_rate);
+            (
+                max_fee_rate.min(fundable_rate),
+                fundable_rate < max_fee_rate,
+            )
+        }
+        None => (max_fee_rate, false),
+    };
+
+    if policy_floor > effective_ceiling {
+        // Distinguish "our own escalation policy outgrew the ceiling" from "BIP-125 alone already
+        // demands more than the ceiling allows", because only the latter is a relay-rule dead end.
+        let error = if reveal_headroom_binds {
+            TerminalError::RevealFeeHeadroomExhausted
+        } else if bip125_min > max_fee_rate {
+            TerminalError::Bip125FeeRuleUnsatisfiable
+        } else {
+            TerminalError::AboveMaxFeeRate
+        };
+        return FeeBumpDecision::Terminal(error);
+    }
+
+    let target = estimate_fee_rate.max(policy_floor);
+    if target > effective_ceiling {
+        return FeeBumpDecision::BlockedByCeiling {
+            estimate: estimate_fee_rate,
+            ceiling: effective_ceiling,
+        };
+    }
+
+    FeeBumpDecision::Replace(FeeBumpRequest {
+        target_fee_rate: target,
+        attempt_no: record.next_attempt_no(),
+    })
+}
+
+/// The fee rates a replacement has to clear, plus the ceiling they are judged against.
+struct FeeFloors {
+    /// Active rate plus the configured minimum delta.
+    additive: FeeRate,
+    /// Active rate scaled by `multiplier_bps`.
+    multiplicative: FeeRate,
+    /// The rate implied by BIP-125 rule 4's absolute-fee floor.
+    bip125_min: FeeRate,
+    /// The configured `max_fee_rate_sat_vb`, carried along because deriving it is one of the same
+    /// conversions and every caller needs it right after.
+    max_fee_rate: FeeRate,
+}
+
+/// Derives the floors a replacement must clear from the active attempt and the node's relay fee.
+///
+/// Every failure here is a conversion that cannot fit [`FeeRate`], which means the rate involved is
+/// already absurd, so they are all terminal.
+fn replacement_fee_floors(
+    config: &FeeBumpingConfig,
+    active_attempt: &TxAttempt,
+    incremental_relay_fee_rate: FeeRate,
+    replacement_vsize: usize,
+) -> Result<FeeFloors, TerminalError> {
+    let active_fee_rate = FeeRate::from_sat_per_vb(active_attempt.fee_rate_sat_vb)
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+    let min_fee_rate_delta = FeeRate::from_sat_per_vb(config.min_fee_rate_delta_sat_vb.get())
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+    let max_fee_rate = FeeRate::from_sat_per_vb(config.max_fee_rate_sat_vb.get())
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+
+    let active_fee_rate_sat_vb = active_fee_rate.to_sat_per_vb_ceil();
+    let additive = FeeRate::from_sat_per_vb(
+        active_fee_rate_sat_vb.saturating_add(min_fee_rate_delta.to_sat_per_vb_ceil()),
+    )
+    .ok_or(TerminalError::AboveMaxFeeRate)?;
+
+    let multiplicative_fee_rate_sat_vb = active_fee_rate_sat_vb
+        .saturating_mul(config.multiplier_bps as u64)
+        .div_ceil(10_000);
+    let multiplicative = FeeRate::from_sat_per_vb(multiplicative_fee_rate_sat_vb)
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+
+    // BIP-125 rule 4 is priced at the node's own `incrementalrelayfee`, which is runtime
+    // configurable. Take the larger of that and the operator's configured delta so a node running
+    // a raised relay fee does not reject every replacement we build.
+    let bip125_relay_fee_rate = incremental_relay_fee_rate.max(min_fee_rate_delta);
+    let bip125_min = bip125_minimum_fee_rate(
+        Amount::from_sat(active_attempt.fee_sats),
+        bip125_relay_fee_rate,
+        replacement_vsize,
+    )
+    .ok_or(TerminalError::Bip125FeeRuleUnsatisfiable)?;
+
+    Ok(FeeFloors {
+        additive,
+        multiplicative,
+        bip125_min,
+        max_fee_rate,
+    })
+}
+
+/// Converts the BIP-125 absolute-fee floor into the replacement's fee rate.
+pub(crate) fn bip125_minimum_fee_rate(
+    active_fee: Amount,
+    incremental_relay_fee_rate: FeeRate,
+    replacement_vsize: usize,
+) -> Option<FeeRate> {
+    if replacement_vsize == 0 {
+        return Some(FeeRate::ZERO);
+    }
+    let relay_fee = incremental_relay_fee_rate.fee_vb(replacement_vsize as u64)?;
+    let required_fee = active_fee.checked_add(relay_fee)?;
+    FeeRate::from_sat_per_vb(required_fee.to_sat().div_ceil(replacement_vsize as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::{NonZeroU32, NonZeroU64};
+
+    use bitcoin::{absolute::LockTime, transaction::Version, Amount, Transaction};
+    use strata_config::btcio::FeeBumpingConfig;
+    use strata_db_types::fee_bump::{TxAttempt, TxNodeId, TxNodeKind, TxNodeRecord};
+
+    use super::*;
+
+    fn config() -> FeeBumpingConfig {
+        FeeBumpingConfig {
+            check_interval_ms: NonZeroU64::new(30_000).unwrap(),
+            min_age_blocks: NonZeroU32::new(2).unwrap(),
+            max_attempts: NonZeroU32::new(5).unwrap(),
+            multiplier_bps: 12_500,
+            min_fee_rate_delta_sat_vb: NonZeroU64::new(1).unwrap(),
+            max_fee_rate_sat_vb: NonZeroU64::new(1_000).unwrap(),
+            max_reveal_fee_headroom_sats: NonZeroU64::new(10_000_000).unwrap(),
+        }
+    }
+
+    fn evaluation(
+        current_l1_tip: L1Height,
+        estimate_fee_rate: FeeRate,
+        incremental_relay_fee_rate: FeeRate,
+        replacement_vsize: usize,
+    ) -> FeeBumpEvaluation {
+        FeeBumpEvaluation {
+            current_l1_tip,
+            estimate_fee_rate,
+            incremental_relay_fee_rate,
+            replacement_vsize,
+            reveal_fee_budget: None,
+        }
+    }
+
+    fn reveal_evaluation(
+        estimate_fee_rate: FeeRate,
+        replacement_vsize: usize,
+        reveal_fee_budget: Amount,
+    ) -> FeeBumpEvaluation {
+        FeeBumpEvaluation {
+            reveal_fee_budget: Some(reveal_fee_budget),
+            ..evaluation(
+                102,
+                estimate_fee_rate,
+                FeeRate::from_sat_per_vb(1).unwrap(),
+                replacement_vsize,
+            )
+        }
+    }
+
+    fn record() -> TxNodeRecord {
+        let tx = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        };
+        let mut attempt = TxAttempt::active(
+            &tx,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            Amount::from_sat(1_000),
+            0,
+        );
+        attempt.first_published_l1_height = Some(100);
+        TxNodeRecord::new(TxNodeKind::SingleEnvelopeCommit { payload_idx: 0 }, attempt)
+    }
+
+    fn record_of_kind(kind: TxNodeKind) -> TxNodeRecord {
+        let mut record = record();
+        record.node_id = TxNodeId::from_kind(&kind);
+        record.kind = kind;
+        record
+    }
+
+    #[test]
+    fn no_bump_before_min_age_blocks() {
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                active,
+                evaluation(
+                    101,
+                    FeeRate::from_sat_per_vb(20).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Wait
+        );
+    }
+
+    #[test]
+    fn max_attempts_returns_terminal_error() {
+        let mut record = record();
+        let active = record.active_attempt().unwrap().clone();
+        record.attempts.resize(5, active);
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(20).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Terminal(TerminalError::MaxAttemptsReached)
+        );
+    }
+
+    #[test]
+    fn target_fee_chooses_maximum_constraint() {
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Replace(FeeBumpRequest {
+                target_fee_rate: FeeRate::from_sat_per_vb(13).unwrap(),
+                attempt_no: 1,
+            })
+        );
+    }
+
+    /// A fee spike must not permanently disable bumping. With the active attempt at 10 sat/vB and
+    /// a ceiling of 20, the additive (11), multiplicative (13) and BIP-125 floors all fit under the
+    /// ceiling; only the market estimate does not. That has to stay retryable.
+    #[test]
+    fn estimate_above_ceiling_is_retryable_not_terminal() {
+        let mut config = config();
+        config.max_fee_rate_sat_vb = NonZeroU64::new(20).unwrap();
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config,
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(500).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::BlockedByCeiling {
+                estimate: FeeRate::from_sat_per_vb(500).unwrap(),
+                ceiling: FeeRate::from_sat_per_vb(20).unwrap(),
+            }
+        );
+    }
+
+    /// The same chain becomes bumpable again once the estimate falls back under the ceiling,
+    /// which is the property the terminal error destroyed.
+    #[test]
+    fn chain_bumps_again_after_the_estimate_falls_back() {
+        let mut config = config();
+        config.max_fee_rate_sat_vb = NonZeroU64::new(20).unwrap();
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        let spiked = evaluate_fee_bump(
+            &config,
+            &record,
+            active,
+            evaluation(
+                102,
+                FeeRate::from_sat_per_vb(500).unwrap(),
+                FeeRate::from_sat_per_vb(1).unwrap(),
+                100,
+            ),
+        );
+        assert!(matches!(spiked, FeeBumpDecision::BlockedByCeiling { .. }));
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config,
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Replace(FeeBumpRequest {
+                target_fee_rate: FeeRate::from_sat_per_vb(13).unwrap(),
+                attempt_no: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn max_fee_returns_terminal_error() {
+        let mut config = config();
+        config.max_fee_rate_sat_vb = NonZeroU64::new(12).unwrap();
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config,
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Terminal(TerminalError::AboveMaxFeeRate)
+        );
+    }
+
+    /// A discarded attempt was built but never broadcast, so it cost the chain nothing and must
+    /// not count against `max_attempts`. Without this the budget silently shrinks every time an
+    /// external signature is abandoned.
+    #[test]
+    fn discarded_attempts_do_not_consume_the_attempt_budget() {
+        let mut record = record();
+        let active = record.active_attempt().unwrap().clone();
+
+        // Fill the budget, then mark all but the active attempt discarded.
+        record.attempts.resize(5, active);
+        for attempt in record.attempts.iter_mut().skip(1) {
+            attempt.status = TxAttemptStatus::Discarded;
+        }
+
+        assert!(
+            matches!(
+                evaluate_fee_bump(
+                    &config(),
+                    &record,
+                    record.active_attempt().unwrap(),
+                    evaluation(
+                        102,
+                        FeeRate::from_sat_per_vb(20).unwrap(),
+                        FeeRate::from_sat_per_vb(1).unwrap(),
+                        100,
+                    )
+                ),
+                FeeBumpDecision::Replace(_)
+            ),
+            "four discarded attempts must leave the budget open"
+        );
+    }
+
+    #[test]
+    fn stale_reveal_with_ample_budget_is_replaceable() {
+        let record = record_of_kind(TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 0,
+            reveal_idx: 0,
+        });
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    100,
+                    Amount::from_sat(5_000),
+                ),
+            ),
+            FeeBumpDecision::Replace(FeeBumpRequest {
+                target_fee_rate: FeeRate::from_sat_per_vb(13).unwrap(),
+                attempt_no: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_shaped_reveal_exhausts_its_zero_headroom_budget() {
+        let record = record_of_kind(TxNodeKind::SingleEnvelopeReveal { payload_idx: 0 });
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    100,
+                    Amount::from_sat(1_000),
+                ),
+            ),
+            FeeBumpDecision::Terminal(TerminalError::RevealFeeHeadroomExhausted)
+        );
+    }
+
+    #[test]
+    fn reveal_recovers_after_estimate_falls_below_fundable_ceiling() {
+        let record = record_of_kind(TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 0,
+            reveal_idx: 0,
+        });
+        let budget = Amount::from_sat(2_000);
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(FeeRate::from_sat_per_vb(500).unwrap(), 100, budget),
+            ),
+            FeeBumpDecision::BlockedByCeiling {
+                estimate: FeeRate::from_sat_per_vb(500).unwrap(),
+                ceiling: FeeRate::from_sat_per_vb(20).unwrap(),
+            }
+        );
+
+        assert!(matches!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(FeeRate::from_sat_per_vb(5).unwrap(), 100, budget),
+            ),
+            FeeBumpDecision::Replace(_)
+        ));
+    }
+}

--- a/crates/btcio/src/broadcaster/fee_bump.rs
+++ b/crates/btcio/src/broadcaster/fee_bump.rs
@@ -1,0 +1,574 @@
+//! Fee bumping policy calculation.
+
+use bitcoin::{Amount, FeeRate};
+use strata_config::btcio::FeeBumpingConfig;
+use strata_db_types::fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeRecord};
+use strata_primitives::L1Height;
+
+/// A concrete fee-bump request for one active transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FeeBumpRequest {
+    /// Replacement fee rate.
+    pub target_fee_rate: FeeRate,
+    /// Attempt number to assign to the replacement.
+    pub attempt_no: u32,
+}
+
+/// Policy decision for one transaction node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FeeBumpDecision {
+    /// The transaction is not eligible for replacement yet.
+    Wait,
+    /// The transaction should be replaced.
+    Replace(FeeBumpRequest),
+    /// The current fee estimate is above the effective ceiling.
+    ///
+    /// Deliberately not [`Self::Terminal`]. The estimate is the one input to the target that
+    /// recovers on its own, so a fee-market spike must leave the chain bumpable once the market
+    /// settles. Reported rather than silently folded into [`Self::Wait`] so an operator whose
+    /// ceiling is holding back every bump can see it.
+    BlockedByCeiling {
+        /// The estimate that exceeded the ceiling.
+        estimate: FeeRate,
+        /// The lower of the configured ceiling and a reveal's fundable ceiling.
+        ceiling: FeeRate,
+    },
+    /// The replacement chain cannot advance further.
+    Terminal(TerminalError),
+}
+
+/// Runtime inputs used to evaluate one replacement candidate.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FeeBumpEvaluation {
+    pub current_l1_tip: L1Height,
+    pub estimate_fee_rate: FeeRate,
+    pub incremental_relay_fee_rate: FeeRate,
+    pub replacement_vsize: usize,
+    /// Maximum absolute replacement fee a reveal can fund while preserving its dust output.
+    pub reveal_fee_budget: Option<Amount>,
+}
+
+/// Evaluates whether an active published transaction should be replaced.
+pub(crate) fn evaluate_fee_bump(
+    config: &FeeBumpingConfig,
+    record: &TxNodeRecord,
+    active_attempt: &TxAttempt,
+    evaluation: FeeBumpEvaluation,
+) -> FeeBumpDecision {
+    let FeeBumpEvaluation {
+        current_l1_tip,
+        estimate_fee_rate,
+        incremental_relay_fee_rate,
+        replacement_vsize,
+        reveal_fee_budget,
+    } = evaluation;
+    let Some(first_published_height) = active_attempt.first_published_l1_height else {
+        return FeeBumpDecision::Wait;
+    };
+
+    let age = current_l1_tip.saturating_sub(first_published_height);
+    if age < config.min_age_blocks.get() {
+        return FeeBumpDecision::Wait;
+    }
+
+    // Discarded attempts were never broadcast, so they must not consume the budget.
+    let broadcast_attempts = record
+        .attempts
+        .iter()
+        .filter(|attempt| attempt.status != TxAttemptStatus::Discarded)
+        .count();
+    if broadcast_attempts >= config.max_attempts.get() as usize {
+        return FeeBumpDecision::Terminal(TerminalError::MaxAttemptsReached);
+    }
+
+    let FeeFloors {
+        additive,
+        multiplicative,
+        bip125_min,
+        max_fee_rate,
+    } = match replacement_fee_floors(
+        config,
+        active_attempt,
+        incremental_relay_fee_rate,
+        replacement_vsize,
+    ) {
+        Ok(floors) => floors,
+        Err(error) => return FeeBumpDecision::Terminal(error),
+    };
+
+    // Split the ceiling check by whether the constraint that breached it can ever ease.
+    //
+    // The floors below are all derived from the active attempt, and within a replacement chain the
+    // active fee rate only ever rises, so a floor above the ceiling stays above it for good. Those
+    // are genuinely terminal. The market estimate is re-read on every pass and falls back on its
+    // own, so terminating on it would let one fee spike disable bumping for this transaction
+    // permanently, which is precisely the situation the bumper exists for.
+    let policy_floor = additive.max(multiplicative).max(bip125_min);
+    let (effective_ceiling, reveal_headroom_binds) = match reveal_fee_budget {
+        Some(budget) => {
+            let replacement_vsize_sat = u64::try_from(replacement_vsize).unwrap_or(u64::MAX);
+            let fundable_rate_sat_vb = budget
+                .to_sat()
+                .checked_div(replacement_vsize_sat)
+                .unwrap_or(0);
+            let fundable_rate =
+                FeeRate::from_sat_per_vb(fundable_rate_sat_vb).unwrap_or(max_fee_rate);
+            (
+                max_fee_rate.min(fundable_rate),
+                fundable_rate < max_fee_rate,
+            )
+        }
+        None => (max_fee_rate, false),
+    };
+
+    if policy_floor > effective_ceiling {
+        // Distinguish "our own escalation policy outgrew the ceiling" from "BIP-125 alone already
+        // demands more than the ceiling allows", because only the latter is a relay-rule dead end.
+        let error = if reveal_headroom_binds {
+            TerminalError::RevealFeeHeadroomExhausted
+        } else if bip125_min > max_fee_rate {
+            TerminalError::Bip125FeeRuleUnsatisfiable
+        } else {
+            TerminalError::AboveMaxFeeRate
+        };
+        return FeeBumpDecision::Terminal(error);
+    }
+
+    let target = estimate_fee_rate.max(policy_floor);
+    if target > effective_ceiling {
+        return FeeBumpDecision::BlockedByCeiling {
+            estimate: estimate_fee_rate,
+            ceiling: effective_ceiling,
+        };
+    }
+
+    FeeBumpDecision::Replace(FeeBumpRequest {
+        target_fee_rate: target,
+        attempt_no: record.next_attempt_no(),
+    })
+}
+
+/// The fee rates a replacement has to clear, plus the ceiling they are judged against.
+struct FeeFloors {
+    /// Active rate plus the configured minimum delta.
+    additive: FeeRate,
+    /// Active rate scaled by `multiplier_bps`.
+    multiplicative: FeeRate,
+    /// The rate implied by BIP-125 rule 4's absolute-fee floor.
+    bip125_min: FeeRate,
+    /// The configured `max_fee_rate_sat_vb`, carried along because deriving it is one of the same
+    /// conversions and every caller needs it right after.
+    max_fee_rate: FeeRate,
+}
+
+/// Derives the floors a replacement must clear from the active attempt and the node's relay fee.
+///
+/// Every failure here is a conversion that cannot fit [`FeeRate`], which means the rate involved is
+/// already absurd, so they are all terminal.
+fn replacement_fee_floors(
+    config: &FeeBumpingConfig,
+    active_attempt: &TxAttempt,
+    incremental_relay_fee_rate: FeeRate,
+    replacement_vsize: usize,
+) -> Result<FeeFloors, TerminalError> {
+    let active_fee_rate = FeeRate::from_sat_per_vb(active_attempt.fee_rate_sat_vb)
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+    let min_fee_rate_delta = FeeRate::from_sat_per_vb(config.min_fee_rate_delta_sat_vb.get())
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+    let max_fee_rate = FeeRate::from_sat_per_vb(config.max_fee_rate_sat_vb.get())
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+
+    let active_fee_rate_sat_vb = active_fee_rate.to_sat_per_vb_ceil();
+    let additive = FeeRate::from_sat_per_vb(
+        active_fee_rate_sat_vb.saturating_add(min_fee_rate_delta.to_sat_per_vb_ceil()),
+    )
+    .ok_or(TerminalError::AboveMaxFeeRate)?;
+
+    let multiplicative_fee_rate_sat_vb = active_fee_rate_sat_vb
+        .saturating_mul(config.multiplier_bps as u64)
+        .div_ceil(10_000);
+    let multiplicative = FeeRate::from_sat_per_vb(multiplicative_fee_rate_sat_vb)
+        .ok_or(TerminalError::AboveMaxFeeRate)?;
+
+    // BIP-125 rule 4 is priced at the node's own `incrementalrelayfee`, which is runtime
+    // configurable. Take the larger of that and the operator's configured delta so a node running
+    // a raised relay fee does not reject every replacement we build.
+    let bip125_relay_fee_rate = incremental_relay_fee_rate.max(min_fee_rate_delta);
+    let bip125_min = bip125_minimum_fee_rate(
+        Amount::from_sat(active_attempt.fee_sats),
+        bip125_relay_fee_rate,
+        replacement_vsize,
+    )
+    .ok_or(TerminalError::Bip125FeeRuleUnsatisfiable)?;
+
+    Ok(FeeFloors {
+        additive,
+        multiplicative,
+        bip125_min,
+        max_fee_rate,
+    })
+}
+
+/// Converts the BIP-125 absolute-fee floor into the replacement's fee rate.
+pub(crate) fn bip125_minimum_fee_rate(
+    active_fee: Amount,
+    incremental_relay_fee_rate: FeeRate,
+    replacement_vsize: usize,
+) -> Option<FeeRate> {
+    if replacement_vsize == 0 {
+        return Some(FeeRate::ZERO);
+    }
+    let relay_fee = incremental_relay_fee_rate.fee_vb(replacement_vsize as u64)?;
+    let required_fee = active_fee.checked_add(relay_fee)?;
+    FeeRate::from_sat_per_vb(required_fee.to_sat().div_ceil(replacement_vsize as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::{NonZeroU32, NonZeroU64};
+
+    use bitcoin::{absolute::LockTime, transaction::Version, Amount, Transaction};
+    use strata_config::btcio::FeeBumpingConfig;
+    use strata_db_types::fee_bump::{TxAttempt, TxNodeId, TxNodeKind, TxNodeRecord};
+
+    use super::*;
+    use crate::tx_attempt::attempt_parts;
+
+    fn config() -> FeeBumpingConfig {
+        FeeBumpingConfig {
+            check_interval_ms: NonZeroU64::new(30_000).unwrap(),
+            min_age_blocks: NonZeroU32::new(2).unwrap(),
+            max_attempts: NonZeroU32::new(5).unwrap(),
+            multiplier_bps: 12_500,
+            min_fee_rate_delta_sat_vb: NonZeroU64::new(1).unwrap(),
+            max_fee_rate_sat_vb: NonZeroU64::new(1_000).unwrap(),
+            max_reveal_fee_headroom_sats: NonZeroU64::new(10_000_000).unwrap(),
+        }
+    }
+
+    fn evaluation(
+        current_l1_tip: L1Height,
+        estimate_fee_rate: FeeRate,
+        incremental_relay_fee_rate: FeeRate,
+        replacement_vsize: usize,
+    ) -> FeeBumpEvaluation {
+        FeeBumpEvaluation {
+            current_l1_tip,
+            estimate_fee_rate,
+            incremental_relay_fee_rate,
+            replacement_vsize,
+            reveal_fee_budget: None,
+        }
+    }
+
+    fn reveal_evaluation(
+        estimate_fee_rate: FeeRate,
+        replacement_vsize: usize,
+        reveal_fee_budget: Amount,
+    ) -> FeeBumpEvaluation {
+        FeeBumpEvaluation {
+            reveal_fee_budget: Some(reveal_fee_budget),
+            ..evaluation(
+                102,
+                estimate_fee_rate,
+                FeeRate::from_sat_per_vb(1).unwrap(),
+                replacement_vsize,
+            )
+        }
+    }
+
+    fn record() -> TxNodeRecord {
+        let tx = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        };
+        let mut attempt = TxAttempt::active(
+            attempt_parts(
+                &tx,
+                FeeRate::from_sat_per_vb(10).unwrap(),
+                Amount::from_sat(1_000),
+            ),
+            0,
+        );
+        attempt.first_published_l1_height = Some(100);
+        TxNodeRecord::new(TxNodeKind::SingleEnvelopeCommit { payload_idx: 0 }, attempt)
+    }
+
+    fn record_of_kind(kind: TxNodeKind) -> TxNodeRecord {
+        let mut record = record();
+        record.node_id = TxNodeId::from_kind(&kind);
+        record.kind = kind;
+        record
+    }
+
+    #[test]
+    fn no_bump_before_min_age_blocks() {
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                active,
+                evaluation(
+                    101,
+                    FeeRate::from_sat_per_vb(20).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Wait
+        );
+    }
+
+    #[test]
+    fn max_attempts_returns_terminal_error() {
+        let mut record = record();
+        let active = record.active_attempt().unwrap().clone();
+        record.attempts.resize(5, active);
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(20).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Terminal(TerminalError::MaxAttemptsReached)
+        );
+    }
+
+    #[test]
+    fn target_fee_chooses_maximum_constraint() {
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Replace(FeeBumpRequest {
+                target_fee_rate: FeeRate::from_sat_per_vb(13).unwrap(),
+                attempt_no: 1,
+            })
+        );
+    }
+
+    /// A fee spike must not permanently disable bumping. With the active attempt at 10 sat/vB and
+    /// a ceiling of 20, the additive (11), multiplicative (13) and BIP-125 floors all fit under the
+    /// ceiling; only the market estimate does not. That has to stay retryable.
+    #[test]
+    fn estimate_above_ceiling_is_retryable_not_terminal() {
+        let mut config = config();
+        config.max_fee_rate_sat_vb = NonZeroU64::new(20).unwrap();
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config,
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(500).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::BlockedByCeiling {
+                estimate: FeeRate::from_sat_per_vb(500).unwrap(),
+                ceiling: FeeRate::from_sat_per_vb(20).unwrap(),
+            }
+        );
+    }
+
+    /// The same chain becomes bumpable again once the estimate falls back under the ceiling,
+    /// which is the property the terminal error destroyed.
+    #[test]
+    fn chain_bumps_again_after_the_estimate_falls_back() {
+        let mut config = config();
+        config.max_fee_rate_sat_vb = NonZeroU64::new(20).unwrap();
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        let spiked = evaluate_fee_bump(
+            &config,
+            &record,
+            active,
+            evaluation(
+                102,
+                FeeRate::from_sat_per_vb(500).unwrap(),
+                FeeRate::from_sat_per_vb(1).unwrap(),
+                100,
+            ),
+        );
+        assert!(matches!(spiked, FeeBumpDecision::BlockedByCeiling { .. }));
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config,
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Replace(FeeBumpRequest {
+                target_fee_rate: FeeRate::from_sat_per_vb(13).unwrap(),
+                attempt_no: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn max_fee_returns_terminal_error() {
+        let mut config = config();
+        config.max_fee_rate_sat_vb = NonZeroU64::new(12).unwrap();
+        let record = record();
+        let active = record.active_attempt().unwrap();
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config,
+                &record,
+                active,
+                evaluation(
+                    102,
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    FeeRate::from_sat_per_vb(1).unwrap(),
+                    100,
+                )
+            ),
+            FeeBumpDecision::Terminal(TerminalError::AboveMaxFeeRate)
+        );
+    }
+
+    /// A discarded attempt was built but never broadcast, so it cost the chain nothing and must
+    /// not count against `max_attempts`. Without this the budget silently shrinks every time an
+    /// external signature is abandoned.
+    #[test]
+    fn discarded_attempts_do_not_consume_the_attempt_budget() {
+        let mut record = record();
+        let active = record.active_attempt().unwrap().clone();
+
+        // Fill the budget, then mark all but the active attempt discarded.
+        record.attempts.resize(5, active);
+        for attempt in record.attempts.iter_mut().skip(1) {
+            attempt.status = TxAttemptStatus::Discarded;
+        }
+
+        assert!(
+            matches!(
+                evaluate_fee_bump(
+                    &config(),
+                    &record,
+                    record.active_attempt().unwrap(),
+                    evaluation(
+                        102,
+                        FeeRate::from_sat_per_vb(20).unwrap(),
+                        FeeRate::from_sat_per_vb(1).unwrap(),
+                        100,
+                    )
+                ),
+                FeeBumpDecision::Replace(_)
+            ),
+            "four discarded attempts must leave the budget open"
+        );
+    }
+
+    #[test]
+    fn stale_reveal_with_ample_budget_is_replaceable() {
+        let record = record_of_kind(TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 0,
+            reveal_idx: 0,
+        });
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    100,
+                    Amount::from_sat(5_000),
+                ),
+            ),
+            FeeBumpDecision::Replace(FeeBumpRequest {
+                target_fee_rate: FeeRate::from_sat_per_vb(13).unwrap(),
+                attempt_no: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_shaped_reveal_exhausts_its_zero_headroom_budget() {
+        let record = record_of_kind(TxNodeKind::SingleEnvelopeReveal { payload_idx: 0 });
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(
+                    FeeRate::from_sat_per_vb(5).unwrap(),
+                    100,
+                    Amount::from_sat(1_000),
+                ),
+            ),
+            FeeBumpDecision::Terminal(TerminalError::RevealFeeHeadroomExhausted)
+        );
+    }
+
+    #[test]
+    fn reveal_recovers_after_estimate_falls_below_fundable_ceiling() {
+        let record = record_of_kind(TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 0,
+            reveal_idx: 0,
+        });
+        let budget = Amount::from_sat(2_000);
+
+        assert_eq!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(FeeRate::from_sat_per_vb(500).unwrap(), 100, budget),
+            ),
+            FeeBumpDecision::BlockedByCeiling {
+                estimate: FeeRate::from_sat_per_vb(500).unwrap(),
+                ceiling: FeeRate::from_sat_per_vb(20).unwrap(),
+            }
+        );
+
+        assert!(matches!(
+            evaluate_fee_bump(
+                &config(),
+                &record,
+                record.active_attempt().unwrap(),
+                reveal_evaluation(FeeRate::from_sat_per_vb(5).unwrap(), 100, budget),
+            ),
+            FeeBumpDecision::Replace(_)
+        ));
+    }
+}

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -25,7 +25,7 @@ use super::{
 /// This is a corruption guard rather than a policy limit: how many replacements a logical
 /// transaction may have is governed by `fee_bumping.max_attempts`, and each replacement adds one
 /// link. The bound is set well above any sane `max_attempts` so a healthy chain never hits it.
-const MAX_REPLACEMENT_CHAIN_HOPS: usize = 64;
+pub(super) const MAX_REPLACEMENT_CHAIN_HOPS: usize = 64;
 
 #[expect(
     missing_debug_implementations,

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -2,8 +2,9 @@ use std::{str, sync::Arc};
 
 use hex::encode_to_slice;
 use strata_db_types::{
+    common::L1TxId,
+    fee_bump::{TxNodeId, TxNodeRecord},
     l1_broadcast::{L1TxEntry, L1TxStatus},
-    DbResult,
 };
 use strata_primitives::buf::Buf32;
 use strata_service::ServiceMonitor;
@@ -17,6 +18,13 @@ use super::{
     service::BroadcasterStatus,
 };
 use crate::tx_entry::L1TxEntryExt;
+
+/// Upper bound on how many [`L1TxStatus::Replaced`] links are followed before giving up.
+///
+/// This is a corruption guard rather than a policy limit: how many replacements a logical
+/// transaction may have is governed by `fee_bumping.max_attempts`, and each replacement adds one
+/// link. The bound is set well above any sane `max_attempts` so a healthy chain never hits it.
+const MAX_REPLACEMENT_CHAIN_HOPS: usize = 64;
 
 #[expect(
     missing_debug_implementations,
@@ -51,7 +59,7 @@ impl L1BroadcastHandle {
         self.monitor.as_ref()
     }
 
-    pub async fn get_tx_status(&self, txid: Buf32) -> DbResult<Option<L1TxStatus>> {
+    pub async fn get_tx_status(&self, txid: Buf32) -> BroadcasterResult<Option<L1TxStatus>> {
         Ok(self
             .ops
             .get_tx_entry_by_id_async(txid)
@@ -81,7 +89,7 @@ impl L1BroadcastHandle {
                 txid = %txid_le,
                 "tx entry was persisted but storage returned no entry index"
             );
-            return Err(BroadcasterError::MissingEntryIndex(txid));
+            return Err(BroadcasterError::MissingEntryIndex(L1TxId::from(txid.0)));
         };
 
         if self
@@ -98,41 +106,183 @@ impl L1BroadcastHandle {
         Ok(idx)
     }
 
-    /// Updates an existing entry and notifies the broadcaster service.
-    pub(crate) async fn put_tx_entry_by_idx(
+    pub async fn get_tx_entry_by_id_async(
         &self,
-        idx: u64,
+        txid: Buf32,
+    ) -> BroadcasterResult<Option<L1TxEntry>> {
+        Ok(self.ops.get_tx_entry_by_id_async(txid).await?)
+    }
+
+    pub async fn update_tx_entry_by_id_async(
+        &self,
+        txid: Buf32,
         txentry: L1TxEntry,
     ) -> BroadcasterResult<()> {
-        assert!(txentry.try_to_tx().is_ok(), "invalid tx entry {txentry:?}");
-
-        self.ops
-            .put_tx_entry_by_idx_async(idx, txentry.clone())
-            .await?;
-
-        if self
-            .sender
-            .send(BroadcasterInputMessage::NotifyNewEntry { idx, txentry })
-            .await
-            .is_err()
-        {
-            // Not really an error, it just means it's shutting down; we'll pick
-            // it up when we restart by scanning persisted entries.
-            warn!("L1 broadcaster service is unavailable");
-        }
-
+        let _ = self.ops.put_tx_entry_async(txid, txentry).await?;
         Ok(())
     }
 
-    pub async fn get_tx_entry_by_id_async(&self, txid: Buf32) -> DbResult<Option<L1TxEntry>> {
-        self.ops.get_tx_entry_by_id_async(txid).await
+    /// Follows the [`L1TxStatus::Replaced`] chain from `txid` to the entry that is still live.
+    ///
+    /// Returns `None` only when `txid` itself is unknown or the chain points at an entry that was
+    /// never written. Walking is bounded by `MAX_REPLACEMENT_CHAIN_HOPS` so a corrupted chain
+    /// cannot loop forever; exceeding it is reported rather than silently reported as missing.
+    pub async fn get_active_tx_entry_by_id_async(
+        &self,
+        txid: Buf32,
+    ) -> BroadcasterResult<Option<(Buf32, L1TxEntry)>> {
+        let mut current = txid;
+        for _ in 0..MAX_REPLACEMENT_CHAIN_HOPS {
+            let Some(entry) = self.get_tx_entry_by_id_async(current).await? else {
+                return Ok(None);
+            };
+            match entry.status {
+                L1TxStatus::Replaced { by } => current = Buf32(by.0),
+                _ => return Ok(Some((current, entry))),
+            }
+        }
+
+        Err(BroadcasterError::ReplacementChainTooLong {
+            txid: L1TxId::from(txid.0),
+            max_hops: MAX_REPLACEMENT_CHAIN_HOPS,
+        })
     }
 
-    pub async fn get_last_tx_entry(&self) -> DbResult<Option<L1TxEntry>> {
-        self.ops.get_last_tx_entry_async().await
+    /// Inserts `replacement` and supersedes `original_txid` with it, atomically.
+    ///
+    /// Returns `false` when the original was no longer in a publishable state, in which case
+    /// nothing was written and the replacement must be discarded.
+    ///
+    /// On success the broadcaster is told about both rows: the new entry so it starts publishing
+    /// it, and the superseded one so it stops.
+    pub async fn put_replacement_tx_entry(
+        &self,
+        original_txid: Buf32,
+        replacement_txid: Buf32,
+        replacement: L1TxEntry,
+    ) -> BroadcasterResult<bool> {
+        assert!(
+            replacement.try_to_tx().is_ok(),
+            "invalid replacement entry {replacement:?}"
+        );
+
+        let Some(idx) = self
+            .ops
+            .put_replacement_tx_entry_async(original_txid, replacement_txid, replacement.clone())
+            .await?
+        else {
+            debug!(
+                ?original_txid,
+                "discarding replacement: the original left the publishable state"
+            );
+            return Ok(false);
+        };
+
+        if self
+            .sender
+            .send(BroadcasterInputMessage::NotifyNewEntry {
+                idx,
+                txentry: replacement,
+            })
+            .await
+            .is_err()
+        {
+            warn!("L1 broadcaster service is unavailable");
+        }
+        if self
+            .sender
+            .send(BroadcasterInputMessage::NotifyReplacedEntry {
+                txid: original_txid,
+            })
+            .await
+            .is_err()
+        {
+            warn!("L1 broadcaster service is unavailable");
+        }
+
+        Ok(true)
     }
 
-    pub async fn get_tx_entry_by_idx_async(&self, idx: u64) -> DbResult<Option<L1TxEntry>> {
-        self.ops.get_tx_entry_async(idx).await
+    pub async fn get_last_tx_entry(&self) -> BroadcasterResult<Option<L1TxEntry>> {
+        Ok(self.ops.get_last_tx_entry_async().await?)
+    }
+
+    pub async fn get_tx_entry_by_idx_async(
+        &self,
+        idx: u64,
+    ) -> BroadcasterResult<Option<L1TxEntry>> {
+        Ok(self.ops.get_tx_entry_async(idx).await?)
+    }
+
+    pub async fn put_tx_entry_by_idx(&self, idx: u64, txentry: L1TxEntry) -> BroadcasterResult<()> {
+        self.ops.put_tx_entry_by_idx_async(idx, txentry).await?;
+        Ok(())
+    }
+
+    pub async fn put_tx_node(&self, node: TxNodeRecord) -> BroadcasterResult<()> {
+        Ok(self.ops.put_tx_node_async(node.node_id, node).await?)
+    }
+
+    pub async fn get_tx_node(&self, node_id: TxNodeId) -> BroadcasterResult<Option<TxNodeRecord>> {
+        Ok(self.ops.get_tx_node_async(node_id).await?)
+    }
+
+    pub async fn get_all_tx_nodes(&self) -> BroadcasterResult<Vec<TxNodeRecord>> {
+        Ok(self.ops.get_all_tx_nodes_async().await?)
+    }
+
+    pub async fn get_active_tx_nodes(&self) -> BroadcasterResult<Vec<TxNodeRecord>> {
+        Ok(self.ops.get_active_tx_nodes_async().await?)
+    }
+
+    pub async fn retire_tx_node(
+        &self,
+        node_id: TxNodeId,
+        expected_active_txid: L1TxId,
+    ) -> BroadcasterResult<bool> {
+        Ok(self
+            .ops
+            .retire_tx_node_async(node_id, expected_active_txid)
+            .await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_db_types::{backend::DatabaseBackend, l1_broadcast::L1TxStatus};
+    use tokio::runtime::Handle;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn replacement_chain_hop_exhaustion_is_typed() {
+        let db = get_test_sled_backend().broadcast_db();
+        let ops = Arc::new(BroadcastDbOps::new(Handle::current(), db));
+        let handle = L1BroadcastHandle::new_for_test(ops.clone());
+        let start = Buf32([0; 32]);
+
+        for hop in 0..MAX_REPLACEMENT_CHAIN_HOPS {
+            let txid = Buf32([hop as u8; 32]);
+            let replacement = L1TxId::from([(hop + 1) as u8; 32]);
+            let entry = L1TxEntry::from_raw_parts(
+                Vec::new(),
+                L1TxStatus::Replaced { by: replacement },
+                None,
+            );
+            ops.put_tx_entry_async(txid, entry).await.unwrap();
+        }
+
+        let err = handle
+            .get_active_tx_entry_by_id_async(start)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BroadcasterError::ReplacementChainTooLong {
+                txid,
+                max_hops: MAX_REPLACEMENT_CHAIN_HOPS,
+            } if txid == L1TxId::from(start.0)
+        ));
     }
 }

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -24,7 +24,7 @@ use crate::tx_entry::L1TxEntryExt;
 /// This is a corruption guard rather than a policy limit: how many replacements a logical
 /// transaction may have is governed by `fee_bumping.max_attempts`, and each replacement adds one
 /// link. The bound is set well above any sane `max_attempts` so a healthy chain never hits it.
-const MAX_REPLACEMENT_CHAIN_HOPS: usize = 64;
+pub(super) const MAX_REPLACEMENT_CHAIN_HOPS: usize = 64;
 
 #[expect(
     missing_debug_implementations,

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -2,6 +2,9 @@ use std::{str, sync::Arc};
 
 use hex::encode_to_slice;
 use strata_db_types::{
+    common::L1TxId,
+    errors::DbError,
+    fee_bump::{TxNodeId, TxNodeRecord},
     l1_broadcast::{L1TxEntry, L1TxStatus},
     DbResult,
 };
@@ -16,6 +19,13 @@ use super::{
     input::BroadcasterInputMessage,
     service::BroadcasterStatus,
 };
+
+/// Upper bound on how many [`L1TxStatus::Replaced`] links are followed before giving up.
+///
+/// This is a corruption guard rather than a policy limit: how many replacements a logical
+/// transaction may have is governed by `fee_bumping.max_attempts`, and each replacement adds one
+/// link. The bound is set well above any sane `max_attempts` so a healthy chain never hits it.
+const MAX_REPLACEMENT_CHAIN_HOPS: usize = 64;
 
 #[expect(
     missing_debug_implementations,
@@ -80,7 +90,7 @@ impl L1BroadcastHandle {
                 txid = %txid_le,
                 "tx entry was persisted but storage returned no entry index"
             );
-            return Err(BroadcasterError::MissingEntryIndex(txid));
+            return Err(BroadcasterError::MissingEntryIndex(L1TxId::from(txid.0)));
         };
 
         if self
@@ -97,34 +107,97 @@ impl L1BroadcastHandle {
         Ok(idx)
     }
 
-    /// Updates an existing entry and notifies the broadcaster service.
-    pub(crate) async fn put_tx_entry_by_idx(
+    pub async fn get_tx_entry_by_id_async(&self, txid: Buf32) -> DbResult<Option<L1TxEntry>> {
+        self.ops.get_tx_entry_by_id_async(txid).await
+    }
+
+    pub async fn update_tx_entry_by_id_async(
         &self,
-        idx: u64,
+        txid: Buf32,
         txentry: L1TxEntry,
-    ) -> BroadcasterResult<()> {
-        assert!(txentry.try_to_tx().is_ok(), "invalid tx entry {txentry:?}");
-
-        self.ops
-            .put_tx_entry_by_idx_async(idx, txentry.clone())
-            .await?;
-
-        if self
-            .sender
-            .send(BroadcasterInputMessage::NotifyNewEntry { idx, txentry })
-            .await
-            .is_err()
-        {
-            // Not really an error, it just means it's shutting down; we'll pick
-            // it up when we restart by scanning persisted entries.
-            warn!("L1 broadcaster service is unavailable");
-        }
-
+    ) -> DbResult<()> {
+        let _ = self.ops.put_tx_entry_async(txid, txentry).await?;
         Ok(())
     }
 
-    pub async fn get_tx_entry_by_id_async(&self, txid: Buf32) -> DbResult<Option<L1TxEntry>> {
-        self.ops.get_tx_entry_by_id_async(txid).await
+    /// Follows the [`L1TxStatus::Replaced`] chain from `txid` to the entry that is still live.
+    ///
+    /// Returns `None` only when `txid` itself is unknown or the chain points at an entry that was
+    /// never written. Walking is bounded by `MAX_REPLACEMENT_CHAIN_HOPS` so a corrupted chain
+    /// cannot loop forever; exceeding it is reported rather than silently reported as missing.
+    pub async fn get_active_tx_entry_by_id_async(
+        &self,
+        txid: Buf32,
+    ) -> DbResult<Option<(Buf32, L1TxEntry)>> {
+        let mut current = txid;
+        for _ in 0..MAX_REPLACEMENT_CHAIN_HOPS {
+            let Some(entry) = self.get_tx_entry_by_id_async(current).await? else {
+                return Ok(None);
+            };
+            match entry.status {
+                L1TxStatus::Replaced { by } => current = Buf32(by.0),
+                _ => return Ok(Some((current, entry))),
+            }
+        }
+
+        Err(DbError::Other(format!(
+            "broadcast replacement chain from {txid:?} exceeded {MAX_REPLACEMENT_CHAIN_HOPS} hops"
+        )))
+    }
+
+    /// Inserts `replacement` and supersedes `original_txid` with it, atomically.
+    ///
+    /// Returns `false` when the original was no longer in a publishable state, in which case
+    /// nothing was written and the replacement must be discarded.
+    ///
+    /// On success the broadcaster is told about both rows: the new entry so it starts publishing
+    /// it, and the superseded one so it stops.
+    pub async fn put_replacement_tx_entry(
+        &self,
+        original_txid: Buf32,
+        replacement_txid: Buf32,
+        replacement: L1TxEntry,
+    ) -> BroadcasterResult<bool> {
+        assert!(
+            replacement.try_to_tx().is_ok(),
+            "invalid replacement entry {replacement:?}"
+        );
+
+        let Some(idx) = self
+            .ops
+            .put_replacement_tx_entry_async(original_txid, replacement_txid, replacement.clone())
+            .await?
+        else {
+            debug!(
+                ?original_txid,
+                "discarding replacement: the original left the publishable state"
+            );
+            return Ok(false);
+        };
+
+        if self
+            .sender
+            .send(BroadcasterInputMessage::NotifyNewEntry {
+                idx,
+                txentry: replacement,
+            })
+            .await
+            .is_err()
+        {
+            warn!("L1 broadcaster service is unavailable");
+        }
+        if self
+            .sender
+            .send(BroadcasterInputMessage::NotifyReplacedEntry {
+                txid: original_txid,
+            })
+            .await
+            .is_err()
+        {
+            warn!("L1 broadcaster service is unavailable");
+        }
+
+        Ok(true)
     }
 
     pub async fn get_last_tx_entry(&self) -> DbResult<Option<L1TxEntry>> {
@@ -133,5 +206,22 @@ impl L1BroadcastHandle {
 
     pub async fn get_tx_entry_by_idx_async(&self, idx: u64) -> DbResult<Option<L1TxEntry>> {
         self.ops.get_tx_entry_async(idx).await
+    }
+
+    pub async fn put_tx_entry_by_idx(&self, idx: u64, txentry: L1TxEntry) -> BroadcasterResult<()> {
+        self.ops.put_tx_entry_by_idx_async(idx, txentry).await?;
+        Ok(())
+    }
+
+    pub async fn put_tx_node(&self, node: TxNodeRecord) -> DbResult<()> {
+        self.ops.put_tx_node_async(node.node_id, node).await
+    }
+
+    pub async fn get_tx_node(&self, node_id: TxNodeId) -> DbResult<Option<TxNodeRecord>> {
+        self.ops.get_tx_node_async(node_id).await
+    }
+
+    pub async fn get_all_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>> {
+        self.ops.get_all_tx_nodes_async().await
     }
 }

--- a/crates/btcio/src/broadcaster/input.rs
+++ b/crates/btcio/src/broadcaster/input.rs
@@ -1,10 +1,20 @@
 use strata_db_types::l1_broadcast::L1TxEntry;
+use strata_primitives::buf::Buf32;
 
 /// Input messages consumed by the broadcaster service.
 #[derive(Debug)]
 pub(crate) enum BroadcasterInputMessage {
     /// Notify the service about a newly persisted entry.
     NotifyNewEntry { idx: u64, txentry: L1TxEntry },
+
+    /// Notify the service that a tracked entry was superseded by an RBF replacement.
+    ///
+    /// The fee bumper persists the [`L1TxStatus::Replaced`](strata_db_types::l1_broadcast::
+    /// L1TxStatus::Replaced) status itself. This message exists so the service also drops its
+    /// in-memory copy: without it the service would keep probing the replaced txid, find it gone
+    /// from the mempool, re-publish it against its own replacement, and then write the stale
+    /// status back over the persisted one.
+    NotifyReplacedEntry { txid: Buf32 },
 }
 
 #[cfg(test)]

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -5,7 +5,7 @@ use bitcoin::{BlockHash, Transaction, Txid};
 use bitcoind_async_client::{error::ClientError, traits::Broadcaster, Client};
 use serde::Deserialize;
 use strata_btc_types::BlockHashExt;
-use strata_db_types::l1_broadcast::L1TxEntry;
+use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
 use strata_primitives::{buf::Buf32, L1Height};
 use strata_storage::BroadcastDbOps;
 use tracing::{debug, info, warn};
@@ -42,6 +42,24 @@ pub(crate) trait BroadcasterIoContext: Send + Sync + 'static {
         idx: u64,
         entry: L1TxEntry,
     ) -> impl Future<Output = BroadcasterResult<()>> + Send;
+
+    /// Returns the broadcast entry for `txid`, or `None` if the row is missing.
+    fn get_tx_entry_by_id(
+        &self,
+        txid: Buf32,
+    ) -> impl Future<Output = BroadcasterResult<Option<L1TxEntry>>> + Send;
+
+    /// Reverses a replacement after the superseded transaction won on-chain.
+    ///
+    /// See [`L1BroadcastDatabase::adopt_confirmed_ancestor`].
+    ///
+    /// [`L1BroadcastDatabase::adopt_confirmed_ancestor`]: strata_db_types::l1_broadcast::L1BroadcastDatabase::adopt_confirmed_ancestor
+    fn adopt_confirmed_ancestor(
+        &self,
+        loser_txid: Buf32,
+        winner_txid: Buf32,
+        winner_status: L1TxStatus,
+    ) -> impl Future<Output = BroadcasterResult<bool>> + Send;
 
     /// Fetches transaction observation data used for confirmation-state transitions.
     fn get_transaction<'a>(
@@ -221,6 +239,22 @@ where
     async fn put_tx_entry_by_idx(&self, idx: u64, entry: L1TxEntry) -> BroadcasterResult<()> {
         self.ops.put_tx_entry_by_idx_async(idx, entry).await?;
         Ok(())
+    }
+
+    async fn get_tx_entry_by_id(&self, txid: Buf32) -> BroadcasterResult<Option<L1TxEntry>> {
+        Ok(self.ops.get_tx_entry_by_id_async(txid).await?)
+    }
+
+    async fn adopt_confirmed_ancestor(
+        &self,
+        loser_txid: Buf32,
+        winner_txid: Buf32,
+        winner_status: L1TxStatus,
+    ) -> BroadcasterResult<bool> {
+        Ok(self
+            .ops
+            .adopt_confirmed_ancestor_async(loser_txid, winner_txid, winner_status)
+            .await?)
     }
 
     async fn get_transaction<'a>(&'a self, txid: &'a Txid) -> BroadcasterResult<TxLookupOutcome> {

--- a/crates/btcio/src/broadcaster/mod.rs
+++ b/crates/btcio/src/broadcaster/mod.rs
@@ -1,5 +1,6 @@
 mod builder;
 mod error;
+pub(crate) mod fee_bump;
 mod handle;
 mod input;
 mod io;

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -1,5 +1,9 @@
-use bitcoin::Txid;
-use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
+use bitcoin::{hashes::Hash, Txid};
+use strata_db_types::{
+    common::L1TxId,
+    l1_broadcast::{L1TxEntry, L1TxStatus},
+};
+use strata_primitives::buf::Buf32;
 use tracing::*;
 
 use super::{
@@ -23,10 +27,7 @@ where
     for entry in unfinalized_entries {
         let idx = *entry.index();
         let txentry = entry.item();
-        let txid = txentry
-            .try_to_tx()
-            .map_err(|e| BroadcasterError::Other(e.to_string()))?
-            .compute_txid();
+        let txid = txentry.try_to_tx()?.compute_txid();
 
         let updated_status = process_tx_entry(io, txentry, &txid, params).await?;
 
@@ -57,7 +58,7 @@ where
     C: BroadcasterIoContext,
 {
     let result = match txentry.status {
-        L1TxStatus::Unpublished => publish_tx(io, txentry).await.map(Some),
+        L1TxStatus::Unpublished => publish_tx(io, params, txentry).await.map(Some),
         L1TxStatus::Published => probe_published_entry(io, txentry, txid, params)
             .await
             .map(Some),
@@ -65,7 +66,7 @@ where
             .await
             .map(Some),
         L1TxStatus::Finalized { .. } => Ok(None),
-        L1TxStatus::InvalidInputs => Ok(None),
+        L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. } => Ok(None),
     };
     if let Ok(ref updated_status) = result {
         debug!(?updated_status);
@@ -84,7 +85,8 @@ where
 /// 3. `Ok(None)`: not found at all. Could be a transient wallet-syncer miss for a freshly broadcast
 ///    tx, or a genuinely dropped tx (mempool eviction, RBF). Re-publish to disambiguate: benign
 ///    mempool messages fold back to Published, `bad-txns-inputs-missingorspent` routes to
-///    InvalidInputs so the watcher rebuilds the envelope.
+///    InvalidInputs so the watcher rebuilds the envelope, unless an ancestor of this entry's own
+///    replacement chain took those inputs by confirming.
 async fn probe_published_entry<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -101,9 +103,28 @@ where
     match txinfo_res? {
         // `confirmation_status` returns `Published` for 0-conf, which is the
         // correct sighting for an already-Published entry still in mempool.
-        TxLookupOutcome::Found(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
-        TxLookupOutcome::Missing => match publish_tx(io, txentry).await? {
-            L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
+        TxLookupOutcome::Found(info) => {
+            // Bitcoin Core reports negative confirmations for a wallet transaction that conflicts
+            // with one already in the best chain. For an ordinary entry that reads as "side branch
+            // after a reorg" and is held at `Published` so it can be re-mined. For an entry that is
+            // itself a replacement it is unambiguous: some other transaction in its replacement
+            // chain confirmed, so this one can never enter the chain. Holding it at `Published`
+            // would leave the envelope waiting on a commit that will never confirm.
+            //
+            // The predicate is the reverse `replaces` link, not the presence of RBF metadata:
+            // every writer-owned entry carries that metadata from its first attempt, and a first
+            // attempt has no chain to lose to.
+            if txentry.rbf.and_then(|rbf| rbf.replaces).is_some() && info.confirmations < 0 {
+                warn!(%txid, confirmations = info.confirmations, "replacement-chain transaction conflicts with a confirmed transaction");
+                return resolve_invalid_inputs(io, params, txid, txentry).await;
+            }
+            Ok(confirmation_status(&info, reorg_safe_depth))
+        }
+        // A rejected re-publish resolves the same way a first publish does, including the
+        // ancestor check, so a `Replaced` verdict must reach the caller rather than fold into
+        // `Published`.
+        TxLookupOutcome::Missing => match publish_tx(io, params, txentry).await? {
+            status @ (L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. }) => Ok(status),
             _ => Ok(L1TxStatus::Published),
         },
         TxLookupOutcome::RetryLater { reason } => {
@@ -111,6 +132,101 @@ where
             Ok(L1TxStatus::Published)
         }
     }
+}
+
+/// Bound on how far back a conflicting-ancestor search walks, matching the forward chain walk.
+const MAX_ANCESTOR_SEARCH_HOPS: usize = 32;
+
+/// Settles an `InvalidInputs` verdict against the entry's own replacement chain.
+///
+/// `InvalidInputs` is what sends the writer off to rebuild, and rebuilding republishes a payload a
+/// confirmed transaction may already carry. For an entry in a replacement chain the transaction
+/// that took its inputs is usually an ancestor of that very chain: a miner included an original
+/// after the local node had already accepted its replacement.
+///
+/// Returns [`L1TxStatus::Replaced`] pointing at the ancestor that won. When no ancestor did, the
+/// conflict is with a transaction outside this chain and the [`L1TxStatus::InvalidInputs`] verdict
+/// stands. An entry with no `replaces` link, which is every entry outside a replacement chain,
+/// resolves to `InvalidInputs` without asking bitcoind anything.
+async fn resolve_invalid_inputs<C>(
+    io: &C,
+    params: &BtcioParams,
+    txid: &Txid,
+    txentry: &L1TxEntry,
+) -> BroadcasterResult<L1TxStatus>
+where
+    C: BroadcasterIoContext,
+{
+    if let Some(winner) = adopt_confirmed_ancestor(io, params, txid, txentry).await? {
+        return Ok(L1TxStatus::Replaced { by: winner });
+    }
+    Ok(L1TxStatus::InvalidInputs)
+}
+
+/// Repoints a replacement chain at a superseded ancestor that was mined anyway.
+///
+/// Bitcoin Core reports negative confirmations for a transaction conflicting with one already in
+/// the best chain. For a replacement chain the conflict is usually its own ancestor: the local node
+/// accepted the replacement and evicted the original, then a miner included the original from
+/// somewhere else. The ancestor is still marked [`L1TxStatus::Replaced`], so the live-entry lookup
+/// walks straight past it and every consumer concludes the chain is dead.
+///
+/// Walks `replaces` back-pointers, asks bitcoind about each ancestor, and on finding a confirmed
+/// one reverses the link so the chain resolves to the winner. Returns the winner's txid when the
+/// reversal applied, or `None` when no ancestor won, which means the conflict is with a transaction
+/// outside this chain and the caller's `InvalidInputs` verdict stands.
+async fn adopt_confirmed_ancestor<C>(
+    io: &C,
+    params: &BtcioParams,
+    loser_txid: &Txid,
+    loser_entry: &L1TxEntry,
+) -> BroadcasterResult<Option<L1TxId>>
+where
+    C: BroadcasterIoContext,
+{
+    let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
+    let mut ancestor = loser_entry.rbf.and_then(|rbf| rbf.replaces);
+
+    for _ in 0..MAX_ANCESTOR_SEARCH_HOPS {
+        let Some(candidate) = ancestor else {
+            return Ok(None);
+        };
+        let candidate_raw = Buf32(candidate.0);
+        let Some(candidate_entry) = io.get_tx_entry_by_id(candidate_raw).await? else {
+            return Ok(None);
+        };
+
+        let candidate_txid = candidate_entry.try_to_tx()?.compute_txid();
+        if let TxLookupOutcome::Found(info) = io.get_transaction(&candidate_txid).await? {
+            if info.confirmations > 0 {
+                let winner_status = confirmation_status(&info, reorg_safe_depth);
+                info!(
+                    loser = %loser_txid,
+                    winner = %candidate_txid,
+                    confirmations = info.confirmations,
+                    "superseded transaction won on-chain; adopting it instead of rebuilding"
+                );
+                // `false` means another poll already reversed this pair, or the chain no longer
+                // links the two. Either way the caller must not report the loser as invalid.
+                if io
+                    .adopt_confirmed_ancestor(
+                        Buf32(loser_txid.to_byte_array()),
+                        candidate_raw,
+                        winner_status,
+                    )
+                    .await?
+                {
+                    return Ok(Some(candidate));
+                }
+                return Ok(None);
+            }
+        }
+
+        ancestor = candidate_entry.rbf.and_then(|rbf| rbf.replaces);
+    }
+
+    warn!(loser = %loser_txid, "conflicting-ancestor search exceeded its hop budget");
+    Ok(None)
 }
 
 /// Maps `TxConfirmationInfo` to the natural confirmation-derived status.
@@ -185,7 +301,17 @@ where
 }
 
 /// Attempts to broadcast an unpublished entry and maps publication outcomes to statuses.
-async fn publish_tx<C>(io: &C, txentry: &L1TxEntry) -> BroadcasterResult<L1TxStatus>
+///
+/// A rejection for spent inputs is settled against the replacement chain before it becomes
+/// [`L1TxStatus::InvalidInputs`]: an original mined between the replacement being persisted and
+/// broadcast takes the inputs out from under it, and the replacement is then rejected on its very
+/// first send, without ever reaching `Published` where the negative-confirmation path would have
+/// caught the same conflict.
+async fn publish_tx<C>(
+    io: &C,
+    params: &BtcioParams,
+    txentry: &L1TxEntry,
+) -> BroadcasterResult<L1TxStatus>
 where
     C: BroadcasterIoContext,
 {
@@ -206,7 +332,7 @@ where
             Ok(PublishTxOutcome::AlreadyInMempool) => Ok(L1TxStatus::Published),
             Ok(PublishTxOutcome::InvalidInputs) => {
                 warn!("tx excluded due to invalid inputs");
-                Ok(L1TxStatus::InvalidInputs)
+                resolve_invalid_inputs(io, params, &txid, txentry).await
             }
             Ok(PublishTxOutcome::RetryLater { reason }) => {
                 warn!(%reason, "broadcast should be retried on next poll");
@@ -275,7 +401,13 @@ where
         };
 
         if !txentry.is_valid() {
-            error!(%idx, status = ?txentry.status, "invalid broadcaster entry in DB; skipping");
+            // A superseded entry is a routine outcome of fee bumping, not a fault, and every one of
+            // them is re-read on each restart.
+            if matches!(txentry.status, L1TxStatus::Replaced { .. }) {
+                debug!(%idx, status = ?txentry.status, "skipping superseded broadcaster entry");
+            } else {
+                error!(%idx, status = ?txentry.status, "invalid broadcaster entry in DB; skipping");
+            }
             continue;
         }
 
@@ -290,14 +422,19 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeMap, future::Future};
+    use std::{
+        collections::BTreeMap,
+        future::Future,
+        iter::once,
+        sync::{Arc, Mutex},
+    };
 
-    use bitcoin::{Transaction, Txid};
+    use bitcoin::{absolute::LockTime, Amount, FeeRate, Transaction, Txid};
     use proptest::prelude::*;
-    use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
-    use strata_identifiers::test_utils::buf32_strategy;
+    use strata_db_types::l1_broadcast::{L1TxEntry, L1TxRbfInfo, L1TxStatus};
+    use strata_identifiers::{test_utils::buf32_strategy, Buf32};
     use strata_l1_txfmt::MagicBytes;
-    use strata_primitives::{buf::Buf32, L1Height};
+    use strata_primitives::L1Height;
     use tokio::runtime::Builder;
 
     use super::*;
@@ -332,6 +469,9 @@ mod test {
         entries: BTreeMap<u64, L1TxEntry>,
         tx_lookup: BTreeMap<Txid, MockTxLookupResult>,
         broadcast_results: BTreeMap<Txid, MockBroadcastResult>,
+        entries_by_id: BTreeMap<Buf32, L1TxEntry>,
+        adoptions: Arc<Mutex<Vec<(Buf32, Buf32, L1TxStatus)>>>,
+        adoption_applies: bool,
     }
 
     impl MockIoContext {
@@ -343,6 +483,20 @@ mod test {
         fn with_broadcast_result(mut self, txid: Txid, result: MockBroadcastResult) -> Self {
             self.broadcast_results.insert(txid, result);
             self
+        }
+
+        fn with_entry_by_id(mut self, txid: Buf32, entry: L1TxEntry) -> Self {
+            self.entries_by_id.insert(txid, entry);
+            self
+        }
+
+        fn with_adoption_applying(mut self, applies: bool) -> Self {
+            self.adoption_applies = applies;
+            self
+        }
+
+        fn adoptions(&self) -> Vec<(Buf32, Buf32, L1TxStatus)> {
+            self.adoptions.lock().unwrap().clone()
         }
     }
 
@@ -357,6 +511,23 @@ mod test {
 
         async fn put_tx_entry_by_idx(&self, _idx: u64, _entry: L1TxEntry) -> BroadcasterResult<()> {
             Ok(())
+        }
+
+        async fn get_tx_entry_by_id(&self, txid: Buf32) -> BroadcasterResult<Option<L1TxEntry>> {
+            Ok(self.entries_by_id.get(&txid).cloned())
+        }
+
+        async fn adopt_confirmed_ancestor(
+            &self,
+            loser_txid: Buf32,
+            winner_txid: Buf32,
+            winner_status: L1TxStatus,
+        ) -> BroadcasterResult<bool> {
+            self.adoptions
+                .lock()
+                .unwrap()
+                .push((loser_txid, winner_txid, winner_status));
+            Ok(self.adoption_applies)
         }
 
         async fn get_transaction<'a>(
@@ -412,6 +583,21 @@ mod test {
         let entry = gen_l1_tx_entry_with_status(status);
         let txid = entry.try_to_tx().unwrap().compute_txid();
         (entry, txid)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn malformed_transaction_returns_typed_error() {
+        let entry = IndexedEntry::new(
+            0,
+            L1TxEntry::from_raw_parts(vec![0xff], L1TxStatus::Published, None),
+        );
+        let io = MockIoContext::default();
+
+        let err = process_unfinalized_entries(once(&entry), &io, &get_test_btcio_params())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, BroadcasterError::InvalidTransaction(_)));
     }
 
     fn confirmation_info(
@@ -554,7 +740,7 @@ mod test {
         #[test]
         fn test_handle_published_entry(
             block_height in 1_u32..1_000_000,
-            block_hash in buf32_strategy(),
+            block_hash in buf32_strategy().prop_map(|buf| buf),
         ) {
             run_async_test(async move {
                 let (e, txid) = entry_with_txid(L1TxStatus::Published);
@@ -611,7 +797,7 @@ mod test {
         #[test]
         fn test_handle_confirmed_entry(
             block_height in 1_u32..1_000_000,
-            block_hash in buf32_strategy(),
+            block_hash in buf32_strategy().prop_map(|buf| buf),
         ) {
             run_async_test(async move {
                 let (e, txid) = entry_with_txid(confirmed_status(1, block_height, block_hash));
@@ -830,7 +1016,7 @@ mod test {
         fn test_process_unfinalized_entries(
             seed_idx in 1_u64..1_000_000,
             block_height in 1_u32..1_000_000,
-            block_hash in buf32_strategy(),
+            block_hash in buf32_strategy().prop_map(|buf| buf),
         ) {
             run_async_test(async move {
                 let btcio_params = get_test_btcio_params();
@@ -893,6 +1079,262 @@ mod test {
     }
 
     // ── confirmation_status ──
+
+    /// Builds a two-attempt chain: `winner` was superseded by `loser`, and the reverse link is set
+    /// as `put_replacement_tx_entry` would have set it.
+    fn replacement_chain() -> (L1TxEntry, Txid, L1TxEntry, Txid, Buf32) {
+        let (mut winner, winner_txid) = entry_with_txid(L1TxStatus::Published);
+        let winner_raw = Buf32(winner_txid.to_byte_array());
+        winner.rbf = Some(L1TxRbfInfo {
+            fee_rate_sat_vb: 2,
+            fee_sats: 200,
+            replaces: None,
+        });
+
+        // A distinct transaction, so the two entries do not collide by txid.
+        let loser_tx = {
+            let mut tx = winner.try_to_tx().unwrap();
+            tx.lock_time = LockTime::from_consensus(7);
+            tx
+        };
+        let loser_txid = loser_tx.compute_txid();
+        let mut loser = L1TxEntry::from_tx_with_fee(
+            &loser_tx,
+            FeeRate::from_sat_per_vb(4).unwrap(),
+            Amount::from_sat(400),
+        );
+        loser.status = L1TxStatus::Published;
+        loser.set_replaces(L1TxId::from(winner_raw.0));
+
+        winner.status = L1TxStatus::Replaced {
+            by: L1TxId::from(loser_txid.to_byte_array()),
+        };
+
+        (winner, winner_txid, loser, loser_txid, winner_raw)
+    }
+
+    /// Regression: a miner can include the original after the local node accepted the replacement.
+    /// Marking the replacement `InvalidInputs` sends the writer off to rebuild, republishing a
+    /// payload the confirmed ancestor already carries.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_adopt_a_confirmed_ancestor() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(3, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+            "the loser must point at the winner, not be marked invalid"
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, winner_raw);
+        assert_eq!(
+            adoptions[0].2,
+            confirmed_status(3, 400, Buf32::new([9u8; 32]))
+        );
+    }
+
+    /// A conflict with something outside the chain is a real double spend, and the original verdict
+    /// stands.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_stay_invalid_without_a_confirmed_ancestor() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            // The ancestor did not win either.
+            .with_tx_lookup(winner_txid, MockTxLookupResult::Missing);
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// Regression: every writer-owned entry carries RBF metadata from its first attempt, so the
+    /// metadata alone must not be read as "in a replacement chain". A first attempt conflicting
+    /// with the best chain is the ordinary side-branch sighting, and rebuilding it would republish
+    /// a payload that gets mined twice once the conflicting transaction is reorged out.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_hold_a_first_attempt_at_published() {
+        let (mut entry, txid) = entry_with_txid(L1TxStatus::Published);
+        entry.rbf = Some(L1TxRbfInfo {
+            fee_rate_sat_vb: 2,
+            fee_sats: 200,
+            replaces: None,
+        });
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default().with_tx_lookup(
+            txid,
+            MockTxLookupResult::Found(TxConfirmationInfo {
+                confirmations: -1,
+                block_hash: None,
+                block_height: None,
+            }),
+        );
+
+        let status = process_status(&io, &entry, &txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::Published));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// If the reversal did not apply the caller must not report the loser as invalid either: some
+    /// other pass already resolved the chain.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_stay_invalid_when_the_reversal_is_refused() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(false)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(3, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert_eq!(io.adoptions().len(), 1);
+    }
+
+    /// Regression: the original can be mined between the replacement being persisted and its first
+    /// broadcast. The replacement is then rejected for spent inputs on that very first send, so it
+    /// never reaches `Published` and the negative-confirmation path never runs. Left as
+    /// `InvalidInputs` the chain resolves to a dead entry and the writer rebuilds a payload the
+    /// confirmed original already carries.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unpublished_replacement_rejected_for_spent_inputs_adopts_its_ancestor() {
+        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        // Never broadcast: the writer persisted it and the block landed first.
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            // The original took the inputs, so bitcoind rejects the replacement outright.
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(1, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+            "a replacement rejected because its ancestor confirmed must adopt that ancestor"
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, winner_raw);
+    }
+
+    /// The verdict still stands when the rejection is a real double spend from outside the chain.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unpublished_replacement_stays_invalid_without_a_confirmed_ancestor() {
+        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(winner_txid, MockTxLookupResult::Missing);
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// The re-publish probe reaches the same rejection by a different route: a `Published`
+    /// replacement evicted from the wallet's view, re-sent, and refused because its ancestor won.
+    /// The `Replaced` verdict must reach the caller instead of folding back to `Published`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_republish_probe_rejected_for_spent_inputs_adopts_its_ancestor() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(loser_txid, MockTxLookupResult::Missing)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(1, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+        );
+        assert_eq!(io.adoptions().len(), 1);
+    }
+
+    /// An entry outside a replacement chain has no ancestor to consult, so a rejection is still a
+    /// rejection and the writer rebuilds as before.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_plain_entry_rejected_for_spent_inputs_stays_invalid() {
+        let (e, txid) = entry_with_txid(L1TxStatus::Unpublished);
+        assert!(
+            e.rbf.is_none(),
+            "test: fixture must be outside an RBF chain"
+        );
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_broadcast_result(txid, MockBroadcastResult::InvalidInputs);
+
+        let status = process_status(&io, &e, &txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
 
     #[test]
     fn confirmation_status_zero_confirmations_returns_published() {

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -8,21 +8,39 @@ use tracing::*;
 
 use super::{
     error::{BroadcasterError, BroadcasterResult},
+    handle::MAX_REPLACEMENT_CHAIN_HOPS,
     io::{BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo, TxLookupOutcome},
     state::{BroadcasterState, IndexedEntry},
 };
 use crate::BtcioParams;
+
+/// Result of one processing pass over the unfinalized set.
+#[derive(Debug, Default)]
+pub(super) struct ProcessingPassResult {
+    /// Indexed entries whose status changed and must be written back.
+    pub updated: Vec<IndexedEntry>,
+
+    /// Whether the in-memory set has to be rebuilt from the full index range.
+    ///
+    /// Set when a superseded ancestor was adopted, either after winning on-chain or after the
+    /// replacement that superseded it was refused while it was still in the mempool. That ancestor
+    /// left `unfinalized_entries` when it was first replaced, and [`update_state`]'s cursor only
+    /// reads rows added since, so without a rebuild nothing would ever poll it again: it would sit
+    /// at its adopted status forever, never reaching `Finalized`, and a reorg on it would go
+    /// unnoticed.
+    pub resync_required: bool,
+}
 
 /// Processes unfinalized entries and returns the indexed entries whose status changed.
 pub(super) async fn process_unfinalized_entries<C>(
     unfinalized_entries: impl Iterator<Item = &IndexedEntry>,
     io: &C,
     params: &BtcioParams,
-) -> BroadcasterResult<Vec<IndexedEntry>>
+) -> BroadcasterResult<ProcessingPassResult>
 where
     C: BroadcasterIoContext,
 {
-    let mut updated_entries = Vec::new();
+    let mut processed = ProcessingPassResult::default();
 
     for entry in unfinalized_entries {
         let idx = *entry.index();
@@ -35,13 +53,19 @@ where
         let updated_status = process_tx_entry(io, txentry, &txid, params).await?;
 
         if let Some(status) = updated_status {
+            // Adoption is the only path that turns a tracked entry into `Replaced`: the fee
+            // bumper writes that status straight to the DB, and an already-`Replaced` entry
+            // returns `None` above. So this is the signal that a winner needs re-admitting.
+            if matches!(status, L1TxStatus::Replaced { .. }) {
+                processed.resync_required = true;
+            }
             let mut new_txentry = txentry.clone();
             new_txentry.status = status;
-            updated_entries.push(IndexedEntry::new(idx, new_txentry));
+            processed.updated.push(IndexedEntry::new(idx, new_txentry));
         }
     }
 
-    Ok(updated_entries)
+    Ok(processed)
 }
 
 /// Computes the next status for a single entry, or `None` when no update is needed.
@@ -87,9 +111,9 @@ where
 ///    here would only spam bitcoind and the logs every poll for the entire pre-confirmation window.
 /// 3. `Ok(None)`: not found at all. Could be a transient wallet-syncer miss for a freshly broadcast
 ///    tx, or a genuinely dropped tx (mempool eviction, RBF). Re-publish to disambiguate: benign
-///    mempool messages fold back to Published, `bad-txns-inputs-missingorspent` routes to
-///    InvalidInputs so the watcher rebuilds the envelope, unless an ancestor of this entry's own
-///    replacement chain took those inputs by confirming.
+///    mempool messages fold back to Published, a rejection routes to InvalidInputs so the watcher
+///    rebuilds the envelope, unless an ancestor of this entry's own replacement chain is still
+///    live.
 async fn probe_published_entry<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -119,7 +143,14 @@ where
             // attempt has no chain to lose to.
             if txentry.rbf.and_then(|rbf| rbf.replaces).is_some() && info.confirmations < 0 {
                 warn!(%txid, confirmations = info.confirmations, "replacement-chain transaction conflicts with a confirmed transaction");
-                return resolve_invalid_inputs(io, params, txid, txentry).await;
+                return resolve_invalid_inputs(
+                    io,
+                    params,
+                    txid,
+                    txentry,
+                    AncestorRescue::Confirmed,
+                )
+                .await;
             }
             Ok(confirmation_status(&info, reorg_safe_depth))
         }
@@ -137,66 +168,102 @@ where
     }
 }
 
-/// Bound on how far back a conflicting-ancestor search walks, matching the forward chain walk.
-const MAX_ANCESTOR_SEARCH_HOPS: usize = 32;
+/// Which ancestors of a replacement chain count as a winner worth repointing the chain at.
+#[derive(Clone, Copy, Debug)]
+enum AncestorRescue {
+    /// Only an ancestor already in the best chain.
+    ///
+    /// The verdict came from the entry conflicting with a confirmed transaction, and only a
+    /// confirmed ancestor explains that sighting. An ancestor merely sitting in the mempool spends
+    /// the same inputs, so it is just as doomed and repointing the chain at it would park the
+    /// payload on a transaction that can never confirm.
+    Confirmed,
+
+    /// An ancestor already in the best chain, or failing that one still in the mempool.
+    ///
+    /// The verdict came from bitcoind refusing the broadcast itself, which proves nothing about
+    /// the inputs: fee-policy rejects (`min relay fee not met`, `insufficient fee, rejecting
+    /// replacement`, `txn-mempool-conflict`) and script-level rejects all arrive as
+    /// [`PublishTxOutcome::InvalidInputs`]. While an ancestor is still live the chain has lost
+    /// nothing, and the refused replacement must not become the verdict for the whole chain.
+    ///
+    /// [`PublishTxOutcome::InvalidInputs`]: super::io::PublishTxOutcome::InvalidInputs
+    ConfirmedOrInMempool,
+}
 
 /// Settles an `InvalidInputs` verdict against the entry's own replacement chain.
 ///
-/// `InvalidInputs` is what sends the writer off to rebuild, and rebuilding republishes a payload a
-/// confirmed transaction may already carry. For an entry in a replacement chain the transaction
-/// that took its inputs is usually an ancestor of that very chain: a miner included an original
-/// after the local node had already accepted its replacement.
+/// `InvalidInputs` is what sends the writer off to rebuild, and rebuilding republishes a payload
+/// another transaction in this very chain may already carry, or may still be about to carry. For an
+/// entry in a replacement chain the transaction standing in its way is usually an ancestor: a miner
+/// included an original after the local node had already accepted its replacement, or the node
+/// refused the replacement and kept the original in its mempool.
 ///
-/// Returns [`L1TxStatus::Replaced`] pointing at the ancestor that won. When no ancestor did, the
-/// conflict is with a transaction outside this chain and the [`L1TxStatus::InvalidInputs`] verdict
-/// stands. An entry with no `replaces` link, which is every entry outside a replacement chain,
-/// resolves to `InvalidInputs` without asking bitcoind anything.
+/// Returns [`L1TxStatus::Replaced`] pointing at the ancestor the chain was repointed at. When no
+/// ancestor qualifies under `rescue`, the conflict is with a transaction outside this chain and the
+/// [`L1TxStatus::InvalidInputs`] verdict stands. An entry with no `replaces` link, which is every
+/// entry outside a replacement chain, resolves to `InvalidInputs` without asking bitcoind anything.
 async fn resolve_invalid_inputs<C>(
     io: &C,
     params: &BtcioParams,
     txid: &Txid,
     txentry: &L1TxEntry,
+    rescue: AncestorRescue,
 ) -> BroadcasterResult<L1TxStatus>
 where
     C: BroadcasterIoContext,
 {
-    if let Some(winner) = adopt_confirmed_ancestor(io, params, txid, txentry).await? {
+    if let Some(winner) = adopt_live_ancestor(io, params, txid, txentry, rescue).await? {
         return Ok(L1TxStatus::Replaced { by: winner });
     }
     Ok(L1TxStatus::InvalidInputs)
 }
 
-/// Repoints a replacement chain at a superseded ancestor that was mined anyway.
+/// Repoints a replacement chain at a superseded ancestor that is still the chain's real tip.
 ///
-/// Bitcoin Core reports negative confirmations for a transaction conflicting with one already in
-/// the best chain. For a replacement chain the conflict is usually its own ancestor: the local node
-/// accepted the replacement and evicted the original, then a miner included the original from
-/// somewhere else. The ancestor is still marked [`L1TxStatus::Replaced`], so the live-entry lookup
-/// walks straight past it and every consumer concludes the chain is dead.
+/// A superseded ancestor is marked [`L1TxStatus::Replaced`], so the live-entry lookup walks
+/// straight past it to the replacement and every consumer reads the replacement's verdict as the
+/// chain's. Two situations make that reading wrong:
 ///
-/// Walks `replaces` back-pointers, asks bitcoind about each ancestor, and on finding a confirmed
-/// one reverses the link so the chain resolves to the winner. Returns the winner's txid when the
-/// reversal applied, or `None` when no ancestor won, which means the conflict is with a transaction
-/// outside this chain and the caller's `InvalidInputs` verdict stands.
-async fn adopt_confirmed_ancestor<C>(
+/// - The ancestor was mined anyway. Bitcoin Core reports negative confirmations for a transaction
+///   conflicting with one already in the best chain; for a replacement chain that conflict is
+///   usually its own ancestor, included by a miner after the local node had accepted the
+///   replacement and evicted the original.
+/// - The replacement was never accepted. A fee-policy or script-level reject leaves the ancestor
+///   sitting in the mempool exactly as before, still able to confirm on its own.
+///
+/// Walks `replaces` back-pointers, asks bitcoind about each ancestor, and reverses the link so the
+/// chain resolves to the winner. A confirmed ancestor is the stronger claim and can sit further
+/// back than a mempool one, so the walk runs to completion before settling for the nearest ancestor
+/// still in the mempool. Returns the winner's txid when the reversal applied, or `None` when no
+/// ancestor qualifies and the caller's `InvalidInputs` verdict stands.
+async fn adopt_live_ancestor<C>(
     io: &C,
     params: &BtcioParams,
     loser_txid: &Txid,
     loser_entry: &L1TxEntry,
+    rescue: AncestorRescue,
 ) -> BroadcasterResult<Option<L1TxId>>
 where
     C: BroadcasterIoContext,
 {
     let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
     let mut ancestor = loser_entry.rbf.and_then(|rbf| rbf.replaces);
+    let mut in_mempool: Option<(L1TxId, Txid)> = None;
+    // Same budget as the forward walk in `L1BroadcastHandle`, so a chain the forward lookup
+    // traverses is never one this search gives up on.
+    let mut hops_left = MAX_REPLACEMENT_CHAIN_HOPS;
 
-    for _ in 0..MAX_ANCESTOR_SEARCH_HOPS {
-        let Some(candidate) = ancestor else {
-            return Ok(None);
-        };
+    while let Some(candidate) = ancestor {
+        if hops_left == 0 {
+            warn!(loser = %loser_txid, "conflicting-ancestor search exceeded its hop budget");
+            break;
+        }
+        hops_left -= 1;
+
         let candidate_raw = Buf32(candidate.0);
         let Some(candidate_entry) = io.get_tx_entry_by_id(candidate_raw).await? else {
-            return Ok(None);
+            break;
         };
 
         let candidate_txid = candidate_entry
@@ -212,26 +279,55 @@ where
                     confirmations = info.confirmations,
                     "superseded transaction won on-chain; adopting it instead of rebuilding"
                 );
-                // `false` means another poll already reversed this pair, or the chain no longer
-                // links the two. Either way the caller must not report the loser as invalid.
-                if io
-                    .adopt_confirmed_ancestor(
-                        Buf32(loser_txid.to_byte_array()),
-                        candidate_raw,
-                        winner_status,
-                    )
-                    .await?
-                {
-                    return Ok(Some(candidate));
-                }
-                return Ok(None);
+                return apply_adoption(io, loser_txid, candidate, winner_status).await;
+            }
+            // Only a 0-conf sighting means the node still holds it in the mempool. Negative
+            // confirmations mean this ancestor conflicts with the best chain too, so it is no
+            // rescue for anyone.
+            if info.confirmations == 0
+                && matches!(rescue, AncestorRescue::ConfirmedOrInMempool)
+                && in_mempool.is_none()
+            {
+                in_mempool = Some((candidate, candidate_txid));
             }
         }
 
         ancestor = candidate_entry.rbf.and_then(|rbf| rbf.replaces);
     }
 
-    warn!(loser = %loser_txid, "conflicting-ancestor search exceeded its hop budget");
+    let Some((winner, winner_txid)) = in_mempool else {
+        return Ok(None);
+    };
+    warn!(
+        loser = %loser_txid,
+        winner = %winner_txid,
+        "replacement refused while the transaction it supersedes is still in the mempool; rolling the chain back to it"
+    );
+    apply_adoption(io, loser_txid, winner, L1TxStatus::Published).await
+}
+
+/// Reverses one replacement link, reporting the winner only when the write took effect.
+async fn apply_adoption<C>(
+    io: &C,
+    loser_txid: &Txid,
+    winner: L1TxId,
+    winner_status: L1TxStatus,
+) -> BroadcasterResult<Option<L1TxId>>
+where
+    C: BroadcasterIoContext,
+{
+    // `false` means another poll already reversed this pair, or the chain no longer links the two.
+    // Stop either way rather than repointing at some older ancestor on a chain that has moved.
+    if io
+        .adopt_confirmed_ancestor(
+            Buf32(loser_txid.to_byte_array()),
+            Buf32(winner.0),
+            winner_status,
+        )
+        .await?
+    {
+        return Ok(Some(winner));
+    }
     Ok(None)
 }
 
@@ -308,11 +404,15 @@ where
 
 /// Attempts to broadcast an unpublished entry and maps publication outcomes to statuses.
 ///
-/// A rejection for spent inputs is settled against the replacement chain before it becomes
-/// [`L1TxStatus::InvalidInputs`]: an original mined between the replacement being persisted and
-/// broadcast takes the inputs out from under it, and the replacement is then rejected on its very
-/// first send, without ever reaching `Published` where the negative-confirmation path would have
-/// caught the same conflict.
+/// A rejected broadcast is settled against the replacement chain before it becomes
+/// [`L1TxStatus::InvalidInputs`]. Two distinct situations reach here as a rejection, and neither
+/// one means the chain is dead:
+///
+/// - An original mined between the replacement being persisted and broadcast takes the inputs out
+///   from under it, and the replacement is rejected on its very first send, without ever reaching
+///   `Published` where the negative-confirmation path would have caught the same conflict.
+/// - Bitcoind refuses the replacement on fee policy or script grounds and keeps the original in its
+///   mempool, where it can still confirm.
 async fn publish_tx<C>(
     io: &C,
     params: &BtcioParams,
@@ -337,8 +437,15 @@ where
             Ok(PublishTxOutcome::Published) => Ok(L1TxStatus::Published),
             Ok(PublishTxOutcome::AlreadyInMempool) => Ok(L1TxStatus::Published),
             Ok(PublishTxOutcome::InvalidInputs) => {
-                warn!("tx excluded due to invalid inputs");
-                resolve_invalid_inputs(io, params, &txid, txentry).await
+                warn!("tx rejected on broadcast");
+                resolve_invalid_inputs(
+                    io,
+                    params,
+                    &txid,
+                    txentry,
+                    AncestorRescue::ConfirmedOrInMempool,
+                )
+                .await
             }
             Ok(PublishTxOutcome::RetryLater { reason }) => {
                 warn!(%reason, "broadcast should be retried on next poll");
@@ -366,12 +473,13 @@ pub(super) async fn update_state<C>(
     state: &mut BroadcasterState,
     updated_entries: impl Iterator<Item = IndexedEntry>,
     io: &C,
+    resync_required: bool,
 ) -> BroadcasterResult<()>
 where
     C: BroadcasterIoContext,
 {
     let unfinalized_entries: Vec<_> = updated_entries
-        .filter(|entry| !entry.item().is_finalized() && entry.item().is_valid())
+        .filter(|entry| !entry.item().is_finalized() && entry.item().is_trackable())
         .collect();
 
     let next_idx = io.get_next_tx_idx().await?;
@@ -380,6 +488,19 @@ where
             expected: state.next_idx,
             got: next_idx,
         });
+    }
+
+    if resync_required {
+        // Rebuild from the whole range rather than the incremental window. The adopted winner
+        // sits at an index below the cursor, so nothing else would pick it back up. Callers have
+        // already written this pass's statuses back, so the DB is authoritative here.
+        //
+        // A full scan is affordable because adoption is a rare recovery path: it needs either a
+        // superseded transaction to win on-chain, or a replacement to be refused outright, and the
+        // replacement pass only builds one per transaction per bump interval.
+        state.unfinalized_entries = fetch_unfinalized_entries(io, 0, next_idx).await?;
+        state.next_idx = next_idx;
+        return Ok(());
     }
 
     let new_unfinalized_entries = fetch_unfinalized_entries(io, state.next_idx, next_idx).await?;
@@ -406,7 +527,7 @@ where
             break;
         };
 
-        if !txentry.is_valid() {
+        if !txentry.is_trackable() {
             // A superseded entry is a routine outcome of fee bumping, not a fault, and every one of
             // them is re-read on each restart.
             if matches!(txentry.status, L1TxStatus::Replaced { .. }) {
@@ -1048,6 +1169,7 @@ mod test {
 
                 assert_eq!(
                     updated_entries
+                        .updated
                         .iter()
                         .find(|e| *e.index() == i1)
                         .map(|e| e.item().status.clone())
@@ -1057,6 +1179,7 @@ mod test {
                 );
                 assert_eq!(
                     updated_entries
+                        .updated
                         .iter()
                         .find(|e| *e.index() == i3)
                         .map(|e| e.item().status.clone())
@@ -1070,9 +1193,20 @@ mod test {
 
     // ── confirmation_status ──
 
+    /// A two-attempt replacement chain, named for how these tests end up using it: `winner` is the
+    /// older attempt that a miner may still include, `loser` is the replacement that superseded it.
+    struct ReplacementChain {
+        winner: L1TxEntry,
+        winner_txid: Txid,
+        loser: L1TxEntry,
+        loser_txid: Txid,
+        /// `winner_txid` as the raw key the broadcast DB is indexed by.
+        winner_raw: Buf32,
+    }
+
     /// Builds a two-attempt chain: `winner` was superseded by `loser`, and the reverse link is set
     /// as `put_replacement_tx_entry` would have set it.
-    fn replacement_chain() -> (L1TxEntry, Txid, L1TxEntry, Txid, Buf32) {
+    fn replacement_chain() -> ReplacementChain {
         let (mut winner, winner_txid) = entry_with_txid(L1TxStatus::Published);
         let winner_raw = Buf32(winner_txid.to_byte_array());
         winner.rbf = Some(L1TxRbfInfo {
@@ -1100,7 +1234,13 @@ mod test {
             by: L1TxId::from(loser_txid.to_byte_array()),
         };
 
-        (winner, winner_txid, loser, loser_txid, winner_raw)
+        ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        }
     }
 
     /// Regression: a miner can include the original after the local node accepted the replacement.
@@ -1108,7 +1248,13 @@ mod test {
     /// payload the confirmed ancestor already carries.
     #[tokio::test(flavor = "multi_thread")]
     async fn negative_confirmations_adopt_a_confirmed_ancestor() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1148,7 +1294,13 @@ mod test {
     /// stands.
     #[tokio::test(flavor = "multi_thread")]
     async fn negative_confirmations_stay_invalid_without_a_confirmed_ancestor() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1198,11 +1350,19 @@ mod test {
         assert!(io.adoptions().is_empty());
     }
 
-    /// If the reversal did not apply the caller must not report the loser as invalid either: some
-    /// other pass already resolved the chain.
+    /// A refused reversal leaves the chain exactly as it was, so the `InvalidInputs` verdict
+    /// stands and the caller still reports it. When the refusal was caused by a concurrent pass
+    /// resolving the chain, that verdict never reaches the DB either: the `replaced_concurrently`
+    /// guard in `state.rs` drops the write-back once it re-reads the row as `Replaced`.
     #[tokio::test(flavor = "multi_thread")]
     async fn negative_confirmations_stay_invalid_when_the_reversal_is_refused() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1233,7 +1393,13 @@ mod test {
     /// confirmed original already carries.
     #[tokio::test(flavor = "multi_thread")]
     async fn an_unpublished_replacement_rejected_for_spent_inputs_adopts_its_ancestor() {
-        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         // Never broadcast: the writer persisted it and the block landed first.
         loser.status = L1TxStatus::Unpublished;
         let btcio_params = get_test_btcio_params();
@@ -1264,7 +1430,13 @@ mod test {
     /// The verdict still stands when the rejection is a real double spend from outside the chain.
     #[tokio::test(flavor = "multi_thread")]
     async fn an_unpublished_replacement_stays_invalid_without_a_confirmed_ancestor() {
-        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         loser.status = L1TxStatus::Unpublished;
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
@@ -1284,7 +1456,13 @@ mod test {
     /// The `Replaced` verdict must reach the caller instead of folding back to `Published`.
     #[tokio::test(flavor = "multi_thread")]
     async fn a_republish_probe_rejected_for_spent_inputs_adopts_its_ancestor() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1305,6 +1483,199 @@ mod test {
             }),
         );
         assert_eq!(io.adoptions().len(), 1);
+    }
+
+    /// Builds a three-attempt chain, oldest first, wired the way `put_replacement_tx_entry` wires
+    /// one: each entry is `Replaced` by the next and each replacement carries the reverse link.
+    fn three_attempt_chain() -> Vec<(L1TxEntry, Txid)> {
+        let (base, _) = entry_with_txid(L1TxStatus::Published);
+        let base_tx = base.try_to_tx().unwrap();
+
+        let mut attempts: Vec<(L1TxEntry, Txid)> = (0..3)
+            .map(|i| {
+                // Distinct lock times, so the three entries do not collide by txid.
+                let mut tx = base_tx.clone();
+                tx.lock_time = LockTime::from_consensus(11 + i);
+                let txid = tx.compute_txid();
+                let mut entry = L1TxEntry::from_tx_with_fee(
+                    &tx,
+                    FeeRate::from_sat_per_vb(2 + u64::from(i)).unwrap(),
+                    Amount::from_sat(200 * (u64::from(i) + 1)),
+                );
+                entry.status = L1TxStatus::Published;
+                (entry, txid)
+            })
+            .collect();
+
+        for i in 0..attempts.len() - 1 {
+            let (older_txid, newer_txid) = (attempts[i].1, attempts[i + 1].1);
+            attempts[i].0.status = L1TxStatus::Replaced {
+                by: L1TxId::from(newer_txid.to_byte_array()),
+            };
+            attempts[i + 1]
+                .0
+                .set_replaces(L1TxId::from(older_txid.to_byte_array()));
+        }
+
+        attempts
+    }
+
+    /// Regression: bitcoind rejects a replacement on fee policy (`min relay fee not met`,
+    /// `insufficient fee, rejecting replacement`) or on script grounds, and the IO layer reports
+    /// every one of those as `InvalidInputs`. The inputs are untouched and the original is still in
+    /// the mempool, but the original row is already `Replaced`, so leaving the refused replacement
+    /// as the chain's verdict makes the writer rebuild and repost the DA a live transaction still
+    /// carries. Roll the chain back to the original instead, where the fee bumper can escalate it
+    /// again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_replacement_refused_on_broadcast_rolls_back_to_its_live_original() {
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            // The original never left the mempool: bitcoind simply refused to swap it out.
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+            "a refused replacement must not outlive the original it never replaced"
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, winner_raw);
+        assert_eq!(
+            adoptions[0].2,
+            L1TxStatus::Published,
+            "the original goes back to the status it held in the mempool"
+        );
+    }
+
+    /// An ancestor at negative confirmations conflicts with the best chain just as the loser does,
+    /// so it is no rescue: the chain really is dead and the writer must rebuild.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_replacement_refused_stays_invalid_when_its_ancestor_conflicts_too() {
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// A tx conflicting with the best chain can only have lost to a confirmed transaction, so a
+    /// mempool ancestor must not rescue it. That ancestor spends the same inputs and is therefore
+    /// just as doomed; adopting it would park the payload on a transaction that can never confirm.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_do_not_adopt_a_mempool_ancestor() {
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// A confirmed ancestor is the stronger claim and can sit further back than a mempool one, so
+    /// the walk must reach it rather than settling for the nearest live ancestor. Adopting the
+    /// mempool one would leave the chain waiting on a transaction the confirmed ancestor has
+    /// already made unspendable.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_confirmed_ancestor_outranks_a_nearer_mempool_one() {
+        let chain = three_attempt_chain();
+        let [(confirmed, confirmed_txid), (mempool, mempool_txid), (mut loser, loser_txid)] =
+            <[_; 3]>::try_from(chain).unwrap();
+        let confirmed_raw = Buf32(confirmed_txid.to_byte_array());
+        loser.status = L1TxStatus::Unpublished;
+
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(confirmed_raw, confirmed)
+            .with_entry_by_id(Buf32(mempool_txid.to_byte_array()), mempool)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                mempool_txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            )
+            .with_tx_lookup(
+                confirmed_txid,
+                MockTxLookupResult::Found(confirmation_info(2, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(confirmed_raw.0)
+            }),
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, confirmed_raw);
+        assert_eq!(
+            adoptions[0].2,
+            confirmed_status(2, 400, Buf32::new([9u8; 32]))
+        );
     }
 
     /// An entry outside a replacement chain has no ancestor to consult, so a rejection is still a

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -1,5 +1,9 @@
-use bitcoin::Txid;
-use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
+use bitcoin::{hashes::Hash, Txid};
+use strata_db_types::{
+    common::L1TxId,
+    l1_broadcast::{L1TxEntry, L1TxStatus},
+};
+use strata_primitives::buf::Buf32;
 use tracing::*;
 
 use super::{
@@ -57,7 +61,7 @@ where
     C: BroadcasterIoContext,
 {
     let result = match txentry.status {
-        L1TxStatus::Unpublished => publish_tx(io, txentry).await.map(Some),
+        L1TxStatus::Unpublished => publish_tx(io, params, txentry).await.map(Some),
         L1TxStatus::Published => probe_published_entry(io, txentry, txid, params)
             .await
             .map(Some),
@@ -65,7 +69,7 @@ where
             .await
             .map(Some),
         L1TxStatus::Finalized { .. } => Ok(None),
-        L1TxStatus::InvalidInputs => Ok(None),
+        L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. } => Ok(None),
     };
     if let Ok(ref updated_status) = result {
         debug!(?updated_status);
@@ -84,7 +88,8 @@ where
 /// 3. `Ok(None)`: not found at all. Could be a transient wallet-syncer miss for a freshly broadcast
 ///    tx, or a genuinely dropped tx (mempool eviction, RBF). Re-publish to disambiguate: benign
 ///    mempool messages fold back to Published, `bad-txns-inputs-missingorspent` routes to
-///    InvalidInputs so the watcher rebuilds the envelope.
+///    InvalidInputs so the watcher rebuilds the envelope, unless an ancestor of this entry's own
+///    replacement chain took those inputs by confirming.
 async fn probe_published_entry<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -101,9 +106,28 @@ where
     match txinfo_res? {
         // `confirmation_status` returns `Published` for 0-conf, which is the
         // correct sighting for an already-Published entry still in mempool.
-        TxLookupOutcome::Found(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
-        TxLookupOutcome::Missing => match publish_tx(io, txentry).await? {
-            L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
+        TxLookupOutcome::Found(info) => {
+            // Bitcoin Core reports negative confirmations for a wallet transaction that conflicts
+            // with one already in the best chain. For an ordinary entry that reads as "side branch
+            // after a reorg" and is held at `Published` so it can be re-mined. For an entry that is
+            // itself a replacement it is unambiguous: some other transaction in its replacement
+            // chain confirmed, so this one can never enter the chain. Holding it at `Published`
+            // would leave the envelope waiting on a commit that will never confirm.
+            //
+            // The predicate is the reverse `replaces` link, not the presence of RBF metadata:
+            // every writer-owned entry carries that metadata from its first attempt, and a first
+            // attempt has no chain to lose to.
+            if txentry.rbf.and_then(|rbf| rbf.replaces).is_some() && info.confirmations < 0 {
+                warn!(%txid, confirmations = info.confirmations, "replacement-chain transaction conflicts with a confirmed transaction");
+                return resolve_invalid_inputs(io, params, txid, txentry).await;
+            }
+            Ok(confirmation_status(&info, reorg_safe_depth))
+        }
+        // A rejected re-publish resolves the same way a first publish does, including the
+        // ancestor check, so a `Replaced` verdict must reach the caller rather than fold into
+        // `Published`.
+        TxLookupOutcome::Missing => match publish_tx(io, params, txentry).await? {
+            status @ (L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. }) => Ok(status),
             _ => Ok(L1TxStatus::Published),
         },
         TxLookupOutcome::RetryLater { reason } => {
@@ -111,6 +135,104 @@ where
             Ok(L1TxStatus::Published)
         }
     }
+}
+
+/// Bound on how far back a conflicting-ancestor search walks, matching the forward chain walk.
+const MAX_ANCESTOR_SEARCH_HOPS: usize = 32;
+
+/// Settles an `InvalidInputs` verdict against the entry's own replacement chain.
+///
+/// `InvalidInputs` is what sends the writer off to rebuild, and rebuilding republishes a payload a
+/// confirmed transaction may already carry. For an entry in a replacement chain the transaction
+/// that took its inputs is usually an ancestor of that very chain: a miner included an original
+/// after the local node had already accepted its replacement.
+///
+/// Returns [`L1TxStatus::Replaced`] pointing at the ancestor that won. When no ancestor did, the
+/// conflict is with a transaction outside this chain and the [`L1TxStatus::InvalidInputs`] verdict
+/// stands. An entry with no `replaces` link, which is every entry outside a replacement chain,
+/// resolves to `InvalidInputs` without asking bitcoind anything.
+async fn resolve_invalid_inputs<C>(
+    io: &C,
+    params: &BtcioParams,
+    txid: &Txid,
+    txentry: &L1TxEntry,
+) -> BroadcasterResult<L1TxStatus>
+where
+    C: BroadcasterIoContext,
+{
+    if let Some(winner) = adopt_confirmed_ancestor(io, params, txid, txentry).await? {
+        return Ok(L1TxStatus::Replaced { by: winner });
+    }
+    Ok(L1TxStatus::InvalidInputs)
+}
+
+/// Repoints a replacement chain at a superseded ancestor that was mined anyway.
+///
+/// Bitcoin Core reports negative confirmations for a transaction conflicting with one already in
+/// the best chain. For a replacement chain the conflict is usually its own ancestor: the local node
+/// accepted the replacement and evicted the original, then a miner included the original from
+/// somewhere else. The ancestor is still marked [`L1TxStatus::Replaced`], so the live-entry lookup
+/// walks straight past it and every consumer concludes the chain is dead.
+///
+/// Walks `replaces` back-pointers, asks bitcoind about each ancestor, and on finding a confirmed
+/// one reverses the link so the chain resolves to the winner. Returns the winner's txid when the
+/// reversal applied, or `None` when no ancestor won, which means the conflict is with a transaction
+/// outside this chain and the caller's `InvalidInputs` verdict stands.
+async fn adopt_confirmed_ancestor<C>(
+    io: &C,
+    params: &BtcioParams,
+    loser_txid: &Txid,
+    loser_entry: &L1TxEntry,
+) -> BroadcasterResult<Option<L1TxId>>
+where
+    C: BroadcasterIoContext,
+{
+    let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
+    let mut ancestor = loser_entry.rbf.and_then(|rbf| rbf.replaces);
+
+    for _ in 0..MAX_ANCESTOR_SEARCH_HOPS {
+        let Some(candidate) = ancestor else {
+            return Ok(None);
+        };
+        let candidate_raw = Buf32(candidate.0);
+        let Some(candidate_entry) = io.get_tx_entry_by_id(candidate_raw).await? else {
+            return Ok(None);
+        };
+
+        let candidate_txid = candidate_entry
+            .try_to_tx()
+            .map_err(|err| BroadcasterError::Other(err.to_string()))?
+            .compute_txid();
+        if let TxLookupOutcome::Found(info) = io.get_transaction(&candidate_txid).await? {
+            if info.confirmations > 0 {
+                let winner_status = confirmation_status(&info, reorg_safe_depth);
+                info!(
+                    loser = %loser_txid,
+                    winner = %candidate_txid,
+                    confirmations = info.confirmations,
+                    "superseded transaction won on-chain; adopting it instead of rebuilding"
+                );
+                // `false` means another poll already reversed this pair, or the chain no longer
+                // links the two. Either way the caller must not report the loser as invalid.
+                if io
+                    .adopt_confirmed_ancestor(
+                        Buf32(loser_txid.to_byte_array()),
+                        candidate_raw,
+                        winner_status,
+                    )
+                    .await?
+                {
+                    return Ok(Some(candidate));
+                }
+                return Ok(None);
+            }
+        }
+
+        ancestor = candidate_entry.rbf.and_then(|rbf| rbf.replaces);
+    }
+
+    warn!(loser = %loser_txid, "conflicting-ancestor search exceeded its hop budget");
+    Ok(None)
 }
 
 /// Maps `TxConfirmationInfo` to the natural confirmation-derived status.
@@ -185,7 +307,17 @@ where
 }
 
 /// Attempts to broadcast an unpublished entry and maps publication outcomes to statuses.
-async fn publish_tx<C>(io: &C, txentry: &L1TxEntry) -> BroadcasterResult<L1TxStatus>
+///
+/// A rejection for spent inputs is settled against the replacement chain before it becomes
+/// [`L1TxStatus::InvalidInputs`]: an original mined between the replacement being persisted and
+/// broadcast takes the inputs out from under it, and the replacement is then rejected on its very
+/// first send, without ever reaching `Published` where the negative-confirmation path would have
+/// caught the same conflict.
+async fn publish_tx<C>(
+    io: &C,
+    params: &BtcioParams,
+    txentry: &L1TxEntry,
+) -> BroadcasterResult<L1TxStatus>
 where
     C: BroadcasterIoContext,
 {
@@ -206,7 +338,7 @@ where
             Ok(PublishTxOutcome::AlreadyInMempool) => Ok(L1TxStatus::Published),
             Ok(PublishTxOutcome::InvalidInputs) => {
                 warn!("tx excluded due to invalid inputs");
-                Ok(L1TxStatus::InvalidInputs)
+                resolve_invalid_inputs(io, params, &txid, txentry).await
             }
             Ok(PublishTxOutcome::RetryLater { reason }) => {
                 warn!(%reason, "broadcast should be retried on next poll");
@@ -275,7 +407,13 @@ where
         };
 
         if !txentry.is_valid() {
-            error!(%idx, status = ?txentry.status, "invalid broadcaster entry in DB; skipping");
+            // A superseded entry is a routine outcome of fee bumping, not a fault, and every one of
+            // them is re-read on each restart.
+            if matches!(txentry.status, L1TxStatus::Replaced { .. }) {
+                debug!(%idx, status = ?txentry.status, "skipping superseded broadcaster entry");
+            } else {
+                error!(%idx, status = ?txentry.status, "invalid broadcaster entry in DB; skipping");
+            }
             continue;
         }
 
@@ -290,14 +428,18 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeMap, future::Future};
+    use std::{
+        collections::BTreeMap,
+        future::Future,
+        sync::{Arc, Mutex},
+    };
 
-    use bitcoin::{Transaction, Txid};
+    use bitcoin::{absolute::LockTime, Amount, FeeRate, Transaction, Txid};
     use proptest::prelude::*;
-    use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
-    use strata_identifiers::test_utils::buf32_strategy;
+    use strata_db_types::l1_broadcast::{L1TxEntry, L1TxRbfInfo, L1TxStatus};
+    use strata_identifiers::{test_utils::buf32_strategy, Buf32};
     use strata_l1_txfmt::MagicBytes;
-    use strata_primitives::{buf::Buf32, L1Height};
+    use strata_primitives::L1Height;
     use tokio::runtime::Builder;
 
     use super::*;
@@ -332,6 +474,9 @@ mod test {
         entries: BTreeMap<u64, L1TxEntry>,
         tx_lookup: BTreeMap<Txid, MockTxLookupResult>,
         broadcast_results: BTreeMap<Txid, MockBroadcastResult>,
+        entries_by_id: BTreeMap<Buf32, L1TxEntry>,
+        adoptions: Arc<Mutex<Vec<(Buf32, Buf32, L1TxStatus)>>>,
+        adoption_applies: bool,
     }
 
     impl MockIoContext {
@@ -343,6 +488,20 @@ mod test {
         fn with_broadcast_result(mut self, txid: Txid, result: MockBroadcastResult) -> Self {
             self.broadcast_results.insert(txid, result);
             self
+        }
+
+        fn with_entry_by_id(mut self, txid: Buf32, entry: L1TxEntry) -> Self {
+            self.entries_by_id.insert(txid, entry);
+            self
+        }
+
+        fn with_adoption_applying(mut self, applies: bool) -> Self {
+            self.adoption_applies = applies;
+            self
+        }
+
+        fn adoptions(&self) -> Vec<(Buf32, Buf32, L1TxStatus)> {
+            self.adoptions.lock().unwrap().clone()
         }
     }
 
@@ -357,6 +516,23 @@ mod test {
 
         async fn put_tx_entry_by_idx(&self, _idx: u64, _entry: L1TxEntry) -> BroadcasterResult<()> {
             Ok(())
+        }
+
+        async fn get_tx_entry_by_id(&self, txid: Buf32) -> BroadcasterResult<Option<L1TxEntry>> {
+            Ok(self.entries_by_id.get(&txid).cloned())
+        }
+
+        async fn adopt_confirmed_ancestor(
+            &self,
+            loser_txid: Buf32,
+            winner_txid: Buf32,
+            winner_status: L1TxStatus,
+        ) -> BroadcasterResult<bool> {
+            self.adoptions
+                .lock()
+                .unwrap()
+                .push((loser_txid, winner_txid, winner_status));
+            Ok(self.adoption_applies)
         }
 
         async fn get_transaction<'a>(
@@ -554,7 +730,7 @@ mod test {
         #[test]
         fn test_handle_published_entry(
             block_height in 1_u32..1_000_000,
-            block_hash in buf32_strategy(),
+            block_hash in buf32_strategy().prop_map(|buf| buf),
         ) {
             run_async_test(async move {
                 let (e, txid) = entry_with_txid(L1TxStatus::Published);
@@ -611,7 +787,7 @@ mod test {
         #[test]
         fn test_handle_confirmed_entry(
             block_height in 1_u32..1_000_000,
-            block_hash in buf32_strategy(),
+            block_hash in buf32_strategy().prop_map(|buf| buf),
         ) {
             run_async_test(async move {
                 let (e, txid) = entry_with_txid(confirmed_status(1, block_height, block_hash));
@@ -830,7 +1006,7 @@ mod test {
         fn test_process_unfinalized_entries(
             seed_idx in 1_u64..1_000_000,
             block_height in 1_u32..1_000_000,
-            block_hash in buf32_strategy(),
+            block_hash in buf32_strategy().prop_map(|buf| buf),
         ) {
             run_async_test(async move {
                 let btcio_params = get_test_btcio_params();
@@ -893,6 +1069,262 @@ mod test {
     }
 
     // ── confirmation_status ──
+
+    /// Builds a two-attempt chain: `winner` was superseded by `loser`, and the reverse link is set
+    /// as `put_replacement_tx_entry` would have set it.
+    fn replacement_chain() -> (L1TxEntry, Txid, L1TxEntry, Txid, Buf32) {
+        let (mut winner, winner_txid) = entry_with_txid(L1TxStatus::Published);
+        let winner_raw = Buf32(winner_txid.to_byte_array());
+        winner.rbf = Some(L1TxRbfInfo {
+            fee_rate_sat_vb: 2,
+            fee_sats: 200,
+            replaces: None,
+        });
+
+        // A distinct transaction, so the two entries do not collide by txid.
+        let loser_tx = {
+            let mut tx = winner.try_to_tx().unwrap();
+            tx.lock_time = LockTime::from_consensus(7);
+            tx
+        };
+        let loser_txid = loser_tx.compute_txid();
+        let mut loser = L1TxEntry::from_tx_with_fee(
+            &loser_tx,
+            FeeRate::from_sat_per_vb(4).unwrap(),
+            Amount::from_sat(400),
+        );
+        loser.status = L1TxStatus::Published;
+        loser.set_replaces(L1TxId::from(winner_raw.0));
+
+        winner.status = L1TxStatus::Replaced {
+            by: L1TxId::from(loser_txid.to_byte_array()),
+        };
+
+        (winner, winner_txid, loser, loser_txid, winner_raw)
+    }
+
+    /// Regression: a miner can include the original after the local node accepted the replacement.
+    /// Marking the replacement `InvalidInputs` sends the writer off to rebuild, republishing a
+    /// payload the confirmed ancestor already carries.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_adopt_a_confirmed_ancestor() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(3, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+            "the loser must point at the winner, not be marked invalid"
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, winner_raw);
+        assert_eq!(
+            adoptions[0].2,
+            confirmed_status(3, 400, Buf32::new([9u8; 32]))
+        );
+    }
+
+    /// A conflict with something outside the chain is a real double spend, and the original verdict
+    /// stands.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_stay_invalid_without_a_confirmed_ancestor() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            // The ancestor did not win either.
+            .with_tx_lookup(winner_txid, MockTxLookupResult::Missing);
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// Regression: every writer-owned entry carries RBF metadata from its first attempt, so the
+    /// metadata alone must not be read as "in a replacement chain". A first attempt conflicting
+    /// with the best chain is the ordinary side-branch sighting, and rebuilding it would republish
+    /// a payload that gets mined twice once the conflicting transaction is reorged out.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_hold_a_first_attempt_at_published() {
+        let (mut entry, txid) = entry_with_txid(L1TxStatus::Published);
+        entry.rbf = Some(L1TxRbfInfo {
+            fee_rate_sat_vb: 2,
+            fee_sats: 200,
+            replaces: None,
+        });
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default().with_tx_lookup(
+            txid,
+            MockTxLookupResult::Found(TxConfirmationInfo {
+                confirmations: -1,
+                block_hash: None,
+                block_height: None,
+            }),
+        );
+
+        let status = process_status(&io, &entry, &txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::Published));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// If the reversal did not apply the caller must not report the loser as invalid either: some
+    /// other pass already resolved the chain.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_stay_invalid_when_the_reversal_is_refused() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(false)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(3, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert_eq!(io.adoptions().len(), 1);
+    }
+
+    /// Regression: the original can be mined between the replacement being persisted and its first
+    /// broadcast. The replacement is then rejected for spent inputs on that very first send, so it
+    /// never reaches `Published` and the negative-confirmation path never runs. Left as
+    /// `InvalidInputs` the chain resolves to a dead entry and the writer rebuilds a payload the
+    /// confirmed original already carries.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unpublished_replacement_rejected_for_spent_inputs_adopts_its_ancestor() {
+        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        // Never broadcast: the writer persisted it and the block landed first.
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            // The original took the inputs, so bitcoind rejects the replacement outright.
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(1, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+            "a replacement rejected because its ancestor confirmed must adopt that ancestor"
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, winner_raw);
+    }
+
+    /// The verdict still stands when the rejection is a real double spend from outside the chain.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unpublished_replacement_stays_invalid_without_a_confirmed_ancestor() {
+        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(winner_txid, MockTxLookupResult::Missing);
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// The re-publish probe reaches the same rejection by a different route: a `Published`
+    /// replacement evicted from the wallet's view, re-sent, and refused because its ancestor won.
+    /// The `Replaced` verdict must reach the caller instead of folding back to `Published`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_republish_probe_rejected_for_spent_inputs_adopts_its_ancestor() {
+        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(loser_txid, MockTxLookupResult::Missing)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(1, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+        );
+        assert_eq!(io.adoptions().len(), 1);
+    }
+
+    /// An entry outside a replacement chain has no ancestor to consult, so a rejection is still a
+    /// rejection and the writer rebuilds as before.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_plain_entry_rejected_for_spent_inputs_stays_invalid() {
+        let (e, txid) = entry_with_txid(L1TxStatus::Unpublished);
+        assert!(
+            e.rbf.is_none(),
+            "test: fixture must be outside an RBF chain"
+        );
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_broadcast_result(txid, MockBroadcastResult::InvalidInputs);
+
+        let status = process_status(&io, &e, &txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
 
     #[test]
     fn confirmation_status_zero_confirmations_returns_published() {

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -8,21 +8,39 @@ use tracing::*;
 
 use super::{
     error::{BroadcasterError, BroadcasterResult},
+    handle::MAX_REPLACEMENT_CHAIN_HOPS,
     io::{BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo, TxLookupOutcome},
     state::{BroadcasterState, IndexedEntry},
 };
 use crate::{tx_entry::L1TxEntryExt, BtcioParams};
+
+/// Result of one processing pass over the unfinalized set.
+#[derive(Debug, Default)]
+pub(super) struct ProcessingPassResult {
+    /// Indexed entries whose status changed and must be written back.
+    pub updated: Vec<IndexedEntry>,
+
+    /// Whether the in-memory set has to be rebuilt from the full index range.
+    ///
+    /// Set when a superseded ancestor was adopted, either after winning on-chain or after the
+    /// replacement that superseded it was refused while it was still in the mempool. That ancestor
+    /// left `unfinalized_entries` when it was first replaced, and [`update_state`]'s cursor only
+    /// reads rows added since, so without a rebuild nothing would ever poll it again: it would sit
+    /// at its adopted status forever, never reaching `Finalized`, and a reorg on it would go
+    /// unnoticed.
+    pub resync_required: bool,
+}
 
 /// Processes unfinalized entries and returns the indexed entries whose status changed.
 pub(super) async fn process_unfinalized_entries<C>(
     unfinalized_entries: impl Iterator<Item = &IndexedEntry>,
     io: &C,
     params: &BtcioParams,
-) -> BroadcasterResult<Vec<IndexedEntry>>
+) -> BroadcasterResult<ProcessingPassResult>
 where
     C: BroadcasterIoContext,
 {
-    let mut updated_entries = Vec::new();
+    let mut processed = ProcessingPassResult::default();
 
     for entry in unfinalized_entries {
         let idx = *entry.index();
@@ -32,13 +50,19 @@ where
         let updated_status = process_tx_entry(io, txentry, &txid, params).await?;
 
         if let Some(status) = updated_status {
+            // Adoption is the only path that turns a tracked entry into `Replaced`: the fee
+            // bumper writes that status straight to the DB, and an already-`Replaced` entry
+            // returns `None` above. So this is the signal that a winner needs re-admitting.
+            if matches!(status, L1TxStatus::Replaced { .. }) {
+                processed.resync_required = true;
+            }
             let mut new_txentry = txentry.clone();
             new_txentry.status = status;
-            updated_entries.push(IndexedEntry::new(idx, new_txentry));
+            processed.updated.push(IndexedEntry::new(idx, new_txentry));
         }
     }
 
-    Ok(updated_entries)
+    Ok(processed)
 }
 
 /// Computes the next status for a single entry, or `None` when no update is needed.
@@ -84,9 +108,9 @@ where
 ///    here would only spam bitcoind and the logs every poll for the entire pre-confirmation window.
 /// 3. `Ok(None)`: not found at all. Could be a transient wallet-syncer miss for a freshly broadcast
 ///    tx, or a genuinely dropped tx (mempool eviction, RBF). Re-publish to disambiguate: benign
-///    mempool messages fold back to Published, `bad-txns-inputs-missingorspent` routes to
-///    InvalidInputs so the watcher rebuilds the envelope, unless an ancestor of this entry's own
-///    replacement chain took those inputs by confirming.
+///    mempool messages fold back to Published, a rejection routes to InvalidInputs so the watcher
+///    rebuilds the envelope, unless an ancestor of this entry's own replacement chain is still
+///    live.
 async fn probe_published_entry<C>(
     io: &C,
     txentry: &L1TxEntry,
@@ -116,7 +140,14 @@ where
             // attempt has no chain to lose to.
             if txentry.rbf.and_then(|rbf| rbf.replaces).is_some() && info.confirmations < 0 {
                 warn!(%txid, confirmations = info.confirmations, "replacement-chain transaction conflicts with a confirmed transaction");
-                return resolve_invalid_inputs(io, params, txid, txentry).await;
+                return resolve_invalid_inputs(
+                    io,
+                    params,
+                    txid,
+                    txentry,
+                    AncestorRescue::Confirmed,
+                )
+                .await;
             }
             Ok(confirmation_status(&info, reorg_safe_depth))
         }
@@ -134,66 +165,102 @@ where
     }
 }
 
-/// Bound on how far back a conflicting-ancestor search walks, matching the forward chain walk.
-const MAX_ANCESTOR_SEARCH_HOPS: usize = 32;
+/// Which ancestors of a replacement chain count as a winner worth repointing the chain at.
+#[derive(Clone, Copy, Debug)]
+enum AncestorRescue {
+    /// Only an ancestor already in the best chain.
+    ///
+    /// The verdict came from the entry conflicting with a confirmed transaction, and only a
+    /// confirmed ancestor explains that sighting. An ancestor merely sitting in the mempool spends
+    /// the same inputs, so it is just as doomed and repointing the chain at it would park the
+    /// payload on a transaction that can never confirm.
+    Confirmed,
+
+    /// An ancestor already in the best chain, or failing that one still in the mempool.
+    ///
+    /// The verdict came from bitcoind refusing the broadcast itself, which proves nothing about
+    /// the inputs: fee-policy rejects (`min relay fee not met`, `insufficient fee, rejecting
+    /// replacement`, `txn-mempool-conflict`) and script-level rejects all arrive as
+    /// [`PublishTxOutcome::InvalidInputs`]. While an ancestor is still live the chain has lost
+    /// nothing, and the refused replacement must not become the verdict for the whole chain.
+    ///
+    /// [`PublishTxOutcome::InvalidInputs`]: super::io::PublishTxOutcome::InvalidInputs
+    ConfirmedOrInMempool,
+}
 
 /// Settles an `InvalidInputs` verdict against the entry's own replacement chain.
 ///
-/// `InvalidInputs` is what sends the writer off to rebuild, and rebuilding republishes a payload a
-/// confirmed transaction may already carry. For an entry in a replacement chain the transaction
-/// that took its inputs is usually an ancestor of that very chain: a miner included an original
-/// after the local node had already accepted its replacement.
+/// `InvalidInputs` is what sends the writer off to rebuild, and rebuilding republishes a payload
+/// another transaction in this very chain may already carry, or may still be about to carry. For an
+/// entry in a replacement chain the transaction standing in its way is usually an ancestor: a miner
+/// included an original after the local node had already accepted its replacement, or the node
+/// refused the replacement and kept the original in its mempool.
 ///
-/// Returns [`L1TxStatus::Replaced`] pointing at the ancestor that won. When no ancestor did, the
-/// conflict is with a transaction outside this chain and the [`L1TxStatus::InvalidInputs`] verdict
-/// stands. An entry with no `replaces` link, which is every entry outside a replacement chain,
-/// resolves to `InvalidInputs` without asking bitcoind anything.
+/// Returns [`L1TxStatus::Replaced`] pointing at the ancestor the chain was repointed at. When no
+/// ancestor qualifies under `rescue`, the conflict is with a transaction outside this chain and the
+/// [`L1TxStatus::InvalidInputs`] verdict stands. An entry with no `replaces` link, which is every
+/// entry outside a replacement chain, resolves to `InvalidInputs` without asking bitcoind anything.
 async fn resolve_invalid_inputs<C>(
     io: &C,
     params: &BtcioParams,
     txid: &Txid,
     txentry: &L1TxEntry,
+    rescue: AncestorRescue,
 ) -> BroadcasterResult<L1TxStatus>
 where
     C: BroadcasterIoContext,
 {
-    if let Some(winner) = adopt_confirmed_ancestor(io, params, txid, txentry).await? {
+    if let Some(winner) = adopt_live_ancestor(io, params, txid, txentry, rescue).await? {
         return Ok(L1TxStatus::Replaced { by: winner });
     }
     Ok(L1TxStatus::InvalidInputs)
 }
 
-/// Repoints a replacement chain at a superseded ancestor that was mined anyway.
+/// Repoints a replacement chain at a superseded ancestor that is still the chain's real tip.
 ///
-/// Bitcoin Core reports negative confirmations for a transaction conflicting with one already in
-/// the best chain. For a replacement chain the conflict is usually its own ancestor: the local node
-/// accepted the replacement and evicted the original, then a miner included the original from
-/// somewhere else. The ancestor is still marked [`L1TxStatus::Replaced`], so the live-entry lookup
-/// walks straight past it and every consumer concludes the chain is dead.
+/// A superseded ancestor is marked [`L1TxStatus::Replaced`], so the live-entry lookup walks
+/// straight past it to the replacement and every consumer reads the replacement's verdict as the
+/// chain's. Two situations make that reading wrong:
 ///
-/// Walks `replaces` back-pointers, asks bitcoind about each ancestor, and on finding a confirmed
-/// one reverses the link so the chain resolves to the winner. Returns the winner's txid when the
-/// reversal applied, or `None` when no ancestor won, which means the conflict is with a transaction
-/// outside this chain and the caller's `InvalidInputs` verdict stands.
-async fn adopt_confirmed_ancestor<C>(
+/// - The ancestor was mined anyway. Bitcoin Core reports negative confirmations for a transaction
+///   conflicting with one already in the best chain; for a replacement chain that conflict is
+///   usually its own ancestor, included by a miner after the local node had accepted the
+///   replacement and evicted the original.
+/// - The replacement was never accepted. A fee-policy or script-level reject leaves the ancestor
+///   sitting in the mempool exactly as before, still able to confirm on its own.
+///
+/// Walks `replaces` back-pointers, asks bitcoind about each ancestor, and reverses the link so the
+/// chain resolves to the winner. A confirmed ancestor is the stronger claim and can sit further
+/// back than a mempool one, so the walk runs to completion before settling for the nearest ancestor
+/// still in the mempool. Returns the winner's txid when the reversal applied, or `None` when no
+/// ancestor qualifies and the caller's `InvalidInputs` verdict stands.
+async fn adopt_live_ancestor<C>(
     io: &C,
     params: &BtcioParams,
     loser_txid: &Txid,
     loser_entry: &L1TxEntry,
+    rescue: AncestorRescue,
 ) -> BroadcasterResult<Option<L1TxId>>
 where
     C: BroadcasterIoContext,
 {
     let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
     let mut ancestor = loser_entry.rbf.and_then(|rbf| rbf.replaces);
+    let mut in_mempool: Option<(L1TxId, Txid)> = None;
+    // Same budget as the forward walk in `L1BroadcastHandle`, so a chain the forward lookup
+    // traverses is never one this search gives up on.
+    let mut hops_left = MAX_REPLACEMENT_CHAIN_HOPS;
 
-    for _ in 0..MAX_ANCESTOR_SEARCH_HOPS {
-        let Some(candidate) = ancestor else {
-            return Ok(None);
-        };
+    while let Some(candidate) = ancestor {
+        if hops_left == 0 {
+            warn!(loser = %loser_txid, "conflicting-ancestor search exceeded its hop budget");
+            break;
+        }
+        hops_left -= 1;
+
         let candidate_raw = Buf32(candidate.0);
         let Some(candidate_entry) = io.get_tx_entry_by_id(candidate_raw).await? else {
-            return Ok(None);
+            break;
         };
 
         let candidate_txid = candidate_entry.try_to_tx()?.compute_txid();
@@ -206,26 +273,55 @@ where
                     confirmations = info.confirmations,
                     "superseded transaction won on-chain; adopting it instead of rebuilding"
                 );
-                // `false` means another poll already reversed this pair, or the chain no longer
-                // links the two. Either way the caller must not report the loser as invalid.
-                if io
-                    .adopt_confirmed_ancestor(
-                        Buf32(loser_txid.to_byte_array()),
-                        candidate_raw,
-                        winner_status,
-                    )
-                    .await?
-                {
-                    return Ok(Some(candidate));
-                }
-                return Ok(None);
+                return apply_adoption(io, loser_txid, candidate, winner_status).await;
+            }
+            // Only a 0-conf sighting means the node still holds it in the mempool. Negative
+            // confirmations mean this ancestor conflicts with the best chain too, so it is no
+            // rescue for anyone.
+            if info.confirmations == 0
+                && matches!(rescue, AncestorRescue::ConfirmedOrInMempool)
+                && in_mempool.is_none()
+            {
+                in_mempool = Some((candidate, candidate_txid));
             }
         }
 
         ancestor = candidate_entry.rbf.and_then(|rbf| rbf.replaces);
     }
 
-    warn!(loser = %loser_txid, "conflicting-ancestor search exceeded its hop budget");
+    let Some((winner, winner_txid)) = in_mempool else {
+        return Ok(None);
+    };
+    warn!(
+        loser = %loser_txid,
+        winner = %winner_txid,
+        "replacement refused while the transaction it supersedes is still in the mempool; rolling the chain back to it"
+    );
+    apply_adoption(io, loser_txid, winner, L1TxStatus::Published).await
+}
+
+/// Reverses one replacement link, reporting the winner only when the write took effect.
+async fn apply_adoption<C>(
+    io: &C,
+    loser_txid: &Txid,
+    winner: L1TxId,
+    winner_status: L1TxStatus,
+) -> BroadcasterResult<Option<L1TxId>>
+where
+    C: BroadcasterIoContext,
+{
+    // `false` means another poll already reversed this pair, or the chain no longer links the two.
+    // Stop either way rather than repointing at some older ancestor on a chain that has moved.
+    if io
+        .adopt_confirmed_ancestor(
+            Buf32(loser_txid.to_byte_array()),
+            Buf32(winner.0),
+            winner_status,
+        )
+        .await?
+    {
+        return Ok(Some(winner));
+    }
     Ok(None)
 }
 
@@ -302,11 +398,15 @@ where
 
 /// Attempts to broadcast an unpublished entry and maps publication outcomes to statuses.
 ///
-/// A rejection for spent inputs is settled against the replacement chain before it becomes
-/// [`L1TxStatus::InvalidInputs`]: an original mined between the replacement being persisted and
-/// broadcast takes the inputs out from under it, and the replacement is then rejected on its very
-/// first send, without ever reaching `Published` where the negative-confirmation path would have
-/// caught the same conflict.
+/// A rejected broadcast is settled against the replacement chain before it becomes
+/// [`L1TxStatus::InvalidInputs`]. Two distinct situations reach here as a rejection, and neither
+/// one means the chain is dead:
+///
+/// - An original mined between the replacement being persisted and broadcast takes the inputs out
+///   from under it, and the replacement is rejected on its very first send, without ever reaching
+///   `Published` where the negative-confirmation path would have caught the same conflict.
+/// - Bitcoind refuses the replacement on fee policy or script grounds and keeps the original in its
+///   mempool, where it can still confirm.
 async fn publish_tx<C>(
     io: &C,
     params: &BtcioParams,
@@ -331,8 +431,15 @@ where
             Ok(PublishTxOutcome::Published) => Ok(L1TxStatus::Published),
             Ok(PublishTxOutcome::AlreadyInMempool) => Ok(L1TxStatus::Published),
             Ok(PublishTxOutcome::InvalidInputs) => {
-                warn!("tx excluded due to invalid inputs");
-                resolve_invalid_inputs(io, params, &txid, txentry).await
+                warn!("tx rejected on broadcast");
+                resolve_invalid_inputs(
+                    io,
+                    params,
+                    &txid,
+                    txentry,
+                    AncestorRescue::ConfirmedOrInMempool,
+                )
+                .await
             }
             Ok(PublishTxOutcome::RetryLater { reason }) => {
                 warn!(%reason, "broadcast should be retried on next poll");
@@ -360,12 +467,13 @@ pub(super) async fn update_state<C>(
     state: &mut BroadcasterState,
     updated_entries: impl Iterator<Item = IndexedEntry>,
     io: &C,
+    resync_required: bool,
 ) -> BroadcasterResult<()>
 where
     C: BroadcasterIoContext,
 {
     let unfinalized_entries: Vec<_> = updated_entries
-        .filter(|entry| !entry.item().is_finalized() && entry.item().is_valid())
+        .filter(|entry| !entry.item().is_finalized() && entry.item().is_trackable())
         .collect();
 
     let next_idx = io.get_next_tx_idx().await?;
@@ -374,6 +482,19 @@ where
             expected: state.next_idx,
             got: next_idx,
         });
+    }
+
+    if resync_required {
+        // Rebuild from the whole range rather than the incremental window. The adopted winner
+        // sits at an index below the cursor, so nothing else would pick it back up. Callers have
+        // already written this pass's statuses back, so the DB is authoritative here.
+        //
+        // A full scan is affordable because adoption is a rare recovery path: it needs either a
+        // superseded transaction to win on-chain, or a replacement to be refused outright, and the
+        // replacement pass only builds one per transaction per bump interval.
+        state.unfinalized_entries = fetch_unfinalized_entries(io, 0, next_idx).await?;
+        state.next_idx = next_idx;
+        return Ok(());
     }
 
     let new_unfinalized_entries = fetch_unfinalized_entries(io, state.next_idx, next_idx).await?;
@@ -400,7 +521,7 @@ where
             break;
         };
 
-        if !txentry.is_valid() {
+        if !txentry.is_trackable() {
             // A superseded entry is a routine outcome of fee bumping, not a fault, and every one of
             // them is re-read on each restart.
             if matches!(txentry.status, L1TxStatus::Replaced { .. }) {
@@ -1058,6 +1179,7 @@ mod test {
 
                 assert_eq!(
                     updated_entries
+                        .updated
                         .iter()
                         .find(|e| *e.index() == i1)
                         .map(|e| e.item().status.clone())
@@ -1067,6 +1189,7 @@ mod test {
                 );
                 assert_eq!(
                     updated_entries
+                        .updated
                         .iter()
                         .find(|e| *e.index() == i3)
                         .map(|e| e.item().status.clone())
@@ -1080,9 +1203,20 @@ mod test {
 
     // ── confirmation_status ──
 
+    /// A two-attempt replacement chain, named for how these tests end up using it: `winner` is the
+    /// older attempt that a miner may still include, `loser` is the replacement that superseded it.
+    struct ReplacementChain {
+        winner: L1TxEntry,
+        winner_txid: Txid,
+        loser: L1TxEntry,
+        loser_txid: Txid,
+        /// `winner_txid` as the raw key the broadcast DB is indexed by.
+        winner_raw: Buf32,
+    }
+
     /// Builds a two-attempt chain: `winner` was superseded by `loser`, and the reverse link is set
     /// as `put_replacement_tx_entry` would have set it.
-    fn replacement_chain() -> (L1TxEntry, Txid, L1TxEntry, Txid, Buf32) {
+    fn replacement_chain() -> ReplacementChain {
         let (mut winner, winner_txid) = entry_with_txid(L1TxStatus::Published);
         let winner_raw = Buf32(winner_txid.to_byte_array());
         winner.rbf = Some(L1TxRbfInfo {
@@ -1110,7 +1244,13 @@ mod test {
             by: L1TxId::from(loser_txid.to_byte_array()),
         };
 
-        (winner, winner_txid, loser, loser_txid, winner_raw)
+        ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        }
     }
 
     /// Regression: a miner can include the original after the local node accepted the replacement.
@@ -1118,7 +1258,13 @@ mod test {
     /// payload the confirmed ancestor already carries.
     #[tokio::test(flavor = "multi_thread")]
     async fn negative_confirmations_adopt_a_confirmed_ancestor() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1158,7 +1304,13 @@ mod test {
     /// stands.
     #[tokio::test(flavor = "multi_thread")]
     async fn negative_confirmations_stay_invalid_without_a_confirmed_ancestor() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1208,11 +1360,19 @@ mod test {
         assert!(io.adoptions().is_empty());
     }
 
-    /// If the reversal did not apply the caller must not report the loser as invalid either: some
-    /// other pass already resolved the chain.
+    /// A refused reversal leaves the chain exactly as it was, so the `InvalidInputs` verdict
+    /// stands and the caller still reports it. When the refusal was caused by a concurrent pass
+    /// resolving the chain, that verdict never reaches the DB either: the `replaced_concurrently`
+    /// guard in `state.rs` drops the write-back once it re-reads the row as `Replaced`.
     #[tokio::test(flavor = "multi_thread")]
     async fn negative_confirmations_stay_invalid_when_the_reversal_is_refused() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1243,7 +1403,13 @@ mod test {
     /// confirmed original already carries.
     #[tokio::test(flavor = "multi_thread")]
     async fn an_unpublished_replacement_rejected_for_spent_inputs_adopts_its_ancestor() {
-        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         // Never broadcast: the writer persisted it and the block landed first.
         loser.status = L1TxStatus::Unpublished;
         let btcio_params = get_test_btcio_params();
@@ -1274,7 +1440,13 @@ mod test {
     /// The verdict still stands when the rejection is a real double spend from outside the chain.
     #[tokio::test(flavor = "multi_thread")]
     async fn an_unpublished_replacement_stays_invalid_without_a_confirmed_ancestor() {
-        let (winner, winner_txid, mut loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         loser.status = L1TxStatus::Unpublished;
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
@@ -1294,7 +1466,13 @@ mod test {
     /// The `Replaced` verdict must reach the caller instead of folding back to `Published`.
     #[tokio::test(flavor = "multi_thread")]
     async fn a_republish_probe_rejected_for_spent_inputs_adopts_its_ancestor() {
-        let (winner, winner_txid, loser, loser_txid, winner_raw) = replacement_chain();
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
         let btcio_params = get_test_btcio_params();
         let io = MockIoContext::default()
             .with_entry_by_id(winner_raw, winner)
@@ -1315,6 +1493,199 @@ mod test {
             }),
         );
         assert_eq!(io.adoptions().len(), 1);
+    }
+
+    /// Builds a three-attempt chain, oldest first, wired the way `put_replacement_tx_entry` wires
+    /// one: each entry is `Replaced` by the next and each replacement carries the reverse link.
+    fn three_attempt_chain() -> Vec<(L1TxEntry, Txid)> {
+        let (base, _) = entry_with_txid(L1TxStatus::Published);
+        let base_tx = base.try_to_tx().unwrap();
+
+        let mut attempts: Vec<(L1TxEntry, Txid)> = (0..3)
+            .map(|i| {
+                // Distinct lock times, so the three entries do not collide by txid.
+                let mut tx = base_tx.clone();
+                tx.lock_time = LockTime::from_consensus(11 + i);
+                let txid = tx.compute_txid();
+                let mut entry = L1TxEntry::from_tx_with_fee(
+                    &tx,
+                    FeeRate::from_sat_per_vb(2 + u64::from(i)).unwrap(),
+                    Amount::from_sat(200 * (u64::from(i) + 1)),
+                );
+                entry.status = L1TxStatus::Published;
+                (entry, txid)
+            })
+            .collect();
+
+        for i in 0..attempts.len() - 1 {
+            let (older_txid, newer_txid) = (attempts[i].1, attempts[i + 1].1);
+            attempts[i].0.status = L1TxStatus::Replaced {
+                by: L1TxId::from(newer_txid.to_byte_array()),
+            };
+            attempts[i + 1]
+                .0
+                .set_replaces(L1TxId::from(older_txid.to_byte_array()));
+        }
+
+        attempts
+    }
+
+    /// Regression: bitcoind rejects a replacement on fee policy (`min relay fee not met`,
+    /// `insufficient fee, rejecting replacement`) or on script grounds, and the IO layer reports
+    /// every one of those as `InvalidInputs`. The inputs are untouched and the original is still in
+    /// the mempool, but the original row is already `Replaced`, so leaving the refused replacement
+    /// as the chain's verdict makes the writer rebuild and repost the DA a live transaction still
+    /// carries. Roll the chain back to the original instead, where the fee bumper can escalate it
+    /// again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_replacement_refused_on_broadcast_rolls_back_to_its_live_original() {
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            // The original never left the mempool: bitcoind simply refused to swap it out.
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(winner_raw.0)
+            }),
+            "a refused replacement must not outlive the original it never replaced"
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, winner_raw);
+        assert_eq!(
+            adoptions[0].2,
+            L1TxStatus::Published,
+            "the original goes back to the status it held in the mempool"
+        );
+    }
+
+    /// An ancestor at negative confirmations conflicts with the best chain just as the loser does,
+    /// so it is no rescue: the chain really is dead and the writer must rebuild.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_replacement_refused_stays_invalid_when_its_ancestor_conflicts_too() {
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            mut loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
+        loser.status = L1TxStatus::Unpublished;
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// A tx conflicting with the best chain can only have lost to a confirmed transaction, so a
+    /// mempool ancestor must not rescue it. That ancestor spends the same inputs and is therefore
+    /// just as doomed; adopting it would park the payload on a transaction that can never confirm.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn negative_confirmations_do_not_adopt_a_mempool_ancestor() {
+        let ReplacementChain {
+            winner,
+            winner_txid,
+            loser,
+            loser_txid,
+            winner_raw,
+        } = replacement_chain();
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(winner_raw, winner)
+            .with_adoption_applying(true)
+            .with_tx_lookup(
+                loser_txid,
+                MockTxLookupResult::Found(TxConfirmationInfo {
+                    confirmations: -1,
+                    block_hash: None,
+                    block_height: None,
+                }),
+            )
+            .with_tx_lookup(
+                winner_txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
+        assert!(io.adoptions().is_empty());
+    }
+
+    /// A confirmed ancestor is the stronger claim and can sit further back than a mempool one, so
+    /// the walk must reach it rather than settling for the nearest live ancestor. Adopting the
+    /// mempool one would leave the chain waiting on a transaction the confirmed ancestor has
+    /// already made unspendable.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_confirmed_ancestor_outranks_a_nearer_mempool_one() {
+        let chain = three_attempt_chain();
+        let [(confirmed, confirmed_txid), (mempool, mempool_txid), (mut loser, loser_txid)] =
+            <[_; 3]>::try_from(chain).unwrap();
+        let confirmed_raw = Buf32(confirmed_txid.to_byte_array());
+        loser.status = L1TxStatus::Unpublished;
+
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_entry_by_id(confirmed_raw, confirmed)
+            .with_entry_by_id(Buf32(mempool_txid.to_byte_array()), mempool)
+            .with_adoption_applying(true)
+            .with_broadcast_result(loser_txid, MockBroadcastResult::InvalidInputs)
+            .with_tx_lookup(
+                mempool_txid,
+                MockTxLookupResult::Found(confirmation_info(0, 0, Buf32::zero())),
+            )
+            .with_tx_lookup(
+                confirmed_txid,
+                MockTxLookupResult::Found(confirmation_info(2, 400, Buf32::new([9u8; 32]))),
+            );
+
+        let status = process_status(&io, &loser, &loser_txid, &btcio_params).await;
+
+        assert_eq!(
+            status,
+            Some(L1TxStatus::Replaced {
+                by: L1TxId::from(confirmed_raw.0)
+            }),
+        );
+        let adoptions = io.adoptions();
+        assert_eq!(adoptions.len(), 1);
+        assert_eq!(adoptions[0].1, confirmed_raw);
+        assert_eq!(
+            adoptions[0].2,
+            confirmed_status(2, 400, Buf32::new([9u8; 32]))
+        );
     }
 
     /// An entry outside a replacement chain has no ancestor to consult, so a rejection is still a

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -80,14 +80,14 @@ where
     }
 
     async fn process_unfinalized_entries(&mut self) -> BroadcasterResult<()> {
-        let updated_entries = process_unfinalized_entries(
+        let processed = process_unfinalized_entries(
             self.inner.unfinalized_entries.iter(),
             &self.io,
             &self.config,
         )
         .await?;
 
-        for entry in updated_entries.iter() {
+        for entry in processed.updated.iter() {
             let idx = *entry.index();
 
             // The fee bumper can mark this entry `Replaced` in the DB between the read that
@@ -109,7 +109,13 @@ where
                 .await?;
         }
 
-        update_state(&mut self.inner, updated_entries.into_iter(), &self.io).await
+        update_state(
+            &mut self.inner,
+            processed.updated.into_iter(),
+            &self.io,
+            processed.resync_required,
+        )
+        .await
     }
 
     /// Drops the in-memory copy of an entry that a fee bump superseded.
@@ -171,7 +177,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+    use std::{iter::once, sync::Arc};
 
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_db_types::{backend::DatabaseBackend, common::L1TxId, l1_broadcast::L1TxStatus};
@@ -302,6 +308,7 @@ mod test {
             &mut service_state.inner,
             updated_entries.into_iter(),
             io_ref,
+            false,
         )
         .await
         .unwrap();
@@ -311,7 +318,7 @@ mod test {
 
         let unf_entries = service_state.inner.unfinalized_entries;
         assert!(!unf_entries.iter().any(|e| e.item().is_finalized()));
-        assert!(unf_entries.iter().all(|e| e.item().is_valid()));
+        assert!(unf_entries.iter().all(|e| e.item().is_trackable()));
     }
 
     #[tokio::test]
@@ -397,6 +404,110 @@ mod test {
             ),
             "persisted Replaced status must survive the processing pass"
         );
+    }
+
+    /// A superseded ancestor that wins on-chain has to come back into the tracked set.
+    ///
+    /// It left `unfinalized_entries` when it was first replaced, and the incremental cursor only
+    /// reads rows added since, so without the resync nothing polls it again: it stays `Confirmed`
+    /// forever, never reaches `Finalized`, and a reorg on it goes unnoticed.
+    #[tokio::test]
+    async fn adopted_winner_is_tracked_again() {
+        let (mut service_state, winner_idx, loser_idx, replaced_loser) = adoption_fixture().await;
+
+        let io_ref = &service_state.io;
+        update_state(
+            &mut service_state.inner,
+            once(IndexedEntry::new(loser_idx, replaced_loser)),
+            io_ref,
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            service_state
+                .inner
+                .unfinalized_entries
+                .iter()
+                .any(|entry| *entry.index() == winner_idx),
+            "adopted winner must be tracked again"
+        );
+    }
+
+    /// Pins what the resync flag is actually buying: without it the winner stays dropped.
+    #[tokio::test]
+    async fn without_resync_the_adopted_winner_stays_untracked() {
+        let (mut service_state, winner_idx, loser_idx, replaced_loser) = adoption_fixture().await;
+
+        let io_ref = &service_state.io;
+        update_state(
+            &mut service_state.inner,
+            once(IndexedEntry::new(loser_idx, replaced_loser)),
+            io_ref,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !service_state
+                .inner
+                .unfinalized_entries
+                .iter()
+                .any(|entry| *entry.index() == winner_idx),
+            "incremental cursor cannot recover the winner on its own"
+        );
+    }
+
+    /// Two entries where the second replaced the first, then the first won on-chain: the winner is
+    /// `Confirmed` in the DB but already dropped from memory, and the loser is `Replaced`.
+    async fn adoption_fixture() -> (
+        BroadcasterServiceState<impl BroadcasterIoContext>,
+        u64,
+        u64,
+        L1TxEntry,
+    ) {
+        let ops = get_ops();
+        let winner = gen_l1_tx_entry_with_status(L1TxStatus::Confirmed {
+            confirmations: 1,
+            block_hash: [1; 32].into(),
+            block_height: 100,
+        });
+        let winner_idx = ops
+            .put_tx_entry_async([20; 32].into(), winner)
+            .await
+            .unwrap()
+            .expect("test: winner index");
+        let loser = gen_l1_tx_entry_with_status(L1TxStatus::Published);
+        let loser_idx = ops
+            .put_tx_entry_async([21; 32].into(), loser.clone())
+            .await
+            .unwrap()
+            .expect("test: loser index");
+
+        let io = make_io(ops.clone(), TestBitcoinClient::new(0));
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+        assert_eq!(service_state.inner.unfinalized_entries.len(), 2);
+
+        // The winner stopped being tracked when it was replaced.
+        service_state
+            .inner
+            .unfinalized_entries
+            .retain(|entry| *entry.index() == loser_idx);
+
+        // Adoption reverses the chain, leaving the loser superseded by the winner.
+        let mut replaced_loser = loser;
+        replaced_loser.status = L1TxStatus::Replaced {
+            by: L1TxId::from([20u8; 32]),
+        };
+        ops.put_tx_entry_async([21; 32].into(), replaced_loser.clone())
+            .await
+            .unwrap();
+
+        (service_state, winner_idx, loser_idx, replaced_loser)
     }
 
     /// Even if the notification is lost, the write-back guard must not resurrect the old status.

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -80,14 +80,14 @@ where
     }
 
     async fn process_unfinalized_entries(&mut self) -> BroadcasterResult<()> {
-        let updated_entries = process_unfinalized_entries(
+        let processed = process_unfinalized_entries(
             self.inner.unfinalized_entries.iter(),
             &self.io,
             &self.config,
         )
         .await?;
 
-        for entry in updated_entries.iter() {
+        for entry in processed.updated.iter() {
             let idx = *entry.index();
 
             // The fee bumper can mark this entry `Replaced` in the DB between the read that
@@ -109,7 +109,13 @@ where
                 .await?;
         }
 
-        update_state(&mut self.inner, updated_entries.into_iter(), &self.io).await
+        update_state(
+            &mut self.inner,
+            processed.updated.into_iter(),
+            &self.io,
+            processed.resync_required,
+        )
+        .await
     }
 
     /// Drops the in-memory copy of an entry that a fee bump superseded.
@@ -174,7 +180,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+    use std::{iter::once, sync::Arc};
 
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_db_types::{backend::DatabaseBackend, common::L1TxId, l1_broadcast::L1TxStatus};
@@ -305,6 +311,7 @@ mod test {
             &mut service_state.inner,
             updated_entries.into_iter(),
             io_ref,
+            false,
         )
         .await
         .unwrap();
@@ -314,7 +321,7 @@ mod test {
 
         let unf_entries = service_state.inner.unfinalized_entries;
         assert!(!unf_entries.iter().any(|e| e.item().is_finalized()));
-        assert!(unf_entries.iter().all(|e| e.item().is_valid()));
+        assert!(unf_entries.iter().all(|e| e.item().is_trackable()));
     }
 
     #[tokio::test]
@@ -400,6 +407,110 @@ mod test {
             ),
             "persisted Replaced status must survive the processing pass"
         );
+    }
+
+    /// A superseded ancestor that wins on-chain has to come back into the tracked set.
+    ///
+    /// It left `unfinalized_entries` when it was first replaced, and the incremental cursor only
+    /// reads rows added since, so without the resync nothing polls it again: it stays `Confirmed`
+    /// forever, never reaches `Finalized`, and a reorg on it goes unnoticed.
+    #[tokio::test]
+    async fn adopted_winner_is_tracked_again() {
+        let (mut service_state, winner_idx, loser_idx, replaced_loser) = adoption_fixture().await;
+
+        let io_ref = &service_state.io;
+        update_state(
+            &mut service_state.inner,
+            once(IndexedEntry::new(loser_idx, replaced_loser)),
+            io_ref,
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            service_state
+                .inner
+                .unfinalized_entries
+                .iter()
+                .any(|entry| *entry.index() == winner_idx),
+            "adopted winner must be tracked again"
+        );
+    }
+
+    /// Pins what the resync flag is actually buying: without it the winner stays dropped.
+    #[tokio::test]
+    async fn without_resync_the_adopted_winner_stays_untracked() {
+        let (mut service_state, winner_idx, loser_idx, replaced_loser) = adoption_fixture().await;
+
+        let io_ref = &service_state.io;
+        update_state(
+            &mut service_state.inner,
+            once(IndexedEntry::new(loser_idx, replaced_loser)),
+            io_ref,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !service_state
+                .inner
+                .unfinalized_entries
+                .iter()
+                .any(|entry| *entry.index() == winner_idx),
+            "incremental cursor cannot recover the winner on its own"
+        );
+    }
+
+    /// Two entries where the second replaced the first, then the first won on-chain: the winner is
+    /// `Confirmed` in the DB but already dropped from memory, and the loser is `Replaced`.
+    async fn adoption_fixture() -> (
+        BroadcasterServiceState<impl BroadcasterIoContext>,
+        u64,
+        u64,
+        L1TxEntry,
+    ) {
+        let ops = get_ops();
+        let winner = gen_l1_tx_entry_with_status(L1TxStatus::Confirmed {
+            confirmations: 1,
+            block_hash: [1; 32].into(),
+            block_height: 100,
+        });
+        let winner_idx = ops
+            .put_tx_entry_async([20; 32].into(), winner)
+            .await
+            .unwrap()
+            .expect("test: winner index");
+        let loser = gen_l1_tx_entry_with_status(L1TxStatus::Published);
+        let loser_idx = ops
+            .put_tx_entry_async([21; 32].into(), loser.clone())
+            .await
+            .unwrap()
+            .expect("test: loser index");
+
+        let io = make_io(ops.clone(), TestBitcoinClient::new(0));
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+        assert_eq!(service_state.inner.unfinalized_entries.len(), 2);
+
+        // The winner stopped being tracked when it was replaced.
+        service_state
+            .inner
+            .unfinalized_entries
+            .retain(|entry| *entry.index() == loser_idx);
+
+        // Adoption reverses the chain, leaving the loser superseded by the winner.
+        let mut replaced_loser = loser;
+        replaced_loser.status = L1TxStatus::Replaced {
+            by: L1TxId::from([20u8; 32]),
+        };
+        ops.put_tx_entry_async([21; 32].into(), replaced_loser.clone())
+            .await
+            .unwrap();
+
+        (service_state, winner_idx, loser_idx, replaced_loser)
     }
 
     /// Even if the notification is lost, the write-back guard must not resurrect the old status.

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -1,10 +1,11 @@
-use strata_db_types::l1_broadcast::L1TxEntry;
-use strata_primitives::indexed::Indexed;
+use bitcoin::hashes::Hash;
+use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
+use strata_primitives::{buf::Buf32, indexed::Indexed};
 use strata_service::{ServiceState, TickMsg};
 use tracing::*;
 
 use super::{
-    error::{BroadcasterError, BroadcasterResult},
+    error::BroadcasterResult,
     input::BroadcasterInputMessage,
     io::BroadcasterIoContext,
     processor::{fetch_unfinalized_entries, process_unfinalized_entries, update_state},
@@ -70,6 +71,9 @@ where
             TickMsg::Msg(BroadcasterInputMessage::NotifyNewEntry { idx, txentry }) => {
                 self.handle_notify_new_entry(idx, txentry).await?;
             }
+            TickMsg::Msg(BroadcasterInputMessage::NotifyReplacedEntry { txid }) => {
+                self.handle_notify_replaced_entry(txid);
+            }
         }
 
         self.process_unfinalized_entries().await
@@ -84,12 +88,50 @@ where
         .await?;
 
         for entry in updated_entries.iter() {
+            let idx = *entry.index();
+
+            // The fee bumper can mark this entry `Replaced` in the DB between the read that
+            // produced our in-memory copy and this write-back. Writing the stale status here
+            // would resurrect a txid that a broadcast replacement has already superseded, so
+            // re-read and leave replaced entries alone. The matching
+            // `NotifyReplacedEntry` message drops it from `unfinalized_entries`.
+            let replaced_concurrently =
+                self.io.get_tx_entry(idx).await?.is_some_and(|persisted| {
+                    matches!(persisted.status, L1TxStatus::Replaced { .. })
+                });
+            if replaced_concurrently {
+                debug!(%idx, "skipping write-back for entry replaced by a fee bump");
+                continue;
+            }
+
             self.io
-                .put_tx_entry_by_idx(*entry.index(), entry.item().clone())
+                .put_tx_entry_by_idx(idx, entry.item().clone())
                 .await?;
         }
 
         update_state(&mut self.inner, updated_entries.into_iter(), &self.io).await
+    }
+
+    /// Drops the in-memory copy of an entry that a fee bump superseded.
+    fn handle_notify_replaced_entry(&mut self, txid: Buf32) {
+        let entries = &mut self.inner.unfinalized_entries;
+        let before = entries.len();
+
+        entries.retain(|entry| {
+            entry
+                .item()
+                .try_to_tx()
+                .map(|tx| Buf32::from(tx.compute_txid().to_byte_array()) != txid)
+                .unwrap_or(true)
+        });
+
+        if entries.len() == before {
+            // Normal when the entry already left the unfinalized set, e.g. it confirmed in the
+            // same tick the replacement was built and was then dropped from tracking.
+            debug!(?txid, "replaced entry was not tracked in memory");
+        } else {
+            info!(?txid, "stopped tracking entry superseded by a fee bump");
+        }
     }
 
     /// Inserts or replaces a tracked unfinalized entry by index.
@@ -98,10 +140,7 @@ where
         idx: u64,
         txentry: L1TxEntry,
     ) -> BroadcasterResult<()> {
-        let txid = txentry
-            .try_to_tx()
-            .map_err(|e| BroadcasterError::Other(e.to_string()))?
-            .compute_txid();
+        let txid = txentry.try_to_tx()?.compute_txid();
         info!(%idx, %txid, "received txentry");
 
         let state = &mut self.inner;
@@ -135,7 +174,7 @@ mod test {
     use std::sync::Arc;
 
     use strata_db_store_sled::test_utils::get_test_sled_backend;
-    use strata_db_types::{backend::DatabaseBackend, l1_broadcast::L1TxStatus};
+    use strata_db_types::{backend::DatabaseBackend, common::L1TxId, l1_broadcast::L1TxStatus};
     use strata_l1_txfmt::MagicBytes;
     use strata_primitives::buf::Buf32;
     use strata_storage::BroadcastDbOps;
@@ -303,5 +342,92 @@ mod test {
             ],
             "warmup must preserve broadcaster entries for the next poll"
         );
+    }
+
+    /// A fee bump marks the old entry `Replaced` in the DB directly. Without the matching
+    /// notification the service would keep the stale `Published` copy in memory, re-publish the
+    /// superseded txid, and write that status back over the persisted `Replaced`.
+    #[tokio::test]
+    async fn replaced_entry_is_dropped_from_memory_and_not_written_back() {
+        let ops = get_ops();
+        let txid: Buf32 = [9; 32].into();
+        let entry = gen_l1_tx_entry_with_status(L1TxStatus::Published);
+        let idx = ops
+            .put_tx_entry_async(txid, entry.clone())
+            .await
+            .unwrap()
+            .expect("entry index should exist");
+
+        let io = make_io(ops.clone(), TestBitcoinClient::new(0));
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+        assert_eq!(service_state.inner.unfinalized_entries.len(), 1);
+
+        // The fee bumper's DB write, made behind the service's back.
+        let replacement_txid = L1TxId::from([10u8; 32]);
+        let mut replaced = entry.clone();
+        replaced.status = L1TxStatus::Replaced {
+            by: replacement_txid,
+        };
+        ops.put_tx_entry_async(txid, replaced).await.unwrap();
+
+        let entry_txid = Buf32::from(
+            entry
+                .try_to_tx()
+                .expect("test: entry holds a valid tx")
+                .compute_txid()
+                .to_byte_array(),
+        );
+        service_state
+            .process_input(TickMsg::Msg(BroadcasterInputMessage::NotifyReplacedEntry {
+                txid: entry_txid,
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            service_state.inner.unfinalized_entries.is_empty(),
+            "replaced entry should no longer be tracked"
+        );
+        assert!(
+            matches!(
+                ops.get_tx_entry_async(idx).await.unwrap().unwrap().status,
+                L1TxStatus::Replaced { .. }
+            ),
+            "persisted Replaced status must survive the processing pass"
+        );
+    }
+
+    /// Even if the notification is lost, the write-back guard must not resurrect the old status.
+    #[tokio::test]
+    async fn write_back_skips_entries_replaced_concurrently() {
+        let ops = get_ops();
+        let txid: Buf32 = [11; 32].into();
+        let entry = gen_l1_tx_entry_with_status(L1TxStatus::Published);
+        let idx = ops
+            .put_tx_entry_async(txid, entry.clone())
+            .await
+            .unwrap()
+            .expect("entry index should exist");
+
+        let io = make_io(ops.clone(), TestBitcoinClient::new(0));
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+
+        let mut replaced = entry;
+        replaced.status = L1TxStatus::Replaced {
+            by: L1TxId::from([12u8; 32]),
+        };
+        ops.put_tx_entry_async(txid, replaced).await.unwrap();
+
+        // No NotifyReplacedEntry: the tick alone must leave the persisted status alone.
+        service_state.process_input(TickMsg::Tick).await.unwrap();
+
+        assert!(matches!(
+            ops.get_tx_entry_async(idx).await.unwrap().unwrap().status,
+            L1TxStatus::Replaced { .. }
+        ));
     }
 }

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -1,5 +1,6 @@
-use strata_db_types::l1_broadcast::L1TxEntry;
-use strata_primitives::indexed::Indexed;
+use bitcoin::hashes::Hash;
+use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
+use strata_primitives::{buf::Buf32, indexed::Indexed};
 use strata_service::{ServiceState, TickMsg};
 use tracing::*;
 
@@ -70,6 +71,9 @@ where
             TickMsg::Msg(BroadcasterInputMessage::NotifyNewEntry { idx, txentry }) => {
                 self.handle_notify_new_entry(idx, txentry).await?;
             }
+            TickMsg::Msg(BroadcasterInputMessage::NotifyReplacedEntry { txid }) => {
+                self.handle_notify_replaced_entry(txid);
+            }
         }
 
         self.process_unfinalized_entries().await
@@ -84,12 +88,50 @@ where
         .await?;
 
         for entry in updated_entries.iter() {
+            let idx = *entry.index();
+
+            // The fee bumper can mark this entry `Replaced` in the DB between the read that
+            // produced our in-memory copy and this write-back. Writing the stale status here
+            // would resurrect a txid that a broadcast replacement has already superseded, so
+            // re-read and leave replaced entries alone. The matching
+            // `NotifyReplacedEntry` message drops it from `unfinalized_entries`.
+            let replaced_concurrently =
+                self.io.get_tx_entry(idx).await?.is_some_and(|persisted| {
+                    matches!(persisted.status, L1TxStatus::Replaced { .. })
+                });
+            if replaced_concurrently {
+                debug!(%idx, "skipping write-back for entry replaced by a fee bump");
+                continue;
+            }
+
             self.io
-                .put_tx_entry_by_idx(*entry.index(), entry.item().clone())
+                .put_tx_entry_by_idx(idx, entry.item().clone())
                 .await?;
         }
 
         update_state(&mut self.inner, updated_entries.into_iter(), &self.io).await
+    }
+
+    /// Drops the in-memory copy of an entry that a fee bump superseded.
+    fn handle_notify_replaced_entry(&mut self, txid: Buf32) {
+        let entries = &mut self.inner.unfinalized_entries;
+        let before = entries.len();
+
+        entries.retain(|entry| {
+            entry
+                .item()
+                .try_to_tx()
+                .map(|tx| Buf32::from(tx.compute_txid().to_byte_array()) != txid)
+                .unwrap_or(true)
+        });
+
+        if entries.len() == before {
+            // Normal when the entry already left the unfinalized set, e.g. it confirmed in the
+            // same tick the replacement was built and was then dropped from tracking.
+            debug!(?txid, "replaced entry was not tracked in memory");
+        } else {
+            info!(?txid, "stopped tracking entry superseded by a fee bump");
+        }
     }
 
     /// Inserts or replaces a tracked unfinalized entry by index.
@@ -135,7 +177,7 @@ mod test {
     use std::sync::Arc;
 
     use strata_db_store_sled::test_utils::get_test_sled_backend;
-    use strata_db_types::{backend::DatabaseBackend, l1_broadcast::L1TxStatus};
+    use strata_db_types::{backend::DatabaseBackend, common::L1TxId, l1_broadcast::L1TxStatus};
     use strata_l1_txfmt::MagicBytes;
     use strata_primitives::buf::Buf32;
     use strata_storage::BroadcastDbOps;
@@ -303,5 +345,92 @@ mod test {
             ],
             "warmup must preserve broadcaster entries for the next poll"
         );
+    }
+
+    /// A fee bump marks the old entry `Replaced` in the DB directly. Without the matching
+    /// notification the service would keep the stale `Published` copy in memory, re-publish the
+    /// superseded txid, and write that status back over the persisted `Replaced`.
+    #[tokio::test]
+    async fn replaced_entry_is_dropped_from_memory_and_not_written_back() {
+        let ops = get_ops();
+        let txid: Buf32 = [9; 32].into();
+        let entry = gen_l1_tx_entry_with_status(L1TxStatus::Published);
+        let idx = ops
+            .put_tx_entry_async(txid, entry.clone())
+            .await
+            .unwrap()
+            .expect("entry index should exist");
+
+        let io = make_io(ops.clone(), TestBitcoinClient::new(0));
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+        assert_eq!(service_state.inner.unfinalized_entries.len(), 1);
+
+        // The fee bumper's DB write, made behind the service's back.
+        let replacement_txid = L1TxId::from([10u8; 32]);
+        let mut replaced = entry.clone();
+        replaced.status = L1TxStatus::Replaced {
+            by: replacement_txid,
+        };
+        ops.put_tx_entry_async(txid, replaced).await.unwrap();
+
+        let entry_txid = Buf32::from(
+            entry
+                .try_to_tx()
+                .expect("test: entry holds a valid tx")
+                .compute_txid()
+                .to_byte_array(),
+        );
+        service_state
+            .process_input(TickMsg::Msg(BroadcasterInputMessage::NotifyReplacedEntry {
+                txid: entry_txid,
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            service_state.inner.unfinalized_entries.is_empty(),
+            "replaced entry should no longer be tracked"
+        );
+        assert!(
+            matches!(
+                ops.get_tx_entry_async(idx).await.unwrap().unwrap().status,
+                L1TxStatus::Replaced { .. }
+            ),
+            "persisted Replaced status must survive the processing pass"
+        );
+    }
+
+    /// Even if the notification is lost, the write-back guard must not resurrect the old status.
+    #[tokio::test]
+    async fn write_back_skips_entries_replaced_concurrently() {
+        let ops = get_ops();
+        let txid: Buf32 = [11; 32].into();
+        let entry = gen_l1_tx_entry_with_status(L1TxStatus::Published);
+        let idx = ops
+            .put_tx_entry_async(txid, entry.clone())
+            .await
+            .unwrap()
+            .expect("entry index should exist");
+
+        let io = make_io(ops.clone(), TestBitcoinClient::new(0));
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+
+        let mut replaced = entry;
+        replaced.status = L1TxStatus::Replaced {
+            by: L1TxId::from([12u8; 32]),
+        };
+        ops.put_tx_entry_async(txid, replaced).await.unwrap();
+
+        // No NotifyReplacedEntry: the tick alone must leave the persisted status alone.
+        service_state.process_input(TickMsg::Tick).await.unwrap();
+
+        assert!(matches!(
+            ops.get_tx_entry_async(idx).await.unwrap().unwrap().status,
+            L1TxStatus::Replaced { .. }
+        ));
     }
 }

--- a/crates/btcio/src/lib.rs
+++ b/crates/btcio/src/lib.rs
@@ -8,9 +8,11 @@ pub mod status;
 
 #[cfg(test)]
 pub mod test_utils;
+pub mod tx_attempt;
 pub mod tx_entry;
 pub mod writer;
 
 pub use params::BtcioParams;
 pub use rpc_error::{is_bitcoind_warmup_error, is_block_height_out_of_range_error};
+pub use tx_attempt::{attempt_parts, TxAttemptExt};
 pub use tx_entry::L1TxEntryExt;

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::{
+    collections::BTreeMap,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 
 use bitcoin::{
     absolute::{Height, LockTime},
@@ -55,6 +59,14 @@ pub struct TestBitcoinClient {
     pub send_raw_transaction_mode: SendRawTransactionMode,
     /// Value returned by the mock wallet UTXO.
     pub utxo_amount_sats: u64,
+    /// Fee estimate, in sat/vB, returned from `estimate_smart_fee`.
+    pub estimate_smart_fee_result: u32,
+    /// Confirmation targets received by `estimate_smart_fee`.
+    pub estimate_smart_fee_targets: Arc<Mutex<Vec<u16>>>,
+    /// Result returned from `wallet_process_psbt`.
+    pub wallet_process_psbt_result: Arc<Mutex<WalletProcessPsbt>>,
+    /// PSBT strings received by `wallet_process_psbt`.
+    pub wallet_process_psbt_calls: Arc<Mutex<Vec<String>>>,
 }
 
 /// Configures how [`TestBitcoinClient`] responds to `send_raw_transaction`.
@@ -78,6 +90,10 @@ impl TestBitcoinClient {
             included_height: 100,
             send_raw_transaction_mode: SendRawTransactionMode::Success,
             utxo_amount_sats: 10_000_000_000,
+            estimate_smart_fee_result: 3,
+            estimate_smart_fee_targets: Arc::new(Mutex::new(Vec::new())),
+            wallet_process_psbt_result: Arc::new(Mutex::new(default_wallet_process_psbt_result())),
+            wallet_process_psbt_calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -89,6 +105,31 @@ impl TestBitcoinClient {
     pub fn with_utxo_amount_sats(mut self, sats: u64) -> Self {
         self.utxo_amount_sats = sats;
         self
+    }
+
+    pub fn with_estimate_smart_fee_result(mut self, fee_rate_sat_vb: u32) -> Self {
+        self.estimate_smart_fee_result = fee_rate_sat_vb;
+        self
+    }
+
+    pub fn estimate_smart_fee_targets(&self) -> Vec<u16> {
+        self.estimate_smart_fee_targets
+            .lock()
+            .expect("test: estimate_smart_fee_targets lock")
+            .clone()
+    }
+
+    pub fn with_wallet_process_psbt_result(self, complete: bool, hex: Option<Transaction>) -> Self {
+        *self.wallet_process_psbt_result.lock().unwrap() = WalletProcessPsbt {
+            psbt: test_psbt(),
+            complete,
+            hex,
+        };
+        self
+    }
+
+    pub fn wallet_process_psbt_calls(&self) -> Vec<String> {
+        self.wallet_process_psbt_calls.lock().unwrap().clone()
     }
 }
 
@@ -102,6 +143,24 @@ const TEST_BLOCKSTR: &str = "000000207d862a78fcb02ab24ebd154a20b9992af6d2f0c94d3
 /// [`rust-bitcoin` test](https://docs.rs/bitcoin/0.32.1/src/bitcoin/blockdata/transaction.rs.html#1638).
 pub const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
+fn default_wallet_process_psbt_result() -> WalletProcessPsbt {
+    WalletProcessPsbt {
+        psbt: test_psbt(),
+        complete: true,
+        hex: Some(consensus::encode::deserialize_hex(SOME_TX).unwrap()),
+    }
+}
+
+fn test_psbt() -> Psbt {
+    Psbt::from_unsigned_tx(Transaction {
+        version: Version(2),
+        lock_time: LockTime::ZERO,
+        input: Vec::new(),
+        output: Vec::new(),
+    })
+    .expect("test unsigned transaction must convert to PSBT")
+}
+
 /// Generates a [`L1TxEntry`] with the provided status from [`SOME_TX`].
 pub fn gen_l1_tx_entry_with_status(status: L1TxStatus) -> L1TxEntry {
     let tx: Transaction = consensus::encode::deserialize_hex(SOME_TX).unwrap();
@@ -110,20 +169,14 @@ pub fn gen_l1_tx_entry_with_status(status: L1TxStatus) -> L1TxEntry {
     entry
 }
 
-fn empty_test_psbt() -> Psbt {
-    Psbt::from_unsigned_tx(Transaction {
-        version: Version(2),
-        lock_time: LockTime::ZERO,
-        input: vec![],
-        output: vec![],
-    })
-    .unwrap()
-}
-
 impl Reader for TestBitcoinClient {
-    async fn estimate_smart_fee(&self, _conf_target: u16) -> ClientResult<EstimateSmartFee> {
+    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<EstimateSmartFee> {
+        self.estimate_smart_fee_targets
+            .lock()
+            .expect("test: estimate_smart_fee_targets lock")
+            .push(conf_target);
         Ok(EstimateSmartFee {
-            fee_rate: Some(bitcoin::FeeRate::from_sat_per_vb_u32(3)),
+            fee_rate: Some(FeeRate::from_sat_per_vb_u32(self.estimate_smart_fee_result)),
             errors: None,
             blocks: 1,
         })
@@ -439,7 +492,7 @@ impl Wallet for TestBitcoinClient {
         _bip32_derivs: Option<bool>,
     ) -> ClientResult<WalletCreateFundedPsbt> {
         Ok(WalletCreateFundedPsbt {
-            psbt: empty_test_psbt(),
+            psbt: test_psbt(),
             fee: SignedAmount::from_btc(0.001).unwrap(),
             change_position: 0,
         })
@@ -510,16 +563,16 @@ impl Signer for TestBitcoinClient {
 
     async fn wallet_process_psbt(
         &self,
-        _psbt: &str,
+        psbt: &str,
         _sign: Option<bool>,
         _sighashtype: Option<SighashType>,
         _bip32_derivs: Option<bool>,
     ) -> ClientResult<WalletProcessPsbt> {
-        Ok(WalletProcessPsbt {
-            psbt: empty_test_psbt(),
-            complete: true,
-            hex: None,
-        })
+        self.wallet_process_psbt_calls
+            .lock()
+            .unwrap()
+            .push(psbt.to_string());
+        Ok(self.wallet_process_psbt_result.lock().unwrap().clone())
     }
 
     async fn psbt_bump_fee(
@@ -528,7 +581,7 @@ impl Signer for TestBitcoinClient {
         _options: Option<PsbtBumpFeeOptions>,
     ) -> ClientResult<PsbtBumpFee> {
         Ok(PsbtBumpFee {
-            psbt: empty_test_psbt(),
+            psbt: test_psbt(),
             original_fee: Amount::from_btc(0.001).unwrap(),
             fee: Amount::from_btc(0.01).unwrap(),
             errors: vec![],
@@ -616,7 +669,7 @@ pub(crate) mod test_context {
     use std::sync::Arc;
 
     use bitcoin::{secp256k1::SecretKey, Address, Network};
-    use strata_config::btcio::{FeePolicy, L1FeePolicyConfig, WriterConfig};
+    use strata_config::btcio::{FeeBumpingConfig, FeePolicy, L1FeePolicyConfig, WriterConfig};
     use strata_l1_txfmt::MagicBytes;
     use strata_status::StatusChannel;
     use strata_test_utils::ArbitraryGenerator;
@@ -657,5 +710,34 @@ pub(crate) mod test_context {
     pub(crate) fn get_writer_context() -> Arc<WriterContext<TestBitcoinClient>> {
         let client = Arc::new(TestBitcoinClient::new(1));
         get_writer_context_with_client(client)
+    }
+
+    /// Builds a writer context with RBF fee bumping enabled.
+    pub(crate) fn get_fee_bumping_writer_context() -> Arc<WriterContext<TestBitcoinClient>> {
+        get_fee_bumping_writer_context_with_client(Arc::new(TestBitcoinClient::new(1)))
+    }
+
+    /// Builds a writer context with RBF fee bumping enabled around `client`.
+    pub(crate) fn get_fee_bumping_writer_context_with_client(
+        client: Arc<TestBitcoinClient>,
+    ) -> Arc<WriterContext<TestBitcoinClient>> {
+        let base = get_writer_context_with_client(client.clone());
+        let config = Arc::new(WriterConfig {
+            fee_bumping: FeeBumpingConfig {
+                ..FeeBumpingConfig::default()
+            },
+            ..(*base.config).clone()
+        });
+        let sk = SecretKey::from_slice(&[0x01; 32]).unwrap();
+        let (pubkey, _) = sk.x_only_public_key(super::SECP256K1);
+        let ctx = WriterContext::new(
+            base.btcio_params,
+            config,
+            base.sequencer_address.clone(),
+            client,
+            base.status_channel.clone(),
+        )
+        .with_envelope_pubkey(&pubkey.serialize());
+        Arc::new(ctx)
     }
 }

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::{
+    collections::BTreeMap,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 
 use bitcoin::{
     absolute::{Height, LockTime},
@@ -52,6 +56,14 @@ pub struct TestBitcoinClient {
     pub send_raw_transaction_mode: SendRawTransactionMode,
     /// Value returned by the mock wallet UTXO.
     pub utxo_amount_sats: u64,
+    /// Fee estimate, in sat/vB, returned from `estimate_smart_fee`.
+    pub estimate_smart_fee_result: u32,
+    /// Confirmation targets received by `estimate_smart_fee`.
+    pub estimate_smart_fee_targets: Arc<Mutex<Vec<u16>>>,
+    /// Result returned from `wallet_process_psbt`.
+    pub wallet_process_psbt_result: Arc<Mutex<WalletProcessPsbt>>,
+    /// PSBT strings received by `wallet_process_psbt`.
+    pub wallet_process_psbt_calls: Arc<Mutex<Vec<String>>>,
 }
 
 /// Configures how [`TestBitcoinClient`] responds to `send_raw_transaction`.
@@ -75,6 +87,10 @@ impl TestBitcoinClient {
             included_height: 100,
             send_raw_transaction_mode: SendRawTransactionMode::Success,
             utxo_amount_sats: 10_000_000_000,
+            estimate_smart_fee_result: 3,
+            estimate_smart_fee_targets: Arc::new(Mutex::new(Vec::new())),
+            wallet_process_psbt_result: Arc::new(Mutex::new(default_wallet_process_psbt_result())),
+            wallet_process_psbt_calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -86,6 +102,31 @@ impl TestBitcoinClient {
     pub fn with_utxo_amount_sats(mut self, sats: u64) -> Self {
         self.utxo_amount_sats = sats;
         self
+    }
+
+    pub fn with_estimate_smart_fee_result(mut self, fee_rate_sat_vb: u32) -> Self {
+        self.estimate_smart_fee_result = fee_rate_sat_vb;
+        self
+    }
+
+    pub fn estimate_smart_fee_targets(&self) -> Vec<u16> {
+        self.estimate_smart_fee_targets
+            .lock()
+            .expect("test: estimate_smart_fee_targets lock")
+            .clone()
+    }
+
+    pub fn with_wallet_process_psbt_result(self, complete: bool, hex: Option<Transaction>) -> Self {
+        *self.wallet_process_psbt_result.lock().unwrap() = WalletProcessPsbt {
+            psbt: test_psbt(),
+            complete,
+            hex,
+        };
+        self
+    }
+
+    pub fn wallet_process_psbt_calls(&self) -> Vec<String> {
+        self.wallet_process_psbt_calls.lock().unwrap().clone()
     }
 }
 
@@ -99,6 +140,24 @@ const TEST_BLOCKSTR: &str = "000000207d862a78fcb02ab24ebd154a20b9992af6d2f0c94d3
 /// [`rust-bitcoin` test](https://docs.rs/bitcoin/0.32.1/src/bitcoin/blockdata/transaction.rs.html#1638).
 pub const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
+fn default_wallet_process_psbt_result() -> WalletProcessPsbt {
+    WalletProcessPsbt {
+        psbt: test_psbt(),
+        complete: true,
+        hex: Some(consensus::encode::deserialize_hex(SOME_TX).unwrap()),
+    }
+}
+
+fn test_psbt() -> Psbt {
+    Psbt::from_unsigned_tx(Transaction {
+        version: Version(2),
+        lock_time: LockTime::ZERO,
+        input: Vec::new(),
+        output: Vec::new(),
+    })
+    .expect("test unsigned transaction must convert to PSBT")
+}
+
 /// Generates a [`L1TxEntry`] with the provided status from [`SOME_TX`].
 pub fn gen_l1_tx_entry_with_status(status: L1TxStatus) -> L1TxEntry {
     let tx: Transaction = consensus::encode::deserialize_hex(SOME_TX).unwrap();
@@ -107,20 +166,14 @@ pub fn gen_l1_tx_entry_with_status(status: L1TxStatus) -> L1TxEntry {
     entry
 }
 
-fn empty_test_psbt() -> Psbt {
-    Psbt::from_unsigned_tx(Transaction {
-        version: Version(2),
-        lock_time: LockTime::ZERO,
-        input: vec![],
-        output: vec![],
-    })
-    .unwrap()
-}
-
 impl Reader for TestBitcoinClient {
-    async fn estimate_smart_fee(&self, _conf_target: u16) -> ClientResult<EstimateSmartFee> {
+    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<EstimateSmartFee> {
+        self.estimate_smart_fee_targets
+            .lock()
+            .expect("test: estimate_smart_fee_targets lock")
+            .push(conf_target);
         Ok(EstimateSmartFee {
-            fee_rate: Some(bitcoin::FeeRate::from_sat_per_vb_u32(3)),
+            fee_rate: Some(FeeRate::from_sat_per_vb_u32(self.estimate_smart_fee_result)),
             errors: None,
             blocks: 1,
         })
@@ -436,7 +489,7 @@ impl Wallet for TestBitcoinClient {
         _bip32_derivs: Option<bool>,
     ) -> ClientResult<WalletCreateFundedPsbt> {
         Ok(WalletCreateFundedPsbt {
-            psbt: empty_test_psbt(),
+            psbt: test_psbt(),
             fee: SignedAmount::from_btc(0.001).unwrap(),
             change_position: 0,
         })
@@ -507,16 +560,16 @@ impl Signer for TestBitcoinClient {
 
     async fn wallet_process_psbt(
         &self,
-        _psbt: &str,
+        psbt: &str,
         _sign: Option<bool>,
         _sighashtype: Option<SighashType>,
         _bip32_derivs: Option<bool>,
     ) -> ClientResult<WalletProcessPsbt> {
-        Ok(WalletProcessPsbt {
-            psbt: empty_test_psbt(),
-            complete: true,
-            hex: None,
-        })
+        self.wallet_process_psbt_calls
+            .lock()
+            .unwrap()
+            .push(psbt.to_string());
+        Ok(self.wallet_process_psbt_result.lock().unwrap().clone())
     }
 
     async fn psbt_bump_fee(
@@ -525,7 +578,7 @@ impl Signer for TestBitcoinClient {
         _options: Option<PsbtBumpFeeOptions>,
     ) -> ClientResult<PsbtBumpFee> {
         Ok(PsbtBumpFee {
-            psbt: empty_test_psbt(),
+            psbt: test_psbt(),
             original_fee: Amount::from_btc(0.001).unwrap(),
             fee: Amount::from_btc(0.01).unwrap(),
             errors: vec![],
@@ -613,7 +666,7 @@ pub(crate) mod test_context {
     use std::sync::Arc;
 
     use bitcoin::{secp256k1::SecretKey, Address, Network};
-    use strata_config::btcio::{FeePolicy, L1FeePolicyConfig, WriterConfig};
+    use strata_config::btcio::{FeeBumpingConfig, FeePolicy, L1FeePolicyConfig, WriterConfig};
     use strata_l1_txfmt::MagicBytes;
     use strata_status::StatusChannel;
     use strata_test_utils::ArbitraryGenerator;
@@ -654,5 +707,34 @@ pub(crate) mod test_context {
     pub(crate) fn get_writer_context() -> Arc<WriterContext<TestBitcoinClient>> {
         let client = Arc::new(TestBitcoinClient::new(1));
         get_writer_context_with_client(client)
+    }
+
+    /// Builds a writer context with RBF fee bumping enabled.
+    pub(crate) fn get_fee_bumping_writer_context() -> Arc<WriterContext<TestBitcoinClient>> {
+        get_fee_bumping_writer_context_with_client(Arc::new(TestBitcoinClient::new(1)))
+    }
+
+    /// Builds a writer context with RBF fee bumping enabled around `client`.
+    pub(crate) fn get_fee_bumping_writer_context_with_client(
+        client: Arc<TestBitcoinClient>,
+    ) -> Arc<WriterContext<TestBitcoinClient>> {
+        let base = get_writer_context_with_client(client.clone());
+        let config = Arc::new(WriterConfig {
+            fee_bumping: FeeBumpingConfig {
+                ..FeeBumpingConfig::default()
+            },
+            ..(*base.config).clone()
+        });
+        let sk = SecretKey::from_slice(&[0x01; 32]).unwrap();
+        let (pubkey, _) = sk.x_only_public_key(super::SECP256K1);
+        let ctx = WriterContext::new(
+            base.btcio_params,
+            config,
+            base.sequencer_address.clone(),
+            client,
+            base.status_channel.clone(),
+        )
+        .with_envelope_pubkey(&pubkey.serialize());
+        Arc::new(ctx)
     }
 }

--- a/crates/btcio/src/tx_attempt.rs
+++ b/crates/btcio/src/tx_attempt.rs
@@ -1,0 +1,52 @@
+//! Bitcoin encoding for fee-bump attempt records.
+//!
+//! [`strata_db_types::fee_bump`] stores attempt transactions as opaque bytes so the database
+//! crate stays free of a Bitcoin dependency. This module supplies the [`Transaction`]
+//! conversions for the code that actually deals in Bitcoin transactions.
+
+use bitcoin::{
+    consensus::{self, deserialize, serialize},
+    hashes::Hash,
+    Amount, FeeRate, Transaction,
+};
+use strata_db_types::{
+    common::{L1TxId, L1WtxId},
+    fee_bump::{TxAttempt, TxAttemptParts},
+};
+
+/// Builds the persistent attempt material for `tx`.
+pub fn attempt_parts(tx: &Transaction, fee_rate: FeeRate, fee: Amount) -> TxAttemptParts {
+    TxAttemptParts {
+        raw_tx: serialize(tx),
+        txid: L1TxId::from(tx.compute_txid().to_byte_array()),
+        wtxid: L1WtxId::from(tx.compute_wtxid().to_byte_array()),
+        fee_rate_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+        fee_sats: fee.to_sat(),
+    }
+}
+
+/// Bitcoin conversions for [`TxAttempt`].
+pub trait TxAttemptExt {
+    /// Deserializes the raw transaction for this attempt.
+    fn try_to_tx(&self) -> Result<Transaction, consensus::encode::Error>;
+
+    /// Returns the fee rate the attempt was built at.
+    fn fee_rate(&self) -> Option<FeeRate>;
+
+    /// Returns the absolute fee the attempt pays.
+    fn fee(&self) -> Amount;
+}
+
+impl TxAttemptExt for TxAttempt {
+    fn try_to_tx(&self) -> Result<Transaction, consensus::encode::Error> {
+        deserialize(&self.raw_tx)
+    }
+
+    fn fee_rate(&self) -> Option<FeeRate> {
+        FeeRate::from_sat_per_vb(self.fee_rate_sat_vb)
+    }
+
+    fn fee(&self) -> Amount {
+        Amount::from_sat(self.fee_sats)
+    }
+}

--- a/crates/btcio/src/tx_entry.rs
+++ b/crates/btcio/src/tx_entry.rs
@@ -6,14 +6,18 @@
 
 use bitcoin::{
     consensus::{self, deserialize, serialize},
-    Transaction,
+    Amount, FeeRate, Transaction,
 };
-use strata_db_types::l1_broadcast::L1TxEntry;
+use strata_db_types::l1_broadcast::{L1TxEntry, L1TxRbfInfo, L1TxStatus};
 
 /// Bitcoin conversions for [`L1TxEntry`].
 pub trait L1TxEntryExt: Sized {
     /// Creates an unpublished entry from a [`Transaction`].
     fn from_tx(tx: &Transaction) -> Self;
+
+    /// Creates a writer-owned unpublished entry carrying the RBF metadata for `fee_rate` and
+    /// `fee`.
+    fn from_tx_with_fee(tx: &Transaction, fee_rate: FeeRate, fee: Amount) -> Self;
 
     /// Deserializes the stored bytes back into a [`Transaction`].
     fn try_to_tx(&self) -> Result<Transaction, consensus::encode::Error>;
@@ -22,6 +26,18 @@ pub trait L1TxEntryExt: Sized {
 impl L1TxEntryExt for L1TxEntry {
     fn from_tx(tx: &Transaction) -> Self {
         Self::new_unpublished(serialize(tx))
+    }
+
+    fn from_tx_with_fee(tx: &Transaction, fee_rate: FeeRate, fee: Amount) -> Self {
+        Self::from_raw_parts(
+            serialize(tx),
+            L1TxStatus::Unpublished,
+            Some(L1TxRbfInfo {
+                fee_rate_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+                fee_sats: fee.to_sat(),
+                replaces: None,
+            }),
+        )
     }
 
     fn try_to_tx(&self) -> Result<Transaction, consensus::encode::Error> {

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -25,6 +25,7 @@ use bitcoind_async_client::{
     traits::{Reader, Signer, Wallet},
 };
 use rand::{rngs::OsRng, RngCore};
+use strata_config::btcio::FeeBumpingConfig;
 use strata_csm_types::L1Payload;
 use strata_l1_envelope_fmt::{builder::EnvelopeScriptBuilder, errors::EnvelopeBuildError};
 use strata_l1_txfmt::{self, MagicBytes, ParseConfig, TxFmtError};
@@ -45,7 +46,8 @@ pub struct EnvelopeConfig {
     pub sequencer_address: Address,
     /// Amount to send to reveal address.
     ///
-    /// NOTE: must be higher than the dust limit.
+    /// Every production caller passes the Bitcoin dust limit, so this only varies in tests. It is
+    /// not validated: a value below the dust limit would produce a non-standard reveal output.
     //
     // TODO(STR-3690): Make this and all other bitcoin related values to Amount
     pub reveal_amount: u64,
@@ -53,6 +55,8 @@ pub struct EnvelopeConfig {
     pub network: Network,
     /// Bitcoin fee rate.
     pub fee_rate: FeeRate,
+    /// Fee-bumping policy used to derive reveal fee headroom.
+    pub fee_bumping: FeeBumpingConfig,
     /// Sequencer public key for the taproot envelope script (SPS-51).
     ///
     /// Used as the `<pubkey>` in `<pubkey> CHECKSIG` of the envelope script.
@@ -70,6 +74,7 @@ impl EnvelopeConfig {
         network: Network,
         fee_rate: FeeRate,
         reveal_amount: u64,
+        fee_bumping: FeeBumpingConfig,
         envelope_pubkey: Option<XOnlyPublicKey>,
     ) -> Self {
         Self {
@@ -77,6 +82,7 @@ impl EnvelopeConfig {
             sequencer_address,
             reveal_amount,
             fee_rate,
+            fee_bumping,
             network,
             envelope_pubkey,
         }
@@ -142,9 +148,19 @@ pub struct EnvelopeData {
     pub taproot_spend_info: TaprootSpendInfo,
     /// The x-only public key committed to by the envelope reveal script.
     pub envelope_pubkey: XOnlyPublicKey,
+    /// Fee rate the envelope transactions were built at.
+    pub fee_rate: FeeRate,
+    /// Absolute fee paid by the commit transaction.
+    pub commit_fee: Amount,
+    /// Absolute fee paid by the reveal transaction.
+    pub reveal_fee: Amount,
 }
 
 impl EnvelopeData {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "EnvelopeData is a plain construction bundle for transaction metadata"
+    )]
     pub fn new(
         commit_tx: Transaction,
         reveal_tx: Transaction,
@@ -152,6 +168,9 @@ impl EnvelopeData {
         reveal_script: ScriptBuf,
         taproot_spend_info: TaprootSpendInfo,
         envelope_pubkey: XOnlyPublicKey,
+        fee_rate: FeeRate,
+        commit_fee: Amount,
+        reveal_fee: Amount,
     ) -> Self {
         Self {
             commit_tx,
@@ -160,6 +179,9 @@ impl EnvelopeData {
             reveal_script,
             taproot_spend_info,
             envelope_pubkey,
+            fee_rate,
+            commit_fee,
+            reveal_fee,
         }
     }
 }
@@ -182,9 +204,11 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
         network,
         fee_rate,
         BITCOIN_DUST_LIMIT,
+        ctx.config.fee_bumping,
         Some(envelope_pubkey),
     );
-    create_envelope_transactions(&env_config, payload, utxos)
+    let envelope = create_envelope_transactions(&env_config, payload, utxos)?;
+    Ok(envelope)
 }
 
 /// Builds envelope transactions using a temporary keypair and signs both commit and reveal
@@ -206,6 +230,7 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
         network,
         fee_rate,
         BITCOIN_DUST_LIMIT,
+        ctx.config.fee_bumping,
         Some(pubkey),
     );
     let mut envelope = create_envelope_transactions(&env_config, payload, utxos)?;
@@ -287,16 +312,32 @@ pub fn create_envelope_transactions(
         &reveal_script,
         &tag_script,
         &taproot_spend_info,
+        &env_config.fee_bumping,
     )?;
 
+    let reveal_vsize = single_reveal_vsize(
+        &env_config.sequencer_address,
+        env_config.reveal_amount,
+        &reveal_script,
+        &tag_script,
+        &taproot_spend_info,
+    );
+    let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
+    let headroom = reveal_fee_headroom(env_config.fee_rate, reveal_vsize, &env_config.fee_bumping)?;
+    let reveal_output_value = env_config
+        .reveal_amount
+        .checked_add(headroom)
+        .ok_or(EnvelopeError::FeeOverflow)?;
+
     // Build commit tx
-    let (commit_tx, _) = build_commit_transaction(
+    let (commit_tx, consumed_utxos) = build_commit_transaction(
         utxos,
         reveal_address,
         env_config.sequencer_address.clone(),
         commit_value,
         env_config.fee_rate,
     )?;
+    let commit_fee_sats = calculate_transaction_fee_from_utxos(&commit_tx, &consumed_utxos);
 
     let output_to_reveal = commit_tx.output[0].clone();
 
@@ -304,7 +345,7 @@ pub fn create_envelope_transactions(
     let reveal_tx = build_reveal_transaction(
         commit_tx.clone(),
         env_config.sequencer_address.clone(),
-        env_config.reveal_amount,
+        reveal_output_value,
         env_config.fee_rate,
         &reveal_script,
         tag_script,
@@ -312,6 +353,13 @@ pub fn create_envelope_transactions(
             .control_block(&(reveal_script.clone(), LeafVersion::TapScript))
             .ok_or(anyhow!("Cannot create control block".to_string()))?,
     )?;
+    let reveal_fee_sats = commit_value.saturating_sub(
+        reveal_tx
+            .output
+            .iter()
+            .map(|output| output.value.to_sat())
+            .sum(),
+    );
 
     // Compute sighash for the reveal tx
     let sighash = compute_reveal_sighash(&reveal_tx, &output_to_reveal, &reveal_script)?;
@@ -323,7 +371,20 @@ pub fn create_envelope_transactions(
         reveal_script,
         taproot_spend_info,
         public_key,
+        env_config.fee_rate,
+        Amount::from_sat(commit_fee_sats),
+        Amount::from_sat(reveal_fee_sats),
     ))
+}
+
+fn calculate_transaction_fee_from_utxos(tx: &Transaction, utxos: &[ListUnspentItem]) -> u64 {
+    let input_total = utxos.iter().map(|utxo| utxo.amount.to_sat()).sum::<u64>();
+    let output_total = tx
+        .output
+        .iter()
+        .map(|output| output.value.to_sat())
+        .sum::<u64>();
+    input_total.saturating_sub(output_total)
 }
 
 /// Computes the taproot script-spend sighash for the reveal transaction.
@@ -588,8 +649,35 @@ pub(crate) fn calculate_commit_output_value(
     reveal_script: &script::ScriptBuf,
     tag_script: &script::ScriptBuf,
     taproot_spend_info: &TaprootSpendInfo,
+    fee_bumping: &FeeBumpingConfig,
 ) -> Result<u64, EnvelopeError> {
-    let reveal_vsize = get_size(
+    let reveal_vsize = single_reveal_vsize(
+        recipient,
+        reveal_value,
+        reveal_script,
+        tag_script,
+        taproot_spend_info,
+    );
+    let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
+    let fee = fee_rate
+        .fee_vb(reveal_vsize)
+        .ok_or(EnvelopeError::FeeOverflow)?
+        .to_sat();
+    let headroom = reveal_fee_headroom(fee_rate, reveal_vsize, fee_bumping)?;
+    reveal_value
+        .checked_add(headroom)
+        .and_then(|value| value.checked_add(fee))
+        .ok_or(EnvelopeError::FeeOverflow)
+}
+
+fn single_reveal_vsize(
+    recipient: &Address,
+    reveal_value: u64,
+    reveal_script: &script::ScriptBuf,
+    tag_script: &script::ScriptBuf,
+    taproot_spend_info: &TaprootSpendInfo,
+) -> usize {
+    get_size(
         &default_txin(),
         &[
             TxOut {
@@ -607,11 +695,41 @@ pub(crate) fn calculate_commit_output_value(
                 .control_block(&(reveal_script.clone(), LeafVersion::TapScript))
                 .expect("Cannot create control block"),
         ),
-    );
-    let fee = fee_sats_for_vsize(reveal_vsize, fee_rate)?;
-    reveal_value
-        .checked_add(fee)
-        .ok_or(EnvelopeError::FeeOverflow)
+    )
+}
+
+/// Derives the absolute fee headroom needed to fund the configured reveal replacement schedule.
+pub(crate) fn reveal_fee_headroom(
+    build_rate: FeeRate,
+    reveal_vsize: u64,
+    config: &FeeBumpingConfig,
+) -> Result<u64, EnvelopeError> {
+    let mut rate = build_rate.to_sat_per_vb_ceil();
+    let max_rate = config.max_fee_rate_sat_vb.get();
+
+    for _ in 0..config.max_attempts.get().saturating_sub(1) {
+        let additive = rate.saturating_add(config.min_fee_rate_delta_sat_vb.get());
+        let multiplicative = u128::from(rate)
+            .saturating_mul(u128::from(config.multiplier_bps))
+            .div_ceil(10_000);
+        let multiplicative = u64::try_from(multiplicative).unwrap_or(u64::MAX);
+        rate = additive.max(multiplicative).min(max_rate);
+        if rate >= max_rate {
+            break;
+        }
+    }
+
+    let top_fee = FeeRate::from_sat_per_vb(rate)
+        .and_then(|fee_rate| fee_rate.fee_vb(reveal_vsize))
+        .ok_or(EnvelopeError::FeeOverflow)?;
+    let base_fee = build_rate
+        .fee_vb(reveal_vsize)
+        .ok_or(EnvelopeError::FeeOverflow)?;
+
+    Ok(top_fee
+        .to_sat()
+        .saturating_sub(base_fee.to_sat())
+        .min(config.max_reveal_fee_headroom().to_sat()))
 }
 
 pub(crate) fn fee_sats_for_vsize(vsize: usize, fee_rate: FeeRate) -> Result<u64, EnvelopeError> {
@@ -685,7 +803,10 @@ pub fn attach_reveal_signature(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{
+        num::{NonZeroU32, NonZeroU64},
+        sync::Arc,
+    };
 
     use bitcoin::{
         absolute::LockTime,
@@ -794,6 +915,7 @@ mod tests {
             Network::Regtest,
             FeeRate::from_sat_per_vb_u32(1_000),
             546,
+            FeeBumpingConfig::default(),
             envelope_pubkey,
         )
     }
@@ -860,6 +982,15 @@ mod tests {
         }
     }
 
+    fn assert_all_inputs_opt_into_rbf(tx: &Transaction) {
+        assert!(
+            tx.input
+                .iter()
+                .all(|input| input.sequence == Sequence::ENABLE_RBF_NO_LOCKTIME),
+            "all writer-built transaction inputs must opt into RBF"
+        );
+    }
+
     #[test]
     fn test_build_reveal_transaction() {
         let (ctx, _, _, utxos) = get_mock_data();
@@ -878,12 +1009,35 @@ mod tests {
         ])
         .unwrap(); // should be 33 bytes
 
+        let fee_rate = FeeRate::from_sat_per_vb_u32(8);
+        let reveal_vsize = get_size(
+            &default_txin(),
+            &[
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: tag_script.clone(),
+                },
+                TxOut {
+                    value: Amount::from_sat(ctx.config.reveal_amount),
+                    script_pubkey: ctx.sequencer_address.script_pubkey(),
+                },
+            ],
+            Some(&_reveal_script),
+            Some(&control_block),
+        );
+        let headroom = reveal_fee_headroom(
+            fee_rate,
+            u64::try_from(reveal_vsize).unwrap(),
+            &ctx.config.fee_bumping,
+        )
+        .unwrap();
+        let reveal_output_value = ctx.config.reveal_amount.checked_add(headroom).unwrap();
         let inp_txn = get_txn_from_utxo(utxo, &ctx.sequencer_address);
         let mut tx = super::build_reveal_transaction(
             inp_txn,
             ctx.sequencer_address.clone(),
-            ctx.config.reveal_amount,
-            FeeRate::from_sat_per_vb_u32(8),
+            reveal_output_value,
+            fee_rate,
             &_reveal_script,
             tag_script.clone(),
             &control_block,
@@ -895,10 +1049,14 @@ mod tests {
         tx.input[0].witness.push(control_block.serialize());
 
         assert_eq!(tx.input.len(), 1);
+        assert_all_inputs_opt_into_rbf(&tx);
         assert_eq!(tx.input[0].previous_output.vout, utxo.vout);
 
         assert_eq!(tx.output.len(), 2);
-        assert_eq!(tx.output[1].value.to_sat(), ctx.config.reveal_amount);
+        assert_eq!(
+            tx.output[1].value.to_sat(),
+            ctx.config.reveal_amount + headroom
+        );
         assert_eq!(
             tx.output[1].script_pubkey,
             ctx.sequencer_address.script_pubkey()
@@ -1032,6 +1190,7 @@ mod tests {
             unsigned.commit_tx.input[0].previous_output.vout, utxos[2].vout,
             "utxo should be chosen correctly"
         );
+        assert_all_inputs_opt_into_rbf(&unsigned.commit_tx);
 
         assert_eq!(
             unsigned.reveal_tx.input[0].previous_output.txid,
@@ -1042,6 +1201,7 @@ mod tests {
             unsigned.reveal_tx.input[0].previous_output.vout, 0,
             "reveal should use commit as input"
         );
+        assert_all_inputs_opt_into_rbf(&unsigned.reveal_tx);
 
         assert_eq!(
             unsigned.reveal_tx.output[1].script_pubkey,
@@ -1051,6 +1211,96 @@ mod tests {
 
         // Sighash should be non-zero
         assert_ne!(unsigned.sighash, Buf32::zero());
+    }
+
+    #[test]
+    fn single_envelope_funds_headroom_without_burning_it() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let env_config = EnvelopeConfig {
+            fee_rate: FeeRate::from_sat_per_vb(1).unwrap(),
+            ..test_envelope_config(&ctx, Some(test_envelope_pubkey()))
+        };
+        let envelope = create_envelope_transactions(&env_config, &test_payload(), utxos).unwrap();
+        let tag_script = ParseConfig::new(env_config.magic_bytes)
+            .encode_script_buf(&test_payload().tag().as_ref())
+            .unwrap();
+        let reveal_vsize = single_reveal_vsize(
+            &env_config.sequencer_address,
+            env_config.reveal_amount,
+            &envelope.reveal_script,
+            &tag_script,
+            &envelope.taproot_spend_info,
+        );
+        let reveal_vsize = u64::try_from(reveal_vsize).unwrap();
+        let base_fee = env_config.fee_rate.fee_vb(reveal_vsize).unwrap();
+        let headroom =
+            reveal_fee_headroom(env_config.fee_rate, reveal_vsize, &env_config.fee_bumping)
+                .unwrap();
+
+        assert!(headroom > 0);
+        assert_eq!(
+            envelope.commit_tx.output[0].value.to_sat(),
+            env_config.reveal_amount + base_fee.to_sat() + headroom
+        );
+        assert_eq!(
+            envelope.reveal_tx.output[1].value.to_sat(),
+            env_config.reveal_amount + headroom
+        );
+        assert_eq!(envelope.reveal_fee, base_fee);
+    }
+
+    #[test]
+    fn zero_derived_headroom_preserves_legacy_single_envelope_values() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let env_config = EnvelopeConfig {
+            fee_rate: FeeRate::from_sat_per_vb(1).unwrap(),
+            fee_bumping: FeeBumpingConfig {
+                max_attempts: NonZeroU32::new(1).unwrap(),
+                ..FeeBumpingConfig::default()
+            },
+            ..test_envelope_config(&ctx, Some(test_envelope_pubkey()))
+        };
+        let envelope = create_envelope_transactions(&env_config, &test_payload(), utxos).unwrap();
+        let base_fee = envelope.reveal_fee.to_sat();
+
+        assert_eq!(
+            envelope.commit_tx.output[0].value.to_sat(),
+            env_config.reveal_amount + base_fee
+        );
+        assert_eq!(
+            envelope.reveal_tx.output[1].value.to_sat(),
+            env_config.reveal_amount
+        );
+    }
+
+    #[test]
+    fn reveal_headroom_cap_binds_in_isolation() {
+        let fee_bumping = FeeBumpingConfig {
+            max_reveal_fee_headroom_sats: NonZeroU64::new(7).unwrap(),
+            ..FeeBumpingConfig::default()
+        };
+
+        assert_eq!(
+            reveal_fee_headroom(FeeRate::from_sat_per_vb(1).unwrap(), 200, &fee_bumping,).unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn build_rate_at_or_above_max_rate_has_no_headroom() {
+        let fee_bumping = FeeBumpingConfig::default();
+
+        for build_rate in [1_000, 1_001] {
+            assert_eq!(
+                reveal_fee_headroom(
+                    FeeRate::from_sat_per_vb(build_rate).unwrap(),
+                    200,
+                    &fee_bumping,
+                )
+                .unwrap(),
+                0
+            );
+        }
     }
 
     #[test]

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -20,13 +20,14 @@ use bitcoin::{
     Address, Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 use bitcoind_async_client::corepc_types::model::ListUnspentItem;
+use strata_config::btcio::FeeBumpingConfig;
 use strata_l1_envelope_fmt::builder::EnvelopeScriptBuilder;
 use strata_l1_txfmt::MagicBytes;
 
 use super::commit_op_return::build_commit_op_return;
 use crate::writer::builder::{
-    choose_utxos, fee_sats_for_vsize, get_size, sign_reveal_transaction, EnvelopeConfig,
-    EnvelopeError, BITCOIN_DUST_LIMIT,
+    choose_utxos, fee_sats_for_vsize, get_size, reveal_fee_headroom, sign_reveal_transaction,
+    EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT,
 };
 
 /// Intermediate state for each reveal before tx construction.
@@ -41,6 +42,12 @@ struct RevealArtifact {
 pub struct ChunkedEnvelopeTxs {
     pub commit_tx: Transaction,
     pub reveal_txs: Vec<Transaction>,
+    /// Exact absolute fee the commit tx pays.
+    ///
+    /// This is `sum(inputs) - sum(outputs)`, not `vsize * fee_rate`: when the leftover change
+    /// would be dust the builder drops the change output and the excess becomes extra fee. Fee
+    /// bumping needs the real figure to compute the BIP-125 absolute-fee floor for a replacement.
+    pub commit_fee: Amount,
 }
 
 /// Builds a chunked envelope from raw chunk payloads.
@@ -73,7 +80,24 @@ pub fn build_chunked_envelope_txs(
 
     let sequencer_xonly = XOnlyPublicKey::from_keypair(sequencer_keypair).0;
     let commit_op_return = build_commit_op_return(magic_bytes, da_blob_version);
+    let artifacts = build_reveal_artifacts(chunks, sequencer_xonly, config)?;
 
+    let (commit_tx, commit_fee) =
+        build_multi_output_commit(config, &artifacts, &commit_op_return, utxos)?;
+    let reveal_txs = build_reveals_for_commit(config, &artifacts, sequencer_keypair, &commit_tx)?;
+
+    Ok(ChunkedEnvelopeTxs {
+        commit_tx,
+        reveal_txs,
+        commit_fee,
+    })
+}
+
+fn build_reveal_artifacts(
+    chunks: &[Vec<u8>],
+    sequencer_xonly: XOnlyPublicKey,
+    config: &EnvelopeConfig,
+) -> Result<Vec<RevealArtifact>, EnvelopeError> {
     let mut artifacts = Vec::with_capacity(chunks.len());
     for chunk in chunks {
         let reveal_script = EnvelopeScriptBuilder::with_pubkey(&sequencer_xonly.serialize())?
@@ -92,6 +116,7 @@ pub fn build_chunked_envelope_txs(
             config.fee_rate,
             &reveal_script,
             &spend_info,
+            &config.fee_bumping,
         )?;
 
         artifacts.push(RevealArtifact {
@@ -100,8 +125,15 @@ pub fn build_chunked_envelope_txs(
             commit_value,
         });
     }
+    Ok(artifacts)
+}
 
-    let commit_tx = build_multi_output_commit(config, &artifacts, &commit_op_return, utxos)?;
+fn build_reveals_for_commit(
+    config: &EnvelopeConfig,
+    artifacts: &[RevealArtifact],
+    sequencer_keypair: &Keypair,
+    commit_tx: &Transaction,
+) -> Result<Vec<Transaction>, EnvelopeError> {
     let commit_txid = commit_tx.compute_txid();
 
     let mut reveal_txs = Vec::with_capacity(artifacts.len());
@@ -109,7 +141,10 @@ pub fn build_chunked_envelope_txs(
     // Reveals spend commit outputs starting at vout=1 (vout=0 is the OP_RETURN).
     for (i, artifact) in artifacts.iter().enumerate() {
         let vout = (i + 1) as u32;
-        let commit_output = &commit_tx.output[vout as usize];
+        let commit_output = commit_tx
+            .output
+            .get(vout as usize)
+            .ok_or(EnvelopeError::NotEnoughUtxos(config.reveal_amount, 0))?;
 
         let control_block = artifact
             .spend_info
@@ -127,8 +162,13 @@ pub fn build_chunked_envelope_txs(
             Some(&control_block),
         );
         let reveal_fee = fee_sats_for_vsize(reveal_vsize, config.fee_rate)?;
-        let required = config
+        let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
+        let headroom = reveal_fee_headroom(config.fee_rate, reveal_vsize, &config.fee_bumping)?;
+        let reveal_output_value = config
             .reveal_amount
+            .checked_add(headroom)
+            .ok_or(EnvelopeError::FeeOverflow)?;
+        let required = reveal_output_value
             .checked_add(reveal_fee)
             .ok_or(EnvelopeError::FeeOverflow)?;
         if commit_output.value < Amount::from_sat(required) {
@@ -143,7 +183,7 @@ pub fn build_chunked_envelope_txs(
             version: Version(2),
             input: vec![make_txin(commit_txid, vout)],
             output: vec![TxOut {
-                value: Amount::from_sat(config.reveal_amount),
+                value: Amount::from_sat(reveal_output_value),
                 script_pubkey: config.sequencer_address.script_pubkey(),
             }],
         };
@@ -159,15 +199,12 @@ pub fn build_chunked_envelope_txs(
         reveal_txs.push(reveal_tx);
     }
 
-    Ok(ChunkedEnvelopeTxs {
-        commit_tx,
-        reveal_txs,
-    })
+    Ok(reveal_txs)
 }
 
 /// Sizes the commit output funding one reveal tx.
 ///
-/// The returned value is `vsize(reveal) * fee_rate + reveal_amount`.
+/// The returned value is `reveal_amount + reveal_fee + reveal_fee_headroom`.
 ///
 /// This is the amount the matching commit P2TR output must hold so the reveal
 /// can pay its fee plus the sequencer dust output.
@@ -177,6 +214,7 @@ fn calculate_reveal_commit_value(
     fee_rate: FeeRate,
     reveal_script: &ScriptBuf,
     spend_info: &TaprootSpendInfo,
+    fee_bumping: &FeeBumpingConfig,
 ) -> Result<u64, EnvelopeError> {
     let reveal_output = TxOut {
         value: Amount::from_sat(reveal_amount),
@@ -192,18 +230,22 @@ fn calculate_reveal_commit_value(
         Some(&control_block),
     );
     let reveal_fee = fee_sats_for_vsize(reveal_vsize, fee_rate)?;
+    let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
+    let headroom = reveal_fee_headroom(fee_rate, reveal_vsize, fee_bumping)?;
     reveal_amount
-        .checked_add(reveal_fee)
+        .checked_add(headroom)
+        .and_then(|value| value.checked_add(reveal_fee))
         .ok_or(EnvelopeError::FeeOverflow)
 }
 
 /// Builds the commit tx with `[OP_RETURN, P2TR_0, ..., P2TR_{N-1}, change?]`.
+/// Builds the commit transaction and returns it alongside the exact fee it pays.
 fn build_multi_output_commit(
     config: &EnvelopeConfig,
     artifacts: &[RevealArtifact],
     op_return_script: &ScriptBuf,
     utxos: Vec<ListUnspentItem>,
-) -> Result<Transaction, EnvelopeError> {
+) -> Result<(Transaction, Amount), EnvelopeError> {
     let spendable: Vec<ListUnspentItem> = utxos
         .into_iter()
         .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT)
@@ -271,12 +313,20 @@ fn build_multi_output_commit(
 
         let size = get_size(&inputs, &outputs, None, None);
         if size == last_size || done {
-            return Ok(Transaction {
-                lock_time: LockTime::ZERO,
-                version: Version(2),
-                input: inputs,
-                output: outputs,
-            });
+            // `done` means the leftover change was dust and got absorbed into the fee, so derive
+            // the fee from the actual input/output totals rather than from `fee_rate * vsize`.
+            let output_total: u64 = outputs.iter().map(|output| output.value.to_sat()).sum();
+            let commit_fee = Amount::from_sat(sum.saturating_sub(output_total));
+
+            return Ok((
+                Transaction {
+                    lock_time: LockTime::ZERO,
+                    version: Version(2),
+                    input: inputs,
+                    output: outputs,
+                },
+                commit_fee,
+            ));
         }
         last_size = size;
     }
@@ -293,6 +343,8 @@ fn make_txin(txid: bitcoin::Txid, vout: u32) -> TxIn {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use bitcoin::{
         opcodes::all::OP_RETURN,
         secp256k1::{rand, Keypair, Secp256k1},
@@ -360,8 +412,9 @@ mod tests {
             ctx.btcio_params.magic_bytes,
             ctx.sequencer_address.clone(),
             Network::Regtest,
-            FeeRate::from_sat_per_vb_u32(1_000),
+            FeeRate::from_sat_per_vb_u32(1),
             546,
+            FeeBumpingConfig::default(),
             None,
         )
     }
@@ -414,7 +467,60 @@ mod tests {
                 reveal.output[0].script_pubkey,
                 config.sequencer_address.script_pubkey()
             );
+            let reveal_vsize = u64::try_from(reveal.vsize()).unwrap();
+            let base_fee = config.fee_rate.fee_vb(reveal_vsize).unwrap();
+            let headroom =
+                reveal_fee_headroom(config.fee_rate, reveal_vsize, &config.fee_bumping).unwrap();
+            let commit_output = &result.commit_tx.output[i + 1];
+            let initial_fee = commit_output
+                .value
+                .checked_sub(reveal.output[0].value)
+                .unwrap();
+
+            assert!(headroom > 0);
+            assert_eq!(
+                commit_output.value.to_sat(),
+                config.reveal_amount + base_fee.to_sat() + headroom
+            );
+            assert_eq!(
+                reveal.output[0].value.to_sat(),
+                config.reveal_amount + headroom
+            );
+            assert_eq!(initial_fee, base_fee);
         }
+    }
+
+    #[test]
+    fn zero_derived_headroom_preserves_legacy_chunked_reveal_values() {
+        let config = EnvelopeConfig {
+            fee_bumping: FeeBumpingConfig {
+                max_attempts: NonZeroU32::new(1).unwrap(),
+                ..FeeBumpingConfig::default()
+            },
+            ..get_test_config()
+        };
+        let chunks = vec![vec![1u8; 150]];
+        let magic = MagicBytes::from([0xAA, 0xBB, 0xCC, 0xDD]);
+        let result = build_chunked_envelope_txs(
+            &config,
+            &chunks,
+            &magic,
+            TEST_DA_BLOB_VERSION,
+            &test_keypair(),
+            get_mock_utxos(),
+        )
+        .unwrap();
+        let reveal = &result.reveal_txs[0];
+        let base_fee = config
+            .fee_rate
+            .fee_vb(u64::try_from(reveal.vsize()).unwrap())
+            .unwrap();
+
+        assert_eq!(reveal.output[0].value.to_sat(), config.reveal_amount);
+        assert_eq!(
+            result.commit_tx.output[1].value.to_sat(),
+            config.reveal_amount + base_fee.to_sat()
+        );
     }
 
     #[test]
@@ -471,6 +577,7 @@ mod tests {
             Network::Regtest,
             FeeRate::from_sat_per_vb_u32(1_000),
             546,
+            FeeBumpingConfig::default(),
             None,
         );
         let chunks = vec![vec![0u8; 150]];

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -20,13 +20,14 @@ use bitcoin::{
     Address, Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 use bitcoind_async_client::corepc_types::model::ListUnspentItem;
+use strata_config::btcio::FeeBumpingConfig;
 use strata_l1_envelope_fmt::builder::EnvelopeScriptBuilder;
 use strata_l1_txfmt::MagicBytes;
 
 use super::commit_op_return::build_commit_op_return;
 use crate::writer::builder::{
-    choose_utxos, fee_sats_for_vsize, get_size, sign_reveal_transaction, EnvelopeConfig,
-    EnvelopeError, BITCOIN_DUST_LIMIT,
+    choose_utxos, fee_sats_for_vsize, get_size, reveal_fee_headroom, sign_reveal_transaction,
+    EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT,
 };
 
 /// Intermediate state for each reveal before tx construction.
@@ -41,6 +42,12 @@ struct RevealArtifact {
 pub struct ChunkedEnvelopeTxs {
     pub commit_tx: Transaction,
     pub reveal_txs: Vec<Transaction>,
+    /// Exact absolute fee the commit tx pays.
+    ///
+    /// This is `sum(inputs) - sum(outputs)`, not `vsize * fee_rate`: when the leftover change
+    /// would be dust the builder drops the change output and the excess becomes extra fee. Fee
+    /// bumping needs the real figure to compute the BIP-125 absolute-fee floor for a replacement.
+    pub commit_fee: Amount,
 }
 
 /// Builds a chunked envelope from raw chunk payloads.
@@ -74,7 +81,24 @@ pub fn build_chunked_envelope_txs<'a>(
 
     let sequencer_xonly = XOnlyPublicKey::from_keypair(sequencer_keypair).0;
     let commit_op_return = build_commit_op_return(magic_bytes, da_blob_version);
+    let artifacts = build_reveal_artifacts(chunks, sequencer_xonly, config)?;
 
+    let (commit_tx, commit_fee) =
+        build_multi_output_commit(config, &artifacts, &commit_op_return, utxos)?;
+    let reveal_txs = build_reveals_for_commit(config, &artifacts, sequencer_keypair, &commit_tx)?;
+
+    Ok(ChunkedEnvelopeTxs {
+        commit_tx,
+        reveal_txs,
+        commit_fee,
+    })
+}
+
+fn build_reveal_artifacts(
+    chunks: Vec<&[u8]>,
+    sequencer_xonly: XOnlyPublicKey,
+    config: &EnvelopeConfig,
+) -> Result<Vec<RevealArtifact>, EnvelopeError> {
     let mut artifacts = Vec::with_capacity(chunks.len());
     for chunk in chunks {
         let reveal_script = EnvelopeScriptBuilder::with_pubkey(&sequencer_xonly.serialize())?
@@ -93,6 +117,7 @@ pub fn build_chunked_envelope_txs<'a>(
             config.fee_rate,
             &reveal_script,
             &spend_info,
+            &config.fee_bumping,
         )?;
 
         artifacts.push(RevealArtifact {
@@ -101,8 +126,15 @@ pub fn build_chunked_envelope_txs<'a>(
             commit_value,
         });
     }
+    Ok(artifacts)
+}
 
-    let commit_tx = build_multi_output_commit(config, &artifacts, &commit_op_return, utxos)?;
+fn build_reveals_for_commit(
+    config: &EnvelopeConfig,
+    artifacts: &[RevealArtifact],
+    sequencer_keypair: &Keypair,
+    commit_tx: &Transaction,
+) -> Result<Vec<Transaction>, EnvelopeError> {
     let commit_txid = commit_tx.compute_txid();
 
     let mut reveal_txs = Vec::with_capacity(artifacts.len());
@@ -110,7 +142,10 @@ pub fn build_chunked_envelope_txs<'a>(
     // Reveals spend commit outputs starting at vout=1 (vout=0 is the OP_RETURN).
     for (i, artifact) in artifacts.iter().enumerate() {
         let vout = (i + 1) as u32;
-        let commit_output = &commit_tx.output[vout as usize];
+        let commit_output = commit_tx
+            .output
+            .get(vout as usize)
+            .ok_or(EnvelopeError::NotEnoughUtxos(config.reveal_amount, 0))?;
 
         let control_block = artifact
             .spend_info
@@ -128,8 +163,13 @@ pub fn build_chunked_envelope_txs<'a>(
             Some(&control_block),
         );
         let reveal_fee = fee_sats_for_vsize(reveal_vsize, config.fee_rate)?;
-        let required = config
+        let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
+        let headroom = reveal_fee_headroom(config.fee_rate, reveal_vsize, &config.fee_bumping)?;
+        let reveal_output_value = config
             .reveal_amount
+            .checked_add(headroom)
+            .ok_or(EnvelopeError::FeeOverflow)?;
+        let required = reveal_output_value
             .checked_add(reveal_fee)
             .ok_or(EnvelopeError::FeeOverflow)?;
         if commit_output.value < Amount::from_sat(required) {
@@ -144,7 +184,7 @@ pub fn build_chunked_envelope_txs<'a>(
             version: Version(2),
             input: vec![make_txin(commit_txid, vout)],
             output: vec![TxOut {
-                value: Amount::from_sat(config.reveal_amount),
+                value: Amount::from_sat(reveal_output_value),
                 script_pubkey: config.sequencer_address.script_pubkey(),
             }],
         };
@@ -160,15 +200,12 @@ pub fn build_chunked_envelope_txs<'a>(
         reveal_txs.push(reveal_tx);
     }
 
-    Ok(ChunkedEnvelopeTxs {
-        commit_tx,
-        reveal_txs,
-    })
+    Ok(reveal_txs)
 }
 
 /// Sizes the commit output funding one reveal tx.
 ///
-/// The returned value is `vsize(reveal) * fee_rate + reveal_amount`.
+/// The returned value is `reveal_amount + reveal_fee + reveal_fee_headroom`.
 ///
 /// This is the amount the matching commit P2TR output must hold so the reveal
 /// can pay its fee plus the sequencer dust output.
@@ -178,6 +215,7 @@ fn calculate_reveal_commit_value(
     fee_rate: FeeRate,
     reveal_script: &ScriptBuf,
     spend_info: &TaprootSpendInfo,
+    fee_bumping: &FeeBumpingConfig,
 ) -> Result<u64, EnvelopeError> {
     let reveal_output = TxOut {
         value: Amount::from_sat(reveal_amount),
@@ -193,18 +231,22 @@ fn calculate_reveal_commit_value(
         Some(&control_block),
     );
     let reveal_fee = fee_sats_for_vsize(reveal_vsize, fee_rate)?;
+    let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
+    let headroom = reveal_fee_headroom(fee_rate, reveal_vsize, fee_bumping)?;
     reveal_amount
-        .checked_add(reveal_fee)
+        .checked_add(headroom)
+        .and_then(|value| value.checked_add(reveal_fee))
         .ok_or(EnvelopeError::FeeOverflow)
 }
 
 /// Builds the commit tx with `[OP_RETURN, P2TR_0, ..., P2TR_{N-1}, change?]`.
+/// Builds the commit transaction and returns it alongside the exact fee it pays.
 fn build_multi_output_commit(
     config: &EnvelopeConfig,
     artifacts: &[RevealArtifact],
     op_return_script: &ScriptBuf,
     utxos: Vec<ListUnspentItem>,
-) -> Result<Transaction, EnvelopeError> {
+) -> Result<(Transaction, Amount), EnvelopeError> {
     let spendable: Vec<ListUnspentItem> = utxos
         .into_iter()
         .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT)
@@ -272,12 +314,20 @@ fn build_multi_output_commit(
 
         let size = get_size(&inputs, &outputs, None, None);
         if size == last_size || done {
-            return Ok(Transaction {
-                lock_time: LockTime::ZERO,
-                version: Version(2),
-                input: inputs,
-                output: outputs,
-            });
+            // `done` means the leftover change was dust and got absorbed into the fee, so derive
+            // the fee from the actual input/output totals rather than from `fee_rate * vsize`.
+            let output_total: u64 = outputs.iter().map(|output| output.value.to_sat()).sum();
+            let commit_fee = Amount::from_sat(sum.saturating_sub(output_total));
+
+            return Ok((
+                Transaction {
+                    lock_time: LockTime::ZERO,
+                    version: Version(2),
+                    input: inputs,
+                    output: outputs,
+                },
+                commit_fee,
+            ));
         }
         last_size = size;
     }
@@ -294,6 +344,8 @@ fn make_txin(txid: bitcoin::Txid, vout: u32) -> TxIn {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use bitcoin::{
         opcodes::all::OP_RETURN,
         secp256k1::{rand, Keypair, Secp256k1},
@@ -361,8 +413,9 @@ mod tests {
             ctx.btcio_params.magic_bytes,
             ctx.sequencer_address.clone(),
             Network::Regtest,
-            FeeRate::from_sat_per_vb_u32(1_000),
+            FeeRate::from_sat_per_vb_u32(1),
             546,
+            FeeBumpingConfig::default(),
             None,
         )
     }
@@ -421,7 +474,60 @@ mod tests {
                 reveal.output[0].script_pubkey,
                 config.sequencer_address.script_pubkey()
             );
+            let reveal_vsize = u64::try_from(reveal.vsize()).unwrap();
+            let base_fee = config.fee_rate.fee_vb(reveal_vsize).unwrap();
+            let headroom =
+                reveal_fee_headroom(config.fee_rate, reveal_vsize, &config.fee_bumping).unwrap();
+            let commit_output = &result.commit_tx.output[i + 1];
+            let initial_fee = commit_output
+                .value
+                .checked_sub(reveal.output[0].value)
+                .unwrap();
+
+            assert!(headroom > 0);
+            assert_eq!(
+                commit_output.value.to_sat(),
+                config.reveal_amount + base_fee.to_sat() + headroom
+            );
+            assert_eq!(
+                reveal.output[0].value.to_sat(),
+                config.reveal_amount + headroom
+            );
+            assert_eq!(initial_fee, base_fee);
         }
+    }
+
+    #[test]
+    fn zero_derived_headroom_preserves_legacy_chunked_reveal_values() {
+        let config = EnvelopeConfig {
+            fee_bumping: FeeBumpingConfig {
+                max_attempts: NonZeroU32::new(1).unwrap(),
+                ..FeeBumpingConfig::default()
+            },
+            ..get_test_config()
+        };
+        let chunks = [vec![1u8; 150]];
+        let magic = MagicBytes::from([0xAA, 0xBB, 0xCC, 0xDD]);
+        let result = build_chunked_envelope_txs(
+            &config,
+            chunks.iter().map(Vec::as_slice),
+            &magic,
+            TEST_DA_BLOB_VERSION,
+            &test_keypair(),
+            get_mock_utxos(),
+        )
+        .unwrap();
+        let reveal = &result.reveal_txs[0];
+        let base_fee = config
+            .fee_rate
+            .fee_vb(u64::try_from(reveal.vsize()).unwrap())
+            .unwrap();
+
+        assert_eq!(reveal.output[0].value.to_sat(), config.reveal_amount);
+        assert_eq!(
+            result.commit_tx.output[1].value.to_sat(),
+            config.reveal_amount + base_fee.to_sat()
+        );
     }
 
     #[test]
@@ -478,6 +584,7 @@ mod tests {
             Network::Regtest,
             FeeRate::from_sat_per_vb_u32(1_000),
             546,
+            FeeBumpingConfig::default(),
             None,
         );
         let chunks = [vec![0u8; 150]];

--- a/crates/btcio/src/writer/chunked_envelope/commit_phase.rs
+++ b/crates/btcio/src/writer/chunked_envelope/commit_phase.rs
@@ -1,0 +1,121 @@
+//! Mutual exclusion between chunked-commit fee bumping and reveal enqueueing.
+//!
+//! Replacing a chunked commit changes its txid, which invalidates every reveal that spends one of
+//! its outputs. The two operations that must never interleave are therefore:
+//!
+//! - the fee bumper replacing a commit, and
+//! - the writer handing that envelope's reveals to the broadcaster.
+//!
+//! Both run as tasks in the same process, so a per-envelope in-process latch is enough to serialise
+//! them. Checking a persisted flag would not be: the check and the writes that follow it are not
+//! one transaction, and a reveal can be enqueued in the gap.
+//!
+//! The latch is advisory across restarts, which is deliberate. On restart nothing is mid-operation,
+//! and the durable fail-closed guard (the envelope row's reveal txids checked against the broadcast
+//! DB, plus the tx-node tree) is what decides whether a commit is still replaceable.
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+/// Tracks which envelopes currently have an operation in flight that the other side must not race.
+///
+/// Cloning shares the underlying state; the writer and the fee bumper are handed clones of the same
+/// latch.
+#[derive(Debug, Clone, Default)]
+pub struct CommitPhaseLatch {
+    inner: Arc<Mutex<HashSet<u64>>>,
+}
+
+/// Releases its envelope's claim when dropped.
+#[derive(Debug)]
+pub struct CommitPhaseClaim {
+    envelope_idx: u64,
+    latch: CommitPhaseLatch,
+}
+
+impl Drop for CommitPhaseClaim {
+    fn drop(&mut self) {
+        self.latch.release(self.envelope_idx);
+    }
+}
+
+impl CommitPhaseClaim {
+    /// Returns the envelope this claim covers.
+    pub fn envelope_idx(&self) -> u64 {
+        self.envelope_idx
+    }
+}
+
+impl CommitPhaseLatch {
+    /// Creates an empty latch.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Claims `envelope_idx`, or returns `None` when the other side already holds it.
+    ///
+    /// Callers must treat `None` as "try again next tick", never as permission to proceed.
+    pub fn try_claim(&self, envelope_idx: u64) -> Option<CommitPhaseClaim> {
+        let claimed = self
+            .inner
+            .lock()
+            .expect("btcio: commit phase latch poisoned")
+            .insert(envelope_idx);
+
+        claimed.then(|| CommitPhaseClaim {
+            envelope_idx,
+            latch: self.clone(),
+        })
+    }
+
+    fn release(&self, envelope_idx: u64) {
+        self.inner
+            .lock()
+            .expect("btcio: commit phase latch poisoned")
+            .remove(&envelope_idx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_claim_excludes_the_other_side() {
+        let latch = CommitPhaseLatch::new();
+
+        let claim = latch.try_claim(7).expect("first claim succeeds");
+        assert!(latch.try_claim(7).is_none(), "second claim must be refused");
+
+        drop(claim);
+        assert!(
+            latch.try_claim(7).is_some(),
+            "claim must be reusable once released"
+        );
+    }
+
+    #[test]
+    fn claims_are_per_envelope() {
+        let latch = CommitPhaseLatch::new();
+
+        let _first = latch.try_claim(1).expect("envelope 1 claim succeeds");
+        assert!(
+            latch.try_claim(2).is_some(),
+            "a different envelope must not be blocked"
+        );
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let latch = CommitPhaseLatch::new();
+        let other = latch.clone();
+
+        let _claim = latch.try_claim(3).expect("claim succeeds");
+        assert!(
+            other.try_claim(3).is_none(),
+            "a clone must observe the same claim"
+        );
+    }
+}

--- a/crates/btcio/src/writer/chunked_envelope/context.rs
+++ b/crates/btcio/src/writer/chunked_envelope/context.rs
@@ -4,6 +4,7 @@ use bitcoin::{key::Keypair, Address};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_config::btcio::WriterConfig;
 
+use super::commit_phase::CommitPhaseLatch;
 use crate::BtcioParams;
 
 /// All the items that chunked writer tasks need as context.
@@ -26,6 +27,9 @@ pub(crate) struct ChunkedWriterContext<R: Reader + Signer + Wallet> {
 
     /// Bitcoin client to sign and submit transactions.
     pub client: Arc<R>,
+
+    /// Serialises reveal enqueueing against commit fee bumping for the same envelope.
+    pub commit_phase: CommitPhaseLatch,
 }
 
 impl<R: Reader + Signer + Wallet> ChunkedWriterContext<R> {
@@ -35,6 +39,7 @@ impl<R: Reader + Signer + Wallet> ChunkedWriterContext<R> {
         sequencer_address: Address,
         sequencer_keypair: Keypair,
         client: Arc<R>,
+        commit_phase: CommitPhaseLatch,
     ) -> Self {
         Self {
             btcio_params,
@@ -42,6 +47,7 @@ impl<R: Reader + Signer + Wallet> ChunkedWriterContext<R> {
             sequencer_address,
             sequencer_keypair,
             client,
+            commit_phase,
         }
     }
 }

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -9,7 +9,10 @@
 
 use std::{collections::BTreeSet, future::Future, sync::Arc, time::Duration};
 
-use bitcoin::{consensus::encode::deserialize as btc_deserialize, key::Keypair, Address};
+use bitcoin::{
+    consensus::encode::deserialize as btc_deserialize, key::Keypair, Address, Amount, FeeRate,
+    Transaction,
+};
 use bitcoind_async_client::{
     error::ClientError,
     traits::{Broadcaster, Reader, Signer, Wallet},
@@ -19,6 +22,7 @@ use strata_config::btcio::WriterConfig;
 use strata_db_types::{
     chunked_envelope::{ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, RevealTxMeta},
     common::L1TxId,
+    fee_bump::{TxAttempt, TxNodeId, TxNodeKind, TxNodeRecord},
     l1_broadcast::{L1TxEntry, L1TxStatus},
 };
 use strata_primitives::buf::Buf32;
@@ -28,13 +32,17 @@ use tokio::time::interval;
 use tracing::*;
 
 use super::{
+    commit_phase::CommitPhaseLatch,
     context::ChunkedWriterContext,
     signer::{sign_chunked_envelope, SignedChunkedEnvelope},
 };
 use crate::{
     broadcaster::{is_benign_minus25_message, L1BroadcastHandle},
     rpc_error::{is_retryable_client_error, is_retryable_envelope_error, retryable_reason},
-    writer::builder::EnvelopeError,
+    writer::{
+        builder::EnvelopeError,
+        replacement::driver::{run_replacement_pass, ReplacementContext, ReplacementPacer},
+    },
     BtcioParams,
 };
 
@@ -96,11 +104,23 @@ fn to_raw_buf32(txid: L1TxId) -> Buf32 {
 )]
 pub struct ChunkedEnvelopeHandle {
     ops: Arc<ChunkedEnvelopeOps>,
+    commit_phase: CommitPhaseLatch,
 }
 
 impl ChunkedEnvelopeHandle {
     pub fn new(ops: Arc<ChunkedEnvelopeOps>) -> Self {
-        Self { ops }
+        Self {
+            ops,
+            commit_phase: CommitPhaseLatch::new(),
+        }
+    }
+
+    /// Returns the latch that serialises reveal enqueueing against commit fee bumping.
+    ///
+    /// The fee bumper must be given this same latch, or the two can interleave and a commit
+    /// replacement can orphan a reveal that was handed to the broadcaster moments earlier.
+    pub fn commit_phase_latch(&self) -> CommitPhaseLatch {
+        self.commit_phase.clone()
     }
 
     /// Stores a new unsigned entry and returns the assigned index.
@@ -149,6 +169,7 @@ pub fn create_chunked_envelope_task(
         sequencer_address,
         sequencer_keypair,
         bitcoin_client,
+        handle.commit_phase_latch(),
     ));
 
     let task = async move {
@@ -250,6 +271,7 @@ fn format_tx_status(txid: L1TxId, status: &L1TxStatus) -> String {
         L1TxStatus::Unpublished => format!("{txid:?}:unpublished"),
         L1TxStatus::Published => format!("{txid:?}:published"),
         L1TxStatus::InvalidInputs => format!("{txid:?}:invalid_inputs"),
+        L1TxStatus::Replaced { by } => format!("{txid:?}:replaced_by({by:?})"),
         L1TxStatus::Confirmed {
             confirmations,
             block_hash,
@@ -295,6 +317,18 @@ async fn watcher_task<R: Reader + Signer + Wallet + Broadcaster>(
     tokio::pin!(tick);
     let mut iteration = 0_u64;
 
+    // Replacement runs inside this watcher rather than in a task of its own: it is the writer that
+    // understands the commit/reveal structure and holds the reveal signing key.
+    let replacement_context = ReplacementContext {
+        chunked_ops: Some(ops.clone()),
+        sequencer_keypair: Some(ctx.sequencer_keypair),
+        commit_phase: ctx.commit_phase.clone(),
+        pacer: Arc::new(ReplacementPacer::new(
+            ctx.config.fee_bumping.check_interval(),
+        )),
+        ..ReplacementContext::default()
+    };
+
     loop {
         tick.as_mut().tick().await;
         let next_db_idx = state.next_db_idx;
@@ -302,7 +336,25 @@ async fn watcher_task<R: Reader + Signer + Wallet + Broadcaster>(
         let active_envelopes = state.active_envelopes.len();
         async {
             state.ingest_new_entries(ops.as_ref()).await?;
-            reconcile_active_entries(&mut state, ops.as_ref(), &broadcast_handle).await?;
+            reconcile_active_entries(
+                &mut state,
+                ops.as_ref(),
+                &broadcast_handle,
+                &ctx.commit_phase,
+            )
+            .await?;
+            // A failed replacement pass must not skip the frontier advance: publication progress
+            // matters more than bumping, and the next tick retries the pass anyway.
+            if let Err(error) = run_replacement_pass(
+                ctx.client.as_ref(),
+                &ctx.config,
+                &broadcast_handle,
+                &replacement_context,
+            )
+            .await
+            {
+                warn!(%error, "chunked envelope replacement pass failed");
+            }
             advance_forward_frontier(&mut state, ctx.clone(), ops.as_ref(), &broadcast_handle).await
         }
         .instrument(info_span!(
@@ -414,6 +466,7 @@ async fn reconcile_active_entries(
     state: &mut ChunkedEnvelopeWatcherState,
     ops: &ChunkedEnvelopeOps,
     broadcast_handle: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<()> {
     let active_indices: Vec<u64> = state.active_envelopes.iter().copied().collect();
     for idx in active_indices {
@@ -431,12 +484,13 @@ async fn reconcile_active_entries(
                 continue;
             }
             ChunkedEnvelopeStatus::Unpublished => {
-                check_commit_and_enqueue_reveals(idx, &entry, broadcast_handle).await?
+                check_commit_and_enqueue_reveals(idx, &entry, broadcast_handle, commit_phase)
+                    .await?
             }
             ChunkedEnvelopeStatus::CommitPublished
             | ChunkedEnvelopeStatus::Published
             | ChunkedEnvelopeStatus::Confirmed => {
-                check_full_broadcast_status(idx, &entry, broadcast_handle).await?
+                check_full_broadcast_status(idx, &entry, broadcast_handle, commit_phase).await?
             }
         };
 
@@ -518,11 +572,19 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
 ) -> anyhow::Result<ChunkedEnvelopeEntry> {
     let mut entry = signed.entry;
     let mut commit_tx_entry = signed.commit_tx_entry;
+    let commit_fee = signed.commit_fee;
 
     // Persist the signed envelope before commit publication. If the process
     // stops after bitcoind accepts the commit, recovery still has the reveal
     // metadata needed to continue the envelope lifecycle.
     ops.put_chunked_envelope_entry_async(envelope_idx, entry.clone())
+        .await?;
+    // Node before broadcast entry, matching the reveal path. A stop between the two writes then
+    // leaves a node whose entry is missing, which `process_record` re-inserts from the record's own
+    // raw tx. The reverse leaves an entry with no node, and nothing backfills it: the commit is
+    // then unbumpable for as long as it stays unconfirmed, which for a multi-reveal envelope is
+    // exactly the window where the reveals cannot be enqueued yet either.
+    put_chunked_commit_tx_node(envelope_idx, &commit_tx_entry, commit_fee, broadcast_handle)
         .await?;
     let commit_broadcast_idx = broadcast_handle
         .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_tx_entry.clone())
@@ -545,8 +607,14 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
                 .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
                 .await?
                 .expect("commit tx was just stored");
-            try_enqueue_reveals_if_policy_safe(envelope_idx, &entry, &commit, broadcast_handle)
-                .await?;
+            try_enqueue_reveals_if_policy_safe(
+                envelope_idx,
+                &entry,
+                &commit,
+                broadcast_handle,
+                &ctx.commit_phase,
+            )
+            .await?;
             entry.status = ChunkedEnvelopeStatus::CommitPublished;
             ops.put_chunked_envelope_entry_async(envelope_idx, entry.clone())
                 .await?;
@@ -674,9 +742,10 @@ async fn check_commit_and_enqueue_reveals(
     envelope_idx: u64,
     entry: &ChunkedEnvelopeEntry,
     bcast: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<ChunkedEnvelopeStatus> {
-    let Some(commit) = bcast
-        .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+    let Some((active_commit_txid, commit)) = bcast
+        .get_active_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
         .await?
     else {
         warn!(
@@ -686,7 +755,6 @@ async fn check_commit_and_enqueue_reveals(
         );
         return Ok(ChunkedEnvelopeStatus::Unsigned);
     };
-
     match commit.status {
         L1TxStatus::InvalidInputs => {
             warn!(
@@ -704,17 +772,20 @@ async fn check_commit_and_enqueue_reveals(
             );
             return Ok(ChunkedEnvelopeStatus::Unpublished);
         }
-        L1TxStatus::Published | L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. } => {}
+        L1TxStatus::Published
+        | L1TxStatus::Confirmed { .. }
+        | L1TxStatus::Finalized { .. }
+        | L1TxStatus::Replaced { .. } => {}
     }
 
     debug!(
         envelope_idx,
-        commit_txid = ?entry.commit_txid,
+        commit_txid = ?active_commit_txid,
         commit_status = ?commit.status,
         reveal_count = entry.reveals.len(),
         "chunked envelope commit publication observed"
     );
-    try_enqueue_reveals_if_policy_safe(envelope_idx, entry, &commit, bcast).await?;
+    try_enqueue_reveals_if_policy_safe(envelope_idx, entry, &commit, bcast, commit_phase).await?;
 
     Ok(ChunkedEnvelopeStatus::CommitPublished)
 }
@@ -724,7 +795,9 @@ fn reveal_enqueue_is_policy_safe(
     commit: &L1TxEntry,
 ) -> anyhow::Result<bool> {
     match commit.status {
-        L1TxStatus::InvalidInputs | L1TxStatus::Unpublished => Ok(false),
+        L1TxStatus::InvalidInputs | L1TxStatus::Unpublished | L1TxStatus::Replaced { .. } => {
+            Ok(false)
+        }
         L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. } => Ok(true),
         L1TxStatus::Published => {
             let [reveal] = entry.reveals.as_slice() else {
@@ -744,7 +817,37 @@ async fn try_enqueue_reveals_if_policy_safe(
     entry: &ChunkedEnvelopeEntry,
     commit: &L1TxEntry,
     bcast: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<bool> {
+    // Hold the claim across the whole loop. Enqueueing only some reveals and then letting a commit
+    // replacement through would orphan the ones already handed over.
+    let Some(_claim) = commit_phase.try_claim(envelope_idx) else {
+        debug!(
+            envelope_idx,
+            "reveal enqueue deferred: a commit fee bump is in flight for this envelope"
+        );
+        return Ok(false);
+    };
+
+    // The row's reveals each spend an output of `entry.commit_txid`. If a fee bump superseded that
+    // commit but crashed before rewriting this row, the reveals reference a txid that no longer
+    // exists and enqueueing them would publish transactions Core must reject. Wait for the fee
+    // bumper to finish the metadata refresh instead.
+    let recorded_commit_txid = to_raw_buf32(entry.commit_txid);
+    let active_commit_txid = bcast
+        .get_active_tx_entry_by_id_async(recorded_commit_txid)
+        .await?
+        .map(|(txid, _)| txid);
+    if active_commit_txid.is_some_and(|txid| txid != recorded_commit_txid) {
+        warn!(
+            envelope_idx,
+            stale_commit_txid = ?entry.commit_txid,
+            ?active_commit_txid,
+            "reveal enqueue deferred: envelope row still references a superseded commit"
+        );
+        return Ok(false);
+    }
+
     if !reveal_enqueue_is_policy_safe(entry, commit)? {
         debug!(
             envelope_idx,
@@ -766,7 +869,7 @@ async fn try_enqueue_reveals_if_policy_safe(
     );
 
     for reveal in &entry.reveals {
-        ensure_reveal_tx_entry(envelope_idx, reveal, bcast).await?;
+        ensure_reveal_tx_entry(envelope_idx, reveal, commit, bcast).await?;
     }
 
     info!(
@@ -784,8 +887,11 @@ async fn try_enqueue_reveals_if_policy_safe(
 async fn ensure_reveal_tx_entry(
     envelope_idx: u64,
     reveal: &RevealTxMeta,
+    commit: &L1TxEntry,
     bcast: &L1BroadcastHandle,
 ) -> anyhow::Result<()> {
+    let tx = btc_deserialize::<Transaction>(&reveal.tx_bytes)
+        .map_err(|e| anyhow::anyhow!("failed to deserialize reveal tx: {}", e))?;
     if bcast
         .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
         .await?
@@ -796,21 +902,124 @@ async fn ensure_reveal_tx_entry(
             txid = ?reveal.txid,
             "reveal tx already tracked by broadcaster"
         );
+    } else {
+        let commit_tx = commit.try_to_tx()?;
+        let fee_sats = commit_tx
+            .output
+            .get(reveal.vout_index as usize)
+            .map(|output| {
+                let output_total = tx
+                    .output
+                    .iter()
+                    .map(|txout| txout.value.to_sat())
+                    .sum::<u64>();
+                output.value.to_sat().saturating_sub(output_total)
+            })
+            .unwrap_or_default();
+        let fee_rate = if tx.vsize() == 0 {
+            FeeRate::ZERO
+        } else {
+            FeeRate::from_sat_per_vb(fee_sats.div_ceil(tx.vsize() as u64))
+                .expect("fee rate must fit")
+        };
+        let tx_entry = L1TxEntry::from_tx_with_fee(&tx, fee_rate, Amount::from_sat(fee_sats));
+        // The fee bumper refuses to replace a chunked commit once any reveal for that envelope
+        // has a tx-node record, because a commit replacement changes the commit txid and would
+        // orphan every reveal spending it. Record the reveal node *before* handing the tx to the
+        // broadcaster so a crash between the two writes cannot leave a broadcastable reveal that
+        // the guard is blind to. The reverse order is safe: the fee bumper re-inserts a broadcast
+        // entry that its record still owns.
+        put_chunked_reveal_tx_node(
+            envelope_idx,
+            reveal,
+            &tx,
+            fee_rate,
+            Amount::from_sat(fee_sats),
+            bcast,
+        )
+        .await?;
+        bcast
+            .put_tx_entry(to_raw_buf32(reveal.txid), tx_entry)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to store reveal tx: {}", e))?;
+
+        debug!(
+            envelope_idx,
+            txid = ?reveal.txid,
+            "reveal tx enqueued in broadcaster"
+        );
+    }
+
+    Ok(())
+}
+
+async fn put_chunked_commit_tx_node(
+    envelope_idx: u64,
+    commit_tx_entry: &L1TxEntry,
+    commit_fee: Amount,
+    bcast: &L1BroadcastHandle,
+) -> anyhow::Result<()> {
+    let tx = commit_tx_entry.try_to_tx()?;
+    let Some(rbf) = commit_tx_entry.rbf else {
+        return Ok(());
+    };
+    let fee_rate = FeeRate::from_sat_per_vb(rbf.fee_rate_sat_vb)
+        .ok_or_else(|| anyhow::anyhow!("invalid commit fee rate {}", rbf.fee_rate_sat_vb))?;
+    // `commit_fee` is the builder's exact input-minus-output figure. Reconstructing it as
+    // `fee_rate * vsize` would under-record whenever dust change was absorbed into the fee, and
+    // the fee bumper would then request a replacement fee that Bitcoin Core rejects.
+    let fee_sats = commit_fee;
+    put_tx_node_if_missing(
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx },
+        &tx,
+        fee_rate,
+        fee_sats,
+        bcast,
+    )
+    .await
+}
+
+async fn put_chunked_reveal_tx_node(
+    envelope_idx: u64,
+    reveal: &RevealTxMeta,
+    tx: &Transaction,
+    fee_rate: FeeRate,
+    fee_sats: Amount,
+    bcast: &L1BroadcastHandle,
+) -> anyhow::Result<()> {
+    put_tx_node_if_missing(
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx: reveal.vout_index.saturating_sub(1),
+        },
+        tx,
+        fee_rate,
+        fee_sats,
+        bcast,
+    )
+    .await
+}
+
+async fn put_tx_node_if_missing(
+    kind: TxNodeKind,
+    tx: &Transaction,
+    fee_rate: FeeRate,
+    fee_sats: Amount,
+    bcast: &L1BroadcastHandle,
+) -> anyhow::Result<()> {
+    let node_id = TxNodeId::from_kind(&kind);
+    let attempt = TxAttempt::active(tx, fee_rate, fee_sats, 0);
+    if let Some(mut record) = bcast.get_tx_node(node_id).await? {
+        if record.active_txid == attempt.txid {
+            return Ok(());
+        }
+        record.replace_initial_attempt(attempt);
+        bcast.put_tx_node(record).await?;
         return Ok(());
     }
 
-    let tx = btc_deserialize(&reveal.tx_bytes)
-        .map_err(|e| anyhow::anyhow!("failed to deserialize reveal tx: {}", e))?;
-    bcast
-        .put_tx_entry(to_raw_buf32(reveal.txid), L1TxEntry::from_tx(&tx))
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to store reveal tx: {}", e))?;
-
-    debug!(
-        envelope_idx,
-        txid = ?reveal.txid,
-        "reveal tx enqueued in broadcaster"
-    );
+    let record = TxNodeRecord::new(kind, attempt);
+    bcast.put_tx_node(record).await?;
     Ok(())
 }
 
@@ -823,9 +1032,10 @@ async fn check_full_broadcast_status(
     envelope_idx: u64,
     entry: &ChunkedEnvelopeEntry,
     bcast: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<ChunkedEnvelopeStatus> {
-    let Some(commit) = bcast
-        .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+    let Some((active_commit_txid, commit)) = bcast
+        .get_active_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
         .await?
     else {
         error!(
@@ -847,12 +1057,24 @@ async fn check_full_broadcast_status(
         return Ok(ChunkedEnvelopeStatus::NeedsResign);
     }
 
+    // Same rule as the normal enqueue path: reveals recorded against a superseded commit must not
+    // be restored into the broadcaster. Wait for the fee bumper to finish refreshing this row.
+    if active_commit_txid != to_raw_buf32(entry.commit_txid) {
+        warn!(
+            envelope_idx,
+            stale_commit_txid = ?entry.commit_txid,
+            ?active_commit_txid,
+            "reveal restore deferred: envelope row still references a superseded commit"
+        );
+        return Ok(ChunkedEnvelopeStatus::CommitPublished);
+    }
+
     let can_enqueue_missing_reveals = reveal_enqueue_is_policy_safe(entry, &commit)?;
     let mut min_progress = commit.status.clone();
     let mut reveal_l1_statuses = Vec::with_capacity(entry.reveals.len());
     for reveal in &entry.reveals {
-        let Some(rtx) = bcast
-            .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+        let Some((active_reveal_txid, rtx)) = bcast
+            .get_active_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
             .await?
         else {
             if !can_enqueue_missing_reveals {
@@ -864,12 +1086,20 @@ async fn check_full_broadcast_status(
                 );
                 return Ok(ChunkedEnvelopeStatus::CommitPublished);
             }
+            let Some(_claim) = commit_phase.try_claim(envelope_idx) else {
+                debug!(
+                    envelope_idx,
+                    txid = ?reveal.txid,
+                    "reveal restore deferred: a commit fee bump is in flight for this envelope"
+                );
+                return Ok(ChunkedEnvelopeStatus::CommitPublished);
+            };
             warn!(
                 envelope_idx,
                 txid = ?reveal.txid,
                 "reveal tx missing from broadcast db, restoring from persisted reveal bytes"
             );
-            ensure_reveal_tx_entry(envelope_idx, reveal, bcast).await?;
+            ensure_reveal_tx_entry(envelope_idx, reveal, &commit, bcast).await?;
             min_progress = L1TxStatus::Unpublished;
             reveal_l1_statuses.push(format_tx_status(reveal.txid, &min_progress));
             continue;
@@ -884,7 +1114,10 @@ async fn check_full_broadcast_status(
             );
             return Ok(ChunkedEnvelopeStatus::NeedsResign);
         }
-        reveal_l1_statuses.push(format_tx_status(reveal.txid, &rtx.status));
+        reveal_l1_statuses.push(format_tx_status(
+            L1TxId::from(active_reveal_txid.0),
+            &rtx.status,
+        ));
         if is_less_progressed(&rtx.status, &min_progress) {
             min_progress = rtx.status;
         }
@@ -895,7 +1128,7 @@ async fn check_full_broadcast_status(
         envelope_status,
         ChunkedEnvelopeStatus::Confirmed | ChunkedEnvelopeStatus::Finalized
     ) {
-        let commit_l1_status = format_tx_status(entry.commit_txid, &commit.status);
+        let commit_l1_status = format_tx_status(L1TxId::from(active_commit_txid.0), &commit.status);
         info!(
             envelope_idx,
             commit_txid = ?entry.commit_txid,
@@ -919,6 +1152,7 @@ fn progress_ordinal(s: &L1TxStatus) -> u8 {
         L1TxStatus::Published => 1,
         L1TxStatus::Confirmed { .. } => 2,
         L1TxStatus::Finalized { .. } => 3,
+        L1TxStatus::Replaced { .. } => 4,
         L1TxStatus::InvalidInputs => {
             unreachable!("InvalidInputs is handled before aggregation")
         }
@@ -945,6 +1179,7 @@ fn to_envelope_status(s: &L1TxStatus) -> ChunkedEnvelopeStatus {
         L1TxStatus::Published => ChunkedEnvelopeStatus::Published,
         L1TxStatus::Confirmed { .. } => ChunkedEnvelopeStatus::Confirmed,
         L1TxStatus::Finalized { .. } => ChunkedEnvelopeStatus::Finalized,
+        L1TxStatus::Replaced { .. } => ChunkedEnvelopeStatus::Published,
         L1TxStatus::InvalidInputs => {
             unreachable!("InvalidInputs is handled before aggregation")
         }
@@ -953,8 +1188,6 @@ fn to_envelope_status(s: &L1TxStatus) -> ChunkedEnvelopeStatus {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use bitcoin::{
         absolute::LockTime, consensus::encode::serialize as btc_serialize, hashes::Hash,
         transaction::Version, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
@@ -965,7 +1198,6 @@ mod tests {
         common::{L1TxId, L1WtxId},
     };
     use strata_l1_txfmt::MagicBytes;
-    use strata_primitives::buf::Buf32;
 
     use super::*;
     use crate::{
@@ -1002,7 +1234,7 @@ mod tests {
         entry.status = status;
         if signed {
             entry.reveals = vec![RevealTxMeta {
-                vout_index: 0,
+                vout_index: 1,
                 txid: L1TxId::from([idx_tag; 32]),
                 wtxid: L1WtxId::from([idx_tag.wrapping_add(1); 32]),
                 tx_bytes: vec![idx_tag],
@@ -1210,7 +1442,7 @@ mod tests {
             .map(|i| {
                 let tx = make_test_tx();
                 RevealTxMeta {
-                    vout_index: i as u32,
+                    vout_index: (i + 1) as u32,
                     txid: L1TxId::from([(0x20 + i as u8); 32]),
                     wtxid: L1WtxId::from([(0x30 + i as u8); 32]),
                     tx_bytes: btc_serialize(&tx),
@@ -1262,7 +1494,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1290,7 +1522,7 @@ mod tests {
         let entry = make_entry_with_reveals(2);
 
         // Don't store commit at all — should return Unsigned for re-signing.
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1312,7 +1544,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::NeedsResign);
@@ -1335,7 +1567,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1371,7 +1603,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::CommitPublished);
@@ -1396,7 +1628,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::CommitPublished);
@@ -1442,7 +1674,7 @@ mod tests {
                 .unwrap();
         }
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::Finalized);
@@ -1491,7 +1723,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1506,7 +1738,7 @@ mod tests {
         let bcast = get_broadcast_handle();
         let entry = make_entry_with_reveals(2);
 
-        let err = check_full_broadcast_status(0, &entry, &bcast)
+        let err = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1545,7 +1777,7 @@ mod tests {
             .unwrap();
 
         // Second reveal is missing.
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1591,7 +1823,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1624,7 +1856,7 @@ mod tests {
                 .unwrap();
         }
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -9,7 +9,10 @@
 
 use std::{collections::BTreeSet, future::Future, sync::Arc, time::Duration};
 
-use bitcoin::{consensus::encode::deserialize as btc_deserialize, key::Keypair, Address};
+use bitcoin::{
+    consensus::encode::deserialize as btc_deserialize, key::Keypair, Address, Amount, FeeRate,
+    Transaction,
+};
 use bitcoind_async_client::{
     error::ClientError,
     traits::{Broadcaster, Reader, Signer, Wallet},
@@ -19,6 +22,7 @@ use strata_config::btcio::WriterConfig;
 use strata_db_types::{
     chunked_envelope::{ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, RevealTxMeta},
     common::L1TxId,
+    fee_bump::{TxAttempt, TxNodeId, TxNodeKind, TxNodeRecord},
     l1_broadcast::{L1TxEntry, L1TxStatus},
 };
 use strata_primitives::buf::Buf32;
@@ -28,14 +32,19 @@ use tokio::time::interval;
 use tracing::*;
 
 use super::{
+    commit_phase::CommitPhaseLatch,
     context::ChunkedWriterContext,
     signer::{sign_chunked_envelope, SignedChunkedEnvelope},
 };
 use crate::{
     broadcaster::{is_benign_minus25_message, L1BroadcastHandle},
     rpc_error::{is_retryable_client_error, is_retryable_envelope_error, retryable_reason},
+    tx_attempt::attempt_parts,
     tx_entry::L1TxEntryExt,
-    writer::builder::EnvelopeError,
+    writer::{
+        builder::EnvelopeError,
+        replacement::driver::{run_replacement_pass, ReplacementContext, ReplacementPacer},
+    },
     BtcioParams,
 };
 
@@ -97,11 +106,23 @@ fn to_raw_buf32(txid: L1TxId) -> Buf32 {
 )]
 pub struct ChunkedEnvelopeHandle {
     ops: Arc<ChunkedEnvelopeOps>,
+    commit_phase: CommitPhaseLatch,
 }
 
 impl ChunkedEnvelopeHandle {
     pub fn new(ops: Arc<ChunkedEnvelopeOps>) -> Self {
-        Self { ops }
+        Self {
+            ops,
+            commit_phase: CommitPhaseLatch::new(),
+        }
+    }
+
+    /// Returns the latch that serialises reveal enqueueing against commit fee bumping.
+    ///
+    /// The fee bumper must be given this same latch, or the two can interleave and a commit
+    /// replacement can orphan a reveal that was handed to the broadcaster moments earlier.
+    pub fn commit_phase_latch(&self) -> CommitPhaseLatch {
+        self.commit_phase.clone()
     }
 
     /// Stores a new unsigned entry and returns the assigned index.
@@ -150,6 +171,7 @@ pub fn create_chunked_envelope_task(
         sequencer_address,
         sequencer_keypair,
         bitcoin_client,
+        handle.commit_phase_latch(),
     ));
 
     let task = async move {
@@ -251,6 +273,7 @@ fn format_tx_status(txid: L1TxId, status: &L1TxStatus) -> String {
         L1TxStatus::Unpublished => format!("{txid:?}:unpublished"),
         L1TxStatus::Published => format!("{txid:?}:published"),
         L1TxStatus::InvalidInputs => format!("{txid:?}:invalid_inputs"),
+        L1TxStatus::Replaced { by } => format!("{txid:?}:replaced_by({by:?})"),
         L1TxStatus::Confirmed {
             confirmations,
             block_hash,
@@ -296,6 +319,18 @@ async fn watcher_task<R: Reader + Signer + Wallet + Broadcaster>(
     tokio::pin!(tick);
     let mut iteration = 0_u64;
 
+    // Replacement runs inside this watcher rather than in a task of its own: it is the writer that
+    // understands the commit/reveal structure and holds the reveal signing key.
+    let replacement_context = ReplacementContext {
+        chunked_ops: Some(ops.clone()),
+        sequencer_keypair: Some(ctx.sequencer_keypair),
+        commit_phase: ctx.commit_phase.clone(),
+        pacer: Arc::new(ReplacementPacer::new(
+            ctx.config.fee_bumping.check_interval(),
+        )),
+        ..ReplacementContext::default()
+    };
+
     loop {
         tick.as_mut().tick().await;
         let next_db_idx = state.next_db_idx;
@@ -303,7 +338,25 @@ async fn watcher_task<R: Reader + Signer + Wallet + Broadcaster>(
         let active_envelopes = state.active_envelopes.len();
         async {
             state.ingest_new_entries(ops.as_ref()).await?;
-            reconcile_active_entries(&mut state, ops.as_ref(), &broadcast_handle).await?;
+            reconcile_active_entries(
+                &mut state,
+                ops.as_ref(),
+                &broadcast_handle,
+                &ctx.commit_phase,
+            )
+            .await?;
+            // A failed replacement pass must not skip the frontier advance: publication progress
+            // matters more than bumping, and the next tick retries the pass anyway.
+            if let Err(error) = run_replacement_pass(
+                ctx.client.as_ref(),
+                &ctx.config,
+                &broadcast_handle,
+                &replacement_context,
+            )
+            .await
+            {
+                warn!(%error, "chunked envelope replacement pass failed");
+            }
             advance_forward_frontier(&mut state, ctx.clone(), ops.as_ref(), &broadcast_handle).await
         }
         .instrument(info_span!(
@@ -415,6 +468,7 @@ async fn reconcile_active_entries(
     state: &mut ChunkedEnvelopeWatcherState,
     ops: &ChunkedEnvelopeOps,
     broadcast_handle: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<()> {
     let active_indices: Vec<u64> = state.active_envelopes.iter().copied().collect();
     for idx in active_indices {
@@ -432,12 +486,13 @@ async fn reconcile_active_entries(
                 continue;
             }
             ChunkedEnvelopeStatus::Unpublished => {
-                check_commit_and_enqueue_reveals(idx, &entry, broadcast_handle).await?
+                check_commit_and_enqueue_reveals(idx, &entry, broadcast_handle, commit_phase)
+                    .await?
             }
             ChunkedEnvelopeStatus::CommitPublished
             | ChunkedEnvelopeStatus::Published
             | ChunkedEnvelopeStatus::Confirmed => {
-                check_full_broadcast_status(idx, &entry, broadcast_handle).await?
+                check_full_broadcast_status(idx, &entry, broadcast_handle, commit_phase).await?
             }
         };
 
@@ -519,11 +574,19 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
 ) -> anyhow::Result<ChunkedEnvelopeEntry> {
     let mut entry = signed.entry;
     let mut commit_tx_entry = signed.commit_tx_entry;
+    let commit_fee = signed.commit_fee;
 
     // Persist the signed envelope before commit publication. If the process
     // stops after bitcoind accepts the commit, recovery still has the reveal
     // metadata needed to continue the envelope lifecycle.
     ops.put_chunked_envelope_entry_async(envelope_idx, entry.clone())
+        .await?;
+    // Node before broadcast entry, matching the reveal path. A stop between the two writes then
+    // leaves a node whose entry is missing, which `process_record` re-inserts from the record's own
+    // raw tx. The reverse leaves an entry with no node, and nothing backfills it: the commit is
+    // then unbumpable for as long as it stays unconfirmed, which for a multi-reveal envelope is
+    // exactly the window where the reveals cannot be enqueued yet either.
+    put_chunked_commit_tx_node(envelope_idx, &commit_tx_entry, commit_fee, broadcast_handle)
         .await?;
     let commit_broadcast_idx = broadcast_handle
         .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_tx_entry.clone())
@@ -546,8 +609,14 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
                 .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
                 .await?
                 .expect("commit tx was just stored");
-            try_enqueue_reveals_if_policy_safe(envelope_idx, &entry, &commit, broadcast_handle)
-                .await?;
+            try_enqueue_reveals_if_policy_safe(
+                envelope_idx,
+                &entry,
+                &commit,
+                broadcast_handle,
+                &ctx.commit_phase,
+            )
+            .await?;
             entry.status = ChunkedEnvelopeStatus::CommitPublished;
             ops.put_chunked_envelope_entry_async(envelope_idx, entry.clone())
                 .await?;
@@ -675,9 +744,10 @@ async fn check_commit_and_enqueue_reveals(
     envelope_idx: u64,
     entry: &ChunkedEnvelopeEntry,
     bcast: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<ChunkedEnvelopeStatus> {
-    let Some(commit) = bcast
-        .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+    let Some((active_commit_txid, commit)) = bcast
+        .get_active_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
         .await?
     else {
         warn!(
@@ -687,7 +757,6 @@ async fn check_commit_and_enqueue_reveals(
         );
         return Ok(ChunkedEnvelopeStatus::Unsigned);
     };
-
     match commit.status {
         L1TxStatus::InvalidInputs => {
             warn!(
@@ -705,17 +774,20 @@ async fn check_commit_and_enqueue_reveals(
             );
             return Ok(ChunkedEnvelopeStatus::Unpublished);
         }
-        L1TxStatus::Published | L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. } => {}
+        L1TxStatus::Published
+        | L1TxStatus::Confirmed { .. }
+        | L1TxStatus::Finalized { .. }
+        | L1TxStatus::Replaced { .. } => {}
     }
 
     debug!(
         envelope_idx,
-        commit_txid = ?entry.commit_txid,
+        commit_txid = ?active_commit_txid,
         commit_status = ?commit.status,
         reveal_count = entry.reveals.len(),
         "chunked envelope commit publication observed"
     );
-    try_enqueue_reveals_if_policy_safe(envelope_idx, entry, &commit, bcast).await?;
+    try_enqueue_reveals_if_policy_safe(envelope_idx, entry, &commit, bcast, commit_phase).await?;
 
     Ok(ChunkedEnvelopeStatus::CommitPublished)
 }
@@ -725,7 +797,9 @@ fn reveal_enqueue_is_policy_safe(
     commit: &L1TxEntry,
 ) -> anyhow::Result<bool> {
     match commit.status {
-        L1TxStatus::InvalidInputs | L1TxStatus::Unpublished => Ok(false),
+        L1TxStatus::InvalidInputs | L1TxStatus::Unpublished | L1TxStatus::Replaced { .. } => {
+            Ok(false)
+        }
         L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. } => Ok(true),
         L1TxStatus::Published => {
             let [reveal] = entry.reveals.as_slice() else {
@@ -745,7 +819,37 @@ async fn try_enqueue_reveals_if_policy_safe(
     entry: &ChunkedEnvelopeEntry,
     commit: &L1TxEntry,
     bcast: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<bool> {
+    // Hold the claim across the whole loop. Enqueueing only some reveals and then letting a commit
+    // replacement through would orphan the ones already handed over.
+    let Some(_claim) = commit_phase.try_claim(envelope_idx) else {
+        debug!(
+            envelope_idx,
+            "reveal enqueue deferred: a commit fee bump is in flight for this envelope"
+        );
+        return Ok(false);
+    };
+
+    // The row's reveals each spend an output of `entry.commit_txid`. If a fee bump superseded that
+    // commit but crashed before rewriting this row, the reveals reference a txid that no longer
+    // exists and enqueueing them would publish transactions Core must reject. Wait for the fee
+    // bumper to finish the metadata refresh instead.
+    let recorded_commit_txid = to_raw_buf32(entry.commit_txid);
+    let active_commit_txid = bcast
+        .get_active_tx_entry_by_id_async(recorded_commit_txid)
+        .await?
+        .map(|(txid, _)| txid);
+    if active_commit_txid.is_some_and(|txid| txid != recorded_commit_txid) {
+        warn!(
+            envelope_idx,
+            stale_commit_txid = ?entry.commit_txid,
+            ?active_commit_txid,
+            "reveal enqueue deferred: envelope row still references a superseded commit"
+        );
+        return Ok(false);
+    }
+
     if !reveal_enqueue_is_policy_safe(entry, commit)? {
         debug!(
             envelope_idx,
@@ -767,7 +871,7 @@ async fn try_enqueue_reveals_if_policy_safe(
     );
 
     for reveal in &entry.reveals {
-        ensure_reveal_tx_entry(envelope_idx, reveal, bcast).await?;
+        ensure_reveal_tx_entry(envelope_idx, reveal, commit, bcast).await?;
     }
 
     info!(
@@ -785,8 +889,11 @@ async fn try_enqueue_reveals_if_policy_safe(
 async fn ensure_reveal_tx_entry(
     envelope_idx: u64,
     reveal: &RevealTxMeta,
+    commit: &L1TxEntry,
     bcast: &L1BroadcastHandle,
 ) -> anyhow::Result<()> {
+    let tx = btc_deserialize::<Transaction>(&reveal.tx_bytes)
+        .map_err(|e| anyhow::anyhow!("failed to deserialize reveal tx: {}", e))?;
     if bcast
         .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
         .await?
@@ -797,21 +904,124 @@ async fn ensure_reveal_tx_entry(
             txid = ?reveal.txid,
             "reveal tx already tracked by broadcaster"
         );
+    } else {
+        let commit_tx = commit.try_to_tx()?;
+        let fee_sats = commit_tx
+            .output
+            .get(reveal.vout_index as usize)
+            .map(|output| {
+                let output_total = tx
+                    .output
+                    .iter()
+                    .map(|txout| txout.value.to_sat())
+                    .sum::<u64>();
+                output.value.to_sat().saturating_sub(output_total)
+            })
+            .unwrap_or_default();
+        let fee_rate = if tx.vsize() == 0 {
+            FeeRate::ZERO
+        } else {
+            FeeRate::from_sat_per_vb(fee_sats.div_ceil(tx.vsize() as u64))
+                .expect("fee rate must fit")
+        };
+        let tx_entry = L1TxEntry::from_tx_with_fee(&tx, fee_rate, Amount::from_sat(fee_sats));
+        // The fee bumper refuses to replace a chunked commit once any reveal for that envelope
+        // has a tx-node record, because a commit replacement changes the commit txid and would
+        // orphan every reveal spending it. Record the reveal node *before* handing the tx to the
+        // broadcaster so a crash between the two writes cannot leave a broadcastable reveal that
+        // the guard is blind to. The reverse order is safe: the fee bumper re-inserts a broadcast
+        // entry that its record still owns.
+        put_chunked_reveal_tx_node(
+            envelope_idx,
+            reveal,
+            &tx,
+            fee_rate,
+            Amount::from_sat(fee_sats),
+            bcast,
+        )
+        .await?;
+        bcast
+            .put_tx_entry(to_raw_buf32(reveal.txid), tx_entry)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to store reveal tx: {}", e))?;
+
+        debug!(
+            envelope_idx,
+            txid = ?reveal.txid,
+            "reveal tx enqueued in broadcaster"
+        );
+    }
+
+    Ok(())
+}
+
+async fn put_chunked_commit_tx_node(
+    envelope_idx: u64,
+    commit_tx_entry: &L1TxEntry,
+    commit_fee: Amount,
+    bcast: &L1BroadcastHandle,
+) -> anyhow::Result<()> {
+    let tx = commit_tx_entry.try_to_tx()?;
+    let Some(rbf) = commit_tx_entry.rbf else {
+        return Ok(());
+    };
+    let fee_rate = FeeRate::from_sat_per_vb(rbf.fee_rate_sat_vb)
+        .ok_or_else(|| anyhow::anyhow!("invalid commit fee rate {}", rbf.fee_rate_sat_vb))?;
+    // `commit_fee` is the builder's exact input-minus-output figure. Reconstructing it as
+    // `fee_rate * vsize` would under-record whenever dust change was absorbed into the fee, and
+    // the fee bumper would then request a replacement fee that Bitcoin Core rejects.
+    let fee_sats = commit_fee;
+    put_tx_node_if_missing(
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx },
+        &tx,
+        fee_rate,
+        fee_sats,
+        bcast,
+    )
+    .await
+}
+
+async fn put_chunked_reveal_tx_node(
+    envelope_idx: u64,
+    reveal: &RevealTxMeta,
+    tx: &Transaction,
+    fee_rate: FeeRate,
+    fee_sats: Amount,
+    bcast: &L1BroadcastHandle,
+) -> anyhow::Result<()> {
+    put_tx_node_if_missing(
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx: reveal.vout_index.saturating_sub(1),
+        },
+        tx,
+        fee_rate,
+        fee_sats,
+        bcast,
+    )
+    .await
+}
+
+async fn put_tx_node_if_missing(
+    kind: TxNodeKind,
+    tx: &Transaction,
+    fee_rate: FeeRate,
+    fee_sats: Amount,
+    bcast: &L1BroadcastHandle,
+) -> anyhow::Result<()> {
+    let node_id = TxNodeId::from_kind(&kind);
+    let attempt = TxAttempt::active(attempt_parts(tx, fee_rate, fee_sats), 0);
+    if let Some(mut record) = bcast.get_tx_node(node_id).await? {
+        if record.active_txid == attempt.txid {
+            return Ok(());
+        }
+        record.replace_initial_attempt(attempt);
+        bcast.put_tx_node(record).await?;
         return Ok(());
     }
 
-    let tx = btc_deserialize(&reveal.tx_bytes)
-        .map_err(|e| anyhow::anyhow!("failed to deserialize reveal tx: {}", e))?;
-    bcast
-        .put_tx_entry(to_raw_buf32(reveal.txid), L1TxEntry::from_tx(&tx))
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to store reveal tx: {}", e))?;
-
-    debug!(
-        envelope_idx,
-        txid = ?reveal.txid,
-        "reveal tx enqueued in broadcaster"
-    );
+    let record = TxNodeRecord::new(kind, attempt);
+    bcast.put_tx_node(record).await?;
     Ok(())
 }
 
@@ -824,9 +1034,10 @@ async fn check_full_broadcast_status(
     envelope_idx: u64,
     entry: &ChunkedEnvelopeEntry,
     bcast: &L1BroadcastHandle,
+    commit_phase: &CommitPhaseLatch,
 ) -> anyhow::Result<ChunkedEnvelopeStatus> {
-    let Some(commit) = bcast
-        .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+    let Some((active_commit_txid, commit)) = bcast
+        .get_active_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
         .await?
     else {
         error!(
@@ -848,12 +1059,24 @@ async fn check_full_broadcast_status(
         return Ok(ChunkedEnvelopeStatus::NeedsResign);
     }
 
+    // Same rule as the normal enqueue path: reveals recorded against a superseded commit must not
+    // be restored into the broadcaster. Wait for the fee bumper to finish refreshing this row.
+    if active_commit_txid != to_raw_buf32(entry.commit_txid) {
+        warn!(
+            envelope_idx,
+            stale_commit_txid = ?entry.commit_txid,
+            ?active_commit_txid,
+            "reveal restore deferred: envelope row still references a superseded commit"
+        );
+        return Ok(ChunkedEnvelopeStatus::CommitPublished);
+    }
+
     let can_enqueue_missing_reveals = reveal_enqueue_is_policy_safe(entry, &commit)?;
     let mut min_progress = commit.status.clone();
     let mut reveal_l1_statuses = Vec::with_capacity(entry.reveals.len());
     for reveal in &entry.reveals {
-        let Some(rtx) = bcast
-            .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+        let Some((active_reveal_txid, rtx)) = bcast
+            .get_active_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
             .await?
         else {
             if !can_enqueue_missing_reveals {
@@ -865,12 +1088,20 @@ async fn check_full_broadcast_status(
                 );
                 return Ok(ChunkedEnvelopeStatus::CommitPublished);
             }
+            let Some(_claim) = commit_phase.try_claim(envelope_idx) else {
+                debug!(
+                    envelope_idx,
+                    txid = ?reveal.txid,
+                    "reveal restore deferred: a commit fee bump is in flight for this envelope"
+                );
+                return Ok(ChunkedEnvelopeStatus::CommitPublished);
+            };
             warn!(
                 envelope_idx,
                 txid = ?reveal.txid,
                 "reveal tx missing from broadcast db, restoring from persisted reveal bytes"
             );
-            ensure_reveal_tx_entry(envelope_idx, reveal, bcast).await?;
+            ensure_reveal_tx_entry(envelope_idx, reveal, &commit, bcast).await?;
             min_progress = L1TxStatus::Unpublished;
             reveal_l1_statuses.push(format_tx_status(reveal.txid, &min_progress));
             continue;
@@ -885,7 +1116,10 @@ async fn check_full_broadcast_status(
             );
             return Ok(ChunkedEnvelopeStatus::NeedsResign);
         }
-        reveal_l1_statuses.push(format_tx_status(reveal.txid, &rtx.status));
+        reveal_l1_statuses.push(format_tx_status(
+            L1TxId::from(active_reveal_txid.0),
+            &rtx.status,
+        ));
         if is_less_progressed(&rtx.status, &min_progress) {
             min_progress = rtx.status;
         }
@@ -896,7 +1130,7 @@ async fn check_full_broadcast_status(
         envelope_status,
         ChunkedEnvelopeStatus::Confirmed | ChunkedEnvelopeStatus::Finalized
     ) {
-        let commit_l1_status = format_tx_status(entry.commit_txid, &commit.status);
+        let commit_l1_status = format_tx_status(L1TxId::from(active_commit_txid.0), &commit.status);
         info!(
             envelope_idx,
             commit_txid = ?entry.commit_txid,
@@ -920,6 +1154,7 @@ fn progress_ordinal(s: &L1TxStatus) -> u8 {
         L1TxStatus::Published => 1,
         L1TxStatus::Confirmed { .. } => 2,
         L1TxStatus::Finalized { .. } => 3,
+        L1TxStatus::Replaced { .. } => 4,
         L1TxStatus::InvalidInputs => {
             unreachable!("InvalidInputs is handled before aggregation")
         }
@@ -946,6 +1181,7 @@ fn to_envelope_status(s: &L1TxStatus) -> ChunkedEnvelopeStatus {
         L1TxStatus::Published => ChunkedEnvelopeStatus::Published,
         L1TxStatus::Confirmed { .. } => ChunkedEnvelopeStatus::Confirmed,
         L1TxStatus::Finalized { .. } => ChunkedEnvelopeStatus::Finalized,
+        L1TxStatus::Replaced { .. } => ChunkedEnvelopeStatus::Published,
         L1TxStatus::InvalidInputs => {
             unreachable!("InvalidInputs is handled before aggregation")
         }
@@ -954,8 +1190,6 @@ fn to_envelope_status(s: &L1TxStatus) -> ChunkedEnvelopeStatus {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use bitcoin::{
         absolute::LockTime, consensus::encode::serialize as btc_serialize, hashes::Hash,
         transaction::Version, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
@@ -966,7 +1200,6 @@ mod tests {
         common::{L1TxId, L1WtxId},
     };
     use strata_l1_txfmt::MagicBytes;
-    use strata_primitives::buf::Buf32;
 
     use super::*;
     use crate::{
@@ -1003,7 +1236,7 @@ mod tests {
         entry.status = status;
         if signed {
             entry.reveals = vec![RevealTxMeta {
-                vout_index: 0,
+                vout_index: 1,
                 txid: L1TxId::from([idx_tag; 32]),
                 wtxid: L1WtxId::from([idx_tag.wrapping_add(1); 32]),
                 tx_bytes: vec![idx_tag],
@@ -1211,7 +1444,7 @@ mod tests {
             .map(|i| {
                 let tx = make_test_tx();
                 RevealTxMeta {
-                    vout_index: i as u32,
+                    vout_index: (i + 1) as u32,
                     txid: L1TxId::from([(0x20 + i as u8); 32]),
                     wtxid: L1WtxId::from([(0x30 + i as u8); 32]),
                     tx_bytes: btc_serialize(&tx),
@@ -1263,7 +1496,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1291,7 +1524,7 @@ mod tests {
         let entry = make_entry_with_reveals(2);
 
         // Don't store commit at all — should return Unsigned for re-signing.
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1313,7 +1546,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::NeedsResign);
@@ -1336,7 +1569,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1372,7 +1605,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::CommitPublished);
@@ -1397,7 +1630,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast)
+        let result = check_commit_and_enqueue_reveals(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::CommitPublished);
@@ -1443,7 +1676,7 @@ mod tests {
                 .unwrap();
         }
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(result, ChunkedEnvelopeStatus::Finalized);
@@ -1492,7 +1725,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1507,7 +1740,7 @@ mod tests {
         let bcast = get_broadcast_handle();
         let entry = make_entry_with_reveals(2);
 
-        let err = check_full_broadcast_status(0, &entry, &bcast)
+        let err = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1546,7 +1779,7 @@ mod tests {
             .unwrap();
 
         // Second reveal is missing.
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1592,7 +1825,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(
@@ -1625,7 +1858,7 @@ mod tests {
                 .unwrap();
         }
 
-        let result = check_full_broadcast_status(0, &entry, &bcast)
+        let result = check_full_broadcast_status(0, &entry, &bcast, &CommitPhaseLatch::new())
             .await
             .unwrap();
         assert_eq!(

--- a/crates/btcio/src/writer/chunked_envelope/mod.rs
+++ b/crates/btcio/src/writer/chunked_envelope/mod.rs
@@ -3,9 +3,11 @@
 
 pub(crate) mod builder;
 pub(crate) mod commit_op_return;
+mod commit_phase;
 mod context;
 mod handle;
 mod signer;
 
 pub use builder::{build_chunked_envelope_txs, ChunkedEnvelopeTxs};
+pub use commit_phase::{CommitPhaseClaim, CommitPhaseLatch};
 pub use handle::{create_chunked_envelope_task, ChunkedEnvelopeHandle};

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use bitcoin::consensus::encode::serialize as btc_serialize;
+use bitcoin::{consensus::encode::serialize as btc_serialize, Amount};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::{TxidExt, WtxidExt};
 use strata_db_types::{
@@ -47,6 +47,8 @@ pub(crate) struct SignedChunkedEnvelope {
     pub entry: ChunkedEnvelopeEntry,
     /// Wallet-signed commit tx entry, initially stored as unpublished.
     pub commit_tx_entry: L1TxEntry,
+    /// Exact absolute fee the commit tx pays, used to seed its fee-bump record.
+    pub commit_fee: Amount,
 }
 
 /// Builds and signs a chunked envelope's commit + N reveal transactions.
@@ -119,6 +121,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             network,
             fee_rate,
             BITCOIN_DUST_LIMIT,
+            ctx.config.fee_bumping,
             None,
         );
 
@@ -172,9 +175,13 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
         updated.commit_wtxid = commit_wtxid;
         updated.reveals = reveals;
         updated.status = ChunkedEnvelopeStatus::Unpublished;
+        let commit_tx_entry =
+            L1TxEntry::from_tx_with_fee(&signed_commit, fee_rate, built.commit_fee);
+
         Ok(SignedChunkedEnvelope {
             entry: updated,
-            commit_tx_entry: L1TxEntry::from_tx(&signed_commit),
+            commit_tx_entry,
+            commit_fee: built.commit_fee,
         })
     }
     .instrument(sign_chunked_envelope_span)

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use bitcoin::consensus::encode::serialize as btc_serialize;
+use bitcoin::{consensus::encode::serialize as btc_serialize, Amount};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::{TxidExt, WtxidExt};
 use strata_db_types::{
@@ -50,6 +50,8 @@ pub(crate) struct SignedChunkedEnvelope {
     pub entry: ChunkedEnvelopeEntry,
     /// Wallet-signed commit tx entry, initially stored as unpublished.
     pub commit_tx_entry: L1TxEntry,
+    /// Exact absolute fee the commit tx pays, used to seed its fee-bump record.
+    pub commit_fee: Amount,
 }
 
 /// Builds and signs a chunked envelope's commit + N reveal transactions.
@@ -122,6 +124,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             network,
             fee_rate,
             BITCOIN_DUST_LIMIT,
+            ctx.config.fee_bumping,
             None,
         );
 
@@ -175,9 +178,13 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
         updated.commit_wtxid = commit_wtxid;
         updated.reveals = reveals;
         updated.status = ChunkedEnvelopeStatus::Unpublished;
+        let commit_tx_entry =
+            L1TxEntry::from_tx_with_fee(&signed_commit, fee_rate, built.commit_fee);
+
         Ok(SignedChunkedEnvelope {
             entry: updated,
-            commit_tx_entry: L1TxEntry::from_tx(&signed_commit),
+            commit_tx_entry,
+            commit_fee: built.commit_fee,
         })
     }
     .instrument(sign_chunked_envelope_span)

--- a/crates/btcio/src/writer/context.rs
+++ b/crates/btcio/src/writer/context.rs
@@ -108,4 +108,12 @@ impl<R: Reader + Signer + Wallet> WriterContext<R> {
     pub fn signing_mode(&self) -> anyhow::Result<EnvelopeSigningMode> {
         self.signing_mode_provider.signing_mode()
     }
+
+    /// Returns the provider backing the envelope signing mode.
+    ///
+    /// Callers that outlive a single resolution should hold the provider and re-resolve, since the
+    /// mode tracks canonical state and changes when the sequencer predicate rotates.
+    pub fn signing_mode_provider(&self) -> Arc<dyn EnvelopeSigningModeProvider> {
+        self.signing_mode_provider.clone()
+    }
 }

--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -1,7 +1,7 @@
 //! Module for resolving fee rates for transactions, supporting multiple fee policies including
 //! Bitcoin Core's `estimatesmartfee` and mempool.space's recommended fees endpoint.
 
-use std::sync::LazyLock;
+use std::{sync::LazyLock, time::Duration};
 
 use anyhow::Context;
 use bitcoin::FeeRate;
@@ -13,8 +13,29 @@ use strata_config::btcio::{
 };
 use tracing::warn;
 
+/// How long a mempool explorer fee lookup may take before it is abandoned.
+///
+/// `resolve_fee_rate` runs on the writer's watcher tick, which also drives the replacement pass, so
+/// an explorer that accepts a connection and then stalls would hold up publication as well as
+/// bumping. `reqwest::Client::new` sets no timeout at all.
+const MEMPOOL_FEE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long the connection itself may take to establish.
+const MEMPOOL_FEE_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// Shared HTTP client reused across mempool fee lookups for connection pooling.
-static SHARED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+static SHARED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(MEMPOOL_FEE_REQUEST_TIMEOUT)
+        .connect_timeout(MEMPOOL_FEE_CONNECT_TIMEOUT)
+        .build()
+        // Only fails when the TLS backend cannot initialise, which an untimed client would hit
+        // just the same. Fall back rather than panic in a `LazyLock`.
+        .unwrap_or_else(|err| {
+            warn!(%err, "falling back to an untimed HTTP client for mempool fee lookups");
+            reqwest::Client::new()
+        })
+});
 
 /// Represents the response from the mempool explorer recommended fees endpoint.
 #[derive(Debug, Deserialize, PartialEq)]
@@ -109,37 +130,22 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
     config: &WriterConfig,
 ) -> anyhow::Result<FeeRate> {
     let fee_rate = match config.fee_policy() {
-        // NOTE(STR-2545, STR-2433): fee estimation is currently being doubled since we don't fully
-        //                           support fee bumping ostensive mechanisms for making sure
-        //                           transactions confirm in a timely manner. This is a temporary
-        //                           measure until we implement more robust fee bumping strategies,
-        //                           at which point we can remove the doubling and rely on the fee
-        //                           policies to provide accurate fee rates.
-        FeePolicy::BitcoinD { conf_target } => {
-            let fee_estimate = client
-                .estimate_smart_fee(*conf_target)
-                .await
-                .context("failed to estimate smart fee")
-                .and_then(|estimate| {
-                    estimate.fee_rate.ok_or_else(|| {
-                        anyhow::anyhow!("smart fee estimate unavailable: {:?}", estimate.errors)
-                    })
-                })?;
-            fee_estimate
-                .checked_mul(2)
-                .ok_or_else(|| anyhow::anyhow!("smart fee estimate overflows when doubled"))?
-        }
+        FeePolicy::BitcoinD { conf_target } => client
+            .estimate_smart_fee(*conf_target)
+            .await
+            .context("failed to estimate smart fee")
+            .and_then(|estimate| {
+                estimate.fee_rate.ok_or_else(|| {
+                    anyhow::anyhow!("smart fee estimate unavailable: {:?}", estimate.errors)
+                })
+            })?,
         FeePolicy::MempoolExplorer {
             policy,
             mempool_base_url,
             fallback_conf_target,
         } => {
-            let fee_estimate =
-                resolve_mempool_fee_rate(client, mempool_base_url, *fallback_conf_target, *policy)
-                    .await?;
-            fee_estimate
-                .checked_mul(2)
-                .ok_or_else(|| anyhow::anyhow!("mempool fee estimate overflows when doubled"))?
+            resolve_mempool_fee_rate(client, mempool_base_url, *fallback_conf_target, *policy)
+                .await?
         }
         FeePolicy::Fixed { fee_rate } => *fee_rate,
     };
@@ -310,8 +316,8 @@ mod tests {
             .await
             .expect("mempool fee lookup should succeed");
 
-        // NOTE: double the fees here, so 0.2 sat/vB becomes 0.4 sat/vB.
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(100));
+        // 0.2 sat/vB, used as reported.
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(50));
     }
 
     #[tokio::test]
@@ -328,8 +334,7 @@ mod tests {
             .await
             .expect("mempool fee lookup should succeed");
 
-        // NOTE: double the fees here
-        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(7 * 2));
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(7));
     }
 
     #[tokio::test]
@@ -346,8 +351,7 @@ mod tests {
             .await
             .expect("mempool fee lookup should succeed");
 
-        // NOTE: double the fees here
-        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(4 * 2));
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(4));
     }
 
     #[tokio::test]
@@ -360,8 +364,7 @@ mod tests {
             .await
             .expect("smart fee fallback should succeed");
 
-        // NOTE: double the fees here
-        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(3 * 2));
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(3));
     }
 
     #[tokio::test]
@@ -374,8 +377,7 @@ mod tests {
             .await
             .expect("smart fee fallback should succeed");
 
-        // NOTE: double the fees here
-        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(3 * 2));
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(3));
     }
 
     #[tokio::test]
@@ -400,7 +402,20 @@ mod tests {
             .await
             .expect("smart fee lookup should succeed");
 
-        // NOTE: double the fees here
-        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(3 * 2));
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(3));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_fee_rate_fixed_policy_is_unscaled() {
+        let client = Arc::new(TestBitcoinClient::new(1));
+        let config = writer_config(L1FeePolicyConfig::new(FeePolicy::Fixed {
+            fee_rate: FeeRate::from_sat_per_vb_u32(9),
+        }));
+
+        let fee_rate = resolve_fee_rate(client.as_ref(), &config)
+            .await
+            .expect("fixed fee policy should resolve");
+
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb_u32(9));
     }
 }

--- a/crates/btcio/src/writer/mod.rs
+++ b/crates/btcio/src/writer/mod.rs
@@ -2,8 +2,9 @@ pub mod builder;
 mod bundler;
 pub mod chunked_envelope;
 mod context;
-mod fees;
+pub(crate) mod fees;
 mod handle;
+pub(crate) mod replacement;
 mod signer;
 mod watcher;
 

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -51,6 +51,13 @@ pub(crate) enum ReplacementError {
     RevealKeyRotated { committed: String, held: String },
     #[error("replacement would reduce reveal output below dust")]
     ReplacementWouldDustOutput,
+    /// Discarded by the commit path rather than treated as terminal: which candidate the wallet
+    /// builds depends on its UTXO set, so a later one can land under the ceiling.
+    #[error("wallet built a replacement paying {built_sat_vb} sat/vB, above the configured ceiling of {ceiling_sat_vb} sat/vB")]
+    ExceedsMaxFeeRate {
+        built_sat_vb: u64,
+        ceiling_sat_vb: u64,
+    },
     #[error("replacement commit output layout is incompatible with the envelope: {0}")]
     IncompatibleCommitLayout(String),
     #[error("replacement would spend {0} wallet input(s) the original did not")]
@@ -70,6 +77,9 @@ impl ReplacementError {
             Self::PsbtBumpFee(error) | Self::WalletProcessPsbt(error) => {
                 is_retryable_client_error(error)
             }
+            // Not transient, but the commit path discards this candidate instead of ending the
+            // chain; see the variant's own note.
+            Self::ExceedsMaxFeeRate { .. } => false,
             Self::UnsupportedKind(_)
             | Self::IncompletePsbt
             | Self::MissingFinalTransaction
@@ -107,6 +117,7 @@ impl ReplacementError {
             | Self::IncompatibleCommitLayout(_) => TerminalError::UnsupportedRbfKind,
             Self::ReplacementAddsInputs(_) => TerminalError::ReplacementAddsInputs,
             Self::ReplacementWouldDustOutput => TerminalError::ReplacementWouldDustOutput,
+            Self::ExceedsMaxFeeRate { .. } => TerminalError::AboveMaxFeeRate,
         }
     }
 }
@@ -130,12 +141,21 @@ impl ReplacementError {
 /// `original_change_index` names the output Core should recycle to pay the higher fee. Passing it
 /// is not an optimisation: see [`chunked_commit_change_index`] for why leaving Core to find the
 /// change itself would make every chunked commit bump fail.
+///
+/// `max_fee_rate` is the operator's configured replacement ceiling. `target_fee_rate` is already
+/// capped by it, but the wallet prices the fee off the transaction it ends up building and can pay
+/// more than it was asked for, so the built candidate is checked against the ceiling too.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the wallet call needs every input threaded through explicitly"
+)]
 pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
     client: &C,
     kind: &TxNodeKind,
     original_tx: &Transaction,
     active_txid: L1TxId,
     target_fee_rate: FeeRate,
+    max_fee_rate: FeeRate,
     attempt_no: u32,
     original_change_index: Option<u32>,
 ) -> Result<TxAttempt, ReplacementError> {
@@ -179,9 +199,21 @@ pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
     // from this number, and a target below the fee rate already on the wire is one Core rejects.
     let fee = Amount::from_sat(bumped.fee.to_sat());
     let effective_fee_rate = effective_fee_rate(&tx, fee).unwrap_or(target_fee_rate);
+    let recorded_fee_rate = effective_fee_rate.max(target_fee_rate);
+
+    // `target_fee_rate` already clears the ceiling, but what the wallet built need not: absorbing a
+    // sub-dust change output into the fee raises the rate above what was asked for. Adopting it
+    // anyway would put a transaction on the wire that breaches the operator's safety cap, and would
+    // also seed the next bump's floors from a rate the ceiling forbids.
+    if recorded_fee_rate > max_fee_rate {
+        return Err(ReplacementError::ExceedsMaxFeeRate {
+            built_sat_vb: recorded_fee_rate.to_sat_per_vb_ceil(),
+            ceiling_sat_vb: max_fee_rate.to_sat_per_vb_ceil(),
+        });
+    }
 
     Ok(TxAttempt::new(
-        attempt_parts(&tx, effective_fee_rate.max(target_fee_rate), fee),
+        attempt_parts(&tx, recorded_fee_rate, fee),
         attempt_no,
         TxAttemptStatus::Active,
     ))
@@ -562,6 +594,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::test_utils::TestBitcoinClient;
 
     fn op_return_output() -> TxOut {
         TxOut {
@@ -942,5 +975,49 @@ mod tests {
         let fee = Amount::from_sat(tx.vsize() as u64 * 3);
 
         assert_eq!(effective_fee_rate(&tx, fee), FeeRate::from_sat_per_vb(3));
+    }
+
+    /// The mock wallet always reports a 0.01 BTC fee, which over this transaction is far more than
+    /// the target asks for — the same overshoot Core produces when it absorbs sub-dust change.
+    async fn wallet_replacement_with_ceiling(
+        ceiling_sat_vb: u64,
+    ) -> Result<TxAttempt, ReplacementError> {
+        let original = commit_with(vec![p2wpkh_output(1_000)]);
+        let client =
+            TestBitcoinClient::new(1).with_wallet_process_psbt_result(true, Some(original.clone()));
+
+        build_wallet_commit_replacement(
+            &client,
+            &TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 0 },
+            &original,
+            L1TxId::from([0u8; 32]),
+            FeeRate::from_sat_per_vb(4).expect("valid fee rate"),
+            FeeRate::from_sat_per_vb(ceiling_sat_vb).expect("valid fee rate"),
+            1,
+            None,
+        )
+        .await
+    }
+
+    /// Regression: the target is capped by the ceiling, but the rate the wallet actually builds is
+    /// not, and it is that transaction which reaches the wire and seeds the next bump's floors.
+    #[tokio::test]
+    async fn rejects_a_wallet_replacement_that_breaches_the_fee_rate_ceiling() {
+        let error = wallet_replacement_with_ceiling(1_000)
+            .await
+            .expect_err("a replacement above the ceiling must not be adopted");
+
+        assert!(matches!(error, ReplacementError::ExceedsMaxFeeRate { .. }));
+        assert!(!error.is_retryable());
+        assert_eq!(error.terminal_error(), TerminalError::AboveMaxFeeRate);
+    }
+
+    #[tokio::test]
+    async fn accepts_a_wallet_replacement_that_stays_under_the_fee_rate_ceiling() {
+        let attempt = wallet_replacement_with_ceiling(1_000_000)
+            .await
+            .expect("a replacement under the ceiling is adopted");
+
+        assert_eq!(attempt.fee(), Amount::from_sat(1_000_000));
     }
 }

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -41,6 +41,11 @@ pub(crate) enum ReplacementError {
     InvalidControlBlock(String),
     #[error("invalid reveal tapscript pubkey: {0}")]
     InvalidRevealPubkey(String),
+    /// Keys are held as strings so the variant stays small: an inline [`XOnlyPublicKey`] pair is
+    /// 128 bytes, which would grow every `Result<_, ReplacementError>` in this module past
+    /// `clippy::result_large_err`.
+    #[error("reveal tapscript commits to {committed} but the signer holds {held}")]
+    RevealKeyRotated { committed: String, held: String },
     #[error("replacement would reduce reveal output below dust")]
     ReplacementWouldDustOutput,
     #[error("replacement commit output layout is incompatible with the envelope: {0}")]
@@ -68,6 +73,7 @@ impl ReplacementError {
             | Self::MissingRevealWitness
             | Self::InvalidControlBlock(_)
             | Self::InvalidRevealPubkey(_)
+            | Self::RevealKeyRotated { .. }
             | Self::ReplacementWouldDustOutput
             | Self::IncompatibleCommitLayout(_)
             | Self::ReplacementAddsInputs(_)
@@ -93,6 +99,7 @@ impl ReplacementError {
             Self::MissingRevealWitness
             | Self::InvalidControlBlock(_)
             | Self::InvalidRevealPubkey(_)
+            | Self::RevealKeyRotated { .. }
             | Self::RevealSigning(_)
             | Self::IncompatibleCommitLayout(_) => TerminalError::UnsupportedRbfKind,
             Self::ReplacementAddsInputs(_) => TerminalError::ReplacementAddsInputs,
@@ -303,6 +310,27 @@ fn reject_added_inputs(
     Ok(())
 }
 
+/// Verifies the sequencer still holds the key `reveal_tx`'s tapscript commits to.
+///
+/// A replacement reuses the original tapscript, so a signature under any other key yields a witness
+/// that can never satisfy it — and by the time bitcoind says so the original is already marked
+/// `Replaced`, leaving the envelope stuck with nothing to rebuild it. The single-envelope path
+/// makes the same check against its external signer's key.
+pub(crate) fn ensure_reveal_signable(
+    reveal_tx: &Transaction,
+    sequencer_keypair: &Keypair,
+) -> Result<(), ReplacementError> {
+    let committed = extract_reveal_pubkey(reveal_tx)?;
+    let held = XOnlyPublicKey::from_keypair(sequencer_keypair).0;
+    if committed != held {
+        return Err(ReplacementError::RevealKeyRotated {
+            committed: committed.to_string(),
+            held: held.to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Rebuilds and signs a chunked-envelope reveal by reducing its spendable output.
 pub(crate) fn build_chunked_reveal_replacement(
     active_reveal_tx: &Transaction,
@@ -311,6 +339,8 @@ pub(crate) fn build_chunked_reveal_replacement(
     attempt_no: u32,
     sequencer_keypair: &Keypair,
 ) -> Result<TxAttempt, ReplacementError> {
+    ensure_reveal_signable(active_reveal_tx, sequencer_keypair)?;
+
     let mut replacement_tx = active_reveal_tx.clone();
     set_reveal_replacement_fee(&mut replacement_tx, commit_output, target_fee_rate)?;
 
@@ -369,6 +399,8 @@ pub(crate) fn rebuild_reveal_for_replaced_commit(
     replacement_commit_output: &TxOut,
     sequencer_keypair: &Keypair,
 ) -> Result<Transaction, ReplacementError> {
+    ensure_reveal_signable(old_reveal_tx, sequencer_keypair)?;
+
     let mut replacement_reveal = old_reveal_tx.clone();
     let input = replacement_reveal
         .input
@@ -554,9 +586,12 @@ mod tests {
         }
     }
 
+    fn test_keypair(seed: u8) -> Keypair {
+        Keypair::from_seckey_slice(SECP256K1, &[seed; 32]).expect("valid secret key")
+    }
+
     fn test_pubkey(seed: u8) -> XOnlyPublicKey {
-        let keypair = Keypair::from_seckey_slice(SECP256K1, &[seed; 32]).expect("valid secret key");
-        XOnlyPublicKey::from_keypair(&keypair).0
+        XOnlyPublicKey::from_keypair(&test_keypair(seed)).0
     }
 
     /// Builds a reveal spending a tapscript that commits to `pubkey`, as SPS-51 reveals do.
@@ -605,6 +640,100 @@ mod tests {
             .expect("pubkey is recoverable");
 
         assert_ne!(extracted, test_pubkey(2));
+    }
+
+    #[test]
+    fn accepts_a_reveal_the_signer_still_holds_the_key_for() {
+        let reveal = reveal_committing_to(&test_pubkey(1));
+
+        assert!(ensure_reveal_signable(&reveal, &test_keypair(1)).is_ok());
+    }
+
+    /// Regression: a replacement reuses the original tapscript, so signing it under a rotated key
+    /// yields a witness that can never satisfy that script — and the original is marked `Replaced`
+    /// before bitcoind ever says so. Refusing is what leaves the envelope for the writer to
+    /// rebuild.
+    #[test]
+    fn refuses_a_reveal_whose_committed_key_has_rotated() {
+        let reveal = reveal_committing_to(&test_pubkey(1));
+
+        let error = ensure_reveal_signable(&reveal, &test_keypair(2))
+            .expect_err("a rotated key must not be signed with");
+
+        assert!(matches!(error, ReplacementError::RevealKeyRotated { .. }));
+        assert!(!error.is_retryable());
+        assert_eq!(error.terminal_error(), TerminalError::UnsupportedRbfKind);
+    }
+
+    /// Documents why [`evaluate_fee_bump`] refuses reveal kinds outright.
+    ///
+    /// Both envelope builders size a reveal's commit output at exactly
+    /// `reveal_amount + reveal_fee(build_rate)`, with `reveal_amount` equal to the dust limit
+    /// (`calculate_reveal_commit_value`, `calculate_commit_output_value`). The reveal's own output
+    /// therefore already sits at dust, and shrinking it is the only way a replacement can pay more.
+    /// A target one sat/vB above the build rate is enough to push it under.
+    ///
+    /// If this ever starts returning `Ok`, the commit output has gained build-time headroom and the
+    /// refusal in the fee-bump policy can be lifted — see TODO(STR-4198), which replaces this test
+    /// with one asserting a production-shaped reveal bump succeeds.
+    ///
+    /// [`evaluate_fee_bump`]: crate::broadcaster::fee_bump::evaluate_fee_bump
+    #[test]
+    fn a_production_shaped_reveal_has_no_headroom_to_bump_into() {
+        let build_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+        let mut reveal = reveal_committing_to(&test_pubkey(1));
+        reveal.output = vec![p2tr_output(BITCOIN_DUST_LIMIT, 1)];
+        let commit_value = Amount::from_sat(BITCOIN_DUST_LIMIT)
+            + build_rate
+                .fee_vb(reveal.vsize() as u64)
+                .expect("reveal fee fits");
+        let commit_output = TxOut {
+            value: commit_value,
+            script_pubkey: reveal.output[0].script_pubkey.clone(),
+        };
+
+        let error = build_chunked_reveal_replacement(
+            &reveal,
+            &commit_output,
+            FeeRate::from_sat_per_vb(3).expect("valid fee rate"),
+            1,
+            &test_keypair(1),
+        )
+        .expect_err("a reveal built this way cannot fund any bump");
+
+        assert!(matches!(
+            error,
+            ReplacementError::ReplacementWouldDustOutput
+        ));
+    }
+
+    #[test]
+    fn chunked_reveal_replacement_refuses_a_rotated_key() {
+        let error = build_chunked_reveal_replacement(
+            &reveal_committing_to(&test_pubkey(1)),
+            &p2tr_output(10_000, 2),
+            FeeRate::from_sat_per_vb(4).expect("valid fee rate"),
+            1,
+            &test_keypair(2),
+        )
+        .expect_err("a rotated key must not be signed with");
+
+        assert!(matches!(error, ReplacementError::RevealKeyRotated { .. }));
+    }
+
+    /// The commit path re-signs every reveal of the envelope, so the same guard has to hold there:
+    /// one rotated reveal would otherwise take the whole envelope down with it.
+    #[test]
+    fn commit_replacement_reveal_rebuild_refuses_a_rotated_key() {
+        let error = rebuild_reveal_for_replaced_commit(
+            &reveal_committing_to(&test_pubkey(1)),
+            Txid::from_byte_array([3u8; 32]),
+            &p2tr_output(10_000, 2),
+            &test_keypair(2),
+        )
+        .expect_err("a rotated key must not be signed with");
+
+        assert!(matches!(error, ReplacementError::RevealKeyRotated { .. }));
     }
 
     #[test]

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -1,0 +1,791 @@
+//! Replacement transaction builders.
+
+use std::slice::from_ref;
+
+use bitcoin::{
+    hashes::Hash,
+    key::Keypair,
+    script::Instruction,
+    secp256k1::{schnorr::Signature, Message, XOnlyPublicKey, SECP256K1},
+    sighash::{Prevouts, SighashCache, TapSighashType},
+    taproot::{ControlBlock, LeafVersion, TapLeafHash},
+    Amount, FeeRate, ScriptBuf, Sequence, Transaction, TxOut, Txid,
+};
+use bitcoind_async_client::{error::ClientError, traits::Signer, types::PsbtBumpFeeOptions};
+use strata_db_types::{
+    common::L1TxId,
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeKind},
+    l1_writer::Sighash,
+};
+use strata_primitives::buf::Buf32;
+use thiserror::Error;
+
+use crate::{rpc_error::is_retryable_client_error, writer::builder::BITCOIN_DUST_LIMIT};
+
+/// Errors raised while building a replacement transaction.
+#[derive(Debug, Error)]
+pub(crate) enum ReplacementError {
+    #[error("unsupported RBF transaction kind: {0:?}")]
+    UnsupportedKind(TxNodeKind),
+    #[error("Bitcoin wallet could not bump fee: {0}")]
+    PsbtBumpFee(#[source] ClientError),
+    #[error("Bitcoin wallet could not sign replacement PSBT: {0}")]
+    WalletProcessPsbt(#[source] ClientError),
+    #[error("wallet returned incomplete replacement PSBT")]
+    IncompletePsbt,
+    #[error("wallet returned no finalized replacement transaction")]
+    MissingFinalTransaction,
+    #[error("active reveal transaction is missing its tapscript witness")]
+    MissingRevealWitness,
+    #[error("invalid reveal control block: {0}")]
+    InvalidControlBlock(String),
+    #[error("invalid reveal tapscript pubkey: {0}")]
+    InvalidRevealPubkey(String),
+    #[error("replacement would reduce reveal output below dust")]
+    ReplacementWouldDustOutput,
+    #[error("replacement commit output layout is incompatible with the envelope: {0}")]
+    IncompatibleCommitLayout(String),
+    #[error("replacement would spend {0} wallet input(s) the original did not")]
+    ReplacementAddsInputs(usize),
+    #[error("failed to sign reveal replacement: {0}")]
+    RevealSigning(#[source] anyhow::Error),
+}
+
+impl ReplacementError {
+    /// Reports whether the failure is transient and the replacement is worth retrying.
+    ///
+    /// Wallet RPC calls fail for transport reasons too — bitcoind restarting, warming up, or
+    /// briefly unreachable. Those must not burn the node's fee-bump chain, because a terminal
+    /// error is permanent and would leave the transaction stuck at its original fee forever.
+    pub(crate) fn is_retryable(&self) -> bool {
+        match self {
+            Self::PsbtBumpFee(error) | Self::WalletProcessPsbt(error) => {
+                is_retryable_client_error(error)
+            }
+            Self::UnsupportedKind(_)
+            | Self::IncompletePsbt
+            | Self::MissingFinalTransaction
+            | Self::MissingRevealWitness
+            | Self::InvalidControlBlock(_)
+            | Self::InvalidRevealPubkey(_)
+            | Self::ReplacementWouldDustOutput
+            | Self::IncompatibleCommitLayout(_)
+            | Self::ReplacementAddsInputs(_)
+            | Self::RevealSigning(_) => false,
+        }
+    }
+
+    /// Maps non-recoverable replacement failures to terminal node errors.
+    ///
+    /// Only call this after [`ReplacementError::is_retryable`] has returned `false`.
+    pub(crate) fn terminal_error(&self) -> TerminalError {
+        match self {
+            Self::UnsupportedKind(_) => TerminalError::UnsupportedRbfKind,
+            Self::PsbtBumpFee(ClientError::Server(_, msg))
+                if msg.to_ascii_lowercase().contains("insufficient") =>
+            {
+                TerminalError::WalletInsufficient
+            }
+            Self::PsbtBumpFee(_) => TerminalError::Bip125FeeRuleUnsatisfiable,
+            Self::WalletProcessPsbt(_) | Self::IncompletePsbt | Self::MissingFinalTransaction => {
+                TerminalError::WalletInsufficient
+            }
+            Self::MissingRevealWitness
+            | Self::InvalidControlBlock(_)
+            | Self::InvalidRevealPubkey(_)
+            | Self::RevealSigning(_)
+            | Self::IncompatibleCommitLayout(_) => TerminalError::UnsupportedRbfKind,
+            Self::ReplacementAddsInputs(_) => TerminalError::ReplacementAddsInputs,
+            Self::ReplacementWouldDustOutput => TerminalError::ReplacementWouldDustOutput,
+        }
+    }
+}
+
+/// Builds a wallet-owned commit replacement using Bitcoin Core's wallet RBF flow.
+///
+/// # Coin selection
+///
+/// When the original change output cannot absorb the higher fee, Core's fee bumper pulls in
+/// additional confirmed wallet UTXOs. `psbtbumpfee` returns a PSBT rather than committing it, so
+/// those inputs stay unlocked and keep appearing in `listunspent` until the replacement is
+/// broadcast — a writer building another envelope in that window could select the same UTXO, and
+/// whichever transaction Core saw first would invalidate the other.
+///
+/// Reserving those inputs properly needs `lockunspent`, which `bitcoind-async-client` does not
+/// expose, plus durable bookkeeping to release the locks when a replacement is discarded. Until
+/// then this fails closed: a replacement that spends any input the original did not is rejected.
+/// Change-funded bumps — the common case — are unaffected. The cost is that a bump needing extra
+/// inputs cannot proceed, which is a liveness limit rather than a correctness hazard.
+///
+/// `original_change_index` names the output Core should recycle to pay the higher fee. Passing it
+/// is not an optimisation: see [`chunked_commit_change_index`] for why leaving Core to find the
+/// change itself would make every chunked commit bump fail.
+pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
+    client: &C,
+    kind: &TxNodeKind,
+    original_tx: &Transaction,
+    active_txid: L1TxId,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+    original_change_index: Option<u32>,
+) -> Result<TxAttempt, ReplacementError> {
+    if !matches!(
+        kind,
+        TxNodeKind::SingleEnvelopeCommit { .. } | TxNodeKind::ChunkedEnvelopeCommit { .. }
+    ) {
+        return Err(ReplacementError::UnsupportedKind(kind.clone()));
+    }
+
+    let txid = Txid::from_byte_array(active_txid.0);
+    let bumped = client
+        .psbt_bump_fee(
+            &txid,
+            Some(PsbtBumpFeeOptions {
+                fee_rate: Some(target_fee_rate),
+                replaceable: Some(true),
+                original_change_index,
+                ..PsbtBumpFeeOptions::default()
+            }),
+        )
+        .await
+        .map_err(ReplacementError::PsbtBumpFee)?;
+
+    let processed = client
+        .wallet_process_psbt(&bumped.psbt.to_string(), Some(true), None, None)
+        .await
+        .map_err(ReplacementError::WalletProcessPsbt)?;
+    if !processed.complete {
+        return Err(ReplacementError::IncompletePsbt);
+    }
+    let tx: Transaction = processed
+        .hex
+        .ok_or(ReplacementError::MissingFinalTransaction)?;
+
+    reject_added_inputs(original_tx, &tx)?;
+
+    // Record what the wallet actually built, not what it was asked for. Core sizes the fee from
+    // the final transaction and can absorb sub-dust change into it, so the replacement often pays
+    // more than `target_fee_rate`. The next bump derives its additive and multiplicative floors
+    // from this number, and a target below the fee rate already on the wire is one Core rejects.
+    let fee = Amount::from_sat(bumped.fee.to_sat());
+    let effective_fee_rate = effective_fee_rate(&tx, fee).unwrap_or(target_fee_rate);
+
+    Ok(TxAttempt::new(
+        &tx,
+        effective_fee_rate.max(target_fee_rate),
+        fee,
+        attempt_no,
+        TxAttemptStatus::Active,
+    ))
+}
+
+/// Derives the fee rate a built transaction actually pays, rounded up.
+///
+/// `None` when the rate does not fit a [`FeeRate`], which leaves the caller with the target it
+/// asked for rather than no attempt at all.
+fn effective_fee_rate(tx: &Transaction, fee: Amount) -> Option<FeeRate> {
+    let vsize = tx.vsize() as u64;
+    if vsize == 0 {
+        return None;
+    }
+    FeeRate::from_sat_per_vb(fee.to_sat().div_ceil(vsize))
+}
+
+/// Locates the change output Core should recycle when bumping a chunked commit.
+///
+/// Core only auto-detects an output as change when it is `IsMine` *and* absent from the wallet's
+/// address book. The commit pays its change to the sequencer address, which both binaries obtain
+/// from `getnewaddress`, and that writes an address-book entry. Left to its own detection Core
+/// therefore treats every output as a fixed recipient, has nothing it is allowed to shrink, and can
+/// only raise the fee by pulling in new inputs — which [`reject_added_inputs`] refuses, ending the
+/// chain terminal on the very first bump. Naming the index sidesteps the heuristic entirely.
+///
+/// The layout is `[OP_RETURN, one funding output per reveal, change?]`; the builder appends change
+/// last and only when the excess clears dust. `None` means there is no change output, and a bump
+/// then genuinely does need new inputs (known gap 1).
+pub(crate) fn chunked_commit_change_index(
+    commit_tx: &Transaction,
+    reveal_count: usize,
+) -> Option<u32> {
+    let change_index = reveal_count + 1;
+    if commit_tx.output.len() > change_index {
+        u32::try_from(change_index).ok()
+    } else {
+        None
+    }
+}
+
+/// Checks that a replacement chunked commit still has the output layout the envelope requires.
+///
+/// The ASM guest infers the reveal count from the run of consecutive P2TR outputs that follows
+/// the commit `OP_RETURN`, and each reveal is funded by exactly one of those outputs. Bitcoin
+/// Core's `psbtbumpfee` is free to reduce, drop, or append a change output; if the wallet's change
+/// type is taproot, an appended change output would extend that run and make the guest expect a
+/// reveal that does not exist. It may also shrink a reveal-funding output below what its reveal
+/// needs. Neither is recoverable, so verify the layout before adopting the replacement.
+pub(crate) fn validate_chunked_commit_replacement_layout(
+    original_commit: &Transaction,
+    replacement_commit: &Transaction,
+    reveal_count: usize,
+) -> Result<(), ReplacementError> {
+    let expected_prefix = reveal_count + 1;
+
+    if original_commit.output.len() < expected_prefix {
+        return Err(ReplacementError::IncompatibleCommitLayout(format!(
+            "original commit has {} outputs, expected at least {expected_prefix}",
+            original_commit.output.len()
+        )));
+    }
+    if replacement_commit.output.len() < expected_prefix {
+        return Err(ReplacementError::IncompatibleCommitLayout(format!(
+            "replacement commit has {} outputs, expected at least {expected_prefix}",
+            replacement_commit.output.len()
+        )));
+    }
+
+    let op_return = &replacement_commit.output[0];
+    if op_return.script_pubkey != original_commit.output[0].script_pubkey {
+        return Err(ReplacementError::IncompatibleCommitLayout(
+            "replacement commit changed the OP_RETURN output".to_string(),
+        ));
+    }
+
+    // Reveal-funding outputs must survive byte-identical: their values size each reveal's fee.
+    for vout in 1..expected_prefix {
+        let original = &original_commit.output[vout];
+        let replacement = &replacement_commit.output[vout];
+        if original.script_pubkey != replacement.script_pubkey
+            || original.value != replacement.value
+        {
+            return Err(ReplacementError::IncompatibleCommitLayout(format!(
+                "replacement commit altered reveal-funding output {vout}"
+            )));
+        }
+    }
+
+    // Anything past the reveal outputs is change, and must not extend the P2TR run.
+    for (offset, output) in replacement_commit.output[expected_prefix..]
+        .iter()
+        .enumerate()
+    {
+        if output.script_pubkey.is_p2tr() {
+            return Err(ReplacementError::IncompatibleCommitLayout(format!(
+                "replacement commit added a P2TR output at index {}, which would extend the reveal run",
+                expected_prefix + offset
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Rejects a replacement that spends wallet inputs the original transaction did not.
+///
+/// See the coin-selection note on [`build_wallet_commit_replacement`].
+fn reject_added_inputs(
+    original_tx: &Transaction,
+    replacement_tx: &Transaction,
+) -> Result<(), ReplacementError> {
+    let original_outpoints: Vec<_> = original_tx
+        .input
+        .iter()
+        .map(|input| input.previous_output)
+        .collect();
+    let added = replacement_tx
+        .input
+        .iter()
+        .filter(|input| !original_outpoints.contains(&input.previous_output))
+        .count();
+
+    if added > 0 {
+        return Err(ReplacementError::ReplacementAddsInputs(added));
+    }
+    Ok(())
+}
+
+/// Rebuilds and signs a chunked-envelope reveal by reducing its spendable output.
+pub(crate) fn build_chunked_reveal_replacement(
+    active_reveal_tx: &Transaction,
+    commit_output: &TxOut,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+    sequencer_keypair: &Keypair,
+) -> Result<TxAttempt, ReplacementError> {
+    let mut replacement_tx = active_reveal_tx.clone();
+    set_reveal_replacement_fee(&mut replacement_tx, commit_output, target_fee_rate)?;
+
+    let (reveal_script, control_block) = extract_reveal_witness(active_reveal_tx)?;
+    replacement_tx.input[0].witness.clear();
+    let sighash =
+        compute_taproot_script_spend_sighash(&replacement_tx, commit_output, &reveal_script)
+            .map_err(ReplacementError::RevealSigning)?;
+    let message = Message::from_digest_slice(sighash.as_ref())
+        .map_err(|error| ReplacementError::RevealSigning(error.into()))?;
+    let signature = SECP256K1.sign_schnorr(&message, sequencer_keypair);
+    attach_reveal_witness(
+        &mut replacement_tx,
+        &reveal_script,
+        &control_block,
+        signature.as_ref(),
+    )?;
+
+    let fee = reveal_fee(&replacement_tx, commit_output);
+    Ok(TxAttempt::new(
+        &replacement_tx,
+        target_fee_rate,
+        fee,
+        attempt_no,
+        TxAttemptStatus::Active,
+    ))
+}
+
+/// Rebuilds a single-envelope reveal with a higher fee, leaving it unsigned.
+pub(crate) fn build_pending_single_reveal_replacement(
+    active_reveal_tx: &Transaction,
+    commit_output: &TxOut,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> Result<(TxAttempt, Sighash), ReplacementError> {
+    let mut replacement_tx = active_reveal_tx.clone();
+    set_reveal_replacement_fee(&mut replacement_tx, commit_output, target_fee_rate)?;
+
+    let (reveal_script, _) = extract_reveal_witness(active_reveal_tx)?;
+    replacement_tx.input[0].witness.clear();
+    let sighash =
+        compute_taproot_script_spend_sighash(&replacement_tx, commit_output, &reveal_script)
+            .map_err(ReplacementError::RevealSigning)?;
+    let fee = reveal_fee(&replacement_tx, commit_output);
+
+    Ok((
+        TxAttempt::pending_signature(&replacement_tx, target_fee_rate, fee, attempt_no),
+        Buf32(sighash),
+    ))
+}
+
+/// Re-signs an existing chunked reveal so it spends a replacement commit output.
+pub(crate) fn rebuild_reveal_for_replaced_commit(
+    old_reveal_tx: &Transaction,
+    replacement_commit_txid: Txid,
+    replacement_commit_output: &TxOut,
+    sequencer_keypair: &Keypair,
+) -> Result<Transaction, ReplacementError> {
+    let mut replacement_reveal = old_reveal_tx.clone();
+    let input = replacement_reveal
+        .input
+        .first_mut()
+        .ok_or(ReplacementError::MissingRevealWitness)?;
+    input.previous_output.txid = replacement_commit_txid;
+    input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+
+    let (reveal_script, control_block) = extract_reveal_witness(old_reveal_tx)?;
+    replacement_reveal.input[0].witness.clear();
+    let sighash = compute_taproot_script_spend_sighash(
+        &replacement_reveal,
+        replacement_commit_output,
+        &reveal_script,
+    )
+    .map_err(ReplacementError::RevealSigning)?;
+    let message = Message::from_digest_slice(sighash.as_ref())
+        .map_err(|error| ReplacementError::RevealSigning(error.into()))?;
+    let signature = SECP256K1.sign_schnorr(&message, sequencer_keypair);
+    attach_reveal_witness(
+        &mut replacement_reveal,
+        &reveal_script,
+        &control_block,
+        signature.as_ref(),
+    )?;
+
+    Ok(replacement_reveal)
+}
+
+pub(crate) fn extract_reveal_witness(
+    tx: &Transaction,
+) -> Result<(ScriptBuf, ControlBlock), ReplacementError> {
+    let witness = tx
+        .input
+        .first()
+        .ok_or(ReplacementError::MissingRevealWitness)?
+        .witness
+        .iter()
+        .collect::<Vec<_>>();
+    let reveal_script = witness
+        .get(1)
+        .ok_or(ReplacementError::MissingRevealWitness)?;
+    let control_block = witness
+        .get(2)
+        .ok_or(ReplacementError::MissingRevealWitness)?;
+    let control_block = ControlBlock::decode(control_block)
+        .map_err(|error| ReplacementError::InvalidControlBlock(error.to_string()))?;
+    Ok((ScriptBuf::from_bytes(reveal_script.to_vec()), control_block))
+}
+
+/// Returns the x-only key committed in an active reveal's tapscript.
+///
+/// SPS-51 reveal scripts open with `<pubkey> OP_CHECKSIG`, so the leading push is the key any
+/// witness signature must verify against. A replacement reuses the original script, which makes
+/// this the key the signer has to still hold.
+pub(crate) fn extract_reveal_pubkey(tx: &Transaction) -> Result<XOnlyPublicKey, ReplacementError> {
+    let (reveal_script, _) = extract_reveal_witness(tx)?;
+    reveal_script_pubkey(&reveal_script)
+}
+
+/// Returns the x-only key a reveal tapscript commits to.
+pub(crate) fn reveal_script_pubkey(
+    reveal_script: &ScriptBuf,
+) -> Result<XOnlyPublicKey, ReplacementError> {
+    let Some(Ok(Instruction::PushBytes(pubkey))) = reveal_script.instructions().next() else {
+        return Err(ReplacementError::MissingRevealWitness);
+    };
+    XOnlyPublicKey::from_slice(pubkey.as_bytes())
+        .map_err(|error| ReplacementError::InvalidRevealPubkey(error.to_string()))
+}
+
+pub(crate) fn compute_taproot_script_spend_sighash(
+    reveal_tx: &Transaction,
+    output_to_reveal: &TxOut,
+    reveal_script: &ScriptBuf,
+) -> anyhow::Result<[u8; 32]> {
+    let mut sighash_cache = SighashCache::new(reveal_tx);
+    let signature_hash = sighash_cache.taproot_script_spend_signature_hash(
+        0,
+        &Prevouts::All(from_ref(output_to_reveal)),
+        TapLeafHash::from_script(reveal_script, LeafVersion::TapScript),
+        TapSighashType::Default,
+    )?;
+    Ok(signature_hash.to_byte_array())
+}
+
+pub(crate) fn attach_reveal_witness(
+    reveal_tx: &mut Transaction,
+    reveal_script: &ScriptBuf,
+    control_block: &ControlBlock,
+    signature: &[u8; 64],
+) -> Result<(), ReplacementError> {
+    let signature = Signature::from_slice(signature).map_err(|error| {
+        ReplacementError::RevealSigning(anyhow::anyhow!("invalid schnorr signature: {error}"))
+    })?;
+    let witness = &mut reveal_tx.input[0].witness;
+    witness.push(signature.as_ref());
+    witness.push(reveal_script);
+    witness.push(control_block.serialize());
+    Ok(())
+}
+
+fn set_reveal_replacement_fee(
+    replacement_tx: &mut Transaction,
+    commit_output: &TxOut,
+    target_fee_rate: FeeRate,
+) -> Result<(), ReplacementError> {
+    if let Some(input) = replacement_tx.input.first_mut() {
+        input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+    }
+
+    let target_fee = target_fee_rate
+        .fee_vb(replacement_tx.vsize() as u64)
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    let other_output_value = replacement_tx
+        .output
+        .iter()
+        .take(replacement_tx.output.len().saturating_sub(1))
+        .map(|output| output.value)
+        .sum::<Amount>();
+    let output_and_fee = other_output_value
+        .checked_add(target_fee)
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    let replacement_output = replacement_tx
+        .output
+        .last_mut()
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    let new_output_value = commit_output
+        .value
+        .checked_sub(output_and_fee)
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    if new_output_value.to_sat() < BITCOIN_DUST_LIMIT {
+        return Err(ReplacementError::ReplacementWouldDustOutput);
+    }
+    replacement_output.value = new_output_value;
+    Ok(())
+}
+
+fn reveal_fee(reveal_tx: &Transaction, commit_output: &TxOut) -> Amount {
+    let output_value = reveal_tx
+        .output
+        .iter()
+        .map(|output| output.value)
+        .sum::<Amount>();
+    commit_output
+        .value
+        .checked_sub(output_value)
+        .unwrap_or(Amount::ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime, opcodes, script::Builder as ScriptBuilder, transaction::Version,
+        OutPoint, TxIn, Witness, WitnessProgram, WitnessVersion,
+    };
+
+    use super::*;
+
+    fn op_return_output() -> TxOut {
+        TxOut {
+            value: Amount::ZERO,
+            script_pubkey: ScriptBuilder::new()
+                .push_opcode(opcodes::all::OP_RETURN)
+                .push_slice([1u8; 8])
+                .into_script(),
+        }
+    }
+
+    /// Builds a P2TR output directly from a witness program so tests need no valid curve point.
+    fn p2tr_output(value: u64, seed: u8) -> TxOut {
+        let program = WitnessProgram::new(WitnessVersion::V1, &[seed; 32]).expect("valid program");
+        TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: ScriptBuf::new_witness_program(&program),
+        }
+    }
+
+    fn p2wpkh_output(value: u64) -> TxOut {
+        TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array([7u8; 20])),
+        }
+    }
+
+    fn test_pubkey(seed: u8) -> XOnlyPublicKey {
+        let keypair = Keypair::from_seckey_slice(SECP256K1, &[seed; 32]).expect("valid secret key");
+        XOnlyPublicKey::from_keypair(&keypair).0
+    }
+
+    /// Builds a reveal spending a tapscript that commits to `pubkey`, as SPS-51 reveals do.
+    fn reveal_committing_to(pubkey: &XOnlyPublicKey) -> Transaction {
+        let reveal_script = ScriptBuilder::new()
+            .push_slice(pubkey.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+
+        let mut control_block = vec![LeafVersion::TapScript.to_consensus()];
+        control_block.extend_from_slice(&pubkey.serialize());
+
+        let mut witness = Witness::new();
+        witness.push([0u8; 64]);
+        witness.push(reveal_script.as_bytes());
+        witness.push(&control_block);
+
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness,
+            }],
+            output: vec![p2tr_output(5_000, 1)],
+        }
+    }
+
+    #[test]
+    fn extracts_the_key_committed_in_the_reveal_script() {
+        let pubkey = test_pubkey(1);
+
+        assert_eq!(
+            extract_reveal_pubkey(&reveal_committing_to(&pubkey)).expect("pubkey is recoverable"),
+            pubkey
+        );
+    }
+
+    /// The rotation guard depends on this: a reveal built under one key must not compare equal to
+    /// a different signer key.
+    #[test]
+    fn extracted_key_differs_across_reveals_built_under_different_keys() {
+        let extracted = extract_reveal_pubkey(&reveal_committing_to(&test_pubkey(1)))
+            .expect("pubkey is recoverable");
+
+        assert_ne!(extracted, test_pubkey(2));
+    }
+
+    #[test]
+    fn rejects_a_reveal_whose_script_does_not_open_with_a_key() {
+        let mut tx = reveal_committing_to(&test_pubkey(1));
+        let control_block = tx.input[0]
+            .witness
+            .iter()
+            .nth(2)
+            .expect("control block")
+            .to_vec();
+        let script = ScriptBuilder::new()
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+
+        let mut witness = Witness::new();
+        witness.push([0u8; 64]);
+        witness.push(script.as_bytes());
+        witness.push(&control_block);
+        tx.input[0].witness = witness;
+
+        assert!(matches!(
+            extract_reveal_pubkey(&tx),
+            Err(ReplacementError::MissingRevealWitness)
+        ));
+    }
+
+    fn commit_with(outputs: Vec<TxOut>) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: outputs,
+        }
+    }
+
+    /// Two reveals: `[OP_RETURN, P2TR, P2TR]` plus an optional change output.
+    fn original_commit() -> Transaction {
+        commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+            p2wpkh_output(20_000),
+        ])
+    }
+
+    /// Core's own change detection ignores anything in the wallet's address book, which is where
+    /// the sequencer address lives, so the index has to be supplied or every bump adds inputs and
+    /// is refused.
+    #[test]
+    fn change_index_points_past_the_reveal_funding_run() {
+        assert_eq!(chunked_commit_change_index(&original_commit(), 2), Some(3));
+    }
+
+    #[test]
+    fn no_change_index_when_the_commit_has_no_change_output() {
+        let commit = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+        ]);
+
+        assert_eq!(chunked_commit_change_index(&commit, 2), None);
+    }
+
+    #[test]
+    fn accepts_replacement_that_only_shrinks_change() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+            p2wpkh_output(18_000),
+        ]);
+
+        assert!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2).is_ok()
+        );
+    }
+
+    #[test]
+    fn accepts_replacement_that_drops_change_entirely() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+        ]);
+
+        assert!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2).is_ok()
+        );
+    }
+
+    /// A taproot change output would extend the P2TR run the ASM guest uses to count reveals.
+    #[test]
+    fn rejects_replacement_with_p2tr_change() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+            p2tr_output(18_000, 3),
+        ]);
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_replacement_that_shrinks_a_reveal_funding_output() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(4_000, 2),
+            p2wpkh_output(20_000),
+        ]);
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_replacement_that_drops_a_reveal_funding_output() {
+        let replacement = commit_with(vec![op_return_output(), p2tr_output(5_000, 1)]);
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_replacement_that_changes_the_op_return() {
+        let mut replacement = original_commit();
+        replacement.output[0].script_pubkey = ScriptBuilder::new()
+            .push_opcode(opcodes::all::OP_RETURN)
+            .push_slice([9u8; 8])
+            .into_script();
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn incompatible_commit_layout_is_not_retryable_and_is_terminal() {
+        let error = ReplacementError::IncompatibleCommitLayout("test".to_string());
+
+        assert!(!error.is_retryable());
+        assert_eq!(error.terminal_error(), TerminalError::UnsupportedRbfKind);
+    }
+
+    /// The wallet can pay more than it was asked for, most often by absorbing sub-dust change into
+    /// the fee. Recording the target instead would understate the rate the next bump escalates
+    /// from, and a target below what is already on the wire is a replacement Core rejects.
+    #[test]
+    fn effective_fee_rate_reflects_what_the_wallet_actually_paid() {
+        let tx = commit_with(vec![p2wpkh_output(1_000)]);
+        let vsize = tx.vsize() as u64;
+        let fee = Amount::from_sat(vsize * 7 + 1);
+
+        assert_eq!(
+            effective_fee_rate(&tx, fee),
+            FeeRate::from_sat_per_vb(8),
+            "the rate rounds up so the recorded value is never under what was paid"
+        );
+    }
+
+    #[test]
+    fn effective_fee_rate_matches_the_target_when_the_wallet_paid_it_exactly() {
+        let tx = commit_with(vec![p2wpkh_output(1_000)]);
+        let fee = Amount::from_sat(tx.vsize() as u64 * 3);
+
+        assert_eq!(effective_fee_rate(&tx, fee), FeeRate::from_sat_per_vb(3));
+    }
+}

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -44,6 +44,11 @@ pub(crate) enum ReplacementError {
     InvalidControlBlock(String),
     #[error("invalid reveal tapscript pubkey: {0}")]
     InvalidRevealPubkey(String),
+    /// Keys are held as strings so the variant stays small: an inline [`XOnlyPublicKey`] pair is
+    /// 128 bytes, which would grow every `Result<_, ReplacementError>` in this module past
+    /// `clippy::result_large_err`.
+    #[error("reveal tapscript commits to {committed} but the signer holds {held}")]
+    RevealKeyRotated { committed: String, held: String },
     #[error("replacement would reduce reveal output below dust")]
     ReplacementWouldDustOutput,
     #[error("replacement commit output layout is incompatible with the envelope: {0}")]
@@ -71,6 +76,7 @@ impl ReplacementError {
             | Self::MissingRevealWitness
             | Self::InvalidControlBlock(_)
             | Self::InvalidRevealPubkey(_)
+            | Self::RevealKeyRotated { .. }
             | Self::ReplacementWouldDustOutput
             | Self::IncompatibleCommitLayout(_)
             | Self::ReplacementAddsInputs(_)
@@ -96,6 +102,7 @@ impl ReplacementError {
             Self::MissingRevealWitness
             | Self::InvalidControlBlock(_)
             | Self::InvalidRevealPubkey(_)
+            | Self::RevealKeyRotated { .. }
             | Self::RevealSigning(_)
             | Self::IncompatibleCommitLayout(_) => TerminalError::UnsupportedRbfKind,
             Self::ReplacementAddsInputs(_) => TerminalError::ReplacementAddsInputs,
@@ -304,6 +311,27 @@ fn reject_added_inputs(
     Ok(())
 }
 
+/// Verifies the sequencer still holds the key `reveal_tx`'s tapscript commits to.
+///
+/// A replacement reuses the original tapscript, so a signature under any other key yields a witness
+/// that can never satisfy it — and by the time bitcoind says so the original is already marked
+/// `Replaced`, leaving the envelope stuck with nothing to rebuild it. The single-envelope path
+/// makes the same check against its external signer's key.
+pub(crate) fn ensure_reveal_signable(
+    reveal_tx: &Transaction,
+    sequencer_keypair: &Keypair,
+) -> Result<(), ReplacementError> {
+    let committed = extract_reveal_pubkey(reveal_tx)?;
+    let held = XOnlyPublicKey::from_keypair(sequencer_keypair).0;
+    if committed != held {
+        return Err(ReplacementError::RevealKeyRotated {
+            committed: committed.to_string(),
+            held: held.to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Rebuilds and signs a chunked-envelope reveal by reducing its spendable output.
 pub(crate) fn build_chunked_reveal_replacement(
     active_reveal_tx: &Transaction,
@@ -312,6 +340,8 @@ pub(crate) fn build_chunked_reveal_replacement(
     attempt_no: u32,
     sequencer_keypair: &Keypair,
 ) -> Result<TxAttempt, ReplacementError> {
+    ensure_reveal_signable(active_reveal_tx, sequencer_keypair)?;
+
     let mut replacement_tx = active_reveal_tx.clone();
     set_reveal_replacement_fee(&mut replacement_tx, commit_output, target_fee_rate)?;
 
@@ -368,6 +398,8 @@ pub(crate) fn rebuild_reveal_for_replaced_commit(
     replacement_commit_output: &TxOut,
     sequencer_keypair: &Keypair,
 ) -> Result<Transaction, ReplacementError> {
+    ensure_reveal_signable(old_reveal_tx, sequencer_keypair)?;
+
     let mut replacement_reveal = old_reveal_tx.clone();
     let input = replacement_reveal
         .input
@@ -557,9 +589,12 @@ mod tests {
         }
     }
 
+    fn test_keypair(seed: u8) -> Keypair {
+        Keypair::from_seckey_slice(SECP256K1, &[seed; 32]).expect("valid secret key")
+    }
+
     fn test_pubkey(seed: u8) -> XOnlyPublicKey {
-        let keypair = Keypair::from_seckey_slice(SECP256K1, &[seed; 32]).expect("valid secret key");
-        XOnlyPublicKey::from_keypair(&keypair).0
+        XOnlyPublicKey::from_keypair(&test_keypair(seed)).0
     }
 
     /// Builds a reveal spending a tapscript that commits to `pubkey`, as SPS-51 reveals do.
@@ -608,6 +643,100 @@ mod tests {
             .expect("pubkey is recoverable");
 
         assert_ne!(extracted, test_pubkey(2));
+    }
+
+    #[test]
+    fn accepts_a_reveal_the_signer_still_holds_the_key_for() {
+        let reveal = reveal_committing_to(&test_pubkey(1));
+
+        assert!(ensure_reveal_signable(&reveal, &test_keypair(1)).is_ok());
+    }
+
+    /// Regression: a replacement reuses the original tapscript, so signing it under a rotated key
+    /// yields a witness that can never satisfy that script — and the original is marked `Replaced`
+    /// before bitcoind ever says so. Refusing is what leaves the envelope for the writer to
+    /// rebuild.
+    #[test]
+    fn refuses_a_reveal_whose_committed_key_has_rotated() {
+        let reveal = reveal_committing_to(&test_pubkey(1));
+
+        let error = ensure_reveal_signable(&reveal, &test_keypair(2))
+            .expect_err("a rotated key must not be signed with");
+
+        assert!(matches!(error, ReplacementError::RevealKeyRotated { .. }));
+        assert!(!error.is_retryable());
+        assert_eq!(error.terminal_error(), TerminalError::UnsupportedRbfKind);
+    }
+
+    /// Documents why [`evaluate_fee_bump`] refuses reveal kinds outright.
+    ///
+    /// Both envelope builders size a reveal's commit output at exactly
+    /// `reveal_amount + reveal_fee(build_rate)`, with `reveal_amount` equal to the dust limit
+    /// (`calculate_reveal_commit_value`, `calculate_commit_output_value`). The reveal's own output
+    /// therefore already sits at dust, and shrinking it is the only way a replacement can pay more.
+    /// A target one sat/vB above the build rate is enough to push it under.
+    ///
+    /// If this ever starts returning `Ok`, the commit output has gained build-time headroom and the
+    /// refusal in the fee-bump policy can be lifted — see TODO(STR-4198), which replaces this test
+    /// with one asserting a production-shaped reveal bump succeeds.
+    ///
+    /// [`evaluate_fee_bump`]: crate::broadcaster::fee_bump::evaluate_fee_bump
+    #[test]
+    fn a_production_shaped_reveal_has_no_headroom_to_bump_into() {
+        let build_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+        let mut reveal = reveal_committing_to(&test_pubkey(1));
+        reveal.output = vec![p2tr_output(BITCOIN_DUST_LIMIT, 1)];
+        let commit_value = Amount::from_sat(BITCOIN_DUST_LIMIT)
+            + build_rate
+                .fee_vb(reveal.vsize() as u64)
+                .expect("reveal fee fits");
+        let commit_output = TxOut {
+            value: commit_value,
+            script_pubkey: reveal.output[0].script_pubkey.clone(),
+        };
+
+        let error = build_chunked_reveal_replacement(
+            &reveal,
+            &commit_output,
+            FeeRate::from_sat_per_vb(3).expect("valid fee rate"),
+            1,
+            &test_keypair(1),
+        )
+        .expect_err("a reveal built this way cannot fund any bump");
+
+        assert!(matches!(
+            error,
+            ReplacementError::ReplacementWouldDustOutput
+        ));
+    }
+
+    #[test]
+    fn chunked_reveal_replacement_refuses_a_rotated_key() {
+        let error = build_chunked_reveal_replacement(
+            &reveal_committing_to(&test_pubkey(1)),
+            &p2tr_output(10_000, 2),
+            FeeRate::from_sat_per_vb(4).expect("valid fee rate"),
+            1,
+            &test_keypair(2),
+        )
+        .expect_err("a rotated key must not be signed with");
+
+        assert!(matches!(error, ReplacementError::RevealKeyRotated { .. }));
+    }
+
+    /// The commit path re-signs every reveal of the envelope, so the same guard has to hold there:
+    /// one rotated reveal would otherwise take the whole envelope down with it.
+    #[test]
+    fn commit_replacement_reveal_rebuild_refuses_a_rotated_key() {
+        let error = rebuild_reveal_for_replaced_commit(
+            &reveal_committing_to(&test_pubkey(1)),
+            Txid::from_byte_array([3u8; 32]),
+            &p2tr_output(10_000, 2),
+            &test_keypair(2),
+        )
+        .expect_err("a rotated key must not be signed with");
+
+        assert!(matches!(error, ReplacementError::RevealKeyRotated { .. }));
     }
 
     #[test]

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -48,6 +48,13 @@ pub(crate) enum ReplacementError {
     RevealKeyRotated { committed: String, held: String },
     #[error("replacement would reduce reveal output below dust")]
     ReplacementWouldDustOutput,
+    /// Discarded by the commit path rather than treated as terminal: which candidate the wallet
+    /// builds depends on its UTXO set, so a later one can land under the ceiling.
+    #[error("wallet built a replacement paying {built_sat_vb} sat/vB, above the configured ceiling of {ceiling_sat_vb} sat/vB")]
+    ExceedsMaxFeeRate {
+        built_sat_vb: u64,
+        ceiling_sat_vb: u64,
+    },
     #[error("replacement commit output layout is incompatible with the envelope: {0}")]
     IncompatibleCommitLayout(String),
     #[error("replacement would spend {0} wallet input(s) the original did not")]
@@ -67,6 +74,9 @@ impl ReplacementError {
             Self::PsbtBumpFee(error) | Self::WalletProcessPsbt(error) => {
                 is_retryable_client_error(error)
             }
+            // Not transient, but the commit path discards this candidate instead of ending the
+            // chain; see the variant's own note.
+            Self::ExceedsMaxFeeRate { .. } => false,
             Self::UnsupportedKind(_)
             | Self::IncompletePsbt
             | Self::MissingFinalTransaction
@@ -104,6 +114,7 @@ impl ReplacementError {
             | Self::IncompatibleCommitLayout(_) => TerminalError::UnsupportedRbfKind,
             Self::ReplacementAddsInputs(_) => TerminalError::ReplacementAddsInputs,
             Self::ReplacementWouldDustOutput => TerminalError::ReplacementWouldDustOutput,
+            Self::ExceedsMaxFeeRate { .. } => TerminalError::AboveMaxFeeRate,
         }
     }
 }
@@ -127,12 +138,21 @@ impl ReplacementError {
 /// `original_change_index` names the output Core should recycle to pay the higher fee. Passing it
 /// is not an optimisation: see [`chunked_commit_change_index`] for why leaving Core to find the
 /// change itself would make every chunked commit bump fail.
+///
+/// `max_fee_rate` is the operator's configured replacement ceiling. `target_fee_rate` is already
+/// capped by it, but the wallet prices the fee off the transaction it ends up building and can pay
+/// more than it was asked for, so the built candidate is checked against the ceiling too.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the wallet call needs every input threaded through explicitly"
+)]
 pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
     client: &C,
     kind: &TxNodeKind,
     original_tx: &Transaction,
     active_txid: L1TxId,
     target_fee_rate: FeeRate,
+    max_fee_rate: FeeRate,
     attempt_no: u32,
     original_change_index: Option<u32>,
 ) -> Result<TxAttempt, ReplacementError> {
@@ -176,10 +196,22 @@ pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
     // from this number, and a target below the fee rate already on the wire is one Core rejects.
     let fee = Amount::from_sat(bumped.fee.to_sat());
     let effective_fee_rate = effective_fee_rate(&tx, fee).unwrap_or(target_fee_rate);
+    let recorded_fee_rate = effective_fee_rate.max(target_fee_rate);
+
+    // `target_fee_rate` already clears the ceiling, but what the wallet built need not: absorbing a
+    // sub-dust change output into the fee raises the rate above what was asked for. Adopting it
+    // anyway would put a transaction on the wire that breaches the operator's safety cap, and would
+    // also seed the next bump's floors from a rate the ceiling forbids.
+    if recorded_fee_rate > max_fee_rate {
+        return Err(ReplacementError::ExceedsMaxFeeRate {
+            built_sat_vb: recorded_fee_rate.to_sat_per_vb_ceil(),
+            ceiling_sat_vb: max_fee_rate.to_sat_per_vb_ceil(),
+        });
+    }
 
     Ok(TxAttempt::new(
         &tx,
-        effective_fee_rate.max(target_fee_rate),
+        recorded_fee_rate,
         fee,
         attempt_no,
         TxAttemptStatus::Active,
@@ -559,6 +591,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::test_utils::TestBitcoinClient;
 
     fn op_return_output() -> TxOut {
         TxOut {
@@ -916,5 +949,49 @@ mod tests {
         let fee = Amount::from_sat(tx.vsize() as u64 * 3);
 
         assert_eq!(effective_fee_rate(&tx, fee), FeeRate::from_sat_per_vb(3));
+    }
+
+    /// The mock wallet always reports a 0.01 BTC fee, which over this transaction is far more than
+    /// the target asks for — the same overshoot Core produces when it absorbs sub-dust change.
+    async fn wallet_replacement_with_ceiling(
+        ceiling_sat_vb: u64,
+    ) -> Result<TxAttempt, ReplacementError> {
+        let original = commit_with(vec![p2wpkh_output(1_000)]);
+        let client =
+            TestBitcoinClient::new(1).with_wallet_process_psbt_result(true, Some(original.clone()));
+
+        build_wallet_commit_replacement(
+            &client,
+            &TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 0 },
+            &original,
+            L1TxId::from([0u8; 32]),
+            FeeRate::from_sat_per_vb(4).expect("valid fee rate"),
+            FeeRate::from_sat_per_vb(ceiling_sat_vb).expect("valid fee rate"),
+            1,
+            None,
+        )
+        .await
+    }
+
+    /// Regression: the target is capped by the ceiling, but the rate the wallet actually builds is
+    /// not, and it is that transaction which reaches the wire and seeds the next bump's floors.
+    #[tokio::test]
+    async fn rejects_a_wallet_replacement_that_breaches_the_fee_rate_ceiling() {
+        let error = wallet_replacement_with_ceiling(1_000)
+            .await
+            .expect_err("a replacement above the ceiling must not be adopted");
+
+        assert!(matches!(error, ReplacementError::ExceedsMaxFeeRate { .. }));
+        assert!(!error.is_retryable());
+        assert_eq!(error.terminal_error(), TerminalError::AboveMaxFeeRate);
+    }
+
+    #[tokio::test]
+    async fn accepts_a_wallet_replacement_that_stays_under_the_fee_rate_ceiling() {
+        let attempt = wallet_replacement_with_ceiling(1_000_000)
+            .await
+            .expect("a replacement under the ceiling is adopted");
+
+        assert_eq!(attempt.fee(), Amount::from_sat(1_000_000));
     }
 }

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -1,0 +1,817 @@
+//! Replacement transaction builders.
+
+use std::slice::from_ref;
+
+use bitcoin::{
+    hashes::Hash,
+    key::Keypair,
+    script::Instruction,
+    secp256k1::{schnorr::Signature, Message, XOnlyPublicKey, SECP256K1},
+    sighash::{Prevouts, SighashCache, TapSighashType},
+    taproot::{ControlBlock, LeafVersion, TapLeafHash},
+    Amount, FeeRate, ScriptBuf, Sequence, Transaction, TxOut, Txid,
+};
+use bitcoind_async_client::{error::ClientError, traits::Signer, types::PsbtBumpFeeOptions};
+use strata_db_types::{
+    common::L1TxId,
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeKind},
+    l1_writer::Sighash,
+};
+use strata_primitives::buf::Buf32;
+use thiserror::Error;
+
+use crate::{
+    rpc_error::is_retryable_client_error, tx_attempt::attempt_parts,
+    writer::builder::BITCOIN_DUST_LIMIT,
+};
+
+/// Errors raised while building a replacement transaction.
+#[derive(Debug, Error)]
+pub(crate) enum ReplacementError {
+    #[error("unsupported RBF transaction kind: {0:?}")]
+    UnsupportedKind(TxNodeKind),
+    #[error("Bitcoin wallet could not bump fee: {0}")]
+    PsbtBumpFee(#[source] ClientError),
+    #[error("Bitcoin wallet could not sign replacement PSBT: {0}")]
+    WalletProcessPsbt(#[source] ClientError),
+    #[error("wallet returned incomplete replacement PSBT")]
+    IncompletePsbt,
+    #[error("wallet returned no finalized replacement transaction")]
+    MissingFinalTransaction,
+    #[error("active reveal transaction is missing its tapscript witness")]
+    MissingRevealWitness,
+    #[error("invalid reveal control block: {0}")]
+    InvalidControlBlock(String),
+    #[error("invalid reveal tapscript pubkey: {0}")]
+    InvalidRevealPubkey(String),
+    #[error("replacement would reduce reveal output below dust")]
+    ReplacementWouldDustOutput,
+    #[error("replacement commit output layout is incompatible with the envelope: {0}")]
+    IncompatibleCommitLayout(String),
+    #[error("replacement would spend {0} wallet input(s) the original did not")]
+    ReplacementAddsInputs(usize),
+    #[error("failed to sign reveal replacement: {0}")]
+    RevealSigning(#[source] anyhow::Error),
+}
+
+impl ReplacementError {
+    /// Reports whether the failure is transient and the replacement is worth retrying.
+    ///
+    /// Wallet RPC calls fail for transport reasons too — bitcoind restarting, warming up, or
+    /// briefly unreachable. Those must not burn the node's fee-bump chain, because a terminal
+    /// error is permanent and would leave the transaction stuck at its original fee forever.
+    pub(crate) fn is_retryable(&self) -> bool {
+        match self {
+            Self::PsbtBumpFee(error) | Self::WalletProcessPsbt(error) => {
+                is_retryable_client_error(error)
+            }
+            Self::UnsupportedKind(_)
+            | Self::IncompletePsbt
+            | Self::MissingFinalTransaction
+            | Self::MissingRevealWitness
+            | Self::InvalidControlBlock(_)
+            | Self::InvalidRevealPubkey(_)
+            | Self::ReplacementWouldDustOutput
+            | Self::IncompatibleCommitLayout(_)
+            | Self::ReplacementAddsInputs(_)
+            | Self::RevealSigning(_) => false,
+        }
+    }
+
+    /// Maps non-recoverable replacement failures to terminal node errors.
+    ///
+    /// Only call this after [`ReplacementError::is_retryable`] has returned `false`.
+    pub(crate) fn terminal_error(&self) -> TerminalError {
+        match self {
+            Self::UnsupportedKind(_) => TerminalError::UnsupportedRbfKind,
+            Self::PsbtBumpFee(ClientError::Server(_, msg))
+                if msg.to_ascii_lowercase().contains("insufficient") =>
+            {
+                TerminalError::WalletInsufficient
+            }
+            Self::PsbtBumpFee(_) => TerminalError::Bip125FeeRuleUnsatisfiable,
+            Self::WalletProcessPsbt(_) | Self::IncompletePsbt | Self::MissingFinalTransaction => {
+                TerminalError::WalletInsufficient
+            }
+            Self::MissingRevealWitness
+            | Self::InvalidControlBlock(_)
+            | Self::InvalidRevealPubkey(_)
+            | Self::RevealSigning(_)
+            | Self::IncompatibleCommitLayout(_) => TerminalError::UnsupportedRbfKind,
+            Self::ReplacementAddsInputs(_) => TerminalError::ReplacementAddsInputs,
+            Self::ReplacementWouldDustOutput => TerminalError::ReplacementWouldDustOutput,
+        }
+    }
+}
+
+/// Builds a wallet-owned commit replacement using Bitcoin Core's wallet RBF flow.
+///
+/// # Coin selection
+///
+/// When the original change output cannot absorb the higher fee, Core's fee bumper pulls in
+/// additional confirmed wallet UTXOs. `psbtbumpfee` returns a PSBT rather than committing it, so
+/// those inputs stay unlocked and keep appearing in `listunspent` until the replacement is
+/// broadcast — a writer building another envelope in that window could select the same UTXO, and
+/// whichever transaction Core saw first would invalidate the other.
+///
+/// Reserving those inputs properly needs `lockunspent`, which `bitcoind-async-client` does not
+/// expose, plus durable bookkeeping to release the locks when a replacement is discarded. Until
+/// then this fails closed: a replacement that spends any input the original did not is rejected.
+/// Change-funded bumps — the common case — are unaffected. The cost is that a bump needing extra
+/// inputs cannot proceed, which is a liveness limit rather than a correctness hazard.
+///
+/// `original_change_index` names the output Core should recycle to pay the higher fee. Passing it
+/// is not an optimisation: see [`chunked_commit_change_index`] for why leaving Core to find the
+/// change itself would make every chunked commit bump fail.
+pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
+    client: &C,
+    kind: &TxNodeKind,
+    original_tx: &Transaction,
+    active_txid: L1TxId,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+    original_change_index: Option<u32>,
+) -> Result<TxAttempt, ReplacementError> {
+    if !matches!(
+        kind,
+        TxNodeKind::SingleEnvelopeCommit { .. } | TxNodeKind::ChunkedEnvelopeCommit { .. }
+    ) {
+        return Err(ReplacementError::UnsupportedKind(kind.clone()));
+    }
+
+    let txid = Txid::from_byte_array(active_txid.0);
+    let bumped = client
+        .psbt_bump_fee(
+            &txid,
+            Some(PsbtBumpFeeOptions {
+                fee_rate: Some(target_fee_rate),
+                replaceable: Some(true),
+                original_change_index,
+                ..PsbtBumpFeeOptions::default()
+            }),
+        )
+        .await
+        .map_err(ReplacementError::PsbtBumpFee)?;
+
+    let processed = client
+        .wallet_process_psbt(&bumped.psbt.to_string(), Some(true), None, None)
+        .await
+        .map_err(ReplacementError::WalletProcessPsbt)?;
+    if !processed.complete {
+        return Err(ReplacementError::IncompletePsbt);
+    }
+    let tx: Transaction = processed
+        .hex
+        .ok_or(ReplacementError::MissingFinalTransaction)?;
+
+    reject_added_inputs(original_tx, &tx)?;
+
+    // Record what the wallet actually built, not what it was asked for. Core sizes the fee from
+    // the final transaction and can absorb sub-dust change into it, so the replacement often pays
+    // more than `target_fee_rate`. The next bump derives its additive and multiplicative floors
+    // from this number, and a target below the fee rate already on the wire is one Core rejects.
+    let fee = Amount::from_sat(bumped.fee.to_sat());
+    let effective_fee_rate = effective_fee_rate(&tx, fee).unwrap_or(target_fee_rate);
+
+    Ok(TxAttempt::new(
+        attempt_parts(&tx, effective_fee_rate.max(target_fee_rate), fee),
+        attempt_no,
+        TxAttemptStatus::Active,
+    ))
+}
+
+/// Derives the fee rate a built transaction actually pays, rounded up.
+///
+/// `None` when the rate does not fit a [`FeeRate`], which leaves the caller with the target it
+/// asked for rather than no attempt at all.
+fn effective_fee_rate(tx: &Transaction, fee: Amount) -> Option<FeeRate> {
+    let vsize = tx.vsize() as u64;
+    if vsize == 0 {
+        return None;
+    }
+    FeeRate::from_sat_per_vb(fee.to_sat().div_ceil(vsize))
+}
+
+/// Locates the change output Core should recycle when bumping a chunked commit.
+///
+/// Core only auto-detects an output as change when it is `IsMine` *and* absent from the wallet's
+/// address book. The commit pays its change to the sequencer address, which both binaries obtain
+/// from `getnewaddress`, and that writes an address-book entry. Left to its own detection Core
+/// therefore treats every output as a fixed recipient, has nothing it is allowed to shrink, and can
+/// only raise the fee by pulling in new inputs — which [`reject_added_inputs`] refuses, ending the
+/// chain terminal on the very first bump. Naming the index sidesteps the heuristic entirely.
+///
+/// The layout is `[OP_RETURN, one funding output per reveal, change?]`; the builder appends change
+/// last and only when the excess clears dust. `None` means there is no change output, and a bump
+/// then genuinely does need new inputs (known gap 1).
+pub(crate) fn chunked_commit_change_index(
+    commit_tx: &Transaction,
+    reveal_count: usize,
+) -> Option<u32> {
+    let change_index = reveal_count + 1;
+    if commit_tx.output.len() > change_index {
+        u32::try_from(change_index).ok()
+    } else {
+        None
+    }
+}
+
+/// Checks that a replacement chunked commit still has the output layout the envelope requires.
+///
+/// The ASM guest infers the reveal count from the run of consecutive P2TR outputs that follows
+/// the commit `OP_RETURN`, and each reveal is funded by exactly one of those outputs. Bitcoin
+/// Core's `psbtbumpfee` is free to reduce, drop, or append a change output; if the wallet's change
+/// type is taproot, an appended change output would extend that run and make the guest expect a
+/// reveal that does not exist. It may also shrink a reveal-funding output below what its reveal
+/// needs. Neither is recoverable, so verify the layout before adopting the replacement.
+pub(crate) fn validate_chunked_commit_replacement_layout(
+    original_commit: &Transaction,
+    replacement_commit: &Transaction,
+    reveal_count: usize,
+) -> Result<(), ReplacementError> {
+    let expected_prefix = reveal_count + 1;
+
+    if original_commit.output.len() < expected_prefix {
+        return Err(ReplacementError::IncompatibleCommitLayout(format!(
+            "original commit has {} outputs, expected at least {expected_prefix}",
+            original_commit.output.len()
+        )));
+    }
+    if replacement_commit.output.len() < expected_prefix {
+        return Err(ReplacementError::IncompatibleCommitLayout(format!(
+            "replacement commit has {} outputs, expected at least {expected_prefix}",
+            replacement_commit.output.len()
+        )));
+    }
+
+    let op_return = &replacement_commit.output[0];
+    if op_return.script_pubkey != original_commit.output[0].script_pubkey {
+        return Err(ReplacementError::IncompatibleCommitLayout(
+            "replacement commit changed the OP_RETURN output".to_string(),
+        ));
+    }
+
+    // Reveal-funding outputs must survive byte-identical: their values size each reveal's fee.
+    for vout in 1..expected_prefix {
+        let original = &original_commit.output[vout];
+        let replacement = &replacement_commit.output[vout];
+        if original.script_pubkey != replacement.script_pubkey
+            || original.value != replacement.value
+        {
+            return Err(ReplacementError::IncompatibleCommitLayout(format!(
+                "replacement commit altered reveal-funding output {vout}"
+            )));
+        }
+    }
+
+    // Anything past the reveal outputs is change, and must not extend the P2TR run.
+    for (offset, output) in replacement_commit.output[expected_prefix..]
+        .iter()
+        .enumerate()
+    {
+        if output.script_pubkey.is_p2tr() {
+            return Err(ReplacementError::IncompatibleCommitLayout(format!(
+                "replacement commit added a P2TR output at index {}, which would extend the reveal run",
+                expected_prefix + offset
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Rejects a replacement that spends wallet inputs the original transaction did not.
+///
+/// See the coin-selection note on [`build_wallet_commit_replacement`].
+fn reject_added_inputs(
+    original_tx: &Transaction,
+    replacement_tx: &Transaction,
+) -> Result<(), ReplacementError> {
+    let original_outpoints: Vec<_> = original_tx
+        .input
+        .iter()
+        .map(|input| input.previous_output)
+        .collect();
+    let added = replacement_tx
+        .input
+        .iter()
+        .filter(|input| !original_outpoints.contains(&input.previous_output))
+        .count();
+
+    if added > 0 {
+        return Err(ReplacementError::ReplacementAddsInputs(added));
+    }
+    Ok(())
+}
+
+/// Rebuilds and signs a chunked-envelope reveal by reducing its spendable output.
+pub(crate) fn build_chunked_reveal_replacement(
+    active_reveal_tx: &Transaction,
+    commit_output: &TxOut,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+    sequencer_keypair: &Keypair,
+) -> Result<TxAttempt, ReplacementError> {
+    let mut replacement_tx = active_reveal_tx.clone();
+    set_reveal_replacement_fee(&mut replacement_tx, commit_output, target_fee_rate)?;
+
+    let (reveal_script, control_block) = extract_reveal_witness(active_reveal_tx)?;
+    replacement_tx.input[0].witness.clear();
+    let sighash =
+        compute_taproot_script_spend_sighash(&replacement_tx, commit_output, &reveal_script)
+            .map_err(ReplacementError::RevealSigning)?;
+    let message = Message::from_digest_slice(sighash.as_ref())
+        .map_err(|error| ReplacementError::RevealSigning(error.into()))?;
+    let signature = SECP256K1.sign_schnorr(&message, sequencer_keypair);
+    attach_reveal_witness(
+        &mut replacement_tx,
+        &reveal_script,
+        &control_block,
+        signature.as_ref(),
+    )?;
+
+    let fee = reveal_fee(&replacement_tx, commit_output);
+    Ok(TxAttempt::new(
+        attempt_parts(&replacement_tx, target_fee_rate, fee),
+        attempt_no,
+        TxAttemptStatus::Active,
+    ))
+}
+
+/// Rebuilds a single-envelope reveal with a higher fee, leaving it unsigned.
+pub(crate) fn build_pending_single_reveal_replacement(
+    active_reveal_tx: &Transaction,
+    commit_output: &TxOut,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> Result<(TxAttempt, Sighash), ReplacementError> {
+    let mut replacement_tx = active_reveal_tx.clone();
+    set_reveal_replacement_fee(&mut replacement_tx, commit_output, target_fee_rate)?;
+
+    let (reveal_script, _) = extract_reveal_witness(active_reveal_tx)?;
+    replacement_tx.input[0].witness.clear();
+    let sighash =
+        compute_taproot_script_spend_sighash(&replacement_tx, commit_output, &reveal_script)
+            .map_err(ReplacementError::RevealSigning)?;
+    let fee = reveal_fee(&replacement_tx, commit_output);
+
+    Ok((
+        TxAttempt::pending_signature(attempt_parts(&replacement_tx, target_fee_rate, fee), attempt_no),
+        Buf32(sighash),
+    ))
+}
+
+/// Re-signs an existing chunked reveal so it spends a replacement commit output.
+pub(crate) fn rebuild_reveal_for_replaced_commit(
+    old_reveal_tx: &Transaction,
+    replacement_commit_txid: Txid,
+    replacement_commit_output: &TxOut,
+    sequencer_keypair: &Keypair,
+) -> Result<Transaction, ReplacementError> {
+    let mut replacement_reveal = old_reveal_tx.clone();
+    let input = replacement_reveal
+        .input
+        .first_mut()
+        .ok_or(ReplacementError::MissingRevealWitness)?;
+    input.previous_output.txid = replacement_commit_txid;
+    input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+
+    let (reveal_script, control_block) = extract_reveal_witness(old_reveal_tx)?;
+    replacement_reveal.input[0].witness.clear();
+    let sighash = compute_taproot_script_spend_sighash(
+        &replacement_reveal,
+        replacement_commit_output,
+        &reveal_script,
+    )
+    .map_err(ReplacementError::RevealSigning)?;
+    let message = Message::from_digest_slice(sighash.as_ref())
+        .map_err(|error| ReplacementError::RevealSigning(error.into()))?;
+    let signature = SECP256K1.sign_schnorr(&message, sequencer_keypair);
+    attach_reveal_witness(
+        &mut replacement_reveal,
+        &reveal_script,
+        &control_block,
+        signature.as_ref(),
+    )?;
+
+    Ok(replacement_reveal)
+}
+
+pub(crate) fn extract_reveal_witness(
+    tx: &Transaction,
+) -> Result<(ScriptBuf, ControlBlock), ReplacementError> {
+    let witness = tx
+        .input
+        .first()
+        .ok_or(ReplacementError::MissingRevealWitness)?
+        .witness
+        .iter()
+        .collect::<Vec<_>>();
+    let reveal_script = witness
+        .get(1)
+        .ok_or(ReplacementError::MissingRevealWitness)?;
+    let control_block = witness
+        .get(2)
+        .ok_or(ReplacementError::MissingRevealWitness)?;
+    let control_block = ControlBlock::decode(control_block)
+        .map_err(|error| ReplacementError::InvalidControlBlock(error.to_string()))?;
+    Ok((ScriptBuf::from_bytes(reveal_script.to_vec()), control_block))
+}
+
+/// Returns the x-only key committed in an active reveal's tapscript.
+///
+/// SPS-51 reveal scripts open with `<pubkey> OP_CHECKSIG`, so the leading push is the key any
+/// witness signature must verify against. A replacement reuses the original script, which makes
+/// this the key the signer has to still hold.
+pub(crate) fn extract_reveal_pubkey(tx: &Transaction) -> Result<XOnlyPublicKey, ReplacementError> {
+    let (reveal_script, _) = extract_reveal_witness(tx)?;
+    reveal_script_pubkey(&reveal_script)
+}
+
+/// Returns the x-only key a reveal tapscript commits to.
+pub(crate) fn reveal_script_pubkey(
+    reveal_script: &ScriptBuf,
+) -> Result<XOnlyPublicKey, ReplacementError> {
+    let Some(Ok(Instruction::PushBytes(pubkey))) = reveal_script.instructions().next() else {
+        return Err(ReplacementError::MissingRevealWitness);
+    };
+    XOnlyPublicKey::from_slice(pubkey.as_bytes())
+        .map_err(|error| ReplacementError::InvalidRevealPubkey(error.to_string()))
+}
+
+pub(crate) fn compute_taproot_script_spend_sighash(
+    reveal_tx: &Transaction,
+    output_to_reveal: &TxOut,
+    reveal_script: &ScriptBuf,
+) -> anyhow::Result<[u8; 32]> {
+    let mut sighash_cache = SighashCache::new(reveal_tx);
+    let signature_hash = sighash_cache.taproot_script_spend_signature_hash(
+        0,
+        &Prevouts::All(from_ref(output_to_reveal)),
+        TapLeafHash::from_script(reveal_script, LeafVersion::TapScript),
+        TapSighashType::Default,
+    )?;
+    Ok(signature_hash.to_byte_array())
+}
+
+pub(crate) fn attach_reveal_witness(
+    reveal_tx: &mut Transaction,
+    reveal_script: &ScriptBuf,
+    control_block: &ControlBlock,
+    signature: &[u8; 64],
+) -> Result<(), ReplacementError> {
+    let signature = Signature::from_slice(signature).map_err(|error| {
+        ReplacementError::RevealSigning(anyhow::anyhow!("invalid schnorr signature: {error}"))
+    })?;
+    let witness = &mut reveal_tx
+        .input
+        .first_mut()
+        .ok_or(ReplacementError::MissingRevealWitness)?
+        .witness;
+    witness.push(signature.as_ref());
+    witness.push(reveal_script);
+    witness.push(control_block.serialize());
+    Ok(())
+}
+
+fn set_reveal_replacement_fee(
+    replacement_tx: &mut Transaction,
+    commit_output: &TxOut,
+    target_fee_rate: FeeRate,
+) -> Result<(), ReplacementError> {
+    if let Some(input) = replacement_tx.input.first_mut() {
+        input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+    }
+
+    let target_fee = target_fee_rate
+        .fee_vb(replacement_tx.vsize() as u64)
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    let other_output_value = replacement_tx
+        .output
+        .iter()
+        .take(replacement_tx.output.len().saturating_sub(1))
+        .map(|output| output.value)
+        .sum::<Amount>();
+    let output_and_fee = other_output_value
+        .checked_add(target_fee)
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    let replacement_output = replacement_tx
+        .output
+        .last_mut()
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    let new_output_value = commit_output
+        .value
+        .checked_sub(output_and_fee)
+        .ok_or(ReplacementError::ReplacementWouldDustOutput)?;
+    if new_output_value.to_sat() < BITCOIN_DUST_LIMIT {
+        return Err(ReplacementError::ReplacementWouldDustOutput);
+    }
+    replacement_output.value = new_output_value;
+    Ok(())
+}
+
+fn reveal_fee(reveal_tx: &Transaction, commit_output: &TxOut) -> Amount {
+    let output_value = reveal_tx
+        .output
+        .iter()
+        .map(|output| output.value)
+        .sum::<Amount>();
+    commit_output
+        .value
+        .checked_sub(output_value)
+        .unwrap_or(Amount::ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime, opcodes, script::Builder as ScriptBuilder, transaction::Version,
+        OutPoint, TxIn, Witness, WitnessProgram, WitnessVersion,
+    };
+
+    use super::*;
+
+    fn op_return_output() -> TxOut {
+        TxOut {
+            value: Amount::ZERO,
+            script_pubkey: ScriptBuilder::new()
+                .push_opcode(opcodes::all::OP_RETURN)
+                .push_slice([1u8; 8])
+                .into_script(),
+        }
+    }
+
+    /// Builds a P2TR output directly from a witness program so tests need no valid curve point.
+    fn p2tr_output(value: u64, seed: u8) -> TxOut {
+        let program = WitnessProgram::new(WitnessVersion::V1, &[seed; 32]).expect("valid program");
+        TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: ScriptBuf::new_witness_program(&program),
+        }
+    }
+
+    fn p2wpkh_output(value: u64) -> TxOut {
+        TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array([7u8; 20])),
+        }
+    }
+
+    fn test_pubkey(seed: u8) -> XOnlyPublicKey {
+        let keypair = Keypair::from_seckey_slice(SECP256K1, &[seed; 32]).expect("valid secret key");
+        XOnlyPublicKey::from_keypair(&keypair).0
+    }
+
+    /// Builds a reveal spending a tapscript that commits to `pubkey`, as SPS-51 reveals do.
+    fn reveal_committing_to(pubkey: &XOnlyPublicKey) -> Transaction {
+        let reveal_script = ScriptBuilder::new()
+            .push_slice(pubkey.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+
+        let mut control_block = vec![LeafVersion::TapScript.to_consensus()];
+        control_block.extend_from_slice(&pubkey.serialize());
+
+        let mut witness = Witness::new();
+        witness.push([0u8; 64]);
+        witness.push(reveal_script.as_bytes());
+        witness.push(&control_block);
+
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness,
+            }],
+            output: vec![p2tr_output(5_000, 1)],
+        }
+    }
+
+    #[test]
+    fn extracts_the_key_committed_in_the_reveal_script() {
+        let pubkey = test_pubkey(1);
+
+        assert_eq!(
+            extract_reveal_pubkey(&reveal_committing_to(&pubkey)).expect("pubkey is recoverable"),
+            pubkey
+        );
+    }
+
+    /// The rotation guard depends on this: a reveal built under one key must not compare equal to
+    /// a different signer key.
+    #[test]
+    fn extracted_key_differs_across_reveals_built_under_different_keys() {
+        let extracted = extract_reveal_pubkey(&reveal_committing_to(&test_pubkey(1)))
+            .expect("pubkey is recoverable");
+
+        assert_ne!(extracted, test_pubkey(2));
+    }
+
+    #[test]
+    fn rejects_a_reveal_whose_script_does_not_open_with_a_key() {
+        let mut tx = reveal_committing_to(&test_pubkey(1));
+        let control_block = tx.input[0]
+            .witness
+            .iter()
+            .nth(2)
+            .expect("control block")
+            .to_vec();
+        let script = ScriptBuilder::new()
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+
+        let mut witness = Witness::new();
+        witness.push([0u8; 64]);
+        witness.push(script.as_bytes());
+        witness.push(&control_block);
+        tx.input[0].witness = witness;
+
+        assert!(matches!(
+            extract_reveal_pubkey(&tx),
+            Err(ReplacementError::MissingRevealWitness)
+        ));
+    }
+
+    #[test]
+    fn refuses_to_attach_a_witness_to_a_reveal_without_inputs() {
+        let reveal = reveal_committing_to(&test_pubkey(1));
+        let (reveal_script, control_block) =
+            extract_reveal_witness(&reveal).expect("test reveal has a witness");
+        let mut empty_reveal = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+
+        let error = attach_reveal_witness(
+            &mut empty_reveal,
+            &reveal_script,
+            &control_block,
+            &[1u8; 64],
+        )
+        .expect_err("a reveal without inputs cannot carry a witness");
+
+        assert!(matches!(error, ReplacementError::MissingRevealWitness));
+    }
+
+    fn commit_with(outputs: Vec<TxOut>) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: outputs,
+        }
+    }
+
+    /// Two reveals: `[OP_RETURN, P2TR, P2TR]` plus an optional change output.
+    fn original_commit() -> Transaction {
+        commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+            p2wpkh_output(20_000),
+        ])
+    }
+
+    /// Core's own change detection ignores anything in the wallet's address book, which is where
+    /// the sequencer address lives, so the index has to be supplied or every bump adds inputs and
+    /// is refused.
+    #[test]
+    fn change_index_points_past_the_reveal_funding_run() {
+        assert_eq!(chunked_commit_change_index(&original_commit(), 2), Some(3));
+    }
+
+    #[test]
+    fn no_change_index_when_the_commit_has_no_change_output() {
+        let commit = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+        ]);
+
+        assert_eq!(chunked_commit_change_index(&commit, 2), None);
+    }
+
+    #[test]
+    fn accepts_replacement_that_only_shrinks_change() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+            p2wpkh_output(18_000),
+        ]);
+
+        assert!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2).is_ok()
+        );
+    }
+
+    #[test]
+    fn accepts_replacement_that_drops_change_entirely() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+        ]);
+
+        assert!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2).is_ok()
+        );
+    }
+
+    /// A taproot change output would extend the P2TR run the ASM guest uses to count reveals.
+    #[test]
+    fn rejects_replacement_with_p2tr_change() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(6_000, 2),
+            p2tr_output(18_000, 3),
+        ]);
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_replacement_that_shrinks_a_reveal_funding_output() {
+        let replacement = commit_with(vec![
+            op_return_output(),
+            p2tr_output(5_000, 1),
+            p2tr_output(4_000, 2),
+            p2wpkh_output(20_000),
+        ]);
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_replacement_that_drops_a_reveal_funding_output() {
+        let replacement = commit_with(vec![op_return_output(), p2tr_output(5_000, 1)]);
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_replacement_that_changes_the_op_return() {
+        let mut replacement = original_commit();
+        replacement.output[0].script_pubkey = ScriptBuilder::new()
+            .push_opcode(opcodes::all::OP_RETURN)
+            .push_slice([9u8; 8])
+            .into_script();
+
+        assert!(matches!(
+            validate_chunked_commit_replacement_layout(&original_commit(), &replacement, 2),
+            Err(ReplacementError::IncompatibleCommitLayout(_))
+        ));
+    }
+
+    #[test]
+    fn incompatible_commit_layout_is_not_retryable_and_is_terminal() {
+        let error = ReplacementError::IncompatibleCommitLayout("test".to_string());
+
+        assert!(!error.is_retryable());
+        assert_eq!(error.terminal_error(), TerminalError::UnsupportedRbfKind);
+    }
+
+    /// The wallet can pay more than it was asked for, most often by absorbing sub-dust change into
+    /// the fee. Recording the target instead would understate the rate the next bump escalates
+    /// from, and a target below what is already on the wire is a replacement Core rejects.
+    #[test]
+    fn effective_fee_rate_reflects_what_the_wallet_actually_paid() {
+        let tx = commit_with(vec![p2wpkh_output(1_000)]);
+        let vsize = tx.vsize() as u64;
+        let fee = Amount::from_sat(vsize * 7 + 1);
+
+        assert_eq!(
+            effective_fee_rate(&tx, fee),
+            FeeRate::from_sat_per_vb(8),
+            "the rate rounds up so the recorded value is never under what was paid"
+        );
+    }
+
+    #[test]
+    fn effective_fee_rate_matches_the_target_when_the_wallet_paid_it_exactly() {
+        let tx = commit_with(vec![p2wpkh_output(1_000)]);
+        let fee = Amount::from_sat(tx.vsize() as u64 * 3);
+
+        assert_eq!(effective_fee_rate(&tx, fee), FeeRate::from_sat_per_vb(3));
+    }
+}

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -418,7 +418,10 @@ pub(crate) fn build_pending_single_reveal_replacement(
     let fee = reveal_fee(&replacement_tx, commit_output);
 
     Ok((
-        TxAttempt::pending_signature(attempt_parts(&replacement_tx, target_fee_rate, fee), attempt_no),
+        TxAttempt::pending_signature(
+            attempt_parts(&replacement_tx, target_fee_rate, fee),
+            attempt_no,
+        ),
         Buf32(sighash),
     ))
 }
@@ -588,13 +591,24 @@ fn reveal_fee(reveal_tx: &Transaction, commit_output: &TxOut) -> Amount {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use bitcoin::{
         absolute::LockTime, opcodes, script::Builder as ScriptBuilder, transaction::Version,
         OutPoint, TxIn, Witness, WitnessProgram, WitnessVersion,
     };
+    use strata_config::btcio::FeeBumpingConfig;
+    use strata_db_types::fee_bump::TxNodeRecord;
 
     use super::*;
-    use crate::test_utils::TestBitcoinClient;
+    use crate::{
+        broadcaster::fee_bump::{
+            evaluate_fee_bump, FeeBumpDecision, FeeBumpEvaluation, FeeBumpRequest,
+        },
+        test_utils::TestBitcoinClient,
+        tx_attempt::TxAttemptExt,
+        writer::builder::reveal_fee_headroom,
+    };
 
     fn op_return_output() -> TxOut {
         TxOut {
@@ -701,46 +715,203 @@ mod tests {
         assert_eq!(error.terminal_error(), TerminalError::UnsupportedRbfKind);
     }
 
-    /// Documents why [`evaluate_fee_bump`] refuses reveal kinds outright.
-    ///
-    /// Both envelope builders size a reveal's commit output at exactly
-    /// `reveal_amount + reveal_fee(build_rate)`, with `reveal_amount` equal to the dust limit
-    /// (`calculate_reveal_commit_value`, `calculate_commit_output_value`). The reveal's own output
-    /// therefore already sits at dust, and shrinking it is the only way a replacement can pay more.
-    /// A target one sat/vB above the build rate is enough to push it under.
-    ///
-    /// If this ever starts returning `Ok`, the commit output has gained build-time headroom and the
-    /// refusal in the fee-bump policy can be lifted — see TODO(STR-4198), which replaces this test
-    /// with one asserting a production-shaped reveal bump succeeds.
-    ///
-    /// [`evaluate_fee_bump`]: crate::broadcaster::fee_bump::evaluate_fee_bump
+    /// A production-shaped reveal uses build-time headroom to pay a valid replacement fee.
     #[test]
-    fn a_production_shaped_reveal_has_no_headroom_to_bump_into() {
+    fn a_production_shaped_reveal_with_headroom_bumps_successfully() {
         let build_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+        let target_rate = FeeRate::from_sat_per_vb(3).expect("valid fee rate");
+        let keypair = test_keypair(1);
         let mut reveal = reveal_committing_to(&test_pubkey(1));
-        reveal.output = vec![p2tr_output(BITCOIN_DUST_LIMIT, 1)];
-        let commit_value = Amount::from_sat(BITCOIN_DUST_LIMIT)
-            + build_rate
-                .fee_vb(reveal.vsize() as u64)
-                .expect("reveal fee fits");
+        let reveal_vsize = u64::try_from(reveal.vsize()).expect("vsize fits");
+        let base_fee = build_rate.fee_vb(reveal_vsize).expect("reveal fee fits");
+        let headroom = reveal_fee_headroom(build_rate, reveal_vsize, &FeeBumpingConfig::default())
+            .expect("headroom fits");
+        reveal.output = vec![p2tr_output(BITCOIN_DUST_LIMIT + headroom, 1)];
+        let commit_value = reveal.output[0].value + base_fee;
         let commit_output = TxOut {
             value: commit_value,
             script_pubkey: reveal.output[0].script_pubkey.clone(),
         };
 
-        let error = build_chunked_reveal_replacement(
-            &reveal,
-            &commit_output,
-            FeeRate::from_sat_per_vb(3).expect("valid fee rate"),
-            1,
-            &test_keypair(1),
+        let replacement =
+            build_chunked_reveal_replacement(&reveal, &commit_output, target_rate, 1, &keypair)
+                .expect("headroom funds the replacement");
+        let replacement_tx = replacement.try_to_tx().expect("replacement decodes");
+        let target_fee = target_rate
+            .fee_vb(u64::try_from(replacement_tx.vsize()).expect("vsize fits"))
+            .expect("target fee fits");
+        let actual_fee = reveal_fee(&replacement_tx, &commit_output);
+        let (reveal_script, _) = extract_reveal_witness(&replacement_tx).expect("witness parses");
+        let sighash =
+            compute_taproot_script_spend_sighash(&replacement_tx, &commit_output, &reveal_script)
+                .expect("sighash computes");
+        let message = Message::from_digest_slice(&sighash).expect("message parses");
+        let signature = Signature::from_slice(
+            replacement_tx.input[0]
+                .witness
+                .iter()
+                .next()
+                .expect("signature witness"),
         )
-        .expect_err("a reveal built this way cannot fund any bump");
+        .expect("signature parses");
 
-        assert!(matches!(
-            error,
-            ReplacementError::ReplacementWouldDustOutput
-        ));
+        assert_eq!(actual_fee, target_fee);
+        assert!(replacement_tx.output.last().unwrap().value.to_sat() >= BITCOIN_DUST_LIMIT);
+        SECP256K1
+            .verify_schnorr(&signature, &message, &test_pubkey(1))
+            .expect("replacement witness verifies under the sequencer key");
+    }
+
+    #[test]
+    fn every_policy_replacement_fits_the_reveal_builder_budget() {
+        let keypair = test_keypair(1);
+        let reveal_kind = TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 0,
+            reveal_idx: 0,
+        };
+
+        for extra_output_count in 0..=2 {
+            for case in [
+                "fundable_boundary",
+                "above_fundable_boundary",
+                "fractional_build_rate",
+                "raised_incremental_relay_fee",
+                "estimator_jump",
+                "headroom_cap",
+                "build_rate_at_max",
+            ] {
+                let default_config = FeeBumpingConfig::default();
+                let config = if case == "headroom_cap" {
+                    FeeBumpingConfig {
+                        max_reveal_fee_headroom_sats: NonZeroU64::new(7).unwrap(),
+                        ..default_config
+                    }
+                } else {
+                    default_config
+                };
+                let build_rate = if case == "fractional_build_rate" {
+                    FeeRate::from_sat_per_kwu(125)
+                } else if case == "build_rate_at_max" {
+                    config.max_fee_rate()
+                } else {
+                    FeeRate::from_sat_per_vb(1).unwrap()
+                };
+                let mut reveal = reveal_committing_to(&test_pubkey(1));
+                for _ in 0..extra_output_count {
+                    reveal.output.insert(0, op_return_output());
+                }
+                let reveal_vsize = u64::try_from(reveal.vsize()).expect("vsize fits");
+                let base_fee = build_rate.fee_vb(reveal_vsize).expect("base fee fits");
+                let headroom = reveal_fee_headroom(build_rate, reveal_vsize, &config)
+                    .expect("headroom derives");
+                reveal.output.last_mut().unwrap().value =
+                    Amount::from_sat(BITCOIN_DUST_LIMIT + headroom);
+                let other_output_value = reveal
+                    .output
+                    .iter()
+                    .take(reveal.output.len() - 1)
+                    .map(|output| output.value)
+                    .sum::<Amount>();
+                let commit_output = TxOut {
+                    value: other_output_value + reveal.output.last().unwrap().value + base_fee,
+                    script_pubkey: reveal.output.last().unwrap().script_pubkey.clone(),
+                };
+                let reveal_fee_budget = commit_output
+                    .value
+                    .checked_sub(other_output_value)
+                    .and_then(|remaining| {
+                        remaining.checked_sub(Amount::from_sat(BITCOIN_DUST_LIMIT))
+                    })
+                    .expect("budget is funded");
+                let fundable_rate =
+                    FeeRate::from_sat_per_vb(reveal_fee_budget.to_sat() / reveal_vsize)
+                        .expect("fundable rate fits");
+                let estimate_fee_rate = match case {
+                    "above_fundable_boundary" => FeeRate::from_sat_per_vb(
+                        fundable_rate.to_sat_per_vb_ceil().saturating_add(1),
+                    )
+                    .unwrap(),
+                    "estimator_jump" => FeeRate::from_sat_per_vb(50_000).unwrap(),
+                    _ => fundable_rate,
+                };
+                let incremental_relay_fee_rate = if case == "raised_incremental_relay_fee" {
+                    FeeRate::from_sat_per_vb(3).unwrap()
+                } else {
+                    FeeRate::from_sat_per_vb(1).unwrap()
+                };
+                let mut active_attempt =
+                    TxAttempt::active(attempt_parts(&reveal, build_rate, base_fee), 0);
+                active_attempt.first_published_l1_height = Some(100);
+                let record = TxNodeRecord::new(reveal_kind.clone(), active_attempt);
+                let decision = evaluate_fee_bump(
+                    &config,
+                    &record,
+                    record.active_attempt().unwrap(),
+                    FeeBumpEvaluation {
+                        current_l1_tip: 102,
+                        estimate_fee_rate,
+                        incremental_relay_fee_rate,
+                        replacement_vsize: reveal.vsize(),
+                        reveal_fee_budget: Some(reveal_fee_budget),
+                    },
+                );
+
+                match decision {
+                    FeeBumpDecision::Replace(FeeBumpRequest {
+                        target_fee_rate, ..
+                    }) => {
+                        let mut direct_replacement = reveal.clone();
+                        set_reveal_replacement_fee(
+                            &mut direct_replacement,
+                            &commit_output,
+                            target_fee_rate,
+                        )
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "policy returned Replace rejected by direct builder for {case} with {extra_output_count} extra outputs: {error}"
+                            )
+                        });
+                        let chunked_replacement = build_chunked_reveal_replacement(
+                            &reveal,
+                            &commit_output,
+                            target_fee_rate,
+                            1,
+                            &keypair,
+                        )
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "policy returned Replace rejected by chunked builder for {case} with {extra_output_count} extra outputs: {error}"
+                            )
+                        })
+                        .try_to_tx()
+                        .expect("replacement decodes");
+
+                        assert!(
+                            direct_replacement.output.last().unwrap().value.to_sat()
+                                >= BITCOIN_DUST_LIMIT
+                        );
+                        assert!(
+                            chunked_replacement.output.last().unwrap().value.to_sat()
+                                >= BITCOIN_DUST_LIMIT
+                        );
+                    }
+                    FeeBumpDecision::BlockedByCeiling { ceiling, .. } => {
+                        assert!(matches!(case, "above_fundable_boundary" | "estimator_jump"));
+                        assert_eq!(ceiling, fundable_rate.min(config.max_fee_rate()));
+                    }
+                    FeeBumpDecision::Terminal(error) => match case {
+                        "headroom_cap" => {
+                            assert_eq!(error, TerminalError::RevealFeeHeadroomExhausted)
+                        }
+                        "build_rate_at_max" => {
+                            assert_eq!(error, TerminalError::Bip125FeeRuleUnsatisfiable)
+                        }
+                        _ => panic!("unexpected terminal decision for {case}: {error}"),
+                    },
+                    FeeBumpDecision::Wait => panic!("stale reveal unexpectedly waited for {case}"),
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -585,13 +585,23 @@ fn reveal_fee(reveal_tx: &Transaction, commit_output: &TxOut) -> Amount {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use bitcoin::{
         absolute::LockTime, opcodes, script::Builder as ScriptBuilder, transaction::Version,
         OutPoint, TxIn, Witness, WitnessProgram, WitnessVersion,
     };
+    use strata_config::btcio::FeeBumpingConfig;
+    use strata_db_types::fee_bump::TxNodeRecord;
 
     use super::*;
-    use crate::test_utils::TestBitcoinClient;
+    use crate::{
+        broadcaster::fee_bump::{
+            evaluate_fee_bump, FeeBumpDecision, FeeBumpEvaluation, FeeBumpRequest,
+        },
+        test_utils::TestBitcoinClient,
+        writer::builder::reveal_fee_headroom,
+    };
 
     fn op_return_output() -> TxOut {
         TxOut {
@@ -698,46 +708,202 @@ mod tests {
         assert_eq!(error.terminal_error(), TerminalError::UnsupportedRbfKind);
     }
 
-    /// Documents why [`evaluate_fee_bump`] refuses reveal kinds outright.
-    ///
-    /// Both envelope builders size a reveal's commit output at exactly
-    /// `reveal_amount + reveal_fee(build_rate)`, with `reveal_amount` equal to the dust limit
-    /// (`calculate_reveal_commit_value`, `calculate_commit_output_value`). The reveal's own output
-    /// therefore already sits at dust, and shrinking it is the only way a replacement can pay more.
-    /// A target one sat/vB above the build rate is enough to push it under.
-    ///
-    /// If this ever starts returning `Ok`, the commit output has gained build-time headroom and the
-    /// refusal in the fee-bump policy can be lifted — see TODO(STR-4198), which replaces this test
-    /// with one asserting a production-shaped reveal bump succeeds.
-    ///
-    /// [`evaluate_fee_bump`]: crate::broadcaster::fee_bump::evaluate_fee_bump
+    /// A production-shaped reveal uses build-time headroom to pay a valid replacement fee.
     #[test]
-    fn a_production_shaped_reveal_has_no_headroom_to_bump_into() {
+    fn a_production_shaped_reveal_with_headroom_bumps_successfully() {
         let build_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+        let target_rate = FeeRate::from_sat_per_vb(3).expect("valid fee rate");
+        let keypair = test_keypair(1);
         let mut reveal = reveal_committing_to(&test_pubkey(1));
-        reveal.output = vec![p2tr_output(BITCOIN_DUST_LIMIT, 1)];
-        let commit_value = Amount::from_sat(BITCOIN_DUST_LIMIT)
-            + build_rate
-                .fee_vb(reveal.vsize() as u64)
-                .expect("reveal fee fits");
+        let reveal_vsize = u64::try_from(reveal.vsize()).expect("vsize fits");
+        let base_fee = build_rate.fee_vb(reveal_vsize).expect("reveal fee fits");
+        let headroom = reveal_fee_headroom(build_rate, reveal_vsize, &FeeBumpingConfig::default())
+            .expect("headroom fits");
+        reveal.output = vec![p2tr_output(BITCOIN_DUST_LIMIT + headroom, 1)];
+        let commit_value = reveal.output[0].value + base_fee;
         let commit_output = TxOut {
             value: commit_value,
             script_pubkey: reveal.output[0].script_pubkey.clone(),
         };
 
-        let error = build_chunked_reveal_replacement(
-            &reveal,
-            &commit_output,
-            FeeRate::from_sat_per_vb(3).expect("valid fee rate"),
-            1,
-            &test_keypair(1),
+        let replacement =
+            build_chunked_reveal_replacement(&reveal, &commit_output, target_rate, 1, &keypair)
+                .expect("headroom funds the replacement");
+        let replacement_tx = replacement.try_to_tx().expect("replacement decodes");
+        let target_fee = target_rate
+            .fee_vb(u64::try_from(replacement_tx.vsize()).expect("vsize fits"))
+            .expect("target fee fits");
+        let actual_fee = reveal_fee(&replacement_tx, &commit_output);
+        let (reveal_script, _) = extract_reveal_witness(&replacement_tx).expect("witness parses");
+        let sighash =
+            compute_taproot_script_spend_sighash(&replacement_tx, &commit_output, &reveal_script)
+                .expect("sighash computes");
+        let message = Message::from_digest_slice(&sighash).expect("message parses");
+        let signature = Signature::from_slice(
+            replacement_tx.input[0]
+                .witness
+                .iter()
+                .next()
+                .expect("signature witness"),
         )
-        .expect_err("a reveal built this way cannot fund any bump");
+        .expect("signature parses");
 
-        assert!(matches!(
-            error,
-            ReplacementError::ReplacementWouldDustOutput
-        ));
+        assert_eq!(actual_fee, target_fee);
+        assert!(replacement_tx.output.last().unwrap().value.to_sat() >= BITCOIN_DUST_LIMIT);
+        SECP256K1
+            .verify_schnorr(&signature, &message, &test_pubkey(1))
+            .expect("replacement witness verifies under the sequencer key");
+    }
+
+    #[test]
+    fn every_policy_replacement_fits_the_reveal_builder_budget() {
+        let keypair = test_keypair(1);
+        let reveal_kind = TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 0,
+            reveal_idx: 0,
+        };
+
+        for extra_output_count in 0..=2 {
+            for case in [
+                "fundable_boundary",
+                "above_fundable_boundary",
+                "fractional_build_rate",
+                "raised_incremental_relay_fee",
+                "estimator_jump",
+                "headroom_cap",
+                "build_rate_at_max",
+            ] {
+                let default_config = FeeBumpingConfig::default();
+                let config = if case == "headroom_cap" {
+                    FeeBumpingConfig {
+                        max_reveal_fee_headroom_sats: NonZeroU64::new(7).unwrap(),
+                        ..default_config
+                    }
+                } else {
+                    default_config
+                };
+                let build_rate = if case == "fractional_build_rate" {
+                    FeeRate::from_sat_per_kwu(125)
+                } else if case == "build_rate_at_max" {
+                    config.max_fee_rate()
+                } else {
+                    FeeRate::from_sat_per_vb(1).unwrap()
+                };
+                let mut reveal = reveal_committing_to(&test_pubkey(1));
+                for _ in 0..extra_output_count {
+                    reveal.output.insert(0, op_return_output());
+                }
+                let reveal_vsize = u64::try_from(reveal.vsize()).expect("vsize fits");
+                let base_fee = build_rate.fee_vb(reveal_vsize).expect("base fee fits");
+                let headroom = reveal_fee_headroom(build_rate, reveal_vsize, &config)
+                    .expect("headroom derives");
+                reveal.output.last_mut().unwrap().value =
+                    Amount::from_sat(BITCOIN_DUST_LIMIT + headroom);
+                let other_output_value = reveal
+                    .output
+                    .iter()
+                    .take(reveal.output.len() - 1)
+                    .map(|output| output.value)
+                    .sum::<Amount>();
+                let commit_output = TxOut {
+                    value: other_output_value + reveal.output.last().unwrap().value + base_fee,
+                    script_pubkey: reveal.output.last().unwrap().script_pubkey.clone(),
+                };
+                let reveal_fee_budget = commit_output
+                    .value
+                    .checked_sub(other_output_value)
+                    .and_then(|remaining| {
+                        remaining.checked_sub(Amount::from_sat(BITCOIN_DUST_LIMIT))
+                    })
+                    .expect("budget is funded");
+                let fundable_rate =
+                    FeeRate::from_sat_per_vb(reveal_fee_budget.to_sat() / reveal_vsize)
+                        .expect("fundable rate fits");
+                let estimate_fee_rate = match case {
+                    "above_fundable_boundary" => FeeRate::from_sat_per_vb(
+                        fundable_rate.to_sat_per_vb_ceil().saturating_add(1),
+                    )
+                    .unwrap(),
+                    "estimator_jump" => FeeRate::from_sat_per_vb(50_000).unwrap(),
+                    _ => fundable_rate,
+                };
+                let incremental_relay_fee_rate = if case == "raised_incremental_relay_fee" {
+                    FeeRate::from_sat_per_vb(3).unwrap()
+                } else {
+                    FeeRate::from_sat_per_vb(1).unwrap()
+                };
+                let mut active_attempt = TxAttempt::active(&reveal, build_rate, base_fee, 0);
+                active_attempt.first_published_l1_height = Some(100);
+                let record = TxNodeRecord::new(reveal_kind.clone(), active_attempt);
+                let decision = evaluate_fee_bump(
+                    &config,
+                    &record,
+                    record.active_attempt().unwrap(),
+                    FeeBumpEvaluation {
+                        current_l1_tip: 102,
+                        estimate_fee_rate,
+                        incremental_relay_fee_rate,
+                        replacement_vsize: reveal.vsize(),
+                        reveal_fee_budget: Some(reveal_fee_budget),
+                    },
+                );
+
+                match decision {
+                    FeeBumpDecision::Replace(FeeBumpRequest {
+                        target_fee_rate, ..
+                    }) => {
+                        let mut direct_replacement = reveal.clone();
+                        set_reveal_replacement_fee(
+                            &mut direct_replacement,
+                            &commit_output,
+                            target_fee_rate,
+                        )
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "policy returned Replace rejected by direct builder for {case} with {extra_output_count} extra outputs: {error}"
+                            )
+                        });
+                        let chunked_replacement = build_chunked_reveal_replacement(
+                            &reveal,
+                            &commit_output,
+                            target_fee_rate,
+                            1,
+                            &keypair,
+                        )
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "policy returned Replace rejected by chunked builder for {case} with {extra_output_count} extra outputs: {error}"
+                            )
+                        })
+                        .try_to_tx()
+                        .expect("replacement decodes");
+
+                        assert!(
+                            direct_replacement.output.last().unwrap().value.to_sat()
+                                >= BITCOIN_DUST_LIMIT
+                        );
+                        assert!(
+                            chunked_replacement.output.last().unwrap().value.to_sat()
+                                >= BITCOIN_DUST_LIMIT
+                        );
+                    }
+                    FeeBumpDecision::BlockedByCeiling { ceiling, .. } => {
+                        assert!(matches!(case, "above_fundable_boundary" | "estimator_jump"));
+                        assert_eq!(ceiling, fundable_rate.min(config.max_fee_rate()));
+                    }
+                    FeeBumpDecision::Terminal(error) => match case {
+                        "headroom_cap" => {
+                            assert_eq!(error, TerminalError::RevealFeeHeadroomExhausted)
+                        }
+                        "build_rate_at_max" => {
+                            assert_eq!(error, TerminalError::Bip125FeeRuleUnsatisfiable)
+                        }
+                        _ => panic!("unexpected terminal decision for {case}: {error}"),
+                    },
+                    FeeBumpDecision::Wait => panic!("stale reveal unexpectedly waited for {case}"),
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -31,9 +31,9 @@ use tracing::*;
 
 use super::build::{
     build_chunked_reveal_replacement, build_pending_single_reveal_replacement,
-    build_wallet_commit_replacement, chunked_commit_change_index, extract_reveal_pubkey,
-    rebuild_reveal_for_replaced_commit, validate_chunked_commit_replacement_layout,
-    ReplacementError,
+    build_wallet_commit_replacement, chunked_commit_change_index, ensure_reveal_signable,
+    extract_reveal_pubkey, rebuild_reveal_for_replaced_commit,
+    validate_chunked_commit_replacement_layout, ReplacementError,
 };
 use crate::{
     broadcaster::{
@@ -740,20 +740,34 @@ where
     // Tell Core which output to recycle rather than letting it guess. Its own change detection
     // skips anything in the wallet's address book, which is where the sequencer address lives, so
     // an unguided bump would add inputs and be refused every time.
-    let original_change_index = match record.kind {
-        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
-            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
-                bail!("chunked commit replacement requires chunked envelope context");
-            };
-            let Some(envelope_entry) = chunked_ops
-                .get_chunked_envelope_entry_async(envelope_idx)
-                .await?
-            else {
-                bail!("chunked envelope {envelope_idx} missing");
-            };
-            chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
-        }
+    let chunked_envelope_idx = match record.kind {
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => Some(envelope_idx),
         _ => None,
+    };
+    let original_change_index = if let Some(envelope_idx) = chunked_envelope_idx {
+        let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+            bail!("chunked commit replacement requires chunked envelope context");
+        };
+        let Some(envelope_entry) = chunked_ops
+            .get_chunked_envelope_entry_async(envelope_idx)
+            .await?
+        else {
+            bail!("chunked envelope {envelope_idx} missing");
+        };
+        // Replacing the commit re-points every reveal at the new commit output and re-signs it,
+        // while each reveal keeps its original tapscript. Under a rotated sequencer key those
+        // signatures could never satisfy those scripts, and the refusal only surfaces at broadcast,
+        // by which point the original commit is already `Replaced` and the envelope has nothing
+        // live left. Refuse before anything is written; the writer rebuilds under the new key, and
+        // that fresh initial attempt clears the terminal error.
+        if let Err(error) = chunked_reveals_signable(context, &envelope_entry) {
+            warn!(envelope_idx, %error, "sequencer key rotated since the envelope was built; refusing to bump its commit");
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+        chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
+    } else {
+        None
     };
 
     let replacement = match build_wallet_commit_replacement(
@@ -1071,6 +1085,7 @@ async fn replace_chunked_reveal(
             return Ok(());
         }
         Err(error) => {
+            warn!(envelope_idx, reveal_idx, %error, "failed to build chunked reveal replacement");
             mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
             return Ok(());
         }
@@ -1290,6 +1305,27 @@ async fn validate_chunked_commit_layout(
         Ok(()) => Ok(CommitLayoutCheck::Ok),
         Err(error) => Ok(CommitLayoutCheck::IncompatibleCandidate(error)),
     }
+}
+
+/// Reports whether every reveal of a chunked envelope still commits to the sequencer's current key.
+///
+/// A commit replacement re-signs all of them, so one rotated reveal is enough to make the whole
+/// envelope unspendable. Reveals whose stored bytes do not decode are left alone here; the metadata
+/// refresh surfaces that as the state corruption it is rather than as a routine refusal to bump.
+fn chunked_reveals_signable(
+    context: &ReplacementContext,
+    envelope_entry: &ChunkedEnvelopeEntry,
+) -> Result<(), ReplacementError> {
+    let Some(sequencer_keypair) = context.sequencer_keypair.as_ref() else {
+        return Ok(());
+    };
+    for reveal in &envelope_entry.reveals {
+        let Ok(reveal_tx) = deserialize::<Transaction>(&reveal.tx_bytes) else {
+            continue;
+        };
+        ensure_reveal_signable(&reveal_tx, sequencer_keypair)?;
+    }
+    Ok(())
 }
 
 async fn update_chunked_commit_replacement_metadata(

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -669,6 +669,7 @@ where
             TxNodeKind::ChunkedEnvelopeCommit { .. } => {
                 replace_wallet_commit(
                     client,
+                    writer_config,
                     broadcast_handle,
                     context,
                     record,
@@ -694,6 +695,7 @@ where
 
 async fn replace_wallet_commit<C>(
     client: &C,
+    writer_config: &WriterConfig,
     broadcast_handle: &L1BroadcastHandle,
     context: &ReplacementContext,
     mut record: TxNodeRecord,
@@ -773,6 +775,7 @@ where
         &original_commit_tx,
         record.active_txid,
         target_fee_rate,
+        writer_config.fee_bumping.max_fee_rate(),
         attempt_no,
         original_change_index,
     )
@@ -781,6 +784,13 @@ where
         Ok(replacement) => replacement,
         Err(error) if error.is_retryable() => {
             warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        // Discard rather than terminate. The overshoot comes from the wallet's coin selection, not
+        // from our escalation policy, so a later candidate built against a different UTXO set can
+        // land under the ceiling; marking the node terminal would strand the envelope for good.
+        Err(error @ ReplacementError::ExceedsMaxFeeRate { .. }) => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "discarding replacement commit that breaches the configured fee-rate ceiling");
             return Ok(());
         }
         Err(error) => {

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -31,9 +31,9 @@ use tracing::*;
 
 use super::build::{
     build_chunked_reveal_replacement, build_pending_single_reveal_replacement,
-    build_wallet_commit_replacement, chunked_commit_change_index, extract_reveal_pubkey,
-    rebuild_reveal_for_replaced_commit, validate_chunked_commit_replacement_layout,
-    ReplacementError,
+    build_wallet_commit_replacement, chunked_commit_change_index, ensure_reveal_signable,
+    extract_reveal_pubkey, rebuild_reveal_for_replaced_commit,
+    validate_chunked_commit_replacement_layout, ReplacementError,
 };
 use crate::{
     broadcaster::{
@@ -737,20 +737,34 @@ where
     // Tell Core which output to recycle rather than letting it guess. Its own change detection
     // skips anything in the wallet's address book, which is where the sequencer address lives, so
     // an unguided bump would add inputs and be refused every time.
-    let original_change_index = match record.kind {
-        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
-            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
-                bail!("chunked commit replacement requires chunked envelope context");
-            };
-            let Some(envelope_entry) = chunked_ops
-                .get_chunked_envelope_entry_async(envelope_idx)
-                .await?
-            else {
-                bail!("chunked envelope {envelope_idx} missing");
-            };
-            chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
-        }
+    let chunked_envelope_idx = match record.kind {
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => Some(envelope_idx),
         _ => None,
+    };
+    let original_change_index = if let Some(envelope_idx) = chunked_envelope_idx {
+        let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+            bail!("chunked commit replacement requires chunked envelope context");
+        };
+        let Some(envelope_entry) = chunked_ops
+            .get_chunked_envelope_entry_async(envelope_idx)
+            .await?
+        else {
+            bail!("chunked envelope {envelope_idx} missing");
+        };
+        // Replacing the commit re-points every reveal at the new commit output and re-signs it,
+        // while each reveal keeps its original tapscript. Under a rotated sequencer key those
+        // signatures could never satisfy those scripts, and the refusal only surfaces at broadcast,
+        // by which point the original commit is already `Replaced` and the envelope has nothing
+        // live left. Refuse before anything is written; the writer rebuilds under the new key, and
+        // that fresh initial attempt clears the terminal error.
+        if let Err(error) = chunked_reveals_signable(context, &envelope_entry) {
+            warn!(envelope_idx, %error, "sequencer key rotated since the envelope was built; refusing to bump its commit");
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+        chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
+    } else {
+        None
     };
 
     let replacement = match build_wallet_commit_replacement(
@@ -1068,6 +1082,7 @@ async fn replace_chunked_reveal(
             return Ok(());
         }
         Err(error) => {
+            warn!(envelope_idx, reveal_idx, %error, "failed to build chunked reveal replacement");
             mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
             return Ok(());
         }
@@ -1287,6 +1302,27 @@ async fn validate_chunked_commit_layout(
         Ok(()) => Ok(CommitLayoutCheck::Ok),
         Err(error) => Ok(CommitLayoutCheck::IncompatibleCandidate(error)),
     }
+}
+
+/// Reports whether every reveal of a chunked envelope still commits to the sequencer's current key.
+///
+/// A commit replacement re-signs all of them, so one rotated reveal is enough to make the whole
+/// envelope unspendable. Reveals whose stored bytes do not decode are left alone here; the metadata
+/// refresh surfaces that as the state corruption it is rather than as a routine refusal to bump.
+fn chunked_reveals_signable(
+    context: &ReplacementContext,
+    envelope_entry: &ChunkedEnvelopeEntry,
+) -> Result<(), ReplacementError> {
+    let Some(sequencer_keypair) = context.sequencer_keypair.as_ref() else {
+        return Ok(());
+    };
+    for reveal in &envelope_entry.reveals {
+        let Ok(reveal_tx) = deserialize::<Transaction>(&reveal.tx_bytes) else {
+            continue;
+        };
+        ensure_reveal_signable(&reveal_tx, sequencer_keypair)?;
+    }
+    Ok(())
 }
 
 async fn update_chunked_commit_replacement_metadata(

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -1,0 +1,2242 @@
+//! Drives RBF replacements for the transactions a writer owns.
+//!
+//! This is not a service. [`run_replacement_pass`] does one pass over the writer's tx-node records
+//! and is called from the writer's existing watcher tick, so replacement runs at the writer's
+//! cadence and inside its task. The broadcaster is what notices a transaction has gone stale.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use anyhow::{bail, Context};
+use bitcoin::{
+    consensus::{deserialize, serialize},
+    hashes::Hash,
+    key::Keypair,
+    Amount, FeeRate, Transaction, TxOut,
+};
+use bitcoind_async_client::traits::{Reader, Signer};
+use strata_config::btcio::{FeeBumpingConfig, WriterConfig};
+use strata_db_types::{
+    chunked_envelope::{ChunkedEnvelopeEntry, RevealTxMeta},
+    common::{L1TxId, L1WtxId},
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeId, TxNodeKind, TxNodeRecord},
+    l1_broadcast::{L1TxEntry, L1TxStatus},
+    l1_writer::L1BundleStatus,
+};
+use strata_primitives::{buf::Buf32, L1Height};
+use strata_storage::ops::{chunked_envelope::ChunkedEnvelopeOps, writer::EnvelopeDataOps};
+use tracing::*;
+
+use super::build::{
+    build_chunked_reveal_replacement, build_pending_single_reveal_replacement,
+    build_wallet_commit_replacement, chunked_commit_change_index, extract_reveal_pubkey,
+    rebuild_reveal_for_replaced_commit, validate_chunked_commit_replacement_layout,
+    ReplacementError,
+};
+use crate::{
+    broadcaster::{
+        fee_bump::{evaluate_fee_bump, FeeBumpDecision, FeeBumpEvaluation},
+        L1BroadcastHandle,
+    },
+    writer::{
+        builder::BITCOIN_DUST_LIMIT, chunked_envelope::CommitPhaseLatch, fees::resolve_fee_rate,
+        EnvelopeSigningMode, EnvelopeSigningModeProvider,
+    },
+};
+
+/// Bitcoin Core's default `incrementalrelayfee`, used when the node does not report one.
+const DEFAULT_INCREMENTAL_RELAY_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_u32(1);
+
+/// Writer-supplied storage and signing handles the replacement path needs.
+///
+/// Each field is populated by the writer that owns the corresponding transaction kind: the
+/// checkpoint writer fills the single-envelope fields, the EE-DA chunked writer fills the chunked
+/// ones. A process runs one writer or the other, so the unused half stays `None`.
+#[derive(Clone, Default)]
+pub(crate) struct ReplacementContext {
+    /// Chunked-envelope storage used by Alpen EE DA reveal replacements.
+    pub chunked_ops: Option<Arc<ChunkedEnvelopeOps>>,
+    /// Single-envelope payload storage used by checkpoint reveal replacements.
+    pub envelope_ops: Option<Arc<EnvelopeDataOps>>,
+    /// Sequencer keypair used to re-sign Alpen EE DA reveal replacements.
+    pub sequencer_keypair: Option<Keypair>,
+    /// Resolves whether single-envelope reveals can be re-signed by an external signer.
+    ///
+    /// Held as a provider rather than a resolved value because the signing mode tracks canonical
+    /// ASM state and rotates at runtime. Resolving once at startup would let a rotation strand
+    /// every reveal node behind a sticky [`TerminalError::UnsupportedRbfKind`].
+    pub signing_mode_provider: Option<Arc<dyn EnvelopeSigningModeProvider>>,
+
+    /// Serialises chunked commit replacement against reveal enqueueing.
+    ///
+    /// Must be the latch the chunked-envelope writer holds
+    /// ([`ChunkedEnvelopeHandle::commit_phase_latch`]). The default is only correct when there is
+    /// no chunked writer in this process, in which case no chunked commit is ever replaced.
+    ///
+    /// [`ChunkedEnvelopeHandle::commit_phase_latch`]: crate::writer::ChunkedEnvelopeHandle::commit_phase_latch
+    pub commit_phase: CommitPhaseLatch,
+
+    /// Paces the pass independently of the watcher tick that drives it.
+    pub pacer: Arc<ReplacementPacer>,
+}
+
+/// Rate-limits the replacement pass.
+///
+/// The pass runs inside a writer's watcher tick, which is paced for payload processing:
+/// `write_poll_dur_ms` is commonly 200. Rescanning every tx-node record and re-resolving the fee
+/// estimate at that rate is pure waste, and under `fee_policy = "mempool"` it means an external
+/// HTTP request several times a second. The work is driven by L1 blocks, so it only needs to
+/// happen on the order of `check_interval_ms`.
+#[derive(Debug)]
+pub(crate) struct ReplacementPacer {
+    interval: Duration,
+    last_run: Mutex<Option<Instant>>,
+}
+
+impl ReplacementPacer {
+    pub(crate) fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            last_run: Mutex::new(None),
+        }
+    }
+
+    /// Reports whether a pass is due, recording the run when it is.
+    ///
+    /// The first call always runs, so a freshly started writer does not wait an interval before
+    /// looking at records a previous process left behind.
+    fn claim(&self) -> bool {
+        let mut last_run = self
+            .last_run
+            .lock()
+            .expect("replacement pacer lock poisoned");
+        let now = Instant::now();
+        match *last_run {
+            Some(previous) if now.duration_since(previous) < self.interval => false,
+            _ => {
+                *last_run = Some(now);
+                true
+            }
+        }
+    }
+}
+
+impl Default for ReplacementPacer {
+    fn default() -> Self {
+        Self::new(FeeBumpingConfig::default().check_interval())
+    }
+}
+
+/// Runs one replacement pass over the writer's tx-node records.
+///
+/// Called from the writer's watcher tick. Errors are returned to the caller, which logs them and
+/// carries on to the next tick; a failed pass is retried by the next one.
+pub(crate) async fn run_replacement_pass<C>(
+    client: &C,
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+) -> anyhow::Result<()>
+where
+    C: Reader + Signer,
+{
+    if !context.pacer.claim() {
+        return Ok(());
+    }
+
+    // Read the records before any network call. On a writer with nothing in flight, or one whose
+    // records have all reached a terminal state, there is nothing for the estimate to price and
+    // the whole pass costs one local DB read.
+    //
+    // TODO(STR-4153): bound this by the active set. Records are never removed once their
+    // transaction finalizes, so the scan loads and decodes every historical checkpoint and reveal
+    // the node has ever published; `check_interval_ms` caps how often that runs, not how big it
+    // gets. Needs an index keyed by node id that a record leaves once its active transaction is
+    // confirmed, finalized or terminal — deleting a record outright is not safe while the watchers
+    // still resolve progress through it.
+    //
+    // What is bounded already: a record's size no longer grows with its attempt count, because
+    // superseded and discarded attempts drop their raw transaction bytes
+    // (`TxAttempt::forget_raw_tx`). That matters most for chunked EE-DA reveals, whose witness
+    // carries the chunk payload. The remaining growth is one live transaction per historical
+    // record, which is what the index above removes.
+    let records = broadcast_handle.get_all_tx_nodes().await?;
+    if records.iter().all(|record| record.terminal_error.is_some()) {
+        return Ok(());
+    }
+
+    let current_l1_tip = client.get_block_count().await? as L1Height;
+    // Price the replacement through the same fee policy the original was built with. Calling
+    // `estimatesmartfee` directly here would silently ignore a `fee_policy = "mempool"` node's
+    // configured estimator and bump against a source it does not otherwise use.
+    let estimate_fee_rate = resolve_fee_rate(client, writer_config).await?;
+    // BIP-125 rule 4 is priced at the node's configured incremental relay fee, so read it rather
+    // than assuming Core's 1 sat/vB default. Fall back to that default when the field is absent.
+    let incremental_relay_fee_rate = client
+        .get_mempool_info()
+        .await?
+        .incremental_relay_fee
+        .unwrap_or(DEFAULT_INCREMENTAL_RELAY_FEE_RATE);
+
+    for mut record in records {
+        if record.terminal_error.is_some() {
+            continue;
+        }
+        if record.pending_signature_attempt().is_some() {
+            if pending_attempt_is_orphaned(context, &record).await? {
+                warn!(node_id = ?record.node_id, "discarding a pending reveal replacement nothing can complete");
+                let snapshot_active_txid = record.active_txid;
+                record.discard_pending_signature_replacement();
+                put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record)
+                    .await?;
+            } else {
+                trace!(node_id = ?record.node_id, "tx-node is waiting for external signature");
+            }
+            continue;
+        }
+        // Per-record failures are logged and skipped rather than propagated. A record that fails
+        // deterministically, an undecodable raw tx say, would otherwise abort the poll at the same
+        // point every tick and starve every record ordered after it.
+        let node_id = record.node_id;
+        if let Err(error) = process_record(
+            client,
+            writer_config,
+            broadcast_handle,
+            ReplacementPolicyInputs {
+                current_l1_tip,
+                estimate_fee_rate,
+                incremental_relay_fee_rate,
+            },
+            record,
+            context,
+        )
+        .await
+        {
+            warn!(?node_id, %error, "skipping tx-node after fee-bump processing failed");
+        }
+    }
+
+    Ok(())
+}
+
+/// Reports whether the row that owns a logical transaction still names its active attempt.
+///
+/// Used to gate re-inserting a broadcast entry the node has but the broadcaster does not. That
+/// state has two causes with opposite remedies: a stop between the two writes, where re-inserting
+/// is the recovery, and a writer rebuild that has already moved the row to a fresh transaction,
+/// where re-inserting resurrects an envelope the writer abandoned.
+///
+/// Fails closed. Without the owning row, or the storage handle to read it, there is no way to tell
+/// the two apart, and re-inserting is the destructive guess.
+async fn active_attempt_is_still_owned(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+) -> anyhow::Result<bool> {
+    match record.kind {
+        TxNodeKind::SingleEnvelopeCommit { payload_idx }
+        | TxNodeKind::SingleEnvelopeReveal { payload_idx } => {
+            let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+                return Ok(false);
+            };
+            let Some(entry) = envelope_ops
+                .get_payload_entry_by_idx_async(payload_idx)
+                .await?
+            else {
+                return Ok(false);
+            };
+            let owned_txid = match record.kind {
+                TxNodeKind::SingleEnvelopeCommit { .. } => entry.commit_txid,
+                _ => entry.reveal_txid,
+            };
+            Ok(owned_txid == record.active_txid)
+        }
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                return Ok(false);
+            };
+            let Some(entry) = chunked_ops
+                .get_chunked_envelope_entry_async(envelope_idx)
+                .await?
+            else {
+                return Ok(false);
+            };
+            Ok(entry.commit_txid == record.active_txid)
+        }
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx,
+        } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                return Ok(false);
+            };
+            let Some(entry) = chunked_ops
+                .get_chunked_envelope_entry_async(envelope_idx)
+                .await?
+            else {
+                return Ok(false);
+            };
+            Ok(entry
+                .reveals
+                .get(reveal_idx as usize)
+                .is_some_and(|reveal| reveal.txid == record.active_txid))
+        }
+    }
+}
+
+/// Reports whether a node's pending-signature attempt can no longer be completed.
+///
+/// Only the watcher activates a pending replacement, and only while the payload row sits in
+/// [`L1BundleStatus::PendingRevealTxSign`]. If the row never reached that state, because the
+/// process stopped between persisting the node and updating the payload, or has already moved past
+/// it, nothing will ever advance the attempt. Since the poll skips every node that carries one, the
+/// chain would stop being bumped for good.
+async fn pending_attempt_is_orphaned(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+) -> anyhow::Result<bool> {
+    let TxNodeKind::SingleEnvelopeReveal { payload_idx } = record.kind else {
+        return Ok(false);
+    };
+    let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+        return Ok(false);
+    };
+    let Some(payload_entry) = envelope_ops
+        .get_payload_entry_by_idx_async(payload_idx)
+        .await?
+    else {
+        return Ok(false);
+    };
+    Ok(!matches!(
+        payload_entry.status,
+        L1BundleStatus::PendingRevealTxSign(_)
+    ))
+}
+
+async fn resolve_reveal_commit_output(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    kind: &TxNodeKind,
+) -> anyhow::Result<Option<TxOut>> {
+    let commit_output = match kind {
+        TxNodeKind::SingleEnvelopeReveal { payload_idx } => {
+            let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+                return Ok(None);
+            };
+            let Some(payload_entry) = envelope_ops
+                .get_payload_entry_by_idx_async(*payload_idx)
+                .await?
+            else {
+                warn!(
+                    payload_idx,
+                    "payload entry missing while resolving single-envelope reveal funding"
+                );
+                return Ok(None);
+            };
+            let Some((_, commit_entry)) = broadcast_handle
+                .get_active_tx_entry_by_id_async(to_raw_buf32(payload_entry.commit_txid))
+                .await?
+            else {
+                debug!(
+                    payload_idx,
+                    "commit entry missing while resolving single-envelope reveal funding"
+                );
+                return Ok(None);
+            };
+            commit_entry.try_to_tx()?.output.first().cloned()
+        }
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx,
+        } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                return Ok(None);
+            };
+            let Some(envelope_entry) = chunked_ops
+                .get_chunked_envelope_entry_async(*envelope_idx)
+                .await?
+            else {
+                warn!(
+                    envelope_idx,
+                    "chunked envelope entry missing while resolving reveal funding"
+                );
+                return Ok(None);
+            };
+            let Some(reveal_meta) = envelope_entry.reveals.get(*reveal_idx as usize) else {
+                warn!(
+                    envelope_idx,
+                    reveal_idx, "chunked reveal metadata missing while resolving funding"
+                );
+                return Ok(None);
+            };
+            let Some((_, commit_entry)) = broadcast_handle
+                .get_active_tx_entry_by_id_async(to_raw_buf32(envelope_entry.commit_txid))
+                .await?
+            else {
+                debug!(
+                    envelope_idx,
+                    reveal_idx, "commit entry missing while resolving chunked reveal funding"
+                );
+                return Ok(None);
+            };
+            commit_entry
+                .try_to_tx()?
+                .output
+                .get(reveal_meta.vout_index as usize)
+                .cloned()
+        }
+        TxNodeKind::SingleEnvelopeCommit { .. } | TxNodeKind::ChunkedEnvelopeCommit { .. } => None,
+    };
+
+    Ok(commit_output)
+}
+
+async fn resolve_reveal_fee_budget(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    kind: &TxNodeKind,
+    active_reveal_tx: &Transaction,
+) -> anyhow::Result<Option<Amount>> {
+    let Some(commit_output) = resolve_reveal_commit_output(broadcast_handle, context, kind).await?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(reveal_fee_budget(&commit_output, active_reveal_tx)))
+}
+
+fn reveal_fee_budget(commit_output: &TxOut, active_reveal_tx: &Transaction) -> Amount {
+    let other_output_value = active_reveal_tx
+        .output
+        .iter()
+        .take(active_reveal_tx.output.len().saturating_sub(1))
+        .try_fold(Amount::ZERO, |total, output| {
+            total.checked_add(output.value)
+        });
+    let Some(other_output_value) = other_output_value else {
+        return Amount::ZERO;
+    };
+    commit_output
+        .value
+        .checked_sub(other_output_value)
+        .and_then(|remaining| remaining.checked_sub(Amount::from_sat(BITCOIN_DUST_LIMIT)))
+        .unwrap_or(Amount::ZERO)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReplacementPolicyInputs {
+    current_l1_tip: L1Height,
+    estimate_fee_rate: FeeRate,
+    incremental_relay_fee_rate: FeeRate,
+}
+
+async fn process_record<C>(
+    client: &C,
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    policy_inputs: ReplacementPolicyInputs,
+    mut record: TxNodeRecord,
+    context: &ReplacementContext,
+) -> anyhow::Result<()>
+where
+    C: Reader + Signer,
+{
+    let ReplacementPolicyInputs {
+        current_l1_tip,
+        estimate_fee_rate,
+        incremental_relay_fee_rate,
+    } = policy_inputs;
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        if matches!(
+            record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::PendingSignature)
+        ) {
+            trace!(node_id = ?record.node_id, active_txid = ?record.active_txid, "tx-node is waiting for external signature");
+            return Ok(());
+        }
+        // A crash between persisting the tx-node record and inserting its broadcast entry
+        // leaves the record pointing at a transaction the broadcaster never saw. The record
+        // holds the raw tx, so re-insert it rather than stalling the chain forever.
+        //
+        // Only while the owning row still names this transaction, though. The writer reacts to the
+        // same missing entry by rebuilding the whole envelope, and a re-insert racing that rebuild
+        // hands the broadcaster a second, complete envelope for one payload: the original commit
+        // entry was written before the node, so both would publish and the payload would land on
+        // L1 twice.
+        if !active_attempt_is_still_owned(context, &record).await? {
+            debug!(node_id = ?record.node_id, active_txid = ?record.active_txid, "not re-inserting a broadcast entry the owning row has moved past");
+            return Ok(());
+        }
+        let Some(active_attempt) = record.active_attempt() else {
+            warn!(node_id = ?record.node_id, "tx-node record has no active attempt");
+            return Ok(());
+        };
+        let active_tx = active_attempt.try_to_tx()?;
+        let fee_rate = active_attempt
+            .fee_rate()
+            .unwrap_or_else(|| estimate_fee_rate.max(FeeRate::from_sat_per_vb_u32(1)));
+        warn!(node_id = ?record.node_id, active_txid = ?record.active_txid, "re-inserting broadcast entry missing for active tx-node");
+        broadcast_handle
+            .put_tx_entry(
+                active_txid,
+                L1TxEntry::from_tx_with_fee(&active_tx, fee_rate, active_attempt.fee()),
+            )
+            .await?;
+        return Ok(());
+    };
+
+    // A crash between marking the original `Replaced` and persisting the updated record leaves
+    // the record pointing at a superseded entry, which would otherwise stall the chain forever.
+    // Adopt the replacement the broadcast DB already knows about.
+    if matches!(active_entry.status, L1TxStatus::Replaced { .. }) {
+        let resolved_txid = broadcast_handle
+            .get_active_tx_entry_by_id_async(active_txid)
+            .await?
+            .map(|(txid, _)| txid);
+
+        match resolved_txid {
+            Some(resolved_txid) if resolved_txid != active_txid => {
+                let resolved = L1TxId::from(resolved_txid.0);
+                warn!(node_id = ?record.node_id, ?resolved, "recovering tx-node stranded on a superseded attempt");
+
+                // Snapshot before the rebuild below, which calls `append_replacement` and moves
+                // `active_txid` onto the new attempt. Taken afterwards it would already equal
+                // `resolved`, never match the durable record's superseded txid, and the write
+                // that repairs the node would be skipped on every pass.
+                let snapshot_active_txid = record.active_txid;
+
+                if !record
+                    .attempts
+                    .iter()
+                    .any(|attempt| attempt.txid == resolved)
+                {
+                    // The crash landed between marking the original replaced and appending the
+                    // replacement, so the record has never seen it. Rebuild the attempt from the
+                    // broadcast entry, which holds the raw tx and the fee rate it was built at.
+                    let Some(resolved_entry) = broadcast_handle
+                        .get_tx_entry_by_id_async(resolved_txid)
+                        .await?
+                    else {
+                        warn!(node_id = ?record.node_id, ?resolved, "replacement entry vanished; leaving tx-node untouched");
+                        return Ok(());
+                    };
+                    let resolved_tx = resolved_entry.try_to_tx()?;
+                    // Read both from the replacement's own metadata. Copying the superseded
+                    // attempt's fee would under-report it and make the next bump undershoot the
+                    // BIP-125 absolute-fee floor.
+                    let Some(rbf) = resolved_entry.rbf else {
+                        warn!(node_id = ?record.node_id, ?resolved, "replacement entry has no fee metadata; leaving tx-node untouched");
+                        return Ok(());
+                    };
+                    let fee_rate =
+                        FeeRate::from_sat_per_vb(rbf.fee_rate_sat_vb).unwrap_or(estimate_fee_rate);
+                    let fee = Amount::from_sat(rbf.fee_sats);
+                    let attempt_no = record.next_attempt_no();
+                    record.append_replacement(TxAttempt::active(
+                        &resolved_tx,
+                        fee_rate,
+                        fee,
+                        attempt_no,
+                    ));
+                }
+
+                record.active_txid = resolved;
+                put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record)
+                    .await?;
+            }
+            _ => {
+                warn!(node_id = ?record.node_id, "tx-node active attempt is replaced but its replacement is unreachable");
+            }
+        }
+        return Ok(());
+    }
+
+    // A crash between persisting the node and refreshing the envelope row leaves the row pointing
+    // at a superseded commit. The writer refuses to enqueue reveals in that state, so finish the
+    // refresh here rather than leaving the envelope wedged.
+    if let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind {
+        retry_stale_chunked_commit_metadata(broadcast_handle, context, &record, envelope_idx)
+            .await?;
+    }
+
+    // The same partial write on the reveal side leaves the envelope row naming a superseded
+    // reveal. Nothing else repairs it, and the DA provider reads that row directly.
+    if let TxNodeKind::ChunkedEnvelopeReveal {
+        envelope_idx,
+        reveal_idx,
+    } = record.kind
+    {
+        retry_stale_chunked_reveal_metadata(
+            broadcast_handle,
+            context,
+            &record,
+            envelope_idx,
+            reveal_idx,
+        )
+        .await?;
+    }
+
+    if active_entry.status != L1TxStatus::Published {
+        return Ok(());
+    }
+
+    if mark_first_published_height(&mut record, current_l1_tip) {
+        let snapshot_active_txid = record.active_txid;
+        put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record).await?;
+        return Ok(());
+    }
+
+    let Some(active_attempt) = record.active_attempt() else {
+        warn!(node_id = ?record.node_id, "tx-node record has no active attempt");
+        return Ok(());
+    };
+    let active_tx = active_attempt.try_to_tx()?;
+
+    let reveal_fee_budget =
+        resolve_reveal_fee_budget(broadcast_handle, context, &record.kind, &active_tx).await?;
+    if matches!(
+        &record.kind,
+        TxNodeKind::SingleEnvelopeReveal { .. } | TxNodeKind::ChunkedEnvelopeReveal { .. }
+    ) && reveal_fee_budget.is_none()
+    {
+        return Ok(());
+    }
+
+    let decision = evaluate_fee_bump(
+        &writer_config.fee_bumping,
+        &record,
+        active_attempt,
+        FeeBumpEvaluation {
+            current_l1_tip,
+            estimate_fee_rate,
+            incremental_relay_fee_rate,
+            replacement_vsize: active_tx.vsize(),
+            reveal_fee_budget,
+        },
+    );
+
+    match decision {
+        FeeBumpDecision::Wait => Ok(()),
+        FeeBumpDecision::BlockedByCeiling { estimate, ceiling } => {
+            // Warn rather than trace: the chain is stuck until the estimate falls below the
+            // effective ceiling, and nothing else surfaces that.
+            warn!(
+                node_id = ?record.node_id,
+                estimate_sat_vb = estimate.to_sat_per_vb_ceil(),
+                ceiling_sat_vb = ceiling.to_sat_per_vb_ceil(),
+                "fee estimate is above the effective ceiling; deferring the bump until it falls back"
+            );
+            Ok(())
+        }
+        FeeBumpDecision::Terminal(error) => {
+            // Logged once per node: every later pass skips a record that carries a terminal error,
+            // so this is the only place an operator learns the chain has stopped advancing.
+            warn!(
+                node_id = ?record.node_id,
+                kind = ?record.kind,
+                %error,
+                "fee bumping is disabled for this transaction; it stays at its current fee rate"
+            );
+            mark_terminal(broadcast_handle, record, error).await?;
+            Ok(())
+        }
+        FeeBumpDecision::Replace(request) => match record.kind.clone() {
+            TxNodeKind::SingleEnvelopeCommit { .. } => {
+                // The checkpoint writer stores a payload's commit and reveal broadcast rows within
+                // the same call, so there is no commit-only phase to bump in: by the time a commit
+                // is old enough to be stale, its reveal is already queued and replacing the commit
+                // would orphan it. Bumping the reveal is what actually unsticks a checkpoint, and
+                // that path is unaffected.
+                mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+                Ok(())
+            }
+            TxNodeKind::SingleEnvelopeReveal { .. } => {
+                replace_single_envelope_reveal(
+                    writer_config,
+                    broadcast_handle,
+                    context,
+                    record,
+                    request.target_fee_rate,
+                    request.attempt_no,
+                )
+                .await
+            }
+            TxNodeKind::ChunkedEnvelopeCommit { .. } => {
+                replace_wallet_commit(
+                    client,
+                    broadcast_handle,
+                    context,
+                    record,
+                    request.target_fee_rate,
+                    request.attempt_no,
+                )
+                .await
+            }
+            TxNodeKind::ChunkedEnvelopeReveal { .. } => {
+                replace_chunked_reveal(
+                    writer_config,
+                    broadcast_handle,
+                    context,
+                    record,
+                    request.target_fee_rate,
+                    request.attempt_no,
+                )
+                .await
+            }
+        },
+    }
+}
+
+async fn replace_wallet_commit<C>(
+    client: &C,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    mut record: TxNodeRecord,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> anyhow::Result<()>
+where
+    C: Signer,
+{
+    // Claim the envelope before checking anything. The durable guard below is a read, and the
+    // writes that follow it are not in the same transaction, so without exclusion a reveal can be
+    // enqueued in the gap and the replacement would orphan it. The claim is released on drop.
+    let _commit_claim = match record.kind {
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            let Some(claim) = context.commit_phase.try_claim(envelope_idx) else {
+                debug!(
+                    envelope_idx,
+                    "commit replacement skipped: reveal enqueueing is in flight"
+                );
+                return Ok(());
+            };
+            Some(claim)
+        }
+        _ => None,
+    };
+
+    if !commit_replacement_allowed(&record, broadcast_handle, context).await? {
+        debug!(node_id = ?record.node_id, kind = ?record.kind, "commit replacement skipped after dependent reveal activity");
+        return Ok(());
+    }
+
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        return Ok(());
+    };
+    let original_commit_tx = active_entry.try_to_tx()?;
+
+    // Tell Core which output to recycle rather than letting it guess. Its own change detection
+    // skips anything in the wallet's address book, which is where the sequencer address lives, so
+    // an unguided bump would add inputs and be refused every time.
+    let original_change_index = match record.kind {
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                bail!("chunked commit replacement requires chunked envelope context");
+            };
+            let Some(envelope_entry) = chunked_ops
+                .get_chunked_envelope_entry_async(envelope_idx)
+                .await?
+            else {
+                bail!("chunked envelope {envelope_idx} missing");
+            };
+            chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
+        }
+        _ => None,
+    };
+
+    let replacement = match build_wallet_commit_replacement(
+        client,
+        &record.kind,
+        &original_commit_tx,
+        record.active_txid,
+        target_fee_rate,
+        attempt_no,
+        original_change_index,
+    )
+    .await
+    {
+        Ok(replacement) => replacement,
+        Err(error) if error.is_retryable() => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        Err(error) => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "failed to build RBF replacement");
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    };
+
+    let active_entry_after_build = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+        .unwrap_or(active_entry);
+    if matches!(
+        active_entry_after_build.status,
+        L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+    ) {
+        debug!(node_id = ?record.node_id, "original transaction confirmed before replacement was persisted");
+        return Ok(());
+    }
+
+    let replacement_tx = replacement.try_to_tx()?;
+    let is_chunked_commit = matches!(record.kind, TxNodeKind::ChunkedEnvelopeCommit { .. });
+
+    // Validate before writing anything: an incompatible layout must not leave partial state.
+    if is_chunked_commit {
+        // A storage or decode failure here propagates: it is our own state that is broken, and
+        // silently retrying would rebuild and re-sign a PSBT every poll while hiding the fault.
+        match validate_chunked_commit_layout(
+            context,
+            &record,
+            &active_entry_after_build,
+            &replacement_tx,
+        )
+        .await?
+        {
+            CommitLayoutCheck::Ok => {}
+            CommitLayoutCheck::IncompatibleCandidate(error) => {
+                // A different candidate (different fee rate, different change handling) may well
+                // be compatible, so discard this one rather than disabling the chain permanently.
+                warn!(node_id = ?record.node_id, %error, "discarding replacement commit whose layout is incompatible with the envelope");
+                return Ok(());
+            }
+        }
+    }
+
+    // Write order across the three trees:
+    //
+    // 1. the replacement's broadcast entry, so anything that later points at the replacement
+    //    resolves to a real entry (an envelope row referencing a commit the broadcaster has never
+    //    seen reads as corruption to the watcher and exits it permanently);
+    // 2. the original's `Replaced` transition, which is atomic and reports whether we actually won
+    //    the race against a confirmation;
+    // 3. the envelope metadata, only once step 2 says the replacement is the live commit;
+    // 4. the tx-node record.
+    //
+    // Rewriting metadata before step 2 is what lets a confirmation land in between and leave the
+    // envelope tracking a replacement that can never confirm.
+    let replacement_txid = replacement.txid;
+    let replacement_txid_raw = to_raw_buf32(replacement_txid);
+    // The attempt's own rate, not the target: the wallet prices the fee off the transaction it
+    // ends up building, and the recovery path in `process_record` rebuilds attempts from this
+    // metadata, so the two must agree.
+    let replacement_entry = L1TxEntry::from_tx_with_fee(
+        &replacement_tx,
+        replacement.fee_rate().unwrap_or(target_fee_rate),
+        replacement.fee(),
+    );
+    if !broadcast_handle
+        .put_replacement_tx_entry(active_txid, replacement_txid_raw, replacement_entry)
+        .await?
+    {
+        debug!(node_id = ?record.node_id, "original transaction left the publishable state before it could be superseded");
+        return Ok(());
+    }
+
+    // Persist the node before the metadata refresh. The refresh can fail, and a node that still
+    // points at the superseded txid is the one state that is not self-healing; with the node
+    // written, `process_record` adopts the replacement and the refresh is retried below.
+    record.append_replacement(replacement);
+    broadcast_handle.put_tx_node(record.clone()).await?;
+
+    if is_chunked_commit {
+        // Deliberately not terminal. Terminal records are skipped by every later poll, so a
+        // transient storage failure here would strand the envelope permanently. Propagating
+        // instead surfaces the fault and retries on the next poll, and until the refresh lands the
+        // writer refuses to enqueue reveals built against the superseded commit.
+        update_chunked_commit_replacement_metadata(context, &record, &replacement_tx)
+            .await
+            .context("refreshing chunked envelope metadata after commit replacement")?;
+    }
+
+    Ok(())
+}
+
+async fn replace_single_envelope_reveal(
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    mut record: TxNodeRecord,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> anyhow::Result<()> {
+    let payload_idx = match &record.kind {
+        TxNodeKind::SingleEnvelopeReveal { payload_idx } => *payload_idx,
+        _ => return Ok(()),
+    };
+    let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+        mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+        return Ok(());
+    };
+    let Some(provider) = context.signing_mode_provider.as_ref() else {
+        mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+        return Ok(());
+    };
+    let signer_pubkey = match provider.signing_mode() {
+        // Only an external signer can re-sign a reveal replacement.
+        Ok(EnvelopeSigningMode::External { pubkey }) => pubkey,
+        Ok(EnvelopeSigningMode::InProcess) => {
+            mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+            return Ok(());
+        }
+        // The mode tracks canonical state, so a transient resolution failure must not mark the
+        // node terminal: that is sticky and would strand it permanently. Defer instead, matching
+        // the watcher's `resolve_signing_mode`.
+        Err(err) => {
+            warn!(%err, "could not resolve envelope signing mode; deferring to next tick");
+            return Ok(());
+        }
+    };
+
+    let Some(commit_output) =
+        resolve_reveal_commit_output(broadcast_handle, context, &record.kind).await?
+    else {
+        return Ok(());
+    };
+
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        return Ok(());
+    };
+    let active_reveal_tx = active_entry.try_to_tx()?;
+
+    // The replacement reuses the original tapscript, so its witness only validates under the key
+    // that script commits to. If the predicate has rotated to a different external key, the signer
+    // would sign the replacement sighash with the new key and produce an invalid witness, while
+    // the original entry was already marked `Replaced`. Refuse instead; the watcher rebuilds the
+    // envelope under the new key, and that fresh initial attempt clears this terminal error.
+    match extract_reveal_pubkey(&active_reveal_tx) {
+        Ok(reveal_pubkey) if reveal_pubkey == signer_pubkey => {}
+        Ok(reveal_pubkey) => {
+            warn!(
+                payload_idx,
+                %reveal_pubkey,
+                %signer_pubkey,
+                "envelope signing key rotated since the reveal was built; refusing to bump it"
+            );
+            mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+            return Ok(());
+        }
+        Err(error) => {
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    }
+
+    let (replacement, sighash) = match build_pending_single_reveal_replacement(
+        &active_reveal_tx,
+        &commit_output,
+        target_fee_rate,
+        attempt_no,
+    ) {
+        Ok(replacement) => replacement,
+        Err(error) if error.is_retryable() => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        Err(error) => {
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    };
+
+    let active_entry_after_build = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+        .unwrap_or(active_entry);
+    if matches!(
+        active_entry_after_build.status,
+        L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+    ) {
+        debug!(
+            payload_idx,
+            "original reveal confirmed before replacement was persisted"
+        );
+        return Ok(());
+    }
+
+    // Both writes below come from a snapshot taken before the replacement was built, and the writer
+    // rebuilds this payload concurrently whenever the original reveal goes invalid. Re-read the row
+    // and give up if it has moved on: writing the stale row back would restore a sighash computed
+    // over the superseded reveal, and the signer would sign that for the rebuilt envelope, whose
+    // witness could then never validate.
+    let Some(mut current_payload_entry) = envelope_ops
+        .get_payload_entry_by_idx_async(payload_idx)
+        .await?
+    else {
+        return Ok(());
+    };
+    if current_payload_entry.reveal_txid != record.active_txid {
+        debug!(
+            payload_idx,
+            "payload rebuilt while its reveal replacement was being built; discarding the replacement"
+        );
+        return Ok(());
+    }
+
+    // Node before metadata. The watcher treats `PendingRevealTxSign` without a pending node
+    // attempt as a stalled signature and resets the payload to `Unsigned`, which rebuilds against
+    // fresh UTXOs while the original reveal is still live. Writing the node first means that state
+    // is never observable. The reverse interleaving only stalls this node's bumping.
+    let snapshot_active_txid = record.active_txid;
+    record.append_pending_signature_replacement(replacement);
+    put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record).await?;
+
+    current_payload_entry.payload_signature = None;
+    current_payload_entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+    envelope_ops
+        .put_payload_entry_async(payload_idx, current_payload_entry)
+        .await?;
+
+    debug!(
+        payload_idx,
+        target_fee_rate_sat_vb = target_fee_rate.to_sat_per_vb_ceil(),
+        max_fee_rate_sat_vb = writer_config.fee_bumping.max_fee_rate_sat_vb.get(),
+        "single-envelope reveal replacement awaiting external signature"
+    );
+    Ok(())
+}
+
+async fn replace_chunked_reveal(
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    mut record: TxNodeRecord,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> anyhow::Result<()> {
+    let (envelope_idx, reveal_idx) = match &record.kind {
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx,
+        } => (*envelope_idx, *reveal_idx),
+        _ => return Ok(()),
+    };
+    let (Some(chunked_ops), Some(sequencer_keypair)) = (
+        context.chunked_ops.as_ref(),
+        context.sequencer_keypair.as_ref(),
+    ) else {
+        mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+        return Ok(());
+    };
+    let Some(mut envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        warn!(
+            envelope_idx,
+            "chunked envelope entry missing for reveal replacement"
+        );
+        return Ok(());
+    };
+    let Some(commit_output) =
+        resolve_reveal_commit_output(broadcast_handle, context, &record.kind).await?
+    else {
+        return Ok(());
+    };
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        return Ok(());
+    };
+    let active_reveal_tx = active_entry.try_to_tx()?;
+    let replacement = match build_chunked_reveal_replacement(
+        &active_reveal_tx,
+        &commit_output,
+        target_fee_rate,
+        attempt_no,
+        sequencer_keypair,
+    ) {
+        Ok(replacement) => replacement,
+        Err(error) if error.is_retryable() => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        Err(error) => {
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    };
+
+    let active_entry_after_build = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+        .unwrap_or(active_entry);
+    if matches!(
+        active_entry_after_build.status,
+        L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+    ) {
+        debug!(
+            envelope_idx,
+            reveal_idx, "original reveal confirmed before replacement was persisted"
+        );
+        return Ok(());
+    }
+
+    let replacement_tx = replacement.try_to_tx()?;
+    let replacement_txid = replacement.txid;
+    let replacement_txid_raw = to_raw_buf32(replacement_txid);
+    let replacement_entry =
+        L1TxEntry::from_tx_with_fee(&replacement_tx, target_fee_rate, replacement.fee());
+    if !broadcast_handle
+        .put_replacement_tx_entry(active_txid, replacement_txid_raw, replacement_entry)
+        .await?
+    {
+        debug!(
+            envelope_idx,
+            reveal_idx, "reveal left the publishable state before it could be superseded"
+        );
+        return Ok(());
+    }
+
+    update_chunked_reveal_meta(&mut envelope_entry, reveal_idx, &replacement_tx);
+    chunked_ops
+        .put_chunked_envelope_entry_async(envelope_idx, envelope_entry)
+        .await?;
+
+    record.append_replacement(replacement);
+    broadcast_handle.put_tx_node(record).await?;
+
+    debug!(
+        envelope_idx,
+        reveal_idx,
+        txid = ?replacement_txid,
+        target_fee_rate_sat_vb = target_fee_rate.to_sat_per_vb_ceil(),
+        max_fee_rate_sat_vb = writer_config.fee_bumping.max_fee_rate_sat_vb.get(),
+        "chunked reveal replacement persisted"
+    );
+    Ok(())
+}
+
+fn update_chunked_reveal_meta(
+    envelope_entry: &mut ChunkedEnvelopeEntry,
+    reveal_idx: u32,
+    replacement_tx: &Transaction,
+) {
+    if let Some(reveal) = envelope_entry.reveals.get_mut(reveal_idx as usize) {
+        *reveal = RevealTxMeta {
+            vout_index: reveal.vout_index,
+            txid: L1TxId::from(replacement_tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(replacement_tx.compute_wtxid().to_byte_array()),
+            tx_bytes: serialize(replacement_tx),
+        };
+    }
+}
+
+/// Outcome of checking a replacement chunked commit before envelope metadata is rewritten.
+enum CommitLayoutCheck {
+    /// The replacement is safe to adopt.
+    Ok,
+    /// This particular candidate is unusable, but a later one may not be.
+    IncompatibleCandidate(ReplacementError),
+}
+
+/// Re-runs the envelope metadata refresh when it did not complete after a commit replacement.
+async fn retry_stale_chunked_commit_metadata(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    envelope_idx: u64,
+) -> anyhow::Result<()> {
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        return Ok(());
+    };
+    let Some(entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        return Ok(());
+    };
+    if entry.commit_txid == record.active_txid {
+        return Ok(());
+    }
+    // Forward-only, same rule as the reveal side. A resign that crashed between writing the row and
+    // writing the node leaves the row on the newer commit and the node on the dead one; without
+    // this the refresh would drag the row back onto the invalidated commit and re-sign every reveal
+    // against it, once per poll, until the watcher's own resign won.
+    let resolves_to_active = broadcast_handle
+        .get_active_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+        .await?
+        .is_some_and(|(resolved_txid, _)| L1TxId::from(resolved_txid.0) == record.active_txid);
+    if !resolves_to_active {
+        return Ok(());
+    }
+    let Some(active_attempt) = record.active_attempt() else {
+        return Ok(());
+    };
+
+    warn!(
+        envelope_idx,
+        stale_commit_txid = ?entry.commit_txid,
+        active_commit_txid = ?record.active_txid,
+        "completing chunked envelope metadata refresh left undone by a commit replacement"
+    );
+    let replacement_tx = active_attempt.try_to_tx()?;
+    update_chunked_commit_replacement_metadata(context, record, &replacement_tx).await
+}
+
+/// Re-points a chunked envelope's reveal metadata when a replacement did not finish rewriting it.
+///
+/// [`replace_chunked_reveal`] supersedes the reveal in the broadcast DB before it rewrites the
+/// envelope row, so a stop in between leaves the row naming a `Replaced` txid. Unlike the commit
+/// path, nothing downstream repairs that: the chunked watcher follows the replacement chain without
+/// rewriting the row, while the EE DA provider looks the row's txid up directly and refuses
+/// anything that is not `Finalized`, which blocks the envelope's DA refs forever.
+async fn retry_stale_chunked_reveal_metadata(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    envelope_idx: u64,
+    reveal_idx: u32,
+) -> anyhow::Result<()> {
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        return Ok(());
+    };
+    let Some(mut entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        return Ok(());
+    };
+    let Some(stale_reveal_txid) = entry
+        .reveals
+        .get(reveal_idx as usize)
+        .map(|reveal| reveal.txid)
+    else {
+        return Ok(());
+    };
+    if stale_reveal_txid == record.active_txid {
+        return Ok(());
+    }
+
+    // Only ever move the row forward: adopt the node's txid when the row's reveal resolves *through
+    // the replacement chain* to it. The inverse partial write, where the row is newer than the
+    // node, is healed by the `Replaced` adoption above and must not be dragged back here.
+    let resolves_to_active = broadcast_handle
+        .get_active_tx_entry_by_id_async(to_raw_buf32(stale_reveal_txid))
+        .await?
+        .is_some_and(|(resolved_txid, _)| L1TxId::from(resolved_txid.0) == record.active_txid);
+    if !resolves_to_active {
+        return Ok(());
+    }
+    let Some(active_attempt) = record.active_attempt() else {
+        return Ok(());
+    };
+    let replacement_tx = active_attempt.try_to_tx()?;
+
+    warn!(
+        envelope_idx,
+        reveal_idx,
+        ?stale_reveal_txid,
+        active_reveal_txid = ?record.active_txid,
+        "completing chunked envelope metadata refresh left undone by a reveal replacement"
+    );
+    update_chunked_reveal_meta(&mut entry, reveal_idx, &replacement_tx);
+    chunked_ops
+        .put_chunked_envelope_entry_async(envelope_idx, entry)
+        .await?;
+    Ok(())
+}
+
+/// Verifies a replacement chunked commit before any envelope metadata is rewritten.
+///
+/// Errors are reserved for problems with our own state (missing context, missing envelope row,
+/// undecodable transaction, storage failure). A replacement that is simply shaped wrong comes back
+/// as [`CommitLayoutCheck::IncompatibleCandidate`] so it can be discarded without masking a real
+/// fault as a routine retry.
+async fn validate_chunked_commit_layout(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    active_commit_entry: &L1TxEntry,
+    replacement_commit_tx: &Transaction,
+) -> anyhow::Result<CommitLayoutCheck> {
+    let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind else {
+        return Ok(CommitLayoutCheck::Ok);
+    };
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        bail!("chunked commit replacement requires chunked envelope context");
+    };
+    let Some(envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        bail!("chunked envelope {envelope_idx} missing");
+    };
+
+    let original_commit_tx = active_commit_entry.try_to_tx()?;
+    match validate_chunked_commit_replacement_layout(
+        &original_commit_tx,
+        replacement_commit_tx,
+        envelope_entry.reveals.len(),
+    ) {
+        Ok(()) => Ok(CommitLayoutCheck::Ok),
+        Err(error) => Ok(CommitLayoutCheck::IncompatibleCandidate(error)),
+    }
+}
+
+async fn update_chunked_commit_replacement_metadata(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    replacement_commit_tx: &Transaction,
+) -> anyhow::Result<()> {
+    let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind else {
+        return Ok(());
+    };
+    let (Some(chunked_ops), Some(sequencer_keypair)) = (
+        context.chunked_ops.as_ref(),
+        context.sequencer_keypair.as_ref(),
+    ) else {
+        bail!("chunked commit replacement requires chunked envelope context");
+    };
+    let Some(mut envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        bail!("chunked envelope {envelope_idx} missing");
+    };
+
+    let replacement_commit_txid = replacement_commit_tx.compute_txid();
+    envelope_entry.commit_txid = L1TxId::from(replacement_commit_txid.to_byte_array());
+    envelope_entry.commit_wtxid =
+        L1WtxId::from(replacement_commit_tx.compute_wtxid().to_byte_array());
+
+    for reveal in &mut envelope_entry.reveals {
+        let old_reveal_tx: Transaction = deserialize(&reveal.tx_bytes)?;
+        let Some(commit_output) = replacement_commit_tx.output.get(reveal.vout_index as usize)
+        else {
+            bail!(
+                "replacement commit missing reveal output {}",
+                reveal.vout_index
+            );
+        };
+        let replacement_reveal = rebuild_reveal_for_replaced_commit(
+            &old_reveal_tx,
+            replacement_commit_txid,
+            commit_output,
+            sequencer_keypair,
+        )?;
+        reveal.txid = L1TxId::from(replacement_reveal.compute_txid().to_byte_array());
+        reveal.wtxid = L1WtxId::from(replacement_reveal.compute_wtxid().to_byte_array());
+        reveal.tx_bytes = serialize(&replacement_reveal);
+    }
+
+    chunked_ops
+        .put_chunked_envelope_entry_async(envelope_idx, envelope_entry)
+        .await?;
+    Ok(())
+}
+
+fn mark_first_published_height(record: &mut TxNodeRecord, current_l1_tip: L1Height) -> bool {
+    let Some(active_attempt) = record.active_attempt_mut() else {
+        return false;
+    };
+    if active_attempt.first_published_l1_height.is_some() {
+        return false;
+    }
+    active_attempt.first_published_l1_height = Some(current_l1_tip);
+    true
+}
+
+async fn mark_terminal(
+    broadcast_handle: &L1BroadcastHandle,
+    mut record: TxNodeRecord,
+    error: TerminalError,
+) -> anyhow::Result<()> {
+    let snapshot_active_txid = record.active_txid;
+    record.set_terminal_error(error);
+    put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record).await
+}
+
+/// Persists a record only while the durable node still names the same active attempt.
+///
+/// The poll works from a snapshot taken before its per-record I/O, and the writer rebuilds a
+/// logical transaction concurrently whenever its original goes `InvalidInputs`:
+/// `put_tx_node_if_enabled` calls [`TxNodeRecord::replace_initial_attempt`], which installs a fresh
+/// attempt under a new txid and clears any terminal error. Writing the snapshot back on top of that
+/// would revive the superseded txid, and because the payload tracks the rebuilt transaction, every
+/// later poll would read a non-`Published` entry and skip the node for good.
+///
+/// This narrows the window to two adjacent reads rather than closing it; the compare and the write
+/// are still separate operations. Making it atomic needs a compare-and-swap in the broadcast DB,
+/// which belongs with the journalling work in known gap 2.
+///
+/// Replacement writes do not need this: they only run once `put_replacement_tx_entry` has
+/// transitioned the original, and that check is atomic and refuses a txid a rebuild has already
+/// invalidated.
+///
+/// `snapshot_active_txid` is the active txid the caller read, which is not always `record`'s own:
+/// the adoption path rewrites it before persisting.
+async fn put_tx_node_if_active_unchanged(
+    broadcast_handle: &L1BroadcastHandle,
+    snapshot_active_txid: L1TxId,
+    record: TxNodeRecord,
+) -> anyhow::Result<()> {
+    if let Some(current) = broadcast_handle.get_tx_node(record.node_id).await? {
+        if current.active_txid != snapshot_active_txid {
+            debug!(
+                node_id = ?record.node_id,
+                ?snapshot_active_txid,
+                active_txid = ?current.active_txid,
+                "skipping tx-node write: the writer rebuilt this transaction during the poll"
+            );
+            return Ok(());
+        }
+    }
+    broadcast_handle.put_tx_node(record).await?;
+    Ok(())
+}
+
+/// Reports whether a commit transaction may still be fee bumped.
+///
+/// Replacing a commit changes its txid, which invalidates every reveal that spends one of its
+/// outputs. So a commit is only replaceable while the envelope is still in the commit-only phase.
+/// This check is deliberately fail-closed: anything it cannot positively confirm as "no reveal has
+/// been handed to the broadcaster" blocks the replacement.
+async fn commit_replacement_allowed(
+    record: &TxNodeRecord,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+) -> anyhow::Result<bool> {
+    match record.kind {
+        TxNodeKind::SingleEnvelopeCommit { payload_idx } => {
+            reveal_node_not_handed_to_broadcaster(
+                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx }),
+                broadcast_handle,
+            )
+            .await
+        }
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            chunked_reveals_not_handed_to_broadcaster(envelope_idx, broadcast_handle, context).await
+        }
+        TxNodeKind::SingleEnvelopeReveal { .. } | TxNodeKind::ChunkedEnvelopeReveal { .. } => {
+            Ok(true)
+        }
+    }
+}
+
+/// Reports whether no reveal of `envelope_idx` has reached the broadcaster yet.
+///
+/// Two independent sources are consulted so the answer does not depend on the order in which the
+/// writer persists a reveal's tx-node record and its broadcast entry:
+///
+/// 1. the persisted envelope row, whose `reveals` carry the authoritative reveal txids, and
+/// 2. the tx-node tree, which covers reveals recorded before the envelope row was refreshed.
+///
+/// A missing envelope row is treated as disqualifying rather than permissive: without it there is
+/// no way to enumerate the reveals that a commit replacement would orphan.
+async fn chunked_reveals_not_handed_to_broadcaster(
+    envelope_idx: u64,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+) -> anyhow::Result<bool> {
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        return Ok(false);
+    };
+    let Some(entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        warn!(
+            envelope_idx,
+            "chunked envelope row missing; refusing commit replacement"
+        );
+        return Ok(false);
+    };
+
+    for reveal in &entry.reveals {
+        if broadcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+            .await?
+            .is_some()
+        {
+            return Ok(false);
+        }
+    }
+
+    let nodes = broadcast_handle.get_all_tx_nodes().await?;
+    Ok(!nodes.iter().any(|node| {
+        matches!(
+            node.kind,
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: node_envelope_idx,
+                ..
+            } if node_envelope_idx == envelope_idx
+        )
+    }))
+}
+
+/// Reports whether this reveal has not yet been handed to the broadcaster.
+///
+/// "Handed over" means a broadcast row exists, not that the row says `Published`. An `Unpublished`
+/// row is already queued and the broadcaster can publish it on any tick, so a commit replacement
+/// that reads it as safe would race the publication and orphan the reveal.
+async fn reveal_node_not_handed_to_broadcaster(
+    node_id: TxNodeId,
+    broadcast_handle: &L1BroadcastHandle,
+) -> anyhow::Result<bool> {
+    let Some(reveal_node) = broadcast_handle.get_tx_node(node_id).await? else {
+        return Ok(true);
+    };
+    Ok(broadcast_handle
+        .get_active_tx_entry_by_id_async(to_raw_buf32(reveal_node.active_txid))
+        .await?
+        .is_none())
+}
+
+fn to_raw_buf32(txid: L1TxId) -> Buf32 {
+    Buf32(txid.0)
+}
+
+#[cfg(test)]
+mod pacer_tests {
+    use super::*;
+
+    #[test]
+    fn first_claim_runs_then_the_interval_holds() {
+        let pacer = ReplacementPacer::new(Duration::from_secs(30));
+
+        // A fresh writer must look at records a previous process left behind rather than idling
+        // for a full interval first.
+        assert!(pacer.claim());
+        assert!(!pacer.claim());
+        assert!(!pacer.claim());
+    }
+
+    #[test]
+    fn a_zero_interval_runs_every_time() {
+        let pacer = ReplacementPacer::new(Duration::ZERO);
+
+        assert!(pacer.claim());
+        assert!(pacer.claim());
+    }
+
+    #[test]
+    fn the_default_interval_matches_the_config_default() {
+        assert_eq!(
+            ReplacementPacer::default().interval,
+            FeeBumpingConfig::default().check_interval()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime, consensus::serialize, transaction::Version, Amount, OutPoint,
+        ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    };
+    use strata_csm_types::L1Payload;
+    use strata_db_types::{
+        chunked_envelope::{ChunkedEnvelopeEntry, ChunkedEnvelopeStatus},
+        common::L1WtxId,
+        fee_bump::TxAttempt,
+        l1_writer::BundledPayloadEntry,
+    };
+    use strata_l1_txfmt::{MagicBytes, TagData};
+
+    use super::*;
+    use crate::writer::test_utils::{
+        get_broadcast_handle, get_chunked_envelope_ops, get_envelope_ops,
+    };
+
+    const ENVELOPE_IDX: u64 = 3;
+    const PAYLOAD_IDX: u64 = 7;
+
+    /// Signing mode provider that yields a fixed mode, or fails when none is set.
+    #[derive(Debug)]
+    struct TestSigningModeProvider {
+        mode: Option<EnvelopeSigningMode>,
+    }
+
+    impl TestSigningModeProvider {
+        fn returning(mode: EnvelopeSigningMode) -> Arc<dyn EnvelopeSigningModeProvider> {
+            Arc::new(Self { mode: Some(mode) })
+        }
+
+        fn failing() -> Arc<dyn EnvelopeSigningModeProvider> {
+            Arc::new(Self { mode: None })
+        }
+    }
+
+    impl EnvelopeSigningModeProvider for TestSigningModeProvider {
+        fn signing_mode(&self) -> anyhow::Result<EnvelopeSigningMode> {
+            self.mode
+                .ok_or_else(|| anyhow::anyhow!("canonical ASM state unavailable"))
+        }
+    }
+
+    fn tx_with_output(value: u64) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn reveal_budget_reserves_other_outputs_and_final_output_dust() {
+        let mut reveal = tx_with_output(900);
+        reveal.output.insert(
+            0,
+            TxOut {
+                value: Amount::from_sat(100),
+                script_pubkey: ScriptBuf::new(),
+            },
+        );
+        let commit_output = TxOut {
+            value: Amount::from_sat(2_000),
+            script_pubkey: ScriptBuf::new(),
+        };
+
+        assert_eq!(
+            reveal_fee_budget(&commit_output, &reveal),
+            Amount::from_sat(1_354)
+        );
+    }
+
+    #[test]
+    fn reveal_budget_saturates_to_zero_when_funding_is_below_reserved_value() {
+        let reveal = tx_with_output(BITCOIN_DUST_LIMIT);
+        let commit_output = TxOut {
+            value: Amount::from_sat(BITCOIN_DUST_LIMIT - 1),
+            script_pubkey: ScriptBuf::new(),
+        };
+
+        assert_eq!(reveal_fee_budget(&commit_output, &reveal), Amount::ZERO);
+    }
+
+    fn fee_rate() -> FeeRate {
+        FeeRate::from_sat_per_vb(2).expect("test: valid fee rate")
+    }
+
+    fn commit_record() -> TxNodeRecord {
+        let attempt = TxAttempt::active(
+            &tx_with_output(10_000),
+            fee_rate(),
+            Amount::from_sat(500),
+            0,
+        );
+        TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeCommit {
+                envelope_idx: ENVELOPE_IDX,
+            },
+            attempt,
+        )
+    }
+
+    /// Builds an envelope row carrying one reveal, returning the row and the reveal tx.
+    fn envelope_entry_with_reveal() -> (ChunkedEnvelopeEntry, Transaction) {
+        let reveal_tx = tx_with_output(900);
+        let mut entry =
+            ChunkedEnvelopeEntry::new_unsigned(vec![vec![1u8; 8]], MagicBytes::new(*b"ALPN"), 0);
+        entry.status = ChunkedEnvelopeStatus::CommitPublished;
+        entry.reveals = vec![RevealTxMeta {
+            vout_index: 1,
+            txid: L1TxId::from(reveal_tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(reveal_tx.compute_wtxid().to_byte_array()),
+            tx_bytes: serialize(&reveal_tx),
+        }];
+        (entry, reveal_tx)
+    }
+
+    /// The commit-only-phase guard is a read, and the writes that follow it are not in the same
+    /// transaction. The latch is what makes the pair safe: while the writer is enqueueing reveals
+    /// for an envelope, a commit replacement for it must not even begin.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_is_refused_while_reveal_enqueue_holds_the_envelope() {
+        let bcast = get_broadcast_handle();
+        let (entry, _reveal_tx) = envelope_entry_with_reveal();
+        let mut context = context_with(Some(entry)).await;
+        let latch = CommitPhaseLatch::new();
+        context.commit_phase = latch.clone();
+
+        // Nothing has been enqueued yet, so the durable guard alone would allow the replacement.
+        assert!(
+            commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+
+        // The writer claims the envelope to enqueue its reveals.
+        let enqueue_claim = latch
+            .try_claim(ENVELOPE_IDX)
+            .expect("writer claims the envelope");
+        assert!(
+            latch.try_claim(ENVELOPE_IDX).is_none(),
+            "the fee bumper must not be able to claim the same envelope"
+        );
+
+        drop(enqueue_claim);
+        assert!(
+            latch.try_claim(ENVELOPE_IDX).is_some(),
+            "the envelope must be claimable again once enqueueing finishes"
+        );
+    }
+
+    fn single_reveal_record() -> TxNodeRecord {
+        TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: PAYLOAD_IDX,
+            },
+            TxAttempt::active(&tx_with_output(900), fee_rate(), Amount::from_sat(100), 0),
+        )
+    }
+
+    /// Runs a single-envelope reveal replacement against `provider` and returns the persisted
+    /// terminal error, if any.
+    async fn terminal_error_after_reveal_replacement(
+        provider: Option<Arc<dyn EnvelopeSigningModeProvider>>,
+    ) -> Option<TerminalError> {
+        let bcast = get_broadcast_handle();
+        let record = single_reveal_record();
+        let node_id = record.node_id;
+        bcast
+            .put_tx_node(record.clone())
+            .await
+            .expect("test: reveal node persists");
+
+        let context = ReplacementContext {
+            envelope_ops: Some(get_envelope_ops()),
+            signing_mode_provider: provider,
+            ..ReplacementContext::default()
+        };
+
+        replace_single_envelope_reveal(
+            &WriterConfig::default(),
+            &bcast,
+            &context,
+            record,
+            fee_rate(),
+            1,
+        )
+        .await
+        .expect("test: replacement attempt returns");
+
+        bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node still exists")
+            .terminal_error
+    }
+
+    /// An in-process signing mode cannot re-sign a reveal, so the node is terminal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_reveal_replacement_is_terminal_for_in_process_signing() {
+        let terminal = terminal_error_after_reveal_replacement(Some(
+            TestSigningModeProvider::returning(EnvelopeSigningMode::InProcess),
+        ))
+        .await;
+
+        assert_eq!(terminal, Some(TerminalError::UnsupportedRbfKind));
+    }
+
+    /// Without a provider there is nothing to resolve, so the node is terminal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_reveal_replacement_is_terminal_without_a_provider() {
+        assert_eq!(
+            terminal_error_after_reveal_replacement(None).await,
+            Some(TerminalError::UnsupportedRbfKind)
+        );
+    }
+
+    /// Regression: the signing mode tracks canonical ASM state, so a transient resolution failure
+    /// must defer to the next tick. Marking the node terminal here is sticky and would strand it
+    /// for good, even once the mode resolves again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_reveal_replacement_defers_when_signing_mode_is_unresolvable() {
+        let terminal =
+            terminal_error_after_reveal_replacement(Some(TestSigningModeProvider::failing())).await;
+
+        assert_eq!(terminal, None, "a provider error must not be terminal");
+    }
+
+    async fn context_with(entry: Option<ChunkedEnvelopeEntry>) -> ReplacementContext {
+        let chunked_ops = get_chunked_envelope_ops();
+        if let Some(entry) = entry {
+            chunked_ops
+                .put_chunked_envelope_entry_async(ENVELOPE_IDX, entry)
+                .await
+                .expect("test: envelope row persists");
+        }
+        ReplacementContext {
+            chunked_ops: Some(chunked_ops),
+            ..ReplacementContext::default()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_allowed_before_any_reveal_is_enqueued() {
+        let bcast = get_broadcast_handle();
+        let (entry, _reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        // The envelope row lists a reveal, but nothing has been handed to the broadcaster and no
+        // reveal tx-node exists: the envelope is still in the commit-only phase.
+        assert!(
+            commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// Regression: a crash between inserting a reveal's broadcast entry and writing its tx-node
+    /// record must not let the commit be replaced, which would orphan the published reveal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_when_reveal_entry_exists_without_tx_node() {
+        let bcast = get_broadcast_handle();
+        let (entry, reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        bcast
+            .put_tx_entry(
+                Buf32(reveal_tx.compute_txid().to_byte_array()),
+                L1TxEntry::from_tx_with_fee(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+            )
+            .await
+            .expect("test: reveal entry persists");
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_when_reveal_tx_node_exists() {
+        let bcast = get_broadcast_handle();
+        let (entry, reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        let reveal_record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 0,
+            },
+            TxAttempt::active(&reveal_tx, fee_rate(), Amount::from_sat(100), 0),
+        );
+        bcast
+            .put_tx_node(reveal_record)
+            .await
+            .expect("test: reveal node persists");
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// Without the envelope row there is no way to enumerate the reveals a replacement would
+    /// orphan, so the guard must refuse rather than assume the commit-only phase.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_when_envelope_row_is_missing() {
+        let bcast = get_broadcast_handle();
+        let context = context_with(None).await;
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_without_chunked_ops() {
+        let bcast = get_broadcast_handle();
+
+        assert!(!commit_replacement_allowed(
+            &commit_record(),
+            &bcast,
+            &ReplacementContext::default()
+        )
+        .await
+        .unwrap());
+    }
+
+    /// Builds a chunked-reveal node whose replacement is live in the broadcast DB while the
+    /// envelope row still names the superseded reveal, the state a stop between the two writes in
+    /// [`replace_chunked_reveal`] leaves behind.
+    async fn chunked_reveal_stranded_after_partial_replacement() -> (
+        Arc<L1BroadcastHandle>,
+        ReplacementContext,
+        TxNodeRecord,
+        L1TxId,
+    ) {
+        let bcast = get_broadcast_handle();
+        let (entry, reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        let replacement_tx = tx_with_output(800);
+        let replacement_txid = L1TxId::from(replacement_tx.compute_txid().to_byte_array());
+        bcast
+            .put_tx_entry(
+                to_raw_buf32(L1TxId::from(reveal_tx.compute_txid().to_byte_array())),
+                L1TxEntry::from_tx_with_fee(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+            )
+            .await
+            .expect("test: original reveal entry persists");
+        assert!(
+            bcast
+                .put_replacement_tx_entry(
+                    to_raw_buf32(L1TxId::from(reveal_tx.compute_txid().to_byte_array())),
+                    to_raw_buf32(replacement_txid),
+                    L1TxEntry::from_tx_with_fee(&replacement_tx, fee_rate(), Amount::from_sat(200)),
+                )
+                .await
+                .expect("test: replacement swap runs"),
+            "test: the original must be replaceable"
+        );
+
+        let mut record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 0,
+            },
+            TxAttempt::active(&reveal_tx, fee_rate(), Amount::from_sat(100), 0),
+        );
+        record.append_replacement(TxAttempt::active(
+            &replacement_tx,
+            fee_rate(),
+            Amount::from_sat(200),
+            1,
+        ));
+
+        (bcast, context, record, replacement_txid)
+    }
+
+    /// Regression: the envelope row is rewritten after the broadcast swap, so a stop in between
+    /// leaves it naming a `Replaced` reveal. Nothing downstream repairs that, and the EE DA
+    /// provider reads the row directly, so the envelope's DA refs would never be built.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stale_chunked_reveal_metadata_is_refreshed_from_the_node() {
+        let (bcast, context, record, replacement_txid) =
+            chunked_reveal_stranded_after_partial_replacement().await;
+
+        retry_stale_chunked_reveal_metadata(&bcast, &context, &record, ENVELOPE_IDX, 0)
+            .await
+            .expect("test: metadata refresh runs");
+
+        let refreshed = context
+            .chunked_ops
+            .as_ref()
+            .expect("test: chunked ops configured")
+            .get_chunked_envelope_entry_async(ENVELOPE_IDX)
+            .await
+            .expect("test: envelope row is readable")
+            .expect("test: envelope row exists");
+        assert_eq!(refreshed.reveals[0].txid, replacement_txid);
+        assert_eq!(refreshed.reveals[0].vout_index, 1, "vout must be preserved");
+    }
+
+    /// The row is only ever moved forward. A reveal that does not resolve through the replacement
+    /// chain to the node's active attempt is left alone, so the inverse partial write, where the
+    /// row is newer than the node, is not dragged back to a superseded reveal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unrelated_chunked_reveal_metadata_is_left_alone() {
+        let (bcast, context, mut record, _) =
+            chunked_reveal_stranded_after_partial_replacement().await;
+        let unrelated_tx = tx_with_output(700);
+        record.append_replacement(TxAttempt::active(
+            &unrelated_tx,
+            fee_rate(),
+            Amount::from_sat(300),
+            2,
+        ));
+
+        retry_stale_chunked_reveal_metadata(&bcast, &context, &record, ENVELOPE_IDX, 0)
+            .await
+            .expect("test: metadata refresh runs");
+
+        let chunked_ops = context
+            .chunked_ops
+            .as_ref()
+            .expect("test: chunked ops configured");
+        let unchanged = chunked_ops
+            .get_chunked_envelope_entry_async(ENVELOPE_IDX)
+            .await
+            .expect("test: envelope row is readable")
+            .expect("test: envelope row exists");
+        let (original_entry, _) = envelope_entry_with_reveal();
+        assert_eq!(unchanged.reveals[0].txid, original_entry.reveals[0].txid);
+    }
+
+    /// Builds a payload row naming `reveal_txid`, and the reveal node for the same payload.
+    async fn payload_row_and_reveal_node(
+        reveal_tx: &Transaction,
+    ) -> (ReplacementContext, TxNodeRecord) {
+        let envelope_ops = get_envelope_ops();
+        let tag = TagData::new(1, 1, vec![]).expect("test: valid tag");
+        let payload = L1Payload::new(vec![vec![1u8; 8]], tag).expect("test: valid payload");
+        let mut payload_entry = BundledPayloadEntry::new_unsigned(payload);
+        payload_entry.reveal_txid = L1TxId::from(reveal_tx.compute_txid().to_byte_array());
+        payload_entry.status = L1BundleStatus::PendingRevealTxSign(Buf32::zero());
+        envelope_ops
+            .put_payload_entry_async(PAYLOAD_IDX, payload_entry)
+            .await
+            .expect("test: payload row persists");
+
+        let record = TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: PAYLOAD_IDX,
+            },
+            TxAttempt::active(reveal_tx, fee_rate(), Amount::from_sat(100), 0),
+        );
+        (
+            ReplacementContext {
+                envelope_ops: Some(envelope_ops),
+                ..ReplacementContext::default()
+            },
+            record,
+        )
+    }
+
+    /// The re-insert recovery only applies while the payload row still names the node's
+    /// transaction, which is the case when the process simply stopped between the two writes.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_entry_is_re_inserted_while_the_payload_still_owns_it() {
+        let reveal_tx = tx_with_output(900);
+        let (context, record) = payload_row_and_reveal_node(&reveal_tx).await;
+
+        assert!(active_attempt_is_still_owned(&context, &record)
+            .await
+            .expect("test: ownership check runs"));
+    }
+
+    /// Regression: the writer reacts to a missing reveal entry by rebuilding the whole envelope.
+    /// Re-inserting the abandoned reveal then hands the broadcaster a second complete envelope for
+    /// one payload, since the original commit entry was written before the node, and the payload
+    /// lands on L1 twice.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_entry_is_not_re_inserted_after_the_payload_was_rebuilt() {
+        let reveal_tx = tx_with_output(900);
+        let (context, record) = payload_row_and_reveal_node(&reveal_tx).await;
+
+        // The writer rebuilt the envelope: the row now names a different reveal.
+        let envelope_ops = context
+            .envelope_ops
+            .as_ref()
+            .expect("test: envelope ops configured");
+        let mut rebuilt = envelope_ops
+            .get_payload_entry_by_idx_async(PAYLOAD_IDX)
+            .await
+            .expect("test: payload row is readable")
+            .expect("test: payload row exists");
+        rebuilt.reveal_txid = L1TxId::from(tx_with_output(800).compute_txid().to_byte_array());
+        envelope_ops
+            .put_payload_entry_async(PAYLOAD_IDX, rebuilt)
+            .await
+            .expect("test: rebuilt row persists");
+
+        assert!(!active_attempt_is_still_owned(&context, &record)
+            .await
+            .expect("test: ownership check runs"));
+    }
+
+    /// Without the owning row there is no way to tell a stopped write from an abandoned envelope,
+    /// and re-inserting is the destructive guess.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_entry_is_not_re_inserted_without_the_owning_row() {
+        let record = single_reveal_record();
+
+        assert!(
+            !active_attempt_is_still_owned(&ReplacementContext::default(), &record)
+                .await
+                .expect("test: ownership check runs")
+        );
+    }
+
+    /// Regression: the poll writes back a record it read before its per-record I/O. If the writer
+    /// rebuilt the transaction in that window, persisting the snapshot would revive the superseded
+    /// txid and clear the rebuild, and since the payload tracks the rebuilt transaction the node
+    /// would read a non-`Published` entry on every later poll and never be bumped again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stale_snapshot_does_not_clobber_a_rebuilt_node() {
+        let bcast = get_broadcast_handle();
+        let snapshot = single_reveal_record();
+        let node_id = snapshot.node_id;
+
+        // The writer rebuilds the logical transaction under a new txid while the poll is
+        // mid-flight.
+        let mut rebuilt = snapshot.clone();
+        let rebuilt_attempt =
+            TxAttempt::active(&tx_with_output(700), fee_rate(), Amount::from_sat(300), 0);
+        let rebuilt_txid = rebuilt_attempt.txid;
+        rebuilt.replace_initial_attempt(rebuilt_attempt);
+        bcast
+            .put_tx_node(rebuilt)
+            .await
+            .expect("test: rebuilt node persists");
+
+        // The poll now finishes with the record it read before the rebuild.
+        let snapshot_active_txid = snapshot.active_txid;
+        put_tx_node_if_active_unchanged(&bcast, snapshot_active_txid, snapshot)
+            .await
+            .expect("test: guarded write runs");
+
+        let stored = bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node exists");
+        assert_eq!(
+            stored.active_txid, rebuilt_txid,
+            "the rebuilt attempt must survive the stale write"
+        );
+    }
+
+    /// A terminal decision made about a transaction the writer has since rebuilt must not land on
+    /// the rebuild, which `replace_initial_attempt` deliberately cleared.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn terminal_error_does_not_land_on_a_rebuilt_node() {
+        let bcast = get_broadcast_handle();
+        let snapshot = single_reveal_record();
+        let node_id = snapshot.node_id;
+
+        let mut rebuilt = snapshot.clone();
+        rebuilt.replace_initial_attempt(TxAttempt::active(
+            &tx_with_output(700),
+            fee_rate(),
+            Amount::from_sat(300),
+            0,
+        ));
+        bcast
+            .put_tx_node(rebuilt)
+            .await
+            .expect("test: rebuilt node persists");
+
+        mark_terminal(&bcast, snapshot, TerminalError::UnsupportedRbfKind)
+            .await
+            .expect("test: terminal marking runs");
+
+        let stored = bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node exists");
+        assert_eq!(stored.terminal_error, None);
+    }
+
+    /// The guard must not block the ordinary case, where nothing has touched the node.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unchanged_node_is_persisted() {
+        let bcast = get_broadcast_handle();
+        let record = single_reveal_record();
+        let node_id = record.node_id;
+        bcast
+            .put_tx_node(record.clone())
+            .await
+            .expect("test: node persists");
+
+        mark_terminal(&bcast, record, TerminalError::UnsupportedRbfKind)
+            .await
+            .expect("test: terminal marking runs");
+
+        assert_eq!(
+            bcast
+                .get_tx_node(node_id)
+                .await
+                .expect("test: node is readable")
+                .expect("test: node exists")
+                .terminal_error,
+            Some(TerminalError::UnsupportedRbfKind)
+        );
+    }
+
+    /// Builds a reveal node carrying a pending-signature attempt, plus the payload row it belongs
+    /// to at `status`.
+    async fn reveal_node_pending_signature(
+        status: L1BundleStatus,
+    ) -> (ReplacementContext, TxNodeRecord) {
+        let envelope_ops = get_envelope_ops();
+        let tag = TagData::new(1, 1, vec![]).expect("test: valid tag");
+        let payload = L1Payload::new(vec![vec![1u8; 8]], tag).expect("test: valid payload");
+        let mut payload_entry = BundledPayloadEntry::new_unsigned(payload);
+        payload_entry.status = status;
+        envelope_ops
+            .put_payload_entry_async(PAYLOAD_IDX, payload_entry)
+            .await
+            .expect("test: payload row persists");
+
+        let mut record = single_reveal_record();
+        record.append_pending_signature_replacement(TxAttempt::active(
+            &tx_with_output(800),
+            fee_rate(),
+            Amount::from_sat(200),
+            1,
+        ));
+
+        (
+            ReplacementContext {
+                envelope_ops: Some(envelope_ops),
+                ..ReplacementContext::default()
+            },
+            record,
+        )
+    }
+
+    /// Regression: the node is written before the payload row, so a stop in between leaves an
+    /// attempt only the watcher could advance, and only from `PendingRevealTxSign`. The poll skips
+    /// every node carrying one, so without this the chain would never be bumped again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pending_attempt_is_orphaned_when_the_payload_never_reached_pending_sign() {
+        let (context, record) = reveal_node_pending_signature(L1BundleStatus::Published).await;
+
+        assert!(pending_attempt_is_orphaned(&context, &record)
+            .await
+            .expect("test: orphan check runs"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pending_attempt_is_kept_while_the_payload_awaits_its_signature() {
+        let (context, record) =
+            reveal_node_pending_signature(L1BundleStatus::PendingRevealTxSign(Buf32::zero())).await;
+
+        assert!(!pending_attempt_is_orphaned(&context, &record)
+            .await
+            .expect("test: orphan check runs"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reveal_kinds_are_always_replaceable() {
+        let bcast = get_broadcast_handle();
+        let reveal_record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 0,
+            },
+            TxAttempt::active(&tx_with_output(900), fee_rate(), Amount::from_sat(100), 0),
+        );
+
+        assert!(
+            commit_replacement_allowed(&reveal_record, &bcast, &ReplacementContext::default())
+                .await
+                .unwrap()
+        );
+    }
+}

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -1,0 +1,2384 @@
+//! Drives RBF replacements for the transactions a writer owns.
+//!
+//! This is not a service. [`run_replacement_pass`] does one pass over the writer's tx-node records
+//! and is called from the writer's existing watcher tick, so replacement runs at the writer's
+//! cadence and inside its task. The broadcaster is what notices a transaction has gone stale.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use anyhow::{bail, Context};
+use bitcoin::{
+    consensus::{deserialize, serialize},
+    hashes::Hash,
+    key::Keypair,
+    Amount, FeeRate, Transaction, TxOut,
+};
+use bitcoind_async_client::traits::{Reader, Signer};
+use strata_config::btcio::{FeeBumpingConfig, WriterConfig};
+use strata_db_types::{
+    chunked_envelope::{ChunkedEnvelopeEntry, RevealTxMeta},
+    common::{L1TxId, L1WtxId},
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeId, TxNodeKind, TxNodeRecord},
+    l1_broadcast::{L1TxEntry, L1TxStatus},
+    l1_writer::L1BundleStatus,
+};
+use strata_primitives::{buf::Buf32, L1Height};
+use strata_storage::ops::{chunked_envelope::ChunkedEnvelopeOps, writer::EnvelopeDataOps};
+use tracing::*;
+
+use super::build::{
+    build_chunked_reveal_replacement, build_pending_single_reveal_replacement,
+    build_wallet_commit_replacement, chunked_commit_change_index, extract_reveal_pubkey,
+    rebuild_reveal_for_replaced_commit, validate_chunked_commit_replacement_layout,
+    ReplacementError,
+};
+use crate::{
+    broadcaster::{
+        fee_bump::{evaluate_fee_bump, FeeBumpDecision, FeeBumpEvaluation},
+        L1BroadcastHandle,
+    },
+    tx_attempt::{attempt_parts, TxAttemptExt},
+    tx_entry::L1TxEntryExt,
+    writer::{
+        builder::BITCOIN_DUST_LIMIT, chunked_envelope::CommitPhaseLatch, fees::resolve_fee_rate,
+        EnvelopeSigningMode, EnvelopeSigningModeProvider,
+    },
+};
+
+/// Bitcoin Core's default `incrementalrelayfee`, used when the node does not report one.
+const DEFAULT_INCREMENTAL_RELAY_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_u32(1);
+
+/// Writer-supplied storage and signing handles the replacement path needs.
+///
+/// Each field is populated by the writer that owns the corresponding transaction kind: the
+/// checkpoint writer fills the single-envelope fields, the EE-DA chunked writer fills the chunked
+/// ones. A process runs one writer or the other, so the unused half stays `None`.
+#[derive(Clone, Default)]
+pub(crate) struct ReplacementContext {
+    /// Chunked-envelope storage used by Alpen EE DA reveal replacements.
+    pub chunked_ops: Option<Arc<ChunkedEnvelopeOps>>,
+    /// Single-envelope payload storage used by checkpoint reveal replacements.
+    pub envelope_ops: Option<Arc<EnvelopeDataOps>>,
+    /// Sequencer keypair used to re-sign Alpen EE DA reveal replacements.
+    pub sequencer_keypair: Option<Keypair>,
+    /// Resolves whether single-envelope reveals can be re-signed by an external signer.
+    ///
+    /// Held as a provider rather than a resolved value because the signing mode tracks canonical
+    /// ASM state and rotates at runtime. Resolving once at startup would let a rotation strand
+    /// every reveal node behind a sticky [`TerminalError::UnsupportedRbfKind`].
+    pub signing_mode_provider: Option<Arc<dyn EnvelopeSigningModeProvider>>,
+
+    /// Serialises chunked commit replacement against reveal enqueueing.
+    ///
+    /// Must be the latch the chunked-envelope writer holds
+    /// ([`ChunkedEnvelopeHandle::commit_phase_latch`]). The default is only correct when there is
+    /// no chunked writer in this process, in which case no chunked commit is ever replaced.
+    ///
+    /// [`ChunkedEnvelopeHandle::commit_phase_latch`]: crate::writer::ChunkedEnvelopeHandle::commit_phase_latch
+    pub commit_phase: CommitPhaseLatch,
+
+    /// Paces the pass independently of the watcher tick that drives it.
+    pub pacer: Arc<ReplacementPacer>,
+}
+
+/// Rate-limits the replacement pass.
+///
+/// The pass runs inside a writer's watcher tick, which is paced for payload processing:
+/// `write_poll_dur_ms` is commonly 200. Rescanning every tx-node record and re-resolving the fee
+/// estimate at that rate is pure waste, and under `fee_policy = "mempool"` it means an external
+/// HTTP request several times a second. The work is driven by L1 blocks, so it only needs to
+/// happen on the order of `check_interval_ms`.
+#[derive(Debug)]
+pub(crate) struct ReplacementPacer {
+    interval: Duration,
+    last_run: Mutex<Option<Instant>>,
+}
+
+impl ReplacementPacer {
+    pub(crate) fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            last_run: Mutex::new(None),
+        }
+    }
+
+    /// Reports whether a pass is due, recording the run when it is.
+    ///
+    /// The first call always runs, so a freshly started writer does not wait an interval before
+    /// looking at records a previous process left behind.
+    fn claim(&self) -> bool {
+        let mut last_run = self
+            .last_run
+            .lock()
+            .expect("replacement pacer lock poisoned");
+        let now = Instant::now();
+        match *last_run {
+            Some(previous) if now.duration_since(previous) < self.interval => false,
+            _ => {
+                *last_run = Some(now);
+                true
+            }
+        }
+    }
+}
+
+impl Default for ReplacementPacer {
+    fn default() -> Self {
+        Self::new(FeeBumpingConfig::default().check_interval())
+    }
+}
+
+/// Runs one replacement pass over the writer's tx-node records.
+///
+/// Called from the writer's watcher tick. Errors are returned to the caller, which logs them and
+/// carries on to the next tick; a failed pass is retried by the next one.
+pub(crate) async fn run_replacement_pass<C>(
+    client: &C,
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+) -> anyhow::Result<()>
+where
+    C: Reader + Signer,
+{
+    if !context.pacer.claim() {
+        return Ok(());
+    }
+
+    // Read the records before any network call. On a writer with nothing in flight there is
+    // nothing for the estimate to price and the whole pass costs one local DB read.
+    //
+    // This scans the active set, not the whole node tree (STR-4153). A node enters the set on a
+    // non-terminal `put_tx_node`, leaves it when a terminal error is recorded or when this pass
+    // observes its transaction finalized, and re-enters when a writer rebuild installs a fresh
+    // attempt. Historical records stay in the node tree — the watchers still resolve crash
+    // recovery through `get_tx_node` point lookups — but the pass no longer loads and decodes
+    // every checkpoint and reveal the node has ever published, each of which retains its live
+    // raw transaction (a chunked EE-DA reveal's carries the chunk payload in its witness).
+    let records = broadcast_handle.get_active_tx_nodes().await?;
+    if records.is_empty() {
+        return Ok(());
+    }
+
+    let current_l1_tip = client.get_block_count().await? as L1Height;
+    // Price the replacement through the same fee policy the original was built with. Calling
+    // `estimatesmartfee` directly here would silently ignore a `fee_policy = "mempool"` node's
+    // configured estimator and bump against a source it does not otherwise use.
+    let estimate_fee_rate = resolve_fee_rate(client, writer_config).await?;
+    // BIP-125 rule 4 is priced at the node's configured incremental relay fee, so read it rather
+    // than assuming Core's 1 sat/vB default. Fall back to that default when the field is absent.
+    let incremental_relay_fee_rate = client
+        .get_mempool_info()
+        .await?
+        .incremental_relay_fee
+        .unwrap_or(DEFAULT_INCREMENTAL_RELAY_FEE_RATE);
+
+    for mut record in records {
+        if record.terminal_error.is_some() {
+            continue;
+        }
+        if record.pending_signature_attempt().is_some() {
+            if pending_attempt_is_orphaned(context, &record).await? {
+                warn!(node_id = ?record.node_id, "discarding a pending reveal replacement nothing can complete");
+                let snapshot_active_txid = record.active_txid;
+                record.discard_pending_signature_replacement();
+                put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record)
+                    .await?;
+            } else {
+                trace!(node_id = ?record.node_id, "tx-node is waiting for external signature");
+            }
+            continue;
+        }
+        // Per-record failures are logged and skipped rather than propagated. A record that fails
+        // deterministically, an undecodable raw tx say, would otherwise abort the poll at the same
+        // point every tick and starve every record ordered after it.
+        let node_id = record.node_id;
+        if let Err(error) = process_record(
+            client,
+            writer_config,
+            broadcast_handle,
+            ReplacementPolicyInputs {
+                current_l1_tip,
+                estimate_fee_rate,
+                incremental_relay_fee_rate,
+            },
+            record,
+            context,
+        )
+        .await
+        {
+            warn!(?node_id, %error, "skipping tx-node after fee-bump processing failed");
+        }
+    }
+
+    Ok(())
+}
+
+/// Reports whether the row that owns a logical transaction still names its active attempt.
+///
+/// Used to gate re-inserting a broadcast entry the node has but the broadcaster does not. That
+/// state has two causes with opposite remedies: a stop between the two writes, where re-inserting
+/// is the recovery, and a writer rebuild that has already moved the row to a fresh transaction,
+/// where re-inserting resurrects an envelope the writer abandoned.
+///
+/// Fails closed. Without the owning row, or the storage handle to read it, there is no way to tell
+/// the two apart, and re-inserting is the destructive guess.
+async fn active_attempt_is_still_owned(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+) -> anyhow::Result<bool> {
+    match record.kind {
+        TxNodeKind::SingleEnvelopeCommit { payload_idx }
+        | TxNodeKind::SingleEnvelopeReveal { payload_idx } => {
+            let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+                return Ok(false);
+            };
+            let Some(entry) = envelope_ops
+                .get_payload_entry_by_idx_async(payload_idx)
+                .await?
+            else {
+                return Ok(false);
+            };
+            let owned_txid = match record.kind {
+                TxNodeKind::SingleEnvelopeCommit { .. } => entry.commit_txid,
+                _ => entry.reveal_txid,
+            };
+            Ok(owned_txid == record.active_txid)
+        }
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                return Ok(false);
+            };
+            let Some(entry) = chunked_ops
+                .get_chunked_envelope_entry_async(envelope_idx)
+                .await?
+            else {
+                return Ok(false);
+            };
+            Ok(entry.commit_txid == record.active_txid)
+        }
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx,
+        } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                return Ok(false);
+            };
+            let Some(entry) = chunked_ops
+                .get_chunked_envelope_entry_async(envelope_idx)
+                .await?
+            else {
+                return Ok(false);
+            };
+            Ok(entry
+                .reveals
+                .get(reveal_idx as usize)
+                .is_some_and(|reveal| reveal.txid == record.active_txid))
+        }
+    }
+}
+
+/// Reports whether a node's pending-signature attempt can no longer be completed.
+///
+/// Only the watcher activates a pending replacement, and only while the payload row sits in
+/// [`L1BundleStatus::PendingRevealTxSign`]. If the row never reached that state, because the
+/// process stopped between persisting the node and updating the payload, or has already moved past
+/// it, nothing will ever advance the attempt. Since the poll skips every node that carries one, the
+/// chain would stop being bumped for good.
+async fn pending_attempt_is_orphaned(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+) -> anyhow::Result<bool> {
+    let TxNodeKind::SingleEnvelopeReveal { payload_idx } = record.kind else {
+        return Ok(false);
+    };
+    let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+        return Ok(false);
+    };
+    let Some(payload_entry) = envelope_ops
+        .get_payload_entry_by_idx_async(payload_idx)
+        .await?
+    else {
+        return Ok(false);
+    };
+    Ok(!matches!(
+        payload_entry.status,
+        L1BundleStatus::PendingRevealTxSign(_)
+    ))
+}
+
+async fn resolve_reveal_commit_output(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    kind: &TxNodeKind,
+) -> anyhow::Result<Option<TxOut>> {
+    let commit_output = match kind {
+        TxNodeKind::SingleEnvelopeReveal { payload_idx } => {
+            let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+                return Ok(None);
+            };
+            let Some(payload_entry) = envelope_ops
+                .get_payload_entry_by_idx_async(*payload_idx)
+                .await?
+            else {
+                warn!(
+                    payload_idx,
+                    "payload entry missing while resolving single-envelope reveal funding"
+                );
+                return Ok(None);
+            };
+            let Some((_, commit_entry)) = broadcast_handle
+                .get_active_tx_entry_by_id_async(to_raw_buf32(payload_entry.commit_txid))
+                .await?
+            else {
+                debug!(
+                    payload_idx,
+                    "commit entry missing while resolving single-envelope reveal funding"
+                );
+                return Ok(None);
+            };
+            commit_entry.try_to_tx()?.output.first().cloned()
+        }
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx,
+        } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                return Ok(None);
+            };
+            let Some(envelope_entry) = chunked_ops
+                .get_chunked_envelope_entry_async(*envelope_idx)
+                .await?
+            else {
+                warn!(
+                    envelope_idx,
+                    "chunked envelope entry missing while resolving reveal funding"
+                );
+                return Ok(None);
+            };
+            let Some(reveal_meta) = envelope_entry.reveals.get(*reveal_idx as usize) else {
+                warn!(
+                    envelope_idx,
+                    reveal_idx, "chunked reveal metadata missing while resolving funding"
+                );
+                return Ok(None);
+            };
+            let Some((_, commit_entry)) = broadcast_handle
+                .get_active_tx_entry_by_id_async(to_raw_buf32(envelope_entry.commit_txid))
+                .await?
+            else {
+                debug!(
+                    envelope_idx,
+                    reveal_idx, "commit entry missing while resolving chunked reveal funding"
+                );
+                return Ok(None);
+            };
+            commit_entry
+                .try_to_tx()?
+                .output
+                .get(reveal_meta.vout_index as usize)
+                .cloned()
+        }
+        TxNodeKind::SingleEnvelopeCommit { .. } | TxNodeKind::ChunkedEnvelopeCommit { .. } => None,
+    };
+
+    Ok(commit_output)
+}
+
+async fn resolve_reveal_fee_budget(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    kind: &TxNodeKind,
+    active_reveal_tx: &Transaction,
+) -> anyhow::Result<Option<Amount>> {
+    let Some(commit_output) = resolve_reveal_commit_output(broadcast_handle, context, kind).await?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(reveal_fee_budget(&commit_output, active_reveal_tx)))
+}
+
+fn reveal_fee_budget(commit_output: &TxOut, active_reveal_tx: &Transaction) -> Amount {
+    let other_output_value = active_reveal_tx
+        .output
+        .iter()
+        .take(active_reveal_tx.output.len().saturating_sub(1))
+        .try_fold(Amount::ZERO, |total, output| {
+            total.checked_add(output.value)
+        });
+    let Some(other_output_value) = other_output_value else {
+        return Amount::ZERO;
+    };
+    commit_output
+        .value
+        .checked_sub(other_output_value)
+        .and_then(|remaining| remaining.checked_sub(Amount::from_sat(BITCOIN_DUST_LIMIT)))
+        .unwrap_or(Amount::ZERO)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReplacementPolicyInputs {
+    current_l1_tip: L1Height,
+    estimate_fee_rate: FeeRate,
+    incremental_relay_fee_rate: FeeRate,
+}
+
+async fn process_record<C>(
+    client: &C,
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    policy_inputs: ReplacementPolicyInputs,
+    mut record: TxNodeRecord,
+    context: &ReplacementContext,
+) -> anyhow::Result<()>
+where
+    C: Reader + Signer,
+{
+    let ReplacementPolicyInputs {
+        current_l1_tip,
+        estimate_fee_rate,
+        incremental_relay_fee_rate,
+    } = policy_inputs;
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        if matches!(
+            record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::PendingSignature)
+        ) {
+            trace!(node_id = ?record.node_id, active_txid = ?record.active_txid, "tx-node is waiting for external signature");
+            return Ok(());
+        }
+        // A crash between persisting the tx-node record and inserting its broadcast entry
+        // leaves the record pointing at a transaction the broadcaster never saw. The record
+        // holds the raw tx, so re-insert it rather than stalling the chain forever.
+        //
+        // Only while the owning row still names this transaction, though. The writer reacts to the
+        // same missing entry by rebuilding the whole envelope, and a re-insert racing that rebuild
+        // hands the broadcaster a second, complete envelope for one payload: the original commit
+        // entry was written before the node, so both would publish and the payload would land on
+        // L1 twice.
+        if !active_attempt_is_still_owned(context, &record).await? {
+            debug!(node_id = ?record.node_id, active_txid = ?record.active_txid, "not re-inserting a broadcast entry the owning row has moved past");
+            return Ok(());
+        }
+        let Some(active_attempt) = record.active_attempt() else {
+            warn!(node_id = ?record.node_id, "tx-node record has no active attempt");
+            return Ok(());
+        };
+        let active_tx = active_attempt.try_to_tx()?;
+        let fee_rate = active_attempt
+            .fee_rate()
+            .unwrap_or_else(|| estimate_fee_rate.max(FeeRate::from_sat_per_vb_u32(1)));
+        warn!(node_id = ?record.node_id, active_txid = ?record.active_txid, "re-inserting broadcast entry missing for active tx-node");
+        broadcast_handle
+            .put_tx_entry(
+                active_txid,
+                L1TxEntry::from_tx_with_fee(&active_tx, fee_rate, active_attempt.fee()),
+            )
+            .await?;
+        return Ok(());
+    };
+
+    // A crash between marking the original `Replaced` and persisting the updated record leaves
+    // the record pointing at a superseded entry, which would otherwise stall the chain forever.
+    // Adopt the replacement the broadcast DB already knows about.
+    if matches!(active_entry.status, L1TxStatus::Replaced { .. }) {
+        let resolved_txid = broadcast_handle
+            .get_active_tx_entry_by_id_async(active_txid)
+            .await?
+            .map(|(txid, _)| txid);
+
+        match resolved_txid {
+            Some(resolved_txid) if resolved_txid != active_txid => {
+                let resolved = L1TxId::from(resolved_txid.0);
+                warn!(node_id = ?record.node_id, ?resolved, "recovering tx-node stranded on a superseded attempt");
+
+                // Snapshot before restoring or appending the attempt below, both of which move
+                // `active_txid` onto `resolved`. Taken afterwards it would no longer equal the
+                // durable record's superseded txid, and the guarded write that repairs the node
+                // would be skipped on every pass.
+                let snapshot_active_txid = record.active_txid;
+
+                // The broadcast entry is authoritative for the transaction bytes and fee
+                // metadata. Even when this attempt already exists in the node, it was previously
+                // marked `Replaced` and dropped its bytes, so merely repointing `active_txid`
+                // would make the next pass fail to deserialize it.
+                let Some(resolved_entry) = broadcast_handle
+                    .get_tx_entry_by_id_async(resolved_txid)
+                    .await?
+                else {
+                    warn!(node_id = ?record.node_id, ?resolved, "replacement entry vanished; leaving tx-node untouched");
+                    return Ok(());
+                };
+                let resolved_tx = resolved_entry.try_to_tx()?;
+                let Some(rbf) = resolved_entry.rbf else {
+                    warn!(node_id = ?record.node_id, ?resolved, "replacement entry has no fee metadata; leaving tx-node untouched");
+                    return Ok(());
+                };
+                let fee_rate =
+                    FeeRate::from_sat_per_vb(rbf.fee_rate_sat_vb).unwrap_or(estimate_fee_rate);
+                let fee = Amount::from_sat(rbf.fee_sats);
+
+                if !record.restore_attempt_as_active(attempt_parts(&resolved_tx, fee_rate, fee)) {
+                    // The crash landed between marking the original replaced and appending the
+                    // replacement, so the record has never seen it. Rebuild the attempt from the
+                    // broadcast entry.
+                    let attempt_no = record.next_attempt_no();
+                    record.append_replacement(TxAttempt::active(
+                        attempt_parts(&resolved_tx, fee_rate, fee),
+                        attempt_no,
+                    ));
+                }
+
+                put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record)
+                    .await?;
+            }
+            _ => {
+                warn!(node_id = ?record.node_id, "tx-node active attempt is replaced but its replacement is unreachable");
+            }
+        }
+        return Ok(());
+    }
+
+    // A crash between persisting the node and refreshing the envelope row leaves the row pointing
+    // at a superseded commit. The writer refuses to enqueue reveals in that state, so finish the
+    // refresh here rather than leaving the envelope wedged.
+    if let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind {
+        retry_stale_chunked_commit_metadata(broadcast_handle, context, &record, envelope_idx)
+            .await?;
+    }
+
+    // The same partial write on the reveal side leaves the envelope row naming a superseded
+    // reveal. Nothing else repairs it, and the DA provider reads that row directly.
+    if let TxNodeKind::ChunkedEnvelopeReveal {
+        envelope_idx,
+        reveal_idx,
+    } = record.kind
+    {
+        retry_stale_chunked_reveal_metadata(
+            broadcast_handle,
+            context,
+            &record,
+            envelope_idx,
+            reveal_idx,
+        )
+        .await?;
+    }
+
+    // A finalized transaction never leaves the chain again, so the node needs no further
+    // bumping: retire it from the active set. `Confirmed` deliberately does not retire — it
+    // regresses to `Published` on reorg (see `confirmation_status`), and a node retired early
+    // would never be bumped again. The txid guard keeps a concurrent writer rebuild, which
+    // installs a fresh attempt under a new txid, out of the retirement.
+    if matches!(active_entry.status, L1TxStatus::Finalized { .. }) {
+        broadcast_handle
+            .retire_tx_node(record.node_id, record.active_txid)
+            .await?;
+        return Ok(());
+    }
+
+    if active_entry.status != L1TxStatus::Published {
+        return Ok(());
+    }
+
+    if mark_first_published_height(&mut record, current_l1_tip) {
+        let snapshot_active_txid = record.active_txid;
+        put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record).await?;
+        return Ok(());
+    }
+
+    let Some(active_attempt) = record.active_attempt() else {
+        warn!(node_id = ?record.node_id, "tx-node record has no active attempt");
+        return Ok(());
+    };
+    let active_tx = active_attempt.try_to_tx()?;
+
+    let reveal_fee_budget =
+        resolve_reveal_fee_budget(broadcast_handle, context, &record.kind, &active_tx).await?;
+    if matches!(
+        &record.kind,
+        TxNodeKind::SingleEnvelopeReveal { .. } | TxNodeKind::ChunkedEnvelopeReveal { .. }
+    ) && reveal_fee_budget.is_none()
+    {
+        return Ok(());
+    }
+
+    let decision = evaluate_fee_bump(
+        &writer_config.fee_bumping,
+        &record,
+        active_attempt,
+        FeeBumpEvaluation {
+            current_l1_tip,
+            estimate_fee_rate,
+            incremental_relay_fee_rate,
+            replacement_vsize: active_tx.vsize(),
+            reveal_fee_budget,
+        },
+    );
+
+    match decision {
+        FeeBumpDecision::Wait => Ok(()),
+        FeeBumpDecision::BlockedByCeiling { estimate, ceiling } => {
+            // Warn rather than trace: the chain is stuck until the estimate falls below the
+            // effective ceiling, and nothing else surfaces that.
+            warn!(
+                node_id = ?record.node_id,
+                estimate_sat_vb = estimate.to_sat_per_vb_ceil(),
+                ceiling_sat_vb = ceiling.to_sat_per_vb_ceil(),
+                "fee estimate is above the effective ceiling; deferring the bump until it falls back"
+            );
+            Ok(())
+        }
+        FeeBumpDecision::Terminal(error) => {
+            // Logged once per node: every later pass skips a record that carries a terminal error,
+            // so this is the only place an operator learns the chain has stopped advancing.
+            warn!(
+                node_id = ?record.node_id,
+                kind = ?record.kind,
+                %error,
+                "fee bumping is disabled for this transaction; it stays at its current fee rate"
+            );
+            mark_terminal(broadcast_handle, record, error).await?;
+            Ok(())
+        }
+        FeeBumpDecision::Replace(request) => match record.kind.clone() {
+            TxNodeKind::SingleEnvelopeCommit { .. } => {
+                // The checkpoint writer stores a payload's commit and reveal broadcast rows within
+                // the same call, so there is no commit-only phase to bump in: by the time a commit
+                // is old enough to be stale, its reveal is already queued and replacing the commit
+                // would orphan it. Bumping the reveal is what actually unsticks a checkpoint, and
+                // that path is unaffected.
+                mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+                Ok(())
+            }
+            TxNodeKind::SingleEnvelopeReveal { .. } => {
+                replace_single_envelope_reveal(
+                    writer_config,
+                    broadcast_handle,
+                    context,
+                    record,
+                    request.target_fee_rate,
+                    request.attempt_no,
+                )
+                .await
+            }
+            TxNodeKind::ChunkedEnvelopeCommit { .. } => {
+                replace_wallet_commit(
+                    client,
+                    broadcast_handle,
+                    context,
+                    record,
+                    request.target_fee_rate,
+                    request.attempt_no,
+                )
+                .await
+            }
+            TxNodeKind::ChunkedEnvelopeReveal { .. } => {
+                replace_chunked_reveal(
+                    writer_config,
+                    broadcast_handle,
+                    context,
+                    record,
+                    request.target_fee_rate,
+                    request.attempt_no,
+                )
+                .await
+            }
+        },
+    }
+}
+
+async fn replace_wallet_commit<C>(
+    client: &C,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    mut record: TxNodeRecord,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> anyhow::Result<()>
+where
+    C: Signer,
+{
+    // Claim the envelope before checking anything. The durable guard below is a read, and the
+    // writes that follow it are not in the same transaction, so without exclusion a reveal can be
+    // enqueued in the gap and the replacement would orphan it. The claim is released on drop.
+    let _commit_claim = match record.kind {
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            let Some(claim) = context.commit_phase.try_claim(envelope_idx) else {
+                debug!(
+                    envelope_idx,
+                    "commit replacement skipped: reveal enqueueing is in flight"
+                );
+                return Ok(());
+            };
+            Some(claim)
+        }
+        _ => None,
+    };
+
+    if !commit_replacement_allowed(&record, broadcast_handle, context).await? {
+        debug!(node_id = ?record.node_id, kind = ?record.kind, "commit replacement skipped after dependent reveal activity");
+        return Ok(());
+    }
+
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        return Ok(());
+    };
+    let original_commit_tx = active_entry.try_to_tx()?;
+
+    // Tell Core which output to recycle rather than letting it guess. Its own change detection
+    // skips anything in the wallet's address book, which is where the sequencer address lives, so
+    // an unguided bump would add inputs and be refused every time.
+    let original_change_index = match record.kind {
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+                bail!("chunked commit replacement requires chunked envelope context");
+            };
+            let Some(envelope_entry) = chunked_ops
+                .get_chunked_envelope_entry_async(envelope_idx)
+                .await?
+            else {
+                bail!("chunked envelope {envelope_idx} missing");
+            };
+            chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
+        }
+        _ => None,
+    };
+
+    let replacement = match build_wallet_commit_replacement(
+        client,
+        &record.kind,
+        &original_commit_tx,
+        record.active_txid,
+        target_fee_rate,
+        attempt_no,
+        original_change_index,
+    )
+    .await
+    {
+        Ok(replacement) => replacement,
+        Err(error) if error.is_retryable() => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        Err(error) => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "failed to build RBF replacement");
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    };
+
+    let active_entry_after_build = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+        .unwrap_or(active_entry);
+    if matches!(
+        active_entry_after_build.status,
+        L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+    ) {
+        debug!(node_id = ?record.node_id, "original transaction confirmed before replacement was persisted");
+        return Ok(());
+    }
+
+    let replacement_tx = replacement.try_to_tx()?;
+    let is_chunked_commit = matches!(record.kind, TxNodeKind::ChunkedEnvelopeCommit { .. });
+
+    // Validate before writing anything: an incompatible layout must not leave partial state.
+    if is_chunked_commit {
+        // A storage or decode failure here propagates: it is our own state that is broken, and
+        // silently retrying would rebuild and re-sign a PSBT every poll while hiding the fault.
+        match validate_chunked_commit_layout(
+            context,
+            &record,
+            &active_entry_after_build,
+            &replacement_tx,
+        )
+        .await?
+        {
+            CommitLayoutCheck::Ok => {}
+            CommitLayoutCheck::IncompatibleCandidate(error) => {
+                // A different candidate (different fee rate, different change handling) may well
+                // be compatible, so discard this one rather than disabling the chain permanently.
+                warn!(node_id = ?record.node_id, %error, "discarding replacement commit whose layout is incompatible with the envelope");
+                return Ok(());
+            }
+        }
+    }
+
+    // Write order across the three trees:
+    //
+    // 1. the replacement's broadcast entry, so anything that later points at the replacement
+    //    resolves to a real entry (an envelope row referencing a commit the broadcaster has never
+    //    seen reads as corruption to the watcher and exits it permanently);
+    // 2. the original's `Replaced` transition, which is atomic and reports whether we actually won
+    //    the race against a confirmation;
+    // 3. the envelope metadata, only once step 2 says the replacement is the live commit;
+    // 4. the tx-node record.
+    //
+    // Rewriting metadata before step 2 is what lets a confirmation land in between and leave the
+    // envelope tracking a replacement that can never confirm.
+    let replacement_txid = replacement.txid;
+    let replacement_txid_raw = to_raw_buf32(replacement_txid);
+    // The attempt's own rate, not the target: the wallet prices the fee off the transaction it
+    // ends up building, and the recovery path in `process_record` rebuilds attempts from this
+    // metadata, so the two must agree.
+    let replacement_entry = L1TxEntry::from_tx_with_fee(
+        &replacement_tx,
+        replacement.fee_rate().unwrap_or(target_fee_rate),
+        replacement.fee(),
+    );
+    if !broadcast_handle
+        .put_replacement_tx_entry(active_txid, replacement_txid_raw, replacement_entry)
+        .await?
+    {
+        debug!(node_id = ?record.node_id, "original transaction left the publishable state before it could be superseded");
+        return Ok(());
+    }
+
+    // Persist the node before the metadata refresh. The refresh can fail, and a node that still
+    // points at the superseded txid is the one state that is not self-healing; with the node
+    // written, `process_record` adopts the replacement and the refresh is retried below.
+    record.append_replacement(replacement);
+    broadcast_handle.put_tx_node(record.clone()).await?;
+
+    if is_chunked_commit {
+        // Deliberately not terminal. Terminal records are skipped by every later poll, so a
+        // transient storage failure here would strand the envelope permanently. Propagating
+        // instead surfaces the fault and retries on the next poll, and until the refresh lands the
+        // writer refuses to enqueue reveals built against the superseded commit.
+        update_chunked_commit_replacement_metadata(context, &record, &replacement_tx)
+            .await
+            .context("refreshing chunked envelope metadata after commit replacement")?;
+    }
+
+    Ok(())
+}
+
+async fn replace_single_envelope_reveal(
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    mut record: TxNodeRecord,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> anyhow::Result<()> {
+    let payload_idx = match &record.kind {
+        TxNodeKind::SingleEnvelopeReveal { payload_idx } => *payload_idx,
+        _ => return Ok(()),
+    };
+    let Some(envelope_ops) = context.envelope_ops.as_ref() else {
+        mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+        return Ok(());
+    };
+    let Some(provider) = context.signing_mode_provider.as_ref() else {
+        mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+        return Ok(());
+    };
+    let signer_pubkey = match provider.signing_mode() {
+        // Only an external signer can re-sign a reveal replacement.
+        Ok(EnvelopeSigningMode::External { pubkey }) => pubkey,
+        Ok(EnvelopeSigningMode::InProcess) => {
+            mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+            return Ok(());
+        }
+        // The mode tracks canonical state, so a transient resolution failure must not mark the
+        // node terminal: that is sticky and would strand it permanently. Defer instead, matching
+        // the watcher's `resolve_signing_mode`.
+        Err(err) => {
+            warn!(%err, "could not resolve envelope signing mode; deferring to next tick");
+            return Ok(());
+        }
+    };
+
+    let Some(commit_output) =
+        resolve_reveal_commit_output(broadcast_handle, context, &record.kind).await?
+    else {
+        return Ok(());
+    };
+
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        return Ok(());
+    };
+    let active_reveal_tx = active_entry.try_to_tx()?;
+
+    // The replacement reuses the original tapscript, so its witness only validates under the key
+    // that script commits to. If the predicate has rotated to a different external key, the signer
+    // would sign the replacement sighash with the new key and produce an invalid witness, while
+    // the original entry was already marked `Replaced`. Refuse instead; the watcher rebuilds the
+    // envelope under the new key, and that fresh initial attempt clears this terminal error.
+    match extract_reveal_pubkey(&active_reveal_tx) {
+        Ok(reveal_pubkey) if reveal_pubkey == signer_pubkey => {}
+        Ok(reveal_pubkey) => {
+            warn!(
+                payload_idx,
+                %reveal_pubkey,
+                %signer_pubkey,
+                "envelope signing key rotated since the reveal was built; refusing to bump it"
+            );
+            mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+            return Ok(());
+        }
+        Err(error) => {
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    }
+
+    let (replacement, sighash) = match build_pending_single_reveal_replacement(
+        &active_reveal_tx,
+        &commit_output,
+        target_fee_rate,
+        attempt_no,
+    ) {
+        Ok(replacement) => replacement,
+        Err(error) if error.is_retryable() => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        Err(error) => {
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    };
+
+    let active_entry_after_build = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+        .unwrap_or(active_entry);
+    if matches!(
+        active_entry_after_build.status,
+        L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+    ) {
+        debug!(
+            payload_idx,
+            "original reveal confirmed before replacement was persisted"
+        );
+        return Ok(());
+    }
+
+    // Both writes below come from a snapshot taken before the replacement was built, and the writer
+    // rebuilds this payload concurrently whenever the original reveal goes invalid. Re-read the row
+    // and give up if it has moved on: writing the stale row back would restore a sighash computed
+    // over the superseded reveal, and the signer would sign that for the rebuilt envelope, whose
+    // witness could then never validate.
+    let Some(mut current_payload_entry) = envelope_ops
+        .get_payload_entry_by_idx_async(payload_idx)
+        .await?
+    else {
+        return Ok(());
+    };
+    if current_payload_entry.reveal_txid != record.active_txid {
+        debug!(
+            payload_idx,
+            "payload rebuilt while its reveal replacement was being built; discarding the replacement"
+        );
+        return Ok(());
+    }
+
+    // Node before metadata. The watcher treats `PendingRevealTxSign` without a pending node
+    // attempt as a stalled signature and resets the payload to `Unsigned`, which rebuilds against
+    // fresh UTXOs while the original reveal is still live. Writing the node first means that state
+    // is never observable. The reverse interleaving only stalls this node's bumping.
+    let snapshot_active_txid = record.active_txid;
+    record.append_pending_signature_replacement(replacement);
+    put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record).await?;
+
+    current_payload_entry.payload_signature = None;
+    current_payload_entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+    envelope_ops
+        .put_payload_entry_async(payload_idx, current_payload_entry)
+        .await?;
+
+    debug!(
+        payload_idx,
+        target_fee_rate_sat_vb = target_fee_rate.to_sat_per_vb_ceil(),
+        max_fee_rate_sat_vb = writer_config.fee_bumping.max_fee_rate_sat_vb.get(),
+        "single-envelope reveal replacement awaiting external signature"
+    );
+    Ok(())
+}
+
+async fn replace_chunked_reveal(
+    writer_config: &WriterConfig,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    mut record: TxNodeRecord,
+    target_fee_rate: FeeRate,
+    attempt_no: u32,
+) -> anyhow::Result<()> {
+    let (envelope_idx, reveal_idx) = match &record.kind {
+        TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx,
+        } => (*envelope_idx, *reveal_idx),
+        _ => return Ok(()),
+    };
+    let (Some(chunked_ops), Some(sequencer_keypair)) = (
+        context.chunked_ops.as_ref(),
+        context.sequencer_keypair.as_ref(),
+    ) else {
+        mark_terminal(broadcast_handle, record, TerminalError::UnsupportedRbfKind).await?;
+        return Ok(());
+    };
+    let Some(mut envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        warn!(
+            envelope_idx,
+            "chunked envelope entry missing for reveal replacement"
+        );
+        return Ok(());
+    };
+    let Some(commit_output) =
+        resolve_reveal_commit_output(broadcast_handle, context, &record.kind).await?
+    else {
+        return Ok(());
+    };
+    let active_txid = to_raw_buf32(record.active_txid);
+    let Some(active_entry) = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+    else {
+        return Ok(());
+    };
+    let active_reveal_tx = active_entry.try_to_tx()?;
+    let replacement = match build_chunked_reveal_replacement(
+        &active_reveal_tx,
+        &commit_output,
+        target_fee_rate,
+        attempt_no,
+        sequencer_keypair,
+    ) {
+        Ok(replacement) => replacement,
+        Err(error) if error.is_retryable() => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        Err(error) => {
+            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+            return Ok(());
+        }
+    };
+
+    let active_entry_after_build = broadcast_handle
+        .get_tx_entry_by_id_async(active_txid)
+        .await?
+        .unwrap_or(active_entry);
+    if matches!(
+        active_entry_after_build.status,
+        L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+    ) {
+        debug!(
+            envelope_idx,
+            reveal_idx, "original reveal confirmed before replacement was persisted"
+        );
+        return Ok(());
+    }
+
+    let replacement_tx = replacement.try_to_tx()?;
+    let replacement_txid = replacement.txid;
+    let replacement_txid_raw = to_raw_buf32(replacement_txid);
+    let replacement_entry =
+        L1TxEntry::from_tx_with_fee(&replacement_tx, target_fee_rate, replacement.fee());
+    if !broadcast_handle
+        .put_replacement_tx_entry(active_txid, replacement_txid_raw, replacement_entry)
+        .await?
+    {
+        debug!(
+            envelope_idx,
+            reveal_idx, "reveal left the publishable state before it could be superseded"
+        );
+        return Ok(());
+    }
+
+    update_chunked_reveal_meta(&mut envelope_entry, reveal_idx, &replacement_tx);
+    chunked_ops
+        .put_chunked_envelope_entry_async(envelope_idx, envelope_entry)
+        .await?;
+
+    record.append_replacement(replacement);
+    broadcast_handle.put_tx_node(record).await?;
+
+    debug!(
+        envelope_idx,
+        reveal_idx,
+        txid = ?replacement_txid,
+        target_fee_rate_sat_vb = target_fee_rate.to_sat_per_vb_ceil(),
+        max_fee_rate_sat_vb = writer_config.fee_bumping.max_fee_rate_sat_vb.get(),
+        "chunked reveal replacement persisted"
+    );
+    Ok(())
+}
+
+fn update_chunked_reveal_meta(
+    envelope_entry: &mut ChunkedEnvelopeEntry,
+    reveal_idx: u32,
+    replacement_tx: &Transaction,
+) {
+    if let Some(reveal) = envelope_entry.reveals.get_mut(reveal_idx as usize) {
+        *reveal = RevealTxMeta {
+            vout_index: reveal.vout_index,
+            txid: L1TxId::from(replacement_tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(replacement_tx.compute_wtxid().to_byte_array()),
+            tx_bytes: serialize(replacement_tx),
+        };
+    }
+}
+
+/// Outcome of checking a replacement chunked commit before envelope metadata is rewritten.
+enum CommitLayoutCheck {
+    /// The replacement is safe to adopt.
+    Ok,
+    /// This particular candidate is unusable, but a later one may not be.
+    IncompatibleCandidate(ReplacementError),
+}
+
+/// Re-runs the envelope metadata refresh when it did not complete after a commit replacement.
+async fn retry_stale_chunked_commit_metadata(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    envelope_idx: u64,
+) -> anyhow::Result<()> {
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        return Ok(());
+    };
+    let Some(entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        return Ok(());
+    };
+    if entry.commit_txid == record.active_txid {
+        return Ok(());
+    }
+    // Forward-only, same rule as the reveal side. A resign that crashed between writing the row and
+    // writing the node leaves the row on the newer commit and the node on the dead one; without
+    // this the refresh would drag the row back onto the invalidated commit and re-sign every reveal
+    // against it, once per poll, until the watcher's own resign won.
+    let resolves_to_active = broadcast_handle
+        .get_active_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+        .await?
+        .is_some_and(|(resolved_txid, _)| L1TxId::from(resolved_txid.0) == record.active_txid);
+    if !resolves_to_active {
+        return Ok(());
+    }
+    let Some(active_attempt) = record.active_attempt() else {
+        return Ok(());
+    };
+
+    warn!(
+        envelope_idx,
+        stale_commit_txid = ?entry.commit_txid,
+        active_commit_txid = ?record.active_txid,
+        "completing chunked envelope metadata refresh left undone by a commit replacement"
+    );
+    let replacement_tx = active_attempt.try_to_tx()?;
+    update_chunked_commit_replacement_metadata(context, record, &replacement_tx).await
+}
+
+/// Re-points a chunked envelope's reveal metadata when a replacement did not finish rewriting it.
+///
+/// [`replace_chunked_reveal`] supersedes the reveal in the broadcast DB before it rewrites the
+/// envelope row, so a stop in between leaves the row naming a `Replaced` txid. Unlike the commit
+/// path, nothing downstream repairs that: the chunked watcher follows the replacement chain without
+/// rewriting the row, while the EE DA provider looks the row's txid up directly and refuses
+/// anything that is not `Finalized`, which blocks the envelope's DA refs forever.
+async fn retry_stale_chunked_reveal_metadata(
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    envelope_idx: u64,
+    reveal_idx: u32,
+) -> anyhow::Result<()> {
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        return Ok(());
+    };
+    let Some(mut entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        return Ok(());
+    };
+    let Some(stale_reveal_txid) = entry
+        .reveals
+        .get(reveal_idx as usize)
+        .map(|reveal| reveal.txid)
+    else {
+        return Ok(());
+    };
+    if stale_reveal_txid == record.active_txid {
+        return Ok(());
+    }
+
+    // Only ever move the row forward: adopt the node's txid when the row's reveal resolves *through
+    // the replacement chain* to it. The inverse partial write, where the row is newer than the
+    // node, is healed by the `Replaced` adoption above and must not be dragged back here.
+    let resolves_to_active = broadcast_handle
+        .get_active_tx_entry_by_id_async(to_raw_buf32(stale_reveal_txid))
+        .await?
+        .is_some_and(|(resolved_txid, _)| L1TxId::from(resolved_txid.0) == record.active_txid);
+    if !resolves_to_active {
+        return Ok(());
+    }
+    let Some(active_attempt) = record.active_attempt() else {
+        return Ok(());
+    };
+    let replacement_tx = active_attempt.try_to_tx()?;
+
+    warn!(
+        envelope_idx,
+        reveal_idx,
+        ?stale_reveal_txid,
+        active_reveal_txid = ?record.active_txid,
+        "completing chunked envelope metadata refresh left undone by a reveal replacement"
+    );
+    update_chunked_reveal_meta(&mut entry, reveal_idx, &replacement_tx);
+    chunked_ops
+        .put_chunked_envelope_entry_async(envelope_idx, entry)
+        .await?;
+    Ok(())
+}
+
+/// Verifies a replacement chunked commit before any envelope metadata is rewritten.
+///
+/// Errors are reserved for problems with our own state (missing context, missing envelope row,
+/// undecodable transaction, storage failure). A replacement that is simply shaped wrong comes back
+/// as [`CommitLayoutCheck::IncompatibleCandidate`] so it can be discarded without masking a real
+/// fault as a routine retry.
+async fn validate_chunked_commit_layout(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    active_commit_entry: &L1TxEntry,
+    replacement_commit_tx: &Transaction,
+) -> anyhow::Result<CommitLayoutCheck> {
+    let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind else {
+        return Ok(CommitLayoutCheck::Ok);
+    };
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        bail!("chunked commit replacement requires chunked envelope context");
+    };
+    let Some(envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        bail!("chunked envelope {envelope_idx} missing");
+    };
+
+    let original_commit_tx = active_commit_entry.try_to_tx()?;
+    match validate_chunked_commit_replacement_layout(
+        &original_commit_tx,
+        replacement_commit_tx,
+        envelope_entry.reveals.len(),
+    ) {
+        Ok(()) => Ok(CommitLayoutCheck::Ok),
+        Err(error) => Ok(CommitLayoutCheck::IncompatibleCandidate(error)),
+    }
+}
+
+async fn update_chunked_commit_replacement_metadata(
+    context: &ReplacementContext,
+    record: &TxNodeRecord,
+    replacement_commit_tx: &Transaction,
+) -> anyhow::Result<()> {
+    let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind else {
+        return Ok(());
+    };
+    let (Some(chunked_ops), Some(sequencer_keypair)) = (
+        context.chunked_ops.as_ref(),
+        context.sequencer_keypair.as_ref(),
+    ) else {
+        bail!("chunked commit replacement requires chunked envelope context");
+    };
+    let Some(mut envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        bail!("chunked envelope {envelope_idx} missing");
+    };
+
+    let replacement_commit_txid = replacement_commit_tx.compute_txid();
+    envelope_entry.commit_txid = L1TxId::from(replacement_commit_txid.to_byte_array());
+    envelope_entry.commit_wtxid =
+        L1WtxId::from(replacement_commit_tx.compute_wtxid().to_byte_array());
+
+    for reveal in &mut envelope_entry.reveals {
+        let old_reveal_tx: Transaction = deserialize(&reveal.tx_bytes)?;
+        let Some(commit_output) = replacement_commit_tx.output.get(reveal.vout_index as usize)
+        else {
+            bail!(
+                "replacement commit missing reveal output {}",
+                reveal.vout_index
+            );
+        };
+        let replacement_reveal = rebuild_reveal_for_replaced_commit(
+            &old_reveal_tx,
+            replacement_commit_txid,
+            commit_output,
+            sequencer_keypair,
+        )?;
+        reveal.txid = L1TxId::from(replacement_reveal.compute_txid().to_byte_array());
+        reveal.wtxid = L1WtxId::from(replacement_reveal.compute_wtxid().to_byte_array());
+        reveal.tx_bytes = serialize(&replacement_reveal);
+    }
+
+    chunked_ops
+        .put_chunked_envelope_entry_async(envelope_idx, envelope_entry)
+        .await?;
+    Ok(())
+}
+
+fn mark_first_published_height(record: &mut TxNodeRecord, current_l1_tip: L1Height) -> bool {
+    let Some(active_attempt) = record.active_attempt_mut() else {
+        return false;
+    };
+    if active_attempt.first_published_l1_height.is_some() {
+        return false;
+    }
+    active_attempt.first_published_l1_height = Some(current_l1_tip);
+    true
+}
+
+async fn mark_terminal(
+    broadcast_handle: &L1BroadcastHandle,
+    mut record: TxNodeRecord,
+    error: TerminalError,
+) -> anyhow::Result<()> {
+    let snapshot_active_txid = record.active_txid;
+    record.set_terminal_error(error);
+    put_tx_node_if_active_unchanged(broadcast_handle, snapshot_active_txid, record).await
+}
+
+/// Persists a record only while the durable node still names the same active attempt.
+///
+/// The poll works from a snapshot taken before its per-record I/O, and the writer rebuilds a
+/// logical transaction concurrently whenever its original goes `InvalidInputs`:
+/// `put_tx_node_if_enabled` calls [`TxNodeRecord::replace_initial_attempt`], which installs a fresh
+/// attempt under a new txid and clears any terminal error. Writing the snapshot back on top of that
+/// would revive the superseded txid, and because the payload tracks the rebuilt transaction, every
+/// later poll would read a non-`Published` entry and skip the node for good.
+///
+/// This narrows the window to two adjacent reads rather than closing it; the compare and the write
+/// are still separate operations. Making it atomic needs a compare-and-swap in the broadcast DB,
+/// which belongs with the journalling work in known gap 2.
+///
+/// Replacement writes do not need this: they only run once `put_replacement_tx_entry` has
+/// transitioned the original, and that check is atomic and refuses a txid a rebuild has already
+/// invalidated.
+///
+/// `snapshot_active_txid` is the active txid the caller read, which is not always `record`'s own:
+/// the adoption path rewrites it before persisting.
+async fn put_tx_node_if_active_unchanged(
+    broadcast_handle: &L1BroadcastHandle,
+    snapshot_active_txid: L1TxId,
+    record: TxNodeRecord,
+) -> anyhow::Result<()> {
+    if let Some(current) = broadcast_handle.get_tx_node(record.node_id).await? {
+        if current.active_txid != snapshot_active_txid {
+            debug!(
+                node_id = ?record.node_id,
+                ?snapshot_active_txid,
+                active_txid = ?current.active_txid,
+                "skipping tx-node write: the writer rebuilt this transaction during the poll"
+            );
+            return Ok(());
+        }
+    }
+    broadcast_handle.put_tx_node(record).await?;
+    Ok(())
+}
+
+/// Reports whether a commit transaction may still be fee bumped.
+///
+/// Replacing a commit changes its txid, which invalidates every reveal that spends one of its
+/// outputs. So a commit is only replaceable while the envelope is still in the commit-only phase.
+/// This check is deliberately fail-closed: anything it cannot positively confirm as "no reveal has
+/// been handed to the broadcaster" blocks the replacement.
+async fn commit_replacement_allowed(
+    record: &TxNodeRecord,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+) -> anyhow::Result<bool> {
+    match record.kind {
+        TxNodeKind::SingleEnvelopeCommit { payload_idx } => {
+            reveal_node_not_handed_to_broadcaster(
+                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx }),
+                broadcast_handle,
+            )
+            .await
+        }
+        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
+            chunked_reveals_not_handed_to_broadcaster(envelope_idx, broadcast_handle, context).await
+        }
+        TxNodeKind::SingleEnvelopeReveal { .. } | TxNodeKind::ChunkedEnvelopeReveal { .. } => {
+            Ok(true)
+        }
+    }
+}
+
+/// Reports whether no reveal of `envelope_idx` has reached the broadcaster yet.
+///
+/// Two independent sources are consulted so the answer does not depend on the order in which the
+/// writer persists a reveal's tx-node record and its broadcast entry:
+///
+/// 1. the persisted envelope row, whose `reveals` carry the authoritative reveal txids, and
+/// 2. the tx-node tree, which covers reveals recorded before the envelope row was refreshed.
+///
+/// A missing envelope row is treated as disqualifying rather than permissive: without it there is
+/// no way to enumerate the reveals that a commit replacement would orphan.
+async fn chunked_reveals_not_handed_to_broadcaster(
+    envelope_idx: u64,
+    broadcast_handle: &L1BroadcastHandle,
+    context: &ReplacementContext,
+) -> anyhow::Result<bool> {
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        return Ok(false);
+    };
+    let Some(entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        warn!(
+            envelope_idx,
+            "chunked envelope row missing; refusing commit replacement"
+        );
+        return Ok(false);
+    };
+
+    for reveal in &entry.reveals {
+        if broadcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+            .await?
+            .is_some()
+        {
+            return Ok(false);
+        }
+    }
+
+    let nodes = broadcast_handle.get_all_tx_nodes().await?;
+    Ok(!nodes.iter().any(|node| {
+        matches!(
+            node.kind,
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: node_envelope_idx,
+                ..
+            } if node_envelope_idx == envelope_idx
+        )
+    }))
+}
+
+/// Reports whether this reveal has not yet been handed to the broadcaster.
+///
+/// "Handed over" means a broadcast row exists, not that the row says `Published`. An `Unpublished`
+/// row is already queued and the broadcaster can publish it on any tick, so a commit replacement
+/// that reads it as safe would race the publication and orphan the reveal.
+async fn reveal_node_not_handed_to_broadcaster(
+    node_id: TxNodeId,
+    broadcast_handle: &L1BroadcastHandle,
+) -> anyhow::Result<bool> {
+    let Some(reveal_node) = broadcast_handle.get_tx_node(node_id).await? else {
+        return Ok(true);
+    };
+    Ok(broadcast_handle
+        .get_active_tx_entry_by_id_async(to_raw_buf32(reveal_node.active_txid))
+        .await?
+        .is_none())
+}
+
+fn to_raw_buf32(txid: L1TxId) -> Buf32 {
+    Buf32(txid.0)
+}
+
+#[cfg(test)]
+mod pacer_tests {
+    use super::*;
+
+    #[test]
+    fn first_claim_runs_then_the_interval_holds() {
+        let pacer = ReplacementPacer::new(Duration::from_secs(30));
+
+        // A fresh writer must look at records a previous process left behind rather than idling
+        // for a full interval first.
+        assert!(pacer.claim());
+        assert!(!pacer.claim());
+        assert!(!pacer.claim());
+    }
+
+    #[test]
+    fn a_zero_interval_runs_every_time() {
+        let pacer = ReplacementPacer::new(Duration::ZERO);
+
+        assert!(pacer.claim());
+        assert!(pacer.claim());
+    }
+
+    #[test]
+    fn the_default_interval_matches_the_config_default() {
+        assert_eq!(
+            ReplacementPacer::default().interval,
+            FeeBumpingConfig::default().check_interval()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime, consensus::serialize, transaction::Version, Amount, OutPoint,
+        ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    };
+    use strata_csm_types::L1Payload;
+    use strata_db_types::{
+        chunked_envelope::{ChunkedEnvelopeEntry, ChunkedEnvelopeStatus},
+        common::L1WtxId,
+        fee_bump::TxAttempt,
+        l1_writer::BundledPayloadEntry,
+    };
+    use strata_l1_txfmt::{MagicBytes, TagData};
+
+    use super::*;
+    use crate::{
+        test_utils::TestBitcoinClient,
+        writer::test_utils::{get_broadcast_handle, get_chunked_envelope_ops, get_envelope_ops},
+    };
+
+    const ENVELOPE_IDX: u64 = 3;
+    const PAYLOAD_IDX: u64 = 7;
+
+    /// Signing mode provider that yields a fixed mode, or fails when none is set.
+    #[derive(Debug)]
+    struct TestSigningModeProvider {
+        mode: Option<EnvelopeSigningMode>,
+    }
+
+    impl TestSigningModeProvider {
+        fn returning(mode: EnvelopeSigningMode) -> Arc<dyn EnvelopeSigningModeProvider> {
+            Arc::new(Self { mode: Some(mode) })
+        }
+
+        fn failing() -> Arc<dyn EnvelopeSigningModeProvider> {
+            Arc::new(Self { mode: None })
+        }
+    }
+
+    impl EnvelopeSigningModeProvider for TestSigningModeProvider {
+        fn signing_mode(&self) -> anyhow::Result<EnvelopeSigningMode> {
+            self.mode
+                .ok_or_else(|| anyhow::anyhow!("canonical ASM state unavailable"))
+        }
+    }
+
+    fn tx_with_output(value: u64) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn reveal_budget_reserves_other_outputs_and_final_output_dust() {
+        let mut reveal = tx_with_output(900);
+        reveal.output.insert(
+            0,
+            TxOut {
+                value: Amount::from_sat(100),
+                script_pubkey: ScriptBuf::new(),
+            },
+        );
+        let commit_output = TxOut {
+            value: Amount::from_sat(2_000),
+            script_pubkey: ScriptBuf::new(),
+        };
+
+        assert_eq!(
+            reveal_fee_budget(&commit_output, &reveal),
+            Amount::from_sat(1_354)
+        );
+    }
+
+    #[test]
+    fn reveal_budget_saturates_to_zero_when_funding_is_below_reserved_value() {
+        let reveal = tx_with_output(BITCOIN_DUST_LIMIT);
+        let commit_output = TxOut {
+            value: Amount::from_sat(BITCOIN_DUST_LIMIT - 1),
+            script_pubkey: ScriptBuf::new(),
+        };
+
+        assert_eq!(reveal_fee_budget(&commit_output, &reveal), Amount::ZERO);
+    }
+
+    fn fee_rate() -> FeeRate {
+        FeeRate::from_sat_per_vb(2).expect("test: valid fee rate")
+    }
+
+    fn commit_record() -> TxNodeRecord {
+        let attempt = TxAttempt::active(attempt_parts(&tx_with_output(10_000), fee_rate(), Amount::from_sat(500)), 0);
+        TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeCommit {
+                envelope_idx: ENVELOPE_IDX,
+            },
+            attempt,
+        )
+    }
+
+    /// Builds an envelope row carrying one reveal, returning the row and the reveal tx.
+    fn envelope_entry_with_reveal() -> (ChunkedEnvelopeEntry, Transaction) {
+        let reveal_tx = tx_with_output(900);
+        let mut entry =
+            ChunkedEnvelopeEntry::new_unsigned(vec![vec![1u8; 8]], MagicBytes::new(*b"ALPN"), 0);
+        entry.status = ChunkedEnvelopeStatus::CommitPublished;
+        entry.reveals = vec![RevealTxMeta {
+            vout_index: 1,
+            txid: L1TxId::from(reveal_tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(reveal_tx.compute_wtxid().to_byte_array()),
+            tx_bytes: serialize(&reveal_tx),
+        }];
+        (entry, reveal_tx)
+    }
+
+    /// The commit-only-phase guard is a read, and the writes that follow it are not in the same
+    /// transaction. The latch is what makes the pair safe: while the writer is enqueueing reveals
+    /// for an envelope, a commit replacement for it must not even begin.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_is_refused_while_reveal_enqueue_holds_the_envelope() {
+        let bcast = get_broadcast_handle();
+        let (entry, _reveal_tx) = envelope_entry_with_reveal();
+        let mut context = context_with(Some(entry)).await;
+        let latch = CommitPhaseLatch::new();
+        context.commit_phase = latch.clone();
+
+        // Nothing has been enqueued yet, so the durable guard alone would allow the replacement.
+        assert!(
+            commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+
+        // The writer claims the envelope to enqueue its reveals.
+        let enqueue_claim = latch
+            .try_claim(ENVELOPE_IDX)
+            .expect("writer claims the envelope");
+        assert!(
+            latch.try_claim(ENVELOPE_IDX).is_none(),
+            "the fee bumper must not be able to claim the same envelope"
+        );
+
+        drop(enqueue_claim);
+        assert!(
+            latch.try_claim(ENVELOPE_IDX).is_some(),
+            "the envelope must be claimable again once enqueueing finishes"
+        );
+    }
+
+    fn single_reveal_record() -> TxNodeRecord {
+        TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: PAYLOAD_IDX,
+            },
+            TxAttempt::active(attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)), 0))
+    }
+
+    /// Runs a single-envelope reveal replacement against `provider` and returns the persisted
+    /// terminal error, if any.
+    async fn terminal_error_after_reveal_replacement(
+        provider: Option<Arc<dyn EnvelopeSigningModeProvider>>,
+    ) -> Option<TerminalError> {
+        let bcast = get_broadcast_handle();
+        let record = single_reveal_record();
+        let node_id = record.node_id;
+        bcast
+            .put_tx_node(record.clone())
+            .await
+            .expect("test: reveal node persists");
+
+        let context = ReplacementContext {
+            envelope_ops: Some(get_envelope_ops()),
+            signing_mode_provider: provider,
+            ..ReplacementContext::default()
+        };
+
+        replace_single_envelope_reveal(
+            &WriterConfig::default(),
+            &bcast,
+            &context,
+            record,
+            fee_rate(),
+            1,
+        )
+        .await
+        .expect("test: replacement attempt returns");
+
+        bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node still exists")
+            .terminal_error
+    }
+
+    /// An in-process signing mode cannot re-sign a reveal, so the node is terminal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_reveal_replacement_is_terminal_for_in_process_signing() {
+        let terminal = terminal_error_after_reveal_replacement(Some(
+            TestSigningModeProvider::returning(EnvelopeSigningMode::InProcess),
+        ))
+        .await;
+
+        assert_eq!(terminal, Some(TerminalError::UnsupportedRbfKind));
+    }
+
+    /// Without a provider there is nothing to resolve, so the node is terminal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_reveal_replacement_is_terminal_without_a_provider() {
+        assert_eq!(
+            terminal_error_after_reveal_replacement(None).await,
+            Some(TerminalError::UnsupportedRbfKind)
+        );
+    }
+
+    /// Regression: the signing mode tracks canonical ASM state, so a transient resolution failure
+    /// must defer to the next tick. Marking the node terminal here is sticky and would strand it
+    /// for good, even once the mode resolves again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_reveal_replacement_defers_when_signing_mode_is_unresolvable() {
+        let terminal =
+            terminal_error_after_reveal_replacement(Some(TestSigningModeProvider::failing())).await;
+
+        assert_eq!(terminal, None, "a provider error must not be terminal");
+    }
+
+    async fn context_with(entry: Option<ChunkedEnvelopeEntry>) -> ReplacementContext {
+        let chunked_ops = get_chunked_envelope_ops();
+        if let Some(entry) = entry {
+            chunked_ops
+                .put_chunked_envelope_entry_async(ENVELOPE_IDX, entry)
+                .await
+                .expect("test: envelope row persists");
+        }
+        ReplacementContext {
+            chunked_ops: Some(chunked_ops),
+            ..ReplacementContext::default()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_allowed_before_any_reveal_is_enqueued() {
+        let bcast = get_broadcast_handle();
+        let (entry, _reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        // The envelope row lists a reveal, but nothing has been handed to the broadcaster and no
+        // reveal tx-node exists: the envelope is still in the commit-only phase.
+        assert!(
+            commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// Regression: a crash between inserting a reveal's broadcast entry and writing its tx-node
+    /// record must not let the commit be replaced, which would orphan the published reveal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_when_reveal_entry_exists_without_tx_node() {
+        let bcast = get_broadcast_handle();
+        let (entry, reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        bcast
+            .put_tx_entry(
+                Buf32(reveal_tx.compute_txid().to_byte_array()),
+                L1TxEntry::from_tx_with_fee(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+            )
+            .await
+            .expect("test: reveal entry persists");
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_when_reveal_tx_node_exists() {
+        let bcast = get_broadcast_handle();
+        let (entry, reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        let reveal_record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 0,
+            },
+            TxAttempt::active(attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
+        bcast
+            .put_tx_node(reveal_record)
+            .await
+            .expect("test: reveal node persists");
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// Without the envelope row there is no way to enumerate the reveals a replacement would
+    /// orphan, so the guard must refuse rather than assume the commit-only phase.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_when_envelope_row_is_missing() {
+        let bcast = get_broadcast_handle();
+        let context = context_with(None).await;
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_without_chunked_ops() {
+        let bcast = get_broadcast_handle();
+
+        assert!(!commit_replacement_allowed(
+            &commit_record(),
+            &bcast,
+            &ReplacementContext::default()
+        )
+        .await
+        .unwrap());
+    }
+
+    /// Regression: when an earlier attempt wins on-chain, it already exists in the tx-node but
+    /// was marked replaced and had its bytes discarded. Repointing `active_txid` alone makes the
+    /// next pass fail while deserializing an empty transaction and prevents owner metadata repair.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn confirmed_earlier_attempt_is_restored_before_reactivation() {
+        let bcast = get_broadcast_handle();
+        let original_tx = tx_with_output(1_000);
+        let original_txid = L1TxId::from(original_tx.compute_txid().to_byte_array());
+        let replacement_tx = tx_with_output(900);
+        let replacement_txid = L1TxId::from(replacement_tx.compute_txid().to_byte_array());
+
+        let mut original_entry =
+            L1TxEntry::from_tx_with_fee(&original_tx, fee_rate(), Amount::from_sat(100));
+        original_entry.status = L1TxStatus::Confirmed {
+            confirmations: 1,
+            block_hash: Buf32::zero(),
+            block_height: 10,
+        };
+        bcast
+            .put_tx_entry(to_raw_buf32(original_txid), original_entry)
+            .await
+            .expect("test: confirmed original persists");
+
+        let mut replacement_entry =
+            L1TxEntry::from_tx_with_fee(&replacement_tx, fee_rate(), Amount::from_sat(200));
+        replacement_entry.status = L1TxStatus::Replaced { by: original_txid };
+        bcast
+            .put_tx_entry(to_raw_buf32(replacement_txid), replacement_entry)
+            .await
+            .expect("test: replaced chain head persists");
+
+        let mut record = TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeCommit { payload_idx: 1 },
+            TxAttempt::active(attempt_parts(&original_tx, fee_rate(), Amount::from_sat(100)), 0));
+        record.append_replacement(TxAttempt::active(attempt_parts(&replacement_tx, fee_rate(), Amount::from_sat(200)), 1));
+        let node_id = record.node_id;
+        bcast
+            .put_tx_node(record.clone())
+            .await
+            .expect("test: replacement node persists");
+
+        let policy_inputs = ReplacementPolicyInputs {
+            current_l1_tip: 10,
+            estimate_fee_rate: fee_rate(),
+            incremental_relay_fee_rate: fee_rate(),
+        };
+        process_record(
+            &TestBitcoinClient::new(1),
+            &WriterConfig::default(),
+            &bcast,
+            policy_inputs,
+            record,
+            &ReplacementContext::default(),
+        )
+        .await
+        .expect("test: adoption succeeds");
+
+        let restored = bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node exists");
+        let active = restored.active_attempt().expect("test: winner is active");
+        assert_eq!(restored.active_txid, original_txid);
+        assert_eq!(active.status, TxAttemptStatus::Active);
+        assert_eq!(active.try_to_tx().unwrap(), original_tx);
+        assert_eq!(restored.attempts[1].status, TxAttemptStatus::Replaced);
+        assert_eq!(restored.attempts[1].replaced_by, Some(original_txid));
+        assert!(restored.attempts[1].raw_tx.is_empty());
+
+        process_record(
+            &TestBitcoinClient::new(1),
+            &WriterConfig::default(),
+            &bcast,
+            policy_inputs,
+            restored,
+            &ReplacementContext::default(),
+        )
+        .await
+        .expect("test: the next pass can deserialize the restored winner");
+    }
+
+    /// Builds a chunked-reveal node whose replacement is live in the broadcast DB while the
+    /// envelope row still names the superseded reveal, the state a stop between the two writes in
+    /// [`replace_chunked_reveal`] leaves behind.
+    async fn chunked_reveal_stranded_after_partial_replacement() -> (
+        Arc<L1BroadcastHandle>,
+        ReplacementContext,
+        TxNodeRecord,
+        L1TxId,
+    ) {
+        let bcast = get_broadcast_handle();
+        let (entry, reveal_tx) = envelope_entry_with_reveal();
+        let context = context_with(Some(entry)).await;
+
+        let replacement_tx = tx_with_output(800);
+        let replacement_txid = L1TxId::from(replacement_tx.compute_txid().to_byte_array());
+        bcast
+            .put_tx_entry(
+                to_raw_buf32(L1TxId::from(reveal_tx.compute_txid().to_byte_array())),
+                L1TxEntry::from_tx_with_fee(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+            )
+            .await
+            .expect("test: original reveal entry persists");
+        assert!(
+            bcast
+                .put_replacement_tx_entry(
+                    to_raw_buf32(L1TxId::from(reveal_tx.compute_txid().to_byte_array())),
+                    to_raw_buf32(replacement_txid),
+                    L1TxEntry::from_tx_with_fee(&replacement_tx, fee_rate(), Amount::from_sat(200)),
+                )
+                .await
+                .expect("test: replacement swap runs"),
+            "test: the original must be replaceable"
+        );
+
+        let mut record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 0,
+            },
+            TxAttempt::active(attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
+        record.append_replacement(TxAttempt::active(attempt_parts(&replacement_tx, fee_rate(), Amount::from_sat(200)), 1));
+
+        (bcast, context, record, replacement_txid)
+    }
+
+    /// Regression: the envelope row is rewritten after the broadcast swap, so a stop in between
+    /// leaves it naming a `Replaced` reveal. Nothing downstream repairs that, and the EE DA
+    /// provider reads the row directly, so the envelope's DA refs would never be built.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stale_chunked_reveal_metadata_is_refreshed_from_the_node() {
+        let (bcast, context, record, replacement_txid) =
+            chunked_reveal_stranded_after_partial_replacement().await;
+
+        retry_stale_chunked_reveal_metadata(&bcast, &context, &record, ENVELOPE_IDX, 0)
+            .await
+            .expect("test: metadata refresh runs");
+
+        let refreshed = context
+            .chunked_ops
+            .as_ref()
+            .expect("test: chunked ops configured")
+            .get_chunked_envelope_entry_async(ENVELOPE_IDX)
+            .await
+            .expect("test: envelope row is readable")
+            .expect("test: envelope row exists");
+        assert_eq!(refreshed.reveals[0].txid, replacement_txid);
+        assert_eq!(refreshed.reveals[0].vout_index, 1, "vout must be preserved");
+    }
+
+    /// The row is only ever moved forward. A reveal that does not resolve through the replacement
+    /// chain to the node's active attempt is left alone, so the inverse partial write, where the
+    /// row is newer than the node, is not dragged back to a superseded reveal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unrelated_chunked_reveal_metadata_is_left_alone() {
+        let (bcast, context, mut record, _) =
+            chunked_reveal_stranded_after_partial_replacement().await;
+        let unrelated_tx = tx_with_output(700);
+        record.append_replacement(TxAttempt::active(attempt_parts(&unrelated_tx, fee_rate(), Amount::from_sat(300)), 2));
+
+        retry_stale_chunked_reveal_metadata(&bcast, &context, &record, ENVELOPE_IDX, 0)
+            .await
+            .expect("test: metadata refresh runs");
+
+        let chunked_ops = context
+            .chunked_ops
+            .as_ref()
+            .expect("test: chunked ops configured");
+        let unchanged = chunked_ops
+            .get_chunked_envelope_entry_async(ENVELOPE_IDX)
+            .await
+            .expect("test: envelope row is readable")
+            .expect("test: envelope row exists");
+        let (original_entry, _) = envelope_entry_with_reveal();
+        assert_eq!(unchanged.reveals[0].txid, original_entry.reveals[0].txid);
+    }
+
+    /// Builds a payload row naming `reveal_txid`, and the reveal node for the same payload.
+    async fn payload_row_and_reveal_node(
+        reveal_tx: &Transaction,
+    ) -> (ReplacementContext, TxNodeRecord) {
+        let envelope_ops = get_envelope_ops();
+        let tag = TagData::new(1, 1, vec![]).expect("test: valid tag");
+        let payload = L1Payload::new(vec![vec![1u8; 8]], tag).expect("test: valid payload");
+        let mut payload_entry = BundledPayloadEntry::new_unsigned(payload);
+        payload_entry.reveal_txid = L1TxId::from(reveal_tx.compute_txid().to_byte_array());
+        payload_entry.status = L1BundleStatus::PendingRevealTxSign(Buf32::zero());
+        envelope_ops
+            .put_payload_entry_async(PAYLOAD_IDX, payload_entry)
+            .await
+            .expect("test: payload row persists");
+
+        let record = TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: PAYLOAD_IDX,
+            },
+            TxAttempt::active(attempt_parts(reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
+        (
+            ReplacementContext {
+                envelope_ops: Some(envelope_ops),
+                ..ReplacementContext::default()
+            },
+            record,
+        )
+    }
+
+    /// The re-insert recovery only applies while the payload row still names the node's
+    /// transaction, which is the case when the process simply stopped between the two writes.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_entry_is_re_inserted_while_the_payload_still_owns_it() {
+        let reveal_tx = tx_with_output(900);
+        let (context, record) = payload_row_and_reveal_node(&reveal_tx).await;
+
+        assert!(active_attempt_is_still_owned(&context, &record)
+            .await
+            .expect("test: ownership check runs"));
+    }
+
+    /// Regression: the writer reacts to a missing reveal entry by rebuilding the whole envelope.
+    /// Re-inserting the abandoned reveal then hands the broadcaster a second complete envelope for
+    /// one payload, since the original commit entry was written before the node, and the payload
+    /// lands on L1 twice.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_entry_is_not_re_inserted_after_the_payload_was_rebuilt() {
+        let reveal_tx = tx_with_output(900);
+        let (context, record) = payload_row_and_reveal_node(&reveal_tx).await;
+
+        // The writer rebuilt the envelope: the row now names a different reveal.
+        let envelope_ops = context
+            .envelope_ops
+            .as_ref()
+            .expect("test: envelope ops configured");
+        let mut rebuilt = envelope_ops
+            .get_payload_entry_by_idx_async(PAYLOAD_IDX)
+            .await
+            .expect("test: payload row is readable")
+            .expect("test: payload row exists");
+        rebuilt.reveal_txid = L1TxId::from(tx_with_output(800).compute_txid().to_byte_array());
+        envelope_ops
+            .put_payload_entry_async(PAYLOAD_IDX, rebuilt)
+            .await
+            .expect("test: rebuilt row persists");
+
+        assert!(!active_attempt_is_still_owned(&context, &record)
+            .await
+            .expect("test: ownership check runs"));
+    }
+
+    /// Without the owning row there is no way to tell a stopped write from an abandoned envelope,
+    /// and re-inserting is the destructive guess.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_entry_is_not_re_inserted_without_the_owning_row() {
+        let record = single_reveal_record();
+
+        assert!(
+            !active_attempt_is_still_owned(&ReplacementContext::default(), &record)
+                .await
+                .expect("test: ownership check runs")
+        );
+    }
+
+    /// Regression: the poll writes back a record it read before its per-record I/O. If the writer
+    /// rebuilt the transaction in that window, persisting the snapshot would revive the superseded
+    /// txid and clear the rebuild, and since the payload tracks the rebuilt transaction the node
+    /// would read a non-`Published` entry on every later poll and never be bumped again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stale_snapshot_does_not_clobber_a_rebuilt_node() {
+        let bcast = get_broadcast_handle();
+        let snapshot = single_reveal_record();
+        let node_id = snapshot.node_id;
+
+        // The writer rebuilds the logical transaction under a new txid while the poll is
+        // mid-flight.
+        let mut rebuilt = snapshot.clone();
+        let rebuilt_attempt =
+            TxAttempt::active(attempt_parts(&tx_with_output(700), fee_rate(), Amount::from_sat(300)), 0);
+        let rebuilt_txid = rebuilt_attempt.txid;
+        rebuilt.replace_initial_attempt(rebuilt_attempt);
+        bcast
+            .put_tx_node(rebuilt)
+            .await
+            .expect("test: rebuilt node persists");
+
+        // The poll now finishes with the record it read before the rebuild.
+        let snapshot_active_txid = snapshot.active_txid;
+        put_tx_node_if_active_unchanged(&bcast, snapshot_active_txid, snapshot)
+            .await
+            .expect("test: guarded write runs");
+
+        let stored = bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node exists");
+        assert_eq!(
+            stored.active_txid, rebuilt_txid,
+            "the rebuilt attempt must survive the stale write"
+        );
+    }
+
+    /// A terminal decision made about a transaction the writer has since rebuilt must not land on
+    /// the rebuild, which `replace_initial_attempt` deliberately cleared.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn terminal_error_does_not_land_on_a_rebuilt_node() {
+        let bcast = get_broadcast_handle();
+        let snapshot = single_reveal_record();
+        let node_id = snapshot.node_id;
+
+        let mut rebuilt = snapshot.clone();
+        rebuilt.replace_initial_attempt(TxAttempt::active(attempt_parts(&tx_with_output(700), fee_rate(), Amount::from_sat(300)), 0));
+        bcast
+            .put_tx_node(rebuilt)
+            .await
+            .expect("test: rebuilt node persists");
+
+        mark_terminal(&bcast, snapshot, TerminalError::UnsupportedRbfKind)
+            .await
+            .expect("test: terminal marking runs");
+
+        let stored = bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .expect("test: node exists");
+        assert_eq!(stored.terminal_error, None);
+    }
+
+    /// The guard must not block the ordinary case, where nothing has touched the node.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unchanged_node_is_persisted() {
+        let bcast = get_broadcast_handle();
+        let record = single_reveal_record();
+        let node_id = record.node_id;
+        bcast
+            .put_tx_node(record.clone())
+            .await
+            .expect("test: node persists");
+
+        mark_terminal(&bcast, record, TerminalError::UnsupportedRbfKind)
+            .await
+            .expect("test: terminal marking runs");
+
+        assert_eq!(
+            bcast
+                .get_tx_node(node_id)
+                .await
+                .expect("test: node is readable")
+                .expect("test: node exists")
+                .terminal_error,
+            Some(TerminalError::UnsupportedRbfKind)
+        );
+    }
+
+    /// Finality is the only broadcast status that retires a node from the active scan:
+    /// `Confirmed` still regresses to `Published` on reorg, and a node retired early would never
+    /// be fee bumped again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn finalized_entry_retires_node_from_active_set_but_confirmed_does_not() {
+        let bcast = get_broadcast_handle();
+        let tx = tx_with_output(1_000);
+        let txid = L1TxId::from(tx.compute_txid().to_byte_array());
+
+        let mut entry = L1TxEntry::from_tx_with_fee(&tx, fee_rate(), Amount::from_sat(100));
+        entry.status = L1TxStatus::Confirmed {
+            confirmations: 1,
+            block_hash: Buf32::zero(),
+            block_height: 10,
+        };
+        let entry_idx = bcast
+            .put_tx_entry(to_raw_buf32(txid), entry.clone())
+            .await
+            .expect("test: confirmed entry persists");
+
+        let record = TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeCommit { payload_idx: 1 },
+            TxAttempt::active(attempt_parts(&tx, fee_rate(), Amount::from_sat(100)), 0));
+        let node_id = record.node_id;
+        bcast
+            .put_tx_node(record.clone())
+            .await
+            .expect("test: node persists");
+
+        let policy_inputs = ReplacementPolicyInputs {
+            current_l1_tip: 10,
+            estimate_fee_rate: fee_rate(),
+            incremental_relay_fee_rate: fee_rate(),
+        };
+        process_record(
+            &TestBitcoinClient::new(1),
+            &WriterConfig::default(),
+            &bcast,
+            policy_inputs,
+            record.clone(),
+            &ReplacementContext::default(),
+        )
+        .await
+        .expect("test: pass over a confirmed entry runs");
+        assert_eq!(
+            bcast
+                .get_active_tx_nodes()
+                .await
+                .expect("test: active set is readable")
+                .len(),
+            1,
+            "a confirmed entry must stay in the active set until it finalizes"
+        );
+
+        entry.status = L1TxStatus::Finalized {
+            confirmations: 100,
+            block_hash: Buf32::zero(),
+            block_height: 10,
+        };
+        bcast
+            .put_tx_entry_by_idx(entry_idx, entry)
+            .await
+            .expect("test: finalized entry persists");
+        process_record(
+            &TestBitcoinClient::new(1),
+            &WriterConfig::default(),
+            &bcast,
+            policy_inputs,
+            record,
+            &ReplacementContext::default(),
+        )
+        .await
+        .expect("test: pass over a finalized entry runs");
+        assert!(bcast
+            .get_active_tx_nodes()
+            .await
+            .expect("test: active set is readable")
+            .is_empty());
+        // The record itself survives for the watchers' crash-recovery point lookups.
+        assert!(bcast
+            .get_tx_node(node_id)
+            .await
+            .expect("test: node is readable")
+            .is_some());
+    }
+
+    /// Builds a reveal node carrying a pending-signature attempt, plus the payload row it belongs
+    /// to at `status`.
+    async fn reveal_node_pending_signature(
+        status: L1BundleStatus,
+    ) -> (ReplacementContext, TxNodeRecord) {
+        let envelope_ops = get_envelope_ops();
+        let tag = TagData::new(1, 1, vec![]).expect("test: valid tag");
+        let payload = L1Payload::new(vec![vec![1u8; 8]], tag).expect("test: valid payload");
+        let mut payload_entry = BundledPayloadEntry::new_unsigned(payload);
+        payload_entry.status = status;
+        envelope_ops
+            .put_payload_entry_async(PAYLOAD_IDX, payload_entry)
+            .await
+            .expect("test: payload row persists");
+
+        let mut record = single_reveal_record();
+        record.append_pending_signature_replacement(TxAttempt::active(attempt_parts(&tx_with_output(800), fee_rate(), Amount::from_sat(200)), 1));
+
+        (
+            ReplacementContext {
+                envelope_ops: Some(envelope_ops),
+                ..ReplacementContext::default()
+            },
+            record,
+        )
+    }
+
+    /// Regression: the node is written before the payload row, so a stop in between leaves an
+    /// attempt only the watcher could advance, and only from `PendingRevealTxSign`. The poll skips
+    /// every node carrying one, so without this the chain would never be bumped again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pending_attempt_is_orphaned_when_the_payload_never_reached_pending_sign() {
+        let (context, record) = reveal_node_pending_signature(L1BundleStatus::Published).await;
+
+        assert!(pending_attempt_is_orphaned(&context, &record)
+            .await
+            .expect("test: orphan check runs"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pending_attempt_is_kept_while_the_payload_awaits_its_signature() {
+        let (context, record) =
+            reveal_node_pending_signature(L1BundleStatus::PendingRevealTxSign(Buf32::zero())).await;
+
+        assert!(!pending_attempt_is_orphaned(&context, &record)
+            .await
+            .expect("test: orphan check runs"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reveal_kinds_are_always_replaceable() {
+        let bcast = get_broadcast_handle();
+        let reveal_record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 0,
+            },
+            TxAttempt::active(attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)), 0));
+
+        assert!(
+            commit_replacement_allowed(&reveal_record, &bcast, &ReplacementContext::default())
+                .await
+                .unwrap()
+        );
+    }
+}

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -672,6 +672,7 @@ where
             TxNodeKind::ChunkedEnvelopeCommit { .. } => {
                 replace_wallet_commit(
                     client,
+                    writer_config,
                     broadcast_handle,
                     context,
                     record,
@@ -697,6 +698,7 @@ where
 
 async fn replace_wallet_commit<C>(
     client: &C,
+    writer_config: &WriterConfig,
     broadcast_handle: &L1BroadcastHandle,
     context: &ReplacementContext,
     mut record: TxNodeRecord,
@@ -776,6 +778,7 @@ where
         &original_commit_tx,
         record.active_txid,
         target_fee_rate,
+        writer_config.fee_bumping.max_fee_rate(),
         attempt_no,
         original_change_index,
     )
@@ -784,6 +787,13 @@ where
         Ok(replacement) => replacement,
         Err(error) if error.is_retryable() => {
             warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "RBF replacement build failed transiently, retrying next poll");
+            return Ok(());
+        }
+        // Discard rather than terminate. The overshoot comes from the wallet's coin selection, not
+        // from our escalation policy, so a later candidate built against a different UTXO set can
+        // land under the ceiling; marking the node terminal would strand the envelope for good.
+        Err(error @ ReplacementError::ExceedsMaxFeeRate { .. }) => {
+            warn!(node_id = ?record.node_id, kind = ?record.kind, %error, "discarding replacement commit that breaches the configured fee-rate ceiling");
             return Ok(());
         }
         Err(error) => {

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -1695,7 +1695,10 @@ mod tests {
     }
 
     fn commit_record() -> TxNodeRecord {
-        let attempt = TxAttempt::active(attempt_parts(&tx_with_output(10_000), fee_rate(), Amount::from_sat(500)), 0);
+        let attempt = TxAttempt::active(
+            attempt_parts(&tx_with_output(10_000), fee_rate(), Amount::from_sat(500)),
+            0,
+        );
         TxNodeRecord::new(
             TxNodeKind::ChunkedEnvelopeCommit {
                 envelope_idx: ENVELOPE_IDX,
@@ -1758,7 +1761,11 @@ mod tests {
             TxNodeKind::SingleEnvelopeReveal {
                 payload_idx: PAYLOAD_IDX,
             },
-            TxAttempt::active(attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)), 0))
+            TxAttempt::active(
+                attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
+        )
     }
 
     /// Runs a single-envelope reveal replacement against `provider` and returns the persisted
@@ -1893,7 +1900,11 @@ mod tests {
                 envelope_idx: ENVELOPE_IDX,
                 reveal_idx: 0,
             },
-            TxAttempt::active(attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
+            TxAttempt::active(
+                attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
+        );
         bcast
             .put_tx_node(reveal_record)
             .await
@@ -1930,7 +1941,10 @@ mod tests {
                 envelope_idx: ENVELOPE_IDX,
                 reveal_idx: 2,
             },
-            TxAttempt::active(&reveal_tx, fee_rate(), Amount::from_sat(100), 0),
+            TxAttempt::active(
+                attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
         );
         bcast
             .put_tx_node(reveal_record)
@@ -2004,8 +2018,15 @@ mod tests {
 
         let mut record = TxNodeRecord::new(
             TxNodeKind::SingleEnvelopeCommit { payload_idx: 1 },
-            TxAttempt::active(attempt_parts(&original_tx, fee_rate(), Amount::from_sat(100)), 0));
-        record.append_replacement(TxAttempt::active(attempt_parts(&replacement_tx, fee_rate(), Amount::from_sat(200)), 1));
+            TxAttempt::active(
+                attempt_parts(&original_tx, fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
+        );
+        record.append_replacement(TxAttempt::active(
+            attempt_parts(&replacement_tx, fee_rate(), Amount::from_sat(200)),
+            1,
+        ));
         let node_id = record.node_id;
         bcast
             .put_tx_node(record.clone())
@@ -2092,8 +2113,15 @@ mod tests {
                 envelope_idx: ENVELOPE_IDX,
                 reveal_idx: 0,
             },
-            TxAttempt::active(attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
-        record.append_replacement(TxAttempt::active(attempt_parts(&replacement_tx, fee_rate(), Amount::from_sat(200)), 1));
+            TxAttempt::active(
+                attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
+        );
+        record.append_replacement(TxAttempt::active(
+            attempt_parts(&replacement_tx, fee_rate(), Amount::from_sat(200)),
+            1,
+        ));
 
         (bcast, context, record, replacement_txid)
     }
@@ -2130,7 +2158,10 @@ mod tests {
         let (bcast, context, mut record, _) =
             chunked_reveal_stranded_after_partial_replacement().await;
         let unrelated_tx = tx_with_output(700);
-        record.append_replacement(TxAttempt::active(attempt_parts(&unrelated_tx, fee_rate(), Amount::from_sat(300)), 2));
+        record.append_replacement(TxAttempt::active(
+            attempt_parts(&unrelated_tx, fee_rate(), Amount::from_sat(300)),
+            2,
+        ));
 
         retry_stale_chunked_reveal_metadata(&bcast, &context, &record, ENVELOPE_IDX, 0)
             .await
@@ -2168,7 +2199,11 @@ mod tests {
             TxNodeKind::SingleEnvelopeReveal {
                 payload_idx: PAYLOAD_IDX,
             },
-            TxAttempt::active(attempt_parts(reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
+            TxAttempt::active(
+                attempt_parts(reveal_tx, fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
+        );
         (
             ReplacementContext {
                 envelope_ops: Some(envelope_ops),
@@ -2246,8 +2281,10 @@ mod tests {
         // The writer rebuilds the logical transaction under a new txid while the poll is
         // mid-flight.
         let mut rebuilt = snapshot.clone();
-        let rebuilt_attempt =
-            TxAttempt::active(attempt_parts(&tx_with_output(700), fee_rate(), Amount::from_sat(300)), 0);
+        let rebuilt_attempt = TxAttempt::active(
+            attempt_parts(&tx_with_output(700), fee_rate(), Amount::from_sat(300)),
+            0,
+        );
         let rebuilt_txid = rebuilt_attempt.txid;
         rebuilt.replace_initial_attempt(rebuilt_attempt);
         bcast
@@ -2281,7 +2318,10 @@ mod tests {
         let node_id = snapshot.node_id;
 
         let mut rebuilt = snapshot.clone();
-        rebuilt.replace_initial_attempt(TxAttempt::active(attempt_parts(&tx_with_output(700), fee_rate(), Amount::from_sat(300)), 0));
+        rebuilt.replace_initial_attempt(TxAttempt::active(
+            attempt_parts(&tx_with_output(700), fee_rate(), Amount::from_sat(300)),
+            0,
+        ));
         bcast
             .put_tx_node(rebuilt)
             .await
@@ -2347,7 +2387,8 @@ mod tests {
 
         let record = TxNodeRecord::new(
             TxNodeKind::SingleEnvelopeCommit { payload_idx: 1 },
-            TxAttempt::active(attempt_parts(&tx, fee_rate(), Amount::from_sat(100)), 0));
+            TxAttempt::active(attempt_parts(&tx, fee_rate(), Amount::from_sat(100)), 0),
+        );
         let node_id = record.node_id;
         bcast
             .put_tx_node(record.clone())
@@ -2427,7 +2468,10 @@ mod tests {
             .expect("test: payload row persists");
 
         let mut record = single_reveal_record();
-        record.append_pending_signature_replacement(TxAttempt::active(attempt_parts(&tx_with_output(800), fee_rate(), Amount::from_sat(200)), 1));
+        record.append_pending_signature_replacement(TxAttempt::active(
+            attempt_parts(&tx_with_output(800), fee_rate(), Amount::from_sat(200)),
+            1,
+        ));
 
         (
             ReplacementContext {
@@ -2468,7 +2512,11 @@ mod tests {
                 envelope_idx: ENVELOPE_IDX,
                 reveal_idx: 0,
             },
-            TxAttempt::active(attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)), 0));
+            TxAttempt::active(
+                attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)),
+                0,
+            ),
+        );
 
         assert!(
             commit_replacement_allowed(&reveal_record, &bcast, &ReplacementContext::default())

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -1474,7 +1474,8 @@ async fn commit_replacement_allowed(
 /// writer persists a reveal's tx-node record and its broadcast entry:
 ///
 /// 1. the persisted envelope row, whose `reveals` carry the authoritative reveal txids, and
-/// 2. the tx-node tree, which covers reveals recorded before the envelope row was refreshed.
+/// 2. the tx-node records for `(envelope_idx, reveal_idx)`, looked up one per reveal, which cover
+///    reveals recorded before the envelope row was refreshed.
 ///
 /// A missing envelope row is treated as disqualifying rather than permissive: without it there is
 /// no way to enumerate the reveals that a commit replacement would orphan.
@@ -1507,16 +1508,26 @@ async fn chunked_reveals_not_handed_to_broadcaster(
         }
     }
 
-    let nodes = broadcast_handle.get_all_tx_nodes().await?;
-    Ok(!nodes.iter().any(|node| {
-        matches!(
-            node.kind,
-            TxNodeKind::ChunkedEnvelopeReveal {
-                envelope_idx: node_envelope_idx,
-                ..
-            } if node_envelope_idx == envelope_idx
-        )
-    }))
+    // Point lookups rather than a tree scan. Tx-node ids are content-derived, and every chunked
+    // reveal node is created from this same row's reveal enumeration with
+    // `reveal_idx = vout_index - 1`, so the row names exactly the ids that can exist. Scanning
+    // instead would cost a full decode of every node the writer has ever published, once per
+    // eligible commit per pass.
+    //
+    // Reading them here rather than from a snapshot taken at pass start also keeps the check
+    // fail-closed: a reveal enqueued between pass start and the commit-phase claim would be
+    // invisible to a snapshot.
+    for reveal_idx in 0..entry.reveals.len() {
+        let node_id = TxNodeId::from_kind(&TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx: reveal_idx as u32,
+        });
+        if broadcast_handle.get_tx_node(node_id).await?.is_some() {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 /// Reports whether this reveal has not yet been handed to the broadcaster.
@@ -1873,6 +1884,44 @@ mod tests {
                 reveal_idx: 0,
             },
             TxAttempt::active(attempt_parts(&reveal_tx, fee_rate(), Amount::from_sat(100)), 0));
+        bcast
+            .put_tx_node(reveal_record)
+            .await
+            .expect("test: reveal node persists");
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// The tx-node check enumerates `reveal_idx` from the envelope row rather than scanning the
+    /// node tree, so an off-by-one in that enumeration would silently stop seeing the reveals it
+    /// exists to catch. Pin the last index of a multi-reveal envelope, which is the one a
+    /// half-open/inclusive slip drops.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_by_a_tx_node_at_the_last_reveal_index() {
+        let bcast = get_broadcast_handle();
+        let (mut entry, reveal_tx) = envelope_entry_with_reveal();
+        // Three reveals, so the last index is 2.
+        let extra = |vout: u32| RevealTxMeta {
+            vout_index: vout,
+            txid: L1TxId::from(reveal_tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(reveal_tx.compute_wtxid().to_byte_array()),
+            tx_bytes: serialize(&reveal_tx),
+        };
+        entry.reveals.push(extra(2));
+        entry.reveals.push(extra(3));
+        let context = context_with(Some(entry)).await;
+
+        let reveal_record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 2,
+            },
+            TxAttempt::active(&reveal_tx, fee_rate(), Amount::from_sat(100), 0),
+        );
         bcast
             .put_tx_node(reveal_record)
             .await

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -1471,7 +1471,8 @@ async fn commit_replacement_allowed(
 /// writer persists a reveal's tx-node record and its broadcast entry:
 ///
 /// 1. the persisted envelope row, whose `reveals` carry the authoritative reveal txids, and
-/// 2. the tx-node tree, which covers reveals recorded before the envelope row was refreshed.
+/// 2. the tx-node records for `(envelope_idx, reveal_idx)`, looked up one per reveal, which cover
+///    reveals recorded before the envelope row was refreshed.
 ///
 /// A missing envelope row is treated as disqualifying rather than permissive: without it there is
 /// no way to enumerate the reveals that a commit replacement would orphan.
@@ -1504,16 +1505,26 @@ async fn chunked_reveals_not_handed_to_broadcaster(
         }
     }
 
-    let nodes = broadcast_handle.get_all_tx_nodes().await?;
-    Ok(!nodes.iter().any(|node| {
-        matches!(
-            node.kind,
-            TxNodeKind::ChunkedEnvelopeReveal {
-                envelope_idx: node_envelope_idx,
-                ..
-            } if node_envelope_idx == envelope_idx
-        )
-    }))
+    // Point lookups rather than a tree scan. Tx-node ids are content-derived, and every chunked
+    // reveal node is created from this same row's reveal enumeration with
+    // `reveal_idx = vout_index - 1`, so the row names exactly the ids that can exist. Scanning
+    // instead would cost a full decode of every node the writer has ever published, once per
+    // eligible commit per pass.
+    //
+    // Reading them here rather than from a snapshot taken at pass start also keeps the check
+    // fail-closed: a reveal enqueued between pass start and the commit-phase claim would be
+    // invisible to a snapshot.
+    for reveal_idx in 0..entry.reveals.len() {
+        let node_id = TxNodeId::from_kind(&TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx,
+            reveal_idx: reveal_idx as u32,
+        });
+        if broadcast_handle.get_tx_node(node_id).await?.is_some() {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 /// Reports whether this reveal has not yet been handed to the broadcaster.
@@ -1873,6 +1884,44 @@ mod tests {
             TxNodeKind::ChunkedEnvelopeReveal {
                 envelope_idx: ENVELOPE_IDX,
                 reveal_idx: 0,
+            },
+            TxAttempt::active(&reveal_tx, fee_rate(), Amount::from_sat(100), 0),
+        );
+        bcast
+            .put_tx_node(reveal_record)
+            .await
+            .expect("test: reveal node persists");
+
+        assert!(
+            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// The tx-node check enumerates `reveal_idx` from the envelope row rather than scanning the
+    /// node tree, so an off-by-one in that enumeration would silently stop seeing the reveals it
+    /// exists to catch. Pin the last index of a multi-reveal envelope, which is the one a
+    /// half-open/inclusive slip drops.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_replacement_blocked_by_a_tx_node_at_the_last_reveal_index() {
+        let bcast = get_broadcast_handle();
+        let (mut entry, reveal_tx) = envelope_entry_with_reveal();
+        // Three reveals, so the last index is 2.
+        let extra = |vout: u32| RevealTxMeta {
+            vout_index: vout,
+            txid: L1TxId::from(reveal_tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(reveal_tx.compute_wtxid().to_byte_array()),
+            tx_bytes: serialize(&reveal_tx),
+        };
+        entry.reveals.push(extra(2));
+        entry.reveals.push(extra(3));
+        let context = context_with(Some(entry)).await;
+
+        let reveal_record = TxNodeRecord::new(
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: ENVELOPE_IDX,
+                reveal_idx: 2,
             },
             TxAttempt::active(&reveal_tx, fee_rate(), Amount::from_sat(100), 0),
         );

--- a/crates/btcio/src/writer/replacement/mod.rs
+++ b/crates/btcio/src/writer/replacement/mod.rs
@@ -1,0 +1,9 @@
+//! Building and persisting RBF replacements for writer-published transactions.
+//!
+//! Replacement is writer work, not a service of its own: the writer is what understands the
+//! commit/reveal structure of an envelope and what holds the keys to re-sign one. The broadcaster
+//! decides *that* a transaction is stale (see [`crate::broadcaster::fee_bump`]); each writer's
+//! existing watcher tick drives the rebuild through [`driver`].
+
+pub(crate) mod build;
+pub(crate) mod driver;

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
-use bitcoin::secp256k1::XOnlyPublicKey;
+use bitcoin::{secp256k1::XOnlyPublicKey, Amount, FeeRate, Transaction};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::TxidExt;
-use strata_db_types::{common::L1TxId, l1_broadcast::L1TxEntry, l1_writer::BundledPayloadEntry};
+use strata_db_types::{
+    common::L1TxId,
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeId, TxNodeKind, TxNodeRecord},
+    l1_broadcast::{L1TxEntry, L1TxStatus},
+    l1_writer::BundledPayloadEntry,
+};
 use strata_primitives::buf::Buf32;
 use tracing::*;
 
@@ -12,9 +17,14 @@ use super::{
         attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs, EnvelopeData,
         EnvelopeError,
     },
-    context::WriterContext,
+    context::{EnvelopeSigningMode, WriterContext},
 };
-use crate::broadcaster::L1BroadcastHandle;
+use crate::{
+    broadcaster::L1BroadcastHandle,
+    writer::replacement::build::{
+        attach_reveal_witness, extract_reveal_witness, reveal_script_pubkey,
+    },
+};
 
 fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
     L1TxId::from(txid.to_buf32().0)
@@ -87,13 +97,35 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(to_raw_buf32(cid), L1TxEntry::from_tx(&envelope.commit_tx))
+            .put_tx_entry(
+                to_raw_buf32(cid),
+                L1TxEntry::from_tx_with_fee(
+                    &envelope.commit_tx,
+                    envelope.fee_rate,
+                    envelope.commit_fee,
+                ),
+            )
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
+        put_tx_node(
+            broadcast_handle,
+            TxNodeKind::SingleEnvelopeCommit { payload_idx },
+            &envelope.commit_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await?;
 
         let rid = to_l1_txid(envelope.reveal_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(to_raw_buf32(rid), L1TxEntry::from_tx(&envelope.reveal_tx))
+            .put_tx_entry(
+                to_raw_buf32(rid),
+                L1TxEntry::from_tx_with_fee(
+                    &envelope.reveal_tx,
+                    envelope.fee_rate,
+                    envelope.reveal_fee,
+                ),
+            )
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
 
@@ -134,16 +166,43 @@ pub(crate) async fn complete_reveal_and_broadcast(
         .map_err(EnvelopeError::Other)?;
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
-        broadcast_handle
-            .put_tx_entry(to_raw_buf32(cid), L1TxEntry::from_tx(&envelope.commit_tx))
-            .await
-            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        put_tx_entry_if_missing(
+            broadcast_handle,
+            cid,
+            &envelope.commit_tx,
+            envelope.commit_fee,
+            envelope,
+        )
+        .await?;
+        put_tx_node(
+            broadcast_handle,
+            TxNodeKind::SingleEnvelopeCommit { payload_idx },
+            &envelope.commit_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await?;
 
+        // Record the reveal node before the broadcast entry: the commit fee bumper keys its
+        // "has a reveal been published yet" check off this record, so it must never lag behind
+        // the broadcaster.
         let rid = to_l1_txid(reveal_tx.compute_txid());
-        broadcast_handle
-            .put_tx_entry(to_raw_buf32(rid), L1TxEntry::from_tx(&reveal_tx))
-            .await
-            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        put_tx_node(
+            broadcast_handle,
+            TxNodeKind::SingleEnvelopeReveal { payload_idx },
+            &reveal_tx,
+            envelope.fee_rate,
+            envelope.reveal_fee,
+        )
+        .await?;
+        put_tx_entry_if_missing(
+            broadcast_handle,
+            rid,
+            &reveal_tx,
+            envelope.reveal_fee,
+            envelope,
+        )
+        .await?;
 
         info!(?cid, reveal_txid = ?rid, "commit and reveal stored for broadcast");
         Ok(rid)
@@ -152,25 +211,292 @@ pub(crate) async fn complete_reveal_and_broadcast(
     .await
 }
 
+/// Attaches the external signature to a pending single-envelope reveal replacement.
+///
+/// `signing_mode` is the mode resolved for the current canonical state, which the replacement's
+/// tapscript has to still match; see the key check below.
+///
+/// Returns `Ok(None)` when no pending replacement exists for this payload, or when the one that
+/// does can no longer be completed.
+pub(crate) async fn complete_pending_reveal_replacement(
+    payload_idx: u64,
+    signature: &[u8; 64],
+    signing_mode: EnvelopeSigningMode,
+    broadcast_handle: &L1BroadcastHandle,
+) -> Result<Option<L1TxId>, EnvelopeError> {
+    let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx });
+    let Some(mut record) = broadcast_handle
+        .get_tx_node(node_id)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    else {
+        return Ok(None);
+    };
+    let Some(previous_signed_attempt) = record.active_attempt().cloned() else {
+        return Ok(None);
+    };
+    if previous_signed_attempt.status != TxAttemptStatus::Active {
+        return Ok(None);
+    };
+    let previous_active_txid = record.active_txid;
+    let Some(pending_attempt) = record.pending_signature_attempt().cloned() else {
+        return Ok(None);
+    };
+    let previous_active_entry = broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(previous_active_txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    if matches!(
+        previous_active_entry.as_ref().map(|entry| &entry.status),
+        Some(L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. })
+    ) {
+        record.discard_pending_signature_replacement();
+        broadcast_handle
+            .put_tx_node(record)
+            .await
+            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        return Ok(None);
+    }
+
+    let previous_signed_tx = previous_signed_attempt
+        .try_to_tx()
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    let (reveal_script, control_block) =
+        extract_reveal_witness(&previous_signed_tx).map_err(|e| EnvelopeError::Other(e.into()))?;
+
+    // The replacement reuses the original tapscript, so its witness only validates under the key
+    // that script commits to. If the canonical predicate rotated while the attempt was waiting, the
+    // signer signed the replacement sighash under the new key and the RPC accepted it, because it
+    // verifies against whatever key is current. Attaching it here would supersede a valid reveal
+    // with one whose witness can never satisfy the script. Refuse and stop bumping this reveal,
+    // matching what the fee bumper does when it notices the rotation before initiating one: the
+    // original stays live at its current fee and a rebuild under the new key clears the error.
+    let reveal_pubkey =
+        reveal_script_pubkey(&reveal_script).map_err(|e| EnvelopeError::Other(e.into()))?;
+    if !matches!(signing_mode, EnvelopeSigningMode::External { pubkey } if pubkey == reveal_pubkey)
+    {
+        warn!(
+            payload_idx,
+            %reveal_pubkey,
+            ?signing_mode,
+            "envelope signing key rotated since the reveal replacement was built; discarding it"
+        );
+        record.discard_pending_signature_replacement();
+        record.set_terminal_error(TerminalError::UnsupportedRbfKind);
+        broadcast_handle
+            .put_tx_node(record)
+            .await
+            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        return Ok(None);
+    }
+
+    let mut signed_tx = pending_attempt
+        .try_to_tx()
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    attach_reveal_witness(&mut signed_tx, &reveal_script, &control_block, signature)
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+
+    let fee_rate = FeeRate::from_sat_per_vb(pending_attempt.fee_rate_sat_vb).ok_or_else(|| {
+        EnvelopeError::Other(anyhow::anyhow!(
+            "invalid pending reveal fee rate {}",
+            pending_attempt.fee_rate_sat_vb
+        ))
+    })?;
+    let fee_sats = Amount::from_sat(pending_attempt.fee_sats);
+    let txid = to_l1_txid(signed_tx.compute_txid());
+
+    if previous_active_entry.is_none() {
+        return Err(EnvelopeError::Other(anyhow::anyhow!(
+            "previous reveal tx entry missing for pending replacement"
+        )));
+    }
+
+    // One transaction: the replacement is inserted and the original superseded together, so there
+    // is never a broadcastable replacement with nothing linking it to what it replaces.
+    if !broadcast_handle
+        .put_replacement_tx_entry(
+            to_raw_buf32(previous_active_txid),
+            to_raw_buf32(txid),
+            L1TxEntry::from_tx_with_fee(&signed_tx, fee_rate, fee_sats),
+        )
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    {
+        // One reason the swap is refused is that it already happened: a previous run committed it
+        // and stopped before the tx-node record caught up. Re-signing lands on the same txid,
+        // because a taproot witness does not change one, so the retry is asking for a row that is
+        // already there. Finish the activation instead of discarding a replacement the broadcaster
+        // is publishing.
+        if !replacement_swap_already_applied(broadcast_handle, previous_active_txid, txid).await? {
+            // Otherwise the original has since gone invalid or confirmed: only `Unpublished` and
+            // `Published` entries are replaceable. The pending attempt was built to supersede that
+            // exact txid and can never be broadcast now; leaving it durable keeps the payload
+            // pinned in `PendingRevealTxSign`, because the watcher waits on a replacement that
+            // will never land and the fee bumper skips every node that carries one. Discard it so
+            // both recover.
+            warn!(
+                ?previous_active_txid,
+                "original reveal left the publishable state before the replacement could supersede it"
+            );
+            record.discard_pending_signature_replacement();
+            broadcast_handle
+                .put_tx_node(record)
+                .await
+                .map_err(|e| EnvelopeError::Other(e.into()))?;
+            return Ok(None);
+        }
+
+        info!(
+            ?txid,
+            ?previous_active_txid,
+            "adopting a reveal replacement a previous run already installed"
+        );
+    }
+
+    // The durable swap is done, so the record must follow it. Activation cannot fail here: the
+    // pending attempt was read above and nothing has removed it since.
+    if !record.activate_pending_signature(&signed_tx, fee_rate, fee_sats) {
+        return Err(EnvelopeError::Other(anyhow::anyhow!(
+            "pending reveal replacement vanished while it was being activated"
+        )));
+    }
+    broadcast_handle
+        .put_tx_node(record)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+
+    info!(
+        ?txid,
+        "pending reveal replacement signed and stored for broadcast"
+    );
+    Ok(Some(txid))
+}
+
+/// Reports whether the broadcast DB already carries the swap that was just refused.
+///
+/// The swap is one transaction, so an original recorded as replaced by exactly this txid, with the
+/// replacement row present, can only come from a run that committed it and stopped before the
+/// tx-node record was written. Anything else — a confirmation, an invalidation, a different
+/// replacement — leaves the original naming something other than this txid.
+async fn replacement_swap_already_applied(
+    broadcast_handle: &L1BroadcastHandle,
+    original_txid: L1TxId,
+    replacement_txid: L1TxId,
+) -> Result<bool, EnvelopeError> {
+    let Some(original) = broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(original_txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    else {
+        return Ok(false);
+    };
+    if !matches!(original.status, L1TxStatus::Replaced { by } if by == replacement_txid) {
+        return Ok(false);
+    }
+
+    Ok(broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(replacement_txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+        .is_some())
+}
+
+async fn put_tx_entry_if_missing(
+    broadcast_handle: &L1BroadcastHandle,
+    txid: L1TxId,
+    tx: &Transaction,
+    fee: Amount,
+    envelope: &EnvelopeData,
+) -> Result<(), EnvelopeError> {
+    if broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    broadcast_handle
+        .put_tx_entry(
+            to_raw_buf32(txid),
+            L1TxEntry::from_tx_with_fee(tx, envelope.fee_rate, fee),
+        )
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    Ok(())
+}
+
+async fn put_tx_node(
+    broadcast_handle: &L1BroadcastHandle,
+    kind: TxNodeKind,
+    tx: &Transaction,
+    fee_rate: FeeRate,
+    fee_sats: Amount,
+) -> Result<(), EnvelopeError> {
+    let node_id = TxNodeId::from_kind(&kind);
+    let attempt = TxAttempt::active(tx, fee_rate, fee_sats, 0);
+    if let Some(mut record) = broadcast_handle
+        .get_tx_node(node_id)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    {
+        if record.active_txid == attempt.txid {
+            return Ok(());
+        }
+        record.replace_initial_attempt(attempt);
+        broadcast_handle
+            .put_tx_node(record)
+            .await
+            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        return Ok(());
+    }
+
+    let record = TxNodeRecord::new(kind, attempt);
+    broadcast_handle
+        .put_tx_node(record)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
-    use strata_btc_types::TxidExt;
     use strata_csm_types::L1Payload;
-    use strata_db_types::l1_writer::{BundledPayloadEntry, L1BundleStatus};
+    use strata_db_types::{
+        fee_bump::{TerminalError, TxNodeId, TxNodeKind},
+        l1_writer::{BundledPayloadEntry, L1BundleStatus},
+    };
     use strata_l1_txfmt::TagData;
     use strata_primitives::buf::Buf32;
 
     use super::*;
     use crate::{
         test_utils::{
-            test_context::{get_writer_context, get_writer_context_with_client},
+            test_context::{
+                get_fee_bumping_writer_context, get_writer_context, get_writer_context_with_client,
+            },
             TestBitcoinClient,
         },
         writer::{
+            replacement::build::build_pending_single_reveal_replacement,
             test_utils::{get_broadcast_handle, get_envelope_ops},
-            EnvelopeSigningMode,
+            EnvelopeSigningMode, WriterContext,
         },
     };
+
+    /// Extracts the external signing pubkey a test writer context is configured with.
+    fn external_signing_pubkey<R: Reader + Signer + Wallet>(
+        ctx: &Arc<WriterContext<R>>,
+    ) -> XOnlyPublicKey {
+        let EnvelopeSigningMode::External { pubkey } = ctx
+            .signing_mode()
+            .expect("test: writer context resolves a signing mode")
+        else {
+            panic!("test: writer context must use external signing");
+        };
+        pubkey
+    }
 
     fn unsigned_test_entry() -> BundledPayloadEntry {
         let tag = TagData::new(1, 1, vec![]).unwrap();
@@ -203,8 +529,11 @@ mod test {
             .unwrap();
 
         // Commit tx should not be in broadcast DB yet — deferred until reveal sig arrives
-        let cid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
-        let ctx_entry = bcast_handle.get_tx_entry_by_id_async(cid).await.unwrap();
+        let cid = to_l1_txid(envelope.commit_tx.compute_txid());
+        let ctx_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(cid))
+            .await
+            .unwrap();
         assert!(ctx_entry.is_none());
 
         // Sighash should be non-zero
@@ -243,7 +572,6 @@ mod test {
             .unwrap()
             .is_some());
     }
-
     #[tokio::test(flavor = "multi_thread")]
     async fn test_create_payload_envelopes_preserves_not_enough_utxos() {
         let client = Arc::new(TestBitcoinClient::new(1).with_utxo_amount_sats(1000));
@@ -272,5 +600,202 @@ mod test {
             .unwrap_err();
 
         assert!(matches!(err, EnvelopeError::NotEnoughUtxos(_, 1000)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sign_and_broadcast_payload_envelopes_persists_rbf_metadata() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+
+        let entry = unsigned_test_entry();
+
+        let (cid, rid) = sign_and_broadcast_payload_envelopes(7, &entry, ctx, &bcast_handle)
+            .await
+            .unwrap();
+
+        let commit_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(cid))
+            .await
+            .unwrap()
+            .expect("commit entry must exist");
+        let reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(rid))
+            .await
+            .unwrap()
+            .expect("reveal entry must exist");
+
+        assert!(commit_entry.rbf.is_some());
+        assert!(reveal_entry.rbf.is_some());
+        assert!(bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeCommit {
+                payload_idx: 7
+            }))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 7
+            }))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_complete_reveal_and_broadcast_creates_reveal_tx_node() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let entry = unsigned_test_entry();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &entry, ctx, pubkey)
+            .await
+            .unwrap();
+        let signature = [1u8; 64];
+
+        complete_reveal_and_broadcast(7, &envelope, &signature, &bcast_handle)
+            .await
+            .unwrap();
+
+        assert!(bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 7
+            }))
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    /// Regression: the swap and the tx-node write are separate, so a run can commit the swap and
+    /// stop before the record catches up. The retry re-signs to the same txid — a taproot witness
+    /// does not change one — so the swap is refused as already done. Discarding the attempt there
+    /// would abandon a replacement the broadcaster is already publishing and leave the record
+    /// active on a superseded txid.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_complete_pending_reveal_replacement_adopts_an_already_committed_swap() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &unsigned_test_entry(), ctx, pubkey)
+            .await
+            .unwrap();
+        let signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(7, &envelope, &signature, &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_tx = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("test: original reveal entry exists")
+            .try_to_tx()
+            .unwrap();
+
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let mut record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("test: reveal tx-node exists");
+        let (pending, _) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(envelope.fee_rate.to_sat_per_vb_ceil() + 5).unwrap(),
+            1,
+        )
+        .unwrap();
+        let replacement_txid = pending.txid;
+        let replacement_entry = L1TxEntry::from_tx_with_fee(
+            &pending.try_to_tx().unwrap(),
+            pending.fee_rate().unwrap(),
+            pending.fee(),
+        );
+        record.append_pending_signature_replacement(pending);
+        bcast_handle.put_tx_node(record).await.unwrap();
+
+        // What the interrupted run left behind: the swap committed, the record untouched.
+        assert!(bcast_handle
+            .put_replacement_tx_entry(
+                to_raw_buf32(original_reveal_txid),
+                to_raw_buf32(replacement_txid),
+                replacement_entry,
+            )
+            .await
+            .unwrap());
+
+        let completed = complete_pending_reveal_replacement(
+            7,
+            &signature,
+            EnvelopeSigningMode::External { pubkey },
+            &bcast_handle,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(completed, Some(replacement_txid));
+        let record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("test: reveal tx-node exists");
+        assert_eq!(record.active_txid, replacement_txid);
+        assert_eq!(
+            record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+        assert_eq!(record.pending_signature_attempt(), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_put_tx_node_refreshes_stale_terminal_record() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let entry = unsigned_test_entry();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &entry, ctx, pubkey)
+            .await
+            .unwrap();
+        let kind = TxNodeKind::SingleEnvelopeCommit { payload_idx: 7 };
+
+        put_tx_node(
+            &bcast_handle,
+            kind.clone(),
+            &envelope.commit_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await
+        .unwrap();
+        let node_id = TxNodeId::from_kind(&kind);
+        let mut stale_record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("tx-node exists");
+        stale_record.set_terminal_error(TerminalError::WalletInsufficient);
+        bcast_handle.put_tx_node(stale_record).await.unwrap();
+
+        let mut replacement_tx = envelope.commit_tx.clone();
+        replacement_tx.output[0].value -= Amount::from_sat(1);
+        let replacement_txid = to_l1_txid(replacement_tx.compute_txid());
+        put_tx_node(
+            &bcast_handle,
+            kind,
+            &replacement_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await
+        .unwrap();
+
+        let refreshed = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("tx-node exists");
+        assert_eq!(refreshed.active_txid, replacement_txid);
+        assert_eq!(refreshed.terminal_error, None);
+        assert_eq!(refreshed.attempts.len(), 1);
     }
 }

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
-use bitcoin::secp256k1::XOnlyPublicKey;
+use bitcoin::{secp256k1::XOnlyPublicKey, Amount, FeeRate, Transaction};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::TxidExt;
-use strata_db_types::{common::L1TxId, l1_broadcast::L1TxEntry, l1_writer::BundledPayloadEntry};
+use strata_db_types::{
+    common::L1TxId,
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeId, TxNodeKind, TxNodeRecord},
+    l1_broadcast::{L1TxEntry, L1TxStatus},
+    l1_writer::BundledPayloadEntry,
+};
 use strata_primitives::buf::Buf32;
 use tracing::*;
 
@@ -12,9 +17,16 @@ use super::{
         attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs, EnvelopeData,
         EnvelopeError,
     },
-    context::WriterContext,
+    context::{EnvelopeSigningMode, WriterContext},
 };
-use crate::{broadcaster::L1BroadcastHandle, tx_entry::L1TxEntryExt};
+use crate::{
+    broadcaster::L1BroadcastHandle,
+    tx_attempt::{attempt_parts, TxAttemptExt},
+    tx_entry::L1TxEntryExt,
+    writer::replacement::build::{
+        attach_reveal_witness, extract_reveal_witness, reveal_script_pubkey,
+    },
+};
 
 fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
     L1TxId::from(txid.to_buf32().0)
@@ -87,13 +99,35 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(to_raw_buf32(cid), L1TxEntry::from_tx(&envelope.commit_tx))
+            .put_tx_entry(
+                to_raw_buf32(cid),
+                L1TxEntry::from_tx_with_fee(
+                    &envelope.commit_tx,
+                    envelope.fee_rate,
+                    envelope.commit_fee,
+                ),
+            )
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
+        put_tx_node(
+            broadcast_handle,
+            TxNodeKind::SingleEnvelopeCommit { payload_idx },
+            &envelope.commit_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await?;
 
         let rid = to_l1_txid(envelope.reveal_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(to_raw_buf32(rid), L1TxEntry::from_tx(&envelope.reveal_tx))
+            .put_tx_entry(
+                to_raw_buf32(rid),
+                L1TxEntry::from_tx_with_fee(
+                    &envelope.reveal_tx,
+                    envelope.fee_rate,
+                    envelope.reveal_fee,
+                ),
+            )
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
 
@@ -134,16 +168,43 @@ pub(crate) async fn complete_reveal_and_broadcast(
         .map_err(EnvelopeError::Other)?;
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
-        broadcast_handle
-            .put_tx_entry(to_raw_buf32(cid), L1TxEntry::from_tx(&envelope.commit_tx))
-            .await
-            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        put_tx_entry_if_missing(
+            broadcast_handle,
+            cid,
+            &envelope.commit_tx,
+            envelope.commit_fee,
+            envelope,
+        )
+        .await?;
+        put_tx_node(
+            broadcast_handle,
+            TxNodeKind::SingleEnvelopeCommit { payload_idx },
+            &envelope.commit_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await?;
 
+        // Record the reveal node before the broadcast entry: the commit fee bumper keys its
+        // "has a reveal been published yet" check off this record, so it must never lag behind
+        // the broadcaster.
         let rid = to_l1_txid(reveal_tx.compute_txid());
-        broadcast_handle
-            .put_tx_entry(to_raw_buf32(rid), L1TxEntry::from_tx(&reveal_tx))
-            .await
-            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        put_tx_node(
+            broadcast_handle,
+            TxNodeKind::SingleEnvelopeReveal { payload_idx },
+            &reveal_tx,
+            envelope.fee_rate,
+            envelope.reveal_fee,
+        )
+        .await?;
+        put_tx_entry_if_missing(
+            broadcast_handle,
+            rid,
+            &reveal_tx,
+            envelope.reveal_fee,
+            envelope,
+        )
+        .await?;
 
         info!(?cid, reveal_txid = ?rid, "commit and reveal stored for broadcast");
         Ok(rid)
@@ -152,25 +213,292 @@ pub(crate) async fn complete_reveal_and_broadcast(
     .await
 }
 
+/// Attaches the external signature to a pending single-envelope reveal replacement.
+///
+/// `signing_mode` is the mode resolved for the current canonical state, which the replacement's
+/// tapscript has to still match; see the key check below.
+///
+/// Returns `Ok(None)` when no pending replacement exists for this payload, or when the one that
+/// does can no longer be completed.
+pub(crate) async fn complete_pending_reveal_replacement(
+    payload_idx: u64,
+    signature: &[u8; 64],
+    signing_mode: EnvelopeSigningMode,
+    broadcast_handle: &L1BroadcastHandle,
+) -> Result<Option<L1TxId>, EnvelopeError> {
+    let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx });
+    let Some(mut record) = broadcast_handle
+        .get_tx_node(node_id)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    else {
+        return Ok(None);
+    };
+    let Some(previous_signed_attempt) = record.active_attempt().cloned() else {
+        return Ok(None);
+    };
+    if previous_signed_attempt.status != TxAttemptStatus::Active {
+        return Ok(None);
+    };
+    let previous_active_txid = record.active_txid;
+    let Some(pending_attempt) = record.pending_signature_attempt().cloned() else {
+        return Ok(None);
+    };
+    let previous_active_entry = broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(previous_active_txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    if matches!(
+        previous_active_entry.as_ref().map(|entry| &entry.status),
+        Some(L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. })
+    ) {
+        record.discard_pending_signature_replacement();
+        broadcast_handle
+            .put_tx_node(record)
+            .await
+            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        return Ok(None);
+    }
+
+    let previous_signed_tx = previous_signed_attempt
+        .try_to_tx()
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    let (reveal_script, control_block) =
+        extract_reveal_witness(&previous_signed_tx).map_err(|e| EnvelopeError::Other(e.into()))?;
+
+    // The replacement reuses the original tapscript, so its witness only validates under the key
+    // that script commits to. If the canonical predicate rotated while the attempt was waiting, the
+    // signer signed the replacement sighash under the new key and the RPC accepted it, because it
+    // verifies against whatever key is current. Attaching it here would supersede a valid reveal
+    // with one whose witness can never satisfy the script. Refuse and stop bumping this reveal,
+    // matching what the fee bumper does when it notices the rotation before initiating one: the
+    // original stays live at its current fee and a rebuild under the new key clears the error.
+    let reveal_pubkey =
+        reveal_script_pubkey(&reveal_script).map_err(|e| EnvelopeError::Other(e.into()))?;
+    if !matches!(signing_mode, EnvelopeSigningMode::External { pubkey } if pubkey == reveal_pubkey)
+    {
+        warn!(
+            payload_idx,
+            %reveal_pubkey,
+            ?signing_mode,
+            "envelope signing key rotated since the reveal replacement was built; discarding it"
+        );
+        record.discard_pending_signature_replacement();
+        record.set_terminal_error(TerminalError::UnsupportedRbfKind);
+        broadcast_handle
+            .put_tx_node(record)
+            .await
+            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        return Ok(None);
+    }
+
+    let mut signed_tx = pending_attempt
+        .try_to_tx()
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    attach_reveal_witness(&mut signed_tx, &reveal_script, &control_block, signature)
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+
+    let fee_rate = FeeRate::from_sat_per_vb(pending_attempt.fee_rate_sat_vb).ok_or_else(|| {
+        EnvelopeError::Other(anyhow::anyhow!(
+            "invalid pending reveal fee rate {}",
+            pending_attempt.fee_rate_sat_vb
+        ))
+    })?;
+    let fee_sats = Amount::from_sat(pending_attempt.fee_sats);
+    let txid = to_l1_txid(signed_tx.compute_txid());
+
+    if previous_active_entry.is_none() {
+        return Err(EnvelopeError::Other(anyhow::anyhow!(
+            "previous reveal tx entry missing for pending replacement"
+        )));
+    }
+
+    // One transaction: the replacement is inserted and the original superseded together, so there
+    // is never a broadcastable replacement with nothing linking it to what it replaces.
+    if !broadcast_handle
+        .put_replacement_tx_entry(
+            to_raw_buf32(previous_active_txid),
+            to_raw_buf32(txid),
+            L1TxEntry::from_tx_with_fee(&signed_tx, fee_rate, fee_sats),
+        )
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    {
+        // One reason the swap is refused is that it already happened: a previous run committed it
+        // and stopped before the tx-node record caught up. Re-signing lands on the same txid,
+        // because a taproot witness does not change one, so the retry is asking for a row that is
+        // already there. Finish the activation instead of discarding a replacement the broadcaster
+        // is publishing.
+        if !replacement_swap_already_applied(broadcast_handle, previous_active_txid, txid).await? {
+            // Otherwise the original has since gone invalid or confirmed: only `Unpublished` and
+            // `Published` entries are replaceable. The pending attempt was built to supersede that
+            // exact txid and can never be broadcast now; leaving it durable keeps the payload
+            // pinned in `PendingRevealTxSign`, because the watcher waits on a replacement that
+            // will never land and the fee bumper skips every node that carries one. Discard it so
+            // both recover.
+            warn!(
+                ?previous_active_txid,
+                "original reveal left the publishable state before the replacement could supersede it"
+            );
+            record.discard_pending_signature_replacement();
+            broadcast_handle
+                .put_tx_node(record)
+                .await
+                .map_err(|e| EnvelopeError::Other(e.into()))?;
+            return Ok(None);
+        }
+
+        info!(
+            ?txid,
+            ?previous_active_txid,
+            "adopting a reveal replacement a previous run already installed"
+        );
+    }
+
+    // The durable swap is done, so the record must follow it. Activation cannot fail here: the
+    // pending attempt was read above and nothing has removed it since.
+    if !record.activate_pending_signature(attempt_parts(&signed_tx, fee_rate, fee_sats)) {
+        return Err(EnvelopeError::Other(anyhow::anyhow!(
+            "pending reveal replacement vanished while it was being activated"
+        )));
+    }
+    broadcast_handle
+        .put_tx_node(record)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+
+    info!(
+        ?txid,
+        "pending reveal replacement signed and stored for broadcast"
+    );
+    Ok(Some(txid))
+}
+
+/// Reports whether the broadcast DB already carries the swap that was just refused.
+///
+/// The swap is one transaction, so an original recorded as replaced by exactly this txid, with the
+/// replacement row present, can only come from a run that committed it and stopped before the
+/// tx-node record was written. Anything else — a confirmation, an invalidation, a different
+/// replacement — leaves the original naming something other than this txid.
+async fn replacement_swap_already_applied(
+    broadcast_handle: &L1BroadcastHandle,
+    original_txid: L1TxId,
+    replacement_txid: L1TxId,
+) -> Result<bool, EnvelopeError> {
+    let Some(original) = broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(original_txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    else {
+        return Ok(false);
+    };
+    if !matches!(original.status, L1TxStatus::Replaced { by } if by == replacement_txid) {
+        return Ok(false);
+    }
+
+    Ok(broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(replacement_txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+        .is_some())
+}
+
+async fn put_tx_entry_if_missing(
+    broadcast_handle: &L1BroadcastHandle,
+    txid: L1TxId,
+    tx: &Transaction,
+    fee: Amount,
+    envelope: &EnvelopeData,
+) -> Result<(), EnvelopeError> {
+    if broadcast_handle
+        .get_tx_entry_by_id_async(to_raw_buf32(txid))
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    broadcast_handle
+        .put_tx_entry(
+            to_raw_buf32(txid),
+            L1TxEntry::from_tx_with_fee(tx, envelope.fee_rate, fee),
+        )
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    Ok(())
+}
+
+async fn put_tx_node(
+    broadcast_handle: &L1BroadcastHandle,
+    kind: TxNodeKind,
+    tx: &Transaction,
+    fee_rate: FeeRate,
+    fee_sats: Amount,
+) -> Result<(), EnvelopeError> {
+    let node_id = TxNodeId::from_kind(&kind);
+    let attempt = TxAttempt::active(attempt_parts(tx, fee_rate, fee_sats), 0);
+    if let Some(mut record) = broadcast_handle
+        .get_tx_node(node_id)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?
+    {
+        if record.active_txid == attempt.txid {
+            return Ok(());
+        }
+        record.replace_initial_attempt(attempt);
+        broadcast_handle
+            .put_tx_node(record)
+            .await
+            .map_err(|e| EnvelopeError::Other(e.into()))?;
+        return Ok(());
+    }
+
+    let record = TxNodeRecord::new(kind, attempt);
+    broadcast_handle
+        .put_tx_node(record)
+        .await
+        .map_err(|e| EnvelopeError::Other(e.into()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
-    use strata_btc_types::TxidExt;
     use strata_csm_types::L1Payload;
-    use strata_db_types::l1_writer::{BundledPayloadEntry, L1BundleStatus};
+    use strata_db_types::{
+        fee_bump::{TerminalError, TxNodeId, TxNodeKind},
+        l1_writer::{BundledPayloadEntry, L1BundleStatus},
+    };
     use strata_l1_txfmt::TagData;
     use strata_primitives::buf::Buf32;
 
     use super::*;
     use crate::{
         test_utils::{
-            test_context::{get_writer_context, get_writer_context_with_client},
+            test_context::{
+                get_fee_bumping_writer_context, get_writer_context, get_writer_context_with_client,
+            },
             TestBitcoinClient,
         },
         writer::{
+            replacement::build::build_pending_single_reveal_replacement,
             test_utils::{get_broadcast_handle, get_envelope_ops},
-            EnvelopeSigningMode,
+            EnvelopeSigningMode, WriterContext,
         },
     };
+
+    /// Extracts the external signing pubkey a test writer context is configured with.
+    fn external_signing_pubkey<R: Reader + Signer + Wallet>(
+        ctx: &Arc<WriterContext<R>>,
+    ) -> XOnlyPublicKey {
+        let EnvelopeSigningMode::External { pubkey } = ctx
+            .signing_mode()
+            .expect("test: writer context resolves a signing mode")
+        else {
+            panic!("test: writer context must use external signing");
+        };
+        pubkey
+    }
 
     fn unsigned_test_entry() -> BundledPayloadEntry {
         let tag = TagData::new(1, 1, vec![]).unwrap();
@@ -203,8 +531,11 @@ mod test {
             .unwrap();
 
         // Commit tx should not be in broadcast DB yet — deferred until reveal sig arrives
-        let cid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
-        let ctx_entry = bcast_handle.get_tx_entry_by_id_async(cid).await.unwrap();
+        let cid = to_l1_txid(envelope.commit_tx.compute_txid());
+        let ctx_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(cid))
+            .await
+            .unwrap();
         assert!(ctx_entry.is_none());
 
         // Sighash should be non-zero
@@ -243,7 +574,6 @@ mod test {
             .unwrap()
             .is_some());
     }
-
     #[tokio::test(flavor = "multi_thread")]
     async fn test_create_payload_envelopes_preserves_not_enough_utxos() {
         let client = Arc::new(TestBitcoinClient::new(1).with_utxo_amount_sats(1000));
@@ -272,5 +602,260 @@ mod test {
             .unwrap_err();
 
         assert!(matches!(err, EnvelopeError::NotEnoughUtxos(_, 1000)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sign_and_broadcast_payload_envelopes_persists_rbf_metadata() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+
+        let entry = unsigned_test_entry();
+
+        let (cid, rid) = sign_and_broadcast_payload_envelopes(7, &entry, ctx, &bcast_handle)
+            .await
+            .unwrap();
+
+        let commit_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(cid))
+            .await
+            .unwrap()
+            .expect("commit entry must exist");
+        let reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(rid))
+            .await
+            .unwrap()
+            .expect("reveal entry must exist");
+
+        assert!(commit_entry.rbf.is_some());
+        assert!(reveal_entry.rbf.is_some());
+        assert!(bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeCommit {
+                payload_idx: 7
+            }))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 7
+            }))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_complete_reveal_and_broadcast_creates_reveal_tx_node() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let entry = unsigned_test_entry();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &entry, ctx, pubkey)
+            .await
+            .unwrap();
+        let signature = [1u8; 64];
+
+        complete_reveal_and_broadcast(7, &envelope, &signature, &bcast_handle)
+            .await
+            .unwrap();
+
+        assert!(bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 7
+            }))
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    /// Regression: the swap and the tx-node write are separate, so a run can commit the swap and
+    /// stop before the record catches up. The retry re-signs to the same txid — a taproot witness
+    /// does not change one — so the swap is refused as already done. Discarding the attempt there
+    /// would abandon a replacement the broadcaster is already publishing and leave the record
+    /// active on a superseded txid.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_complete_pending_reveal_replacement_adopts_an_already_committed_swap() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &unsigned_test_entry(), ctx, pubkey)
+            .await
+            .unwrap();
+        let signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(7, &envelope, &signature, &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_tx = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("test: original reveal entry exists")
+            .try_to_tx()
+            .unwrap();
+
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let mut record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("test: reveal tx-node exists");
+        let (pending, _) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(envelope.fee_rate.to_sat_per_vb_ceil() + 5).unwrap(),
+            1,
+        )
+        .unwrap();
+        let replacement_txid = pending.txid;
+        let replacement_entry = L1TxEntry::from_tx_with_fee(
+            &pending.try_to_tx().unwrap(),
+            pending.fee_rate().unwrap(),
+            pending.fee(),
+        );
+        record.append_pending_signature_replacement(pending);
+        bcast_handle.put_tx_node(record).await.unwrap();
+
+        // What the interrupted run left behind: the swap committed, the record untouched.
+        assert!(bcast_handle
+            .put_replacement_tx_entry(
+                to_raw_buf32(original_reveal_txid),
+                to_raw_buf32(replacement_txid),
+                replacement_entry,
+            )
+            .await
+            .unwrap());
+
+        let completed = complete_pending_reveal_replacement(
+            7,
+            &signature,
+            EnvelopeSigningMode::External { pubkey },
+            &bcast_handle,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(completed, Some(replacement_txid));
+        let record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("test: reveal tx-node exists");
+        assert_eq!(record.active_txid, replacement_txid);
+        assert_eq!(
+            record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+        assert_eq!(record.pending_signature_attempt(), None);
+    }
+
+    /// Regression: a corrupt persisted pending transaction can decode with no inputs. Completing
+    /// it must return an error instead of indexing the absent reveal input and crashing the writer
+    /// task.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_complete_pending_reveal_replacement_rejects_a_zero_input_transaction() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &unsigned_test_entry(), ctx, pubkey)
+            .await
+            .unwrap();
+        let signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(7, &envelope, &signature, &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_tx = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("test: original reveal entry exists")
+            .try_to_tx()
+            .unwrap();
+
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let mut record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("test: reveal tx-node exists");
+        let (mut pending, _) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(envelope.fee_rate.to_sat_per_vb_ceil() + 5).unwrap(),
+            1,
+        )
+        .unwrap();
+        // Segwit marker and flag followed by empty input and output vectors. The Bitcoin decoder
+        // accepts this shape even though it cannot be a valid reveal transaction.
+        pending.raw_tx = vec![2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0];
+        assert!(pending.try_to_tx().unwrap().input.is_empty());
+        record.append_pending_signature_replacement(pending);
+        bcast_handle.put_tx_node(record).await.unwrap();
+
+        let error = complete_pending_reveal_replacement(
+            7,
+            &signature,
+            EnvelopeSigningMode::External { pubkey },
+            &bcast_handle,
+        )
+        .await
+        .expect_err("a zero-input pending reveal must be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("active reveal transaction is missing its tapscript witness"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_put_tx_node_refreshes_stale_terminal_record() {
+        let bcast_handle = get_broadcast_handle();
+        let ctx = get_fee_bumping_writer_context();
+        let entry = unsigned_test_entry();
+        let pubkey = external_signing_pubkey(&ctx);
+        let envelope = create_payload_envelopes(7, &entry, ctx, pubkey)
+            .await
+            .unwrap();
+        let kind = TxNodeKind::SingleEnvelopeCommit { payload_idx: 7 };
+
+        put_tx_node(
+            &bcast_handle,
+            kind.clone(),
+            &envelope.commit_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await
+        .unwrap();
+        let node_id = TxNodeId::from_kind(&kind);
+        let mut stale_record = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("tx-node exists");
+        stale_record.set_terminal_error(TerminalError::WalletInsufficient);
+        bcast_handle.put_tx_node(stale_record).await.unwrap();
+
+        let mut replacement_tx = envelope.commit_tx.clone();
+        replacement_tx.output[0].value -= Amount::from_sat(1);
+        let replacement_txid = to_l1_txid(replacement_tx.compute_txid());
+        put_tx_node(
+            &bcast_handle,
+            kind,
+            &replacement_tx,
+            envelope.fee_rate,
+            envelope.commit_fee,
+        )
+        .await
+        .unwrap();
+
+        let refreshed = bcast_handle
+            .get_tx_node(node_id)
+            .await
+            .unwrap()
+            .expect("tx-node exists");
+        assert_eq!(refreshed.active_txid, replacement_txid);
+        assert_eq!(refreshed.terminal_error, None);
+        assert_eq!(refreshed.attempts.len(), 1);
     }
 }

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use strata_btc_types::{Buf32BitcoinExt, TxidExt};
 use strata_db_types::{
     common::L1TxId,
+    fee_bump::{TxNodeId, TxNodeKind},
     l1_broadcast::{L1TxEntry, L1TxStatus},
     l1_writer::{BundledPayloadEntry, L1BundleStatus},
 };
@@ -33,9 +34,10 @@ use crate::{
     writer::{
         builder::{EnvelopeData, EnvelopeError},
         context::{EnvelopeSigningMode, WriterContext},
+        replacement::driver::{run_replacement_pass, ReplacementContext, ReplacementPacer},
         signer::{
-            complete_reveal_and_broadcast, create_payload_envelopes,
-            sign_and_broadcast_payload_envelopes,
+            complete_pending_reveal_replacement, complete_reveal_and_broadcast,
+            create_payload_envelopes, sign_and_broadcast_payload_envelopes,
         },
     },
 };
@@ -46,6 +48,21 @@ fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
 
 fn to_raw_buf32(txid: L1TxId) -> Buf32 {
     Buf32(txid.0)
+}
+
+/// Discards the pending externally-signed replacement on a payload's reveal tx-node.
+async fn discard_pending_reveal_replacement(
+    broadcast_handle: &L1BroadcastHandle,
+    payload_idx: u64,
+) -> anyhow::Result<()> {
+    let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx });
+    let Some(mut record) = broadcast_handle.get_tx_node(node_id).await? else {
+        return Ok(());
+    };
+    if record.discard_pending_signature_replacement() {
+        broadcast_handle.put_tx_node(record).await?;
+    }
+    Ok(())
 }
 
 /// Abstracts the external dependencies of the watcher so that `process_input` can be
@@ -83,10 +100,40 @@ pub(crate) trait WatcherServiceContext: Send + Sync + 'static {
         envelope: &EnvelopeData,
         sig: &[u8; 64],
     ) -> impl Future<Output = anyhow::Result<L1TxId>> + Send;
+
+    /// Attaches an external signature to this payload's pending fee-bump reveal replacement.
+    ///
+    /// `signing_mode` is the mode resolved for the current canonical state; the replacement is
+    /// refused when it no longer matches the key its tapscript commits to.
+    fn complete_pending_reveal_replacement(
+        &self,
+        idx: u64,
+        sig: &[u8; 64],
+        signing_mode: EnvelopeSigningMode,
+    ) -> impl Future<Output = anyhow::Result<Option<L1TxId>>> + Send;
+
+    /// Reports whether a fee bump is waiting on a signature for this payload's reveal.
+    fn has_pending_reveal_replacement(
+        &self,
+        idx: u64,
+    ) -> impl Future<Output = anyhow::Result<bool>> + Send;
+
+    /// Discards this payload's pending fee-bump reveal replacement, if it still has one.
+    fn discard_pending_reveal_replacement(
+        &self,
+        idx: u64,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+
+    /// Returns the reveal txid this payload's tx-node currently considers active, if recorded.
+    fn active_reveal_txid(
+        &self,
+        idx: u64,
+    ) -> impl Future<Output = anyhow::Result<Option<L1TxId>>> + Send;
+
     fn get_tx_status(
         &self,
         txid: L1TxId,
-    ) -> impl Future<Output = anyhow::Result<Option<L1TxEntry>>> + Send;
+    ) -> impl Future<Output = anyhow::Result<Option<(L1TxId, L1TxEntry)>>> + Send;
 
     fn report_status(
         &self,
@@ -95,12 +142,20 @@ pub(crate) trait WatcherServiceContext: Send + Sync + 'static {
     ) -> impl Future<Output = ()> + Send;
 
     fn report_rpc_error(&self, reason: String) -> impl Future<Output = ()> + Send;
+
+    /// Runs one RBF replacement pass over this writer's tx-node records.
+    ///
+    /// Driven from the watcher tick rather than a service of its own: rebuilding a reveal needs
+    /// the writer's payload storage and signing mode, both of which live here.
+    fn run_replacement_pass(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
 pub(crate) struct WatcherContextImpl<R: Reader + Signer + Wallet + Send + Sync + 'static> {
     context: Arc<WriterContext<R>>,
     ops: Arc<EnvelopeDataOps>,
     broadcast_handle: Arc<L1BroadcastHandle>,
+    /// Held here rather than rebuilt per call so the interval actually spans watcher ticks.
+    replacement_pacer: Arc<ReplacementPacer>,
 }
 
 impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherContextImpl<R> {
@@ -109,10 +164,14 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherContextImpl<R> 
         ops: Arc<EnvelopeDataOps>,
         broadcast_handle: Arc<L1BroadcastHandle>,
     ) -> Self {
+        let replacement_pacer = Arc::new(ReplacementPacer::new(
+            context.config.fee_bumping.check_interval(),
+        ));
         Self {
             context,
             ops,
             broadcast_handle,
+            replacement_pacer,
         }
     }
 }
@@ -120,6 +179,22 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherContextImpl<R> 
 impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
     for WatcherContextImpl<R>
 {
+    async fn run_replacement_pass(&self) -> anyhow::Result<()> {
+        let replacement_context = ReplacementContext {
+            envelope_ops: Some(self.ops.clone()),
+            signing_mode_provider: Some(self.context.signing_mode_provider()),
+            pacer: self.replacement_pacer.clone(),
+            ..ReplacementContext::default()
+        };
+        run_replacement_pass(
+            self.context.client.as_ref(),
+            &self.context.config,
+            self.broadcast_handle.as_ref(),
+            &replacement_context,
+        )
+        .await
+    }
+
     async fn get_payload_entry(&self, idx: u64) -> anyhow::Result<Option<BundledPayloadEntry>> {
         self.ops
             .get_payload_entry_by_idx_async(idx)
@@ -172,10 +247,44 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
             .map_err(Into::into)
     }
 
-    async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<L1TxEntry>> {
-        self.broadcast_handle
-            .get_tx_entry_by_id_async(Buf32(txid.0))
+    async fn complete_pending_reveal_replacement(
+        &self,
+        idx: u64,
+        sig: &[u8; 64],
+        signing_mode: EnvelopeSigningMode,
+    ) -> anyhow::Result<Option<L1TxId>> {
+        complete_pending_reveal_replacement(idx, sig, signing_mode, &self.broadcast_handle)
             .await
+            .map_err(Into::into)
+    }
+
+    async fn has_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<bool> {
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+        Ok(self
+            .broadcast_handle
+            .get_tx_node(node_id)
+            .await?
+            .is_some_and(|record| record.pending_signature_attempt().is_some()))
+    }
+
+    async fn discard_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<()> {
+        discard_pending_reveal_replacement(&self.broadcast_handle, idx).await
+    }
+
+    async fn active_reveal_txid(&self, idx: u64) -> anyhow::Result<Option<L1TxId>> {
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+        Ok(self
+            .broadcast_handle
+            .get_tx_node(node_id)
+            .await?
+            .map(|record| record.active_txid))
+    }
+
+    async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<(L1TxId, L1TxEntry)>> {
+        self.broadcast_handle
+            .get_active_tx_entry_by_id_async(to_raw_buf32(txid))
+            .await
+            .map(|entry| entry.map(|(txid, entry)| (L1TxId::from(txid.0), entry)))
             .map_err(Into::into)
     }
 
@@ -245,6 +354,11 @@ impl<C: WatcherServiceContext> AsyncService for WatcherService<C> {
     async fn process_input(state: &mut Self::State, _: Self::Msg) -> anyhow::Result<Response> {
         let dspan = debug_span!("process payload", idx=%state.curr_payloadidx);
         let _ = dspan.enter();
+
+        // A failed pass must not stall payload processing; the next tick retries it.
+        if let Err(error) = state.ctx.run_replacement_pass().await {
+            warn!(%error, "payload envelope replacement pass failed");
+        }
 
         if let Some(payloadentry) = state.ctx.get_payload_entry(state.curr_payloadidx).await? {
             match payloadentry.status {
@@ -395,6 +509,39 @@ impl<C: WatcherServiceContext> WatcherState<C> {
         payloadentry: BundledPayloadEntry,
     ) -> anyhow::Result<()> {
         let Some(sig) = &payloadentry.payload_signature else {
+            // A fee-bump replacement can be waiting on a signature that will never arrive because
+            // the original reveal confirmed first. Advance off the pending state instead of
+            // blocking on the signer forever.
+            if self
+                .advance_if_reveal_replacement_already_confirmed(&payloadentry)
+                .await?
+            {
+                return Ok(());
+            }
+
+            // Resetting to `Unsigned` rebuilds the envelope from fresh UTXOs, which is only safe
+            // while nothing has been broadcast. A fee bump breaks that assumption: it moves an
+            // already-published reveal back into `PendingRevealTxSign` while the original stays
+            // live, so rebuilding here would publish the same payload twice.
+            if self
+                .ctx
+                .has_pending_reveal_replacement(self.curr_payloadidx)
+                .await?
+            {
+                // Unless what it supersedes has itself gone invalid, in which case waiting pins
+                // the payload here for good: the replacement spends inputs that are gone so no
+                // signature can rescue it, and the fee bumper skips every node carrying a pending
+                // attempt.
+                if self
+                    .abandon_reveal_replacement_if_invalid(&payloadentry)
+                    .await?
+                {
+                    return Ok(());
+                }
+                trace!("waiting for signer to sign the fee-bump reveal replacement");
+                return Ok(());
+            }
+
             let Some(envelope) = self.envelope_cache.get(&self.curr_payloadidx) else {
                 // Cache miss (e.g. restart) — reset to Unsigned to rebuild
                 // envelope from scratch (new UTXOs, new sighash).
@@ -430,18 +577,114 @@ impl<C: WatcherServiceContext> WatcherState<C> {
             trace!("waiting for signer to provide reveal signature");
             return Ok(());
         };
-        let Some(envelope) = self.envelope_cache.remove(&self.curr_payloadidx) else {
-            // Cache miss (e.g. restart) — reset to Unsigned to rebuild
-            // envelope from scratch (new UTXOs, new sighash).
-            // Safe: nothing has been broadcast yet.
-            warn!("envelope not in cache, resetting to Unsigned");
-            let mut updated_entry = payloadentry.clone();
-            updated_entry.payload_signature = None;
-            updated_entry.status = L1BundleStatus::Unsigned;
-            self.ctx
-                .put_payload_entry(self.curr_payloadidx, updated_entry)
-                .await?;
-            return Ok(());
+        let envelope = match self.envelope_cache.remove(&self.curr_payloadidx) {
+            Some(envelope) => envelope,
+            None => {
+                // Resolved before completion, not after: a fee-bump replacement reuses the original
+                // reveal's tapscript, so an external signature is only usable while the canonical
+                // key still matches what that script commits to. A resolution failure only skips
+                // the completion attempt, which the pending attempt survives; the recovery paths
+                // below still need to run.
+                if let Some(signing_mode) = self.resolve_signing_mode() {
+                    if let Some(rid) = self
+                        .ctx
+                        .complete_pending_reveal_replacement(
+                            self.curr_payloadidx,
+                            sig.as_ref(),
+                            signing_mode,
+                        )
+                        .await?
+                    {
+                        let mut updated_entry = payloadentry.clone();
+                        updated_entry.reveal_txid = rid;
+                        updated_entry.status = L1BundleStatus::Unpublished;
+                        self.ctx
+                            .put_payload_entry(self.curr_payloadidx, updated_entry)
+                            .await?;
+                        debug!(reveal_txid = ?rid, "pending reveal replacement signed and stored for broadcast");
+                        return Ok(());
+                    }
+                }
+                if self
+                    .advance_if_reveal_replacement_already_confirmed(&payloadentry)
+                    .await?
+                {
+                    return Ok(());
+                }
+
+                if self
+                    .ctx
+                    .has_pending_reveal_replacement(self.curr_payloadidx)
+                    .await?
+                {
+                    // The replacement could not be completed this tick but the original reveal
+                    // is still live. Rebuilding would double-publish the payload.
+                    warn!(
+                        payload_idx = %self.curr_payloadidx,
+                        "pending fee-bump reveal replacement could not be completed, retrying"
+                    );
+                    return Ok(());
+                }
+
+                // A crash between activating a replacement and writing the payload row leaves no
+                // pending attempt, so completion above returned `None`. The activated replacement
+                // is live, so reconcile the payload row from the tx-node instead of rebuilding.
+                //
+                // Only ever move forward: adopt the node's txid when the payload's current reveal
+                // resolves *through the replacement chain* to it. The opposite partial write
+                // (payload newer than node) must not drag the payload back to a superseded reveal.
+                let node_reveal_txid = self.ctx.active_reveal_txid(self.curr_payloadidx).await?;
+                let reconcile_to = match node_reveal_txid {
+                    Some(node_txid) if node_txid != payloadentry.reveal_txid => self
+                        .ctx
+                        .get_tx_status(payloadentry.reveal_txid)
+                        .await?
+                        .and_then(|(resolved_txid, _)| {
+                            (resolved_txid == node_txid).then_some(node_txid)
+                        }),
+                    _ => None,
+                };
+
+                if let Some(active_reveal_txid) = reconcile_to {
+                    warn!(
+                        payload_idx = %self.curr_payloadidx,
+                        ?active_reveal_txid,
+                        "reconciling payload row with an already-activated reveal replacement"
+                    );
+                    let mut updated_entry = payloadentry.clone();
+                    updated_entry.reveal_txid = active_reveal_txid;
+                    updated_entry.status = L1BundleStatus::Unpublished;
+                    self.ctx
+                        .put_payload_entry(self.curr_payloadidx, updated_entry)
+                        .await?;
+                    return Ok(());
+                }
+
+                // The payload's own transactions may still be live: a replacement that was refused
+                // leaves the original published, and so does a stop between broadcasting and
+                // writing the payload row. Resetting to `Unsigned` here rebuilds against fresh
+                // UTXOs and would put the same payload on L1 twice, so adopt what the broadcaster
+                // is tracking instead.
+                if self
+                    .reconcile_payload_with_broadcast_state(&payloadentry)
+                    .await?
+                {
+                    return Ok(());
+                }
+
+                warn!(
+                    payload_idx = %self.curr_payloadidx,
+                    commit_txid = ?payloadentry.commit_txid,
+                    reveal_txid = ?payloadentry.reveal_txid,
+                    "envelope not in cache, resetting to Unsigned");
+                let mut updated_entry = payloadentry.clone();
+                updated_entry.payload_signature = None;
+                updated_entry.status = L1BundleStatus::Unsigned;
+                self.ctx
+                    .put_payload_entry(self.curr_payloadidx, updated_entry)
+                    .await?;
+                return Ok(());
+            }
         };
         let Some(signing_mode) = self.resolve_signing_mode() else {
             // Preserve the cached envelope so a transient failure does not force
@@ -462,6 +705,30 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 return Ok(());
             }
         }
+        // The signature the RPC stored was validated against the sighash on the payload row, which
+        // is not necessarily the one this cached envelope commits to: the fee bumper writes that
+        // row too, so a row write racing a rebuild can leave the two describing different reveals.
+        // Attaching a signature over the wrong sighash produces a witness that can never validate,
+        // and a reveal rejected on script grounds never becomes `InvalidInputs`, so nothing would
+        // rebuild it. Rebuild now instead, while nothing has been broadcast.
+        if !matches!(
+            payloadentry.status,
+            L1BundleStatus::PendingRevealTxSign(sighash) if sighash == envelope.sighash
+        ) {
+            warn!(
+                payload_idx = %self.curr_payloadidx,
+                envelope_sighash = %envelope.sighash,
+                "signature does not cover the cached envelope; resetting to Unsigned"
+            );
+            let mut updated_entry = payloadentry.clone();
+            updated_entry.payload_signature = None;
+            updated_entry.status = L1BundleStatus::Unsigned;
+            self.ctx
+                .put_payload_entry(self.curr_payloadidx, updated_entry)
+                .await?;
+            return Ok(());
+        }
+
         match self
             .ctx
             .complete_reveal_and_broadcast(self.curr_payloadidx, &envelope, sig.as_ref())
@@ -482,6 +749,134 @@ impl<C: WatcherServiceContext> WatcherState<C> {
         Ok(())
     }
 
+    async fn advance_if_reveal_replacement_already_confirmed(
+        &mut self,
+        payloadentry: &BundledPayloadEntry,
+    ) -> anyhow::Result<bool> {
+        let Some((_, reveal_tx)) = self.ctx.get_tx_status(payloadentry.reveal_txid).await? else {
+            return Ok(false);
+        };
+        if !matches!(
+            reveal_tx.status,
+            L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+        ) {
+            return Ok(false);
+        }
+        if !self
+            .reconcile_payload_with_broadcast_state(payloadentry)
+            .await?
+        {
+            return Ok(false);
+        }
+
+        debug!(
+            payload_idx = self.curr_payloadidx,
+            "pending reveal replacement discarded because original reveal already advanced"
+        );
+        Ok(true)
+    }
+
+    /// Abandons a pending fee-bump reveal replacement once the payload's own transactions are dead.
+    ///
+    /// A pending attempt is built to supersede one exact txid. When that transaction, or the commit
+    /// it spends, reaches [`L1TxStatus::InvalidInputs`], the replacement can never be broadcast, so
+    /// there is nothing left to wait for and rebuilding is the only way forward — the same verdict
+    /// [`Self::reconcile_payload_with_broadcast_state`] reaches for an invalid reveal outside a fee
+    /// bump. Resetting is safe for the same reason: the inputs are gone, so nothing this payload
+    /// published can still confirm.
+    ///
+    /// Returns whether the payload was reset for a rebuild.
+    async fn abandon_reveal_replacement_if_invalid(
+        &mut self,
+        payloadentry: &BundledPayloadEntry,
+    ) -> anyhow::Result<bool> {
+        let commit_status = self
+            .ctx
+            .get_tx_status(payloadentry.commit_txid)
+            .await?
+            .map(|(_, entry)| entry.status);
+        let reveal_status = self
+            .ctx
+            .get_tx_status(payloadentry.reveal_txid)
+            .await?
+            .map(|(_, entry)| entry.status);
+        if !matches!(commit_status, Some(L1TxStatus::InvalidInputs))
+            && !matches!(reveal_status, Some(L1TxStatus::InvalidInputs))
+        {
+            return Ok(false);
+        }
+
+        warn!(
+            payload_idx = %self.curr_payloadidx,
+            ?commit_status,
+            ?reveal_status,
+            "discarding a pending reveal replacement whose original went invalid"
+        );
+        self.ctx
+            .discard_pending_reveal_replacement(self.curr_payloadidx)
+            .await?;
+        self.envelope_cache.remove(&self.curr_payloadidx);
+
+        let mut updated_entry = payloadentry.clone();
+        updated_entry.payload_signature = None;
+        updated_entry.status = L1BundleStatus::Unsigned;
+        self.ctx
+            .put_payload_entry(self.curr_payloadidx, updated_entry)
+            .await?;
+        Ok(true)
+    }
+
+    /// Re-points the payload row at the transactions the broadcaster is already tracking.
+    ///
+    /// Both txids are resolved through the replacement chain, so a payload naming a superseded
+    /// attempt lands on the one that is actually live. Returns whether the row was rewritten;
+    /// `false` means there is nothing live to track and the caller is free to rebuild.
+    ///
+    /// A reveal with `InvalidInputs` counts as nothing live: its inputs are gone, so rebuilding is
+    /// the only way forward.
+    async fn reconcile_payload_with_broadcast_state(
+        &mut self,
+        payloadentry: &BundledPayloadEntry,
+    ) -> anyhow::Result<bool> {
+        let Some((commit_txid, commit_tx)) =
+            self.ctx.get_tx_status(payloadentry.commit_txid).await?
+        else {
+            return Ok(false);
+        };
+        let Some((reveal_txid, reveal_tx)) =
+            self.ctx.get_tx_status(payloadentry.reveal_txid).await?
+        else {
+            return Ok(false);
+        };
+        if matches!(reveal_tx.status, L1TxStatus::InvalidInputs) {
+            return Ok(false);
+        }
+
+        let new_status = determine_payload_next_status(&commit_tx.status, &reveal_tx.status);
+        let mut updated_entry = payloadentry.clone();
+        updated_entry.commit_txid = commit_txid;
+        updated_entry.reveal_txid = reveal_txid;
+        updated_entry.payload_signature = None;
+        updated_entry.status = new_status.clone();
+        self.ctx.report_status(&updated_entry, &new_status).await;
+        self.ctx
+            .put_payload_entry(self.curr_payloadidx, updated_entry)
+            .await?;
+
+        if new_status == L1BundleStatus::Finalized {
+            self.curr_payloadidx += 1;
+        }
+
+        debug!(
+            payload_idx = self.curr_payloadidx,
+            ?commit_txid,
+            ?reveal_txid,
+            ?new_status,
+            "payload row reconciled with broadcast state"
+        );
+        Ok(true)
+    }
+
     /// Checks broadcast tx statuses and advances the payload state machine.
     async fn handle_broadcast_status(
         &mut self,
@@ -492,7 +887,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
         let reveal_tx = self.ctx.get_tx_status(payloadentry.reveal_txid).await?;
 
         match (commit_tx, reveal_tx) {
-            (Some(ctx), Some(rtx)) => {
+            (Some((commit_txid, ctx)), Some((reveal_txid, rtx))) => {
                 let new_status = determine_payload_next_status(&ctx.status, &rtx.status);
                 debug!(?new_status, "The next status for payload");
                 if matches!(
@@ -502,8 +897,8 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     debug!(
                         component = "btcio_writer",
                         payload_idx = self.curr_payloadidx,
-                        commit_txid = ?payloadentry.commit_txid,
-                        reveal_txid = ?payloadentry.reveal_txid,
+                        ?commit_txid,
+                        ?reveal_txid,
                         payload_status = ?new_status,
                         commit_l1_status = ?ctx.status,
                         reveal_l1_status = ?rtx.status,
@@ -511,11 +906,11 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     );
                 }
 
-                self.ctx.report_status(&payloadentry, &new_status).await;
-
-                // Update payloadentry with new status
                 let mut updated_entry = payloadentry.clone();
+                updated_entry.commit_txid = commit_txid;
+                updated_entry.reveal_txid = reveal_txid;
                 updated_entry.status = new_status.clone();
+                self.ctx.report_status(&updated_entry, &new_status).await;
                 self.ctx
                     .put_payload_entry(self.curr_payloadidx, updated_entry)
                     .await?;
@@ -570,6 +965,11 @@ pub(crate) fn determine_payload_next_status(
         (_, L1TxStatus::Confirmed { .. }) => L1BundleStatus::Confirmed,
         // If reveal is published regardless of commit, the payload is published
         (_, L1TxStatus::Published) => L1BundleStatus::Published,
+        // Replacement chains are normally followed before this function. If a
+        // stale entry reaches here, keep the watcher from needlessly resigning.
+        (L1TxStatus::Replaced { .. }, _) | (_, L1TxStatus::Replaced { .. }) => {
+            L1BundleStatus::Published
+        }
         // if commit has invalid inputs, needs resign
         (L1TxStatus::InvalidInputs, _) => L1BundleStatus::NeedsResign,
         // If commit is unpublished, both are upublished
@@ -598,12 +998,13 @@ mod tests {
         secp256k1::{XOnlyPublicKey, SECP256K1},
         taproot::TaprootBuilder,
         transaction::Version,
-        Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+        Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
     };
     use bitcoind_async_client::error::ClientError;
     use strata_csm_types::L1Payload;
     use strata_db_types::{
         common::L1TxId,
+        fee_bump::{TerminalError, TxAttemptStatus, TxNodeId, TxNodeKind, TxNodeRecord},
         l1_broadcast::L1TxEntry,
         l1_writer::{BundledPayloadEntry, L1BundleStatus},
     };
@@ -613,9 +1014,11 @@ mod tests {
     use super::*;
     use crate::{
         broadcaster::L1BroadcastHandle,
+        tx_entry::L1TxEntryExt,
         writer::{
             builder::{EnvelopeData, EnvelopeError},
-            signer::complete_reveal_and_broadcast,
+            replacement::build::build_pending_single_reveal_replacement,
+            signer::{complete_pending_reveal_replacement, complete_reveal_and_broadcast},
             test_utils::get_broadcast_handle,
         },
     };
@@ -649,12 +1052,18 @@ mod tests {
     }
 
     fn minimal_envelope_data() -> EnvelopeData {
-        let keypair =
-            UntweakedKeypair::from_seckey_slice(SECP256K1, &[1u8; 32]).expect("valid key");
+        minimal_envelope_data_for(&[1u8; 32])
+    }
+
+    fn minimal_envelope_data_for(seckey: &[u8; 32]) -> EnvelopeData {
+        let keypair = UntweakedKeypair::from_seckey_slice(SECP256K1, seckey).expect("valid key");
         let pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
-        // A single OP_TRUE leaf so control_block lookup succeeds in attach_reveal_signature
+        // A single `<pubkey> OP_CHECKSIG` leaf, as SPS-51 reveal scripts open: the control_block
+        // lookup in attach_reveal_signature succeeds, and the key the script commits to is the one
+        // a replacement's signature has to verify against.
         let reveal_script = ScriptBuilder::new()
-            .push_opcode(opcodes::OP_TRUE)
+            .push_slice(pubkey.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
         let taproot_spend_info = TaprootBuilder::new()
             .add_leaf(0, reveal_script.clone())
@@ -695,6 +1104,9 @@ mod tests {
             reveal_script,
             taproot_spend_info,
             pubkey,
+            FeeRate::from_sat_per_vb(2).expect("test: valid fee rate"),
+            Amount::from_sat(100),
+            Amount::from_sat(50),
         )
     }
 
@@ -771,6 +1183,12 @@ mod tests {
     }
 
     impl WatcherServiceContext for MockWatcherContext {
+        // Replacement is exercised by the driver's own tests; the watcher tests care about
+        // payload-status transitions, so this is a no-op here.
+        async fn run_replacement_pass(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
         async fn get_payload_entry(&self, idx: u64) -> anyhow::Result<Option<BundledPayloadEntry>> {
             Ok(self.stored.lock().unwrap().get(&idx).cloned())
         }
@@ -825,8 +1243,47 @@ mod tests {
                 .map_err(Into::into)
         }
 
-        async fn get_tx_status(&self, _txid: L1TxId) -> anyhow::Result<Option<L1TxEntry>> {
-            Ok(None)
+        async fn complete_pending_reveal_replacement(
+            &self,
+            idx: u64,
+            sig: &[u8; 64],
+            signing_mode: EnvelopeSigningMode,
+        ) -> anyhow::Result<Option<L1TxId>> {
+            complete_pending_reveal_replacement(idx, sig, signing_mode, &self.broadcast_handle)
+                .await
+                .map_err(Into::into)
+        }
+
+        async fn has_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<bool> {
+            let node_id =
+                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+            Ok(self
+                .broadcast_handle
+                .get_tx_node(node_id)
+                .await?
+                .is_some_and(|record| record.pending_signature_attempt().is_some()))
+        }
+
+        async fn discard_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<()> {
+            discard_pending_reveal_replacement(&self.broadcast_handle, idx).await
+        }
+
+        async fn active_reveal_txid(&self, idx: u64) -> anyhow::Result<Option<L1TxId>> {
+            let node_id =
+                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+            Ok(self
+                .broadcast_handle
+                .get_tx_node(node_id)
+                .await?
+                .map(|record| record.active_txid))
+        }
+
+        async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<(L1TxId, L1TxEntry)>> {
+            self.broadcast_handle
+                .get_active_tx_entry_by_id_async(to_raw_buf32(txid))
+                .await
+                .map(|entry| entry.map(|(txid, entry)| (L1TxId::from(txid.0), entry)))
+                .map_err(Into::into)
         }
 
         async fn report_status(&self, _entry: &BundledPayloadEntry, _status: &L1BundleStatus) {}
@@ -875,6 +1332,64 @@ mod tests {
         assert_eq!(stored.reveal_txid, L1TxId::zero());
         assert_eq!(state.curr_payloadidx, 0);
         assert!(state.envelope_cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_status_resolves_active_fee_bump_txids() {
+        let ctx = MockWatcherContext::new(false);
+        let mut entry = test_unsigned_entry();
+        entry.status = L1BundleStatus::Published;
+        entry.commit_txid = L1TxId::from([0x10; 32]);
+        entry.reveal_txid = L1TxId::from([0x20; 32]);
+
+        let replacement_commit_txid = L1TxId::from([0x11; 32]);
+        let replacement_reveal_txid = L1TxId::from([0x21; 32]);
+        let envelope = minimal_envelope_data();
+        let finalized = L1TxStatus::Finalized {
+            confirmations: 6,
+            block_hash: Buf32::from([0xBB; 32]),
+            block_height: 100,
+        };
+        let mut replacement_commit_entry = L1TxEntry::from_tx(&envelope.commit_tx);
+        replacement_commit_entry.status = finalized.clone();
+        let mut replacement_reveal_entry = L1TxEntry::from_tx(&envelope.reveal_tx);
+        replacement_reveal_entry.status = finalized;
+
+        let mut original_commit_entry = L1TxEntry::from_tx(&envelope.commit_tx);
+        original_commit_entry.status = L1TxStatus::Replaced {
+            by: replacement_commit_txid,
+        };
+        let mut original_reveal_entry = L1TxEntry::from_tx(&envelope.reveal_tx);
+        original_reveal_entry.status = L1TxStatus::Replaced {
+            by: replacement_reveal_txid,
+        };
+
+        for (txid, tx_entry) in [
+            (to_raw_buf32(entry.commit_txid), original_commit_entry),
+            (to_raw_buf32(entry.reveal_txid), original_reveal_entry),
+            (
+                to_raw_buf32(replacement_commit_txid),
+                replacement_commit_entry,
+            ),
+            (
+                to_raw_buf32(replacement_reveal_txid),
+                replacement_reveal_entry,
+            ),
+        ] {
+            ctx.broadcast_handle
+                .put_tx_entry(txid, tx_entry)
+                .await
+                .unwrap();
+        }
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_broadcast_status(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Finalized);
+        assert_eq!(stored.commit_txid, replacement_commit_txid);
+        assert_eq!(stored.reveal_txid, replacement_reveal_txid);
+        assert_eq!(state.curr_payloadidx, 1);
     }
 
     #[tokio::test]
@@ -1032,8 +1547,8 @@ mod tests {
         let bcast_handle = ctx.broadcast_handle.clone();
 
         let envelope = minimal_envelope_data();
-        let commit_txid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
-        let reveal_txid: Buf32 = envelope.reveal_tx.compute_txid().to_buf32();
+        let commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        let reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
 
         // Set up entry already in PendingRevealTxSign with a signature present
         let mut entry = test_unsigned_entry();
@@ -1052,12 +1567,12 @@ mod tests {
         assert!(!state.envelope_cache.contains_key(&0));
         // Both txs stored in broadcaster DB
         assert!(bcast_handle
-            .get_tx_entry_by_id_async(commit_txid)
+            .get_tx_entry_by_id_async(to_raw_buf32(commit_txid))
             .await
             .unwrap()
             .is_some());
         assert!(bcast_handle
-            .get_tx_entry_by_id_async(reveal_txid)
+            .get_tx_entry_by_id_async(to_raw_buf32(reveal_txid))
             .await
             .unwrap()
             .is_some());
@@ -1090,5 +1605,502 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_pending_reveal_cache_miss_resets_to_unsigned() {
+        let envelope = minimal_envelope_data();
+        let commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        let reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
+        let ctx = MockWatcherContext::new(true);
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = commit_txid;
+        entry.reveal_txid = reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(Buf32([42u8; 32]));
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+        assert_eq!(stored.commit_txid, L1TxId::from(commit_txid.0));
+        assert_eq!(stored.reveal_txid, L1TxId::from(reveal_txid.0));
+    }
+
+    #[tokio::test]
+    async fn test_pending_reveal_cache_miss_completes_pending_replacement_node() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let original_signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(0, &envelope, &original_signature, &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        let original_reveal_tx = original_reveal_entry.try_to_tx().unwrap();
+        let reveal_node_id =
+            TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 0 });
+        let mut reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        let (pending_reveal, sighash) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            1,
+        )
+        .unwrap();
+        let pending_reveal_txid = pending_reveal.txid;
+        reveal_record.append_pending_signature_replacement(pending_reveal);
+        bcast_handle.put_tx_node(reveal_record).await.unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = pending_reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+        entry.payload_signature = Some(Buf64([2u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unpublished);
+        assert_eq!(stored.reveal_txid, pending_reveal_txid);
+        assert!(bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(matches!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+                .await
+                .unwrap()
+                .expect("original reveal entry exists")
+                .status,
+            L1TxStatus::Replaced { .. }
+        ));
+
+        let reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        assert_eq!(
+            reveal_record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+    }
+
+    /// Regression: the RPC validates a signature against the sighash on the payload row, and the
+    /// fee bumper is a second writer of that row. If the row and the cached envelope describe
+    /// different reveals, attaching the signature yields a witness that can never validate, and a
+    /// reveal rejected on script grounds never becomes `InvalidInputs`, so nothing rebuilds it.
+    #[tokio::test]
+    async fn test_reveal_signature_for_a_different_sighash_is_not_attached() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
+        // A sighash that is not the cached envelope's.
+        entry.status = L1BundleStatus::PendingRevealTxSign(Buf32([7u8; 32]));
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.envelope_cache.insert(0, envelope.clone());
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+        assert!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(to_l1_txid(
+                    envelope.reveal_tx.compute_txid()
+                )))
+                .await
+                .unwrap()
+                .is_none(),
+            "nothing may reach the broadcaster"
+        );
+    }
+
+    /// The matching sighash still goes through, so the check does not block the normal path.
+    #[tokio::test]
+    async fn test_reveal_signature_for_the_cached_sighash_is_attached() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
+        entry.status = L1BundleStatus::PendingRevealTxSign(envelope.sighash);
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.envelope_cache.insert(0, envelope);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        assert_eq!(
+            state.ctx.get_stored(0).unwrap().status,
+            L1BundleStatus::Unpublished
+        );
+    }
+
+    /// Sets up a payload whose published reveal has a pending externally signed fee-bump
+    /// replacement, the state the fee bumper leaves behind while it waits on the signer.
+    ///
+    /// Returns the mock context, the original reveal's txid and the pending replacement's txid.
+    /// The payload row names the original reveal, as the fee bumper leaves it: the replacement
+    /// only takes its place once its witness is attached.
+    async fn pending_reveal_replacement_fixture(
+    ) -> (MockWatcherContext, BundledPayloadEntry, L1TxId, L1TxId) {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(0, &envelope, &[1u8; 64], &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_tx = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists")
+            .try_to_tx()
+            .unwrap();
+        let mut reveal_record = bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 0,
+            }))
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        let (pending_reveal, sighash) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            1,
+        )
+        .unwrap();
+        let pending_reveal_txid = pending_reveal.txid;
+        reveal_record.append_pending_signature_replacement(pending_reveal);
+        bcast_handle.put_tx_node(reveal_record).await.unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = original_reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+        entry.payload_signature = Some(Buf64([2u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        (ctx, entry, original_reveal_txid, pending_reveal_txid)
+    }
+
+    async fn reveal_record(bcast_handle: &L1BroadcastHandle) -> TxNodeRecord {
+        bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 0,
+            }))
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists")
+    }
+
+    /// Regression: a replacement reuses the original reveal's tapscript, so it can only be
+    /// completed under the key that script commits to. The signing RPC verifies against whatever
+    /// key is canonical *now*, so after a rotation it accepts a signature that cannot satisfy the
+    /// old script — attaching it would supersede a valid reveal with an unspendable one.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_refused_when_signing_key_rotates() {
+        let (ctx, entry, original_reveal_txid, pending_reveal_txid) =
+            pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        ctx.set_signing_mode(EnvelopeSigningMode::External {
+            pubkey: minimal_envelope_data_for(&[2u8; 32]).envelope_pubkey,
+        });
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        assert!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+                .await
+                .unwrap()
+                .is_none(),
+            "the replacement must never reach the broadcaster"
+        );
+        assert_eq!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+                .await
+                .unwrap()
+                .expect("original reveal entry exists")
+                .status,
+            L1TxStatus::Unpublished,
+            "the original must not be superseded"
+        );
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(
+            record.terminal_error,
+            Some(TerminalError::UnsupportedRbfKind)
+        );
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded)
+        );
+
+        // The original is still live, so the payload tracks it rather than being rebuilt.
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unpublished);
+        assert_eq!(stored.reveal_txid, original_reveal_txid);
+    }
+
+    /// Regression: only `Unpublished` and `Published` entries are replaceable, so an original that
+    /// went invalid refuses the swap. The pending attempt is dead at that point, and leaving it
+    /// durable pins the payload in `PendingRevealTxSign` forever.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_discarded_when_original_is_invalid() {
+        let (ctx, entry, original_reveal_txid, pending_reveal_txid) =
+            pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let mut original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        original_reveal_entry.status = L1TxStatus::InvalidInputs;
+        bcast_handle
+            .update_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid), original_reveal_entry)
+            .await
+            .unwrap();
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(record.terminal_error, None, "the chain is still bumpable");
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded)
+        );
+
+        // Nothing spendable is left, so the payload rebuilds from fresh UTXOs.
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+    }
+
+    /// Regression: the signature may never arrive. If the original reveal goes invalid first, the
+    /// no-signature path used to return early on the pending attempt every tick, so the payload sat
+    /// in `PendingRevealTxSign` forever — the fee bumper skips nodes carrying a pending attempt, so
+    /// nothing else would move it either.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_without_signature_rebuilds_when_original_is_invalid() {
+        let (ctx, mut entry, original_reveal_txid, pending_reveal_txid) =
+            pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        entry.payload_signature = None;
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        original_reveal_entry.status = L1TxStatus::InvalidInputs;
+        bcast_handle
+            .update_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid), original_reveal_entry)
+            .await
+            .unwrap();
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded),
+            "the replacement can never be broadcast, so it must not keep blocking the node"
+        );
+        assert!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+                .await
+                .unwrap()
+                .is_none(),
+            "the replacement must never reach the broadcaster"
+        );
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+    }
+
+    /// The same path must keep waiting while the original is still live, or a fee bump would
+    /// double-publish the payload.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_without_signature_waits_on_a_live_original() {
+        let (ctx, mut entry, _, pending_reveal_txid) = pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        entry.payload_signature = None;
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state
+            .handle_pending_reveal_tx_sign(entry.clone())
+            .await
+            .unwrap();
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::PendingSignature)
+        );
+        assert_eq!(state.ctx.get_stored(0).unwrap().status, entry.status);
+    }
+
+    /// Regression: a stop between broadcasting an envelope and writing its payload row leaves the
+    /// row in `PendingRevealTxSign` with both transactions already queued. Rebuilding there draws
+    /// fresh UTXOs and publishes the same payload twice.
+    #[tokio::test]
+    async fn test_pending_reveal_cache_miss_adopts_live_broadcast_state() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let reveal_txid = complete_reveal_and_broadcast(0, &envelope, &[1u8; 64], &bcast_handle)
+            .await
+            .unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(Buf32([42u8; 32]));
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unpublished);
+        assert_eq!(stored.reveal_txid, reveal_txid);
+    }
+
+    #[tokio::test]
+    async fn test_pending_reveal_signature_keeps_confirmed_original() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let original_signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(0, &envelope, &original_signature, &bcast_handle)
+                .await
+                .unwrap();
+        let mut original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        let original_reveal_tx = original_reveal_entry.try_to_tx().unwrap();
+        let reveal_node_id =
+            TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 0 });
+        let mut reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        let (pending_reveal, sighash) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            1,
+        )
+        .unwrap();
+        let pending_reveal_txid = pending_reveal.txid;
+        reveal_record.append_pending_signature_replacement(pending_reveal);
+        bcast_handle.put_tx_node(reveal_record).await.unwrap();
+
+        original_reveal_entry.status = L1TxStatus::Confirmed {
+            confirmations: 1,
+            block_hash: Buf32::zero(),
+            block_height: 100,
+        };
+        bcast_handle
+            .update_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid), original_reveal_entry)
+            .await
+            .unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = original_reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+        entry.payload_signature = Some(Buf64([2u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Confirmed);
+        assert_eq!(stored.reveal_txid, original_reveal_txid);
+        assert!(bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+            .await
+            .unwrap()
+            .is_none());
+
+        let reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        assert_eq!(
+            reveal_record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+        assert_eq!(
+            reveal_record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded)
+        );
     }
 }

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use strata_btc_types::{Buf32BitcoinExt, TxidExt};
 use strata_db_types::{
     common::L1TxId,
+    fee_bump::{TxNodeId, TxNodeKind},
     l1_broadcast::{L1TxEntry, L1TxStatus},
     l1_writer::{BundledPayloadEntry, L1BundleStatus},
 };
@@ -33,9 +34,10 @@ use crate::{
     writer::{
         builder::{EnvelopeData, EnvelopeError},
         context::{EnvelopeSigningMode, WriterContext},
+        replacement::driver::{run_replacement_pass, ReplacementContext, ReplacementPacer},
         signer::{
-            complete_reveal_and_broadcast, create_payload_envelopes,
-            sign_and_broadcast_payload_envelopes,
+            complete_pending_reveal_replacement, complete_reveal_and_broadcast,
+            create_payload_envelopes, sign_and_broadcast_payload_envelopes,
         },
     },
 };
@@ -46,6 +48,21 @@ fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
 
 fn to_raw_buf32(txid: L1TxId) -> Buf32 {
     Buf32(txid.0)
+}
+
+/// Discards the pending externally-signed replacement on a payload's reveal tx-node.
+async fn discard_pending_reveal_replacement(
+    broadcast_handle: &L1BroadcastHandle,
+    payload_idx: u64,
+) -> anyhow::Result<()> {
+    let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx });
+    let Some(mut record) = broadcast_handle.get_tx_node(node_id).await? else {
+        return Ok(());
+    };
+    if record.discard_pending_signature_replacement() {
+        broadcast_handle.put_tx_node(record).await?;
+    }
+    Ok(())
 }
 
 /// Abstracts the external dependencies of the watcher so that `process_input` can be
@@ -83,10 +100,40 @@ pub(crate) trait WatcherServiceContext: Send + Sync + 'static {
         envelope: &EnvelopeData,
         sig: &[u8; 64],
     ) -> impl Future<Output = anyhow::Result<L1TxId>> + Send;
+
+    /// Attaches an external signature to this payload's pending fee-bump reveal replacement.
+    ///
+    /// `signing_mode` is the mode resolved for the current canonical state; the replacement is
+    /// refused when it no longer matches the key its tapscript commits to.
+    fn complete_pending_reveal_replacement(
+        &self,
+        idx: u64,
+        sig: &[u8; 64],
+        signing_mode: EnvelopeSigningMode,
+    ) -> impl Future<Output = anyhow::Result<Option<L1TxId>>> + Send;
+
+    /// Reports whether a fee bump is waiting on a signature for this payload's reveal.
+    fn has_pending_reveal_replacement(
+        &self,
+        idx: u64,
+    ) -> impl Future<Output = anyhow::Result<bool>> + Send;
+
+    /// Discards this payload's pending fee-bump reveal replacement, if it still has one.
+    fn discard_pending_reveal_replacement(
+        &self,
+        idx: u64,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+
+    /// Returns the reveal txid this payload's tx-node currently considers active, if recorded.
+    fn active_reveal_txid(
+        &self,
+        idx: u64,
+    ) -> impl Future<Output = anyhow::Result<Option<L1TxId>>> + Send;
+
     fn get_tx_status(
         &self,
         txid: L1TxId,
-    ) -> impl Future<Output = anyhow::Result<Option<L1TxEntry>>> + Send;
+    ) -> impl Future<Output = anyhow::Result<Option<(L1TxId, L1TxEntry)>>> + Send;
 
     fn report_status(
         &self,
@@ -95,12 +142,20 @@ pub(crate) trait WatcherServiceContext: Send + Sync + 'static {
     ) -> impl Future<Output = ()> + Send;
 
     fn report_rpc_error(&self, reason: String) -> impl Future<Output = ()> + Send;
+
+    /// Runs one RBF replacement pass over this writer's tx-node records.
+    ///
+    /// Driven from the watcher tick rather than a service of its own: rebuilding a reveal needs
+    /// the writer's payload storage and signing mode, both of which live here.
+    fn run_replacement_pass(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
 pub(crate) struct WatcherContextImpl<R: Reader + Signer + Wallet + Send + Sync + 'static> {
     context: Arc<WriterContext<R>>,
     ops: Arc<EnvelopeDataOps>,
     broadcast_handle: Arc<L1BroadcastHandle>,
+    /// Held here rather than rebuilt per call so the interval actually spans watcher ticks.
+    replacement_pacer: Arc<ReplacementPacer>,
 }
 
 impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherContextImpl<R> {
@@ -109,10 +164,14 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherContextImpl<R> 
         ops: Arc<EnvelopeDataOps>,
         broadcast_handle: Arc<L1BroadcastHandle>,
     ) -> Self {
+        let replacement_pacer = Arc::new(ReplacementPacer::new(
+            context.config.fee_bumping.check_interval(),
+        ));
         Self {
             context,
             ops,
             broadcast_handle,
+            replacement_pacer,
         }
     }
 }
@@ -120,6 +179,22 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherContextImpl<R> 
 impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
     for WatcherContextImpl<R>
 {
+    async fn run_replacement_pass(&self) -> anyhow::Result<()> {
+        let replacement_context = ReplacementContext {
+            envelope_ops: Some(self.ops.clone()),
+            signing_mode_provider: Some(self.context.signing_mode_provider()),
+            pacer: self.replacement_pacer.clone(),
+            ..ReplacementContext::default()
+        };
+        run_replacement_pass(
+            self.context.client.as_ref(),
+            &self.context.config,
+            self.broadcast_handle.as_ref(),
+            &replacement_context,
+        )
+        .await
+    }
+
     async fn get_payload_entry(&self, idx: u64) -> anyhow::Result<Option<BundledPayloadEntry>> {
         self.ops
             .get_payload_entry_by_idx_async(idx)
@@ -172,10 +247,44 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
             .map_err(Into::into)
     }
 
-    async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<L1TxEntry>> {
-        self.broadcast_handle
-            .get_tx_entry_by_id_async(Buf32(txid.0))
+    async fn complete_pending_reveal_replacement(
+        &self,
+        idx: u64,
+        sig: &[u8; 64],
+        signing_mode: EnvelopeSigningMode,
+    ) -> anyhow::Result<Option<L1TxId>> {
+        complete_pending_reveal_replacement(idx, sig, signing_mode, &self.broadcast_handle)
             .await
+            .map_err(Into::into)
+    }
+
+    async fn has_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<bool> {
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+        Ok(self
+            .broadcast_handle
+            .get_tx_node(node_id)
+            .await?
+            .is_some_and(|record| record.pending_signature_attempt().is_some()))
+    }
+
+    async fn discard_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<()> {
+        discard_pending_reveal_replacement(&self.broadcast_handle, idx).await
+    }
+
+    async fn active_reveal_txid(&self, idx: u64) -> anyhow::Result<Option<L1TxId>> {
+        let node_id = TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+        Ok(self
+            .broadcast_handle
+            .get_tx_node(node_id)
+            .await?
+            .map(|record| record.active_txid))
+    }
+
+    async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<(L1TxId, L1TxEntry)>> {
+        self.broadcast_handle
+            .get_active_tx_entry_by_id_async(to_raw_buf32(txid))
+            .await
+            .map(|entry| entry.map(|(txid, entry)| (L1TxId::from(txid.0), entry)))
             .map_err(Into::into)
     }
 
@@ -245,6 +354,11 @@ impl<C: WatcherServiceContext> AsyncService for WatcherService<C> {
     async fn process_input(state: &mut Self::State, _: Self::Msg) -> anyhow::Result<Response> {
         let dspan = debug_span!("process payload", idx=%state.curr_payloadidx);
         let _ = dspan.enter();
+
+        // A failed pass must not stall payload processing; the next tick retries it.
+        if let Err(error) = state.ctx.run_replacement_pass().await {
+            warn!(%error, "payload envelope replacement pass failed");
+        }
 
         if let Some(payloadentry) = state.ctx.get_payload_entry(state.curr_payloadidx).await? {
             match payloadentry.status {
@@ -395,6 +509,39 @@ impl<C: WatcherServiceContext> WatcherState<C> {
         payloadentry: BundledPayloadEntry,
     ) -> anyhow::Result<()> {
         let Some(sig) = &payloadentry.payload_signature else {
+            // A fee-bump replacement can be waiting on a signature that will never arrive because
+            // the original reveal confirmed first. Advance off the pending state instead of
+            // blocking on the signer forever.
+            if self
+                .advance_if_reveal_replacement_already_confirmed(&payloadentry)
+                .await?
+            {
+                return Ok(());
+            }
+
+            // Resetting to `Unsigned` rebuilds the envelope from fresh UTXOs, which is only safe
+            // while nothing has been broadcast. A fee bump breaks that assumption: it moves an
+            // already-published reveal back into `PendingRevealTxSign` while the original stays
+            // live, so rebuilding here would publish the same payload twice.
+            if self
+                .ctx
+                .has_pending_reveal_replacement(self.curr_payloadidx)
+                .await?
+            {
+                // Unless what it supersedes has itself gone invalid, in which case waiting pins
+                // the payload here for good: the replacement spends inputs that are gone so no
+                // signature can rescue it, and the fee bumper skips every node carrying a pending
+                // attempt.
+                if self
+                    .abandon_reveal_replacement_if_invalid(&payloadentry)
+                    .await?
+                {
+                    return Ok(());
+                }
+                trace!("waiting for signer to sign the fee-bump reveal replacement");
+                return Ok(());
+            }
+
             let Some(envelope) = self.envelope_cache.get(&self.curr_payloadidx) else {
                 // Cache miss (e.g. restart) — reset to Unsigned to rebuild
                 // envelope from scratch (new UTXOs, new sighash).
@@ -430,18 +577,114 @@ impl<C: WatcherServiceContext> WatcherState<C> {
             trace!("waiting for signer to provide reveal signature");
             return Ok(());
         };
-        let Some(envelope) = self.envelope_cache.remove(&self.curr_payloadidx) else {
-            // Cache miss (e.g. restart) — reset to Unsigned to rebuild
-            // envelope from scratch (new UTXOs, new sighash).
-            // Safe: nothing has been broadcast yet.
-            warn!("envelope not in cache, resetting to Unsigned");
-            let mut updated_entry = payloadentry.clone();
-            updated_entry.payload_signature = None;
-            updated_entry.status = L1BundleStatus::Unsigned;
-            self.ctx
-                .put_payload_entry(self.curr_payloadidx, updated_entry)
-                .await?;
-            return Ok(());
+        let envelope = match self.envelope_cache.remove(&self.curr_payloadidx) {
+            Some(envelope) => envelope,
+            None => {
+                // Resolved before completion, not after: a fee-bump replacement reuses the original
+                // reveal's tapscript, so an external signature is only usable while the canonical
+                // key still matches what that script commits to. A resolution failure only skips
+                // the completion attempt, which the pending attempt survives; the recovery paths
+                // below still need to run.
+                if let Some(signing_mode) = self.resolve_signing_mode() {
+                    if let Some(rid) = self
+                        .ctx
+                        .complete_pending_reveal_replacement(
+                            self.curr_payloadidx,
+                            sig.as_ref(),
+                            signing_mode,
+                        )
+                        .await?
+                    {
+                        let mut updated_entry = payloadentry.clone();
+                        updated_entry.reveal_txid = rid;
+                        updated_entry.status = L1BundleStatus::Unpublished;
+                        self.ctx
+                            .put_payload_entry(self.curr_payloadidx, updated_entry)
+                            .await?;
+                        debug!(reveal_txid = ?rid, "pending reveal replacement signed and stored for broadcast");
+                        return Ok(());
+                    }
+                }
+                if self
+                    .advance_if_reveal_replacement_already_confirmed(&payloadentry)
+                    .await?
+                {
+                    return Ok(());
+                }
+
+                if self
+                    .ctx
+                    .has_pending_reveal_replacement(self.curr_payloadidx)
+                    .await?
+                {
+                    // The replacement could not be completed this tick but the original reveal
+                    // is still live. Rebuilding would double-publish the payload.
+                    warn!(
+                        payload_idx = %self.curr_payloadidx,
+                        "pending fee-bump reveal replacement could not be completed, retrying"
+                    );
+                    return Ok(());
+                }
+
+                // A crash between activating a replacement and writing the payload row leaves no
+                // pending attempt, so completion above returned `None`. The activated replacement
+                // is live, so reconcile the payload row from the tx-node instead of rebuilding.
+                //
+                // Only ever move forward: adopt the node's txid when the payload's current reveal
+                // resolves *through the replacement chain* to it. The opposite partial write
+                // (payload newer than node) must not drag the payload back to a superseded reveal.
+                let node_reveal_txid = self.ctx.active_reveal_txid(self.curr_payloadidx).await?;
+                let reconcile_to = match node_reveal_txid {
+                    Some(node_txid) if node_txid != payloadentry.reveal_txid => self
+                        .ctx
+                        .get_tx_status(payloadentry.reveal_txid)
+                        .await?
+                        .and_then(|(resolved_txid, _)| {
+                            (resolved_txid == node_txid).then_some(node_txid)
+                        }),
+                    _ => None,
+                };
+
+                if let Some(active_reveal_txid) = reconcile_to {
+                    warn!(
+                        payload_idx = %self.curr_payloadidx,
+                        ?active_reveal_txid,
+                        "reconciling payload row with an already-activated reveal replacement"
+                    );
+                    let mut updated_entry = payloadentry.clone();
+                    updated_entry.reveal_txid = active_reveal_txid;
+                    updated_entry.status = L1BundleStatus::Unpublished;
+                    self.ctx
+                        .put_payload_entry(self.curr_payloadidx, updated_entry)
+                        .await?;
+                    return Ok(());
+                }
+
+                // The payload's own transactions may still be live: a replacement that was refused
+                // leaves the original published, and so does a stop between broadcasting and
+                // writing the payload row. Resetting to `Unsigned` here rebuilds against fresh
+                // UTXOs and would put the same payload on L1 twice, so adopt what the broadcaster
+                // is tracking instead.
+                if self
+                    .reconcile_payload_with_broadcast_state(&payloadentry)
+                    .await?
+                {
+                    return Ok(());
+                }
+
+                warn!(
+                    payload_idx = %self.curr_payloadidx,
+                    commit_txid = ?payloadentry.commit_txid,
+                    reveal_txid = ?payloadentry.reveal_txid,
+                    "envelope not in cache, resetting to Unsigned");
+                let mut updated_entry = payloadentry.clone();
+                updated_entry.payload_signature = None;
+                updated_entry.status = L1BundleStatus::Unsigned;
+                self.ctx
+                    .put_payload_entry(self.curr_payloadidx, updated_entry)
+                    .await?;
+                return Ok(());
+            }
         };
         let Some(signing_mode) = self.resolve_signing_mode() else {
             // Preserve the cached envelope so a transient failure does not force
@@ -462,6 +705,30 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 return Ok(());
             }
         }
+        // The signature the RPC stored was validated against the sighash on the payload row, which
+        // is not necessarily the one this cached envelope commits to: the fee bumper writes that
+        // row too, so a row write racing a rebuild can leave the two describing different reveals.
+        // Attaching a signature over the wrong sighash produces a witness that can never validate,
+        // and a reveal rejected on script grounds never becomes `InvalidInputs`, so nothing would
+        // rebuild it. Rebuild now instead, while nothing has been broadcast.
+        if !matches!(
+            payloadentry.status,
+            L1BundleStatus::PendingRevealTxSign(sighash) if sighash == envelope.sighash
+        ) {
+            warn!(
+                payload_idx = %self.curr_payloadidx,
+                envelope_sighash = %envelope.sighash,
+                "signature does not cover the cached envelope; resetting to Unsigned"
+            );
+            let mut updated_entry = payloadentry.clone();
+            updated_entry.payload_signature = None;
+            updated_entry.status = L1BundleStatus::Unsigned;
+            self.ctx
+                .put_payload_entry(self.curr_payloadidx, updated_entry)
+                .await?;
+            return Ok(());
+        }
+
         match self
             .ctx
             .complete_reveal_and_broadcast(self.curr_payloadidx, &envelope, sig.as_ref())
@@ -482,6 +749,134 @@ impl<C: WatcherServiceContext> WatcherState<C> {
         Ok(())
     }
 
+    async fn advance_if_reveal_replacement_already_confirmed(
+        &mut self,
+        payloadentry: &BundledPayloadEntry,
+    ) -> anyhow::Result<bool> {
+        let Some((_, reveal_tx)) = self.ctx.get_tx_status(payloadentry.reveal_txid).await? else {
+            return Ok(false);
+        };
+        if !matches!(
+            reveal_tx.status,
+            L1TxStatus::Confirmed { .. } | L1TxStatus::Finalized { .. }
+        ) {
+            return Ok(false);
+        }
+        if !self
+            .reconcile_payload_with_broadcast_state(payloadentry)
+            .await?
+        {
+            return Ok(false);
+        }
+
+        debug!(
+            payload_idx = self.curr_payloadidx,
+            "pending reveal replacement discarded because original reveal already advanced"
+        );
+        Ok(true)
+    }
+
+    /// Abandons a pending fee-bump reveal replacement once the payload's own transactions are dead.
+    ///
+    /// A pending attempt is built to supersede one exact txid. When that transaction, or the commit
+    /// it spends, reaches [`L1TxStatus::InvalidInputs`], the replacement can never be broadcast, so
+    /// there is nothing left to wait for and rebuilding is the only way forward — the same verdict
+    /// [`Self::reconcile_payload_with_broadcast_state`] reaches for an invalid reveal outside a fee
+    /// bump. Resetting is safe for the same reason: the inputs are gone, so nothing this payload
+    /// published can still confirm.
+    ///
+    /// Returns whether the payload was reset for a rebuild.
+    async fn abandon_reveal_replacement_if_invalid(
+        &mut self,
+        payloadentry: &BundledPayloadEntry,
+    ) -> anyhow::Result<bool> {
+        let commit_status = self
+            .ctx
+            .get_tx_status(payloadentry.commit_txid)
+            .await?
+            .map(|(_, entry)| entry.status);
+        let reveal_status = self
+            .ctx
+            .get_tx_status(payloadentry.reveal_txid)
+            .await?
+            .map(|(_, entry)| entry.status);
+        if !matches!(commit_status, Some(L1TxStatus::InvalidInputs))
+            && !matches!(reveal_status, Some(L1TxStatus::InvalidInputs))
+        {
+            return Ok(false);
+        }
+
+        warn!(
+            payload_idx = %self.curr_payloadidx,
+            ?commit_status,
+            ?reveal_status,
+            "discarding a pending reveal replacement whose original went invalid"
+        );
+        self.ctx
+            .discard_pending_reveal_replacement(self.curr_payloadidx)
+            .await?;
+        self.envelope_cache.remove(&self.curr_payloadidx);
+
+        let mut updated_entry = payloadentry.clone();
+        updated_entry.payload_signature = None;
+        updated_entry.status = L1BundleStatus::Unsigned;
+        self.ctx
+            .put_payload_entry(self.curr_payloadidx, updated_entry)
+            .await?;
+        Ok(true)
+    }
+
+    /// Re-points the payload row at the transactions the broadcaster is already tracking.
+    ///
+    /// Both txids are resolved through the replacement chain, so a payload naming a superseded
+    /// attempt lands on the one that is actually live. Returns whether the row was rewritten;
+    /// `false` means there is nothing live to track and the caller is free to rebuild.
+    ///
+    /// A reveal with `InvalidInputs` counts as nothing live: its inputs are gone, so rebuilding is
+    /// the only way forward.
+    async fn reconcile_payload_with_broadcast_state(
+        &mut self,
+        payloadentry: &BundledPayloadEntry,
+    ) -> anyhow::Result<bool> {
+        let Some((commit_txid, commit_tx)) =
+            self.ctx.get_tx_status(payloadentry.commit_txid).await?
+        else {
+            return Ok(false);
+        };
+        let Some((reveal_txid, reveal_tx)) =
+            self.ctx.get_tx_status(payloadentry.reveal_txid).await?
+        else {
+            return Ok(false);
+        };
+        if matches!(reveal_tx.status, L1TxStatus::InvalidInputs) {
+            return Ok(false);
+        }
+
+        let new_status = determine_payload_next_status(&commit_tx.status, &reveal_tx.status);
+        let mut updated_entry = payloadentry.clone();
+        updated_entry.commit_txid = commit_txid;
+        updated_entry.reveal_txid = reveal_txid;
+        updated_entry.payload_signature = None;
+        updated_entry.status = new_status.clone();
+        self.ctx.report_status(&updated_entry, &new_status).await;
+        self.ctx
+            .put_payload_entry(self.curr_payloadidx, updated_entry)
+            .await?;
+
+        if new_status == L1BundleStatus::Finalized {
+            self.curr_payloadidx += 1;
+        }
+
+        debug!(
+            payload_idx = self.curr_payloadidx,
+            ?commit_txid,
+            ?reveal_txid,
+            ?new_status,
+            "payload row reconciled with broadcast state"
+        );
+        Ok(true)
+    }
+
     /// Checks broadcast tx statuses and advances the payload state machine.
     async fn handle_broadcast_status(
         &mut self,
@@ -492,7 +887,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
         let reveal_tx = self.ctx.get_tx_status(payloadentry.reveal_txid).await?;
 
         match (commit_tx, reveal_tx) {
-            (Some(ctx), Some(rtx)) => {
+            (Some((commit_txid, ctx)), Some((reveal_txid, rtx))) => {
                 let new_status = determine_payload_next_status(&ctx.status, &rtx.status);
                 debug!(?new_status, "The next status for payload");
                 if matches!(
@@ -502,8 +897,8 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     debug!(
                         component = "btcio_writer",
                         payload_idx = self.curr_payloadidx,
-                        commit_txid = ?payloadentry.commit_txid,
-                        reveal_txid = ?payloadentry.reveal_txid,
+                        ?commit_txid,
+                        ?reveal_txid,
                         payload_status = ?new_status,
                         commit_l1_status = ?ctx.status,
                         reveal_l1_status = ?rtx.status,
@@ -511,11 +906,11 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     );
                 }
 
-                self.ctx.report_status(&payloadentry, &new_status).await;
-
-                // Update payloadentry with new status
                 let mut updated_entry = payloadentry.clone();
+                updated_entry.commit_txid = commit_txid;
+                updated_entry.reveal_txid = reveal_txid;
                 updated_entry.status = new_status.clone();
+                self.ctx.report_status(&updated_entry, &new_status).await;
                 self.ctx
                     .put_payload_entry(self.curr_payloadidx, updated_entry)
                     .await?;
@@ -570,6 +965,11 @@ pub(crate) fn determine_payload_next_status(
         (_, L1TxStatus::Confirmed { .. }) => L1BundleStatus::Confirmed,
         // If reveal is published regardless of commit, the payload is published
         (_, L1TxStatus::Published) => L1BundleStatus::Published,
+        // Replacement chains are normally followed before this function. If a
+        // stale entry reaches here, keep the watcher from needlessly resigning.
+        (L1TxStatus::Replaced { .. }, _) | (_, L1TxStatus::Replaced { .. }) => {
+            L1BundleStatus::Published
+        }
         // if commit has invalid inputs, needs resign
         (L1TxStatus::InvalidInputs, _) => L1BundleStatus::NeedsResign,
         // If commit is unpublished, both are upublished
@@ -598,12 +998,13 @@ mod tests {
         secp256k1::{XOnlyPublicKey, SECP256K1},
         taproot::TaprootBuilder,
         transaction::Version,
-        Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+        Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
     };
     use bitcoind_async_client::error::ClientError;
     use strata_csm_types::L1Payload;
     use strata_db_types::{
         common::L1TxId,
+        fee_bump::{TerminalError, TxAttemptStatus, TxNodeId, TxNodeKind, TxNodeRecord},
         l1_broadcast::L1TxEntry,
         l1_writer::{BundledPayloadEntry, L1BundleStatus},
     };
@@ -615,7 +1016,8 @@ mod tests {
         broadcaster::L1BroadcastHandle,
         writer::{
             builder::{EnvelopeData, EnvelopeError},
-            signer::complete_reveal_and_broadcast,
+            replacement::build::build_pending_single_reveal_replacement,
+            signer::{complete_pending_reveal_replacement, complete_reveal_and_broadcast},
             test_utils::get_broadcast_handle,
         },
     };
@@ -649,12 +1051,18 @@ mod tests {
     }
 
     fn minimal_envelope_data() -> EnvelopeData {
-        let keypair =
-            UntweakedKeypair::from_seckey_slice(SECP256K1, &[1u8; 32]).expect("valid key");
+        minimal_envelope_data_for(&[1u8; 32])
+    }
+
+    fn minimal_envelope_data_for(seckey: &[u8; 32]) -> EnvelopeData {
+        let keypair = UntweakedKeypair::from_seckey_slice(SECP256K1, seckey).expect("valid key");
         let pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
-        // A single OP_TRUE leaf so control_block lookup succeeds in attach_reveal_signature
+        // A single `<pubkey> OP_CHECKSIG` leaf, as SPS-51 reveal scripts open: the control_block
+        // lookup in attach_reveal_signature succeeds, and the key the script commits to is the one
+        // a replacement's signature has to verify against.
         let reveal_script = ScriptBuilder::new()
-            .push_opcode(opcodes::OP_TRUE)
+            .push_slice(pubkey.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
         let taproot_spend_info = TaprootBuilder::new()
             .add_leaf(0, reveal_script.clone())
@@ -695,6 +1103,9 @@ mod tests {
             reveal_script,
             taproot_spend_info,
             pubkey,
+            FeeRate::from_sat_per_vb(2).expect("test: valid fee rate"),
+            Amount::from_sat(100),
+            Amount::from_sat(50),
         )
     }
 
@@ -771,6 +1182,12 @@ mod tests {
     }
 
     impl WatcherServiceContext for MockWatcherContext {
+        // Replacement is exercised by the driver's own tests; the watcher tests care about
+        // payload-status transitions, so this is a no-op here.
+        async fn run_replacement_pass(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
         async fn get_payload_entry(&self, idx: u64) -> anyhow::Result<Option<BundledPayloadEntry>> {
             Ok(self.stored.lock().unwrap().get(&idx).cloned())
         }
@@ -825,8 +1242,47 @@ mod tests {
                 .map_err(Into::into)
         }
 
-        async fn get_tx_status(&self, _txid: L1TxId) -> anyhow::Result<Option<L1TxEntry>> {
-            Ok(None)
+        async fn complete_pending_reveal_replacement(
+            &self,
+            idx: u64,
+            sig: &[u8; 64],
+            signing_mode: EnvelopeSigningMode,
+        ) -> anyhow::Result<Option<L1TxId>> {
+            complete_pending_reveal_replacement(idx, sig, signing_mode, &self.broadcast_handle)
+                .await
+                .map_err(Into::into)
+        }
+
+        async fn has_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<bool> {
+            let node_id =
+                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+            Ok(self
+                .broadcast_handle
+                .get_tx_node(node_id)
+                .await?
+                .is_some_and(|record| record.pending_signature_attempt().is_some()))
+        }
+
+        async fn discard_pending_reveal_replacement(&self, idx: u64) -> anyhow::Result<()> {
+            discard_pending_reveal_replacement(&self.broadcast_handle, idx).await
+        }
+
+        async fn active_reveal_txid(&self, idx: u64) -> anyhow::Result<Option<L1TxId>> {
+            let node_id =
+                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: idx });
+            Ok(self
+                .broadcast_handle
+                .get_tx_node(node_id)
+                .await?
+                .map(|record| record.active_txid))
+        }
+
+        async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<(L1TxId, L1TxEntry)>> {
+            self.broadcast_handle
+                .get_active_tx_entry_by_id_async(to_raw_buf32(txid))
+                .await
+                .map(|entry| entry.map(|(txid, entry)| (L1TxId::from(txid.0), entry)))
+                .map_err(Into::into)
         }
 
         async fn report_status(&self, _entry: &BundledPayloadEntry, _status: &L1BundleStatus) {}
@@ -875,6 +1331,64 @@ mod tests {
         assert_eq!(stored.reveal_txid, L1TxId::zero());
         assert_eq!(state.curr_payloadidx, 0);
         assert!(state.envelope_cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_status_resolves_active_fee_bump_txids() {
+        let ctx = MockWatcherContext::new(false);
+        let mut entry = test_unsigned_entry();
+        entry.status = L1BundleStatus::Published;
+        entry.commit_txid = L1TxId::from([0x10; 32]);
+        entry.reveal_txid = L1TxId::from([0x20; 32]);
+
+        let replacement_commit_txid = L1TxId::from([0x11; 32]);
+        let replacement_reveal_txid = L1TxId::from([0x21; 32]);
+        let envelope = minimal_envelope_data();
+        let finalized = L1TxStatus::Finalized {
+            confirmations: 6,
+            block_hash: Buf32::from([0xBB; 32]),
+            block_height: 100,
+        };
+        let mut replacement_commit_entry = L1TxEntry::from_tx(&envelope.commit_tx);
+        replacement_commit_entry.status = finalized.clone();
+        let mut replacement_reveal_entry = L1TxEntry::from_tx(&envelope.reveal_tx);
+        replacement_reveal_entry.status = finalized;
+
+        let mut original_commit_entry = L1TxEntry::from_tx(&envelope.commit_tx);
+        original_commit_entry.status = L1TxStatus::Replaced {
+            by: replacement_commit_txid,
+        };
+        let mut original_reveal_entry = L1TxEntry::from_tx(&envelope.reveal_tx);
+        original_reveal_entry.status = L1TxStatus::Replaced {
+            by: replacement_reveal_txid,
+        };
+
+        for (txid, tx_entry) in [
+            (to_raw_buf32(entry.commit_txid), original_commit_entry),
+            (to_raw_buf32(entry.reveal_txid), original_reveal_entry),
+            (
+                to_raw_buf32(replacement_commit_txid),
+                replacement_commit_entry,
+            ),
+            (
+                to_raw_buf32(replacement_reveal_txid),
+                replacement_reveal_entry,
+            ),
+        ] {
+            ctx.broadcast_handle
+                .put_tx_entry(txid, tx_entry)
+                .await
+                .unwrap();
+        }
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_broadcast_status(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Finalized);
+        assert_eq!(stored.commit_txid, replacement_commit_txid);
+        assert_eq!(stored.reveal_txid, replacement_reveal_txid);
+        assert_eq!(state.curr_payloadidx, 1);
     }
 
     #[tokio::test]
@@ -1032,8 +1546,8 @@ mod tests {
         let bcast_handle = ctx.broadcast_handle.clone();
 
         let envelope = minimal_envelope_data();
-        let commit_txid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
-        let reveal_txid: Buf32 = envelope.reveal_tx.compute_txid().to_buf32();
+        let commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        let reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
 
         // Set up entry already in PendingRevealTxSign with a signature present
         let mut entry = test_unsigned_entry();
@@ -1052,12 +1566,12 @@ mod tests {
         assert!(!state.envelope_cache.contains_key(&0));
         // Both txs stored in broadcaster DB
         assert!(bcast_handle
-            .get_tx_entry_by_id_async(commit_txid)
+            .get_tx_entry_by_id_async(to_raw_buf32(commit_txid))
             .await
             .unwrap()
             .is_some());
         assert!(bcast_handle
-            .get_tx_entry_by_id_async(reveal_txid)
+            .get_tx_entry_by_id_async(to_raw_buf32(reveal_txid))
             .await
             .unwrap()
             .is_some());
@@ -1090,5 +1604,502 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_pending_reveal_cache_miss_resets_to_unsigned() {
+        let envelope = minimal_envelope_data();
+        let commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        let reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
+        let ctx = MockWatcherContext::new(true);
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = commit_txid;
+        entry.reveal_txid = reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(Buf32([42u8; 32]));
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+        assert_eq!(stored.commit_txid, L1TxId::from(commit_txid.0));
+        assert_eq!(stored.reveal_txid, L1TxId::from(reveal_txid.0));
+    }
+
+    #[tokio::test]
+    async fn test_pending_reveal_cache_miss_completes_pending_replacement_node() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let original_signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(0, &envelope, &original_signature, &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        let original_reveal_tx = original_reveal_entry.try_to_tx().unwrap();
+        let reveal_node_id =
+            TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 0 });
+        let mut reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        let (pending_reveal, sighash) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            1,
+        )
+        .unwrap();
+        let pending_reveal_txid = pending_reveal.txid;
+        reveal_record.append_pending_signature_replacement(pending_reveal);
+        bcast_handle.put_tx_node(reveal_record).await.unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = pending_reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+        entry.payload_signature = Some(Buf64([2u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unpublished);
+        assert_eq!(stored.reveal_txid, pending_reveal_txid);
+        assert!(bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(matches!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+                .await
+                .unwrap()
+                .expect("original reveal entry exists")
+                .status,
+            L1TxStatus::Replaced { .. }
+        ));
+
+        let reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        assert_eq!(
+            reveal_record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+    }
+
+    /// Regression: the RPC validates a signature against the sighash on the payload row, and the
+    /// fee bumper is a second writer of that row. If the row and the cached envelope describe
+    /// different reveals, attaching the signature yields a witness that can never validate, and a
+    /// reveal rejected on script grounds never becomes `InvalidInputs`, so nothing rebuilds it.
+    #[tokio::test]
+    async fn test_reveal_signature_for_a_different_sighash_is_not_attached() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
+        // A sighash that is not the cached envelope's.
+        entry.status = L1BundleStatus::PendingRevealTxSign(Buf32([7u8; 32]));
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.envelope_cache.insert(0, envelope.clone());
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+        assert!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(to_l1_txid(
+                    envelope.reveal_tx.compute_txid()
+                )))
+                .await
+                .unwrap()
+                .is_none(),
+            "nothing may reach the broadcaster"
+        );
+    }
+
+    /// The matching sighash still goes through, so the check does not block the normal path.
+    #[tokio::test]
+    async fn test_reveal_signature_for_the_cached_sighash_is_attached() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = to_l1_txid(envelope.reveal_tx.compute_txid());
+        entry.status = L1BundleStatus::PendingRevealTxSign(envelope.sighash);
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.envelope_cache.insert(0, envelope);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        assert_eq!(
+            state.ctx.get_stored(0).unwrap().status,
+            L1BundleStatus::Unpublished
+        );
+    }
+
+    /// Sets up a payload whose published reveal has a pending externally signed fee-bump
+    /// replacement, the state the fee bumper leaves behind while it waits on the signer.
+    ///
+    /// Returns the mock context, the original reveal's txid and the pending replacement's txid.
+    /// The payload row names the original reveal, as the fee bumper leaves it: the replacement
+    /// only takes its place once its witness is attached.
+    async fn pending_reveal_replacement_fixture(
+    ) -> (MockWatcherContext, BundledPayloadEntry, L1TxId, L1TxId) {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(0, &envelope, &[1u8; 64], &bcast_handle)
+                .await
+                .unwrap();
+        let original_reveal_tx = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists")
+            .try_to_tx()
+            .unwrap();
+        let mut reveal_record = bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 0,
+            }))
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        let (pending_reveal, sighash) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            1,
+        )
+        .unwrap();
+        let pending_reveal_txid = pending_reveal.txid;
+        reveal_record.append_pending_signature_replacement(pending_reveal);
+        bcast_handle.put_tx_node(reveal_record).await.unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = original_reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+        entry.payload_signature = Some(Buf64([2u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        (ctx, entry, original_reveal_txid, pending_reveal_txid)
+    }
+
+    async fn reveal_record(bcast_handle: &L1BroadcastHandle) -> TxNodeRecord {
+        bcast_handle
+            .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal {
+                payload_idx: 0,
+            }))
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists")
+    }
+
+    /// Regression: a replacement reuses the original reveal's tapscript, so it can only be
+    /// completed under the key that script commits to. The signing RPC verifies against whatever
+    /// key is canonical *now*, so after a rotation it accepts a signature that cannot satisfy the
+    /// old script — attaching it would supersede a valid reveal with an unspendable one.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_refused_when_signing_key_rotates() {
+        let (ctx, entry, original_reveal_txid, pending_reveal_txid) =
+            pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        ctx.set_signing_mode(EnvelopeSigningMode::External {
+            pubkey: minimal_envelope_data_for(&[2u8; 32]).envelope_pubkey,
+        });
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        assert!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+                .await
+                .unwrap()
+                .is_none(),
+            "the replacement must never reach the broadcaster"
+        );
+        assert_eq!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+                .await
+                .unwrap()
+                .expect("original reveal entry exists")
+                .status,
+            L1TxStatus::Unpublished,
+            "the original must not be superseded"
+        );
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(
+            record.terminal_error,
+            Some(TerminalError::UnsupportedRbfKind)
+        );
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded)
+        );
+
+        // The original is still live, so the payload tracks it rather than being rebuilt.
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unpublished);
+        assert_eq!(stored.reveal_txid, original_reveal_txid);
+    }
+
+    /// Regression: only `Unpublished` and `Published` entries are replaceable, so an original that
+    /// went invalid refuses the swap. The pending attempt is dead at that point, and leaving it
+    /// durable pins the payload in `PendingRevealTxSign` forever.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_discarded_when_original_is_invalid() {
+        let (ctx, entry, original_reveal_txid, pending_reveal_txid) =
+            pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let mut original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        original_reveal_entry.status = L1TxStatus::InvalidInputs;
+        bcast_handle
+            .update_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid), original_reveal_entry)
+            .await
+            .unwrap();
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(record.terminal_error, None, "the chain is still bumpable");
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded)
+        );
+
+        // Nothing spendable is left, so the payload rebuilds from fresh UTXOs.
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+    }
+
+    /// Regression: the signature may never arrive. If the original reveal goes invalid first, the
+    /// no-signature path used to return early on the pending attempt every tick, so the payload sat
+    /// in `PendingRevealTxSign` forever — the fee bumper skips nodes carrying a pending attempt, so
+    /// nothing else would move it either.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_without_signature_rebuilds_when_original_is_invalid() {
+        let (ctx, mut entry, original_reveal_txid, pending_reveal_txid) =
+            pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        entry.payload_signature = None;
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        original_reveal_entry.status = L1TxStatus::InvalidInputs;
+        bcast_handle
+            .update_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid), original_reveal_entry)
+            .await
+            .unwrap();
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded),
+            "the replacement can never be broadcast, so it must not keep blocking the node"
+        );
+        assert!(
+            bcast_handle
+                .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+                .await
+                .unwrap()
+                .is_none(),
+            "the replacement must never reach the broadcaster"
+        );
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.payload_signature, None);
+    }
+
+    /// The same path must keep waiting while the original is still live, or a fee bump would
+    /// double-publish the payload.
+    #[tokio::test]
+    async fn test_pending_reveal_replacement_without_signature_waits_on_a_live_original() {
+        let (ctx, mut entry, _, pending_reveal_txid) = pending_reveal_replacement_fixture().await;
+        let bcast_handle = ctx.broadcast_handle.clone();
+        entry.payload_signature = None;
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state
+            .handle_pending_reveal_tx_sign(entry.clone())
+            .await
+            .unwrap();
+
+        let record = reveal_record(&bcast_handle).await;
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::PendingSignature)
+        );
+        assert_eq!(state.ctx.get_stored(0).unwrap().status, entry.status);
+    }
+
+    /// Regression: a stop between broadcasting an envelope and writing its payload row leaves the
+    /// row in `PendingRevealTxSign` with both transactions already queued. Rebuilding there draws
+    /// fresh UTXOs and publishes the same payload twice.
+    #[tokio::test]
+    async fn test_pending_reveal_cache_miss_adopts_live_broadcast_state() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let reveal_txid = complete_reveal_and_broadcast(0, &envelope, &[1u8; 64], &bcast_handle)
+            .await
+            .unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(Buf32([42u8; 32]));
+        entry.payload_signature = Some(Buf64([1u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unpublished);
+        assert_eq!(stored.reveal_txid, reveal_txid);
+    }
+
+    #[tokio::test]
+    async fn test_pending_reveal_signature_keeps_confirmed_original() {
+        let envelope = minimal_envelope_data();
+        let ctx = MockWatcherContext::new(true);
+        let bcast_handle = ctx.broadcast_handle.clone();
+        let original_signature = [1u8; 64];
+        let original_reveal_txid =
+            complete_reveal_and_broadcast(0, &envelope, &original_signature, &bcast_handle)
+                .await
+                .unwrap();
+        let mut original_reveal_entry = bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid))
+            .await
+            .unwrap()
+            .expect("original reveal entry exists");
+        let original_reveal_tx = original_reveal_entry.try_to_tx().unwrap();
+        let reveal_node_id =
+            TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 0 });
+        let mut reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        let (pending_reveal, sighash) = build_pending_single_reveal_replacement(
+            &original_reveal_tx,
+            &envelope.commit_tx.output[0],
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            1,
+        )
+        .unwrap();
+        let pending_reveal_txid = pending_reveal.txid;
+        reveal_record.append_pending_signature_replacement(pending_reveal);
+        bcast_handle.put_tx_node(reveal_record).await.unwrap();
+
+        original_reveal_entry.status = L1TxStatus::Confirmed {
+            confirmations: 1,
+            block_hash: Buf32::zero(),
+            block_height: 100,
+        };
+        bcast_handle
+            .update_tx_entry_by_id_async(to_raw_buf32(original_reveal_txid), original_reveal_entry)
+            .await
+            .unwrap();
+
+        let mut entry = test_unsigned_entry();
+        entry.commit_txid = to_l1_txid(envelope.commit_tx.compute_txid());
+        entry.reveal_txid = original_reveal_txid;
+        entry.status = L1BundleStatus::PendingRevealTxSign(sighash);
+        entry.payload_signature = Some(Buf64([2u8; 64]));
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_pending_reveal_tx_sign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Confirmed);
+        assert_eq!(stored.reveal_txid, original_reveal_txid);
+        assert!(bcast_handle
+            .get_tx_entry_by_id_async(to_raw_buf32(pending_reveal_txid))
+            .await
+            .unwrap()
+            .is_none());
+
+        let reveal_record = bcast_handle
+            .get_tx_node(reveal_node_id)
+            .await
+            .unwrap()
+            .expect("reveal tx-node exists");
+        assert_eq!(
+            reveal_record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+        assert_eq!(
+            reveal_record
+                .attempts
+                .iter()
+                .find(|attempt| attempt.txid == pending_reveal_txid)
+                .map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Discarded)
+        );
     }
 }

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -1,4 +1,9 @@
-use bitcoin::FeeRate;
+use std::{
+    num::{NonZeroU32, NonZeroU64},
+    time::Duration,
+};
+
+use bitcoin::{Amount, FeeRate};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Configuration for btcio tasks.
@@ -54,6 +59,9 @@ pub struct WriterConfig {
     pub reveal_amount: u64,
     /// How often to bundle write intents.
     pub bundle_interval_ms: u64,
+    /// Fee bumping parameters for writer-published transactions.
+    #[serde(default)]
+    pub fee_bumping: FeeBumpingConfig,
 }
 
 impl WriterConfig {
@@ -65,6 +73,135 @@ impl WriterConfig {
     /// Returns the configured L1 fee policy.
     pub fn fee_policy(&self) -> &FeePolicy {
         self.l1_fee_policy_config.fee_policy()
+    }
+}
+
+/// Configures automatic fee bumping for BTCIO writer transactions.
+///
+/// Fee bumping is unconditional: every writer-published transaction that stays unconfirmed for
+/// longer than [`min_age_blocks`](Self::min_age_blocks) is replaced at a higher fee rate. There is
+/// no switch to turn it off, because the writer no longer scales its fee estimates to compensate
+/// for a stuck transaction. [`max_attempts`](Self::max_attempts) and
+/// [`max_fee_rate_sat_vb`](Self::max_fee_rate_sat_vb) are what bound the escalation.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct FeeBumpingConfig {
+    /// Minimum time between replacement passes, in ms.
+    ///
+    /// The pass runs inside the writer's watcher tick, which is paced for payload processing and
+    /// is far faster than this work needs: `write_poll_dur_ms` is commonly 200. Without its own
+    /// interval the pass would rescan every tx-node record, and re-resolve the fee estimate,
+    /// several times a second.
+    pub check_interval_ms: NonZeroU64,
+
+    /// Number of L1 blocks a published transaction may remain unconfirmed before it is stale.
+    pub min_age_blocks: NonZeroU32,
+
+    /// Maximum number of broadcast attempts for one replacement chain.
+    pub max_attempts: NonZeroU32,
+
+    /// Minimum multiplicative fee increase, expressed in basis points.
+    ///
+    /// This value must be at least `10_000` so an RBF replacement never lowers
+    /// the active fee rate, which would violate BIP-125 replacement rules.
+    pub multiplier_bps: u32,
+
+    /// Minimum additive fee-rate increase over the active attempt.
+    pub min_fee_rate_delta_sat_vb: NonZeroU64,
+
+    /// Maximum replacement fee rate the service is allowed to use.
+    pub max_fee_rate_sat_vb: NonZeroU64,
+
+    /// Maximum absolute fee headroom funded into each reveal transaction.
+    pub max_reveal_fee_headroom_sats: NonZeroU64,
+}
+
+impl FeeBumpingConfig {
+    /// Returns the minimum time between replacement passes.
+    pub fn check_interval(&self) -> Duration {
+        Duration::from_millis(self.check_interval_ms.get())
+    }
+
+    /// Validates the fee bumping configuration.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_attempts.get() > 64 {
+            return Err(
+                "fee_bumping.max_attempts must be at most 64 because replacement-chain resolution gives up after MAX_REPLACEMENT_CHAIN_HOPS (64) hops, so a larger value cannot be resolved"
+                    .to_string(),
+            );
+        }
+
+        if self.multiplier_bps < 10_000 {
+            return Err(
+                "fee_bumping.multiplier_bps must be at least 10_000 so bumps do not lower fees"
+                    .to_string(),
+            );
+        }
+
+        if self.max_fee_rate_sat_vb < self.min_fee_rate_delta_sat_vb {
+            return Err(
+                "fee_bumping.max_fee_rate_sat_vb must be at least min_fee_rate_delta_sat_vb"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns the replacement fee-rate ceiling.
+    pub fn max_fee_rate(&self) -> FeeRate {
+        FeeRate::from_sat_per_vb(self.max_fee_rate_sat_vb.get())
+            .expect("config: max fee rate is bounded by validation")
+    }
+
+    /// Returns the minimum additive fee-rate increase over the active attempt.
+    pub fn min_fee_rate_delta(&self) -> FeeRate {
+        FeeRate::from_sat_per_vb(self.min_fee_rate_delta_sat_vb.get())
+            .expect("config: min fee-rate delta is bounded by validation")
+    }
+
+    /// Returns the maximum absolute fee headroom funded into each reveal transaction.
+    pub fn max_reveal_fee_headroom(&self) -> Amount {
+        Amount::from_sat(self.max_reveal_fee_headroom_sats.get())
+    }
+}
+
+/// Mirror of [`FeeBumpingConfig`] that runs [`FeeBumpingConfig::validate`] after deserialization.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FeeBumpingConfigUnchecked {
+    #[serde(default = "default_fee_bumping_check_interval_ms")]
+    check_interval_ms: NonZeroU64,
+    #[serde(default = "default_fee_bumping_min_age_blocks")]
+    min_age_blocks: NonZeroU32,
+    #[serde(default = "default_fee_bumping_max_attempts")]
+    max_attempts: NonZeroU32,
+    #[serde(default = "default_fee_bumping_multiplier_bps")]
+    multiplier_bps: u32,
+    #[serde(default = "default_fee_bumping_min_fee_rate_delta_sat_vb")]
+    min_fee_rate_delta_sat_vb: NonZeroU64,
+    #[serde(default = "default_fee_bumping_max_fee_rate_sat_vb")]
+    max_fee_rate_sat_vb: NonZeroU64,
+    #[serde(default = "default_fee_bumping_max_reveal_fee_headroom_sats")]
+    max_reveal_fee_headroom_sats: NonZeroU64,
+}
+
+impl<'de> Deserialize<'de> for FeeBumpingConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let unchecked = FeeBumpingConfigUnchecked::deserialize(deserializer)?;
+        let config = Self {
+            check_interval_ms: unchecked.check_interval_ms,
+            min_age_blocks: unchecked.min_age_blocks,
+            max_attempts: unchecked.max_attempts,
+            multiplier_bps: unchecked.multiplier_bps,
+            min_fee_rate_delta_sat_vb: unchecked.min_fee_rate_delta_sat_vb,
+            max_fee_rate_sat_vb: unchecked.max_fee_rate_sat_vb,
+            max_reveal_fee_headroom_sats: unchecked.max_reveal_fee_headroom_sats,
+        };
+        config.validate().map_err(DeError::custom)?;
+        Ok(config)
     }
 }
 
@@ -220,6 +357,21 @@ impl Default for WriterConfig {
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
             l1_fee_policy_config: L1FeePolicyConfig::default(),
+            fee_bumping: FeeBumpingConfig::default(),
+        }
+    }
+}
+
+impl Default for FeeBumpingConfig {
+    fn default() -> Self {
+        Self {
+            check_interval_ms: default_fee_bumping_check_interval_ms(),
+            min_age_blocks: default_fee_bumping_min_age_blocks(),
+            max_attempts: default_fee_bumping_max_attempts(),
+            multiplier_bps: default_fee_bumping_multiplier_bps(),
+            min_fee_rate_delta_sat_vb: default_fee_bumping_min_fee_rate_delta_sat_vb(),
+            max_fee_rate_sat_vb: default_fee_bumping_max_fee_rate_sat_vb(),
+            max_reveal_fee_headroom_sats: default_fee_bumping_max_reveal_fee_headroom_sats(),
         }
     }
 }
@@ -234,6 +386,48 @@ impl Default for FeePolicy {
 
 const fn default_bitcoind_conf_target() -> u16 {
     1
+}
+
+const fn nonzero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => panic!("default value must be non-zero"),
+    }
+}
+
+const fn nonzero_u64(value: u64) -> NonZeroU64 {
+    match NonZeroU64::new(value) {
+        Some(value) => value,
+        None => panic!("default value must be non-zero"),
+    }
+}
+
+const fn default_fee_bumping_check_interval_ms() -> NonZeroU64 {
+    nonzero_u64(30_000)
+}
+
+const fn default_fee_bumping_min_age_blocks() -> NonZeroU32 {
+    nonzero_u32(2)
+}
+
+const fn default_fee_bumping_max_attempts() -> NonZeroU32 {
+    nonzero_u32(5)
+}
+
+const fn default_fee_bumping_multiplier_bps() -> u32 {
+    12_500
+}
+
+const fn default_fee_bumping_min_fee_rate_delta_sat_vb() -> NonZeroU64 {
+    nonzero_u64(1)
+}
+
+const fn default_fee_bumping_max_fee_rate_sat_vb() -> NonZeroU64 {
+    nonzero_u64(1_000)
+}
+
+const fn default_fee_bumping_max_reveal_fee_headroom_sats() -> NonZeroU64 {
+    nonzero_u64(10_000_000)
 }
 
 impl Default for ReaderConfig {
@@ -257,6 +451,35 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn fee_bumping_reveal_headroom_serde_default_and_roundtrip() {
+        let defaulted: FeeBumpingConfig = toml::from_str("").expect("defaults should deserialize");
+        assert_eq!(
+            defaulted.max_reveal_fee_headroom_sats,
+            nonzero_u64(10_000_000)
+        );
+
+        let configured = FeeBumpingConfig {
+            max_reveal_fee_headroom_sats: nonzero_u64(42_000),
+            ..FeeBumpingConfig::default()
+        };
+        let encoded = toml::to_string(&configured).expect("config should serialize");
+        let decoded: FeeBumpingConfig =
+            toml::from_str(&encoded).expect("serialized config should deserialize");
+
+        assert_eq!(decoded, configured);
+        assert_eq!(decoded.max_reveal_fee_headroom(), Amount::from_sat(42_000));
+    }
+
+    #[test]
+    fn fee_bumping_rejects_more_attempts_than_replacement_resolution_can_follow() {
+        let error = toml::from_str::<FeeBumpingConfig>("max_attempts = 65")
+            .expect_err("more than 64 attempts must be rejected")
+            .to_string();
+
+        assert!(error.contains("MAX_REPLACEMENT_CHAIN_HOPS (64)"));
+    }
 
     proptest! {
         #[test]

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -1,4 +1,9 @@
-use bitcoin::FeeRate;
+use std::{
+    num::{NonZeroU32, NonZeroU64},
+    time::Duration,
+};
+
+use bitcoin::{Amount, FeeRate};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Configuration for btcio tasks.
@@ -54,6 +59,9 @@ pub struct WriterConfig {
     pub reveal_amount: u64,
     /// How often to bundle write intents.
     pub bundle_interval_ms: u64,
+    /// Fee bumping parameters for writer-published transactions.
+    #[serde(default)]
+    pub fee_bumping: FeeBumpingConfig,
 }
 
 impl WriterConfig {
@@ -65,6 +73,149 @@ impl WriterConfig {
     /// Returns the configured L1 fee policy.
     pub fn fee_policy(&self) -> &FeePolicy {
         self.l1_fee_policy_config.fee_policy()
+    }
+}
+
+/// Configures automatic fee bumping for BTCIO writer transactions.
+///
+/// Fee bumping is unconditional: every writer-published transaction that stays unconfirmed for
+/// longer than [`min_age_blocks`](Self::min_age_blocks) is replaced at a higher fee rate. There is
+/// no switch to turn it off, because the writer no longer scales its fee estimates to compensate
+/// for a stuck transaction. [`max_attempts`](Self::max_attempts) and
+/// [`max_fee_rate_sat_vb`](Self::max_fee_rate_sat_vb) are what bound the escalation.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct FeeBumpingConfig {
+    /// Minimum time between replacement passes, in ms.
+    ///
+    /// The pass runs inside the writer's watcher tick, which is paced for payload processing and
+    /// is far faster than this work needs: `write_poll_dur_ms` is commonly 200. Without its own
+    /// interval the pass would rescan every tx-node record, and re-resolve the fee estimate,
+    /// several times a second.
+    pub check_interval_ms: NonZeroU64,
+
+    /// Number of L1 blocks a published transaction may remain unconfirmed before it is stale.
+    pub min_age_blocks: NonZeroU32,
+
+    /// Maximum number of broadcast attempts for one replacement chain.
+    pub max_attempts: NonZeroU32,
+
+    /// Minimum multiplicative fee increase, expressed in basis points.
+    ///
+    /// This value must be at least `10_000` so an RBF replacement never lowers
+    /// the active fee rate, which would violate BIP-125 replacement rules.
+    pub multiplier_bps: u32,
+
+    /// Minimum additive fee-rate increase over the active attempt.
+    pub min_fee_rate_delta_sat_vb: NonZeroU64,
+
+    /// Maximum replacement fee rate the service is allowed to use.
+    pub max_fee_rate_sat_vb: NonZeroU64,
+
+    /// Maximum absolute fee headroom funded into each reveal transaction.
+    pub max_reveal_fee_headroom_sats: NonZeroU64,
+}
+
+impl FeeBumpingConfig {
+    /// Returns the minimum time between replacement passes.
+    pub fn check_interval(&self) -> Duration {
+        Duration::from_millis(self.check_interval_ms.get())
+    }
+
+    /// Validates the fee bumping configuration.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_attempts.get() > 64 {
+            return Err(
+                "fee_bumping.max_attempts must be at most 64 because replacement-chain resolution gives up after MAX_REPLACEMENT_CHAIN_HOPS (64) hops, so a larger value cannot be resolved"
+                    .to_string(),
+            );
+        }
+
+        if self.multiplier_bps < 10_000 {
+            return Err(
+                "fee_bumping.multiplier_bps must be at least 10_000 so bumps do not lower fees"
+                    .to_string(),
+            );
+        }
+
+        if FeeRate::from_sat_per_vb(self.min_fee_rate_delta_sat_vb.get()).is_none() {
+            return Err(
+                "fee_bumping.min_fee_rate_delta_sat_vb is too large to represent as a Bitcoin fee rate"
+                    .to_string(),
+            );
+        }
+
+        if FeeRate::from_sat_per_vb(self.max_fee_rate_sat_vb.get()).is_none() {
+            return Err(
+                "fee_bumping.max_fee_rate_sat_vb is too large to represent as a Bitcoin fee rate"
+                    .to_string(),
+            );
+        }
+
+        if self.max_fee_rate_sat_vb < self.min_fee_rate_delta_sat_vb {
+            return Err(
+                "fee_bumping.max_fee_rate_sat_vb must be at least min_fee_rate_delta_sat_vb"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns the replacement fee-rate ceiling.
+    pub fn max_fee_rate(&self) -> FeeRate {
+        FeeRate::from_sat_per_vb(self.max_fee_rate_sat_vb.get())
+            .expect("config: max fee rate is bounded by validation")
+    }
+
+    /// Returns the minimum additive fee-rate increase over the active attempt.
+    pub fn min_fee_rate_delta(&self) -> FeeRate {
+        FeeRate::from_sat_per_vb(self.min_fee_rate_delta_sat_vb.get())
+            .expect("config: min fee-rate delta is bounded by validation")
+    }
+
+    /// Returns the maximum absolute fee headroom funded into each reveal transaction.
+    pub fn max_reveal_fee_headroom(&self) -> Amount {
+        Amount::from_sat(self.max_reveal_fee_headroom_sats.get())
+    }
+}
+
+/// Mirror of [`FeeBumpingConfig`] that runs [`FeeBumpingConfig::validate`] after deserialization.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FeeBumpingConfigUnchecked {
+    #[serde(default = "default_fee_bumping_check_interval_ms")]
+    check_interval_ms: NonZeroU64,
+    #[serde(default = "default_fee_bumping_min_age_blocks")]
+    min_age_blocks: NonZeroU32,
+    #[serde(default = "default_fee_bumping_max_attempts")]
+    max_attempts: NonZeroU32,
+    #[serde(default = "default_fee_bumping_multiplier_bps")]
+    multiplier_bps: u32,
+    #[serde(default = "default_fee_bumping_min_fee_rate_delta_sat_vb")]
+    min_fee_rate_delta_sat_vb: NonZeroU64,
+    #[serde(default = "default_fee_bumping_max_fee_rate_sat_vb")]
+    max_fee_rate_sat_vb: NonZeroU64,
+    #[serde(default = "default_fee_bumping_max_reveal_fee_headroom_sats")]
+    max_reveal_fee_headroom_sats: NonZeroU64,
+}
+
+impl<'de> Deserialize<'de> for FeeBumpingConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let unchecked = FeeBumpingConfigUnchecked::deserialize(deserializer)?;
+        let config = Self {
+            check_interval_ms: unchecked.check_interval_ms,
+            min_age_blocks: unchecked.min_age_blocks,
+            max_attempts: unchecked.max_attempts,
+            multiplier_bps: unchecked.multiplier_bps,
+            min_fee_rate_delta_sat_vb: unchecked.min_fee_rate_delta_sat_vb,
+            max_fee_rate_sat_vb: unchecked.max_fee_rate_sat_vb,
+            max_reveal_fee_headroom_sats: unchecked.max_reveal_fee_headroom_sats,
+        };
+        config.validate().map_err(DeError::custom)?;
+        Ok(config)
     }
 }
 
@@ -220,6 +371,21 @@ impl Default for WriterConfig {
             reveal_amount: 1_000,
             bundle_interval_ms: 500,
             l1_fee_policy_config: L1FeePolicyConfig::default(),
+            fee_bumping: FeeBumpingConfig::default(),
+        }
+    }
+}
+
+impl Default for FeeBumpingConfig {
+    fn default() -> Self {
+        Self {
+            check_interval_ms: default_fee_bumping_check_interval_ms(),
+            min_age_blocks: default_fee_bumping_min_age_blocks(),
+            max_attempts: default_fee_bumping_max_attempts(),
+            multiplier_bps: default_fee_bumping_multiplier_bps(),
+            min_fee_rate_delta_sat_vb: default_fee_bumping_min_fee_rate_delta_sat_vb(),
+            max_fee_rate_sat_vb: default_fee_bumping_max_fee_rate_sat_vb(),
+            max_reveal_fee_headroom_sats: default_fee_bumping_max_reveal_fee_headroom_sats(),
         }
     }
 }
@@ -234,6 +400,48 @@ impl Default for FeePolicy {
 
 const fn default_bitcoind_conf_target() -> u16 {
     1
+}
+
+const fn nonzero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => panic!("default value must be non-zero"),
+    }
+}
+
+const fn nonzero_u64(value: u64) -> NonZeroU64 {
+    match NonZeroU64::new(value) {
+        Some(value) => value,
+        None => panic!("default value must be non-zero"),
+    }
+}
+
+const fn default_fee_bumping_check_interval_ms() -> NonZeroU64 {
+    nonzero_u64(30_000)
+}
+
+const fn default_fee_bumping_min_age_blocks() -> NonZeroU32 {
+    nonzero_u32(2)
+}
+
+const fn default_fee_bumping_max_attempts() -> NonZeroU32 {
+    nonzero_u32(5)
+}
+
+const fn default_fee_bumping_multiplier_bps() -> u32 {
+    12_500
+}
+
+const fn default_fee_bumping_min_fee_rate_delta_sat_vb() -> NonZeroU64 {
+    nonzero_u64(1)
+}
+
+const fn default_fee_bumping_max_fee_rate_sat_vb() -> NonZeroU64 {
+    nonzero_u64(1_000)
+}
+
+const fn default_fee_bumping_max_reveal_fee_headroom_sats() -> NonZeroU64 {
+    nonzero_u64(10_000_000)
 }
 
 impl Default for ReaderConfig {
@@ -257,6 +465,73 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn fee_bumping_reveal_headroom_serde_default_and_roundtrip() {
+        let defaulted: FeeBumpingConfig = toml::from_str("").expect("defaults should deserialize");
+        assert_eq!(
+            defaulted.max_reveal_fee_headroom_sats,
+            nonzero_u64(10_000_000)
+        );
+
+        let configured = FeeBumpingConfig {
+            max_reveal_fee_headroom_sats: nonzero_u64(42_000),
+            ..FeeBumpingConfig::default()
+        };
+        let encoded = toml::to_string(&configured).expect("config should serialize");
+        let decoded: FeeBumpingConfig =
+            toml::from_str(&encoded).expect("serialized config should deserialize");
+
+        assert_eq!(decoded, configured);
+        assert_eq!(decoded.max_reveal_fee_headroom(), Amount::from_sat(42_000));
+    }
+
+    #[test]
+    fn fee_bumping_rejects_more_attempts_than_replacement_resolution_can_follow() {
+        let error = toml::from_str::<FeeBumpingConfig>("max_attempts = 65")
+            .expect_err("more than 64 attempts must be rejected")
+            .to_string();
+
+        assert!(error.contains("MAX_REPLACEMENT_CHAIN_HOPS (64)"));
+    }
+
+    #[test]
+    fn fee_bumping_rejects_unrepresentable_max_fee_rate() {
+        let unrepresentable = u64::MAX / 250 + 1;
+        let error =
+            toml::from_str::<FeeBumpingConfig>(&format!("max_fee_rate_sat_vb = {unrepresentable}"))
+                .expect_err("an unrepresentable maximum fee rate must be rejected")
+                .to_string();
+
+        assert!(error.contains("max_fee_rate_sat_vb is too large to represent"));
+    }
+
+    #[test]
+    fn fee_bumping_rejects_unrepresentable_min_fee_rate_delta() {
+        let unrepresentable = u64::MAX / 250 + 1;
+        let error = toml::from_str::<FeeBumpingConfig>(&format!(
+            "min_fee_rate_delta_sat_vb = {unrepresentable}\nmax_fee_rate_sat_vb = {unrepresentable}"
+        ))
+        .expect_err("an unrepresentable fee-rate delta must be rejected")
+        .to_string();
+
+        assert!(error.contains("min_fee_rate_delta_sat_vb is too large to represent"));
+    }
+
+    #[test]
+    fn fee_bumping_accepts_largest_representable_fee_rates() {
+        let largest_representable = u64::MAX / 250;
+        let config = toml::from_str::<FeeBumpingConfig>(&format!(
+            "min_fee_rate_delta_sat_vb = {largest_representable}\nmax_fee_rate_sat_vb = {largest_representable}"
+        ))
+        .expect("the largest representable fee rates must be accepted");
+
+        assert_eq!(
+            config.min_fee_rate_delta(),
+            FeeRate::from_sat_per_vb(largest_representable).unwrap()
+        );
+        assert_eq!(config.max_fee_rate(), config.min_fee_rate_delta());
+    }
 
     proptest! {
         #[test]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -461,7 +461,9 @@ mod test {
     use bitcoin::FeeRate;
 
     use super::*;
-    use crate::btcio::{FeePolicy, L1FeePolicyConfig, MempoolExplorerFeePolicy, WriterConfig};
+    use crate::btcio::{
+        FeeBumpingConfig, FeePolicy, L1FeePolicyConfig, MempoolExplorerFeePolicy, WriterConfig,
+    };
 
     #[test]
     fn test_config_load() {
@@ -934,6 +936,7 @@ mod test {
             reveal_amount: 100,
             bundle_interval_ms: 1_000,
             l1_fee_policy_config: L1FeePolicyConfig::new(FeePolicy::BitcoinD { conf_target: 6 }),
+            fee_bumping: Default::default(),
         };
 
         let toml = toml::to_string(&config).expect("writer config should serialize");
@@ -951,11 +954,131 @@ mod test {
             l1_fee_policy_config: L1FeePolicyConfig::new(FeePolicy::Fixed {
                 fee_rate: FeeRate::from_sat_per_kwu(125),
             }),
+            fee_bumping: FeeBumpingConfig::default(),
         };
 
         let toml = toml::to_string(&config).expect("writer config should serialize");
 
         assert!(toml.contains("fee_policy = \"fixed\""));
         assert!(toml.contains("fixed_fee_rate = 0.5"));
+    }
+
+    #[test]
+    fn test_writer_config_defaults_fee_bumping_parameters() {
+        let config: WriterConfig = toml::from_str(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "bitcoind"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+            "#,
+        )
+        .expect("writer config should parse");
+
+        assert_eq!(config.fee_bumping.check_interval_ms.get(), 30_000);
+        assert_eq!(config.fee_bumping.min_age_blocks.get(), 2);
+        assert_eq!(config.fee_bumping.max_attempts.get(), 5);
+        assert_eq!(config.fee_bumping.multiplier_bps, 12_500);
+        assert_eq!(config.fee_bumping.min_fee_rate_delta_sat_vb.get(), 1);
+        assert_eq!(config.fee_bumping.max_fee_rate_sat_vb.get(), 1_000);
+    }
+
+    #[test]
+    fn test_writer_config_accepts_fee_bumping_overrides() {
+        let config = toml::from_str::<WriterConfig>(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "bitcoind"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+
+            [fee_bumping]
+            check_interval_ms = 10_000
+            min_age_blocks = 3
+            max_attempts = 4
+            multiplier_bps = 15_000
+            min_fee_rate_delta_sat_vb = 2
+            max_fee_rate_sat_vb = 500
+            "#,
+        )
+        .expect("writer config should accept fee bumping overrides");
+
+        assert_eq!(config.fee_bumping.check_interval_ms.get(), 10_000);
+        assert_eq!(config.fee_bumping.min_age_blocks.get(), 3);
+        assert_eq!(config.fee_bumping.max_attempts.get(), 4);
+        assert_eq!(config.fee_bumping.multiplier_bps, 15_000);
+        assert_eq!(config.fee_bumping.min_fee_rate_delta_sat_vb.get(), 2);
+        assert_eq!(config.fee_bumping.max_fee_rate_sat_vb.get(), 500);
+    }
+
+    /// A `policy` key is what an operator config written against the earlier optional design
+    /// carries. Fee bumping is unconditional now, so the key must be rejected loudly rather than
+    /// silently ignored: `policy = "disabled"` reads as "off" and is not.
+    #[test]
+    fn test_writer_config_rejects_legacy_fee_bumping_policy_key() {
+        let error = toml::from_str::<WriterConfig>(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "bitcoind"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+
+            [fee_bumping]
+            policy = "disabled"
+            "#,
+        )
+        .expect_err("fee bumping config should reject the removed policy key");
+
+        assert!(
+            error.to_string().contains("policy"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_writer_config_rejects_fee_bumping_multiplier_below_one_hundred_percent() {
+        let error = toml::from_str::<WriterConfig>(
+            r#"
+            write_poll_dur_ms = 200
+            fee_policy = "bitcoind"
+            reveal_amount = 100
+            bundle_interval_ms = 1_000
+
+            [fee_bumping]
+            multiplier_bps = 9_999
+            "#,
+        )
+        .expect_err("fee bumping config should reject fee-lowering multiplier");
+
+        assert!(
+            error.to_string().contains("must be at least 10_000"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_writer_config_rejects_zero_fee_bumping_nonzero_fields() {
+        for field in [
+            "check_interval_ms",
+            "min_age_blocks",
+            "max_attempts",
+            "min_fee_rate_delta_sat_vb",
+            "max_fee_rate_sat_vb",
+        ] {
+            let toml = format!(
+                r#"
+                write_poll_dur_ms = 200
+                fee_policy = "bitcoind"
+                reveal_amount = 100
+                bundle_interval_ms = 1_000
+
+                [fee_bumping]
+                {field} = 0
+                "#
+            );
+
+            toml::from_str::<WriterConfig>(&toml)
+                .expect_err("fee bumping config should reject zero nonzero fields");
+        }
     }
 }

--- a/crates/db/store-sled/src/broadcaster/db.rs
+++ b/crates/db/store-sled/src/broadcaster/db.rs
@@ -1,9 +1,16 @@
+use sled::transaction::ConflictableTransactionError;
 use strata_db_types::DbResult;
+use strata_db_types::common::L1TxId;
 use strata_db_types::errors::DbError;
-use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry};
+use strata_db_types::fee_bump::{TxNodeId, TxNodeRecord};
+use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry, L1TxStatus};
 use strata_primitives::buf::Buf32;
+use typed_sled::error::Error as TSledError;
+use typed_sled::tree::SledTransactionalTree;
 
-use super::schemas::{BcastL1TxIdSchema, BcastL1TxSchema};
+use super::schemas::{
+    BcastActiveL1TxNodeSchema, BcastL1TxIdSchema, BcastL1TxNodeSchema, BcastL1TxSchema,
+};
 use crate::define_sled_database;
 use crate::utils::{conv_sled_err, find_next_available_id, first, second};
 
@@ -11,6 +18,8 @@ define_sled_database!(
     pub struct L1BroadcastDBSled {
         tx_id_tree: BcastL1TxIdSchema,
         tx_tree: BcastL1TxSchema,
+        tx_node_tree: BcastL1TxNodeSchema,
+        active_tx_node_tree: BcastActiveL1TxNodeSchema,
     }
 );
 
@@ -43,28 +52,41 @@ impl L1BroadcastDatabase for L1BroadcastDBSled {
     }
 
     fn put_tx_entry_by_idx(&self, idx: u64, txentry: L1TxEntry) -> DbResult<()> {
-        if let Some(txid) = self.tx_id_tree.get(&idx).map_err(conv_sled_err)? {
-            let existing = self
-                .tx_tree
-                .get(&txid)
-                .map_err(conv_sled_err)?
-                .ok_or_else(|| {
-                    DbError::Other(format!("Entry does not exist for txid at idx {idx:?}"))
-                })?;
-            if existing.tx_raw() != txentry.tx_raw() {
-                return Err(DbError::Other(format!(
-                    "tx entry at idx {idx:?} cannot be updated with a different transaction"
-                )));
-            }
-            self.tx_tree
-                .insert(&txid, &txentry)
-                .map_err(conv_sled_err)?;
-            Ok(())
-        } else {
-            Err(DbError::Other(format!(
+        let Some(txid) = self.tx_id_tree.get(&idx).map_err(conv_sled_err)? else {
+            return Err(DbError::Other(format!(
                 "Entry does not exist for idx {idx:?}"
-            )))
-        }
+            )));
+        };
+
+        // Read and write in one retried transaction. The fee bumper can mark an entry
+        // `Replaced` concurrently, and a non-atomic read-then-write here would resurrect the
+        // superseded transaction with whatever status the caller last observed.
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, _)| {
+                let Some(existing) = txtree.get(&txid)? else {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::Other(format!("Entry does not exist for txid at idx {idx:?}")),
+                    )));
+                };
+                if existing.tx_raw() != txentry.tx_raw() {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::Other(format!(
+                            "tx entry at idx {idx:?} cannot be updated with a different transaction"
+                        )),
+                    )));
+                }
+                // `Replaced` is terminal for a txid: a concurrent fee bump has already superseded
+                // it, so refuse to move the status backwards.
+                if matches!(existing.status, L1TxStatus::Replaced { .. })
+                    && !matches!(txentry.status, L1TxStatus::Replaced { .. })
+                {
+                    return Ok(());
+                }
+                txtree.insert(&txid, &txentry)?;
+                Ok(())
+            })?;
+
+        Ok(())
     }
 
     fn del_tx_entry(&self, txid: Buf32) -> DbResult<bool> {
@@ -129,6 +151,216 @@ impl L1BroadcastDatabase for L1BroadcastDBSled {
     fn get_last_tx_entry(&self) -> DbResult<Option<L1TxEntry>> {
         Ok(self.tx_tree.last().map_err(conv_sled_err)?.map(second))
     }
+
+    fn put_replacement_tx_entry(
+        &self,
+        original_txid: Buf32,
+        replacement_txid: Buf32,
+        replacement: L1TxEntry,
+    ) -> DbResult<Option<u64>> {
+        let next = self.get_next_idx()?;
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, txidtree)| {
+                let Some(mut original) = txtree.get(&original_txid)? else {
+                    return Ok(None);
+                };
+                if !matches!(
+                    original.status,
+                    L1TxStatus::Unpublished | L1TxStatus::Published
+                ) {
+                    return Ok(None);
+                }
+
+                // The swap is all-or-nothing, and `None` tells the caller nothing was written. An
+                // already-present replacement row would break that contract: there would be no
+                // index to report yet the original would still be transitioned. It also cannot
+                // happen from a completed swap, since insert and transition commit together.
+                if txtree.get(&replacement_txid)?.is_some() {
+                    return Ok(None);
+                }
+                let idx = find_next_available_id(&txidtree, next)?;
+                txidtree.insert(&idx, &replacement_txid)?;
+                // The reverse link is written here so it can never disagree with the forward one.
+                let mut replacement = replacement.clone();
+                replacement.set_replaces(L1TxId::from(original_txid.0));
+                txtree.insert(&replacement_txid, &replacement)?;
+
+                original.status = L1TxStatus::Replaced {
+                    by: L1TxId::from(replacement_txid.0),
+                };
+                txtree.insert(&original_txid, &original)?;
+
+                Ok(Some(idx))
+            })
+    }
+
+    fn adopt_confirmed_ancestor(
+        &self,
+        loser_txid: Buf32,
+        winner_txid: Buf32,
+        winner_status: L1TxStatus,
+    ) -> DbResult<bool> {
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, _)| {
+                let (Some(mut loser), Some(mut winner)) =
+                    (txtree.get(&loser_txid)?, txtree.get(&winner_txid)?)
+                else {
+                    return Ok(false);
+                };
+
+                // A loser that has already left the bumpable states was superseded by a
+                // concurrent replacement write. Reversing over it would cut that replacement
+                // out of the chain while it stays indexed and broadcastable, so the chain head
+                // would report the older ancestor while a live transaction spent the same
+                // inputs. `put_replacement_tx_entry` and `try_mark_tx_entry_replaced` gate on
+                // the same two states.
+                if !matches!(
+                    loser.status,
+                    L1TxStatus::Unpublished | L1TxStatus::Published
+                ) {
+                    return Ok(false);
+                }
+
+                // Only reverse a link this chain actually has. Without the check a stale caller
+                // could point two unrelated entries at each other.
+                if !replacement_chain_reaches(&txtree, &winner.status, loser_txid)? {
+                    return Ok(false);
+                }
+
+                winner.status = winner_status.clone();
+                loser.status = L1TxStatus::Replaced {
+                    by: L1TxId::from(winner_txid.0),
+                };
+                txtree.insert(&winner_txid, &winner)?;
+                txtree.insert(&loser_txid, &loser)?;
+
+                Ok(true)
+            })
+    }
+
+    fn try_mark_tx_entry_replaced(&self, txid: Buf32, replacement_txid: L1TxId) -> DbResult<bool> {
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, _)| {
+                let Some(mut entry) = txtree.get(&txid)? else {
+                    return Ok(false);
+                };
+                if !matches!(
+                    entry.status,
+                    L1TxStatus::Unpublished | L1TxStatus::Published
+                ) {
+                    return Ok(false);
+                }
+                entry.status = L1TxStatus::Replaced {
+                    by: replacement_txid,
+                };
+                txtree.insert(&txid, &entry)?;
+                Ok(true)
+            })
+    }
+
+    fn put_tx_node(&self, node_id: TxNodeId, record: TxNodeRecord) -> DbResult<()> {
+        // Record and active-set membership commit together so a crash cannot leave a live chain
+        // outside the set the replacement pass scans.
+        self.config.with_retry(
+            (&self.tx_node_tree, &self.active_tx_node_tree),
+            |(node_tree, active_tree)| {
+                node_tree.insert(&node_id, &record)?;
+                if record.terminal_error.is_some() {
+                    active_tree.remove(&node_id)?;
+                } else {
+                    active_tree.insert(&node_id, &())?;
+                }
+                Ok(())
+            },
+        )?;
+        Ok(())
+    }
+
+    fn get_tx_node(&self, node_id: TxNodeId) -> DbResult<Option<TxNodeRecord>> {
+        self.tx_node_tree.get(&node_id).map_err(conv_sled_err)
+    }
+
+    fn get_all_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>> {
+        let mut records = Vec::new();
+        for item in self.tx_node_tree.iter() {
+            let (_, record) = item.map_err(conv_sled_err)?;
+            records.push(record);
+        }
+        Ok(records)
+    }
+
+    fn get_active_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>> {
+        let mut records = Vec::new();
+        for item in self.active_tx_node_tree.iter() {
+            let (node_id, ()) = item.map_err(conv_sled_err)?;
+            if let Some(record) = self.tx_node_tree.get(&node_id).map_err(conv_sled_err)? {
+                records.push(record);
+            }
+        }
+        Ok(records)
+    }
+
+    fn retire_tx_node(&self, node_id: TxNodeId, expected_active_txid: L1TxId) -> DbResult<bool> {
+        self.config.with_retry(
+            (&self.tx_node_tree, &self.active_tx_node_tree),
+            |(node_tree, active_tree)| {
+                let Some(mut record) = node_tree.get(&node_id)? else {
+                    // A membership entry without a record indexes nothing; drop it.
+                    active_tree.remove(&node_id)?;
+                    return Ok(false);
+                };
+                if record.active_txid != expected_active_txid {
+                    return Ok(false);
+                }
+                // The record is kept forever for point lookups, but a retired chain never
+                // rebroadcasts or re-signs, so its raw transaction bytes are dead weight.
+                // Dropping them here bounds the permanent record to metadata size; without this,
+                // every finalized chain retains its active attempt's full serialized transaction.
+                record.forget_all_raw_txs();
+                node_tree.insert(&node_id, &record)?;
+                active_tree.remove(&node_id)?;
+                Ok(true)
+            },
+        )
+    }
+}
+
+/// Bound on how far the adoption check walks a replacement chain.
+///
+/// Comfortably above the hop budget the broadcaster's ancestor search uses, so the check never
+/// refuses a pair that search was able to find.
+const MAX_ADOPTION_CHAIN_HOPS: usize = 64;
+
+/// Reports whether following `status`'s forward [`L1TxStatus::Replaced`] links arrives at `target`.
+///
+/// The winner of an adoption need not be the loser's immediate parent. A chain bumped more than
+/// once has intermediate attempts between them, and the miner is free to include any of them, so
+/// requiring a direct link would refuse every adoption in a chain longer than two and leave the
+/// caller marking a live payload invalid.
+fn replacement_chain_reaches(
+    txtree: &SledTransactionalTree<BcastL1TxSchema>,
+    status: &L1TxStatus,
+    target: Buf32,
+) -> Result<bool, TSledError> {
+    let L1TxStatus::Replaced { by } = status else {
+        return Ok(false);
+    };
+    let mut current = Buf32(by.0);
+
+    for _ in 0..MAX_ADOPTION_CHAIN_HOPS {
+        if current == target {
+            return Ok(true);
+        }
+        let Some(entry) = txtree.get(&current)? else {
+            return Ok(false);
+        };
+        let L1TxStatus::Replaced { by } = entry.status else {
+            return Ok(false);
+        };
+        current = Buf32(by.0);
+    }
+
+    Ok(false)
 }
 
 #[cfg(feature = "test_utils")]

--- a/crates/db/store-sled/src/broadcaster/db.rs
+++ b/crates/db/store-sled/src/broadcaster/db.rs
@@ -1,9 +1,14 @@
+use sled::transaction::ConflictableTransactionError;
 use strata_db_types::DbResult;
+use strata_db_types::common::L1TxId;
 use strata_db_types::errors::DbError;
-use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry};
+use strata_db_types::fee_bump::{TxNodeId, TxNodeRecord};
+use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry, L1TxStatus};
 use strata_primitives::buf::Buf32;
+use typed_sled::error::Error as TSledError;
+use typed_sled::tree::SledTransactionalTree;
 
-use super::schemas::{BcastL1TxIdSchema, BcastL1TxSchema};
+use super::schemas::{BcastL1TxIdSchema, BcastL1TxNodeSchema, BcastL1TxSchema};
 use crate::define_sled_database;
 use crate::utils::{find_next_available_id, first, second};
 
@@ -11,6 +16,7 @@ define_sled_database!(
     pub struct L1BroadcastDBSled {
         tx_id_tree: BcastL1TxIdSchema,
         tx_tree: BcastL1TxSchema,
+        tx_node_tree: BcastL1TxNodeSchema,
     }
 );
 
@@ -43,22 +49,41 @@ impl L1BroadcastDatabase for L1BroadcastDBSled {
     }
 
     fn put_tx_entry_by_idx(&self, idx: u64, txentry: L1TxEntry) -> DbResult<()> {
-        if let Some(txid) = self.tx_id_tree.get(&idx)? {
-            let existing = self.tx_tree.get(&txid)?.ok_or_else(|| {
-                DbError::Other(format!("Entry does not exist for txid at idx {idx:?}"))
-            })?;
-            if existing.tx_raw() != txentry.tx_raw() {
-                return Err(DbError::Other(format!(
-                    "tx entry at idx {idx:?} cannot be updated with a different transaction"
-                )));
-            }
-            self.tx_tree.insert(&txid, &txentry)?;
-            Ok(())
-        } else {
-            Err(DbError::Other(format!(
+        let Some(txid) = self.tx_id_tree.get(&idx)? else {
+            return Err(DbError::Other(format!(
                 "Entry does not exist for idx {idx:?}"
-            )))
-        }
+            )));
+        };
+
+        // Read and write in one retried transaction. The fee bumper can mark an entry
+        // `Replaced` concurrently, and a non-atomic read-then-write here would resurrect the
+        // superseded transaction with whatever status the caller last observed.
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, _)| {
+                let Some(existing) = txtree.get(&txid)? else {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::Other(format!("Entry does not exist for txid at idx {idx:?}")),
+                    )));
+                };
+                if existing.tx_raw() != txentry.tx_raw() {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::Other(format!(
+                            "tx entry at idx {idx:?} cannot be updated with a different transaction"
+                        )),
+                    )));
+                }
+                // `Replaced` is terminal for a txid: a concurrent fee bump has already superseded
+                // it, so refuse to move the status backwards.
+                if matches!(existing.status, L1TxStatus::Replaced { .. })
+                    && !matches!(txentry.status, L1TxStatus::Replaced { .. })
+                {
+                    return Ok(());
+                }
+                txtree.insert(&txid, &txentry)?;
+                Ok(())
+            })?;
+
+        Ok(())
     }
 
     fn del_tx_entry(&self, txid: Buf32) -> DbResult<bool> {
@@ -121,6 +146,168 @@ impl L1BroadcastDatabase for L1BroadcastDBSled {
     fn get_last_tx_entry(&self) -> DbResult<Option<L1TxEntry>> {
         Ok(self.tx_tree.last()?.map(second))
     }
+
+    fn put_replacement_tx_entry(
+        &self,
+        original_txid: Buf32,
+        replacement_txid: Buf32,
+        replacement: L1TxEntry,
+    ) -> DbResult<Option<u64>> {
+        let next = self.get_next_idx()?;
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, txidtree)| {
+                let Some(mut original) = txtree.get(&original_txid)? else {
+                    return Ok(None);
+                };
+                if !matches!(
+                    original.status,
+                    L1TxStatus::Unpublished | L1TxStatus::Published
+                ) {
+                    return Ok(None);
+                }
+
+                // The swap is all-or-nothing, and `None` tells the caller nothing was written. An
+                // already-present replacement row would break that contract: there would be no
+                // index to report yet the original would still be transitioned. It also cannot
+                // happen from a completed swap, since insert and transition commit together.
+                if txtree.get(&replacement_txid)?.is_some() {
+                    return Ok(None);
+                }
+                let idx = find_next_available_id(&txidtree, next)?;
+                txidtree.insert(&idx, &replacement_txid)?;
+                // The reverse link is written here so it can never disagree with the forward one.
+                let mut replacement = replacement.clone();
+                replacement.set_replaces(L1TxId::from(original_txid.0));
+                txtree.insert(&replacement_txid, &replacement)?;
+
+                original.status = L1TxStatus::Replaced {
+                    by: L1TxId::from(replacement_txid.0),
+                };
+                txtree.insert(&original_txid, &original)?;
+
+                Ok(Some(idx))
+            })
+    }
+
+    fn adopt_confirmed_ancestor(
+        &self,
+        loser_txid: Buf32,
+        winner_txid: Buf32,
+        winner_status: L1TxStatus,
+    ) -> DbResult<bool> {
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, _)| {
+                let (Some(mut loser), Some(mut winner)) =
+                    (txtree.get(&loser_txid)?, txtree.get(&winner_txid)?)
+                else {
+                    return Ok(false);
+                };
+
+                // A loser that has already left the bumpable states was superseded by a
+                // concurrent replacement write. Reversing over it would cut that replacement
+                // out of the chain while it stays indexed and broadcastable, so the chain head
+                // would report the older ancestor while a live transaction spent the same
+                // inputs. `put_replacement_tx_entry` and `try_mark_tx_entry_replaced` gate on
+                // the same two states.
+                if !matches!(
+                    loser.status,
+                    L1TxStatus::Unpublished | L1TxStatus::Published
+                ) {
+                    return Ok(false);
+                }
+
+                // Only reverse a link this chain actually has. Without the check a stale caller
+                // could point two unrelated entries at each other.
+                if !replacement_chain_reaches(&txtree, &winner.status, loser_txid)? {
+                    return Ok(false);
+                }
+
+                winner.status = winner_status.clone();
+                loser.status = L1TxStatus::Replaced {
+                    by: L1TxId::from(winner_txid.0),
+                };
+                txtree.insert(&winner_txid, &winner)?;
+                txtree.insert(&loser_txid, &loser)?;
+
+                Ok(true)
+            })
+    }
+
+    fn try_mark_tx_entry_replaced(&self, txid: Buf32, replacement_txid: L1TxId) -> DbResult<bool> {
+        self.config
+            .with_retry((&self.tx_tree, &self.tx_id_tree), |(txtree, _)| {
+                let Some(mut entry) = txtree.get(&txid)? else {
+                    return Ok(false);
+                };
+                if !matches!(
+                    entry.status,
+                    L1TxStatus::Unpublished | L1TxStatus::Published
+                ) {
+                    return Ok(false);
+                }
+                entry.status = L1TxStatus::Replaced {
+                    by: replacement_txid,
+                };
+                txtree.insert(&txid, &entry)?;
+                Ok(true)
+            })
+    }
+
+    fn put_tx_node(&self, node_id: TxNodeId, record: TxNodeRecord) -> DbResult<()> {
+        self.tx_node_tree.insert(&node_id, &record)?;
+        Ok(())
+    }
+
+    fn get_tx_node(&self, node_id: TxNodeId) -> DbResult<Option<TxNodeRecord>> {
+        Ok(self.tx_node_tree.get(&node_id)?)
+    }
+
+    fn get_all_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>> {
+        let mut records = Vec::new();
+        for item in self.tx_node_tree.iter() {
+            let (_, record) = item?;
+            records.push(record);
+        }
+        Ok(records)
+    }
+}
+
+/// Bound on how far the adoption check walks a replacement chain.
+///
+/// Comfortably above the hop budget the broadcaster's ancestor search uses, so the check never
+/// refuses a pair that search was able to find.
+const MAX_ADOPTION_CHAIN_HOPS: usize = 64;
+
+/// Reports whether following `status`'s forward [`L1TxStatus::Replaced`] links arrives at `target`.
+///
+/// The winner of an adoption need not be the loser's immediate parent. A chain bumped more than
+/// once has intermediate attempts between them, and the miner is free to include any of them, so
+/// requiring a direct link would refuse every adoption in a chain longer than two and leave the
+/// caller marking a live payload invalid.
+fn replacement_chain_reaches(
+    txtree: &SledTransactionalTree<BcastL1TxSchema>,
+    status: &L1TxStatus,
+    target: Buf32,
+) -> Result<bool, TSledError> {
+    let L1TxStatus::Replaced { by } = status else {
+        return Ok(false);
+    };
+    let mut current = Buf32(by.0);
+
+    for _ in 0..MAX_ADOPTION_CHAIN_HOPS {
+        if current == target {
+            return Ok(true);
+        }
+        let Some(entry) = txtree.get(&current)? else {
+            return Ok(false);
+        };
+        let L1TxStatus::Replaced { by } = entry.status else {
+            return Ok(false);
+        };
+        current = Buf32(by.0);
+    }
+
+    Ok(false)
 }
 
 #[cfg(feature = "test_utils")]

--- a/crates/db/store-sled/src/broadcaster/schemas.rs
+++ b/crates/db/store-sled/src/broadcaster/schemas.rs
@@ -1,14 +1,152 @@
-use strata_db_types::l1_broadcast::L1TxEntry;
-use strata_primitives::buf::Buf32;
+use std::io::Error;
 
-use crate::{define_table_with_default_codec, define_table_with_integer_key};
+use borsh::BorshDeserialize;
+#[cfg(test)]
+use borsh::BorshSerialize;
+use strata_db_types::fee_bump::{TxNodeId, TxNodeRecord};
+use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
+use strata_primitives::buf::Buf32;
+use typed_sled::codec::{CodecError, ValueCodec};
+
+use crate::{
+    define_table_with_integer_key, define_table_without_codec, impl_borsh_key_codec,
+    impl_cbor_value_codec,
+};
 
 define_table_with_integer_key!(
     /// A table to store mapping of idx to L1 txid
     (BcastL1TxIdSchema) u64 => Buf32
 );
 
-define_table_with_default_codec!(
+define_table_without_codec!(
     /// A table to store L1 txs
     (BcastL1TxSchema) Buf32 => L1TxEntry
 );
+
+define_table_without_codec!(
+    /// A table to store logical L1 transaction replacement chains
+    (BcastL1TxNodeSchema) TxNodeId => TxNodeRecord
+);
+
+impl_borsh_key_codec!(BcastL1TxSchema, Buf32);
+impl_borsh_key_codec!(BcastL1TxNodeSchema, TxNodeId);
+impl_cbor_value_codec!(BcastL1TxNodeSchema, TxNodeRecord);
+
+/// CBOR value codec for [`L1TxEntry`] that still reads pre-fee-bumping Borsh rows.
+///
+/// [`L1TxEntry`] gained an `rbf` field, so its value codec moved from Borsh to CBOR for forward
+/// compatibility. Existing databases hold Borsh-encoded rows, so decoding falls back to the legacy
+/// layout and fills in `rbf: None`.
+impl ValueCodec<BcastL1TxSchema> for L1TxEntry {
+    type Decoded = Self;
+
+    fn encode_value(&self) -> Result<Vec<u8>, CodecError> {
+        let mut buf = Vec::new();
+        ciborium::into_writer(self, &mut buf).map_err(|err| CodecError::SerializationFailed {
+            schema: BcastL1TxSchema::tree_name(),
+            source: Box::new(err),
+        })?;
+        Ok(buf)
+    }
+
+    fn decode_value(data: sled::IVec) -> Result<Self::Decoded, CodecError> {
+        if let Ok(entry) = ciborium::from_reader(data.as_ref()) {
+            return Ok(entry);
+        }
+
+        decode_legacy_l1_tx_entry(data.as_ref()).map_err(|err| CodecError::DeserializationFailed {
+            schema: BcastL1TxSchema::tree_name(),
+            source: Box::new(err),
+        })
+    }
+}
+
+/// Pre-fee-bumping on-disk layout of [`L1TxEntry`].
+#[derive(BorshDeserialize)]
+#[cfg_attr(test, derive(BorshSerialize))]
+struct LegacyL1TxEntry {
+    tx_raw: Vec<u8>,
+    status: L1TxStatus,
+}
+
+fn decode_legacy_l1_tx_entry(data: &[u8]) -> Result<L1TxEntry, Error> {
+    let legacy = LegacyL1TxEntry::deserialize_reader(&mut &data[..])?;
+    Ok(L1TxEntry::from_raw_parts(
+        legacy.tx_raw,
+        legacy.status,
+        None,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_db_types::common::{L1TxId, L1WtxId};
+    use strata_db_types::fee_bump::{TxAttempt, TxAttemptStatus, TxNodeKind};
+    use strata_db_types::l1_broadcast::L1TxRbfInfo;
+
+    use super::*;
+
+    #[test]
+    fn bcast_l1_tx_schema_decodes_legacy_borsh_entries() {
+        let legacy = LegacyL1TxEntry {
+            tx_raw: vec![1, 2, 3],
+            status: L1TxStatus::Published,
+        };
+        let bytes = borsh::to_vec(&legacy).unwrap();
+
+        let decoded =
+            <L1TxEntry as ValueCodec<BcastL1TxSchema>>::decode_value(sled::IVec::from(bytes))
+                .unwrap();
+
+        assert_eq!(decoded.tx_raw(), &[1, 2, 3]);
+        assert_eq!(decoded.status, L1TxStatus::Published);
+        assert_eq!(decoded.rbf, None);
+    }
+
+    #[test]
+    fn bcast_l1_tx_schema_cbor_roundtrip_preserves_rbf_metadata() {
+        let entry = L1TxEntry::from_raw_parts(
+            vec![1, 2, 3],
+            L1TxStatus::Published,
+            Some(L1TxRbfInfo {
+                fee_rate_sat_vb: 7,
+                fee_sats: 700,
+                replaces: None,
+            }),
+        );
+
+        let bytes = <L1TxEntry as ValueCodec<BcastL1TxSchema>>::encode_value(&entry).unwrap();
+        let decoded =
+            <L1TxEntry as ValueCodec<BcastL1TxSchema>>::decode_value(sled::IVec::from(bytes))
+                .unwrap();
+
+        assert_eq!(decoded, entry);
+    }
+
+    #[test]
+    fn bcast_l1_tx_node_schema_cbor_roundtrip() {
+        let kind = TxNodeKind::SingleEnvelopeCommit { payload_idx: 42 };
+        let attempt = TxAttempt {
+            attempt_no: 0,
+            raw_tx: vec![1, 2, 3],
+            txid: L1TxId::from([1; 32]),
+            wtxid: L1WtxId::from([2; 32]),
+            fee_rate_sat_vb: 7,
+            fee_sats: 700,
+            created_at_unix_secs: 123,
+            first_published_l1_height: None,
+            status: TxAttemptStatus::Active,
+            replaced_by: None,
+        };
+        let record = TxNodeRecord::new(kind, attempt);
+
+        let bytes =
+            <TxNodeRecord as ValueCodec<BcastL1TxNodeSchema>>::encode_value(&record).unwrap();
+        let decoded = <TxNodeRecord as ValueCodec<BcastL1TxNodeSchema>>::decode_value(
+            sled::IVec::from(bytes),
+        )
+        .unwrap();
+
+        assert_eq!(decoded, record);
+    }
+}

--- a/crates/db/store-sled/src/broadcaster/schemas.rs
+++ b/crates/db/store-sled/src/broadcaster/schemas.rs
@@ -1,5 +1,7 @@
+use strata_db_types::fee_bump::{TxNodeId, TxNodeRecord};
 use strata_db_types::l1_broadcast::L1TxEntry;
 use strata_primitives::buf::Buf32;
+use typed_sled::codec::{CodecError, KeyCodec};
 
 use crate::{define_table_without_codec, impl_cbor_value_codec, impl_codec_key_codec};
 
@@ -16,3 +18,173 @@ define_table_without_codec!(
 );
 impl_codec_key_codec!(BcastL1TxSchema, Buf32);
 impl_cbor_value_codec!(BcastL1TxSchema, L1TxEntry);
+
+define_table_without_codec!(
+    /// A table to store logical L1 transaction replacement chains
+    (BcastL1TxNodeSchema) TxNodeId => TxNodeRecord
+);
+
+define_table_without_codec!(
+    /// Presence marker: this replacement chain may still need fee bumping.
+    ///
+    /// The replacement pass scans this set instead of the full node tree, whose records are kept
+    /// forever for crash-recovery point lookups.
+    (BcastActiveL1TxNodeSchema) TxNodeId => ()
+);
+
+const HASH_KEY_LEN: usize = 32;
+
+fn decode_hash_key(data: &[u8], schema: &'static str) -> Result<Buf32, CodecError> {
+    let bytes = data.try_into().map_err(|_| CodecError::InvalidKeyLength {
+        schema,
+        expected: HASH_KEY_LEN,
+        actual: data.len(),
+    })?;
+    Ok(Buf32(bytes))
+}
+
+impl KeyCodec<BcastL1TxNodeSchema> for TxNodeId {
+    fn encode_key(&self) -> Result<Vec<u8>, CodecError> {
+        Ok(self.0.0.to_vec())
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self, CodecError> {
+        decode_hash_key(data, BcastL1TxNodeSchema::tree_name()).map(Self)
+    }
+}
+
+impl KeyCodec<BcastActiveL1TxNodeSchema> for TxNodeId {
+    fn encode_key(&self) -> Result<Vec<u8>, CodecError> {
+        Ok(self.0.0.to_vec())
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self, CodecError> {
+        decode_hash_key(data, BcastActiveL1TxNodeSchema::tree_name()).map(Self)
+    }
+}
+
+impl_cbor_value_codec!(BcastL1TxNodeSchema, TxNodeRecord);
+impl_cbor_value_codec!(BcastActiveL1TxNodeSchema, ());
+
+#[cfg(test)]
+mod tests {
+    use strata_db_types::common::{L1TxId, L1WtxId};
+    use strata_db_types::fee_bump::{TxAttempt, TxAttemptStatus, TxNodeKind};
+    use strata_db_types::l1_broadcast::{L1TxRbfInfo, L1TxStatus};
+    use typed_sled::codec::ValueCodec;
+
+    use super::*;
+
+    #[test]
+    fn bcast_l1_tx_schema_decodes_cbor_without_rbf_metadata() {
+        let old_shape = ciborium::Value::Map(vec![
+            (
+                ciborium::Value::Text("tx_raw".into()),
+                ciborium::Value::Bytes(vec![1, 2, 3]),
+            ),
+            (
+                ciborium::Value::Text("status".into()),
+                ciborium::Value::Map(vec![(
+                    ciborium::Value::Text("status".into()),
+                    ciborium::Value::Text("published".into()),
+                )]),
+            ),
+        ]);
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&old_shape, &mut bytes).unwrap();
+
+        let decoded =
+            <L1TxEntry as ValueCodec<BcastL1TxSchema>>::decode_value(sled::IVec::from(bytes))
+                .unwrap();
+
+        assert_eq!(decoded.tx_raw(), &[1, 2, 3]);
+        assert_eq!(decoded.status, L1TxStatus::Published);
+        assert_eq!(decoded.rbf, None);
+    }
+
+    #[test]
+    fn broadcaster_schema_keys_use_raw_hash_bytes() {
+        let txid = Buf32([0x11; HASH_KEY_LEN]);
+        let txid_bytes = <Buf32 as KeyCodec<BcastL1TxSchema>>::encode_key(&txid).unwrap();
+        assert_eq!(txid_bytes, vec![0x11; HASH_KEY_LEN]);
+        assert_eq!(
+            <Buf32 as KeyCodec<BcastL1TxSchema>>::decode_key(&txid_bytes).unwrap(),
+            txid
+        );
+
+        let node_id = TxNodeId(Buf32([0x22; HASH_KEY_LEN]));
+        let node_id_bytes =
+            <TxNodeId as KeyCodec<BcastL1TxNodeSchema>>::encode_key(&node_id).unwrap();
+        assert_eq!(node_id_bytes, vec![0x22; HASH_KEY_LEN]);
+        assert_eq!(
+            <TxNodeId as KeyCodec<BcastL1TxNodeSchema>>::decode_key(&node_id_bytes).unwrap(),
+            node_id
+        );
+    }
+
+    #[test]
+    fn broadcaster_schema_keys_reject_invalid_lengths() {
+        let txid_err =
+            <Buf32 as KeyCodec<BcastL1TxSchema>>::decode_key(&[0; HASH_KEY_LEN - 1]).unwrap_err();
+        assert!(matches!(txid_err, CodecError::SerializationFailed { .. }));
+
+        let node_err =
+            <TxNodeId as KeyCodec<BcastL1TxNodeSchema>>::decode_key(&[0; HASH_KEY_LEN + 1])
+                .unwrap_err();
+        assert!(matches!(
+            node_err,
+            CodecError::InvalidKeyLength {
+                expected: HASH_KEY_LEN,
+                actual: 33,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bcast_l1_tx_schema_cbor_roundtrip_preserves_rbf_metadata() {
+        let entry = L1TxEntry::from_raw_parts(
+            vec![1, 2, 3],
+            L1TxStatus::Published,
+            Some(L1TxRbfInfo {
+                fee_rate_sat_vb: 7,
+                fee_sats: 700,
+                replaces: None,
+            }),
+        );
+
+        let bytes = <L1TxEntry as ValueCodec<BcastL1TxSchema>>::encode_value(&entry).unwrap();
+        let decoded =
+            <L1TxEntry as ValueCodec<BcastL1TxSchema>>::decode_value(sled::IVec::from(bytes))
+                .unwrap();
+
+        assert_eq!(decoded, entry);
+    }
+
+    #[test]
+    fn bcast_l1_tx_node_schema_cbor_roundtrip() {
+        let kind = TxNodeKind::SingleEnvelopeCommit { payload_idx: 42 };
+        let attempt = TxAttempt {
+            attempt_no: 0,
+            raw_tx: vec![1, 2, 3],
+            txid: L1TxId::from([1; 32]),
+            wtxid: L1WtxId::from([2; 32]),
+            fee_rate_sat_vb: 7,
+            fee_sats: 700,
+            created_at_unix_secs: 123,
+            first_published_l1_height: None,
+            status: TxAttemptStatus::Active,
+            replaced_by: None,
+        };
+        let record = TxNodeRecord::new(kind, attempt);
+
+        let bytes =
+            <TxNodeRecord as ValueCodec<BcastL1TxNodeSchema>>::encode_value(&record).unwrap();
+        let decoded = <TxNodeRecord as ValueCodec<BcastL1TxNodeSchema>>::decode_value(
+            sled::IVec::from(bytes),
+        )
+        .unwrap();
+
+        assert_eq!(decoded, record);
+    }
+}

--- a/crates/db/tests/src/l1_broadcast_tests.rs
+++ b/crates/db/tests/src/l1_broadcast_tests.rs
@@ -1,6 +1,8 @@
 use bitcoin::consensus::deserialize;
 use bitcoin::hashes::Hash;
-use bitcoin::Transaction;
+use bitcoin::{Amount, FeeRate, Transaction};
+use strata_db_types::common::L1TxId;
+use strata_db_types::fee_bump::{TxAttempt, TxNodeId, TxNodeKind, TxNodeRecord};
 use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry, L1TxStatus};
 use strata_primitives::buf::Buf32;
 
@@ -199,6 +201,448 @@ pub fn test_del_tx_entries_empty_database(db: &impl L1BroadcastDatabase) {
     );
 }
 
+/// `Replaced` is terminal for a txid: the broadcaster must not be able to write a stale
+/// pre-replacement status back over a fee bump's transition.
+pub fn test_put_tx_entry_by_idx_refuses_to_unreplace(db: &impl L1BroadcastDatabase) {
+    let (txid, txentry) = generate_l1_tx_entry();
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap().unwrap();
+
+    let mut replaced = txentry.clone();
+    replaced.status = L1TxStatus::Replaced {
+        by: L1TxId::from([9u8; 32]),
+    };
+    db.put_tx_entry_by_idx(idx, replaced).unwrap();
+
+    // A stale writer tries to move it back to Published.
+    let mut stale = txentry;
+    stale.status = L1TxStatus::Published;
+    db.put_tx_entry_by_idx(idx, stale).unwrap();
+
+    assert!(matches!(
+        db.get_tx_entry(idx).unwrap().unwrap().status,
+        L1TxStatus::Replaced { .. }
+    ));
+}
+
+/// A later replacement in the same chain must still be recordable.
+pub fn test_put_tx_entry_by_idx_allows_rereplacement(db: &impl L1BroadcastDatabase) {
+    let (txid, txentry) = generate_l1_tx_entry();
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap().unwrap();
+
+    let mut replaced = txentry.clone();
+    replaced.status = L1TxStatus::Replaced {
+        by: L1TxId::from([9u8; 32]),
+    };
+    db.put_tx_entry_by_idx(idx, replaced).unwrap();
+
+    let mut replaced_again = txentry;
+    replaced_again.status = L1TxStatus::Replaced {
+        by: L1TxId::from([10u8; 32]),
+    };
+    db.put_tx_entry_by_idx(idx, replaced_again).unwrap();
+
+    assert_eq!(
+        db.get_tx_entry(idx).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from([10u8; 32])
+        }
+    );
+}
+
+/// The swap inserts the replacement and supersedes the original in one step.
+pub fn test_put_replacement_tx_entry_swaps_atomically(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut original = L1TxEntry::from_tx(&txns[0]);
+    original.status = L1TxStatus::Published;
+    db.put_tx_entry(original_txid, original).unwrap();
+
+    let replacement = L1TxEntry::from_tx(&txns[1]);
+    let idx = db
+        .put_replacement_tx_entry(original_txid, replacement_txid, replacement.clone())
+        .unwrap()
+        .expect("swap applies to a published original");
+
+    assert_eq!(db.get_tx_entry(idx).unwrap(), Some(replacement));
+    assert_eq!(
+        db.get_tx_entry_by_id(original_txid)
+            .unwrap()
+            .unwrap()
+            .status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(replacement_txid.0)
+        }
+    );
+}
+
+/// The reverse link is what lets the broadcaster walk back to the ancestors of a replacement, so
+/// the swap has to record it alongside the forward one.
+pub fn test_put_replacement_tx_entry_records_the_reverse_link(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut original = L1TxEntry::from_tx_with_fee(
+        &txns[0],
+        FeeRate::from_sat_per_vb(2).unwrap(),
+        Amount::from_sat(200),
+    );
+    original.status = L1TxStatus::Published;
+    db.put_tx_entry(original_txid, original).unwrap();
+
+    db.put_replacement_tx_entry(
+        original_txid,
+        replacement_txid,
+        L1TxEntry::from_tx_with_fee(
+            &txns[1],
+            FeeRate::from_sat_per_vb(4).unwrap(),
+            Amount::from_sat(400),
+        ),
+    )
+    .unwrap()
+    .expect("swap applies to a published original");
+
+    assert_eq!(
+        db.get_tx_entry_by_id(replacement_txid)
+            .unwrap()
+            .unwrap()
+            .rbf
+            .unwrap()
+            .replaces,
+        Some(L1TxId::from(original_txid.0))
+    );
+}
+
+/// A miner can include an original after the local node accepted its replacement. The chain then
+/// has to be repointed at the winner, or every consumer walks past it and concludes the chain died.
+pub fn test_adopt_confirmed_ancestor_reverses_the_chain(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = L1TxEntry::from_tx(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_replacement_tx_entry(winner_txid, loser_txid, L1TxEntry::from_tx(&txns[1]))
+        .unwrap()
+        .expect("swap applies");
+
+    let confirmed = L1TxStatus::Confirmed {
+        confirmations: 3,
+        block_hash: Buf32::zero(),
+        block_height: 400,
+    };
+    assert!(db
+        .adopt_confirmed_ancestor(loser_txid, winner_txid, confirmed.clone())
+        .unwrap());
+
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        confirmed
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(winner_txid.0)
+        }
+    );
+}
+
+/// The winner does not have to be the loser's immediate parent. A chain bumped twice has an
+/// intermediate attempt between them, and a miner can still include the original.
+pub fn test_adopt_confirmed_ancestor_reverses_a_multi_hop_chain(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let middle_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[2].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = L1TxEntry::from_tx(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_replacement_tx_entry(winner_txid, middle_txid, L1TxEntry::from_tx(&txns[1]))
+        .unwrap()
+        .expect("first swap applies");
+    // The replacement lands `Unpublished`; only a published entry can itself be replaced.
+    let mut middle = db.get_tx_entry_by_id(middle_txid).unwrap().unwrap();
+    middle.status = L1TxStatus::Published;
+    db.put_tx_entry(middle_txid, middle).unwrap();
+    db.put_replacement_tx_entry(middle_txid, loser_txid, L1TxEntry::from_tx(&txns[2]))
+        .unwrap()
+        .expect("second swap applies");
+
+    let confirmed = L1TxStatus::Confirmed {
+        confirmations: 3,
+        block_hash: Buf32::zero(),
+        block_height: 400,
+    };
+    assert!(db
+        .adopt_confirmed_ancestor(loser_txid, winner_txid, confirmed.clone())
+        .unwrap());
+
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        confirmed
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(winner_txid.0)
+        }
+    );
+    // The intermediate keeps its forward link, which now resolves to the winner through the
+    // reversed one rather than dead-ending on the loser.
+    assert_eq!(
+        db.get_tx_entry_by_id(middle_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(loser_txid.0)
+        }
+    );
+}
+
+/// A concurrent fee bump can supersede the loser while an adoption is still deciding, since the
+/// adoption makes an RPC round-trip per ancestor before it writes. Reversing over the loser then
+/// cuts the newer replacement out of the chain while it stays indexed and broadcastable, so the
+/// chain head names the old ancestor while a live transaction spends the same inputs.
+pub fn test_adopt_confirmed_ancestor_refuses_a_superseded_loser(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let newer_txid: Buf32 = txns[2].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = L1TxEntry::from_tx(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_replacement_tx_entry(winner_txid, loser_txid, L1TxEntry::from_tx(&txns[1]))
+        .unwrap()
+        .expect("first swap applies");
+
+    // The writer's fee-bump pass supersedes the loser while the adoption is deciding.
+    db.put_replacement_tx_entry(loser_txid, newer_txid, L1TxEntry::from_tx(&txns[2]))
+        .unwrap()
+        .expect("second swap applies");
+
+    assert!(!db
+        .adopt_confirmed_ancestor(
+            loser_txid,
+            winner_txid,
+            L1TxStatus::Confirmed {
+                confirmations: 3,
+                block_hash: Buf32::zero(),
+                block_height: 400,
+            },
+        )
+        .unwrap());
+
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(newer_txid.0)
+        },
+        "the loser must keep pointing at the replacement that superseded it"
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(loser_txid.0)
+        },
+        "a refused adoption must not advance the winner either"
+    );
+}
+
+/// Only a link the chain actually has may be reversed, otherwise a stale caller could point two
+/// unrelated entries at each other and strand both.
+pub fn test_adopt_confirmed_ancestor_refuses_an_unlinked_pair(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = L1TxEntry::from_tx(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_tx_entry(loser_txid, L1TxEntry::from_tx(&txns[1]))
+        .unwrap();
+
+    assert!(!db
+        .adopt_confirmed_ancestor(
+            loser_txid,
+            winner_txid,
+            L1TxStatus::Confirmed {
+                confirmations: 3,
+                block_hash: Buf32::zero(),
+                block_height: 400,
+            },
+        )
+        .unwrap());
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        L1TxStatus::Published
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Unpublished
+    );
+}
+
+/// If the original already confirmed the swap writes nothing at all, replacement row included.
+pub fn test_put_replacement_tx_entry_writes_nothing_when_refused(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let confirmed_status = L1TxStatus::Confirmed {
+        confirmations: 1,
+        block_hash: Buf32::zero(),
+        block_height: 100,
+    };
+    let mut original = L1TxEntry::from_tx(&txns[0]);
+    original.status = confirmed_status.clone();
+    db.put_tx_entry(original_txid, original).unwrap();
+
+    assert_eq!(
+        db.put_replacement_tx_entry(
+            original_txid,
+            replacement_txid,
+            L1TxEntry::from_tx(&txns[1])
+        )
+        .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(original_txid)
+            .unwrap()
+            .unwrap()
+            .status,
+        confirmed_status
+    );
+    assert_eq!(db.get_tx_entry_by_id(replacement_txid).unwrap(), None);
+}
+
+/// An already-present replacement row means an earlier swap ran. Writing again would transition
+/// the original with no index to report, so the swap must refuse and leave both rows alone.
+pub fn test_put_replacement_tx_entry_refuses_existing_replacement(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+
+    let mut original = L1TxEntry::from_tx(&txns[0]);
+    original.status = L1TxStatus::Published;
+    db.put_tx_entry(original_txid, original.clone()).unwrap();
+    db.put_tx_entry(replacement_txid, L1TxEntry::from_tx(&txns[1]))
+        .unwrap();
+
+    assert_eq!(
+        db.put_replacement_tx_entry(
+            original_txid,
+            replacement_txid,
+            L1TxEntry::from_tx(&txns[1])
+        )
+        .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(original_txid)
+            .unwrap()
+            .unwrap()
+            .status,
+        L1TxStatus::Published,
+        "the original must not be transitioned when the swap refuses"
+    );
+}
+
+/// A published transaction can be superseded, and the transition reports that it applied.
+pub fn test_try_mark_tx_entry_replaced_applies_to_published(db: &impl L1BroadcastDatabase) {
+    let (txid, mut txentry) = generate_l1_tx_entry();
+    txentry.status = L1TxStatus::Published;
+    db.put_tx_entry(txid, txentry).unwrap();
+
+    let replacement = L1TxId::from([9u8; 32]);
+    assert!(db.try_mark_tx_entry_replaced(txid, replacement).unwrap());
+    assert_eq!(
+        db.get_tx_entry_by_id(txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced { by: replacement }
+    );
+}
+
+/// A transaction that already confirmed has won. The transition must not apply, and — critically —
+/// must not report success, or callers would advance metadata onto an unconfirmable replacement.
+pub fn test_try_mark_tx_entry_replaced_refuses_confirmed(db: &impl L1BroadcastDatabase) {
+    let (txid, mut txentry) = generate_l1_tx_entry();
+    let confirmed_status = L1TxStatus::Confirmed {
+        confirmations: 1,
+        block_hash: Buf32::zero(),
+        block_height: 100,
+    };
+    txentry.status = confirmed_status.clone();
+    db.put_tx_entry(txid, txentry).unwrap();
+
+    assert!(!db
+        .try_mark_tx_entry_replaced(txid, L1TxId::from([9u8; 32]))
+        .unwrap());
+    assert_eq!(
+        db.get_tx_entry_by_id(txid).unwrap().unwrap().status,
+        confirmed_status
+    );
+}
+
+/// An unknown txid reports no transition rather than erroring.
+pub fn test_try_mark_tx_entry_replaced_missing_entry(db: &impl L1BroadcastDatabase) {
+    assert!(!db
+        .try_mark_tx_entry_replaced(Buf32::from([3u8; 32]), L1TxId::from([9u8; 32]))
+        .unwrap());
+}
+
+pub fn test_tx_node_roundtrip(db: &impl L1BroadcastDatabase) {
+    let kind = TxNodeKind::ChunkedEnvelopeReveal {
+        envelope_idx: 4,
+        reveal_idx: 2,
+    };
+    let node_id = TxNodeId::from_kind(&kind);
+
+    assert_eq!(db.get_tx_node(node_id).unwrap(), None);
+
+    let record = generate_tx_node_record(kind);
+    db.put_tx_node(node_id, record.clone()).unwrap();
+
+    assert_eq!(db.get_tx_node(node_id).unwrap(), Some(record));
+}
+
+pub fn test_tx_node_overwrite_and_list(db: &impl L1BroadcastDatabase) {
+    assert!(db.get_all_tx_nodes().unwrap().is_empty());
+
+    let commit_kind = TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 1 };
+    let reveal_kind = TxNodeKind::ChunkedEnvelopeReveal {
+        envelope_idx: 1,
+        reveal_idx: 0,
+    };
+    let commit = generate_tx_node_record(commit_kind);
+    let reveal = generate_tx_node_record(reveal_kind);
+
+    db.put_tx_node(commit.node_id, commit.clone()).unwrap();
+    db.put_tx_node(reveal.node_id, reveal.clone()).unwrap();
+    assert_eq!(db.get_all_tx_nodes().unwrap().len(), 2);
+
+    // Re-putting the same node id replaces the record rather than adding a second one.
+    let txns = get_test_bitcoin_txs();
+    let mut bumped = commit.clone();
+    bumped.append_replacement(TxAttempt::active(
+        &txns[1],
+        FeeRate::from_sat_per_vb(4).expect("test: valid fee rate"),
+        Amount::from_sat(800),
+        bumped.next_attempt_no(),
+    ));
+    db.put_tx_node(bumped.node_id, bumped.clone()).unwrap();
+
+    assert_eq!(db.get_all_tx_nodes().unwrap().len(), 2);
+    assert_eq!(db.get_tx_node(commit.node_id).unwrap(), Some(bumped));
+}
+
+// Helper function to generate a TxNodeRecord with a single active attempt
+fn generate_tx_node_record(kind: TxNodeKind) -> TxNodeRecord {
+    let txns = get_test_bitcoin_txs();
+    let attempt = TxAttempt::active(
+        &txns[0],
+        FeeRate::from_sat_per_vb(2).expect("test: valid fee rate"),
+        Amount::from_sat(400),
+        0,
+    );
+    TxNodeRecord::new(kind, attempt)
+}
+
 // Helper function to generate L1TxEntry
 fn generate_l1_tx_entry() -> (Buf32, L1TxEntry) {
     let txns = get_test_bitcoin_txs();
@@ -286,6 +730,104 @@ macro_rules! l1_broadcast_db_tests {
         fn test_del_tx_entries_empty_database() {
             let db = $setup_expr;
             $crate::l1_broadcast_tests::test_del_tx_entries_empty_database(&db);
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_refuses_existing_replacement() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_refuses_existing_replacement(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_swaps_atomically() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_swaps_atomically(&db);
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_records_the_reverse_link() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_records_the_reverse_link(&db);
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_reverses_the_chain() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_reverses_the_chain(&db);
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_reverses_a_multi_hop_chain() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_reverses_a_multi_hop_chain(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_refuses_a_superseded_loser() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_refuses_a_superseded_loser(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_refuses_an_unlinked_pair() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_refuses_an_unlinked_pair(&db);
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_writes_nothing_when_refused() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_writes_nothing_when_refused(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_try_mark_tx_entry_replaced_applies_to_published() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_try_mark_tx_entry_replaced_applies_to_published(&db);
+        }
+
+        #[test]
+        fn test_try_mark_tx_entry_replaced_refuses_confirmed() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_try_mark_tx_entry_replaced_refuses_confirmed(&db);
+        }
+
+        #[test]
+        fn test_try_mark_tx_entry_replaced_missing_entry() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_try_mark_tx_entry_replaced_missing_entry(&db);
+        }
+
+        #[test]
+        fn test_put_tx_entry_by_idx_refuses_to_unreplace() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_tx_entry_by_idx_refuses_to_unreplace(&db);
+        }
+
+        #[test]
+        fn test_put_tx_entry_by_idx_allows_rereplacement() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_tx_entry_by_idx_allows_rereplacement(&db);
+        }
+
+        #[test]
+        fn test_tx_node_roundtrip() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_tx_node_roundtrip(&db);
+        }
+
+        #[test]
+        fn test_tx_node_overwrite_and_list() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_tx_node_overwrite_and_list(&db);
         }
     };
 }

--- a/crates/db/tests/src/l1_broadcast_tests.rs
+++ b/crates/db/tests/src/l1_broadcast_tests.rs
@@ -1,7 +1,11 @@
 use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::hashes::Hash;
-use bitcoin::Transaction;
-use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry, L1TxStatus};
+use bitcoin::{Amount, FeeRate, Transaction};
+use strata_db_types::common::{L1TxId, L1WtxId};
+use strata_db_types::fee_bump::{
+    TerminalError, TxAttempt, TxAttemptParts, TxNodeId, TxNodeKind, TxNodeRecord,
+};
+use strata_db_types::l1_broadcast::{L1BroadcastDatabase, L1TxEntry, L1TxRbfInfo, L1TxStatus};
 use strata_primitives::buf::Buf32;
 
 /// Builds an unpublished entry for a transaction.
@@ -10,6 +14,30 @@ use strata_primitives::buf::Buf32;
 /// database crate.
 fn tx_entry(tx: &Transaction) -> L1TxEntry {
     L1TxEntry::new_unpublished(serialize(tx))
+}
+
+/// Builds the persistent attempt material for `tx`, mirroring `strata_btcio::tx_attempt`.
+fn attempt_parts(tx: &Transaction, fee_rate: FeeRate, fee: Amount) -> TxAttemptParts {
+    TxAttemptParts {
+        raw_tx: serialize(tx),
+        txid: L1TxId::from(tx.compute_txid().to_byte_array()),
+        wtxid: L1WtxId::from(tx.compute_wtxid().to_byte_array()),
+        fee_rate_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+        fee_sats: fee.to_sat(),
+    }
+}
+
+/// Builds a writer-owned unpublished entry carrying the RBF metadata for `fee_rate` and `fee`.
+fn tx_entry_with_fee(tx: &Transaction, fee_rate: FeeRate, fee: Amount) -> L1TxEntry {
+    L1TxEntry::from_raw_parts(
+        serialize(tx),
+        L1TxStatus::Unpublished,
+        Some(L1TxRbfInfo {
+            fee_rate_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+            fee_sats: fee.to_sat(),
+            replaces: None,
+        }),
+    )
 }
 
 pub fn test_get_last_tx_entry(db: &impl L1BroadcastDatabase) {
@@ -207,6 +235,494 @@ pub fn test_del_tx_entries_empty_database(db: &impl L1BroadcastDatabase) {
     );
 }
 
+/// `Replaced` is terminal for a txid: the broadcaster must not be able to write a stale
+/// pre-replacement status back over a fee bump's transition.
+pub fn test_put_tx_entry_by_idx_refuses_to_unreplace(db: &impl L1BroadcastDatabase) {
+    let (txid, txentry) = generate_l1_tx_entry();
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap().unwrap();
+
+    let mut replaced = txentry.clone();
+    replaced.status = L1TxStatus::Replaced {
+        by: L1TxId::from([9u8; 32]),
+    };
+    db.put_tx_entry_by_idx(idx, replaced).unwrap();
+
+    // A stale writer tries to move it back to Published.
+    let mut stale = txentry;
+    stale.status = L1TxStatus::Published;
+    db.put_tx_entry_by_idx(idx, stale).unwrap();
+
+    assert!(matches!(
+        db.get_tx_entry(idx).unwrap().unwrap().status,
+        L1TxStatus::Replaced { .. }
+    ));
+}
+
+/// A later replacement in the same chain must still be recordable.
+pub fn test_put_tx_entry_by_idx_allows_rereplacement(db: &impl L1BroadcastDatabase) {
+    let (txid, txentry) = generate_l1_tx_entry();
+    let idx = db.put_tx_entry(txid, txentry.clone()).unwrap().unwrap();
+
+    let mut replaced = txentry.clone();
+    replaced.status = L1TxStatus::Replaced {
+        by: L1TxId::from([9u8; 32]),
+    };
+    db.put_tx_entry_by_idx(idx, replaced).unwrap();
+
+    let mut replaced_again = txentry;
+    replaced_again.status = L1TxStatus::Replaced {
+        by: L1TxId::from([10u8; 32]),
+    };
+    db.put_tx_entry_by_idx(idx, replaced_again).unwrap();
+
+    assert_eq!(
+        db.get_tx_entry(idx).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from([10u8; 32])
+        }
+    );
+}
+
+/// The swap inserts the replacement and supersedes the original in one step.
+pub fn test_put_replacement_tx_entry_swaps_atomically(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut original = tx_entry(&txns[0]);
+    original.status = L1TxStatus::Published;
+    db.put_tx_entry(original_txid, original).unwrap();
+
+    let replacement = tx_entry(&txns[1]);
+    let idx = db
+        .put_replacement_tx_entry(original_txid, replacement_txid, replacement.clone())
+        .unwrap()
+        .expect("swap applies to a published original");
+
+    assert_eq!(db.get_tx_entry(idx).unwrap(), Some(replacement));
+    assert_eq!(
+        db.get_tx_entry_by_id(original_txid)
+            .unwrap()
+            .unwrap()
+            .status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(replacement_txid.0)
+        }
+    );
+}
+
+/// The reverse link is what lets the broadcaster walk back to the ancestors of a replacement, so
+/// the swap has to record it alongside the forward one.
+pub fn test_put_replacement_tx_entry_records_the_reverse_link(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut original = tx_entry_with_fee(
+        &txns[0],
+        FeeRate::from_sat_per_vb(2).unwrap(),
+        Amount::from_sat(200),
+    );
+    original.status = L1TxStatus::Published;
+    db.put_tx_entry(original_txid, original).unwrap();
+
+    db.put_replacement_tx_entry(
+        original_txid,
+        replacement_txid,
+        tx_entry_with_fee(
+            &txns[1],
+            FeeRate::from_sat_per_vb(4).unwrap(),
+            Amount::from_sat(400),
+        ),
+    )
+    .unwrap()
+    .expect("swap applies to a published original");
+
+    assert_eq!(
+        db.get_tx_entry_by_id(replacement_txid)
+            .unwrap()
+            .unwrap()
+            .rbf
+            .unwrap()
+            .replaces,
+        Some(L1TxId::from(original_txid.0))
+    );
+}
+
+/// A miner can include an original after the local node accepted its replacement. The chain then
+/// has to be repointed at the winner, or every consumer walks past it and concludes the chain died.
+pub fn test_adopt_confirmed_ancestor_reverses_the_chain(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = tx_entry(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_replacement_tx_entry(winner_txid, loser_txid, tx_entry(&txns[1]))
+        .unwrap()
+        .expect("swap applies");
+
+    let confirmed = L1TxStatus::Confirmed {
+        confirmations: 3,
+        block_hash: Buf32::zero(),
+        block_height: 400,
+    };
+    assert!(db
+        .adopt_confirmed_ancestor(loser_txid, winner_txid, confirmed.clone())
+        .unwrap());
+
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        confirmed
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(winner_txid.0)
+        }
+    );
+}
+
+/// The winner does not have to be the loser's immediate parent. A chain bumped twice has an
+/// intermediate attempt between them, and a miner can still include the original.
+pub fn test_adopt_confirmed_ancestor_reverses_a_multi_hop_chain(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let middle_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[2].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = tx_entry(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_replacement_tx_entry(winner_txid, middle_txid, tx_entry(&txns[1]))
+        .unwrap()
+        .expect("first swap applies");
+    // The replacement lands `Unpublished`; only a published entry can itself be replaced.
+    let mut middle = db.get_tx_entry_by_id(middle_txid).unwrap().unwrap();
+    middle.status = L1TxStatus::Published;
+    db.put_tx_entry(middle_txid, middle).unwrap();
+    db.put_replacement_tx_entry(middle_txid, loser_txid, tx_entry(&txns[2]))
+        .unwrap()
+        .expect("second swap applies");
+
+    let confirmed = L1TxStatus::Confirmed {
+        confirmations: 3,
+        block_hash: Buf32::zero(),
+        block_height: 400,
+    };
+    assert!(db
+        .adopt_confirmed_ancestor(loser_txid, winner_txid, confirmed.clone())
+        .unwrap());
+
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        confirmed
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(winner_txid.0)
+        }
+    );
+    // The intermediate keeps its forward link, which now resolves to the winner through the
+    // reversed one rather than dead-ending on the loser.
+    assert_eq!(
+        db.get_tx_entry_by_id(middle_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(loser_txid.0)
+        }
+    );
+}
+
+/// A concurrent fee bump can supersede the loser while an adoption is still deciding, since the
+/// adoption makes an RPC round-trip per ancestor before it writes. Reversing over the loser then
+/// cuts the newer replacement out of the chain while it stays indexed and broadcastable, so the
+/// chain head names the old ancestor while a live transaction spends the same inputs.
+pub fn test_adopt_confirmed_ancestor_refuses_a_superseded_loser(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let newer_txid: Buf32 = txns[2].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = tx_entry(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_replacement_tx_entry(winner_txid, loser_txid, tx_entry(&txns[1]))
+        .unwrap()
+        .expect("first swap applies");
+
+    // The writer's fee-bump pass supersedes the loser while the adoption is deciding.
+    db.put_replacement_tx_entry(loser_txid, newer_txid, tx_entry(&txns[2]))
+        .unwrap()
+        .expect("second swap applies");
+
+    assert!(!db
+        .adopt_confirmed_ancestor(
+            loser_txid,
+            winner_txid,
+            L1TxStatus::Confirmed {
+                confirmations: 3,
+                block_hash: Buf32::zero(),
+                block_height: 400,
+            },
+        )
+        .unwrap());
+
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(newer_txid.0)
+        },
+        "the loser must keep pointing at the replacement that superseded it"
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced {
+            by: L1TxId::from(loser_txid.0)
+        },
+        "a refused adoption must not advance the winner either"
+    );
+}
+
+/// Only a link the chain actually has may be reversed, otherwise a stale caller could point two
+/// unrelated entries at each other and strand both.
+pub fn test_adopt_confirmed_ancestor_refuses_an_unlinked_pair(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let winner_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let loser_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let mut winner = tx_entry(&txns[0]);
+    winner.status = L1TxStatus::Published;
+    db.put_tx_entry(winner_txid, winner).unwrap();
+    db.put_tx_entry(loser_txid, tx_entry(&txns[1])).unwrap();
+
+    assert!(!db
+        .adopt_confirmed_ancestor(
+            loser_txid,
+            winner_txid,
+            L1TxStatus::Confirmed {
+                confirmations: 3,
+                block_hash: Buf32::zero(),
+                block_height: 400,
+            },
+        )
+        .unwrap());
+    assert_eq!(
+        db.get_tx_entry_by_id(winner_txid).unwrap().unwrap().status,
+        L1TxStatus::Published
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(loser_txid).unwrap().unwrap().status,
+        L1TxStatus::Unpublished
+    );
+}
+
+/// If the original already confirmed the swap writes nothing at all, replacement row included.
+pub fn test_put_replacement_tx_entry_writes_nothing_when_refused(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+    let confirmed_status = L1TxStatus::Confirmed {
+        confirmations: 1,
+        block_hash: Buf32::zero(),
+        block_height: 100,
+    };
+    let mut original = tx_entry(&txns[0]);
+    original.status = confirmed_status.clone();
+    db.put_tx_entry(original_txid, original).unwrap();
+
+    assert_eq!(
+        db.put_replacement_tx_entry(original_txid, replacement_txid, tx_entry(&txns[1]))
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(original_txid)
+            .unwrap()
+            .unwrap()
+            .status,
+        confirmed_status
+    );
+    assert_eq!(db.get_tx_entry_by_id(replacement_txid).unwrap(), None);
+}
+
+/// An already-present replacement row means an earlier swap ran. Writing again would transition
+/// the original with no index to report, so the swap must refuse and leave both rows alone.
+pub fn test_put_replacement_tx_entry_refuses_existing_replacement(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let original_txid: Buf32 = txns[0].compute_txid().as_raw_hash().to_byte_array().into();
+    let replacement_txid: Buf32 = txns[1].compute_txid().as_raw_hash().to_byte_array().into();
+
+    let mut original = tx_entry(&txns[0]);
+    original.status = L1TxStatus::Published;
+    db.put_tx_entry(original_txid, original.clone()).unwrap();
+    db.put_tx_entry(replacement_txid, tx_entry(&txns[1]))
+        .unwrap();
+
+    assert_eq!(
+        db.put_replacement_tx_entry(original_txid, replacement_txid, tx_entry(&txns[1]))
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_tx_entry_by_id(original_txid)
+            .unwrap()
+            .unwrap()
+            .status,
+        L1TxStatus::Published,
+        "the original must not be transitioned when the swap refuses"
+    );
+}
+
+/// A published transaction can be superseded, and the transition reports that it applied.
+pub fn test_try_mark_tx_entry_replaced_applies_to_published(db: &impl L1BroadcastDatabase) {
+    let (txid, mut txentry) = generate_l1_tx_entry();
+    txentry.status = L1TxStatus::Published;
+    db.put_tx_entry(txid, txentry).unwrap();
+
+    let replacement = L1TxId::from([9u8; 32]);
+    assert!(db.try_mark_tx_entry_replaced(txid, replacement).unwrap());
+    assert_eq!(
+        db.get_tx_entry_by_id(txid).unwrap().unwrap().status,
+        L1TxStatus::Replaced { by: replacement }
+    );
+}
+
+/// A transaction that already confirmed has won. The transition must not apply, and — critically —
+/// must not report success, or callers would advance metadata onto an unconfirmable replacement.
+pub fn test_try_mark_tx_entry_replaced_refuses_confirmed(db: &impl L1BroadcastDatabase) {
+    let (txid, mut txentry) = generate_l1_tx_entry();
+    let confirmed_status = L1TxStatus::Confirmed {
+        confirmations: 1,
+        block_hash: Buf32::zero(),
+        block_height: 100,
+    };
+    txentry.status = confirmed_status.clone();
+    db.put_tx_entry(txid, txentry).unwrap();
+
+    assert!(!db
+        .try_mark_tx_entry_replaced(txid, L1TxId::from([9u8; 32]))
+        .unwrap());
+    assert_eq!(
+        db.get_tx_entry_by_id(txid).unwrap().unwrap().status,
+        confirmed_status
+    );
+}
+
+/// An unknown txid reports no transition rather than erroring.
+pub fn test_try_mark_tx_entry_replaced_missing_entry(db: &impl L1BroadcastDatabase) {
+    assert!(!db
+        .try_mark_tx_entry_replaced(Buf32::from([3u8; 32]), L1TxId::from([9u8; 32]))
+        .unwrap());
+}
+
+pub fn test_tx_node_roundtrip(db: &impl L1BroadcastDatabase) {
+    let kind = TxNodeKind::ChunkedEnvelopeReveal {
+        envelope_idx: 4,
+        reveal_idx: 2,
+    };
+    let node_id = TxNodeId::from_kind(&kind);
+
+    assert_eq!(db.get_tx_node(node_id).unwrap(), None);
+
+    let record = generate_tx_node_record(kind);
+    db.put_tx_node(node_id, record.clone()).unwrap();
+
+    assert_eq!(db.get_tx_node(node_id).unwrap(), Some(record));
+}
+
+pub fn test_tx_node_overwrite_and_list(db: &impl L1BroadcastDatabase) {
+    assert!(db.get_all_tx_nodes().unwrap().is_empty());
+
+    let commit_kind = TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 1 };
+    let reveal_kind = TxNodeKind::ChunkedEnvelopeReveal {
+        envelope_idx: 1,
+        reveal_idx: 0,
+    };
+    let commit = generate_tx_node_record(commit_kind);
+    let reveal = generate_tx_node_record(reveal_kind);
+
+    db.put_tx_node(commit.node_id, commit.clone()).unwrap();
+    db.put_tx_node(reveal.node_id, reveal.clone()).unwrap();
+    assert_eq!(db.get_all_tx_nodes().unwrap().len(), 2);
+
+    // Re-putting the same node id replaces the record rather than adding a second one.
+    let txns = get_test_bitcoin_txs();
+    let mut bumped = commit.clone();
+    bumped.append_replacement(TxAttempt::active(
+        attempt_parts(
+            &txns[1],
+            FeeRate::from_sat_per_vb(4).expect("test: valid fee rate"),
+            Amount::from_sat(800),
+        ),
+        bumped.next_attempt_no(),
+    ));
+    db.put_tx_node(bumped.node_id, bumped.clone()).unwrap();
+
+    assert_eq!(db.get_all_tx_nodes().unwrap().len(), 2);
+    assert_eq!(db.get_tx_node(commit.node_id).unwrap(), Some(bumped));
+}
+
+pub fn test_active_tx_node_index_lifecycle(db: &impl L1BroadcastDatabase) {
+    let txns = get_test_bitcoin_txs();
+    let kind = TxNodeKind::SingleEnvelopeReveal { payload_idx: 11 };
+    let mut record = generate_tx_node_record(kind);
+    let node_id = record.node_id;
+
+    // A non-terminal write enters the active set.
+    db.put_tx_node(node_id, record.clone()).unwrap();
+    assert_eq!(db.get_active_tx_nodes().unwrap(), vec![record.clone()]);
+
+    // A terminal write leaves it, while the record stays readable for point lookups.
+    record.set_terminal_error(TerminalError::MaxAttemptsReached);
+    db.put_tx_node(node_id, record.clone()).unwrap();
+    assert!(db.get_active_tx_nodes().unwrap().is_empty());
+    assert_eq!(db.get_tx_node(node_id).unwrap(), Some(record.clone()));
+
+    // A writer rebuild clears the terminal error and re-enters the set.
+    record.replace_initial_attempt(TxAttempt::active(
+        attempt_parts(
+            &txns[1],
+            FeeRate::from_sat_per_vb(3).expect("test: valid fee rate"),
+            Amount::from_sat(500),
+        ),
+        0,
+    ));
+    db.put_tx_node(node_id, record.clone()).unwrap();
+    assert_eq!(db.get_active_tx_nodes().unwrap().len(), 1);
+
+    // Retirement is guarded on the active txid the caller observed.
+    assert!(!db
+        .retire_tx_node(node_id, L1TxId::from([0xEE; 32]))
+        .unwrap());
+    assert_eq!(db.get_active_tx_nodes().unwrap().len(), 1);
+    assert!(db.retire_tx_node(node_id, record.active_txid).unwrap());
+    assert!(db.get_active_tx_nodes().unwrap().is_empty());
+
+    // The retired record stays readable for point lookups, but its attempts drop their raw
+    // transaction bytes: a retired chain never rebroadcasts, and keeping the bytes would grow
+    // the database without bound.
+    let retired = db
+        .get_tx_node(node_id)
+        .unwrap()
+        .expect("retired record stays readable");
+    assert!(retired
+        .attempts
+        .iter()
+        .all(|attempt| attempt.raw_tx.is_empty()));
+    record.forget_all_raw_txs();
+    assert_eq!(retired, record);
+}
+
+// Helper function to generate a TxNodeRecord with a single active attempt
+fn generate_tx_node_record(kind: TxNodeKind) -> TxNodeRecord {
+    let txns = get_test_bitcoin_txs();
+    let attempt = TxAttempt::active(
+        attempt_parts(
+            &txns[0],
+            FeeRate::from_sat_per_vb(2).expect("test: valid fee rate"),
+            Amount::from_sat(400),
+        ),
+        0,
+    );
+    TxNodeRecord::new(kind, attempt)
+}
+
 // Helper function to generate L1TxEntry
 fn generate_l1_tx_entry() -> (Buf32, L1TxEntry) {
     let txns = get_test_bitcoin_txs();
@@ -294,6 +810,110 @@ macro_rules! l1_broadcast_db_tests {
         fn test_del_tx_entries_empty_database() {
             let db = $setup_expr;
             $crate::l1_broadcast_tests::test_del_tx_entries_empty_database(&db);
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_refuses_existing_replacement() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_refuses_existing_replacement(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_swaps_atomically() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_swaps_atomically(&db);
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_records_the_reverse_link() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_records_the_reverse_link(&db);
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_reverses_the_chain() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_reverses_the_chain(&db);
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_reverses_a_multi_hop_chain() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_reverses_a_multi_hop_chain(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_refuses_a_superseded_loser() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_refuses_a_superseded_loser(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_adopt_confirmed_ancestor_refuses_an_unlinked_pair() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_adopt_confirmed_ancestor_refuses_an_unlinked_pair(&db);
+        }
+
+        #[test]
+        fn test_put_replacement_tx_entry_writes_nothing_when_refused() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_replacement_tx_entry_writes_nothing_when_refused(
+                &db,
+            );
+        }
+
+        #[test]
+        fn test_try_mark_tx_entry_replaced_applies_to_published() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_try_mark_tx_entry_replaced_applies_to_published(&db);
+        }
+
+        #[test]
+        fn test_try_mark_tx_entry_replaced_refuses_confirmed() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_try_mark_tx_entry_replaced_refuses_confirmed(&db);
+        }
+
+        #[test]
+        fn test_try_mark_tx_entry_replaced_missing_entry() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_try_mark_tx_entry_replaced_missing_entry(&db);
+        }
+
+        #[test]
+        fn test_put_tx_entry_by_idx_refuses_to_unreplace() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_tx_entry_by_idx_refuses_to_unreplace(&db);
+        }
+
+        #[test]
+        fn test_put_tx_entry_by_idx_allows_rereplacement() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_put_tx_entry_by_idx_allows_rereplacement(&db);
+        }
+
+        #[test]
+        fn test_tx_node_roundtrip() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_tx_node_roundtrip(&db);
+        }
+
+        #[test]
+        fn test_tx_node_overwrite_and_list() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_tx_node_overwrite_and_list(&db);
+        }
+
+        #[test]
+        fn test_active_tx_node_index_lifecycle() {
+            let db = $setup_expr;
+            $crate::l1_broadcast_tests::test_active_tx_node_index_lifecycle(&db);
         }
     };
 }

--- a/crates/db/types/Cargo.toml
+++ b/crates/db/types/Cargo.toml
@@ -29,6 +29,7 @@ anyhow.workspace = true
 arbitrary.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, optional = true, features = ["rt"] }
 tracing = { workspace = true, optional = true }

--- a/crates/db/types/src/fee_bump.rs
+++ b/crates/db/types/src/fee_bump.rs
@@ -1,0 +1,745 @@
+//! Persistent bookkeeping for writer-side fee bumping.
+//!
+//! A logical writer transaction (for example "the reveal tx of chunked envelope 3") can be
+//! published several times with increasing fee rates. Each concrete transaction is a
+//! [`TxAttempt`], and the ordered chain of attempts for one logical transaction is a
+//! [`TxNodeRecord`] keyed by a [`TxNodeId`] derived from its [`TxNodeKind`].
+//!
+//! Records are persisted with CBOR so new fields stay forward compatible. [`TxNodeId`] is
+//! deliberately derived from an explicit, versioned encoding of the kind, because the key must
+//! stay byte-stable across releases and is independent of the value codec.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use strata_identifiers::Buf32;
+use strata_primitives::L1Height;
+
+use crate::common::{L1TxId, L1WtxId};
+
+/// Domain separator for [`TxNodeId`] derivation.
+const TX_NODE_ID_DOMAIN: &[u8] = b"alpen.btcio.tx-node.v1";
+
+/// Deterministic identifier for one logical writer transaction replacement chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TxNodeId(pub Buf32);
+
+impl TxNodeId {
+    /// Derives a stable id from the logical transaction kind.
+    pub fn from_kind(kind: &TxNodeKind) -> Self {
+        let mut bytes = Vec::with_capacity(TX_NODE_ID_DOMAIN.len() + 13);
+        bytes.extend_from_slice(TX_NODE_ID_DOMAIN);
+        kind.extend_id_material(&mut bytes);
+
+        Self(Buf32(Sha256::digest(&bytes).into()))
+    }
+}
+
+/// Logical BTCIO writer transaction kind.
+///
+/// The explicit encoding of this enum feeds [`TxNodeId::from_kind`], so variant tags and field
+/// encodings are persistent identifiers. New variants must use new tags, and existing encodings
+/// must not change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TxNodeKind {
+    /// Commit transaction for a single-envelope payload row.
+    SingleEnvelopeCommit { payload_idx: u64 },
+    /// Reveal transaction for a single-envelope payload row.
+    SingleEnvelopeReveal { payload_idx: u64 },
+    /// Commit transaction for a chunked-envelope row.
+    ChunkedEnvelopeCommit { envelope_idx: u64 },
+    /// One reveal transaction for a chunked-envelope row.
+    ChunkedEnvelopeReveal { envelope_idx: u64, reveal_idx: u32 },
+}
+
+impl TxNodeKind {
+    /// Appends the stable identifier material for this logical transaction kind.
+    fn extend_id_material(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::SingleEnvelopeCommit { payload_idx } => {
+                bytes.push(0);
+                bytes.extend_from_slice(&payload_idx.to_le_bytes());
+            }
+            Self::SingleEnvelopeReveal { payload_idx } => {
+                bytes.push(1);
+                bytes.extend_from_slice(&payload_idx.to_le_bytes());
+            }
+            Self::ChunkedEnvelopeCommit { envelope_idx } => {
+                bytes.push(2);
+                bytes.extend_from_slice(&envelope_idx.to_le_bytes());
+            }
+            Self::ChunkedEnvelopeReveal {
+                envelope_idx,
+                reveal_idx,
+            } => {
+                bytes.push(3);
+                bytes.extend_from_slice(&envelope_idx.to_le_bytes());
+                bytes.extend_from_slice(&reveal_idx.to_le_bytes());
+            }
+        }
+    }
+}
+
+/// Replacement-attempt lifecycle within a logical transaction node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TxAttemptStatus {
+    /// The attempt is the currently broadcastable transaction.
+    Active,
+    /// The attempt has been superseded by another txid.
+    Replaced,
+    /// The attempt was abandoned before becoming active.
+    Discarded,
+    /// The attempt is waiting for an external reveal signature.
+    PendingSignature,
+}
+
+/// Concrete transaction material for one attempt.
+///
+/// Produced by Bitcoin-aware callers (see `strata_btcio::tx_attempt`); this crate treats the
+/// transaction bytes and ids as opaque so it stays free of a Bitcoin dependency.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxAttemptParts {
+    /// `consensus::serialize()` of the attempt transaction.
+    pub raw_tx: Vec<u8>,
+
+    /// Transaction id of the attempt.
+    pub txid: L1TxId,
+
+    /// Witness transaction id of the attempt.
+    pub wtxid: L1WtxId,
+
+    /// Fee rate the attempt was built at, in sat/vB.
+    pub fee_rate_sat_vb: u64,
+
+    /// Absolute fee the attempt pays, in satoshis.
+    pub fee_sats: u64,
+}
+
+/// One concrete transaction attempt in a logical replacement chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxAttempt {
+    /// Zero-based position of this attempt within its chain.
+    pub attempt_no: u32,
+
+    /// `consensus::serialize()` of the attempt transaction.
+    ///
+    /// Emptied once the attempt is `Replaced` or `Discarded`, since nothing rebroadcasts or
+    /// re-signs an attempt in either state and these bytes dominate a record's size.
+    pub raw_tx: Vec<u8>,
+
+    /// Transaction id of the attempt.
+    pub txid: L1TxId,
+
+    /// Witness transaction id of the attempt.
+    pub wtxid: L1WtxId,
+
+    /// Fee rate the attempt was built at, in sat/vB.
+    pub fee_rate_sat_vb: u64,
+
+    /// Absolute fee the attempt pays, in satoshis.
+    pub fee_sats: u64,
+
+    /// Wall-clock creation time, used only for operational logging.
+    pub created_at_unix_secs: u64,
+
+    /// L1 height at which the attempt was first observed as published.
+    pub first_published_l1_height: Option<L1Height>,
+
+    /// Lifecycle status of the attempt.
+    pub status: TxAttemptStatus,
+
+    /// Txid of the attempt that superseded this one.
+    pub replaced_by: Option<L1TxId>,
+}
+
+impl TxAttempt {
+    /// Creates an active attempt for a transaction.
+    pub fn active(parts: TxAttemptParts, attempt_no: u32) -> Self {
+        Self::new(parts, attempt_no, TxAttemptStatus::Active)
+    }
+
+    /// Creates an attempt that is waiting for an external reveal signature.
+    pub fn pending_signature(parts: TxAttemptParts, attempt_no: u32) -> Self {
+        Self::new(parts, attempt_no, TxAttemptStatus::PendingSignature)
+    }
+
+    /// Creates an attempt for a transaction with the provided status.
+    pub fn new(parts: TxAttemptParts, attempt_no: u32, status: TxAttemptStatus) -> Self {
+        Self {
+            attempt_no,
+            raw_tx: parts.raw_tx,
+            txid: parts.txid,
+            wtxid: parts.wtxid,
+            fee_rate_sat_vb: parts.fee_rate_sat_vb,
+            fee_sats: parts.fee_sats,
+            created_at_unix_secs: unix_secs_now(),
+            first_published_l1_height: None,
+            status,
+            replaced_by: None,
+        }
+    }
+
+    /// Drops the raw transaction bytes of an attempt that can no longer be broadcast.
+    ///
+    /// A record keeps every attempt of its chain forever, and `raw_tx` is by far the largest field
+    /// in one: a chunked EE-DA reveal carries its chunk payload in the witness, up to a few hundred
+    /// kilobytes. Retaining that for superseded attempts multiplies a record's size by its attempt
+    /// count, and the replacement pass loads every record it has. The metadata that outlives the
+    /// bytes — txid, wtxid, fee, status, `replaced_by` — is what the chain is actually reconstructed
+    /// and audited from.
+    ///
+    /// Only ever called on `Replaced` and `Discarded` attempts, and on every attempt of a chain
+    /// retired via [`TxNodeRecord::forget_all_raw_txs`]. Everything that deserializes an attempt
+    /// reads it through [`TxNodeRecord::active_attempt`] or
+    /// [`TxNodeRecord::pending_signature_attempt`], and neither can return a superseded or retired
+    /// one.
+    fn forget_raw_tx(&mut self) {
+        self.raw_tx = Vec::new();
+    }
+
+    fn refresh_tx(&mut self, parts: TxAttemptParts) {
+        self.raw_tx = parts.raw_tx;
+        self.txid = parts.txid;
+        self.wtxid = parts.wtxid;
+        self.fee_rate_sat_vb = parts.fee_rate_sat_vb;
+        self.fee_sats = parts.fee_sats;
+    }
+}
+
+/// Persistent replacement-chain record for one logical writer transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxNodeRecord {
+    /// Identifier derived from [`TxNodeRecord::kind`].
+    pub node_id: TxNodeId,
+
+    /// Logical transaction this chain publishes.
+    pub kind: TxNodeKind,
+
+    /// Txid of the attempt that is currently broadcastable.
+    pub active_txid: L1TxId,
+
+    /// Attempts in creation order.
+    pub attempts: Vec<TxAttempt>,
+
+    /// Set once the chain can no longer be bumped.
+    pub terminal_error: Option<TerminalError>,
+}
+
+impl TxNodeRecord {
+    /// Creates a replacement-chain record from its first active attempt.
+    pub fn new(kind: TxNodeKind, first_attempt: TxAttempt) -> Self {
+        let node_id = TxNodeId::from_kind(&kind);
+        let active_txid = first_attempt.txid;
+        Self {
+            node_id,
+            kind,
+            active_txid,
+            attempts: vec![first_attempt],
+            terminal_error: None,
+        }
+    }
+
+    /// Replaces the chain with a fresh initial attempt for the same logical node.
+    ///
+    /// Used when the underlying transaction is rebuilt from scratch rather than fee bumped, for
+    /// example when a chunked-envelope commit replacement forces its reveals to be regenerated.
+    pub fn replace_initial_attempt(&mut self, mut attempt: TxAttempt) {
+        attempt.attempt_no = 0;
+        attempt.status = TxAttemptStatus::Active;
+        self.active_txid = attempt.txid;
+        self.attempts = vec![attempt];
+        self.terminal_error = None;
+    }
+
+    /// Returns the active attempt.
+    pub fn active_attempt(&self) -> Option<&TxAttempt> {
+        self.attempts
+            .iter()
+            .find(|attempt| attempt.txid == self.active_txid)
+    }
+
+    /// Returns the mutable active attempt.
+    pub fn active_attempt_mut(&mut self) -> Option<&mut TxAttempt> {
+        let active_txid = self.active_txid;
+        self.attempts
+            .iter_mut()
+            .find(|attempt| attempt.txid == active_txid)
+    }
+
+    /// Returns the number of the next attempt to append to this chain.
+    pub fn next_attempt_no(&self) -> u32 {
+        self.attempts
+            .iter()
+            .map(|attempt| attempt.attempt_no)
+            .max()
+            .map(|highest| highest.saturating_add(1))
+            .unwrap_or(0)
+    }
+
+    /// Returns the pending externally-signed replacement attempt, if any.
+    ///
+    /// A chain with a pending attempt is skipped by the fee bumper until the signature arrives or
+    /// the attempt is discarded. There is deliberately no timeout: the previous attempt stays
+    /// active and broadcastable throughout, so a silent signer delays further bumping rather than
+    /// stalling publication.
+    pub fn pending_signature_attempt(&self) -> Option<&TxAttempt> {
+        self.attempts
+            .iter()
+            .rev()
+            .find(|attempt| attempt.status == TxAttemptStatus::PendingSignature)
+    }
+
+    /// Appends a replacement attempt and marks the previous active attempt as replaced.
+    pub fn append_replacement(&mut self, mut replacement: TxAttempt) {
+        if let Some(active) = self.active_attempt_mut() {
+            active.status = TxAttemptStatus::Replaced;
+            active.replaced_by = Some(replacement.txid);
+            active.forget_raw_tx();
+        }
+        replacement.status = TxAttemptStatus::Active;
+        self.active_txid = replacement.txid;
+        self.attempts.push(replacement);
+    }
+
+    /// Restores a superseded attempt that became the live transaction again.
+    ///
+    /// The broadcaster can reverse a replacement chain when a miner confirms an earlier attempt.
+    /// Superseded attempts normally discard their transaction bytes, so adopting one requires
+    /// restoring those bytes and fee metadata before making it active. The previous chain head is
+    /// marked as replaced by the adopted transaction.
+    ///
+    /// Returns `false` when the transaction in `parts` is not already present in this record.
+    pub fn restore_attempt_as_active(&mut self, parts: TxAttemptParts) -> bool {
+        let restored_txid = parts.txid;
+        let Some(restored_idx) = self
+            .attempts
+            .iter()
+            .position(|attempt| attempt.txid == restored_txid)
+        else {
+            return false;
+        };
+
+        if let Some(previous_active_idx) = self
+            .attempts
+            .iter()
+            .position(|attempt| attempt.txid == self.active_txid)
+        {
+            if previous_active_idx != restored_idx {
+                let previous_active = &mut self.attempts[previous_active_idx];
+                previous_active.status = TxAttemptStatus::Replaced;
+                previous_active.replaced_by = Some(restored_txid);
+                previous_active.forget_raw_tx();
+            }
+        }
+
+        let restored = &mut self.attempts[restored_idx];
+        restored.refresh_tx(parts);
+        restored.status = TxAttemptStatus::Active;
+        restored.replaced_by = None;
+        self.active_txid = restored_txid;
+        true
+    }
+
+    /// Appends a replacement attempt that still needs an external signature.
+    ///
+    /// The previous active attempt stays active, because the unsigned replacement cannot be
+    /// broadcast until the external signer returns its witness.
+    pub fn append_pending_signature_replacement(&mut self, mut replacement: TxAttempt) {
+        replacement.status = TxAttemptStatus::PendingSignature;
+        self.attempts
+            .retain(|attempt| attempt.status != TxAttemptStatus::PendingSignature);
+        self.attempts.push(replacement);
+    }
+
+    /// Activates the current pending-signature attempt after the final witness is attached.
+    ///
+    /// Returns whether a pending attempt was found and activated.
+    pub fn activate_pending_signature(&mut self, parts: TxAttemptParts) -> bool {
+        let Some(pending_idx) = self
+            .attempts
+            .iter()
+            .position(|attempt| attempt.status == TxAttemptStatus::PendingSignature)
+        else {
+            return false;
+        };
+
+        let previous_active_txid = self.active_txid;
+        self.attempts[pending_idx].refresh_tx(parts);
+        let active_txid = self.attempts[pending_idx].txid;
+
+        if let Some(active_idx) = self
+            .attempts
+            .iter()
+            .position(|attempt| attempt.txid == previous_active_txid)
+        {
+            self.attempts[active_idx].status = TxAttemptStatus::Replaced;
+            self.attempts[active_idx].replaced_by = Some(active_txid);
+            self.attempts[active_idx].forget_raw_tx();
+        }
+
+        self.attempts[pending_idx].status = TxAttemptStatus::Active;
+        self.active_txid = active_txid;
+        true
+    }
+
+    /// Discards any unsigned pending-signature replacement attempts.
+    ///
+    /// Returns whether anything was discarded.
+    pub fn discard_pending_signature_replacement(&mut self) -> bool {
+        let mut discarded = false;
+        for attempt in &mut self.attempts {
+            if attempt.status == TxAttemptStatus::PendingSignature {
+                attempt.status = TxAttemptStatus::Discarded;
+                attempt.forget_raw_tx();
+                discarded = true;
+            }
+        }
+        discarded
+    }
+
+    /// Marks the replacement chain permanently terminal.
+    pub fn set_terminal_error(&mut self, error: TerminalError) {
+        self.terminal_error = Some(error);
+    }
+
+    /// Drops the raw transaction bytes of every attempt in the chain.
+    ///
+    /// For a retired chain — one whose active transaction is finalized on L1 — nothing ever
+    /// rebroadcasts or re-signs any attempt again, active one included, so the bytes are dead
+    /// weight. The record itself is kept forever for crash-recovery point lookups, and without
+    /// this the active attempt of every finalized chain would retain its full serialized
+    /// transaction — for chunked EE-DA reveals a few hundred kilobytes each — growing the
+    /// broadcaster database without bound.
+    pub fn forget_all_raw_txs(&mut self) {
+        for attempt in &mut self.attempts {
+            attempt.forget_raw_tx();
+        }
+    }
+}
+
+/// Terminal reason that prevents further fee bumping for a logical transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum TerminalError {
+    /// The configured replacement budget for the chain is exhausted.
+    #[error("reached the configured maximum number of fee-bump attempts")]
+    MaxAttemptsReached,
+
+    /// The next replacement would exceed the configured fee-rate ceiling.
+    #[error("required fee rate is above the configured maximum")]
+    AboveMaxFeeRate,
+
+    /// BIP-125 rule 3/4 cannot be satisfied below the configured fee-rate ceiling.
+    #[error("BIP-125 replacement fee rules cannot be satisfied below the configured maximum")]
+    Bip125FeeRuleUnsatisfiable,
+
+    /// The wallet does not hold enough funds to pay for the replacement.
+    #[error("wallet has insufficient funds for the replacement")]
+    WalletInsufficient,
+
+    /// The replacement would push an output below the dust threshold.
+    #[error("replacement would create a dust output")]
+    ReplacementWouldDustOutput,
+
+    /// The logical transaction kind cannot be replaced in place.
+    #[error("transaction kind does not support RBF replacement")]
+    UnsupportedRbfKind,
+
+    /// The wallet funded the replacement with inputs the original did not spend.
+    ///
+    /// Not a funding shortfall. The wallet had spare UTXOs and pulled them in, but `psbtbumpfee`
+    /// returns a PSBT rather than committing it, so those inputs stay unlocked and a concurrent
+    /// envelope build could select the same one. Refusing is the conservative choice until
+    /// `lockunspent` is available.
+    #[error("replacement would spend wallet inputs the original did not")]
+    ReplacementAddsInputs,
+
+    /// The reveal cannot pay the required replacement fee while keeping its final output above dust.
+    #[error("reveal fee headroom is exhausted")]
+    RevealFeeHeadroomExhausted,
+}
+
+fn unix_secs_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("db: system time is after Unix epoch")
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn parts(seed: u8, fee_rate_sat_vb: u64, fee_sats: u64) -> TxAttemptParts {
+        TxAttemptParts {
+            raw_tx: vec![seed; 8],
+            txid: L1TxId::from([seed; 32]),
+            wtxid: L1WtxId::from([seed.wrapping_add(0x80); 32]),
+            fee_rate_sat_vb,
+            fee_sats,
+        }
+    }
+
+    fn record_with_initial_attempt(kind: TxNodeKind) -> TxNodeRecord {
+        let initial = TxAttempt::active(parts(1, 2, 100), 0);
+        TxNodeRecord::new(kind, initial)
+    }
+
+    #[test]
+    fn tx_node_id_matches_stable_vectors() {
+        #[rustfmt::skip]
+        let cases = [
+            (
+                TxNodeKind::SingleEnvelopeCommit { payload_idx: 7 },
+                [0x4d, 0xa7, 0xe7, 0x28, 0x05, 0x6f, 0x7e, 0xfe, 0x88, 0x49, 0x5d, 0x6a, 0x27, 0xe1, 0x3d, 0x3e, 0x23, 0xf0, 0x87, 0xb2, 0xaa, 0xf1, 0xa2, 0x8f, 0x64, 0xb8, 0xea, 0x26, 0xa4, 0x8a, 0x86, 0xa8],
+            ),
+            (
+                TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 },
+                [0x5b, 0x9a, 0x32, 0xfe, 0x9f, 0x33, 0xf0, 0x62, 0x6e, 0x9c, 0x55, 0xd9, 0xcb, 0xde, 0x3a, 0x19, 0xf5, 0x66, 0x6b, 0x98, 0x73, 0x00, 0x8b, 0xf6, 0x44, 0xb2, 0x59, 0xba, 0xfc, 0x57, 0x37, 0xd6],
+            ),
+            (
+                TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 7 },
+                [0xa2, 0x3d, 0xca, 0xbc, 0xbc, 0x04, 0xae, 0x74, 0xfb, 0x5b, 0xa2, 0xef, 0x83, 0xa7, 0xf2, 0xac, 0x49, 0x5d, 0x99, 0xb3, 0xb9, 0x14, 0x4e, 0xbd, 0x99, 0x70, 0xb4, 0x87, 0xaa, 0x49, 0x60, 0x60],
+            ),
+            (
+                TxNodeKind::ChunkedEnvelopeReveal { envelope_idx: 7, reveal_idx: 3 },
+                [0xa9, 0xf9, 0x2f, 0xe3, 0x9f, 0xde, 0x2f, 0xd1, 0x1c, 0x07, 0x4a, 0xef, 0x2e, 0x1f, 0x63, 0x8d, 0x0b, 0xca, 0x8d, 0xbf, 0x09, 0xb1, 0x2b, 0xce, 0x07, 0x37, 0xe1, 0xfc, 0xd3, 0xa4, 0x5e, 0xeb],
+            ),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(TxNodeId::from_kind(&kind), TxNodeId(Buf32(expected)));
+        }
+    }
+
+    #[test]
+    fn tx_node_id_separates_kinds_and_indices() {
+        let kinds = [
+            TxNodeKind::SingleEnvelopeCommit { payload_idx: 3 },
+            TxNodeKind::SingleEnvelopeCommit { payload_idx: 4 },
+            TxNodeKind::SingleEnvelopeReveal { payload_idx: 3 },
+            TxNodeKind::SingleEnvelopeReveal { payload_idx: 4 },
+            TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 3 },
+            TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 4 },
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: 3,
+                reveal_idx: 0,
+            },
+            TxNodeKind::ChunkedEnvelopeReveal {
+                envelope_idx: 3,
+                reveal_idx: 1,
+            },
+        ];
+        let ids = kinds
+            .iter()
+            .map(TxNodeId::from_kind)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), kinds.len());
+    }
+
+    #[test]
+    fn append_replacement_marks_previous_attempt_replaced() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeCommit { payload_idx: 7 });
+        let initial_txid = record.active_txid;
+        let replacement = TxAttempt::active(parts(2, 3, 200), record.next_attempt_no());
+        let replacement_txid = replacement.txid;
+
+        record.append_replacement(replacement);
+
+        assert_eq!(record.active_txid, replacement_txid);
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert_eq!(record.attempts[0].replaced_by, Some(replacement_txid));
+        assert_ne!(initial_txid, replacement_txid);
+        assert_eq!(record.next_attempt_no(), 2);
+    }
+
+    #[test]
+    fn restoring_superseded_attempt_rehydrates_and_activates_it() {
+        let original = parts(1, 2, 100);
+        let original_txid = original.txid;
+        let mut record = TxNodeRecord::new(
+            TxNodeKind::SingleEnvelopeCommit { payload_idx: 7 },
+            TxAttempt::active(original.clone(), 0),
+        );
+        let replacement = parts(2, 3, 200);
+        let replacement_txid = replacement.txid;
+        record.append_replacement(TxAttempt::active(replacement, 1));
+
+        assert!(record.attempts[0].raw_tx.is_empty());
+        assert!(record.restore_attempt_as_active(original.clone()));
+
+        let restored = record.active_attempt().expect("restored attempt is active");
+        assert_eq!(record.active_txid, original_txid);
+        assert_eq!(restored.status, TxAttemptStatus::Active);
+        assert_eq!(restored.replaced_by, None);
+        assert_eq!(restored.raw_tx, original.raw_tx);
+        assert_eq!(record.attempts[1].status, TxAttemptStatus::Replaced);
+        assert_eq!(record.attempts[1].replaced_by, Some(original_txid));
+        assert!(record.attempts[1].raw_tx.is_empty());
+        assert_ne!(original_txid, replacement_txid);
+    }
+
+    #[test]
+    fn pending_signature_replacement_keeps_previous_attempt_active() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let initial_txid = record.active_txid;
+        let replacement = TxAttempt::pending_signature(parts(2, 2, 200), 1);
+        let replacement_txid = replacement.txid;
+
+        record.append_pending_signature_replacement(replacement);
+
+        assert_eq!(record.active_txid, initial_txid);
+        assert_eq!(
+            record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+        assert_eq!(
+            record
+                .pending_signature_attempt()
+                .map(|attempt| attempt.txid),
+            Some(replacement_txid)
+        );
+        assert_eq!(record.attempts[0].replaced_by, None);
+    }
+
+    #[test]
+    fn pending_signature_attempt_becomes_active_after_signature() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let unsigned = parts(2, 2, 200);
+        record.append_pending_signature_replacement(TxAttempt::pending_signature(
+            unsigned.clone(),
+            1,
+        ));
+
+        // Attaching the witness keeps the txid but changes the bytes and wtxid.
+        let signed = TxAttemptParts {
+            raw_tx: vec![3; 12],
+            wtxid: L1WtxId::from([0xee; 32]),
+            fee_rate_sat_vb: 3,
+            fee_sats: 300,
+            ..unsigned
+        };
+        let signed_wtxid = signed.wtxid;
+        let activated = record.activate_pending_signature(signed);
+
+        let active = record.active_attempt().expect("active attempt");
+        assert!(activated);
+        assert_eq!(active.status, TxAttemptStatus::Active);
+        assert_eq!(active.fee_rate_sat_vb, 3);
+        assert_eq!(active.fee_sats, 300);
+        assert_eq!(active.wtxid, signed_wtxid);
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert_eq!(record.attempts[0].replaced_by, Some(active.txid));
+    }
+
+    #[test]
+    fn pending_signature_attempt_can_be_discarded() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let initial_txid = record.active_txid;
+        record.append_pending_signature_replacement(TxAttempt::pending_signature(
+            parts(2, 2, 200),
+            1,
+        ));
+
+        assert!(record.discard_pending_signature_replacement());
+
+        assert_eq!(record.active_txid, initial_txid);
+        assert_eq!(record.pending_signature_attempt(), None);
+        assert_eq!(record.attempts[1].status, TxAttemptStatus::Discarded);
+        assert!(record.attempts[1].raw_tx.is_empty());
+    }
+
+    /// A record keeps every attempt forever and the replacement pass loads every record, so an
+    /// attempt that can no longer be broadcast must not keep carrying its serialized transaction —
+    /// a chunked EE-DA reveal's is a few hundred kilobytes of witness.
+    #[test]
+    fn superseded_attempts_drop_their_raw_transaction() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 2 });
+        let replacement = TxAttempt::active(parts(2, 4, 200), 1);
+        let replacement_txid = replacement.txid;
+
+        record.append_replacement(replacement);
+
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert!(record.attempts[0].raw_tx.is_empty());
+        // The metadata the chain is reconstructed and audited from outlives the bytes.
+        assert_eq!(record.attempts[0].replaced_by, Some(replacement_txid));
+        assert_eq!(record.attempts[0].fee_sats, 100);
+        // The live attempt keeps its bytes: everything that rebroadcasts or re-signs reads them.
+        assert!(!record
+            .active_attempt()
+            .expect("replacement is active")
+            .raw_tx
+            .is_empty());
+    }
+
+    #[test]
+    fn activating_a_pending_signature_drops_the_superseded_attempt_bytes() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 4 });
+        record.append_pending_signature_replacement(TxAttempt::pending_signature(
+            parts(2, 3, 300),
+            1,
+        ));
+
+        assert!(record.activate_pending_signature(parts(2, 3, 320)));
+
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert!(record.attempts[0].raw_tx.is_empty());
+        assert!(!record
+            .active_attempt()
+            .expect("activated attempt is active")
+            .raw_tx
+            .is_empty());
+    }
+
+    /// A retired chain keeps its record forever, so every attempt — the active one included —
+    /// must shed its serialized transaction while the audit metadata survives.
+    #[test]
+    fn forgetting_all_raw_txs_strips_every_attempt_but_keeps_metadata() {
+        let mut record = record_with_initial_attempt(TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 5,
+            reveal_idx: 1,
+        });
+        record.append_replacement(TxAttempt::active(parts(2, 4, 200), 1));
+        let active_txid = record.active_txid;
+
+        record.forget_all_raw_txs();
+
+        assert!(record
+            .attempts
+            .iter()
+            .all(|attempt| attempt.raw_tx.is_empty()));
+        assert_eq!(record.active_txid, active_txid);
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert_eq!(record.attempts[0].replaced_by, Some(active_txid));
+        assert_eq!(record.attempts[1].status, TxAttemptStatus::Active);
+        assert_eq!(record.attempts[1].fee_sats, 200);
+    }
+
+    #[test]
+    fn replace_initial_attempt_clears_terminal_errors() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 1 });
+        record.set_terminal_error(TerminalError::MaxAttemptsReached);
+        let rebuilt = TxAttempt::active(parts(3, 5, 400), 9);
+        let rebuilt_txid = rebuilt.txid;
+
+        record.replace_initial_attempt(rebuilt);
+
+        assert_eq!(record.terminal_error, None);
+        assert_eq!(record.active_txid, rebuilt_txid);
+        assert_eq!(record.attempts.len(), 1);
+        assert_eq!(record.attempts[0].attempt_no, 0);
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Active);
+        assert_eq!(record.next_attempt_no(), 1);
+    }
+}

--- a/crates/db/types/src/fee_bump.rs
+++ b/crates/db/types/src/fee_bump.rs
@@ -1,0 +1,642 @@
+//! Persistent bookkeeping for writer-side fee bumping.
+//!
+//! A logical writer transaction (for example "the reveal tx of chunked envelope 3") can be
+//! published several times with increasing fee rates. Each concrete transaction is a
+//! [`TxAttempt`], and the ordered chain of attempts for one logical transaction is a
+//! [`TxNodeRecord`] keyed by a [`TxNodeId`] derived from its [`TxNodeKind`].
+//!
+//! Records are persisted with CBOR so new fields stay forward compatible. [`TxNodeId`] is
+//! deliberately derived from a Borsh encoding of the kind instead, because the key must stay
+//! byte-stable across releases and is independent of the value codec.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bitcoin::consensus::{self, deserialize, serialize};
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::{Amount, FeeRate, Transaction};
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use strata_identifiers::Buf32;
+use strata_primitives::L1Height;
+
+use crate::common::{L1TxId, L1WtxId};
+
+/// Domain separator for [`TxNodeId`] derivation.
+const TX_NODE_ID_DOMAIN: &[u8] = b"alpen.btcio.tx-node.v1";
+
+/// Deterministic identifier for one logical writer transaction replacement chain.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
+)]
+pub struct TxNodeId(pub Buf32);
+
+impl TxNodeId {
+    /// Derives a stable id from the logical transaction kind.
+    pub fn from_kind(kind: &TxNodeKind) -> Self {
+        let mut bytes = Vec::with_capacity(TX_NODE_ID_DOMAIN.len() + 64);
+        bytes.extend_from_slice(TX_NODE_ID_DOMAIN);
+        bytes.extend_from_slice(&borsh::to_vec(kind).expect("db: tx-node kind must serialize"));
+
+        Self(Buf32(sha256::Hash::hash(&bytes).to_byte_array()))
+    }
+}
+
+/// Logical BTCIO writer transaction kind.
+///
+/// The Borsh encoding of this enum feeds [`TxNodeId::from_kind`], so variants must only ever be
+/// appended and existing fields must not be reordered or retyped.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum TxNodeKind {
+    /// Commit transaction for a single-envelope payload row.
+    SingleEnvelopeCommit { payload_idx: u64 },
+    /// Reveal transaction for a single-envelope payload row.
+    SingleEnvelopeReveal { payload_idx: u64 },
+    /// Commit transaction for a chunked-envelope row.
+    ChunkedEnvelopeCommit { envelope_idx: u64 },
+    /// One reveal transaction for a chunked-envelope row.
+    ChunkedEnvelopeReveal { envelope_idx: u64, reveal_idx: u32 },
+}
+
+/// Replacement-attempt lifecycle within a logical transaction node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TxAttemptStatus {
+    /// The attempt is the currently broadcastable transaction.
+    Active,
+    /// The attempt has been superseded by another txid.
+    Replaced,
+    /// The attempt was abandoned before becoming active.
+    Discarded,
+    /// The attempt is waiting for an external reveal signature.
+    PendingSignature,
+}
+
+/// One concrete transaction attempt in a logical replacement chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxAttempt {
+    /// Zero-based position of this attempt within its chain.
+    pub attempt_no: u32,
+
+    /// `consensus::serialize()` of the attempt transaction.
+    ///
+    /// Emptied once the attempt is `Replaced` or `Discarded`, since nothing rebroadcasts or
+    /// re-signs an attempt in either state and these bytes dominate a record's size.
+    pub raw_tx: Vec<u8>,
+
+    /// Transaction id of the attempt.
+    pub txid: L1TxId,
+
+    /// Witness transaction id of the attempt.
+    pub wtxid: L1WtxId,
+
+    /// Fee rate the attempt was built at, in sat/vB.
+    pub fee_rate_sat_vb: u64,
+
+    /// Absolute fee the attempt pays, in satoshis.
+    pub fee_sats: u64,
+
+    /// Wall-clock creation time, used only for operational logging.
+    pub created_at_unix_secs: u64,
+
+    /// L1 height at which the attempt was first observed as published.
+    pub first_published_l1_height: Option<L1Height>,
+
+    /// Lifecycle status of the attempt.
+    pub status: TxAttemptStatus,
+
+    /// Txid of the attempt that superseded this one.
+    pub replaced_by: Option<L1TxId>,
+}
+
+impl TxAttempt {
+    /// Creates an active attempt for a transaction.
+    pub fn active(tx: &Transaction, fee_rate: FeeRate, fee_sats: Amount, attempt_no: u32) -> Self {
+        Self::new(tx, fee_rate, fee_sats, attempt_no, TxAttemptStatus::Active)
+    }
+
+    /// Creates an attempt that is waiting for an external reveal signature.
+    pub fn pending_signature(
+        tx: &Transaction,
+        fee_rate: FeeRate,
+        fee_sats: Amount,
+        attempt_no: u32,
+    ) -> Self {
+        Self::new(
+            tx,
+            fee_rate,
+            fee_sats,
+            attempt_no,
+            TxAttemptStatus::PendingSignature,
+        )
+    }
+
+    /// Creates an attempt for a transaction with the provided status.
+    pub fn new(
+        tx: &Transaction,
+        fee_rate: FeeRate,
+        fee_sats: Amount,
+        attempt_no: u32,
+        status: TxAttemptStatus,
+    ) -> Self {
+        Self {
+            attempt_no,
+            raw_tx: serialize(tx),
+            txid: L1TxId::from(tx.compute_txid().to_byte_array()),
+            wtxid: L1WtxId::from(tx.compute_wtxid().to_byte_array()),
+            fee_rate_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+            fee_sats: fee_sats.to_sat(),
+            created_at_unix_secs: unix_secs_now(),
+            first_published_l1_height: None,
+            status,
+            replaced_by: None,
+        }
+    }
+
+    /// Deserializes the raw transaction for this attempt.
+    pub fn try_to_tx(&self) -> Result<Transaction, consensus::encode::Error> {
+        deserialize(&self.raw_tx)
+    }
+
+    /// Returns the fee rate the attempt was built at.
+    pub fn fee_rate(&self) -> Option<FeeRate> {
+        FeeRate::from_sat_per_vb(self.fee_rate_sat_vb)
+    }
+
+    /// Returns the absolute fee the attempt pays.
+    pub fn fee(&self) -> Amount {
+        Amount::from_sat(self.fee_sats)
+    }
+
+    /// Drops the raw transaction bytes of an attempt that can no longer be broadcast.
+    ///
+    /// A record keeps every attempt of its chain forever, and `raw_tx` is by far the largest field
+    /// in one: a chunked EE-DA reveal carries its chunk payload in the witness, up to a few hundred
+    /// kilobytes. Retaining that for superseded attempts multiplies a record's size by its attempt
+    /// count, and the replacement pass loads every record it has. The metadata that outlives the
+    /// bytes — txid, wtxid, fee, status, `replaced_by` — is what the chain is actually reconstructed
+    /// and audited from.
+    ///
+    /// Only ever called on `Replaced` and `Discarded` attempts. Everything that deserializes an
+    /// attempt reads it through [`TxNodeRecord::active_attempt`] or
+    /// [`TxNodeRecord::pending_signature_attempt`], and neither can return one of those.
+    fn forget_raw_tx(&mut self) {
+        self.raw_tx = Vec::new();
+    }
+
+    fn refresh_tx(&mut self, tx: &Transaction, fee_rate: FeeRate, fee_sats: Amount) {
+        self.raw_tx = serialize(tx);
+        self.txid = L1TxId::from(tx.compute_txid().to_byte_array());
+        self.wtxid = L1WtxId::from(tx.compute_wtxid().to_byte_array());
+        self.fee_rate_sat_vb = fee_rate.to_sat_per_vb_ceil();
+        self.fee_sats = fee_sats.to_sat();
+    }
+}
+
+/// Persistent replacement-chain record for one logical writer transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxNodeRecord {
+    /// Identifier derived from [`TxNodeRecord::kind`].
+    pub node_id: TxNodeId,
+
+    /// Logical transaction this chain publishes.
+    pub kind: TxNodeKind,
+
+    /// Txid of the attempt that is currently broadcastable.
+    pub active_txid: L1TxId,
+
+    /// Attempts in creation order.
+    pub attempts: Vec<TxAttempt>,
+
+    /// Set once the chain can no longer be bumped.
+    pub terminal_error: Option<TerminalError>,
+}
+
+impl TxNodeRecord {
+    /// Creates a replacement-chain record from its first active attempt.
+    pub fn new(kind: TxNodeKind, first_attempt: TxAttempt) -> Self {
+        let node_id = TxNodeId::from_kind(&kind);
+        let active_txid = first_attempt.txid;
+        Self {
+            node_id,
+            kind,
+            active_txid,
+            attempts: vec![first_attempt],
+            terminal_error: None,
+        }
+    }
+
+    /// Replaces the chain with a fresh initial attempt for the same logical node.
+    ///
+    /// Used when the underlying transaction is rebuilt from scratch rather than fee bumped, for
+    /// example when a chunked-envelope commit replacement forces its reveals to be regenerated.
+    pub fn replace_initial_attempt(&mut self, mut attempt: TxAttempt) {
+        attempt.attempt_no = 0;
+        attempt.status = TxAttemptStatus::Active;
+        self.active_txid = attempt.txid;
+        self.attempts = vec![attempt];
+        self.terminal_error = None;
+    }
+
+    /// Returns the active attempt.
+    pub fn active_attempt(&self) -> Option<&TxAttempt> {
+        self.attempts
+            .iter()
+            .find(|attempt| attempt.txid == self.active_txid)
+    }
+
+    /// Returns the mutable active attempt.
+    pub fn active_attempt_mut(&mut self) -> Option<&mut TxAttempt> {
+        let active_txid = self.active_txid;
+        self.attempts
+            .iter_mut()
+            .find(|attempt| attempt.txid == active_txid)
+    }
+
+    /// Returns the number of the next attempt to append to this chain.
+    pub fn next_attempt_no(&self) -> u32 {
+        self.attempts
+            .iter()
+            .map(|attempt| attempt.attempt_no)
+            .max()
+            .map(|highest| highest.saturating_add(1))
+            .unwrap_or(0)
+    }
+
+    /// Returns the pending externally-signed replacement attempt, if any.
+    ///
+    /// A chain with a pending attempt is skipped by the fee bumper until the signature arrives or
+    /// the attempt is discarded. There is deliberately no timeout: the previous attempt stays
+    /// active and broadcastable throughout, so a silent signer delays further bumping rather than
+    /// stalling publication.
+    pub fn pending_signature_attempt(&self) -> Option<&TxAttempt> {
+        self.attempts
+            .iter()
+            .rev()
+            .find(|attempt| attempt.status == TxAttemptStatus::PendingSignature)
+    }
+
+    /// Appends a replacement attempt and marks the previous active attempt as replaced.
+    pub fn append_replacement(&mut self, mut replacement: TxAttempt) {
+        if let Some(active) = self.active_attempt_mut() {
+            active.status = TxAttemptStatus::Replaced;
+            active.replaced_by = Some(replacement.txid);
+            active.forget_raw_tx();
+        }
+        replacement.status = TxAttemptStatus::Active;
+        self.active_txid = replacement.txid;
+        self.attempts.push(replacement);
+    }
+
+    /// Appends a replacement attempt that still needs an external signature.
+    ///
+    /// The previous active attempt stays active, because the unsigned replacement cannot be
+    /// broadcast until the external signer returns its witness.
+    pub fn append_pending_signature_replacement(&mut self, mut replacement: TxAttempt) {
+        replacement.status = TxAttemptStatus::PendingSignature;
+        self.attempts
+            .retain(|attempt| attempt.status != TxAttemptStatus::PendingSignature);
+        self.attempts.push(replacement);
+    }
+
+    /// Activates the current pending-signature attempt after the final witness is attached.
+    ///
+    /// Returns whether a pending attempt was found and activated.
+    pub fn activate_pending_signature(
+        &mut self,
+        signed_tx: &Transaction,
+        fee_rate: FeeRate,
+        fee_sats: Amount,
+    ) -> bool {
+        let Some(pending_idx) = self
+            .attempts
+            .iter()
+            .position(|attempt| attempt.status == TxAttemptStatus::PendingSignature)
+        else {
+            return false;
+        };
+
+        let previous_active_txid = self.active_txid;
+        self.attempts[pending_idx].refresh_tx(signed_tx, fee_rate, fee_sats);
+        let active_txid = self.attempts[pending_idx].txid;
+
+        if let Some(active_idx) = self
+            .attempts
+            .iter()
+            .position(|attempt| attempt.txid == previous_active_txid)
+        {
+            self.attempts[active_idx].status = TxAttemptStatus::Replaced;
+            self.attempts[active_idx].replaced_by = Some(active_txid);
+            self.attempts[active_idx].forget_raw_tx();
+        }
+
+        self.attempts[pending_idx].status = TxAttemptStatus::Active;
+        self.active_txid = active_txid;
+        true
+    }
+
+    /// Discards any unsigned pending-signature replacement attempts.
+    ///
+    /// Returns whether anything was discarded.
+    pub fn discard_pending_signature_replacement(&mut self) -> bool {
+        let mut discarded = false;
+        for attempt in &mut self.attempts {
+            if attempt.status == TxAttemptStatus::PendingSignature {
+                attempt.status = TxAttemptStatus::Discarded;
+                attempt.forget_raw_tx();
+                discarded = true;
+            }
+        }
+        discarded
+    }
+
+    /// Marks the replacement chain permanently terminal.
+    pub fn set_terminal_error(&mut self, error: TerminalError) {
+        self.terminal_error = Some(error);
+    }
+}
+
+/// Terminal reason that prevents further fee bumping for a logical transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum TerminalError {
+    /// The configured replacement budget for the chain is exhausted.
+    #[error("reached the configured maximum number of fee-bump attempts")]
+    MaxAttemptsReached,
+
+    /// The next replacement would exceed the configured fee-rate ceiling.
+    #[error("required fee rate is above the configured maximum")]
+    AboveMaxFeeRate,
+
+    /// BIP-125 rule 3/4 cannot be satisfied below the configured fee-rate ceiling.
+    #[error("BIP-125 replacement fee rules cannot be satisfied below the configured maximum")]
+    Bip125FeeRuleUnsatisfiable,
+
+    /// The wallet does not hold enough funds to pay for the replacement.
+    #[error("wallet has insufficient funds for the replacement")]
+    WalletInsufficient,
+
+    /// The replacement would push an output below the dust threshold.
+    #[error("replacement would create a dust output")]
+    ReplacementWouldDustOutput,
+
+    /// The logical transaction kind cannot be replaced in place.
+    #[error("transaction kind does not support RBF replacement")]
+    UnsupportedRbfKind,
+
+    /// The wallet funded the replacement with inputs the original did not spend.
+    ///
+    /// Not a funding shortfall. The wallet had spare UTXOs and pulled them in, but `psbtbumpfee`
+    /// returns a PSBT rather than committing it, so those inputs stay unlocked and a concurrent
+    /// envelope build could select the same one. Refusing is the conservative choice until
+    /// `lockunspent` is available.
+    #[error("replacement would spend wallet inputs the original did not")]
+    ReplacementAddsInputs,
+
+    /// The reveal cannot pay the required replacement fee while keeping its final output above dust.
+    #[error("reveal fee headroom is exhausted")]
+    RevealFeeHeadroomExhausted,
+}
+
+fn unix_secs_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("db: system time is after Unix epoch")
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::absolute::LockTime;
+    use bitcoin::transaction::Version;
+    use bitcoin::{OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Witness};
+
+    use super::*;
+
+    fn tx_with_output(value: u64) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    fn fee_rate(sat_per_vb: u64) -> FeeRate {
+        FeeRate::from_sat_per_vb(sat_per_vb).expect("valid fee rate")
+    }
+
+    fn record_with_initial_attempt(kind: TxNodeKind) -> TxNodeRecord {
+        let initial = TxAttempt::active(
+            &tx_with_output(1_000),
+            fee_rate(2),
+            Amount::from_sat(100),
+            0,
+        );
+        TxNodeRecord::new(kind, initial)
+    }
+
+    #[test]
+    fn tx_node_id_is_stable_and_kind_separated() {
+        let commit = TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 3 };
+        let reveal = TxNodeKind::ChunkedEnvelopeReveal {
+            envelope_idx: 3,
+            reveal_idx: 0,
+        };
+
+        assert_eq!(TxNodeId::from_kind(&commit), TxNodeId::from_kind(&commit));
+        assert_ne!(TxNodeId::from_kind(&commit), TxNodeId::from_kind(&reveal));
+        assert_ne!(
+            TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeCommit { payload_idx: 3 }),
+            TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx: 3 }),
+        );
+    }
+
+    #[test]
+    fn append_replacement_marks_previous_attempt_replaced() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeCommit { payload_idx: 7 });
+        let initial_txid = record.active_txid;
+        let replacement = TxAttempt::active(
+            &tx_with_output(900),
+            fee_rate(3),
+            Amount::from_sat(200),
+            record.next_attempt_no(),
+        );
+        let replacement_txid = replacement.txid;
+
+        record.append_replacement(replacement);
+
+        assert_eq!(record.active_txid, replacement_txid);
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert_eq!(record.attempts[0].replaced_by, Some(replacement_txid));
+        assert_ne!(initial_txid, replacement_txid);
+        assert_eq!(record.next_attempt_no(), 2);
+    }
+
+    #[test]
+    fn pending_signature_replacement_keeps_previous_attempt_active() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let initial_txid = record.active_txid;
+        let replacement = TxAttempt::pending_signature(
+            &tx_with_output(900),
+            fee_rate(2),
+            Amount::from_sat(200),
+            1,
+        );
+        let replacement_txid = replacement.txid;
+
+        record.append_pending_signature_replacement(replacement);
+
+        assert_eq!(record.active_txid, initial_txid);
+        assert_eq!(
+            record.active_attempt().map(|attempt| attempt.status),
+            Some(TxAttemptStatus::Active)
+        );
+        assert_eq!(
+            record
+                .pending_signature_attempt()
+                .map(|attempt| attempt.txid),
+            Some(replacement_txid)
+        );
+        assert_eq!(record.attempts[0].replaced_by, None);
+    }
+
+    #[test]
+    fn pending_signature_attempt_becomes_active_after_signature() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let unsigned = tx_with_output(900);
+        record.append_pending_signature_replacement(TxAttempt::pending_signature(
+            &unsigned,
+            fee_rate(2),
+            Amount::from_sat(200),
+            1,
+        ));
+
+        let mut signed = unsigned;
+        signed.input[0].witness.push([1u8; 64]);
+        let activated =
+            record.activate_pending_signature(&signed, fee_rate(3), Amount::from_sat(300));
+
+        let active = record.active_attempt().expect("active attempt");
+        assert!(activated);
+        assert_eq!(active.status, TxAttemptStatus::Active);
+        assert_eq!(active.fee_rate_sat_vb, 3);
+        assert_eq!(active.fee_sats, 300);
+        assert_eq!(
+            active.wtxid,
+            L1WtxId::from(signed.compute_wtxid().to_byte_array())
+        );
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert_eq!(record.attempts[0].replaced_by, Some(active.txid));
+    }
+
+    #[test]
+    fn pending_signature_attempt_can_be_discarded() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 7 });
+        let initial_txid = record.active_txid;
+        record.append_pending_signature_replacement(TxAttempt::pending_signature(
+            &tx_with_output(900),
+            fee_rate(2),
+            Amount::from_sat(200),
+            1,
+        ));
+
+        assert!(record.discard_pending_signature_replacement());
+
+        assert_eq!(record.active_txid, initial_txid);
+        assert_eq!(record.pending_signature_attempt(), None);
+        assert_eq!(record.attempts[1].status, TxAttemptStatus::Discarded);
+        assert!(record.attempts[1].raw_tx.is_empty());
+    }
+
+    /// A record keeps every attempt forever and the replacement pass loads every record, so an
+    /// attempt that can no longer be broadcast must not keep carrying its serialized transaction —
+    /// a chunked EE-DA reveal's is a few hundred kilobytes of witness.
+    #[test]
+    fn superseded_attempts_drop_their_raw_transaction() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 2 });
+        let replacement =
+            TxAttempt::active(&tx_with_output(900), fee_rate(4), Amount::from_sat(200), 1);
+        let replacement_txid = replacement.txid;
+
+        record.append_replacement(replacement);
+
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert!(record.attempts[0].raw_tx.is_empty());
+        // The metadata the chain is reconstructed and audited from outlives the bytes.
+        assert_eq!(record.attempts[0].replaced_by, Some(replacement_txid));
+        assert_eq!(record.attempts[0].fee_sats, 100);
+        // The live attempt keeps its bytes: everything that rebroadcasts or re-signs reads them.
+        assert!(record
+            .active_attempt()
+            .expect("replacement is active")
+            .try_to_tx()
+            .is_ok());
+    }
+
+    #[test]
+    fn activating_a_pending_signature_drops_the_superseded_attempt_bytes() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::SingleEnvelopeReveal { payload_idx: 4 });
+        record.append_pending_signature_replacement(TxAttempt::pending_signature(
+            &tx_with_output(900),
+            fee_rate(3),
+            Amount::from_sat(300),
+            1,
+        ));
+
+        assert!(record.activate_pending_signature(
+            &tx_with_output(880),
+            fee_rate(3),
+            Amount::from_sat(320)
+        ));
+
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Replaced);
+        assert!(record.attempts[0].raw_tx.is_empty());
+        assert!(record
+            .active_attempt()
+            .expect("activated attempt is active")
+            .try_to_tx()
+            .is_ok());
+    }
+
+    #[test]
+    fn replace_initial_attempt_clears_terminal_errors() {
+        let mut record =
+            record_with_initial_attempt(TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 1 });
+        record.set_terminal_error(TerminalError::MaxAttemptsReached);
+        let rebuilt =
+            TxAttempt::active(&tx_with_output(800), fee_rate(5), Amount::from_sat(400), 9);
+        let rebuilt_txid = rebuilt.txid;
+
+        record.replace_initial_attempt(rebuilt);
+
+        assert_eq!(record.terminal_error, None);
+        assert_eq!(record.active_txid, rebuilt_txid);
+        assert_eq!(record.attempts.len(), 1);
+        assert_eq!(record.attempts[0].attempt_no, 0);
+        assert_eq!(record.attempts[0].status, TxAttemptStatus::Active);
+        assert_eq!(record.next_attempt_no(), 1);
+    }
+}

--- a/crates/db/types/src/l1_broadcast.rs
+++ b/crates/db/types/src/l1_broadcast.rs
@@ -11,6 +11,8 @@ use strata_db_macros::gen_proxy;
 use strata_identifiers::Buf32;
 use strata_primitives::L1Height;
 
+use crate::common::L1TxId;
+use crate::fee_bump::{TxNodeId, TxNodeRecord};
 #[cfg(feature = "proxies")]
 use crate::DbError;
 use crate::DbResult;
@@ -25,6 +27,13 @@ pub struct L1TxEntry {
 
     /// The status of the transaction in bitcoin
     pub status: L1TxStatus,
+
+    /// Metadata used by writer-side RBF replacement logic.
+    ///
+    /// Only set for writer-owned entries published while fee bumping is enabled; `None` for every
+    /// other entry, including ones written before fee bumping existed.
+    #[serde(default)]
+    pub rbf: Option<L1TxRbfInfo>,
 }
 
 impl L1TxEntry {
@@ -36,6 +45,25 @@ impl L1TxEntry {
         Self {
             tx_raw,
             status: L1TxStatus::Unpublished,
+            rbf: None,
+        }
+    }
+
+    /// Records that this entry replaced `original_txid`.
+    ///
+    /// A no-op for an entry with no RBF metadata, which is never part of a replacement chain.
+    pub fn set_replaces(&mut self, original_txid: L1TxId) {
+        if let Some(rbf) = self.rbf.as_mut() {
+            rbf.replaces = Some(original_txid);
+        }
+    }
+
+    /// Creates an entry from persisted raw transaction bytes and metadata.
+    pub fn from_raw_parts(tx_raw: Vec<u8>, status: L1TxStatus, rbf: Option<L1TxRbfInfo>) -> Self {
+        Self {
+            tx_raw,
+            status,
+            rbf,
         }
     }
 
@@ -45,12 +73,43 @@ impl L1TxEntry {
     }
 
     pub fn is_valid(&self) -> bool {
-        !matches!(self.status, L1TxStatus::InvalidInputs)
+        !matches!(
+            self.status,
+            L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. }
+        )
     }
 
     pub fn is_finalized(&self) -> bool {
         matches!(self.status, L1TxStatus::Finalized { .. })
     }
+}
+
+/// RBF metadata for one concrete broadcast transaction.
+///
+/// Replacement bookkeeping (attempt history, publication height, terminal errors) lives on the
+/// [`TxNodeRecord`] for the logical transaction. This entry-level record only carries what the
+/// broadcast row itself needs: the fee rate the transaction was built at, which seeds the
+/// tx-node's first attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Arbitrary, Serialize, Deserialize)]
+pub struct L1TxRbfInfo {
+    /// Fee rate used to construct this transaction in sat/vB.
+    pub fee_rate_sat_vb: u64,
+
+    /// Absolute fee this transaction pays, in satoshis.
+    ///
+    /// Recorded rather than derived: for chunked commits the builder absorbs sub-dust change into
+    /// the fee, so `fee_rate_sat_vb * vsize` under-reports it, and the BIP-125 absolute-fee floor
+    /// for a replacement is computed from this value.
+    pub fee_sats: u64,
+
+    /// The transaction this one replaced, if it is itself a replacement.
+    ///
+    /// [`L1TxStatus::Replaced`] only links forward, which is all the live-entry lookup needs. This
+    /// is the reverse link, and it exists for one case: a superseded ancestor that gets mined
+    /// anyway. Bitcoin Core then reports negative confirmations for the replacement, and without a
+    /// way back through the chain there is no way to find out which transaction actually won.
+    #[serde(default)]
+    pub replaces: Option<L1TxId>,
 }
 
 /// The possible statuses of a publishable transaction
@@ -85,6 +144,12 @@ pub enum L1TxStatus {
 
     /// The transaction is not included in L1 because it's inputs were invalid
     InvalidInputs,
+
+    /// The transaction has been superseded by an RBF replacement.
+    Replaced {
+        /// Replacement transaction id.
+        by: L1TxId,
+    },
 }
 
 impl fmt::Display for L1TxStatus {
@@ -113,6 +178,7 @@ impl fmt::Display for L1TxStatus {
                 )
             }
             Self::InvalidInputs => f.write_str("invalid_inputs"),
+            Self::Replaced { by } => write!(f, "replaced_by({by})"),
         }
     }
 }
@@ -155,6 +221,91 @@ pub trait L1BroadcastDatabase: Send + Sync + 'static {
 
     /// Get last broadcast entry
     fn get_last_tx_entry(&self) -> DbResult<Option<L1TxEntry>>;
+
+    /// Atomically inserts `replacement` and marks `original_txid` as superseded by it.
+    ///
+    /// Both rows live in the broadcast tree, so the insert and the transition happen in one
+    /// transaction. Doing them separately leaves a window where the replacement exists, and can be
+    /// broadcast, with nothing linking it back to the transaction it supersedes.
+    ///
+    /// The transition follows the same eligibility rule as
+    /// [`try_mark_tx_entry_replaced`](Self::try_mark_tx_entry_replaced). Returns the replacement's
+    /// broadcast index when the swap applied, or `None` when the original was no longer
+    /// replaceable, in which case nothing is written.
+    fn put_replacement_tx_entry(
+        &self,
+        original_txid: Buf32,
+        replacement_txid: Buf32,
+        replacement: L1TxEntry,
+    ) -> DbResult<Option<u64>>;
+
+    /// Atomically marks `txid` as superseded by `replacement_txid`.
+    ///
+    /// The transition only applies to an entry that is still awaiting inclusion
+    /// ([`L1TxStatus::Unpublished`] or [`L1TxStatus::Published`]); a transaction that already
+    /// confirmed has won and is left untouched. Read and write happen in one transaction so a
+    /// concurrent confirmation cannot be clobbered.
+    ///
+    /// Returns whether the entry was transitioned.
+    fn try_mark_tx_entry_replaced(&self, txid: Buf32, replacement_txid: L1TxId) -> DbResult<bool>;
+
+    /// Atomically reverses a replacement after the superseded transaction won on-chain.
+    ///
+    /// A miner can include an original after the local node accepted its replacement. The
+    /// replacement can then never confirm, and the ancestor that did is still marked
+    /// [`L1TxStatus::Replaced`], so the live-entry lookup walks straight past it.
+    ///
+    /// This repoints the chain at the winner: `winner_txid` takes `winner_status`, and `loser_txid`
+    /// becomes `Replaced { by: winner_txid }`. Both writes commit together because the intermediate
+    /// state is a cycle, which would make the lookup exhaust its hop budget and fail.
+    ///
+    /// The winner may sit anywhere in the loser's ancestry, not just one hop back: a chain bumped
+    /// several times has intermediate attempts between them and a miner can include any of them.
+    /// Intermediates keep their forward links, which still resolve to the winner through the
+    /// reversed one.
+    ///
+    /// Returns whether the reversal applied; `false` when either row is missing, when the winner's
+    /// replacement chain does not reach the loser, or when the loser has already left
+    /// `Unpublished`/`Published`, so nothing is written. That last case means a concurrent
+    /// replacement superseded the loser while this adoption was deciding, and reversing over it
+    /// would cut the replacement out of the chain while it stays indexed and broadcastable.
+    fn adopt_confirmed_ancestor(
+        &self,
+        loser_txid: Buf32,
+        winner_txid: Buf32,
+        winner_status: L1TxStatus,
+    ) -> DbResult<bool>;
+
+    /// Stores a logical transaction replacement-chain record.
+    ///
+    /// Also maintains the active-set index behind
+    /// [`get_active_tx_nodes`](Self::get_active_tx_nodes): a record without a terminal error
+    /// enters the set, a record with one leaves it. Record and membership commit together, so a
+    /// crash cannot leave a live chain outside the set the replacement pass scans.
+    fn put_tx_node(&self, node_id: TxNodeId, record: TxNodeRecord) -> DbResult<()>;
+
+    /// Fetches a logical transaction replacement-chain record by id.
+    fn get_tx_node(&self, node_id: TxNodeId) -> DbResult<Option<TxNodeRecord>>;
+
+    /// Fetches all logical transaction replacement-chain records.
+    fn get_all_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>>;
+
+    /// Fetches the replacement-chain records that may still need fee bumping.
+    ///
+    /// This is the bounded read the replacement pass scans instead of
+    /// [`get_all_tx_nodes`](Self::get_all_tx_nodes): membership is maintained by
+    /// [`put_tx_node`](Self::put_tx_node) and [`retire_tx_node`](Self::retire_tx_node), so
+    /// historical chains whose transaction finalized are not decoded on every pass.
+    fn get_active_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>>;
+
+    /// Removes a record from the active set once its chain needs no further fee bumping.
+    ///
+    /// Guarded on `expected_active_txid`: a concurrent writer rebuild installs a fresh attempt
+    /// under a new txid, and retiring over it would silently stop bumping a live chain. The
+    /// record itself stays readable through [`get_tx_node`](Self::get_tx_node).
+    ///
+    /// Returns whether the record was retired.
+    fn retire_tx_node(&self, node_id: TxNodeId, expected_active_txid: L1TxId) -> DbResult<bool>;
 }
 
 #[cfg(test)]
@@ -185,6 +336,10 @@ mod tests {
                 r#"{"status":"finalized","confirmations":100,"block_hash":"0000000000000000000000000000000000000000000000000000000000000000","block_height":42}"#,
             ),
             (L1TxStatus::InvalidInputs, r#"{"status":"invalidinputs"}"#),
+            (
+                L1TxStatus::Replaced { by: L1TxId::zero() },
+                r#"{"status":"replaced","by":"0000000000000000000000000000000000000000000000000000000000000000"}"#,
+            ),
         ];
 
         // check serialization and deserialization

--- a/crates/db/types/src/l1_broadcast.rs
+++ b/crates/db/types/src/l1_broadcast.rs
@@ -91,7 +91,14 @@ impl L1TxEntry {
         deserialize(&self.tx_raw)
     }
 
-    pub fn is_valid(&self) -> bool {
+    /// Reports whether the broadcaster should keep polling this entry under its own txid.
+    ///
+    /// `InvalidInputs` is dead: the inputs are gone and nothing can bring the transaction back.
+    /// `Replaced` is not dead, but it is no longer the chain's head, so it is followed through
+    /// the replacement rather than polled directly. A superseded transaction that a miner
+    /// includes anyway is recovered by `adopt_live_ancestor`, which reverses the link and
+    /// re-admits the winner.
+    pub fn is_trackable(&self) -> bool {
         !matches!(
             self.status,
             L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. }

--- a/crates/db/types/src/l1_broadcast.rs
+++ b/crates/db/types/src/l1_broadcast.rs
@@ -72,7 +72,14 @@ impl L1TxEntry {
         &self.tx_raw
     }
 
-    pub fn is_valid(&self) -> bool {
+    /// Reports whether the broadcaster should keep polling this entry under its own txid.
+    ///
+    /// `InvalidInputs` is dead: the inputs are gone and nothing can bring the transaction back.
+    /// `Replaced` is not dead, but it is no longer the chain's head, so it is followed through
+    /// the replacement rather than polled directly. A superseded transaction that a miner
+    /// includes anyway is recovered by `adopt_live_ancestor`, which reverses the link and
+    /// re-admits the winner.
+    pub fn is_trackable(&self) -> bool {
         !matches!(
             self.status,
             L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. }

--- a/crates/db/types/src/l1_broadcast.rs
+++ b/crates/db/types/src/l1_broadcast.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use arbitrary::Arbitrary;
 use bitcoin::consensus::{self, deserialize, serialize};
-use bitcoin::Transaction;
+use bitcoin::{Amount, FeeRate, Transaction};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "proxies")]
@@ -12,21 +12,27 @@ use strata_db_macros::gen_proxy;
 use strata_identifiers::Buf32;
 use strata_primitives::L1Height;
 
+use crate::common::L1TxId;
+use crate::fee_bump::{TxNodeId, TxNodeRecord};
 #[cfg(feature = "proxies")]
 use crate::DbError;
 use crate::DbResult;
 
 /// This is the entry that gets saved to the database corresponding to a bitcoin transaction that
 /// the broadcaster will publish and watches for until finalization
-#[derive(
-    Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, Arbitrary, Serialize, Deserialize)]
 pub struct L1TxEntry {
     /// Raw serialized transaction. This is basically `consensus::serialize()` of [`Transaction`]
     tx_raw: Vec<u8>,
 
     /// The status of the transaction in bitcoin
     pub status: L1TxStatus,
+
+    /// Metadata used by writer-side RBF replacement logic.
+    ///
+    /// Only set for writer-owned entries published while fee bumping is enabled; `None` for every
+    /// other entry, including ones written before fee bumping existed.
+    pub rbf: Option<L1TxRbfInfo>,
 }
 
 impl L1TxEntry {
@@ -35,6 +41,38 @@ impl L1TxEntry {
         Self {
             tx_raw: serialize(tx),
             status: L1TxStatus::Unpublished,
+            rbf: None,
+        }
+    }
+
+    /// Creates a writer-owned [`L1TxEntry`] carrying the RBF metadata for `fee_rate` and `fee`.
+    pub fn from_tx_with_fee(tx: &Transaction, fee_rate: FeeRate, fee: Amount) -> Self {
+        Self {
+            tx_raw: serialize(tx),
+            status: L1TxStatus::Unpublished,
+            rbf: Some(L1TxRbfInfo {
+                fee_rate_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+                fee_sats: fee.to_sat(),
+                replaces: None,
+            }),
+        }
+    }
+
+    /// Records that this entry replaced `original_txid`.
+    ///
+    /// A no-op for an entry with no RBF metadata, which is never part of a replacement chain.
+    pub fn set_replaces(&mut self, original_txid: L1TxId) {
+        if let Some(rbf) = self.rbf.as_mut() {
+            rbf.replaces = Some(original_txid);
+        }
+    }
+
+    /// Creates an entry from persisted raw transaction bytes and metadata.
+    pub fn from_raw_parts(tx_raw: Vec<u8>, status: L1TxStatus, rbf: Option<L1TxRbfInfo>) -> Self {
+        Self {
+            tx_raw,
+            status,
+            rbf,
         }
     }
 
@@ -54,12 +92,54 @@ impl L1TxEntry {
     }
 
     pub fn is_valid(&self) -> bool {
-        !matches!(self.status, L1TxStatus::InvalidInputs)
+        !matches!(
+            self.status,
+            L1TxStatus::InvalidInputs | L1TxStatus::Replaced { .. }
+        )
     }
 
     pub fn is_finalized(&self) -> bool {
         matches!(self.status, L1TxStatus::Finalized { .. })
     }
+}
+
+/// RBF metadata for one concrete broadcast transaction.
+///
+/// Replacement bookkeeping (attempt history, publication height, terminal errors) lives on the
+/// [`TxNodeRecord`] for the logical transaction. This entry-level record only carries what the
+/// broadcast row itself needs: the fee rate the transaction was built at, which seeds the
+/// tx-node's first attempt.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    Arbitrary,
+    Serialize,
+    Deserialize,
+)]
+pub struct L1TxRbfInfo {
+    /// Fee rate used to construct this transaction in sat/vB.
+    pub fee_rate_sat_vb: u64,
+
+    /// Absolute fee this transaction pays, in satoshis.
+    ///
+    /// Recorded rather than derived: for chunked commits the builder absorbs sub-dust change into
+    /// the fee, so `fee_rate_sat_vb * vsize` under-reports it, and the BIP-125 absolute-fee floor
+    /// for a replacement is computed from this value.
+    pub fee_sats: u64,
+
+    /// The transaction this one replaced, if it is itself a replacement.
+    ///
+    /// [`L1TxStatus::Replaced`] only links forward, which is all the live-entry lookup needs. This
+    /// is the reverse link, and it exists for one case: a superseded ancestor that gets mined
+    /// anyway. Bitcoin Core then reports negative confirmations for the replacement, and without a
+    /// way back through the chain there is no way to find out which transaction actually won.
+    #[serde(default)]
+    pub replaces: Option<L1TxId>,
 }
 
 /// The possible statuses of a publishable transaction
@@ -94,6 +174,12 @@ pub enum L1TxStatus {
 
     /// The transaction is not included in L1 because it's inputs were invalid
     InvalidInputs,
+
+    /// The transaction has been superseded by an RBF replacement.
+    Replaced {
+        /// Replacement transaction id.
+        by: L1TxId,
+    },
 }
 
 impl fmt::Display for L1TxStatus {
@@ -122,6 +208,7 @@ impl fmt::Display for L1TxStatus {
                 )
             }
             Self::InvalidInputs => f.write_str("invalid_inputs"),
+            Self::Replaced { by } => write!(f, "replaced_by({by})"),
         }
     }
 }
@@ -164,6 +251,69 @@ pub trait L1BroadcastDatabase: Send + Sync + 'static {
 
     /// Get last broadcast entry
     fn get_last_tx_entry(&self) -> DbResult<Option<L1TxEntry>>;
+
+    /// Atomically inserts `replacement` and marks `original_txid` as superseded by it.
+    ///
+    /// Both rows live in the broadcast tree, so the insert and the transition happen in one
+    /// transaction. Doing them separately leaves a window where the replacement exists, and can be
+    /// broadcast, with nothing linking it back to the transaction it supersedes.
+    ///
+    /// The transition follows the same eligibility rule as
+    /// [`try_mark_tx_entry_replaced`](Self::try_mark_tx_entry_replaced). Returns the replacement's
+    /// broadcast index when the swap applied, or `None` when the original was no longer
+    /// replaceable, in which case nothing is written.
+    fn put_replacement_tx_entry(
+        &self,
+        original_txid: Buf32,
+        replacement_txid: Buf32,
+        replacement: L1TxEntry,
+    ) -> DbResult<Option<u64>>;
+
+    /// Atomically marks `txid` as superseded by `replacement_txid`.
+    ///
+    /// The transition only applies to an entry that is still awaiting inclusion
+    /// ([`L1TxStatus::Unpublished`] or [`L1TxStatus::Published`]); a transaction that already
+    /// confirmed has won and is left untouched. Read and write happen in one transaction so a
+    /// concurrent confirmation cannot be clobbered.
+    ///
+    /// Returns whether the entry was transitioned.
+    fn try_mark_tx_entry_replaced(&self, txid: Buf32, replacement_txid: L1TxId) -> DbResult<bool>;
+
+    /// Atomically reverses a replacement after the superseded transaction won on-chain.
+    ///
+    /// A miner can include an original after the local node accepted its replacement. The
+    /// replacement can then never confirm, and the ancestor that did is still marked
+    /// [`L1TxStatus::Replaced`], so the live-entry lookup walks straight past it.
+    ///
+    /// This repoints the chain at the winner: `winner_txid` takes `winner_status`, and `loser_txid`
+    /// becomes `Replaced { by: winner_txid }`. Both writes commit together because the intermediate
+    /// state is a cycle, which would make the lookup exhaust its hop budget and fail.
+    ///
+    /// The winner may sit anywhere in the loser's ancestry, not just one hop back: a chain bumped
+    /// several times has intermediate attempts between them and a miner can include any of them.
+    /// Intermediates keep their forward links, which still resolve to the winner through the
+    /// reversed one.
+    ///
+    /// Returns whether the reversal applied; `false` when either row is missing, when the winner's
+    /// replacement chain does not reach the loser, or when the loser has already left
+    /// `Unpublished`/`Published`, so nothing is written. That last case means a concurrent
+    /// replacement superseded the loser while this adoption was deciding, and reversing over it
+    /// would cut the replacement out of the chain while it stays indexed and broadcastable.
+    fn adopt_confirmed_ancestor(
+        &self,
+        loser_txid: Buf32,
+        winner_txid: Buf32,
+        winner_status: L1TxStatus,
+    ) -> DbResult<bool>;
+
+    /// Stores a logical transaction replacement-chain record.
+    fn put_tx_node(&self, node_id: TxNodeId, record: TxNodeRecord) -> DbResult<()>;
+
+    /// Fetches a logical transaction replacement-chain record by id.
+    fn get_tx_node(&self, node_id: TxNodeId) -> DbResult<Option<TxNodeRecord>>;
+
+    /// Fetches all logical transaction replacement-chain records.
+    fn get_all_tx_nodes(&self) -> DbResult<Vec<TxNodeRecord>>;
 }
 
 #[cfg(test)]
@@ -194,6 +344,10 @@ mod tests {
                 r#"{"status":"Finalized","confirmations":100,"block_hash":"0000000000000000000000000000000000000000000000000000000000000000","block_height":42}"#,
             ),
             (L1TxStatus::InvalidInputs, r#"{"status":"InvalidInputs"}"#),
+            (
+                L1TxStatus::Replaced { by: L1TxId::zero() },
+                r#"{"status":"Replaced","by":"0000000000000000000000000000000000000000000000000000000000000000"}"#,
+            ),
         ];
 
         // check serialization and deserialization

--- a/crates/db/types/src/lib.rs
+++ b/crates/db/types/src/lib.rs
@@ -7,6 +7,7 @@ pub mod chunked_envelope;
 pub mod client_state;
 pub mod common;
 pub mod errors;
+pub mod fee_bump;
 pub mod l1;
 pub mod l1_broadcast;
 pub mod l1_writer;

--- a/crates/ol/block-assembly/src/builder.rs
+++ b/crates/ol/block-assembly/src/builder.rs
@@ -92,7 +92,7 @@ where
     <P::State as IStateAccessorMut>::AccountStateMut: Clone,
     <<P::State as IStateAccessorMut>::AccountStateMut as IAccountStateMut>::SnarkAccountStateMut:
             Clone,
-    {
+{
         let context = Arc::new(BlockAssemblyContext::new(
             self.storage,
             self.mempool_provider,


### PR DESCRIPTION
## Description

Adds RBF fee bumping for writer-published Bitcoin transactions. It is always on.

The writer records each logical transaction it publishes (single-envelope commit/reveal, chunked commit, each chunked reveal) as a replacement chain in a new broadcaster DB tree. Once a chain has sat unconfirmed for longer than `min_age_blocks`, a higher-fee replacement is built and handed to the broadcaster.

Replacement is not a service. It runs as one pass inside each writer's existing watcher tick, rate-limited to `check_interval_ms` so it does not run at the tick's much faster cadence. The policy that decides a transaction has gone stale lives in `broadcaster/fee_bump.rs`, next to the loop that already watches unfinalized transactions. Building and re-signing lives in `writer/replacement/`, because that is where the commit/reveal structure and the keys are.

Chunked EE DA follows the post-#1751 commit/reveal split. A commit can only be replaced while the envelope is still commit-only, because replacing it changes the commit txid and would invalidate every reveal spending its outputs. Once any reveal reaches the broadcaster the commit is fixed and reveals are bumped one at a time.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Config change

```toml
[btcio.writer.fee_bumping]
check_interval_ms = 30_000
min_age_blocks = 2
max_attempts = 5
multiplier_bps = 12_500
min_fee_rate_delta_sat_vb = 1
max_fee_rate_sat_vb = 1_000
```

`multiplier_bps` must be at least `10_000` so a replacement never lowers the active fee rate, which would be invalid for BIP-125. The table now rejects unknown keys, so a config still carrying `policy = "disabled"` fails to load instead of quietly reading as "off". Nothing in the repo sets these today, so no existing config or functional test needed updating.

## Notes to reviewers

RBF is the only policy. CPFP and hybrid are out of scope.

This removes the doubling of fee rate estimates we had as a safeguard. Because bumping is now unconditional there is no configuration that loses its safety net in the process.

In-process (`AlwaysAccept`) checkpoints cannot be bumped at all: `build_and_sign_envelope_txs` signs the reveal with a throwaway keypair that is never persisted, so no replacement can be re-signed under the same tapscript. Once the predicate rotates to `Bip340Schnorr` the external path writes a reveal tx-node and bumping starts working on its own.

Single-envelope commit RBF is unreachable by construction. The checkpoint writer stores a payload's commit and reveal broadcast rows in the same call, so there is no commit-only phase to bump in. Bumping the reveal is what unsticks a checkpoint.

### Known gaps

1. Tx-node records are never pruned when their transactions finalize, so each pass loads and decodes the whole tree and does one broadcast-entry lookup per record. `check_interval_ms` bounds how often that runs, not how big it gets, so the cost still grows with every historical checkpoint and reveal. Pruning needs its own change: the watchers resolve progress through these records, so deleting one out from under them is not obviously safe. Ticket rather than fold in.

2. The broadcaster does not yet do the detection itself. @bewakes' suggested boundary was that the broadcaster notices a stale transaction and asks the writer for a replacement. The policy code now lives in the broadcaster module, but it is still called from the writer's pass. Whether the request should be passed at all is worth settling first: staleness is derivable from the publication height and the current tip, so the writer can compute it from the entry it already reads, and the BIP-125 rule 4 floor depends on the replacement's vsize, which only the writer knows after it builds.

3. `ReplacementContext` still carries `Option` fields. @delbonis asked for context values to be separated from the business logic. Dropping the standalone service removed the reason those fields were a grab-bag, but splitting the struct per writer is about 1300 lines of mechanical churn and I would rather do it on its own.

4. Only change-funded bumps work. If the original change output cannot absorb the higher fee, Core pulls in extra wallet UTXOs, and since `psbtbumpfee` returns a PSBT rather than committing it, those inputs stay unlocked and keep showing up in `listunspent`. A concurrent envelope build can then select the same UTXO. `lockunspent` is not exposed by `bitcoind-async-client` 0.10.8, so for now a replacement that spends any outpoint the original did not is rejected. That removes the correctness hazard; the cost is that such transactions stop being bumpable at all.

   Chunked commits pass `original_change_index` explicitly rather than letting Core find the change itself. Core only auto-detects change for an output that is `IsMine` and absent from the wallet's address book, and the commit pays change to the sequencer address, which comes from `getnewaddress`. Without the explicit index every chunked commit bump would add inputs and be refused on its first attempt.

5. The remaining multi-store writes are not journalled. The broadcast-DB half is atomic, but the envelope or payload metadata and the tx-node record are still separate writes after it. Ordering (node before metadata), the stale-row refusal on the writer side, and the refresh retry make the crash points converge rather than wedge, but there is no journal. Worth a ticket.

6. The BIP-125 floor uses the active transaction's vsize for the replacement, and there is no post-build check of Core's returned fee against `max_fee_rate_sat_vb`. Not a safety problem, since a larger replacement lowers the required floor and Core validates independently, but a bump can stall where a slightly higher rate would have cleared.

7. No signer timeout. A chain waiting on an external signature is skipped until the signature arrives or the attempt is discarded. The previous attempt stays live and broadcastable, so this delays further bumping rather than stalling publication.

8. Functional regtest coverage is still thin. Simulating mempool fee pressure and replacement behaviour reliably is hard in the current harness and I did not crack it. Regtest mines on demand, so writer transactions confirm before `min_age_blocks` elapses and nothing goes stale, which is also why making bumping unconditional needed no test config changes.

---

AI-assistance was used in preparing this PR.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:
- [BTCIO Fee Bumping](https://www.notion.so/BTCIO-Fee-Bumping-35a901ba000f805d8ca3d24fba06dc59). The doc still describes the optional standalone service and needs updating to match this branch.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-2433
