### PR TITLE
ci(build): add strata-signer to image build matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,7 @@ on:
       - "crates/**"
       - "docker/strata/**"
       - "docker/alpen-client/**"
+      - "docker/strata-signer/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -53,7 +54,7 @@ jobs:
           INPUT: ${{ inputs.programs }}
         run: |
           # New architecture images only — pushed to shared ECR account
-          ALL='["strata","alpen-client"]'
+          ALL='["strata","alpen-client","strata-signer"]'
 
           if [ -z "$INPUT" ]; then
             echo "matrix={\"program\":${ALL}}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add `docker/strata-signer/**` to the `ci-build.yml` path filter so changes to the signer Dockerfile/entrypoint trigger an image build.
- Add `strata-signer` to the build matrix (alongside `strata` and `alpen-client`) so its image is built and pushed to shared ECR on every merge to `main`.

The `strata-signer` binary already exists under `bin/strata-signer/` and `docker/strata-signer/` has a Dockerfile, but `ci-build.yml` was not building/pushing it. This change closes that gap.

## Test plan
- [ ] CI: `prepare` job emits matrix containing `strata-signer`
- [ ] CI: `build-and-push` job for `strata-signer` succeeds and pushes to `${SHARED_ECR_REPOSITORY_PREFIX}/strata-signer:<sha-short>`
- [ ] Subsequent edits to `docker/strata-signer/**` correctly trigger the workflow