### PR TITLE
fix(btcio): keep insufficient funds errors retryable

### DIFF
--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -50,6 +50,8 @@ pub struct TestBitcoinClient {
     pub included_height: u64,
     /// Behavior for `send_raw_transaction`.
     pub send_raw_transaction_mode: SendRawTransactionMode,
+    /// Value returned by the mock wallet UTXO.
+    pub utxo_amount_sats: i64,
 }
 
 /// Configures how [`TestBitcoinClient`] responds to `send_raw_transaction`.
@@ -70,11 +72,17 @@ impl TestBitcoinClient {
             // Use arbitrary value, make configurable as necessary
             included_height: 100,
             send_raw_transaction_mode: SendRawTransactionMode::Success,
+            utxo_amount_sats: 10_000_000_000,
         }
     }
 
     pub fn with_send_raw_transaction_mode(mut self, mode: SendRawTransactionMode) -> Self {
         self.send_raw_transaction_mode = mode;
+        self
+    }
+
+    pub fn with_utxo_amount_sats(mut self, sats: i64) -> Self {
+        self.utxo_amount_sats = sats;
         self
     }
 }
@@ -356,7 +364,6 @@ impl Wallet for TestBitcoinClient {
         _include_unsafe: Option<bool>,
         _query_options: Option<ListUnspentQueryOptions>,
     ) -> ClientResult<ListUnspent> {
-        // plenty of sats
         Ok(ListUnspent(vec![ListUnspentItem {
             txid: Txid::from_slice(&[1; 32]).unwrap(),
             vout: 0,
@@ -366,7 +373,7 @@ impl Wallet for TestBitcoinClient {
             label: "test".to_string(),
             script_pubkey: ScriptBuf::from_hex("001478a93a5b649de9deabd9494ae9bc41f3c9c13837")
                 .unwrap(),
-            amount: SignedAmount::from_btc(100.0).unwrap(),
+            amount: SignedAmount::from_sat(self.utxo_amount_sats),
             confirmations: self.confs as u32,
             spendable: true,
             solvable: true,
@@ -582,8 +589,9 @@ pub(crate) mod test_context {
 
     use crate::{test_utils::TestBitcoinClient, writer::WriterContext, BtcioParams};
 
-    pub(crate) fn get_writer_context() -> Arc<WriterContext<TestBitcoinClient>> {
-        let client = Arc::new(TestBitcoinClient::new(1));
+    pub(crate) fn get_writer_context_with_client(
+        client: Arc<TestBitcoinClient>,
+    ) -> Arc<WriterContext<TestBitcoinClient>> {
         let addr = "bcrt1q6u6qyya3sryhh42lahtnz2m7zuufe7dlt8j0j5"
             .parse::<Address<_>>()
             .unwrap()
@@ -610,5 +618,10 @@ pub(crate) mod test_context {
         let ctx = WriterContext::new(btcio_params, cfg, addr, client, status_channel)
             .with_envelope_pubkey(&pubkey.serialize());
         Arc::new(ctx)
+    }
+
+    pub(crate) fn get_writer_context() -> Arc<WriterContext<TestBitcoinClient>> {
+        let client = Arc::new(TestBitcoinClient::new(1));
+        get_writer_context_with_client(client)
     }
 }

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -154,11 +154,15 @@ impl EnvelopeData {
 pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
     payload: &L1Payload,
     ctx: &WriterContext<R>,
-) -> anyhow::Result<EnvelopeData> {
-    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx).await?;
-    let envelope_pubkey = ctx
-        .envelope_pubkey
-        .ok_or_else(|| anyhow::anyhow!("envelope_pubkey is required for envelope transactions"))?;
+) -> Result<EnvelopeData, EnvelopeError> {
+    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx)
+        .await
+        .map_err(EnvelopeError::Other)?;
+    let envelope_pubkey = ctx.envelope_pubkey.ok_or_else(|| {
+        EnvelopeError::Other(anyhow!(
+            "envelope_pubkey is required for envelope transactions"
+        ))
+    })?;
     let env_config = EnvelopeConfig::new(
         ctx.btcio_params.magic_bytes(),
         ctx.sequencer_address.clone(),
@@ -168,7 +172,6 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
         Some(envelope_pubkey),
     );
     create_envelope_transactions(&env_config, payload, utxos)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))
 }
 
 /// Builds envelope transactions using a temporary keypair and signs both commit and reveal
@@ -178,8 +181,10 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
 pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
     payload: &L1Payload,
     ctx: &WriterContext<R>,
-) -> anyhow::Result<EnvelopeData> {
-    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx).await?;
+) -> Result<EnvelopeData, EnvelopeError> {
+    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx)
+        .await
+        .map_err(EnvelopeError::Other)?;
     let keypair = generate_key_pair()?;
     let pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
     let env_config = EnvelopeConfig::new(
@@ -190,13 +195,13 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
         BITCOIN_DUST_LIMIT,
         Some(pubkey),
     );
-    let mut envelope = create_envelope_transactions(&env_config, payload, utxos)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let mut envelope = create_envelope_transactions(&env_config, payload, utxos)?;
 
     let signed_commit = ctx
         .client
         .sign_raw_transaction_with_wallet(&envelope.commit_tx, None)
-        .await?
+        .await
+        .map_err(|e| EnvelopeError::SignRawTransaction(e.to_string()))?
         .tx;
     envelope.commit_tx = signed_commit;
 

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -94,6 +94,12 @@ pub enum EnvelopeError {
     #[error("Could not sign raw transaction: {0}")]
     SignRawTransaction(String),
 
+    #[error("envelope_pubkey is required for envelope transactions")]
+    MissingEnvelopePubkey,
+
+    #[error("failed to fetch envelope prerequisites: {0}")]
+    PrereqFetch(#[source] anyhow::Error),
+
     #[error("Error building taproot")]
     Taproot(#[from] TaprootBuilderError),
 
@@ -157,12 +163,10 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
 ) -> Result<EnvelopeData, EnvelopeError> {
     let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx)
         .await
-        .map_err(EnvelopeError::Other)?;
-    let envelope_pubkey = ctx.envelope_pubkey.ok_or_else(|| {
-        EnvelopeError::Other(anyhow!(
-            "envelope_pubkey is required for envelope transactions"
-        ))
-    })?;
+        .map_err(EnvelopeError::PrereqFetch)?;
+    let envelope_pubkey = ctx
+        .envelope_pubkey
+        .ok_or(EnvelopeError::MissingEnvelopePubkey)?;
     let env_config = EnvelopeConfig::new(
         ctx.btcio_params.magic_bytes(),
         ctx.sequencer_address.clone(),
@@ -184,7 +188,7 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
 ) -> Result<EnvelopeData, EnvelopeError> {
     let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx)
         .await
-        .map_err(EnvelopeError::Other)?;
+        .map_err(EnvelopeError::PrereqFetch)?;
     let keypair = generate_key_pair()?;
     let pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
     let env_config = EnvelopeConfig::new(
@@ -218,6 +222,7 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
 }
 
 /// Fetches the shared prerequisites for building envelope transactions.
+// TODO(STR-3411): make OL node resilient against the Bitcoin node not being available.
 async fn fetch_envelope_prereqs<R: Reader + Signer + Wallet>(
     ctx: &WriterContext<R>,
 ) -> anyhow::Result<(Network, Vec<ListUnspentItem>, u64)> {
@@ -242,7 +247,7 @@ pub fn create_envelope_transactions(
 ) -> Result<EnvelopeData, EnvelopeError> {
     let public_key = env_config
         .envelope_pubkey
-        .ok_or_else(|| anyhow!("envelope_pubkey is required for single-envelope transactions"))?;
+        .ok_or(EnvelopeError::MissingEnvelopePubkey)?;
 
     let reveal_script = EnvelopeScriptBuilder::with_pubkey(&public_key.serialize())?
         .add_envelopes(payload.data())?

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -151,9 +151,18 @@ mod test {
 
     use super::*;
     use crate::{
-        test_utils::test_context::get_writer_context,
+        test_utils::{
+            test_context::{get_writer_context, get_writer_context_with_client},
+            TestBitcoinClient,
+        },
         writer::test_utils::{get_broadcast_handle, get_envelope_ops},
     };
+
+    fn unsigned_test_entry() -> BundledPayloadEntry {
+        let tag = TagData::new(1, 1, vec![]).unwrap();
+        let payload = L1Payload::new(vec![vec![1; 150]; 1], tag);
+        BundledPayloadEntry::new_unsigned(payload)
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_create_payload_envelopes() {
@@ -162,9 +171,7 @@ mod test {
         let ctx = get_writer_context();
 
         // First insert an unsigned blob
-        let tag = TagData::new(1, 1, vec![]).unwrap();
-        let payload = L1Payload::new(vec![vec![1; 150]; 1], tag);
-        let entry = BundledPayloadEntry::new_unsigned(payload);
+        let entry = unsigned_test_entry();
 
         assert_eq!(entry.status, L1BundleStatus::Unsigned);
         assert_eq!(entry.commit_txid, Buf32::zero());
@@ -191,9 +198,7 @@ mod test {
         let bcast_handle = get_broadcast_handle();
         let ctx = get_writer_context();
 
-        let tag = TagData::new(1, 1, vec![]).unwrap();
-        let payload = L1Payload::new(vec![vec![1; 150]; 1], tag);
-        let entry = BundledPayloadEntry::new_unsigned(payload);
+        let entry = unsigned_test_entry();
 
         iops.put_payload_entry_async(0, entry.clone())
             .await
@@ -218,5 +223,30 @@ mod test {
             .await
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_payload_envelopes_preserves_not_enough_utxos() {
+        let client = Arc::new(TestBitcoinClient::new(1).with_utxo_amount_sats(1000));
+        let ctx = get_writer_context_with_client(client);
+        let entry = unsigned_test_entry();
+
+        let err = create_payload_envelopes(0, &entry, ctx).await.unwrap_err();
+
+        assert!(matches!(err, EnvelopeError::NotEnoughUtxos(_, 1000)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sign_and_broadcast_payload_envelopes_preserves_not_enough_utxos() {
+        let client = Arc::new(TestBitcoinClient::new(1).with_utxo_amount_sats(1000));
+        let ctx = get_writer_context_with_client(client);
+        let bcast_handle = get_broadcast_handle();
+        let entry = unsigned_test_entry();
+
+        let err = sign_and_broadcast_payload_envelopes(0, &entry, ctx, &bcast_handle)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, EnvelopeError::NotEnoughUtxos(_, 1000)));
     }
 }

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -491,6 +491,9 @@ mod tests {
         },
     };
 
+    const TEST_REQUIRED_SATS: u64 = 4096;
+    const TEST_AVAILABLE_SATS: u64 = 2658;
+
     fn minimal_envelope_data() -> EnvelopeData {
         let keypair =
             UntweakedKeypair::from_seckey_slice(SECP256K1, &[1u8; 32]).expect("valid key");
@@ -598,7 +601,10 @@ mod tests {
             _entry: &BundledPayloadEntry,
         ) -> Result<EnvelopeData, EnvelopeError> {
             if self.fail_create_not_enough_utxos {
-                return Err(EnvelopeError::NotEnoughUtxos(4096, 2658));
+                return Err(EnvelopeError::NotEnoughUtxos(
+                    TEST_REQUIRED_SATS,
+                    TEST_AVAILABLE_SATS,
+                ));
             }
             Ok(minimal_envelope_data())
         }
@@ -609,7 +615,10 @@ mod tests {
             _entry: &BundledPayloadEntry,
         ) -> Result<(Buf32, Buf32), EnvelopeError> {
             if self.fail_sign_not_enough_utxos {
-                return Err(EnvelopeError::NotEnoughUtxos(4096, 2658));
+                return Err(EnvelopeError::NotEnoughUtxos(
+                    TEST_REQUIRED_SATS,
+                    TEST_AVAILABLE_SATS,
+                ));
             }
             Ok((Buf32([1u8; 32]), Buf32([2u8; 32])))
         }
@@ -666,6 +675,7 @@ mod tests {
 
         let stored = state.ctx.get_stored(0).unwrap();
         assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        // Unsigned entries use zero txids as sentinels because no txs have been built yet.
         assert_eq!(stored.commit_txid, Buf32::zero());
         assert_eq!(stored.reveal_txid, Buf32::zero());
         assert_eq!(state.curr_payloadidx, 0);
@@ -701,6 +711,7 @@ mod tests {
 
         let stored = state.ctx.get_stored(0).unwrap();
         assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        // Unsigned entries use zero txids as sentinels because no txs have been built yet.
         assert_eq!(stored.commit_txid, Buf32::zero());
         assert_eq!(stored.reveal_txid, Buf32::zero());
         assert_eq!(state.curr_payloadidx, 0);

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -279,7 +279,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     debug!(%sighash, "envelope built, awaiting signer");
                 }
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
-                    error!(%required, %available, "not enough utxos to create commit/reveal transaction");
+                    warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
                 e => {
                     e?;
@@ -303,7 +303,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     debug!(%cid, reveal_txid = %rid, "envelope signed and queued for broadcast");
                 }
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
-                    error!(%required, %available, "not enough utxos to create commit/reveal transaction");
+                    warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
                 e => {
                     e?;
@@ -544,6 +544,8 @@ mod tests {
         stored: Mutex<HashMap<u64, BundledPayloadEntry>>,
         broadcast_handle: Arc<L1BroadcastHandle>,
         external_signing: bool,
+        fail_create_not_enough_utxos: bool,
+        fail_sign_not_enough_utxos: bool,
     }
 
     impl MockWatcherContext {
@@ -552,7 +554,19 @@ mod tests {
                 stored: Mutex::new(HashMap::new()),
                 broadcast_handle: get_broadcast_handle(),
                 external_signing,
+                fail_create_not_enough_utxos: false,
+                fail_sign_not_enough_utxos: false,
             }
+        }
+
+        fn with_create_not_enough_utxos(mut self) -> Self {
+            self.fail_create_not_enough_utxos = true;
+            self
+        }
+
+        fn with_sign_not_enough_utxos(mut self) -> Self {
+            self.fail_sign_not_enough_utxos = true;
+            self
         }
 
         fn get_stored(&self, idx: u64) -> Option<BundledPayloadEntry> {
@@ -583,6 +597,9 @@ mod tests {
             _idx: u64,
             _entry: &BundledPayloadEntry,
         ) -> Result<EnvelopeData, EnvelopeError> {
+            if self.fail_create_not_enough_utxos {
+                return Err(EnvelopeError::NotEnoughUtxos(4096, 2658));
+            }
             Ok(minimal_envelope_data())
         }
 
@@ -591,6 +608,9 @@ mod tests {
             _idx: u64,
             _entry: &BundledPayloadEntry,
         ) -> Result<(Buf32, Buf32), EnvelopeError> {
+            if self.fail_sign_not_enough_utxos {
+                return Err(EnvelopeError::NotEnoughUtxos(4096, 2658));
+            }
             Ok((Buf32([1u8; 32]), Buf32([2u8; 32])))
         }
 
@@ -636,6 +656,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_unchecked_not_enough_utxos_keeps_unsigned_for_retry() {
+        let ctx = MockWatcherContext::new(false).with_sign_not_enough_utxos();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_unsigned_or_needs_resign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.commit_txid, Buf32::zero());
+        assert_eq!(stored.reveal_txid, Buf32::zero());
+        assert_eq!(state.curr_payloadidx, 0);
+        assert!(state.envelope_cache.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_schnorr_key_transitions_to_pending_reveal_sign() {
         let ctx = MockWatcherContext::new(true);
         let entry = test_unsigned_entry();
@@ -651,6 +688,23 @@ mod tests {
         );
         // Envelope is cached for the reveal sig step
         assert!(state.envelope_cache.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn test_schnorr_key_not_enough_utxos_keeps_unsigned_for_retry() {
+        let ctx = MockWatcherContext::new(true).with_create_not_enough_utxos();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_unsigned_or_needs_resign(entry).await.unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(stored.commit_txid, Buf32::zero());
+        assert_eq!(stored.reveal_txid, Buf32::zero());
+        assert_eq!(state.curr_payloadidx, 0);
+        assert!(state.envelope_cache.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Preserve EnvelopeError::NotEnoughUtxos through the normal BTCIO envelope builder and signer paths instead of converting it into a generic anyhow error.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
https://alpenlabs.atlassian.net/browse/STR-3406