### PR TITLE
STR-2771 ASM MMR unweirdening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14698,7 +14698,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -14725,7 +14725,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -14739,7 +14739,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -14761,7 +14761,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14779,7 +14779,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14820,7 +14820,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14845,7 +14845,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -14858,7 +14858,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14871,14 +14871,14 @@ dependencies = [
  "strata-codec",
  "strata-crypto",
  "strata-l1-txfmt",
- "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8)",
+ "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.10.0",
@@ -14895,32 +14895,23 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
- "bitcoin-bosd 0.10.0",
- "ssz",
- "ssz_derive",
- "ssz_primitives",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-msgs",
- "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-msgs",
  "strata-asm-proto-checkpoint-txs",
  "strata-asm-proto-checkpoint-types",
- "strata-btc-types",
- "strata-codec",
- "strata-crypto",
+ "strata-checkpoint-verification",
  "strata-identifiers",
- "strata-predicate",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -14933,7 +14924,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -14948,7 +14939,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "borsh",
  "proptest",
@@ -14969,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-debug-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "bitcoin-bosd 0.10.0",
  "serde",
@@ -14988,7 +14979,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-txs-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "bitcoin",
  "rand 0.8.5",
@@ -15000,7 +14991,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -15013,7 +15004,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec-debug"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -15024,7 +15015,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -15037,7 +15028,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -15079,7 +15070,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -15231,6 +15222,32 @@ dependencies = [
  "strata-identifiers",
  "strata-params",
  "zkaleido",
+]
+
+[[package]]
+name = "strata-checkpoint-verification"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
+dependencies = [
+ "bitcoin-bosd 0.10.0",
+ "ssz",
+ "ssz_codegen",
+ "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
+ "strata-asm-manifest-types",
+ "strata-asm-params",
+ "strata-asm-proto-bridge-v1-types",
+ "strata-asm-proto-checkpoint-types",
+ "strata-btc-types",
+ "strata-codec",
+ "strata-crypto",
+ "strata-identifiers",
+ "strata-predicate",
+ "thiserror 2.0.18",
+ "tree_hash 0.15.0",
+ "tree_hash_derive 0.15.0",
+ "zkaleido-logging",
 ]
 
 [[package]]
@@ -16872,7 +16889,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "bitcoin",
  "strata-identifiers",
@@ -16895,7 +16912,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btcio"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.9#dfb8e53cfdb2ec1f70f09c1d592b581b68fe0537"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -19380,7 +19397,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
 dependencies = [
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,28 +255,28 @@ strata-service = { git = "https://github.com/alpenlabs/strata-common", tag = "v0
 strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
 
 # asm
-strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-logs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-manifest-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-admin = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-admin-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-bridge-v1-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-bridge-v1-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-checkpoint-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-debug-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-proto-txs-test-utils = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-spec-debug = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-stf = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-btc-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
-strata-test-utils-btc = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.8" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-logs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-manifest-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-admin = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-admin-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-bridge-v1-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-bridge-v1-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-checkpoint-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-debug-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-proto-txs-test-utils = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-spec-debug = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-stf = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-btc-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
+strata-test-utils-btc = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.9" }
 
 # sled wrapper
 typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }

--- a/bin/alpen-client/src/dummy_ol_client.rs
+++ b/bin/alpen-client/src/dummy_ol_client.rs
@@ -102,7 +102,10 @@ impl SequencerOLClient for DummyOLClient {
         })
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError> {
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> Result<Hash, OLClientError> {
         Ok(Hash::from(u64_to_256(l1_height as u64)))
     }
 

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -634,7 +634,6 @@ fn main() {
                     batch_storage_dyn.clone(),
                     storage.clone(),
                     ol_client.clone(),
-                    ext.genesis_l1_height,
                     genesis,
                 ))
                 .task_store(task_store)
@@ -728,7 +727,6 @@ fn main() {
                     batch_prover,
                     batch_lifecycle_handle.latest_proof_ready_watcher(),
                     status_watcher,
-                    ext.genesis_l1_height,
                 );
 
                 node.task_executor

--- a/bin/alpen-client/src/ol_client.rs
+++ b/bin/alpen-client/src/ol_client.rs
@@ -73,10 +73,13 @@ impl SequencerOLClient for OLClientKind {
         }
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError> {
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> Result<Hash, OLClientError> {
         match self {
-            Self::Rpc(client) => client.get_l1_header_commitment(l1_height).await,
-            Self::Dummy(client) => client.get_l1_header_commitment(l1_height).await,
+            Self::Rpc(client) => client.get_asm_manifest_commitment(l1_height).await,
+            Self::Dummy(client) => client.get_asm_manifest_commitment(l1_height).await,
         }
     }
 

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -25,7 +25,6 @@ use strata_codec::encode_to_vec;
 use strata_ee_acct_runtime::{ChunkInput, EePrivateInput};
 use strata_ee_acct_types::UpdateExtraData;
 use strata_ee_chain_types::ChunkTransition;
-use strata_identifiers::L1Height;
 use strata_paas::{ProofSpec, ProverError as PaasError, ProverResult, ReceiptStore};
 use strata_proofimpl_alpen_acct::{EeAcctProgram, EeAcctProofInput};
 use strata_snark_acct_runtime::{Coinput, IInnerState, PrivateInput as UpdatePrivateInput};
@@ -150,7 +149,6 @@ pub(crate) struct AcctSpec {
     batch_storage: Arc<dyn BatchStorage>,
     storage: Arc<EeNodeStorage>,
     ol_client: Arc<dyn SequencerOLClient + Send + Sync>,
-    genesis_l1_height: L1Height,
     genesis: Genesis,
 }
 
@@ -160,7 +158,6 @@ impl AcctSpec {
         batch_storage: Arc<dyn BatchStorage>,
         storage: Arc<EeNodeStorage>,
         ol_client: Arc<dyn SequencerOLClient + Send + Sync>,
-        genesis_l1_height: L1Height,
         genesis: Genesis,
     ) -> Self {
         Self {
@@ -168,7 +165,6 @@ impl AcctSpec {
             batch_storage,
             storage,
             ol_client,
-            genesis_l1_height,
             genesis,
         }
     }
@@ -368,17 +364,13 @@ impl ProofSpec for AcctSpec {
             UpdateExtraData::new(new_tip_blkid, new_tip_state_root, processed_inputs, 0);
         let extra_data_bytes = encode_to_vec(&extra_data)
             .map_err(|e| PaasError::PermanentFailure(format!("encode extra data: {e}")))?;
-        let ledger_refs =
-            build_ledger_refs_from_da(&da_refs, self.ol_client.as_ref(), self.genesis_l1_height)
-                .await
-                .map_err(|e| match e {
-                    LedgerRefsError::FetchCommitment { .. } => PaasError::TransientFailure(
-                        format!("build ledger refs for batch {batch_id}: {e}"),
-                    ),
-                    LedgerRefsError::OffsetUnderflow { .. } => PaasError::PermanentFailure(
-                        format!("build ledger refs for batch {batch_id}: {e}"),
-                    ),
-                })?;
+        let ledger_refs = build_ledger_refs_from_da(&da_refs, self.ol_client.as_ref())
+            .await
+            .map_err(|e| match e {
+                LedgerRefsError::FetchCommitment { .. } => PaasError::TransientFailure(format!(
+                    "build ledger refs for batch {batch_id}: {e}"
+                )),
+            })?;
 
         let pub_params = UpdateProofPubParams::new(
             cur_state,

--- a/bin/alpen-client/src/rpc_client.rs
+++ b/bin/alpen-client/src/rpc_client.rs
@@ -213,13 +213,16 @@ impl SequencerOLClient for RpcOLClient {
         })
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError> {
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> Result<Hash, OLClientError> {
         retry_with_backoff_async(
-            "ol_client_get_l1_header_commitment",
+            "ol_client_get_asm_manifest_commitment",
             DEFAULT_ENGINE_CALL_MAX_RETRIES,
             &ExponentialBackoff::default(),
             || async {
-                let commitment = call_rpc!(self, get_l1_header_commitment(l1_height))?;
+                let commitment = call_rpc!(self, get_asm_manifest_commitment(l1_height))?;
 
                 commitment.map(|h| Hash::from(h.0)).ok_or_else(|| {
                     OLClientError::rpc(format!(
@@ -238,7 +241,7 @@ impl SequencerOLClient for RpcOLClient {
         let next_inbox_msg_idx = operation.new_proof_state().next_inbox_msg_idx();
         let l1_ref_heights: Vec<_> = operation
             .ledger_refs()
-            .l1_header_refs()
+            .asm_manifest_refs()
             .iter()
             .map(|claim| claim.idx())
             .collect();

--- a/bin/strata-test-cli/src/mock_ee/withdrawal.rs
+++ b/bin/strata-test-cli/src/mock_ee/withdrawal.rs
@@ -148,7 +148,7 @@ mod tests {
         assert_eq!(decoded.new_proof_state().inner_state(), inner_state);
         assert_eq!(decoded.new_proof_state().next_inbox_msg_idx(), 3);
         assert_eq!(decoded.processed_messages().len(), 0);
-        assert_eq!(decoded.ledger_refs().l1_header_refs().len(), 0);
+        assert_eq!(decoded.ledger_refs().asm_manifest_refs().len(), 0);
         assert_eq!(decoded.outputs().transfers().len(), 0);
         assert_eq!(decoded.outputs().messages().len(), 1);
 

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -765,7 +765,10 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .ok_or_else(|| not_found_error(format!("No epoch commitment found for epoch {epoch}")))
     }
 
-    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> RpcResult<Option<HexBytes32>> {
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> RpcResult<Option<HexBytes32>> {
         let manifest = self
             .provider
             .get_block_manifest_at_height(l1_height)

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -775,7 +775,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .await
             .map_err(db_error)?;
 
-        Ok(manifest.map(|m| HexBytes32::from(m.compute_hash())))
+        Ok(manifest.map(|m| HexBytes32::from(*m.compute_hash().as_ref())))
     }
 
     async fn submit_transaction(&self, tx: RpcOLTransaction) -> RpcResult<OLTxId> {

--- a/crates/alpen-ee/common/src/traits/ol_client.rs
+++ b/crates/alpen-ee/common/src/traits/ol_client.rs
@@ -86,10 +86,11 @@ pub trait SequencerOLClient {
     /// Retrieves latest account state in the OL Chain for this account.
     async fn get_latest_account_state(&self) -> Result<OLAccountStateView, OLClientError>;
 
-    /// Retrieves the canonical L1 header commitment for an L1 block height.
+    /// Retrieves the canonical ASM manifest commitment for an L1 block height.
     ///
     /// The returned hash is the exact MMR leaf value used by OL ledger-ref verification.
-    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> Result<Hash, OLClientError>;
+    async fn get_asm_manifest_commitment(&self, l1_height: L1Height)
+        -> Result<Hash, OLClientError>;
 
     /// Submits an account update with proof to the OL chain sequencer.
     ///

--- a/crates/alpen-ee/common/src/utils/ledger_refs.rs
+++ b/crates/alpen-ee/common/src/utils/ledger_refs.rs
@@ -36,7 +36,7 @@ pub enum LedgerRefsError {
 /// Resolves each L1 height to its canonical L1 header commitment via
 /// `ol_client`, uses the raw L1 height as the MMR leaf index (the OL
 /// ASM-manifests MMR is height-indexed, prefilled at genesis with
-/// zero-hash leaves), then sorts and dedups by index (multiple DA txns
+/// dummy-hash leaves), then sorts and dedups by index (multiple DA txns
 /// may land in one L1 block).
 ///
 /// The `?Sized` relaxation on the `impl SequencerOLClient` bound is

--- a/crates/alpen-ee/common/src/utils/ledger_refs.rs
+++ b/crates/alpen-ee/common/src/utils/ledger_refs.rs
@@ -23,7 +23,7 @@ use crate::{
 #[derive(Debug, thiserror::Error)]
 pub enum LedgerRefsError {
     /// Failed to fetch the canonical L1 header commitment for a given height.
-    #[error("get_l1_header_commitment({height}): {source}")]
+    #[error("get_asm_manifest_commitment({height}): {source}")]
     FetchCommitment {
         height: L1Height,
         #[source]
@@ -46,11 +46,12 @@ pub async fn build_ledger_refs_from_da(
     da_refs: &[L1DaBlockRef],
     ol_client: &(impl SequencerOLClient + ?Sized),
 ) -> Result<LedgerRefs, LedgerRefsError> {
-    let l1_header_commitments = fetch_l1_header_commitments_by_height(da_refs, ol_client).await?;
-    Ok(build_ledger_refs(da_refs, &l1_header_commitments))
+    let asm_manifest_commitments =
+        fetch_asm_manifest_commitments_by_height(da_refs, ol_client).await?;
+    Ok(build_ledger_refs(da_refs, &asm_manifest_commitments))
 }
 
-async fn fetch_l1_header_commitments_by_height(
+async fn fetch_asm_manifest_commitments_by_height(
     da_refs: &[L1DaBlockRef],
     ol_client: &(impl SequencerOLClient + ?Sized),
 ) -> Result<HashMap<L1Height, Hash>, LedgerRefsError> {
@@ -60,7 +61,7 @@ async fn fetch_l1_header_commitments_by_height(
 
     let pairs = try_join_all(heights.into_iter().map(|height| async move {
         let hash = ol_client
-            .get_l1_header_commitment(height)
+            .get_asm_manifest_commitment(height)
             .await
             .map_err(|source| LedgerRefsError::FetchCommitment { height, source })?;
         Ok::<_, LedgerRefsError>((height, hash))
@@ -72,24 +73,24 @@ async fn fetch_l1_header_commitments_by_height(
 
 fn build_ledger_refs(
     da_refs: &[L1DaBlockRef],
-    l1_header_commitments: &HashMap<L1Height, Hash>,
+    asm_manifest_commitments: &HashMap<L1Height, Hash>,
 ) -> LedgerRefs {
-    let mut l1_header_refs: Vec<AccumulatorClaim> = da_refs
+    let mut asm_manifest_refs: Vec<AccumulatorClaim> = da_refs
         .iter()
         .map(|da_ref| {
             let height = da_ref.block.height();
-            // `fetch_l1_header_commitments_by_height` populates an entry for
+            // `fetch_asm_manifest_commitments_by_height` populates an entry for
             // every height present in `da_refs`, so a miss here is a bug, not
             // a transient error — leave it as an `expect` to surface that.
-            let hash = *l1_header_commitments
+            let hash = *asm_manifest_commitments
                 .get(&height)
                 .expect("commitment map covers every DA-ref height");
             AccumulatorClaim::new(height as u64, *hash.as_ref())
         })
         .collect();
 
-    l1_header_refs.sort_by_key(|c| c.idx());
-    l1_header_refs.dedup_by_key(|c| c.idx());
+    asm_manifest_refs.sort_by_key(|c| c.idx());
+    asm_manifest_refs.dedup_by_key(|c| c.idx());
 
-    LedgerRefs::new(l1_header_refs)
+    LedgerRefs::new(asm_manifest_refs)
 }

--- a/crates/alpen-ee/common/src/utils/ledger_refs.rs
+++ b/crates/alpen-ee/common/src/utils/ledger_refs.rs
@@ -29,18 +29,15 @@ pub enum LedgerRefsError {
         #[source]
         source: OLClientError,
     },
-
-    /// An L1 height in the DA refs is before the configured MMR start offset.
-    #[error("L1 height {height} is before MMR start offset {mmr_offset}")]
-    OffsetUnderflow { height: L1Height, mmr_offset: u64 },
 }
 
 /// Builds canonical [`LedgerRefs`] from `da_refs`.
 ///
 /// Resolves each L1 height to its canonical L1 header commitment via
-/// `ol_client`, maps it to its MMR leaf index using `genesis_l1_height + 1`
-/// as the offset, then sorts and dedups by index (multiple DA txns may
-/// land in one L1 block).
+/// `ol_client`, uses the raw L1 height as the MMR leaf index (the OL
+/// ASM-manifests MMR is height-indexed, prefilled at genesis with
+/// zero-hash leaves), then sorts and dedups by index (multiple DA txns
+/// may land in one L1 block).
 ///
 /// The `?Sized` relaxation on the `impl SequencerOLClient` bound is
 /// required so that callers may pass a `&dyn SequencerOLClient`; the
@@ -48,10 +45,9 @@ pub enum LedgerRefsError {
 pub async fn build_ledger_refs_from_da(
     da_refs: &[L1DaBlockRef],
     ol_client: &(impl SequencerOLClient + ?Sized),
-    genesis_l1_height: L1Height,
 ) -> Result<LedgerRefs, LedgerRefsError> {
     let l1_header_commitments = fetch_l1_header_commitments_by_height(da_refs, ol_client).await?;
-    build_ledger_refs(da_refs, &l1_header_commitments, genesis_l1_height)
+    Ok(build_ledger_refs(da_refs, &l1_header_commitments))
 }
 
 async fn fetch_l1_header_commitments_by_height(
@@ -77,9 +73,7 @@ async fn fetch_l1_header_commitments_by_height(
 fn build_ledger_refs(
     da_refs: &[L1DaBlockRef],
     l1_header_commitments: &HashMap<L1Height, Hash>,
-    genesis_l1_height: L1Height,
-) -> Result<LedgerRefs, LedgerRefsError> {
-    let mmr_offset = genesis_l1_height as u64 + 1;
+) -> LedgerRefs {
     let mut l1_header_refs: Vec<AccumulatorClaim> = da_refs
         .iter()
         .map(|da_ref| {
@@ -90,15 +84,12 @@ fn build_ledger_refs(
             let hash = *l1_header_commitments
                 .get(&height)
                 .expect("commitment map covers every DA-ref height");
-            let mmr_idx = (height as u64)
-                .checked_sub(mmr_offset)
-                .ok_or(LedgerRefsError::OffsetUnderflow { height, mmr_offset })?;
-            Ok(AccumulatorClaim::new(mmr_idx, *hash.as_ref()))
+            AccumulatorClaim::new(height as u64, *hash.as_ref())
         })
-        .collect::<Result<Vec<_>, LedgerRefsError>>()?;
+        .collect();
 
     l1_header_refs.sort_by_key(|c| c.idx());
     l1_header_refs.dedup_by_key(|c| c.idx());
 
-    Ok(LedgerRefs::new(l1_header_refs))
+    LedgerRefs::new(l1_header_refs)
 }

--- a/crates/alpen-ee/sequencer/src/update_submitter/task.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/task.rs
@@ -7,7 +7,6 @@ use alpen_ee_common::{
     SequencerOLClient,
 };
 use eyre::{eyre, Result};
-use strata_identifiers::L1Height;
 use strata_snark_acct_types::SnarkAccountUpdate;
 use tokio::{sync::watch, time};
 use tracing::{debug, error, info, warn};
@@ -67,7 +66,6 @@ pub async fn create_update_submitter_task<C, S, ES, P>(
     prover: Arc<P>,
     mut batch_ready_rx: watch::Receiver<Option<BatchId>>,
     mut ol_status_rx: watch::Receiver<OLFinalizedStatus>,
-    genesis_l1_height: L1Height,
 ) where
     C: SequencerOLClient + Send + Sync,
     S: BatchStorage,
@@ -83,7 +81,6 @@ pub async fn create_update_submitter_task<C, S, ES, P>(
         exec_storage.as_ref(),
         prover.as_ref(),
         &mut update_cache,
-        genesis_l1_height,
     )
     .await
     {
@@ -118,7 +115,6 @@ pub async fn create_update_submitter_task<C, S, ES, P>(
             exec_storage.as_ref(),
             prover.as_ref(),
             &mut update_cache,
-            genesis_l1_height,
         )
         .await
         {
@@ -138,7 +134,6 @@ async fn process_ready_batches(
     exec_storage: &impl ExecBlockStorage,
     prover: &impl BatchProver,
     update_cache: &mut UpdateCache,
-    genesis_l1_height: L1Height,
 ) -> Result<()> {
     // Get latest account state from OL to determine next expected seq_no
     let account_state = ol_client.get_latest_account_state().await?;
@@ -174,16 +169,9 @@ async fn process_ready_batches(
         let update = if let Some(cached) = update_cache.get(&batch_id) {
             cached.clone()
         } else {
-            let update = build_update_from_batch(
-                &batch,
-                &da,
-                &proof,
-                ol_client,
-                exec_storage,
-                prover,
-                genesis_l1_height,
-            )
-            .await?;
+            let update =
+                build_update_from_batch(&batch, &da, &proof, ol_client, exec_storage, prover)
+                    .await?;
             update_cache.insert(batch_id, batch_idx, update.clone());
             update
         };

--- a/crates/alpen-ee/sequencer/src/update_submitter/task.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/task.rs
@@ -177,7 +177,7 @@ async fn process_ready_batches(
         };
 
         let seq_no = update.operation().seq_no();
-        let l1_ref_count = update.operation().ledger_refs().l1_header_refs().len();
+        let l1_ref_count = update.operation().ledger_refs().asm_manifest_refs().len();
         let txid = ol_client.submit_update(update).await?;
 
         info!(

--- a/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
@@ -10,7 +10,6 @@ use strata_acct_types::{
 };
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::UpdateExtraData;
-use strata_identifiers::L1Height;
 use strata_snark_acct_types::{
     LedgerRefs, OutputMessage, OutputTransfer, ProofState, SnarkAccountUpdate, UpdateOperationData,
     UpdateOutputs,
@@ -24,7 +23,6 @@ pub(super) async fn build_update_from_batch(
     ol_client: &(impl SequencerOLClient + Send + Sync),
     exec_storage: &impl ExecBlockStorage,
     prover: &impl BatchProver,
-    genesis_l1_height: L1Height,
 ) -> Result<SnarkAccountUpdate> {
     // Get all blocks in the batch
     let blocks = try_join_all(batch.blocks_iter().map(|hash| {
@@ -48,7 +46,7 @@ pub(super) async fn build_update_from_batch(
 
     // Ledger refs MUST be byte-identical to what the prover commits — see
     // `build_ledger_refs_from_da` in alpen-ee-common.
-    let ledger_refs = build_ledger_refs_from_da(da_refs, ol_client, genesis_l1_height).await?;
+    let ledger_refs = build_ledger_refs_from_da(da_refs, ol_client).await?;
     let update_operation = build_update_operation(seq_no, ledger_refs, blocks)?;
 
     // Should we re-check that proof is valid ?

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -19,7 +19,7 @@ use strata_primitives::prelude::L1BlockCommitment;
 use strata_service::{ServiceBuilder, ServiceMonitor, SyncAsyncInput};
 use strata_state::asm_state::AsmState as StorageAsmState;
 use strata_status::StatusChannel;
-use strata_storage::{MmrId, NodeStorage};
+use strata_storage::{MmrId, MmrIndexHandle, NodeStorage};
 use strata_tasks::TaskExecutor;
 use tokio::{runtime::Handle, sync::mpsc};
 
@@ -294,12 +294,20 @@ pub fn spawn_asm_worker(
     // This feels weird to pass both L1BlockManager and Bitcoin client, but ASM consumes raw bitcoin
     // blocks while following canonical chain (and "canonicity" of l1 chain is imposed by the l1
     // block manager).
+    let mmr_handle = storage.mmr_index().get_handle(MmrId::Asm);
+
+    // Prefill the ASM manifest MMR with zero-hash leaves up to and including
+    // the genesis L1 height, so that the manifest for height `h` lands at MMR
+    // index `h`. This mirrors the in-memory OL state initialization.
+    let genesis_l1_height = asm_params.anchor.block.height() as u64;
+    prefill_asm_mmr(&mmr_handle, genesis_l1_height + 1)?;
+
     let context = AsmWorkerCtx::new(
         handle.clone(),
         bitcoin_client,
         storage.l1().clone(),
         storage.asm().clone(),
-        storage.mmr_index().get_handle(MmrId::Asm),
+        mmr_handle,
     );
 
     // Construct the ASM spec based on the enabled feature.
@@ -320,4 +328,23 @@ pub fn spawn_asm_worker(
 
 fn storage_to_worker_state(state: StorageAsmState) -> WorkerAsmState {
     WorkerAsmState::new(state.state().clone(), state.logs().clone())
+}
+
+/// Prefills the ASM manifest MMR with sentinel leaves until it has at least
+/// `target_count` entries.
+///
+/// This is idempotent: a no-op when the MMR already has at least
+/// `target_count` entries. It is used to align DB-side MMR leaf indices with
+/// L1 block heights, mirroring the in-memory OL state initialization.
+fn prefill_asm_mmr(handle: &MmrIndexHandle, target_count: u64) -> anyhow::Result<()> {
+    let current = handle.get_num_leaves_blocking()?;
+    if current >= target_count {
+        return Ok(());
+    }
+
+    let sentinel = strata_identifiers::Hash::from(strata_ol_state_types::MMR_PREFILL_LEAF);
+    for _ in current..target_count {
+        handle.append_leaf_blocking(sentinel)?;
+    }
+    Ok(())
 }

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -14,6 +14,7 @@ use strata_chain_worker::ChainWorkerHandle;
 use strata_csm_worker::{CsmWorkerService, CsmWorkerState, CsmWorkerStatus};
 use strata_eectl::{builder::ExecWorkerBuilder, engine::ExecEngineCtl, handle::ExecCtlHandle};
 use strata_node_context::NodeContext;
+use strata_ol_state_types::MMR_SENTINEL_DUMMY_LEAF_HASH;
 use strata_params::{Params, RollupParams};
 use strata_primitives::prelude::L1BlockCommitment;
 use strata_service::{ServiceBuilder, ServiceMonitor, SyncAsyncInput};
@@ -342,9 +343,8 @@ fn prefill_asm_mmr(handle: &MmrIndexHandle, target_count: u64) -> anyhow::Result
         return Ok(());
     }
 
-    let sentinel = strata_identifiers::Hash::from(strata_ol_state_types::MMR_PREFILL_LEAF);
     for _ in current..target_count {
-        handle.append_leaf_blocking(sentinel)?;
+        handle.append_leaf_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH)?;
     }
     Ok(())
 }

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -297,7 +297,7 @@ pub fn spawn_asm_worker(
     // block manager).
     let mmr_handle = storage.mmr_index().get_handle(MmrId::Asm);
 
-    // Prefill the ASM manifest MMR with zero-hash leaves up to and including
+    // Prefill the ASM manifest MMR with dummy-hash leaves up to and including
     // the genesis L1 height, so that the manifest for height `h` lands at MMR
     // index `h`. This mirrors the in-memory OL state initialization.
     let genesis_l1_height = asm_params.anchor.block.height() as u64;

--- a/crates/ledger-types/src/state_accessor.rs
+++ b/crates/ledger-types/src/state_accessor.rs
@@ -46,6 +46,10 @@ pub trait IStateAccessor {
     fn total_ledger_balance(&self) -> BitcoinAmount;
 
     /// Gets the ASM manifests MMR for ledger reference verification.
+    ///
+    /// Indices into this MMR are L1 block heights. The MMR is prefilled at
+    /// genesis with zero-hash leaves for heights `0..=genesis_l1_height`, so
+    /// callers can use raw L1 heights as MMR leaf indices everywhere.
     fn asm_manifests_mmr(&self) -> &Mmr64;
 
     // ===== Account methods =====
@@ -129,30 +133,4 @@ pub trait IStateAccessorMut: IStateAccessor {
         id: AccountId,
         new_acct_data: NewAccountData,
     ) -> StateResult<AccountSerial>;
-}
-
-/// Resolves the first L1 block height represented by the ASM manifests MMR.
-///
-/// This is derived from canonical state as:
-/// `mmr_start_height = last_l1_height + 1 - manifests_mmr_entries`.
-///
-/// For an empty MMR, this reduces to `last_l1_height + 1`.
-pub fn asm_manifests_mmr_start_height(state: &impl IStateAccessor) -> Option<L1Height> {
-    let last_l1_height_u64 = state.last_l1_height() as u64;
-    let num_entries = state.asm_manifests_mmr().num_entries();
-    let start_height_u64 = last_l1_height_u64
-        .checked_add(1)?
-        .checked_sub(num_entries)?;
-    start_height_u64.try_into().ok()
-}
-
-/// Resolves an L1 block height into the corresponding ASM manifests MMR leaf index.
-///
-/// Returns `None` when the height is before the MMR start height.
-pub fn asm_manifest_mmr_index_for_height(
-    state: &impl IStateAccessor,
-    height: L1Height,
-) -> Option<u64> {
-    let start_height_u64 = asm_manifests_mmr_start_height(state)? as u64;
-    (height as u64).checked_sub(start_height_u64)
 }

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -82,7 +82,7 @@ fn block_assembly_error_to_mempool_reason(err: &BlockAssemblyError) -> MempoolTx
         BlockAssemblyError::InvalidAccumulatorClaim(_)
         | BlockAssemblyError::Acct(_)
         | BlockAssemblyError::State(_)
-        | BlockAssemblyError::L1HeaderHashMismatch { .. }
+        | BlockAssemblyError::AsmManifestHashMismatch { .. }
         | BlockAssemblyError::InboxEntryHashMismatch { .. }
         | BlockAssemblyError::AccountNotFound(_)
         | BlockAssemblyError::InboxProofCountMismatch { .. } => MempoolTxInvalidReason::Invalid,
@@ -798,8 +798,9 @@ fn add_accumulator_proofs<P: AccumulatorProofGenerator, S: IStateAccessor>(
     for check in proof_indexer.accumulator_checks() {
         match check {
             AccProofCheck::AsmHistory(claim) => {
-                let proofs = proof_gen.generate_l1_header_proofs(slice::from_ref(claim), state)?;
-                all_acc_proofs.extend(proofs.l1_headers_proofs().iter().cloned());
+                let proofs =
+                    proof_gen.generate_asm_manifest_proofs(slice::from_ref(claim), state)?;
+                all_acc_proofs.extend(proofs.asm_manifest_proofs().iter().cloned());
             }
             AccProofCheck::Inbox(claim) => {
                 let inbox_proofs = proof_gen.generate_inbox_proofs_for_claims(
@@ -851,11 +852,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_proof_gen_success() {
+    async fn test_asm_manifest_proof_gen_success() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -864,13 +865,13 @@ mod tests {
             .await
             .expect("fetch stored state")
             .expect("stored state missing");
-        let l1_claim = fixture
-            .l1_header_ref(1)
+        let asm_manifest_claim = fixture
+            .asm_manifest_ref(1)
             .expect("claim for L1 height 1 should exist");
 
         // Create tx with claims from the tracker using builder
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(vec![l1_claim])
+            .with_asm_manifest_claims(vec![asm_manifest_claim])
             .build();
 
         let ctx = create_test_context(fixture.storage().clone());
@@ -1014,11 +1015,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_claim_hash_mismatch() {
+    async fn test_asm_manifest_claim_hash_mismatch() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -1028,7 +1029,7 @@ mod tests {
             .expect("fetch stored state")
             .expect("stored state missing");
         let seeded_claim = fixture
-            .l1_header_ref(1)
+            .asm_manifest_ref(1)
             .expect("claim for L1 height 1 should exist");
 
         // Create claim with correct MMR index but wrong hash.
@@ -1041,7 +1042,7 @@ mod tests {
         let invalid_claims = vec![AccumulatorClaim::new(seeded_claim.idx(), wrong_hash)];
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(invalid_claims)
+            .with_asm_manifest_claims(invalid_claims)
             .build();
         let ctx = create_test_context(fixture.storage().clone());
         let result = add_accumulator_proofs(
@@ -1052,19 +1053,19 @@ mod tests {
         assert!(result.is_err(), "Should fail with hash mismatch");
         let err = result.unwrap_err();
         assert!(
-            matches!(err, BlockAssemblyError::L1HeaderHashMismatch { .. }),
-            "Expected L1HeaderHashMismatch, got: {:?}",
+            matches!(err, BlockAssemblyError::AsmManifestHashMismatch { .. }),
+            "Expected AsmManifestHashMismatch, got: {:?}",
             err
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_claim_missing_index() {
+    async fn test_asm_manifest_claim_missing_index() {
         // Seed one L1 header so we can reuse its hash with a missing index.
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -1074,7 +1075,7 @@ mod tests {
             .expect("fetch stored state")
             .expect("stored state missing");
         let seeded_claim = fixture
-            .l1_header_ref(1)
+            .asm_manifest_ref(1)
             .expect("claim for L1 height 1 should exist");
 
         // Create claim with non-existent index.
@@ -1085,7 +1086,7 @@ mod tests {
         )];
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(invalid_claims)
+            .with_asm_manifest_claims(invalid_claims)
             .build();
         let ctx = create_test_context(fixture.storage().clone());
         let result = add_accumulator_proofs(
@@ -1108,7 +1109,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_claim_with_only_genesis_prefill() {
+    async fn test_asm_manifest_claim_with_only_genesis_prefill() {
         // No real manifests are seeded, so the MMR contains only the genesis
         // sentinel at index 0. A claim quoting an arbitrary hash at that index
         // must be rejected as a hash mismatch.
@@ -1128,7 +1129,7 @@ mod tests {
             .expect("stored state missing");
 
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(invalid_claims)
+            .with_asm_manifest_claims(invalid_claims)
             .build();
 
         let ctx = create_test_context(fixture.storage().clone());
@@ -1140,7 +1141,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(BlockAssemblyError::L1HeaderHashMismatch { idx: 0, .. })
+            Err(BlockAssemblyError::AsmManifestHashMismatch { idx: 0, .. })
         ));
     }
 
@@ -1312,12 +1313,12 @@ mod tests {
     /// the accumulator proofs are ordered: L1 headers first, then inbox proofs.
     /// This must match the verification order in snark-acct-sys verification.rs.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_proof_ordering_l1_headers_before_inbox() {
+    async fn test_proof_ordering_asm_manifests_before_inbox() {
         let account_id = test_account_id(1);
         let source_account = test_account_id(2);
         let messages = generate_message_entries(2, source_account);
         let fixture_builder = TestStorageFixtureBuilder::new()
-            .with_l1_header_refs([1])
+            .with_asm_manifests([1])
             .with_account(TestAccount::new(account_id, 100_000).with_inbox(messages.clone()));
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
@@ -1327,15 +1328,15 @@ mod tests {
             .await
             .expect("fetch stored state")
             .expect("stored state missing");
-        let l1_claims = vec![
+        let asm_manifest_claims = vec![
             fixture
-                .l1_header_ref(1)
+                .asm_manifest_ref(1)
                 .expect("claim for L1 height 1 should exist"),
         ];
 
         // Create tx with BOTH L1 claims and inbox messages
         let mempool_tx = MempoolSnarkTxBuilder::new(account_id)
-            .with_l1_claims(l1_claims.clone())
+            .with_asm_manifest_claims(asm_manifest_claims.clone())
             .with_processed_messages(messages.clone())
             .build();
 
@@ -1352,13 +1353,13 @@ mod tests {
         let acc_proofs = tx_proofs
             .accumulator_proofs()
             .expect("should have accumulator proofs");
-        let n_l1 = l1_claims.len();
+        let n_asm_manifests = asm_manifest_claims.len();
         let n_inbox = messages.len();
         assert_eq!(
             acc_proofs.proofs().len(),
-            n_l1 + n_inbox,
-            "Should have {n_l1} L1 header + {n_inbox} inbox = {} total accumulator proofs",
-            n_l1 + n_inbox
+            n_asm_manifests + n_inbox,
+            "Should have {n_asm_manifests} L1 header + {n_inbox} inbox = {} total accumulator proofs",
+            n_asm_manifests + n_inbox
         );
 
         // Verify predicate satisfier exists
@@ -1690,7 +1691,7 @@ mod tests {
         // Set last_l1_height to 2, but only provide manifests starting at 3.
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
-            .with_l1_header_refs([1, 2])
+            .with_asm_manifests([1, 2])
             .with_l1_manifest_height_range(3..=4);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let mut env = TestEnv::from_fixture(fixture, parent_commitment);
@@ -1713,7 +1714,7 @@ mod tests {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
             .with_l1_manifest_height_range(1..=3)
-            .with_l1_header_refs([1, 2, 3]);
+            .with_asm_manifests([1, 2, 3]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
@@ -1734,7 +1735,7 @@ mod tests {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
             .with_l1_manifest_height_range(1..=3)
-            .with_l1_header_refs([1, 2, 3, 4, 5]);
+            .with_asm_manifests([1, 2, 3, 4, 5]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
@@ -1755,7 +1756,7 @@ mod tests {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
             .with_l1_manifest_height_range(1..=2)
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
@@ -2011,7 +2012,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_mmr_claims() {
+    async fn test_asm_manifest_mmr_claims() {
         // Setup env with two snark accounts and manifests in both state and storage MMRs
         let account1 = test_account_id(1);
         let account2 = test_account_id(2);
@@ -2019,25 +2020,25 @@ mod tests {
             .with_parent_slot(1) // Start from slot 1 instead of genesis to avoid genesis manifest conflicts
             .with_account(TestAccount::new(account1, DEFAULT_ACCOUNT_BALANCE))
             .with_account(TestAccount::new(account2, DEFAULT_ACCOUNT_BALANCE))
-            .with_l1_header_refs([1, 2]);
+            .with_asm_manifests([1, 2]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         // Valid tx for account1: L1 header claims exist in both MMRs for the requested L1 height.
         let valid_claims = vec![
-            env.l1_header_ref(1)
+            env.asm_manifest_ref(1)
                 .expect("claim for L1 height 1 should exist"),
         ];
         let valid_tx = MempoolSnarkTxBuilder::new(account1)
             .with_seq_no(0)
-            .with_l1_claims(valid_claims)
+            .with_asm_manifest_claims(valid_claims)
             .build();
         let valid_txid = valid_tx.compute_txid();
 
         // Invalid tx for account2: non-existent MMR index (no corresponding MMR leaf)
         let fake_hash = test_hash(99);
         let max_seeded_idx = env
-            .l1_header_refs()
+            .asm_manifest_refs()
             .iter()
             .map(|claim| claim.idx())
             .max()
@@ -2046,7 +2047,7 @@ mod tests {
         let invalid_claims = vec![AccumulatorClaim::new(missing_idx, fake_hash)];
         let invalid_tx = MempoolSnarkTxBuilder::new(account2)
             .with_seq_no(0)
-            .with_l1_claims(invalid_claims)
+            .with_asm_manifest_claims(invalid_claims)
             .build();
         let invalid_txid = invalid_tx.compute_txid();
 
@@ -2874,18 +2875,18 @@ mod tests {
         let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
             .with_account(TestAccount::new(account_id, DEFAULT_ACCOUNT_BALANCE))
-            .with_l1_header_refs(1..=25)
+            .with_asm_manifests(1..=25)
             .build_fixture()
             .await;
         let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let mut claims: Vec<_> = env.l1_header_refs().to_vec();
+        let mut claims: Vec<_> = env.asm_manifest_refs().to_vec();
         claims.extend(claims.clone());
         assert_eq!(claims.len(), 50, "stress setup should build 50 claims");
 
         let tx = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
-            .with_l1_claims(claims)
+            .with_asm_manifest_claims(claims)
             .build();
         let txid = tx.compute_txid();
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -1108,8 +1108,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_claim_empty_mmr() {
-        // Create claim for MMR index 0 with arbitrary hash (MMR is empty)
+    async fn test_l1_header_claim_with_only_genesis_prefill() {
+        // No real manifests are seeded, so the MMR contains only the genesis
+        // sentinel at index 0. A claim quoting an arbitrary hash at that index
+        // must be rejected as a hash mismatch.
         let arbitrary_hash = test_hash(42);
         let invalid_claims = vec![AccumulatorClaim::new(0, arbitrary_hash)];
 
@@ -1130,24 +1132,16 @@ mod tests {
             .build();
 
         let ctx = create_test_context(fixture.storage().clone());
-        // Conversion should fail with an index/range DB error.
         let result = add_accumulator_proofs(
             &ctx,
             &MemoryStateBaseLayer::new(state.as_ref().clone()),
             mempool_tx,
         );
 
-        assert!(result.is_err(), "Should fail when MMR is empty");
-        let err = result.unwrap_err();
-        assert!(
-            matches!(
-                err,
-                BlockAssemblyError::Db(DbError::MmrIndexOutOfRange { .. })
-                    | BlockAssemblyError::Db(DbError::MmrLeafNotFound(_))
-            ),
-            "Expected Db(MmrIndexOutOfRange|MmrLeafNotFound), got: {:?}",
-            err
-        );
+        assert!(matches!(
+            result,
+            Err(BlockAssemblyError::L1HeaderHashMismatch { idx: 0, .. })
+        ));
     }
 
     #[test]
@@ -2025,8 +2019,7 @@ mod tests {
             .with_parent_slot(1) // Start from slot 1 instead of genesis to avoid genesis manifest conflicts
             .with_account(TestAccount::new(account1, DEFAULT_ACCOUNT_BALANCE))
             .with_account(TestAccount::new(account2, DEFAULT_ACCOUNT_BALANCE))
-            .with_l1_header_refs([1, 2])
-            .with_expected_l1_header_ref_indices([(1, 0), (2, 1)]);
+            .with_l1_header_refs([1, 2]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let env = TestEnv::from_fixture(fixture, parent_commitment);
 
@@ -2046,7 +2039,7 @@ mod tests {
         let max_seeded_idx = env
             .l1_header_refs()
             .iter()
-            .map(|(_, claim)| claim.idx())
+            .map(|claim| claim.idx())
             .max()
             .expect("seeded claims");
         let missing_idx = max_seeded_idx + 100;
@@ -2886,11 +2879,7 @@ mod tests {
             .await;
         let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let mut claims: Vec<_> = env
-            .l1_header_refs()
-            .iter()
-            .map(|(_, claim)| claim.clone())
-            .collect();
+        let mut claims: Vec<_> = env.l1_header_refs().to_vec();
         claims.extend(claims.clone());
         assert_eq!(claims.len(), 50, "stress setup should build 50 claims");
 

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -99,9 +99,9 @@ pub trait AccumulatorProofGenerator: Send + Sync + 'static {
     ) -> BlockAssemblyResult<Vec<RawMerkleProof>>;
 
     /// Validates claims and generates L1 header reference proofs.
-    fn generate_l1_header_proofs<T: IStateAccessor>(
+    fn generate_asm_manifest_proofs<T: IStateAccessor>(
         &self,
-        l1_header_refs: &[AccumulatorClaim],
+        asm_manifest_refs: &[AccumulatorClaim],
         state: &T,
     ) -> BlockAssemblyResult<LedgerRefProofs>;
 }
@@ -337,12 +337,12 @@ where
             .collect())
     }
 
-    fn generate_l1_header_proofs<T: IStateAccessor>(
+    fn generate_asm_manifest_proofs<T: IStateAccessor>(
         &self,
-        l1_header_refs: &[AccumulatorClaim],
+        asm_manifest_refs: &[AccumulatorClaim],
         state: &T,
     ) -> BlockAssemblyResult<LedgerRefProofs> {
-        if l1_header_refs.is_empty() {
+        if asm_manifest_refs.is_empty() {
             return Ok(LedgerRefProofs::new(Vec::new()));
         }
 
@@ -351,7 +351,7 @@ where
 
         // Claims already carry MMR leaf indices (not L1 heights), so use them
         // directly for proof generation.
-        let indices_and_hashes: Vec<_> = l1_header_refs
+        let indices_and_hashes: Vec<_> = asm_manifest_refs
             .iter()
             .map(|claim| (claim.idx(), claim.entry_hash()))
             .collect();
@@ -360,7 +360,7 @@ where
             .generate_proofs_for_indices(&indices_and_hashes, at_leaf_count)
             .map_err(|err| match err {
                 DbError::MmrLeafHashMismatch { idx, expected, got } => {
-                    BlockAssemblyError::L1HeaderHashMismatch {
+                    BlockAssemblyError::AsmManifestHashMismatch {
                         idx,
                         expected,
                         actual: got,
@@ -369,11 +369,11 @@ where
                 other => BlockAssemblyError::Db(other),
             })?;
 
-        let l1_header_proofs = merkle_proofs
+        let asm_manifest_proofs = merkle_proofs
             .into_iter()
             .map(|merkle_proof| merkle_proof.inner.clone())
             .collect();
-        Ok(LedgerRefProofs::new(l1_header_proofs))
+        Ok(LedgerRefProofs::new(asm_manifest_proofs))
     }
 }
 
@@ -393,11 +393,11 @@ mod tests {
     // =========================================================================
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_proof_gen_success() {
+    async fn test_asm_manifest_proof_gen_success() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -408,25 +408,27 @@ mod tests {
             .expect("stored state missing");
         let claims = vec![
             fixture
-                .l1_header_ref(1)
+                .asm_manifest_ref(1)
                 .expect("claim for L1 height 1 should exist"),
         ];
 
         let ctx = create_test_context(fixture.storage().clone());
-        let result = ctx
-            .generate_l1_header_proofs(&claims, &MemoryStateBaseLayer::new(state.as_ref().clone()));
+        let result = ctx.generate_asm_manifest_proofs(
+            &claims,
+            &MemoryStateBaseLayer::new(state.as_ref().clone()),
+        );
 
         assert!(result.is_ok(), "Should succeed with valid claim");
         let proofs = result.unwrap();
-        assert_eq!(proofs.l1_headers_proofs().len(), 1);
+        assert_eq!(proofs.asm_manifest_proofs().len(), 1);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_proof_gen_multiple_claims() {
+    async fn test_asm_manifest_proof_gen_multiple_claims() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1, 2, 3]);
+            .with_asm_manifests([1, 2, 3]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -435,23 +437,25 @@ mod tests {
             .await
             .expect("fetch stored state")
             .expect("stored state missing");
-        let claims = fixture.l1_header_refs().to_vec();
+        let claims = fixture.asm_manifest_refs().to_vec();
 
         let ctx = create_test_context(fixture.storage().clone());
-        let result = ctx
-            .generate_l1_header_proofs(&claims, &MemoryStateBaseLayer::new(state.as_ref().clone()));
+        let result = ctx.generate_asm_manifest_proofs(
+            &claims,
+            &MemoryStateBaseLayer::new(state.as_ref().clone()),
+        );
 
         assert!(result.is_ok(), "Should succeed with multiple valid claims");
         let proofs = result.unwrap();
-        assert_eq!(proofs.l1_headers_proofs().len(), 3);
+        assert_eq!(proofs.asm_manifest_proofs().len(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_proof_gen_hash_mismatch() {
+    async fn test_asm_manifest_proof_gen_hash_mismatch() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -461,7 +465,7 @@ mod tests {
             .expect("fetch stored state")
             .expect("stored state missing");
         let seeded_claim = fixture
-            .l1_header_ref(1)
+            .asm_manifest_ref(1)
             .expect("claim for L1 height 1 should exist");
 
         // Create claim with correct MMR index but wrong hash.
@@ -471,7 +475,7 @@ mod tests {
 
         let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(
+        let result = ctx.generate_asm_manifest_proofs(
             &[claim],
             &MemoryStateBaseLayer::new(state.as_ref().clone()),
         );
@@ -484,23 +488,23 @@ mod tests {
         assert!(
             matches!(
                 err,
-                BlockAssemblyError::L1HeaderHashMismatch {
+                BlockAssemblyError::AsmManifestHashMismatch {
                     idx: 1,
                     expected,
                     actual
                 } if expected == wrong_hash && actual == expected_hash
             ),
-            "Expected L1HeaderHashMismatch, got: {:?}",
+            "Expected AsmManifestHashMismatch, got: {:?}",
             err
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_proof_gen_missing_index() {
+    async fn test_asm_manifest_proof_gen_missing_index() {
         let account_id = test_account_id(1);
         let fixture_builder = TestStorageFixtureBuilder::new()
             .with_account(TestAccount::new(account_id, 100_000))
-            .with_l1_header_refs([1]);
+            .with_asm_manifests([1]);
         let (fixture, parent_commitment) = fixture_builder.build_fixture().await;
         let state = fixture
             .storage()
@@ -510,7 +514,7 @@ mod tests {
             .expect("fetch stored state")
             .expect("stored state missing");
         let seeded_claim = fixture
-            .l1_header_ref(1)
+            .asm_manifest_ref(1)
             .expect("claim for L1 height 1 should exist");
 
         // Create claim with non-existent MMR index (999 doesn't exist, MMR has 1 entry)
@@ -519,7 +523,7 @@ mod tests {
 
         let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(
+        let result = ctx.generate_asm_manifest_proofs(
             &[claim],
             &MemoryStateBaseLayer::new(state.as_ref().clone()),
         );
@@ -538,7 +542,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_claim_with_only_genesis_prefill() {
+    async fn test_asm_manifest_claim_with_only_genesis_prefill() {
         // The MMR is height-indexed; with no real manifests seeded, the only
         // leaf present is the genesis sentinel at index 0. A claim quoting any
         // hash other than the sentinel must fail with a hash mismatch.
@@ -557,19 +561,19 @@ mod tests {
         let claim = AccumulatorClaim::new(0, test_hash(42));
         let ctx = create_test_context(fixture.storage().clone());
 
-        let result = ctx.generate_l1_header_proofs(
+        let result = ctx.generate_asm_manifest_proofs(
             &[claim],
             &MemoryStateBaseLayer::new(state.as_ref().clone()),
         );
 
         assert!(matches!(
             result,
-            Err(BlockAssemblyError::L1HeaderHashMismatch { idx: 0, .. })
+            Err(BlockAssemblyError::AsmManifestHashMismatch { idx: 0, .. })
         ));
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_proof_gen_empty_claims() {
+    async fn test_asm_manifest_proof_gen_empty_claims() {
         let account_id = test_account_id(1);
         let fixture_builder =
             TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
@@ -583,12 +587,12 @@ mod tests {
             .expect("stored state missing");
         let ctx = create_test_context(fixture.storage().clone());
 
-        let result =
-            ctx.generate_l1_header_proofs(&[], &MemoryStateBaseLayer::new(state.as_ref().clone()));
+        let result = ctx
+            .generate_asm_manifest_proofs(&[], &MemoryStateBaseLayer::new(state.as_ref().clone()));
 
         assert!(result.is_ok(), "Should succeed with empty claims");
         let proofs = result.unwrap();
-        assert!(proofs.l1_headers_proofs().is_empty());
+        assert!(proofs.asm_manifest_proofs().is_empty());
     }
 
     // =========================================================================

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -435,11 +435,7 @@ mod tests {
             .await
             .expect("fetch stored state")
             .expect("stored state missing");
-        let claims = fixture
-            .l1_header_refs()
-            .iter()
-            .map(|(_, claim)| claim.clone())
-            .collect::<Vec<_>>();
+        let claims = fixture.l1_header_refs().to_vec();
 
         let ctx = create_test_context(fixture.storage().clone());
         let result = ctx
@@ -489,7 +485,7 @@ mod tests {
             matches!(
                 err,
                 BlockAssemblyError::L1HeaderHashMismatch {
-                    idx: 0,
+                    idx: 1,
                     expected,
                     actual
                 } if expected == wrong_hash && actual == expected_hash
@@ -534,7 +530,7 @@ mod tests {
             matches!(
                 &err,
                 BlockAssemblyError::Db(DbError::MmrIndexOutOfRange { requested, cur })
-                    if *requested == nonexistent_idx && *cur == 1
+                    if *requested == nonexistent_idx && *cur == 2
             ),
             "Expected Db(MmrIndexOutOfRange) error, got: {:?}",
             err
@@ -542,7 +538,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_l1_header_claim_empty_mmr() {
+    async fn test_l1_header_claim_with_only_genesis_prefill() {
+        // The MMR is height-indexed; with no real manifests seeded, the only
+        // leaf present is the genesis sentinel at index 0. A claim quoting any
+        // hash other than the sentinel must fail with a hash mismatch.
         let account_id = test_account_id(1);
         let fixture_builder =
             TestStorageFixtureBuilder::new().with_account(TestAccount::new(account_id, 100_000));
@@ -555,7 +554,6 @@ mod tests {
             .expect("fetch stored state")
             .expect("stored state missing");
 
-        // MMR index 0 is valid but the MMR is empty
         let claim = AccumulatorClaim::new(0, test_hash(42));
         let ctx = create_test_context(fixture.storage().clone());
 
@@ -564,19 +562,10 @@ mod tests {
             &MemoryStateBaseLayer::new(state.as_ref().clone()),
         );
 
-        assert!(result.is_err(), "Should fail when MMR is empty");
-        let err = result.unwrap_err();
-        assert!(
-            matches!(
-                err,
-                BlockAssemblyError::Db(DbError::MmrIndexOutOfRange {
-                    requested: 0,
-                    cur: 0
-                })
-            ),
-            "Expected Db(MmrIndexOutOfRange {{ requested: 0, cur: 0 }}), got: {:?}",
-            err
-        );
+        assert!(matches!(
+            result,
+            Err(BlockAssemblyError::L1HeaderHashMismatch { idx: 0, .. })
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/ol/block-assembly/src/error.rs
+++ b/crates/ol/block-assembly/src/error.rs
@@ -19,7 +19,7 @@ pub enum BlockAssemblyError {
 
     /// L1 header claim hash does not match MMR entry.
     #[error("L1 header hash mismatch at index {idx} (expected {expected}, got {actual})")]
-    L1HeaderHashMismatch {
+    AsmManifestHashMismatch {
         idx: u64,
         expected: Hash,
         actual: Hash,

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -371,7 +371,7 @@ pub(crate) struct MempoolSnarkTxBuilder {
     seq_no: u64,
     processed_messages: Vec<MessageEntry>,
     new_msg_idx: u64,
-    l1_claims: Vec<AccumulatorClaim>,
+    asm_manifest_claims: Vec<AccumulatorClaim>,
     outputs: Vec<(AccountId, u64)>,
     output_messages: Vec<OutputMessage>,
 }
@@ -438,7 +438,7 @@ impl MempoolSnarkTxBuilder {
             seq_no: 0,
             processed_messages: Vec::new(),
             new_msg_idx: 0,
-            l1_claims: Vec::new(),
+            asm_manifest_claims: Vec::new(),
             outputs: Vec::new(),
             output_messages: Vec::new(),
         }
@@ -458,8 +458,8 @@ impl MempoolSnarkTxBuilder {
     }
 
     /// Sets L1 header claims from AccumulatorClaim objects.
-    pub(crate) fn with_l1_claims(mut self, claims: Vec<AccumulatorClaim>) -> Self {
-        self.l1_claims = claims;
+    pub(crate) fn with_asm_manifest_claims(mut self, claims: Vec<AccumulatorClaim>) -> Self {
+        self.asm_manifest_claims = claims;
         self
     }
 
@@ -521,11 +521,11 @@ impl MempoolSnarkTxBuilder {
         let proof_state = SauTxProofState::new(self.new_msg_idx, inner_state);
         let update_data = SauTxUpdateData::new(self.seq_no, proof_state, vec![]);
 
-        let ledger_refs = if self.l1_claims.is_empty() {
+        let ledger_refs = if self.asm_manifest_claims.is_empty() {
             SauTxLedgerRefs::new_empty()
         } else {
-            let claim_list =
-                ClaimList::new(self.l1_claims).expect("snark update has too many ASM claims");
+            let claim_list = ClaimList::new(self.asm_manifest_claims)
+                .expect("snark update has too many ASM claims");
             SauTxLedgerRefs::new_with_claims(claim_list)
         };
 
@@ -793,7 +793,7 @@ pub(crate) struct TestStorageFixture {
     storage: Arc<NodeStorage>,
     /// Seeded ASM-manifest claims. Each claim's `idx()` is the L1 height of the
     /// corresponding manifest, since the ASM manifests MMR is height-indexed.
-    l1_header_refs: Vec<AccumulatorClaim>,
+    asm_manifest_refs: Vec<AccumulatorClaim>,
     inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
 }
 
@@ -804,7 +804,7 @@ impl TestStorageFixture {
     pub(crate) fn new(storage: Arc<NodeStorage>) -> Self {
         Self {
             storage,
-            l1_header_refs: Vec::new(),
+            asm_manifest_refs: Vec::new(),
             inbox_message_claims: Vec::new(),
         }
     }
@@ -812,10 +812,10 @@ impl TestStorageFixture {
     /// Sets seeded L1 header refs and inbox message claims produced during fixture setup.
     pub(crate) fn with_seeded_claims(
         mut self,
-        l1_header_refs: Vec<AccumulatorClaim>,
+        asm_manifest_refs: Vec<AccumulatorClaim>,
         inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
     ) -> Self {
-        self.l1_header_refs = l1_header_refs;
+        self.asm_manifest_refs = asm_manifest_refs;
         self.inbox_message_claims = inbox_message_claims;
         self
     }
@@ -826,13 +826,13 @@ impl TestStorageFixture {
     }
 
     /// Returns the seeded L1 header ref claims.
-    pub(crate) fn l1_header_refs(&self) -> &[AccumulatorClaim] {
-        &self.l1_header_refs
+    pub(crate) fn asm_manifest_refs(&self) -> &[AccumulatorClaim] {
+        &self.asm_manifest_refs
     }
 
     /// Returns an L1 header ref for a specific L1 height.
-    pub(crate) fn l1_header_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
-        self.l1_header_refs
+    pub(crate) fn asm_manifest_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
+        self.asm_manifest_refs
             .iter()
             .find(|claim| claim.idx() == height as u64)
             .cloned()
@@ -935,13 +935,13 @@ impl TestEnv {
     }
 
     /// Returns configured L1 header refs keyed by L1 height.
-    pub(crate) fn l1_header_refs(&self) -> &[AccumulatorClaim] {
-        self.fixture.l1_header_refs()
+    pub(crate) fn asm_manifest_refs(&self) -> &[AccumulatorClaim] {
+        self.fixture.asm_manifest_refs()
     }
 
     /// Returns an L1 header ref for a specific L1 height.
-    pub(crate) fn l1_header_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
-        self.fixture.l1_header_ref(height)
+    pub(crate) fn asm_manifest_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
+        self.fixture.asm_manifest_ref(height)
     }
 
     /// Returns inbox message claims for a specific account.
@@ -1086,7 +1086,7 @@ pub(crate) fn block_and_post_state_from_output(
 pub(crate) struct TestStorageFixtureBuilder {
     parent_slot: Option<u64>,
     l1_manifest_height_range: Option<RangeInclusive<L1Height>>,
-    l1_header_ref_heights: Vec<L1Height>,
+    asm_manifest_heights: Vec<L1Height>,
     expected_inbox_message_indices: Vec<(AccountId, Vec<u64>)>,
     accounts: Vec<TestAccount>,
 }
@@ -1131,11 +1131,11 @@ impl TestStorageFixtureBuilder {
     }
 
     /// Seeds L1 header refs for the provided L1 heights.
-    pub(crate) fn with_l1_header_refs(
+    pub(crate) fn with_asm_manifests(
         mut self,
         heights: impl IntoIterator<Item = L1Height>,
     ) -> Self {
-        self.l1_header_ref_heights = heights.into_iter().collect();
+        self.asm_manifest_heights = heights.into_iter().collect();
         self
     }
 
@@ -1219,11 +1219,11 @@ impl TestStorageFixtureBuilder {
         // Seed requested L1 header refs into both state claims and the ASM MMR.
         // The MMR is height-indexed, so each returned claim's `idx()` is the
         // L1 height of the corresponding manifest.
-        let mut l1_heights = self.l1_header_ref_heights.clone();
+        let mut l1_heights = self.asm_manifest_heights.clone();
         l1_heights.sort_unstable();
         l1_heights.dedup();
 
-        let seeded_l1_header_refs = if l1_heights.is_empty() {
+        let seeded_asm_manifest_refs = if l1_heights.is_empty() {
             vec![]
         } else {
             let asm_manifests = create_test_manifests_for_heights(&l1_heights);
@@ -1301,7 +1301,7 @@ impl TestStorageFixtureBuilder {
         };
 
         let fixture =
-            Arc::new(fixture.with_seeded_claims(seeded_l1_header_refs, inbox_message_claims));
+            Arc::new(fixture.with_seeded_claims(seeded_asm_manifest_refs, inbox_message_claims));
         (fixture, parent_commitment)
     }
 }

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -45,7 +45,7 @@ use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, Withdraw
 use strata_ol_params::OLParams;
 use strata_ol_state_provider::{OLStateManagerProviderImpl, StateProvider};
 use strata_ol_state_support_types::{EpochDaAccumulator, MemoryStateBaseLayer};
-use strata_ol_state_types::OLState;
+use strata_ol_state_types::{MMR_SENTINEL_DUMMY_LEAF_HASH, OLState};
 use strata_ol_stf::{
     BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BlockComponents, BlockContext, BlockInfo,
     construct_block as stf_construct_block,
@@ -1337,9 +1337,10 @@ fn prefill_db_asm_mmr_to_match_state(storage: &NodeStorage, state: &impl IStateA
     let mmr_handle = storage.mmr_index().as_ref().get_handle(MmrId::Asm);
     let state_prefill = state.asm_manifests_mmr().num_entries();
     let db_count = mmr_handle.get_num_leaves_blocking().unwrap();
-    let sentinel: Hash = strata_ol_state_types::MMR_PREFILL_LEAF.into();
     for _ in db_count..state_prefill {
-        mmr_handle.append_leaf_blocking(sentinel).unwrap();
+        mmr_handle
+            .append_leaf_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH)
+            .unwrap();
     }
 }
 

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -791,7 +791,9 @@ impl TestAccount {
 /// Storage fixture layer for block assembly tests.
 pub(crate) struct TestStorageFixture {
     storage: Arc<NodeStorage>,
-    l1_header_refs: Vec<(L1Height, AccumulatorClaim)>,
+    /// Seeded ASM-manifest claims. Each claim's `idx()` is the L1 height of the
+    /// corresponding manifest, since the ASM manifests MMR is height-indexed.
+    l1_header_refs: Vec<AccumulatorClaim>,
     inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
 }
 
@@ -810,7 +812,7 @@ impl TestStorageFixture {
     /// Sets seeded L1 header refs and inbox message claims produced during fixture setup.
     pub(crate) fn with_seeded_claims(
         mut self,
-        l1_header_refs: Vec<(L1Height, AccumulatorClaim)>,
+        l1_header_refs: Vec<AccumulatorClaim>,
         inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
     ) -> Self {
         self.l1_header_refs = l1_header_refs;
@@ -823,8 +825,8 @@ impl TestStorageFixture {
         &self.storage
     }
 
-    /// Returns configured L1 header refs keyed by L1 height.
-    pub(crate) fn l1_header_refs(&self) -> &[(L1Height, AccumulatorClaim)] {
+    /// Returns the seeded L1 header ref claims.
+    pub(crate) fn l1_header_refs(&self) -> &[AccumulatorClaim] {
         &self.l1_header_refs
     }
 
@@ -832,8 +834,8 @@ impl TestStorageFixture {
     pub(crate) fn l1_header_ref(&self, height: L1Height) -> Option<AccumulatorClaim> {
         self.l1_header_refs
             .iter()
-            .find(|(h, _)| *h == height)
-            .map(|(_, claim)| claim.clone())
+            .find(|claim| claim.idx() == height as u64)
+            .cloned()
     }
 
     /// Returns inbox message claims for a specific account.
@@ -933,7 +935,7 @@ impl TestEnv {
     }
 
     /// Returns configured L1 header refs keyed by L1 height.
-    pub(crate) fn l1_header_refs(&self) -> &[(L1Height, AccumulatorClaim)] {
+    pub(crate) fn l1_header_refs(&self) -> &[AccumulatorClaim] {
         self.fixture.l1_header_refs()
     }
 
@@ -1085,7 +1087,6 @@ pub(crate) struct TestStorageFixtureBuilder {
     parent_slot: Option<u64>,
     l1_manifest_height_range: Option<RangeInclusive<L1Height>>,
     l1_header_ref_heights: Vec<L1Height>,
-    expected_l1_header_ref_indices: Vec<(L1Height, u64)>,
     expected_inbox_message_indices: Vec<(AccountId, Vec<u64>)>,
     accounts: Vec<TestAccount>,
 }
@@ -1138,15 +1139,6 @@ impl TestStorageFixtureBuilder {
         self
     }
 
-    /// Asserts exact seeded L1 header ref indices as `(l1_height, expected_mmr_index)` entries.
-    pub(crate) fn with_expected_l1_header_ref_indices(
-        mut self,
-        expected: impl IntoIterator<Item = (L1Height, u64)>,
-    ) -> Self {
-        self.expected_l1_header_ref_indices = expected.into_iter().collect();
-        self
-    }
-
     /// Asserts exact seeded inbox message indices as `(account_id, [expected_mmr_index])` entries.
     ///
     /// Inbox messages come from account fixtures (`TestAccount::with_inbox`).
@@ -1172,8 +1164,11 @@ impl TestStorageFixtureBuilder {
                 .await;
         }
 
-        // Create genesis state
+        // Create genesis state and align the DB-side ASM MMR with the state's
+        // genesis prefill so leaf indices == L1 heights everywhere, even when
+        // no manifests are seeded.
         let mut state = create_test_genesis_state();
+        prefill_db_asm_mmr_to_match_state(fixture.storage().as_ref(), &state);
 
         // Add snark accounts
         let mut inbox_message_claims = Vec::new();
@@ -1222,38 +1217,21 @@ impl TestStorageFixtureBuilder {
         }
 
         // Seed requested L1 header refs into both state claims and the ASM MMR.
+        // The MMR is height-indexed, so each returned claim's `idx()` is the
+        // L1 height of the corresponding manifest.
         let mut l1_heights = self.l1_header_ref_heights.clone();
-        l1_heights.extend(
-            self.expected_l1_header_ref_indices
-                .iter()
-                .map(|(height, _)| *height),
-        );
         l1_heights.sort_unstable();
         l1_heights.dedup();
 
-        let seeded_l1_header_refs = if !l1_heights.is_empty() {
+        let seeded_l1_header_refs = if l1_heights.is_empty() {
+            vec![]
+        } else {
             let asm_manifests = create_test_manifests_for_heights(&l1_heights);
-            let claims_by_height = setup_manifests_in_state_and_storage(
+            setup_manifests_in_state_and_storage(
                 fixture.storage().as_ref(),
                 &mut state,
                 asm_manifests,
-            );
-
-            for (height, expected_idx) in &self.expected_l1_header_ref_indices {
-                let (_, claim) = claims_by_height
-                    .iter()
-                    .find(|(h, _)| h == height)
-                    .unwrap_or_else(|| panic!("missing seeded claim for l1 height {height}"));
-                assert_eq!(
-                    claim.idx(),
-                    *expected_idx,
-                    "seeded claim index mismatch for l1 height {height}"
-                );
-            }
-
-            claims_by_height
-        } else {
-            vec![]
+            )
         };
 
         let parent_commitment = if let Some(slot) = self.parent_slot {
@@ -1350,37 +1328,54 @@ fn create_test_manifests_for_heights(heights: &[L1Height]) -> Vec<AsmManifest> {
         .collect()
 }
 
+/// Aligns the DB-side ASM manifests MMR with the state's genesis prefill by
+/// appending sentinel leaves until the DB MMR has at least as many entries as
+/// the state MMR.
+///
+/// After this runs, leaf indices in both MMRs coincide with L1 block heights.
+fn prefill_db_asm_mmr_to_match_state(storage: &NodeStorage, state: &impl IStateAccessor) {
+    let mmr_handle = storage.mmr_index().as_ref().get_handle(MmrId::Asm);
+    let state_prefill = state.asm_manifests_mmr().num_entries();
+    let db_count = mmr_handle.get_num_leaves_blocking().unwrap();
+    let sentinel: Hash = strata_ol_state_types::MMR_PREFILL_LEAF.into();
+    for _ in db_count..state_prefill {
+        mmr_handle.append_leaf_blocking(sentinel).unwrap();
+    }
+}
+
 /// Setup manifests in both storage MMR and state's manifest MMR.
 ///
 /// This ensures consistency between proof generation (uses storage MMR) and
-/// verification (uses state's manifest MMR).
+/// verification (uses state's manifest MMR). The fixture caller is expected
+/// to have already prefilled the DB MMR via [`prefill_db_asm_mmr_to_match_state`].
 ///
-/// Returns `(l1_height, claim)` pairs for each inserted manifest.
+/// Each returned `AccumulatorClaim`'s `idx()` equals the L1 height of the
+/// corresponding manifest.
 fn setup_manifests_in_state_and_storage(
     storage: &NodeStorage,
     state: &mut impl IStateAccessorMut,
     manifests: Vec<AsmManifest>,
-) -> Vec<(L1Height, AccumulatorClaim)> {
+) -> Vec<AccumulatorClaim> {
     let mmr_handle = storage.mmr_index().as_ref().get_handle(MmrId::Asm);
 
-    let mut claims_by_l1_height = Vec::with_capacity(manifests.len());
-
+    let mut claims = Vec::with_capacity(manifests.len());
     for manifest in manifests {
-        // Compute manifest hash
         let manifest_hash: Hash = manifest.compute_hash().into();
-
-        // Add to storage MMR (for proof generation)
         let leaf_idx = mmr_handle.append_leaf_blocking(manifest_hash).unwrap();
-        let claim = AccumulatorClaim::new(leaf_idx, manifest_hash);
 
-        // Add to state's manifest MMR (for verification)
         let height = manifest.height();
         state.append_manifest(height, manifest);
-        claims_by_l1_height.push((height, claim));
+
+        debug_assert_eq!(
+            leaf_idx, height as u64,
+            "DB MMR index must equal L1 height after prefill alignment",
+        );
+
+        claims.push(AccumulatorClaim::new(height as u64, manifest_hash));
     }
 
-    claims_by_l1_height.sort_by_key(|(height, _)| *height);
-    claims_by_l1_height
+    claims.sort_by_key(|c| c.idx());
+    claims
 }
 
 fn build_inbox_claims_for_messages(

--- a/crates/ol/mempool/src/test_utils.rs
+++ b/crates/ol/mempool/src/test_utils.rs
@@ -128,7 +128,7 @@ pub(crate) fn create_test_snark_tx_from_update(
         operation.extra_data().to_vec(),
     );
 
-    let asm_hist_refs = operation.ledger_refs().l1_header_refs();
+    let asm_hist_refs = operation.ledger_refs().asm_manifest_refs();
     let sau_ledger_refs = if asm_hist_refs.is_empty() {
         SauTxLedgerRefs::new_empty()
     } else {

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -64,9 +64,13 @@ pub trait OLClientRpc {
         account_id: AccountId,
     ) -> RpcResult<EpochCommitment>;
 
-    /// Get canonical L1 header commitment for the given L1 block height.
-    #[method(name = "getL1HeaderCommitment")]
-    async fn get_l1_header_commitment(&self, l1_height: L1Height) -> RpcResult<Option<HexBytes32>>;
+    /// Get the canonical ASM-manifest commitment (the manifest's tree-hash root)
+    /// for the given L1 block height.
+    #[method(name = "getAsmManifestCommitment")]
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> RpcResult<Option<HexBytes32>>;
 
     /// Submit transaction to the node. Returns immediately with tx ID.
     #[method(name = "submitTransaction")]

--- a/crates/ol/rpc/types/src/tx.rs
+++ b/crates/ol/rpc/types/src/tx.rs
@@ -185,7 +185,7 @@ impl TryFrom<RpcOLTransaction> for OLTransaction {
                     operation.extra_data().to_vec(),
                 );
 
-                let asm_hist_refs = operation.ledger_refs().l1_header_refs();
+                let asm_hist_refs = operation.ledger_refs().asm_manifest_refs();
                 let sau_ledger_refs = if asm_hist_refs.is_empty() {
                     SauTxLedgerRefs::new_empty()
                 } else {

--- a/crates/ol/state-support-types/src/indexer_layer.rs
+++ b/crates/ol/state-support-types/src/indexer_layer.rs
@@ -778,8 +778,9 @@ mod tests {
         let state = create_test_base_layer();
         let mut indexer = IndexerState::new(state);
 
-        // Create a test manifest
-        let height = L1Height::from(100u32);
+        // Create a test manifest. The base layer is built from a default
+        // genesis (L1 height 0), so the next valid contiguous height is 1.
+        let height = L1Height::from(1u32);
         let l1_blkid = L1BlockId::from(Buf32::from([1u8; 32]));
         let wtxids_root = WtxidsRoot::from(Buf32::from([2u8; 32]));
         let manifest =

--- a/crates/ol/state-types/src/constants.rs
+++ b/crates/ol/state-types/src/constants.rs
@@ -14,5 +14,5 @@ use strata_identifiers::Hash;
 // TODO(STR-3417): move to strata-identifiers
 pub const MMR_SENTINEL_DUMMY_LEAF: [u8; 32] = [0xffu8; 32];
 
-/// Just [`MMR_SENTINEL_DUMMY_LEAF`] as a [`Hash`].
+/// Just [`MMR_SENTINEL_DUMMY_LEAF`] as a [`tyalias@Hash`].
 pub const MMR_SENTINEL_DUMMY_LEAF_HASH: Hash = Hash::new(MMR_SENTINEL_DUMMY_LEAF);

--- a/crates/ol/state-types/src/constants.rs
+++ b/crates/ol/state-types/src/constants.rs
@@ -1,0 +1,13 @@
+//! Protocol constants.
+
+/// Sentinel leaf value used to prefill the ASM manifests MMR for L1 heights at
+/// or before ASM genesis.
+///
+/// The MMR is height-indexed.  Positions for blocks at heights
+/// `0..=genesis_l1_height` are filled with this constant so that the manifest
+/// for height `h` lands at MMR index `h`. The value is non-zero because the
+/// MMR encoding treats `[0; 32]` as "no peak present"; the specific bytes do
+/// not affect protocol semantics, since no proof verifies against a prefilled
+/// position.
+// TODO(STR-3417): move to strata-identifiers
+pub const MMR_SENTINEL_DUMMY_LEAF: [u8; 32] = [0xffu8; 32];

--- a/crates/ol/state-types/src/constants.rs
+++ b/crates/ol/state-types/src/constants.rs
@@ -1,5 +1,7 @@
 //! Protocol constants.
 
+use strata_identifiers::Hash;
+
 /// Sentinel leaf value used to prefill the ASM manifests MMR for L1 heights at
 /// or before ASM genesis.
 ///
@@ -11,3 +13,6 @@
 /// position.
 // TODO(STR-3417): move to strata-identifiers
 pub const MMR_SENTINEL_DUMMY_LEAF: [u8; 32] = [0xffu8; 32];
+
+/// Just [`MMR_SENTINEL_DUMMY_LEAF`] as a [`Hash`].
+pub const MMR_SENTINEL_DUMMY_LEAF_HASH: Hash = Hash::new(MMR_SENTINEL_DUMMY_LEAF);

--- a/crates/ol/state-types/src/epochal.rs
+++ b/crates/ol/state-types/src/epochal.rs
@@ -17,7 +17,6 @@ impl EpochalState {
         last_l1_block: L1BlockCommitment,
         checkpointed_epoch: EpochCommitment,
         manifests_mmr: Mmr64,
-        manifests_mmr_offset: u64,
     ) -> Self {
         Self {
             total_ledger_funds,
@@ -25,7 +24,6 @@ impl EpochalState {
             last_l1_block,
             checkpointed_epoch,
             manifests_mmr,
-            manifests_mmr_offset,
         }
     }
 
@@ -51,7 +49,18 @@ impl EpochalState {
 
     /// Appends a new ASM manifest to the accumulator, also updating the last L1
     /// block height and other fields.
+    ///
+    /// The MMR is height-indexed: the leaf for an L1 block at height `h` lives
+    /// at MMR index `h`. The MMR is prefilled with zero-hash entries up to
+    /// `genesis_l1_height` at genesis, so callers must append manifests with
+    /// strictly contiguous heights matching the next available MMR index.
     pub fn append_manifest(&mut self, height: L1Height, mf: AsmManifest) {
+        debug_assert_eq!(
+            self.manifests_mmr.num_entries(),
+            height as u64,
+            "append_manifest: height must equal next MMR index"
+        );
+
         let manifest_hash = <AsmManifest as TreeHash>::tree_hash_root(&mf);
 
         Mmr::<StrataHasher>::add_leaf(&mut self.manifests_mmr, manifest_hash.into_inner())
@@ -86,13 +95,10 @@ impl EpochalState {
     }
 
     /// Gets the ASM manifests MMR.
+    ///
+    /// Indices into this MMR are L1 block heights.
     pub fn asm_manifests_mmr(&self) -> &Mmr64 {
         &self.manifests_mmr
-    }
-
-    /// Gets the offset for mapping L1 block heights to MMR leaf indices.
-    pub fn manifests_mmr_offset(&self) -> u64 {
-        self.manifests_mmr_offset
     }
 }
 

--- a/crates/ol/state-types/src/epochal.rs
+++ b/crates/ol/state-types/src/epochal.rs
@@ -51,20 +51,20 @@ impl EpochalState {
     /// block height and other fields.
     ///
     /// The MMR is height-indexed: the leaf for an L1 block at height `h` lives
-    /// at MMR index `h`. The MMR is prefilled with zero-hash entries up to
+    /// at MMR index `h`. The MMR is prefilled with dummy-hash entries up to
     /// `genesis_l1_height` at genesis, so callers must append manifests with
     /// strictly contiguous heights matching the next available MMR index.
     pub fn append_manifest(&mut self, height: L1Height, mf: AsmManifest) {
         debug_assert_eq!(
             self.manifests_mmr.num_entries(),
             height as u64,
-            "append_manifest: height must equal next MMR index"
+            "ol/state: L1 height must equal next MMR index"
         );
 
         let manifest_hash = <AsmManifest as TreeHash>::tree_hash_root(&mf);
 
         Mmr::<StrataHasher>::add_leaf(&mut self.manifests_mmr, manifest_hash.into_inner())
-            .expect("MMR capacity exceeded");
+            .expect("ol/state: MMR capacity exceeded");
         self.last_l1_block = L1BlockCommitment::new(height, *mf.blkid());
     }
 

--- a/crates/ol/state-types/src/lib.rs
+++ b/crates/ol/state-types/src/lib.rs
@@ -32,4 +32,5 @@ pub mod test_utils;
 pub use batch_application::*;
 pub use serial_map::*;
 pub use ssz_generated::ssz::state::*;
+pub use toplevel::MMR_PREFILL_LEAF;
 pub use write_batch::*;

--- a/crates/ol/state-types/src/lib.rs
+++ b/crates/ol/state-types/src/lib.rs
@@ -31,7 +31,7 @@ pub mod test_utils;
 
 // Re-export SSZ-generated types that are used publicly
 pub use batch_application::*;
-pub use constants::MMR_SENTINEL_DUMMY_LEAF;
+pub use constants::*;
 pub use serial_map::*;
 pub use ssz_generated::ssz::state::*;
 pub use write_batch::*;

--- a/crates/ol/state-types/src/lib.rs
+++ b/crates/ol/state-types/src/lib.rs
@@ -17,6 +17,7 @@ mod ssz_generated {
 
 mod account;
 mod batch_application;
+mod constants;
 mod epochal;
 mod global;
 mod ledger;
@@ -30,7 +31,7 @@ pub mod test_utils;
 
 // Re-export SSZ-generated types that are used publicly
 pub use batch_application::*;
+pub use constants::MMR_SENTINEL_DUMMY_LEAF;
 pub use serial_map::*;
 pub use ssz_generated::ssz::state::*;
-pub use toplevel::MMR_PREFILL_LEAF;
 pub use write_batch::*;

--- a/crates/ol/state-types/src/test_utils.rs
+++ b/crates/ol/state-types/src/test_utils.rs
@@ -57,7 +57,6 @@ pub fn epochal_state_strategy() -> impl Strategy<Value = EpochalState> {
                     entries: 0,
                     roots: Default::default(),
                 },
-                manifests_mmr_offset: 1,
             },
         )
 }

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -6,22 +6,11 @@ use strata_merkle::Mmr;
 use strata_ol_params::OLParams;
 
 use crate::{
-    OLAccountTypeState, OLSnarkAccountState, WriteBatch,
+    MMR_SENTINEL_DUMMY_LEAF, OLAccountTypeState, OLSnarkAccountState, WriteBatch,
     ssz_generated::ssz::state::{
         EpochalState, GlobalState, OLAccountState, OLState, TsnlLedgerAccountsTable,
     },
 };
-
-/// Sentinel leaf used to prefill the ASM manifests MMR for L1 heights at or
-/// before genesis.
-///
-/// The MMR is height-indexed; positions for blocks at heights
-/// `0..=genesis_l1_height` are filled with this constant so that the manifest
-/// for height `h` lands at MMR index `h`. The value is non-zero because the
-/// MMR encoding treats `[0; 32]` as "no peak present"; the specific bytes do
-/// not affect protocol semantics, since no proof verifies against a prefilled
-/// position.
-pub const MMR_PREFILL_LEAF: [u8; 32] = [0xffu8; 32];
 
 impl OLState {
     /// Creates initial OL state from genesis parameters.
@@ -40,7 +29,7 @@ impl OLState {
         // state and the DB-side ASM MMR agree on it.
         let prefill_count = params.last_l1_block.height() as u64 + 1;
         let manifests_mmr =
-            <Mmr64 as Mmr<StrataHasher>>::new_repeated(MMR_PREFILL_LEAF, prefill_count);
+            <Mmr64 as Mmr<StrataHasher>>::new_repeated(MMR_SENTINEL_DUMMY_LEAF, prefill_count);
 
         let mut next_serial = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
         let mut ledger = TsnlLedgerAccountsTable::new_empty();

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -1,8 +1,8 @@
 //! Toplevel state.
 
-use strata_acct_types::{AccountId, AccountSerial, Mmr64, SYSTEM_RESERVED_ACCTS};
+use strata_acct_types::{AccountId, AccountSerial, Mmr64, SYSTEM_RESERVED_ACCTS, StrataHasher};
 use strata_ledger_types::{NewAccountData, StateError, StateResult};
-use strata_merkle::CompactMmr64;
+use strata_merkle::Mmr;
 use strata_ol_params::OLParams;
 
 use crate::{
@@ -12,11 +12,35 @@ use crate::{
     },
 };
 
+/// Sentinel leaf used to prefill the ASM manifests MMR for L1 heights at or
+/// before genesis.
+///
+/// The MMR is height-indexed; positions for blocks at heights
+/// `0..=genesis_l1_height` are filled with this constant so that the manifest
+/// for height `h` lands at MMR index `h`. The value is non-zero because the
+/// MMR encoding treats `[0; 32]` as "no peak present"; the specific bytes do
+/// not affect protocol semantics, since no proof verifies against a prefilled
+/// position.
+pub const MMR_PREFILL_LEAF: [u8; 32] = [0xffu8; 32];
+
 impl OLState {
     /// Creates initial OL state from genesis parameters.
     pub fn from_genesis_params(params: &OLParams) -> StateResult<Self> {
         let checkpointed_epoch = params.checkpointed_epoch();
-        let manifests_mmr = Mmr64::from_generic(&CompactMmr64::new(64));
+
+        // Prefill the manifests MMR with a sentinel leaf for every L1 block up
+        // to and including `genesis_l1_height`, so that subsequent appends for
+        // height `h` land at MMR index `h` (i.e., MMR indices == L1 heights).
+        //
+        // The leaf value is `[0xff; 32]` rather than `[0; 32]` because the
+        // underlying MMR encoding treats a zero hash as "no peak present", so a
+        // literal zero leaf would not increment the entry counter. The exact
+        // sentinel value does not matter for correctness — no real proof
+        // references an L1 block at or before genesis — as long as the OL
+        // state and the DB-side ASM MMR agree on it.
+        let prefill_count = params.last_l1_block.height() as u64 + 1;
+        let manifests_mmr =
+            <Mmr64 as Mmr<StrataHasher>>::new_repeated(MMR_PREFILL_LEAF, prefill_count);
 
         let mut next_serial = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
         let mut ledger = TsnlLedgerAccountsTable::new_empty();
@@ -45,14 +69,12 @@ impl OLState {
         let total_ledger_funds = ledger.calculate_total_funds();
 
         let global = GlobalState::new(params.header.slot, next_serial);
-        let manifests_mmr_offset = params.last_l1_block.height() as u64 + 1;
         let epoch = EpochalState::new(
             total_ledger_funds,
             params.header.epoch,
             params.last_l1_block,
             checkpointed_epoch,
             manifests_mmr,
-            manifests_mmr_offset,
         );
 
         Ok(Self {

--- a/crates/ol/state-types/ssz/state.ssz
+++ b/crates/ol/state-types/ssz/state.ssz
@@ -94,9 +94,9 @@ class EpochalState(Container):
     ### Manifests MMR
     ###
     ### Indices into this MMR are L1 block heights. At genesis the MMR is
-    ### prefilled with zero-hash leaves for heights 0..=genesis_l1_height,
-    ### so the first appended manifest (for genesis_l1_height + 1) lands at
-    ### the correct height-indexed position.
+    ### prefilled with dummy sentinel values of `[0xff, 32]`, so the first
+    ### real appended manifest (for genesis_l1_height + 1) lands at the
+    ### correct height-indexed position.
     #~# external_kind: container
     manifests_mmr: strata_acct_types.Mmr64
 

--- a/crates/ol/state-types/ssz/state.ssz
+++ b/crates/ol/state-types/ssz/state.ssz
@@ -92,11 +92,13 @@ class EpochalState(Container):
     checkpointed_epoch: strata_identifiers.EpochCommitment
 
     ### Manifests MMR
+    ###
+    ### Indices into this MMR are L1 block heights. At genesis the MMR is
+    ### prefilled with zero-hash leaves for heights 0..=genesis_l1_height,
+    ### so the first appended manifest (for genesis_l1_height + 1) lands at
+    ### the correct height-indexed position.
     #~# external_kind: container
     manifests_mmr: strata_acct_types.Mmr64
-
-    ### Offset for mapping L1 block heights to MMR leaf indices (genesis_height + 1)
-    manifests_mmr_offset: uint64
 
 ### Global state tracking current slot
 class GlobalState(Container):

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -560,7 +560,7 @@ impl ManifestMmrTracker {
     pub fn with_genesis_l1_height(genesis_l1_height: u32) -> Self {
         let prefill_count = genesis_l1_height as u64 + 1;
         let mmr = <Mmr64 as strata_merkle::Mmr<StrataHasher>>::new_repeated(
-            strata_ol_state_types::MMR_PREFILL_LEAF,
+            strata_ol_state_types::MMR_SENTINEL_DUMMY_LEAF,
             prefill_count,
         );
         Self {

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -547,9 +547,24 @@ impl Default for ManifestMmrTracker {
 }
 
 impl ManifestMmrTracker {
+    /// Creates a tracker matching the test genesis state (genesis L1 height 0).
+    ///
+    /// This prefills the tracked MMR with a single sentinel leaf so its index
+    /// space lines up with `create_test_genesis_state`'s prefilled state MMR.
     pub fn new() -> Self {
+        Self::with_genesis_l1_height(0)
+    }
+
+    /// Creates a tracker prefilled with sentinel leaves up to and including
+    /// the given L1 height, so MMR indices match L1 heights.
+    pub fn with_genesis_l1_height(genesis_l1_height: u32) -> Self {
+        let prefill_count = genesis_l1_height as u64 + 1;
+        let mmr = <Mmr64 as strata_merkle::Mmr<StrataHasher>>::new_repeated(
+            strata_ol_state_types::MMR_PREFILL_LEAF,
+            prefill_count,
+        );
         Self {
-            mmr: Mmr64::from_generic(&CompactMmr64::new(64)),
+            mmr,
             proofs: Vec::new(),
         }
     }

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -20,7 +20,9 @@ use strata_merkle::{CompactMmr64, MerkleProof, Mmr};
 use strata_ol_chain_types_new::*;
 use strata_ol_params::OLParams;
 use strata_ol_state_support_types::MemoryStateBaseLayer;
-use strata_ol_state_types::{OLAccountState, OLSnarkAccountState, OLState};
+use strata_ol_state_types::{
+    MMR_SENTINEL_DUMMY_LEAF, OLAccountState, OLSnarkAccountState, OLState,
+};
 use strata_predicate::PredicateKey;
 
 /// Creates a genesis state layer using minimal empty parameters.
@@ -560,7 +562,7 @@ impl ManifestMmrTracker {
     pub fn with_genesis_l1_height(genesis_l1_height: u32) -> Self {
         let prefill_count = genesis_l1_height as u64 + 1;
         let mmr = <Mmr64 as strata_merkle::Mmr<StrataHasher>>::new_repeated(
-            strata_ol_state_types::MMR_SENTINEL_DUMMY_LEAF,
+            MMR_SENTINEL_DUMMY_LEAF,
             prefill_count,
         );
         Self {

--- a/crates/ol/stf/src/tests/ledger_references.rs
+++ b/crates/ol/stf/src/tests/ledger_references.rs
@@ -56,7 +56,10 @@ fn test_snark_update_with_valid_ledger_reference() {
         manifest_tracker.num_entries(),
         "State MMR should match tracker MMR"
     );
-    assert_eq!(manifest1_index, 0, "First manifest should be at index 0");
+    assert_eq!(
+        manifest1_index, 1,
+        "First real manifest is for L1 height 1 and lands at MMR index 1 (index 0 is the genesis prefill)"
+    );
 
     // Step 2: Create a snark update that references the manifest
     // AccumulatorClaim.idx is the MMR leaf index directly
@@ -149,9 +152,11 @@ fn test_snark_update_with_invalid_ledger_reference() {
     // AccumulatorClaim.idx is the MMR leaf index directly
     let claim = AccumulatorClaim::new(manifest1_index, manifest1_hash.into_inner());
 
-    // Create an invalid proof with wrong cohashes
+    // Create an invalid proof with wrong cohashes. Using a value distinct from
+    // the genesis-prefill sentinel so the proof can't accidentally verify
+    // against the prefilled sibling at index 0.
     let invalid_proof = RawMerkleProof {
-        cohashes: vec![ssz_primitives::FixedBytes::<32>::from([0xff; 32])]
+        cohashes: vec![ssz_primitives::FixedBytes::<32>::from([0xeeu8; 32])]
             .try_into()
             .unwrap(),
     };
@@ -249,10 +254,10 @@ fn test_snark_update_with_mismatched_ledger_reference_proof_index() {
             let mut cohashes: Vec<_> = manifest1_proof.cohashes.iter().cloned().collect();
             // Corrupt the proof by replacing the first cohash with a bogus one
             if !cohashes.is_empty() {
-                cohashes[0] = ssz_primitives::FixedBytes::<32>::from([0xff; 32]);
+                cohashes[0] = ssz_primitives::FixedBytes::<32>::from([0xeeu8; 32]);
             } else {
                 // If no cohashes, add a bogus one
-                cohashes.push(ssz_primitives::FixedBytes::<32>::from([0xff; 32]));
+                cohashes.push(ssz_primitives::FixedBytes::<32>::from([0xeeu8; 32]));
             }
             cohashes
                 .try_into()

--- a/crates/proof-impl/checkpoint/src/statements.rs
+++ b/crates/proof-impl/checkpoint/src/statements.rs
@@ -5,7 +5,7 @@
 
 use ssz::{Decode, Encode};
 use ssz_primitives::FixedBytes;
-use strata_asm_manifest_types::{compute_asm_manifests_hash, AsmManifestRangeHash};
+use strata_asm_manifest_types::{AsmManifestRangeHash, compute_asm_manifests_hash};
 use strata_asm_proto_checkpoint_types::{CheckpointClaim, L2BlockRange, TerminalHeaderComplement};
 use strata_crypto::hash;
 use strata_ledger_types::IStateAccessor;

--- a/crates/proof-impl/checkpoint/src/statements.rs
+++ b/crates/proof-impl/checkpoint/src/statements.rs
@@ -5,7 +5,7 @@
 
 use ssz::{Decode, Encode};
 use ssz_primitives::FixedBytes;
-use strata_asm_manifest_types::compute_asm_manifests_hash;
+use strata_asm_manifest_types::{compute_asm_manifests_hash, AsmManifestRangeHash};
 use strata_asm_proto_checkpoint_types::{CheckpointClaim, L2BlockRange, TerminalHeaderComplement};
 use strata_crypto::hash;
 use strata_ledger_types::IStateAccessor;
@@ -235,7 +235,7 @@ fn execute_block_batch(
     state: &mut MemoryStateBaseLayer,
     blocks: &[OLBlock],
     initial_parent: &OLBlockHeader,
-) -> (Vec<OLLog>, FixedBytes<32>, OLBlockHeader) {
+) -> (Vec<OLLog>, AsmManifestRangeHash, OLBlockHeader) {
     // Exactly one block per epoch must carry an L1 update (the terminal block).
     // The manifest hash is computed by overwriting a single `Option` in the loop
     // below, so multiple L1 updates would silently drop earlier hashes and zero
@@ -251,7 +251,7 @@ fn execute_block_batch(
     );
 
     let mut parent = initial_parent.clone();
-    let mut asm_manifests_hash: Option<FixedBytes<32>> = None;
+    let mut asm_manifests_hash: Option<AsmManifestRangeHash> = None;
     let mut logs = Vec::new();
 
     // Process each block in the batch sequentially, applying state transitions

--- a/crates/snark-acct-sys/src/verification.rs
+++ b/crates/snark-acct-sys/src/verification.rs
@@ -88,7 +88,7 @@ fn verify_ledger_refs(
     proof_verifier: &mut impl TxProofVerifier,
     ledger_refs: &LedgerRefs,
 ) -> ExecResult<()> {
-    let manifest_claims = ledger_refs.l1_header_refs();
+    let manifest_claims = ledger_refs.asm_manifest_refs();
 
     for claim in manifest_claims {
         proof_verifier

--- a/crates/snark-acct-types/src/proof_interface.rs
+++ b/crates/snark-acct-types/src/proof_interface.rs
@@ -105,7 +105,7 @@ mod tests {
 
     fn ledger_refs_strategy() -> impl Strategy<Value = LedgerRefs> {
         prop::collection::vec(accumulator_claim_strategy(), 0..3).prop_map(|refs| LedgerRefs {
-            l1_header_refs: refs
+            asm_manifest_refs: refs
                 .try_into()
                 .expect("ledger refs must fit within SSZ max length"),
         })

--- a/crates/snark-acct-types/src/update.rs
+++ b/crates/snark-acct-types/src/update.rs
@@ -113,10 +113,10 @@ impl From<UpdateOperationData> for UpdateInputData {
 }
 
 impl LedgerRefs {
-    pub fn new(l1_header_refs: Vec<AccumulatorClaim>) -> Self {
+    pub fn new(asm_manifest_refs: Vec<AccumulatorClaim>) -> Self {
         Self {
             // FIXME does this panic?
-            l1_header_refs: l1_header_refs
+            asm_manifest_refs: asm_manifest_refs
                 .try_into()
                 .expect("ledger refs must fit within SSZ max length"),
         }
@@ -126,23 +126,25 @@ impl LedgerRefs {
         Self::new(Vec::new())
     }
 
-    pub fn l1_header_refs(&self) -> &[AccumulatorClaim] {
-        self.l1_header_refs.as_ref()
+    /// Claims against the ASM manifests MMR. Each claim's `idx` is the L1
+    /// block height of the referenced manifest.
+    pub fn asm_manifest_refs(&self) -> &[AccumulatorClaim] {
+        self.asm_manifest_refs.as_ref()
     }
 }
 
 impl LedgerRefProofs {
-    pub fn new(l1_headers_proofs: Vec<RawMerkleProof>) -> Self {
+    pub fn new(asm_manifest_proofs: Vec<RawMerkleProof>) -> Self {
         Self {
             // FIXME does this panic?
-            l1_headers_proofs: l1_headers_proofs
+            asm_manifest_proofs: asm_manifest_proofs
                 .try_into()
                 .expect("ledger ref proofs must fit within SSZ max length"),
         }
     }
 
-    pub fn l1_headers_proofs(&self) -> &[RawMerkleProof] {
-        self.l1_headers_proofs.as_ref()
+    pub fn asm_manifest_proofs(&self) -> &[RawMerkleProof] {
+        self.asm_manifest_proofs.as_ref()
     }
 }
 

--- a/crates/snark-acct-types/ssz/update.ssz
+++ b/crates/snark-acct-types/ssz/update.ssz
@@ -15,13 +15,15 @@ MAX_EXTRA_DATA_BYTES = 1024
 
 ### Describes references to entries in accumulators available in the ledger.
 class LedgerRefs(Container):
+    ### Claims against the ASM manifests MMR. Each claim's `idx` is the L1
+    ### block height of the manifest being referenced.
     #~# external_kind: container
-    l1_header_refs: List[strata_acct_types.AccumulatorClaim, MAX_TYPE_LEDGER_REFS]
+    asm_manifest_refs: List[strata_acct_types.AccumulatorClaim, MAX_TYPE_LEDGER_REFS]
 
 class LedgerRefProofs(Container):
     ### Proofs for each entry in LedgerRefs.
     #~# external_kind: container
-    l1_headers_proofs: List[strata_acct_types.RawMerkleProof, MAX_TYPE_LEDGER_REFS]
+    asm_manifest_proofs: List[strata_acct_types.RawMerkleProof, MAX_TYPE_LEDGER_REFS]
 
 ### Represents the state update that will eventually go into DA on OL.
 class UpdateStateData(Container):

--- a/crates/test-utils/l2/src/checkpoint.rs
+++ b/crates/test-utils/l2/src/checkpoint.rs
@@ -178,7 +178,7 @@ impl CheckpointTestHarness {
             AsmHistoryAccumulatorState::new(self.genesis_l1_height as u64);
 
         for leaf in &leaves {
-            asm_accumulator_state.add_manifest_leaf(*leaf).unwrap();
+            asm_accumulator_state.add_manifest_leaf((*leaf).into()).unwrap();
 
             let proof1 = Mmr::<Sha256Hasher>::add_leaf_updating_proof_list(
                 &mut manifest_mmr,
@@ -192,7 +192,7 @@ impl CheckpointTestHarness {
         let manifest_hashes = leaves
             .iter()
             .zip(proof_list)
-            .map(|(leaf, proof)| VerifiableManifestHash::new(*leaf, proof))
+            .map(|(leaf, proof)| VerifiableManifestHash::new((*leaf).into(), proof))
             .collect();
 
         let data = AuxData::new(manifest_hashes, vec![]);
@@ -237,7 +237,11 @@ impl CheckpointTestHarness {
         let state_diff_hash = hash::raw(&state_diff).into();
         let ol_logs_hash = hash::raw(&ol_logs.as_ssz_bytes()).into();
 
-        let manifest_hashes = self.gen_manifest_leaves(&new_tip);
+        let manifest_hashes: Vec<_> = self
+            .gen_manifest_leaves(&new_tip)
+            .into_iter()
+            .map(Into::into)
+            .collect();
         let asm_manifests_hash = compute_asm_manifests_hash_from_leaves(&manifest_hashes);
 
         let l2_range = L2BlockRange::new(self.verified_tip.l2_commitment, new_tip.l2_commitment);
@@ -291,7 +295,10 @@ impl CheckpointTestHarness {
         let state_diff_hash = hash::raw(&state_diff).into();
         let ol_logs_hash = hash::raw(&ol_logs.as_ssz_bytes()).into();
 
-        let asm_manifests_hash = compute_asm_manifests_hash_from_leaves(manifest_hashes);
+        let manifest_hashes_converted: Vec<_> =
+            manifest_hashes.iter().copied().map(Into::into).collect();
+        let asm_manifests_hash =
+            compute_asm_manifests_hash_from_leaves(&manifest_hashes_converted);
 
         let l2_range = L2BlockRange::new(self.verified_tip.l2_commitment, new_tip.l2_commitment);
         let claim = CheckpointClaim::new(

--- a/crates/test-utils/l2/src/checkpoint.rs
+++ b/crates/test-utils/l2/src/checkpoint.rs
@@ -178,7 +178,9 @@ impl CheckpointTestHarness {
             AsmHistoryAccumulatorState::new(self.genesis_l1_height as u64);
 
         for leaf in &leaves {
-            asm_accumulator_state.add_manifest_leaf((*leaf).into()).unwrap();
+            asm_accumulator_state
+                .add_manifest_leaf((*leaf).into())
+                .unwrap();
 
             let proof1 = Mmr::<Sha256Hasher>::add_leaf_updating_proof_list(
                 &mut manifest_mmr,
@@ -297,8 +299,7 @@ impl CheckpointTestHarness {
 
         let manifest_hashes_converted: Vec<_> =
             manifest_hashes.iter().copied().map(Into::into).collect();
-        let asm_manifests_hash =
-            compute_asm_manifests_hash_from_leaves(&manifest_hashes_converted);
+        let asm_manifests_hash = compute_asm_manifests_hash_from_leaves(&manifest_hashes_converted);
 
         let l2_range = L2BlockRange::new(self.verified_tip.l2_commitment, new_tip.l2_commitment);
         let claim = CheckpointClaim::new(

--- a/functional-tests/common/services/strata.py
+++ b/functional-tests/common/services/strata.py
@@ -288,7 +288,7 @@ class StrataService(RpcService):
         )
         return self.get_cur_block_height(rpc)
 
-    def wait_for_l1_commitment_at(
+    def wait_for_asm_manifest_commitment_at(
         self,
         height: int,
         rpc: JsonRpcClient | None = None,
@@ -296,7 +296,7 @@ class StrataService(RpcService):
         poll_interval: float = 0.5,
         differs_from: object | None = None,
     ) -> object:
-        """Wait for an L1 header commitment at a given height.
+        """Wait for an ASM-manifest commitment at a given L1 height.
 
         Args:
             height: L1 block height to check.
@@ -307,7 +307,7 @@ class StrataService(RpcService):
                 from this value (useful for reorg detection).
 
         Returns:
-            The L1 header commitment value.
+            The ASM-manifest commitment value.
         """
         if rpc is None:
             rpc = self.create_rpc()
@@ -318,9 +318,9 @@ class StrataService(RpcService):
             return differs_from is None or v != differs_from
 
         return wait_until_with_value(
-            lambda: rpc.strata_getL1HeaderCommitment(height),
+            lambda: rpc.strata_getAsmManifestCommitment(height),
             predicate,
-            error_with=f"No L1 header commitment at height {height}",
+            error_with=f"No ASM manifest commitment at L1 height {height}",
             timeout=timeout,
             step=poll_interval,
         )

--- a/functional-tests/tests/btcio/test_l1_connected.py
+++ b/functional-tests/tests/btcio/test_l1_connected.py
@@ -46,7 +46,9 @@ class TestL1Connected(StrataNodeTest):
         genesis_l1_height = chain_info["blocks"]
         logger.info(f"Genesis L1 height: {genesis_l1_height}")
 
-        commitment = strata.wait_for_l1_commitment_at(genesis_l1_height, rpc=rpc, timeout=60)
+        commitment = strata.wait_for_asm_manifest_commitment_at(
+            genesis_l1_height, rpc=rpc, timeout=60
+        )
 
         logger.info(f"L1 header commitment at {genesis_l1_height}: {commitment}")
         return True

--- a/functional-tests/tests/btcio/test_l1_reorg.py
+++ b/functional-tests/tests/btcio/test_l1_reorg.py
@@ -60,7 +60,7 @@ class TestL1Reorg(StrataNodeTest):
         logger.info(f"Will invalidate from height {invalidate_height}")
 
         # Wait for strata to have processed the block at this height.
-        pre_reorg_commitment = strata.wait_for_l1_commitment_at(
+        pre_reorg_commitment = strata.wait_for_asm_manifest_commitment_at(
             invalidate_height, rpc=rpc, timeout=120
         )
         logger.info(f"Pre-reorg commitment at {invalidate_height}: {pre_reorg_commitment}")
@@ -89,7 +89,7 @@ class TestL1Reorg(StrataNodeTest):
 
         # Wait for strata to pick up the new chain; the commitment
         # at invalidate_height must differ from the pre-reorg value.
-        post_reorg_commitment = strata.wait_for_l1_commitment_at(
+        post_reorg_commitment = strata.wait_for_asm_manifest_commitment_at(
             invalidate_height,
             rpc=rpc,
             timeout=120,

--- a/functional-tests/tests/btcio/test_l1_tracking.py
+++ b/functional-tests/tests/btcio/test_l1_tracking.py
@@ -16,7 +16,7 @@ class TestL1Tracking(StrataNodeTest):
     """Verify strata's L1 reader picks up newly mined Bitcoin blocks.
 
     Mines additional Bitcoin blocks after strata is running and verifies
-    that strata_getL1HeaderCommitment returns data for the new heights.
+    that strata_getAsmManifestCommitment returns data for the new heights.
 
     Uses a standalone env to avoid interference from other tests that
     may restart the sequencer.
@@ -41,7 +41,7 @@ class TestL1Tracking(StrataNodeTest):
         logger.info(f"Bitcoin tip before mining: {pre_tip}")
 
         # Wait for strata to have caught up to pre_tip
-        strata.wait_for_l1_commitment_at(pre_tip, rpc=rpc, timeout=120)
+        strata.wait_for_asm_manifest_commitment_at(pre_tip, rpc=rpc, timeout=120)
 
         # Mine additional blocks one at a time.  Mining in a single batch can
         # trigger a race in the L1 reader / ASM pipeline where the ASM is
@@ -56,14 +56,14 @@ class TestL1Tracking(StrataNodeTest):
             raise AssertionError(f"Expected tip {pre_tip + self.EXTRA_BLOCKS}, got {post_tip}")
 
         # Wait for strata to pick up the new blocks
-        commitment = strata.wait_for_l1_commitment_at(post_tip, rpc=rpc, timeout=120)
-        logger.info(f"L1 header commitment at new tip {post_tip}: {commitment}")
+        commitment = strata.wait_for_asm_manifest_commitment_at(post_tip, rpc=rpc, timeout=120)
+        logger.info(f"ASM manifest commitment at new tip {post_tip}: {commitment}")
 
         # Verify intermediate heights also have commitments.
         # The tip is already confirmed, so intermediate heights should be
         # available immediately — use a short timeout.
         for h in range(pre_tip + 1, post_tip + 1):
-            strata.wait_for_l1_commitment_at(h, rpc=rpc, timeout=5)
+            strata.wait_for_asm_manifest_commitment_at(h, rpc=rpc, timeout=5)
 
         logger.info(
             "Strata tracked all %d new L1 blocks (%d -> %d)",


### PR DESCRIPTION
## Description

This PR updates the bookkeeping around the ASM manifest MMR in the OL state such that the indexes match the L1 heights that the manifests correspond to.  This also has the ASM genesis manifest not be included in the accumulator, since it's probably going to be empty anyways.  It also updates old names for the MMR based around old "L1 header" terminology, clarifying that it's actual ASM manifests.

Most of this was done by Claude with me closely supervising so that it didn't make off-target changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
