### PR TITLE
test(functional): add real bridge e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
  "zkaleido-sp1-host",
 ]
 
@@ -1251,7 +1251,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -2031,6 +2031,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2083,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3850,6 +3870,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2 0.4.3",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2 0.4.3",
+ "parking_lot 0.12.5",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,6 +3959,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3938,6 +3995,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4332,6 +4398,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepsize2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b5184084af9beed35eecbf4c36baf6e26b9dc47b61b74e02f930c72a58e71b"
+dependencies = [
+ "deepsize_derive2",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "deepsize_derive2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f8817865cacf3b93b943ca06b0fc5fd8e99eabfdb7ea5d296efcbc4afc4f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "delay_map"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +4787,33 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dynasm"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
 
 [[package]]
 name = "ecdsa"
@@ -5119,6 +5233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5506,17 +5626,6 @@ checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "goblin"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
-dependencies = [
- "log",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -7011,6 +7120,15 @@ checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
@@ -7061,10 +7179,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memmap2"
@@ -7111,7 +7248,7 @@ checksum = "58b8984fa38406b80c094943c0ba90e53d5fff0aea051ff9fac96cf6940993c8"
 dependencies = [
  "metrics",
  "metrics-util 0.20.1",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "portable-atomic",
  "scc",
 ]
@@ -7145,7 +7282,7 @@ checksum = "f615e08e049bd14a44c4425415782efb9bcd479fc1e19ddeb971509074c060d0"
 dependencies = [
  "libc",
  "libproc",
- "mach2",
+ "mach2 0.5.0",
  "metrics",
  "once_cell",
  "procfs 0.18.0",
@@ -7335,6 +7472,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "mti"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9563a7d5556636e74bbd8773241fbcbc5c89b9f6bfdc97b29b56e740c2c74b9"
+dependencies = [
+ "typeid_prefix",
+ "typeid_suffix",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7374,6 +7521,12 @@ dependencies = [
  "core2",
  "unsigned-varint",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "munge"
@@ -7849,6 +8002,20 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -7870,7 +8037,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
 ]
 
@@ -7881,7 +8048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http 1.4.0",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -7899,7 +8066,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry_sdk",
  "prost 0.14.3",
  "tonic 0.14.2",
@@ -7921,7 +8088,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -7959,8 +8126,19 @@ version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05a97452c4b1cfa8626e69181d901fc8231d99ff7d87e9701a2e6b934606615"
 dependencies = [
- "p3-field",
- "p3-matrix",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+]
+
+[[package]]
+name = "p3-air"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d275c27bb81483d669709d7244ce333b51f9743af2474cdc09ba1509f5c290db"
+dependencies = [
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "serde",
 ]
 
 [[package]]
@@ -7970,10 +8148,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7521838ecab2ddf4f7bc4ceebad06ec02414729598485c1ada516c39900820e8"
 dependencies = [
  "num-bigint 0.4.6",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.2.3-succinct",
+ "p3-mds 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a083928c9055f2171e3cb0bb4767969e4955473e71ba61affe46d7a3c98a89"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field 0.3.2-succinct",
+ "p3-mds 0.3.2-succinct",
+ "p3-poseidon2 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -7986,9 +8179,24 @@ checksum = "c0dd4d095d254783098bd09fc5fdf33fd781a1be54608ab93cb3ed4bd723da54"
 dependencies = [
  "ff 0.13.1",
  "num-bigint 0.4.6",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-bn254-fr"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abf208fbfe540d6e2a6caaa2a9a345b1c8cb23ffdcdfcc6987244525d4fc821"
+dependencies = [
+ "ff 0.13.1",
+ "num-bigint 0.4.6",
+ "p3-field 0.3.2-succinct",
+ "p3-poseidon2 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -7999,10 +8207,24 @@ version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d18c223b7e0177f4ac91070fa3f6cc557d5ee3b279869924c3102fb1b20910"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b725b453bbb35117a1abf0ddfd900b0676063d6e4231e0fa6bb0d76018d8ad"
+dependencies = [
+ "p3-field 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "serde",
  "tracing",
 ]
@@ -8014,10 +8236,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b38fe979d53d4f1d64158c40b3cd9ea1bd6b7bc8f085e489165c542ef914ae28"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-challenger 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "serde",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518695b56f450f9223bdd8994dda87916b97ebf1d1c03c956807e78522fdb333"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger 0.3.2-succinct",
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "serde",
 ]
 
@@ -8027,10 +8263,23 @@ version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46414daedd796f1eefcdc1811c0484e4bced5729486b6eaba9521c572c76761a"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a1f81101bff744b7ebba7f4497e917a2c6716d6e62736e4a56e555a2d98cb7"
+dependencies = [
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "tracing",
 ]
 
@@ -8043,7 +8292,21 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util",
+ "p3-util 0.2.3-succinct",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36459d4acb03d08097d713f336c7393990bb489ab19920d4f68658c7a5c10968"
+dependencies = [
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-util 0.3.2-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -8055,14 +8318,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c274dab2dcd060cdea9ab3f8f7129f5fa5f08917d6092dc2b297a31d883aa0"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-interpolation 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-fri"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2529a174a04189cfe705d756fb0e33d3c8fb06b167b521ddb877c78407f12a"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger 0.3.2-succinct",
+ "p3-commit 0.3.2-succinct",
+ "p3-dft 0.3.2-succinct",
+ "p3-field 0.3.2-succinct",
+ "p3-interpolation 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "serde",
  "tracing",
 ]
@@ -8073,9 +8355,20 @@ version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed8de7333abb0ad0a17bb78726a43749cc7fcab4763f296894e8b2933841d4d8"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+]
+
+[[package]]
+name = "p3-interpolation"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662049877c802155cdb4863db59899469fc3565d22d9047e1bd22d6b71f28e5"
+dependencies = [
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
 ]
 
 [[package]]
@@ -8084,12 +8377,41 @@ version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01c7ec21317c455d39588428e4ec85b96d663ff171ddf102a10e2ca54c942dea"
 dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-air 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "tracing",
+]
+
+[[package]]
+name = "p3-keccak-air"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169c96f8f0aaa9042872fdb6bbae0477fd1363b87c23877dbb2ec7fb46f8fcfa"
+dependencies = [
+ "p3-air 0.3.2-succinct",
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
+ "tracing",
+]
+
+[[package]]
+name = "p3-koala-bear"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1f52bcb6be38bdc8fa6b38b3434d4eedd511f361d4249fd798c6a5ef817b40"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field 0.3.2-succinct",
+ "p3-mds 0.3.2-succinct",
+ "p3-poseidon2 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -8099,9 +8421,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4de3f373589477cb735ea58e125898ed20935e03664b4614c7fac258b3c42f"
 dependencies = [
  "itertools 0.12.1",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e9cd136a4095a25c41a9edfdcce2dfae58ef01639317813bdbbd5b55c583"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -8117,17 +8454,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-maybe-rayon"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e524d47a49fb4265611303339c4ef970d892817b006cc330dad18afb91e411b1"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "p3-mds"
 version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2356b1ed0add6d5dfbf7a338ce534a6fde827374394a52cec16a0840af6e97c9"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6cb8edcb276033d43769a3725570c340d2ed6f35c3cca4cddeee07718fa376"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-dft 0.3.2-succinct",
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "rand 0.8.5",
 ]
 
@@ -8138,12 +8499,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f159e073afbee02c00d22390bf26ebb9ce03bbcd3e6dcd13c6a7a3811ab39608"
 dependencies = [
  "itertools 0.12.1",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-commit 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-merkle-tree"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e8bc3c224fc70d22f9556393e1482b52539e11c7b82ac6933c436fd82738f4"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-commit 0.3.2-succinct",
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "serde",
  "tracing",
 ]
@@ -8155,9 +8533,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1eec7e1b6900581bedd95e76e1ef4975608dd55be9872c9d257a8a9651c3a"
 dependencies = [
  "gcd",
- "p3-field",
- "p3-mds",
- "p3-symmetric",
+ "p3-field 0.2.3-succinct",
+ "p3-mds 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a26197df2097b98ab7038d59a01e1fe1a0f545e7e04aa9436b2454b1836654f"
+dependencies = [
+ "gcd",
+ "p3-field 0.3.2-succinct",
+ "p3-mds 0.3.2-succinct",
+ "p3-symmetric 0.3.2-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -8169,7 +8561,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb439bea1d822623b41ff4b51e3309e80d13cadf8b86d16ffd5e6efb9fdc360"
 dependencies = [
  "itertools 0.12.1",
- "p3-field",
+ "p3-field 0.2.3-succinct",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1d3b5202096bca57cde912fbbb9cbaedaf5ac7c42a924c7166b98709d64d21"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field 0.3.2-succinct",
  "serde",
 ]
 
@@ -8180,14 +8583,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a86f29c32bf46fa4acb6547d2065a711e146d4faca388b56d75718c60a0097d"
 dependencies = [
  "itertools 0.12.1",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-air 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-uni-stark"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef1cdb8285a7adb78df991852d3b66d3b25cf6ffc34f528505d1aee49bdb968"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-air 0.3.2-succinct",
+ "p3-challenger 0.3.2-succinct",
+ "p3-commit 0.3.2-succinct",
+ "p3-dft 0.3.2-succinct",
+ "p3-field 0.3.2-succinct",
+ "p3-matrix 0.3.2-succinct",
+ "p3-maybe-rayon 0.3.2-succinct",
+ "p3-util 0.3.2-succinct",
  "serde",
  "tracing",
 ]
@@ -8197,6 +8619,15 @@ name = "p3-util"
 version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c2c2010678b9332b563eaa38364915b585c1a94b5ca61e2c7541c087ddda5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f0388aa6d935ca3a17444086120f393f0b2f0816010b5ff95998c1c4095e3"
 dependencies = [
  "serde",
 ]
@@ -8405,6 +8836,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8504,12 +8945,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -8798,6 +9233,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8821,6 +9276,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -11621,7 +12085,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5
 dependencies = [
  "clap",
  "eyre",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -12176,6 +12640,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rrs-succinct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd079cd303257a4cb4e5aadfa79a7fe23f3c8301aa4740ccc3a99673485a352"
+dependencies = [
+ "downcast-rs",
+ "num_enum 0.5.11",
+ "paste",
+]
+
+[[package]]
 name = "rsp-client-executor"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.1b#1ddb68b4bcf7060af7eb4930e79a17f927c99c93"
@@ -12618,26 +13093,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scroll"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12998,6 +13453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13219,6 +13680,443 @@ dependencies = [
 ]
 
 [[package]]
+name = "slop-air"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bfd4c0fb41e0638afd60ce2ebf74d59225e3c20e25b8f202912c8a38f793de4"
+dependencies = [
+ "p3-air 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-algebra"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field 0.3.2-succinct",
+ "serde",
+]
+
+[[package]]
+name = "slop-alloc"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee6cc091290f9db6e3d3452430970f5234dbd270541300c9554d8172e18d0c2"
+dependencies = [
+ "serde",
+ "slop-algebra",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-baby-bear"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0138bae78c3d8f1691ee28315dd87b3d71c0b71e51e7b9eabf8d2e6ffffcfa"
+dependencies = [
+ "lazy_static",
+ "p3-baby-bear 0.3.2-succinct",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-basefold"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272d5e3082f066bcdd6ded60e3dd403a7697f4bbfaeea4c4e00f088bd555305e"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-primitives",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-basefold-prover"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175433ed8fc9a45fcb835b4375bbe54c5df0022b920f248055da6ae99e141104"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-fri",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-bn254"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
+dependencies = [
+ "ff 0.13.1",
+ "p3-bn254-fr 0.3.2-succinct",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-challenger"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
+dependencies = [
+ "futures",
+ "p3-challenger 0.3.2-succinct",
+ "serde",
+ "slop-algebra",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-commit"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe1a49612ffedb6a44825ccbaa54ea53670a61366b8112a80865fef462630f9"
+dependencies = [
+ "p3-commit 0.3.2-succinct",
+ "serde",
+ "slop-alloc",
+]
+
+[[package]]
+name = "slop-dft"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fe8ca56f2cb47f22658f923e8d1a97413bb89ecc4e7185722ec406e61b82e9"
+dependencies = [
+ "p3-dft 0.3.2-succinct",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-fri"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434a8e3f5fc6c5a1973a3c3964b4589af26c74bd480fd7cd6dcb0feb7d7e8f92"
+dependencies = [
+ "p3-fri 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-futures"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e76ea10d2865798d6a9c39faffbc2c23c0bbf34a6e449e83de409aa265171a"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "pin-project",
+ "rayon",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "slop-jagged"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8677ede7f5b5f1fa19884ba07b6120cbb74b4e4ff4cb56cd068e01fffd4e603b"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "slop-keccak-air"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794162816eb0c8869f2bf09881ac6a7c808da1aab11e097ca25460e4ef895cc7"
+dependencies = [
+ "p3-keccak-air 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-koala-bear"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
+dependencies = [
+ "lazy_static",
+ "p3-koala-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-matrix"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89bef0d6e09bc5431c6b50b3eee460722ca9eb569dffcdec582bd1d72db496c"
+dependencies = [
+ "p3-matrix 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-maybe-rayon"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e135011bcdae048b9e85f42ba95cc8dc69cb4f5566289044cabe67a6ac65e6e0"
+dependencies = [
+ "p3-maybe-rayon 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-merkle-tree"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "748e3fb2d76fd2e2017d9e544072a8318efc1deac6277b5721d31381a674d505"
+dependencies = [
+ "derive-where",
+ "ff 0.13.1",
+ "itertools 0.14.0",
+ "p3-merkle-tree 0.3.2-succinct",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-multilinear"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b579ce845ca26e0c2750d11f09327add269e4b695c21b35f1659f49b9bd08311"
+dependencies = [
+ "derive-where",
+ "futures",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-poseidon2"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
+dependencies = [
+ "p3-poseidon2 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-primitives"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
+dependencies = [
+ "slop-algebra",
+]
+
+[[package]]
+name = "slop-stacked"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8992c338b13abe792faf62000a47096f08817ea655036c530990b1c60c5ff256"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-sumcheck"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45fdcab8b7e0fa43b808112fd1c387eabfa7e09435c6a4fb92e45b917971ade8"
+dependencies = [
+ "futures",
+ "itertools 0.14.0",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-challenger",
+ "slop-multilinear",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-symmetric"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
+dependencies = [
+ "p3-symmetric 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-tensor"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a6b65130a06d1b1a24ab4928e1eadc5a6e14f35c171c0e69d5b9cf6c4d56e9"
+dependencies = [
+ "arrayvec",
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-futures",
+ "slop-matrix",
+ "thiserror 1.0.69",
+ "transpose",
+]
+
+[[package]]
+name = "slop-uni-stark"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3655347bb0dc0e559a63fa8c5053a79d9d0258af04b6b3bebfc51fff880416a"
+dependencies = [
+ "p3-uni-stark 0.3.2-succinct",
+]
+
+[[package]]
+name = "slop-utils"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fad36458e05b6ccc8ebe951734e9d036128eb0f01596824e1104a37b3216654"
+dependencies = [
+ "p3-util 0.3.2-succinct",
+ "tracing-forest",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "slop-whir"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d104106013cf050132b47d73568b4562e273c0dda3a1d304a96afab25737d414"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13290,7 +14188,21 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 5.0.1",
- "sp1-prover",
+ "sp1-prover 5.2.2",
+]
+
+[[package]]
+name = "sp1-build"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7321136acefff985b0fb201b84359d609451bbd0a63203d4b601eaabe28da14f"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.18.1",
+ "chrono",
+ "clap",
+ "dirs 5.0.1",
+ "sp1-primitives 6.1.0",
 ]
 
 [[package]]
@@ -13305,26 +14217,22 @@ dependencies = [
  "elf",
  "enum-map",
  "eyre",
- "gecko_profile",
- "goblin",
  "hashbrown 0.14.5",
  "hex",
- "indicatif",
  "itertools 0.13.0",
  "nohash-hasher",
  "num",
- "p3-baby-bear",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
  "range-set-blaze",
- "rrs-succinct",
- "rustc-demangle",
+ "rrs-succinct 0.1.0",
  "serde",
  "serde_json",
- "sp1-curves",
- "sp1-primitives",
+ "sp1-curves 5.2.4",
+ "sp1-primitives 5.2.4",
  "sp1-stark",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -13334,6 +14242,86 @@ dependencies = [
  "tracing",
  "typenum",
  "vec_map",
+]
+
+[[package]]
+name = "sp1-core-executor"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e911afd7e96cab3936e275445e23d1e6cb26776bd06223cb4466e812b13b54"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "cfg-if",
+ "clap",
+ "deepsize2",
+ "elf",
+ "enum-map",
+ "eyre",
+ "gecko_profile",
+ "hashbrown 0.14.5",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "memmap2",
+ "num",
+ "rrs-succinct 0.2.0",
+ "rustc-demangle",
+ "serde",
+ "serde_arrays",
+ "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-curves 6.1.0",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives 6.1.0",
+ "strum 0.27.2",
+ "subenum",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tracing",
+ "typenum",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-core-executor-runner"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bf24cda2b466c097e62a60a3e1ac7ff014d7972f4ff350d72ff2b89eff5128"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "cargo_metadata 0.18.1",
+ "hashbrown 0.14.5",
+ "hex",
+ "libc",
+ "sha2",
+ "sp1-core-executor 6.1.0",
+ "sp1-core-executor-runner-binary",
+ "sp1-jit",
+ "sp1-primitives 6.1.0",
+ "sysinfo 0.30.13",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-core-executor-runner-binary"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf22b7b1696ce686f79efb99a543a10b0b82d1068834087d21f0fe3d76d9054d"
+dependencies = [
+ "bincode",
+ "crash-handler",
+ "libc",
+ "serde",
+ "sp1-core-executor 6.1.0",
+ "sp1-jit",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13356,17 +14344,17 @@ dependencies = [
  "num",
  "num_cpus",
  "p256",
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-field",
- "p3-keccak-air",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-keccak-air 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-uni-stark 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "pathdiff",
  "rand 0.8.5",
  "rayon",
@@ -13375,10 +14363,10 @@ dependencies = [
  "serde_json",
  "size",
  "snowbridge-amcl",
- "sp1-core-executor",
- "sp1-curves",
- "sp1-derive",
- "sp1-primitives",
+ "sp1-core-executor 5.2.4",
+ "sp1-curves 5.2.4",
+ "sp1-derive 5.2.4",
+ "sp1-primitives 5.2.4",
  "sp1-stark",
  "static_assertions",
  "strum 0.26.3",
@@ -13393,6 +14381,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-core-machine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fd9328937306a831184febaae80c7b63ee15d3716573f0a34d62f5dee7408d"
+dependencies = [
+ "bincode",
+ "cfg-if",
+ "enum-map",
+ "futures",
+ "generic-array 1.1.0",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "rrs-succinct 0.2.0",
+ "serde",
+ "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-futures",
+ "slop-keccak-air",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-uni-stark",
+ "snowbridge-amcl",
+ "sp1-core-executor 6.1.0",
+ "sp1-core-executor-runner",
+ "sp1-curves 6.1.0",
+ "sp1-derive 6.1.0",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives 6.1.0",
+ "static_assertions",
+ "strum 0.27.2",
+ "sysinfo 0.30.13",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-forest",
+ "tracing-subscriber 0.3.23",
+ "typenum",
+]
+
+[[package]]
 name = "sp1-cuda"
 version = "5.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13402,8 +14438,8 @@ dependencies = [
  "ctrlc",
  "prost 0.13.5",
  "serde",
- "sp1-core-machine",
- "sp1-prover",
+ "sp1-core-machine 5.2.4",
+ "sp1-prover 5.2.2",
  "tokio",
  "tracing",
  "twirp-rs",
@@ -13423,11 +14459,32 @@ dependencies = [
  "k256",
  "num",
  "p256",
- "p3-field",
+ "p3-field 0.2.3-succinct",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives",
+ "sp1-primitives 5.2.4",
  "sp1-stark",
+ "typenum",
+]
+
+[[package]]
+name = "sp1-curves"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf1e420a0980906ff8f875525664209395c7a5243243ff70283adb357e921ef2"
+dependencies = [
+ "cfg-if",
+ "dashu",
+ "elliptic-curve",
+ "generic-array 1.1.0",
+ "itertools 0.14.0",
+ "k256",
+ "num",
+ "p256",
+ "serde",
+ "slop-algebra",
+ "snowbridge-amcl",
+ "sp1-primitives 6.1.0",
  "typenum",
 ]
 
@@ -13442,12 +14499,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-derive"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa1235972b67b86514c3f23ba690972b712dd009159c2e50f723d7ac02173d8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sp1-helper"
 version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bec35a20c556505bfe6891b97a8899c77d11fcd8170a9b27d5cc60f65aa1cc"
 dependencies = [
- "sp1-build",
+ "sp1-build 5.2.2",
+]
+
+[[package]]
+name = "sp1-hypercube"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8314d1620d659913912121a3ecae19d1384fdd06e43d954034cad8bd082f5db"
+dependencies = [
+ "arrayref",
+ "deepsize2",
+ "derive-where",
+ "futures",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-poseidon2",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-uni-stark",
+ "slop-whir",
+ "sp1-derive 6.1.0",
+ "sp1-primitives 6.1.0",
+ "strum 0.27.2",
+ "thiserror 1.0.69",
+ "thousands",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-jit"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6b9a7102c21e5ecd5b65861188f068f17951a2db9bc3fd4f65cd5f9b0e8449"
+dependencies = [
+ "dynasmrt",
+ "hashbrown 0.14.5",
+ "libc",
+ "memfd",
+ "memmap2",
+ "serde",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -13459,7 +14591,7 @@ dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives",
+ "sp1-primitives 5.2.4",
 ]
 
 [[package]]
@@ -13474,12 +14606,36 @@ dependencies = [
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "serde",
  "sha2",
+]
+
+[[package]]
+name = "sp1-primitives"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
+dependencies = [
+ "bincode",
+ "blake3",
+ "elf",
+ "hex",
+ "itertools 0.14.0",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "serde",
+ "sha2",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-poseidon2",
+ "slop-primitives",
+ "slop-symmetric",
 ]
 
 [[package]]
@@ -13500,31 +14656,116 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.12.5",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rayon",
  "serde",
  "serde_json",
  "serial_test",
  "sha2",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-recursion-circuit",
- "sp1-recursion-compiler",
+ "sp1-core-executor 5.2.4",
+ "sp1-core-machine 5.2.4",
+ "sp1-primitives 5.2.4",
+ "sp1-recursion-circuit 5.2.4",
+ "sp1-recursion-compiler 5.2.4",
  "sp1-recursion-core",
- "sp1-recursion-gnark-ffi",
+ "sp1-recursion-gnark-ffi 5.2.4",
  "sp1-stark",
  "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
  "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sp1-prover"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba1691f53df50f8024f756c3a0e7b009e544e31c7297ae591eceba1d27232c"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "clap",
+ "dirs 5.0.1",
+ "either",
+ "enum-map",
+ "eyre",
+ "futures",
+ "hashbrown 0.14.5",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "lru 0.12.5",
+ "mti",
+ "num-bigint 0.4.6",
+ "opentelemetry 0.23.0",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-futures",
+ "slop-jagged",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-symmetric",
+ "sp1-core-executor 6.1.0",
+ "sp1-core-executor-runner",
+ "sp1-core-machine 6.1.0",
+ "sp1-derive 6.1.0",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives 6.1.0",
+ "sp1-prover-types",
+ "sp1-recursion-circuit 6.1.0",
+ "sp1-recursion-compiler 6.1.0",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi 6.1.0",
+ "sp1-recursion-machine",
+ "sp1-verifier 6.1.0",
+ "static_assertions",
+ "sysinfo 0.30.13",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sp1-prover-types"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011fe0b63d8b930665e5e6ca5f9f766c1b442727ec473d0baeea629d225c4360"
+dependencies = [
+ "anyhow",
+ "async-scoped",
+ "bincode",
+ "chrono",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "mti",
+ "prost 0.13.5",
+ "serde",
+ "tokio",
+ "tonic 0.12.3",
+ "tonic-build",
+ "tracing",
 ]
 
 [[package]]
@@ -13536,29 +14777,69 @@ dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-traits",
- "p3-air",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-uni-stark 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
  "rayon",
  "serde",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-derive",
- "sp1-primitives",
- "sp1-recursion-compiler",
+ "sp1-core-executor 5.2.4",
+ "sp1-core-machine 5.2.4",
+ "sp1-derive 5.2.4",
+ "sp1-primitives 5.2.4",
+ "sp1-recursion-compiler 5.2.4",
  "sp1-recursion-core",
- "sp1-recursion-gnark-ffi",
+ "sp1-recursion-gnark-ffi 5.2.4",
  "sp1-stark",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-circuit"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1bb2594e6480d20c6d4be6099408df3a0de85bc956f0e74511c80515ac9e2d"
+dependencies = [
+ "bincode",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-whir",
+ "sp1-core-executor 6.1.0",
+ "sp1-core-machine 6.1.0",
+ "sp1-derive 6.1.0",
+ "sp1-hypercube",
+ "sp1-primitives 6.1.0",
+ "sp1-recursion-compiler 6.1.0",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
  "tracing",
 ]
 
@@ -13570,16 +14851,37 @@ checksum = "06aa784cfdc5c979da22ad6c36fe393e9005b6b57702fa9bdd041f112ead5ec5"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-field",
- "p3-symmetric",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "serde",
- "sp1-core-machine",
- "sp1-primitives",
+ "sp1-core-machine 5.2.4",
+ "sp1-primitives 5.2.4",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
+ "tracing",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-recursion-compiler"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e113c225149badeda05e679f169281cad6ef0480919f726e21acdfbf38848fb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-symmetric",
+ "sp1-core-machine 6.1.0",
+ "sp1-hypercube",
+ "sp1-primitives 6.1.0",
+ "sp1-recursion-executor",
  "tracing",
  "vec_map",
 ]
@@ -13599,26 +14901,26 @@ dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num_cpus",
- "p3-air",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-merkle-tree 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "pathdiff",
  "rand 0.8.5",
  "serde",
- "sp1-core-machine",
- "sp1-derive",
- "sp1-primitives",
+ "sp1-core-machine 5.2.4",
+ "sp1-derive 5.2.4",
+ "sp1-primitives 5.2.4",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -13638,6 +14940,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-recursion-executor"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8805b6ad230dbfc249a4c8a2ddb8cdad1053377739b7c8a6a78f06328170b63"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "range-set-blaze",
+ "serde",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "smallvec",
+ "sp1-derive 6.1.0",
+ "sp1-hypercube",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13650,17 +14976,64 @@ dependencies = [
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-symmetric",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "serde",
  "serde_json",
  "sha2",
- "sp1-core-machine",
- "sp1-recursion-compiler",
+ "sp1-core-machine 5.2.4",
+ "sp1-recursion-compiler 5.2.4",
  "sp1-stark",
  "tempfile",
  "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-gnark-ffi"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7892c7c442aa109053998b360e91a26d776f63cb394fa50caf59ca626c08dd"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "hex",
+ "num-bigint 0.4.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "slop-algebra",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives 6.1.0",
+ "sp1-recursion-compiler 6.1.0",
+ "sp1-verifier 6.1.0",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-machine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb19db493ef086f0b5869e6c5ad52da728f265647a8a1f2bf765c3236eda6b0"
+dependencies = [
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-derive 6.1.0",
+ "sp1-hypercube",
+ "sp1-primitives 6.1.0",
+ "sp1-recursion-executor",
+ "strum 0.27.2",
+ "tracing",
+ "zkhash",
 ]
 
 [[package]]
@@ -13689,21 +15062,21 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "k256",
- "p3-baby-bear",
- "p3-field",
- "p3-fri",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
  "prost 0.13.5",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "rustls 0.23.31",
  "serde",
  "serde_json",
- "sp1-build",
- "sp1-core-executor",
- "sp1-core-machine",
+ "sp1-build 5.2.2",
+ "sp1-core-executor 5.2.4",
+ "sp1-core-machine 5.2.4",
  "sp1-cuda",
- "sp1-primitives",
- "sp1-prover",
+ "sp1-primitives 5.2.4",
+ "sp1-prover 5.2.2",
  "sp1-stark",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -13717,6 +15090,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-sdk"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-aws",
+ "alloy-signer-local",
+ "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "backoff",
+ "bincode",
+ "cfg-if",
+ "dirs 5.0.1",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "k256",
+ "num-bigint 0.4.6",
+ "prost 0.13.5",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "rustls 0.23.31",
+ "serde",
+ "sha2",
+ "sp1-build 6.1.0",
+ "sp1-core-executor 6.1.0",
+ "sp1-core-executor-runner",
+ "sp1-core-machine 6.1.0",
+ "sp1-hypercube",
+ "sp1-primitives 6.1.0",
+ "sp1-prover 6.1.0",
+ "sp1-prover-types",
+ "sp1-recursion-executor",
+ "sp1-verifier 6.1.0",
+ "strum 0.27.2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic 0.12.3",
+ "tracing",
+ "twirp-rs",
+ "zstd",
+]
+
+[[package]]
 name = "sp1-stark"
 version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13727,24 +15151,24 @@ dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-merkle-tree 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-uni-stark 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rayon-scan",
  "serde",
- "sp1-derive",
- "sp1-primitives",
+ "sp1-derive 5.2.4",
+ "sp1-primitives 5.2.4",
  "strum 0.26.3",
  "sysinfo 0.30.13",
  "tracing",
@@ -13762,6 +15186,33 @@ dependencies = [
  "lazy_static",
  "sha2",
  "substrate-bn-succinct",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sp1-verifier"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97f6c90e5f44ffaa18e0cf7aab2f4f02d0a2261aee21d4a48e09cc453ef0e0e"
+dependencies = [
+ "bincode",
+ "blake3",
+ "cfg-if",
+ "dirs 5.0.1",
+ "hex",
+ "lazy_static",
+ "serde",
+ "sha2",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-primitives",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives 6.1.0",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "strum 0.27.2",
+ "substrate-bn-succinct-rs",
  "thiserror 2.0.18",
 ]
 
@@ -13927,7 +15378,6 @@ dependencies = [
  "strata-ol-state-provider",
  "strata-ol-state-support-types",
  "strata-ol-state-types",
- "strata-ol-stf",
  "strata-paas",
  "strata-params",
  "strata-predicate",
@@ -13946,8 +15396,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
- "zkaleido-sp1-host",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -14508,7 +15957,7 @@ dependencies = [
  "strata-crypto",
  "strata-identifiers",
  "strata-params",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -14624,7 +16073,7 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -14713,7 +16162,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reth-chainspec",
  "serde_json",
- "sp1-verifier",
+ "sp1-verifier 5.2.1",
  "strata-asm-params",
  "strata-btc-types",
  "strata-btc-verification",
@@ -14729,9 +16178,10 @@ dependencies = [
  "strata-primitives",
  "strata-snark-acct-runtime",
  "strata-sp1-guest-builder",
+ "strata-zkvm-hosts",
  "tokio",
  "zeroize",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -14765,7 +16215,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -14790,7 +16240,7 @@ dependencies = [
  "strata-primitives",
  "strata-state",
  "strata-test-utils",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -14823,7 +16273,7 @@ dependencies = [
  "strata-storage-common",
  "thiserror 2.0.18",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -15086,7 +16536,7 @@ source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f
 dependencies = [
  "metrics",
  "metrics-exporter-otel",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "tracing",
@@ -15298,8 +16748,8 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
+ "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -15662,7 +17112,7 @@ dependencies = [
  "strata-predicate",
  "strata-snark-acct-runtime",
  "strata-snark-acct-types",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
  "zkaleido-native-adapter",
 ]
 
@@ -15684,7 +17134,7 @@ dependencies = [
  "strata-ee-chain-types",
  "strata-ee-chunk-runtime",
  "strata-evm-ee",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
  "zkaleido-native-adapter",
 ]
 
@@ -15706,7 +17156,7 @@ dependencies = [
  "strata-ol-state-support-types",
  "strata-ol-state-types",
  "strata-ol-stf",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
  "zkaleido-native-adapter",
 ]
 
@@ -15734,7 +17184,7 @@ dependencies = [
  "strata-ol-chain-types",
  "strata-primitives",
  "strata-state",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
  "zkaleido-native-adapter",
 ]
 
@@ -15749,7 +17199,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -15765,7 +17215,7 @@ dependencies = [
  "rsp-client-executor",
  "serde",
  "serde_json",
- "sp1-sdk",
+ "sp1-sdk 5.2.1",
  "ssz",
  "strata-acct-types",
  "strata-codec",
@@ -15790,7 +17240,7 @@ dependencies = [
  "strata-zkvm-hosts",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
  "zkaleido-sp1-host",
 ]
 
@@ -15876,7 +17326,7 @@ source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f
 dependencies = [
  "anyhow",
  "futures",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "serde",
  "serde_json",
  "strata-tasks",
@@ -15992,9 +17442,9 @@ dependencies = [
  "once_cell",
  "sha2",
  "sp1-helper",
- "sp1-sdk",
- "sp1-verifier",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "sp1-sdk 5.2.1",
+ "sp1-verifier 5.2.1",
+ "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -16055,7 +17505,7 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -16242,9 +17692,22 @@ dependencies = [
 name = "strata-zkvm-hosts"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "bincode",
+ "k256",
+ "serde",
+ "strata-predicate",
  "strata-sp1-guest-builder",
+ "tokio",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
+ "zkaleido-native-adapter",
  "zkaleido-sp1-host",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -16335,6 +17798,22 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "sp1-lib",
+]
+
+[[package]]
+name = "substrate-bn-succinct-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a241fd7c1016fb8ad30fcf5a20986c0c4538e8f15a1b41a1761516299e377ec1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -16545,6 +18024,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
@@ -16877,6 +18362,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -16903,6 +18389,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17109,7 +18609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -17156,6 +18656,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -17268,6 +18778,21 @@ dependencies = [
  "rkyv",
  "sled",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "typeid_prefix"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9da1387307fdee46aa441e4f08a1b491e659fcac1aca9cd71f2c624a0de5d1b"
+
+[[package]]
+name = "typeid_suffix"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b55e96f110c6db5d1a2f24072552537f0091dc90cebeaa679540bac93e7405"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -17439,8 +18964,11 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "md-5",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -18603,7 +20131,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25#ac91ce4fe417b6d2b738d152d884943f399cb3a5"
+source = "git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581#f287d06b91a140bffff9ab7dbf037296b6915581"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -18625,13 +20153,13 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25#ac91ce4fe417b6d2b738d152d884943f399cb3a5"
+source = "git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581#f287d06b91a140bffff9ab7dbf037296b6915581"
 dependencies = [
  "bincode",
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
@@ -18652,7 +20180,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25#ac91ce4fe417b6d2b738d152d884943f399cb3a5"
+source = "git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581#f287d06b91a140bffff9ab7dbf037296b6915581"
 dependencies = [
  "blake3",
  "borsh",
@@ -18661,21 +20189,24 @@ dependencies = [
  "sha2",
  "substrate-bn",
  "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]
 name = "zkaleido-sp1-host"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25#ac91ce4fe417b6d2b738d152d884943f399cb3a5"
+source = "git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581#f287d06b91a140bffff9ab7dbf037296b6915581"
 dependencies = [
  "async-trait",
  "bincode",
+ "hex",
+ "num-bigint 0.4.6",
  "serde",
- "sp1-prover",
- "sp1-sdk",
- "sp1-stark",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc25)",
+ "sha2",
+ "sp1-sdk 6.1.0",
+ "sp1-verifier 6.1.0",
+ "tokio",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?rev=f287d06b91a140bffff9ab7dbf037296b6915581)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,12 +285,10 @@ typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }
 zkaleido = { git = "https://github.com/alpenlabs/zkaleido", features = [
   "arbitrary",
   "ssz",
-], tag = "v0.1.0-alpha-rc25" }
-zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc25" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc25" }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc25", features = [
-  "remote-prover",
-] }
+], rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
+zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
 
 make_buf = { git = "https://github.com/alpenlabs/make_buf", version = "1.0.2" }
 

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -77,11 +77,14 @@ mod sequencer_imports {
     pub(super) use strata_paas::{
         ProverBuilder, ProverServiceBuilder, ReceiptStore, RetryConfig, TaskStore,
     };
-    pub(super) use strata_proofimpl_alpen_acct::EeAcctProgram;
-    pub(super) use strata_proofimpl_alpen_chunk::EeChunkProgram;
+    pub(super) use strata_proofimpl_alpen_acct::process_ee_acct_update;
+    pub(super) use strata_proofimpl_alpen_chunk::process_ee_chunk;
     pub(super) use strata_tasks::TaskManager;
+    pub(super) use strata_zkvm_hosts::native::{DeterministicNativeHost, NativeProofKind};
     #[cfg(feature = "sp1")]
-    pub(super) use strata_zkvm_hosts::sp1::{ALPEN_ACCT_HOST, ALPEN_CHUNK_HOST};
+    pub(super) use strata_zkvm_hosts::sp1::{
+        alpen_acct_host_with_deadline, alpen_chunk_host_with_deadline,
+    };
     pub(super) use tokio::{runtime::Handle, sync::oneshot};
     #[cfg(feature = "sp1")]
     pub(super) use zkaleido_sp1_host::SP1Host;
@@ -685,20 +688,26 @@ fn main() {
                 ))
                 .retry(RetryConfig::default());
 
-                // Dev/test escape hatch: use zkaleido NativeHost instead of
-                // the SP1 remote host. This skips real Groth16 proving and
-                // the need for compiled guest ELFs — only safe for
-                // functional tests. For native acct, the chunk predicate
-                // key is always-accept since native mode does not verify
-                // chunk receipts.
+                // Dev/test escape hatch: use deterministic native hosts
+                // instead of the SP1 remote host. This skips real Groth16
+                // proving and the need for compiled guest ELFs while still
+                // requiring Schnorr receipts in OL.
                 let (chunk_prover, acct_prover) = if ext.dev_native_prover {
                     info!(
                         target: "alpen-client",
                         "EE chunk + acct provers: native host (dev/test only)"
                     );
-                    let chunk = chunk_builder.native(EeChunkProgram::native_host());
-                    let acct_program = EeAcctProgram::new(PredicateKey::always_accept());
-                    let acct = acct_builder.native(acct_program.native_host());
+                    let chunk_host =
+                        DeterministicNativeHost::new(process_ee_chunk, NativeProofKind::AlpenChunk);
+                    let chunk_predicate = chunk_host.predicate_key();
+                    let chunk = chunk_builder.native(chunk_host);
+
+                    let acct_chunk_predicate = chunk_predicate.clone();
+                    let acct_host = DeterministicNativeHost::new(
+                        move |zkvm| process_ee_acct_update(zkvm, &acct_chunk_predicate),
+                        NativeProofKind::AlpenAcct,
+                    );
+                    let acct = acct_builder.native(acct_host);
                     (chunk, acct)
                 } else {
                     #[cfg(feature = "sp1")]
@@ -712,10 +721,8 @@ fn main() {
                             deadline_secs,
                             "sp1 EE prover deadline configured"
                         );
-                        let chunk_host: SP1Host =
-                            (**ALPEN_CHUNK_HOST).clone().with_deadline(deadline);
-                        let acct_host: SP1Host =
-                            (**ALPEN_ACCT_HOST).clone().with_deadline(deadline);
+                        let chunk_host: SP1Host = alpen_chunk_host_with_deadline(deadline);
+                        let acct_host: SP1Host = alpen_acct_host_with_deadline(deadline);
                         (
                             chunk_builder.remote(chunk_host),
                             acct_builder.remote(acct_host),

--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -26,6 +26,7 @@ strata-params.workspace = true
 strata-predicate.workspace = true
 strata-primitives.workspace = true
 strata-snark-acct-runtime.workspace = true
+strata-zkvm-hosts.workspace = true
 
 sp1-verifier = { workspace = true, optional = true }
 strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }

--- a/bin/datatool/src/acct_predicate.rs
+++ b/bin/datatool/src/acct_predicate.rs
@@ -8,6 +8,7 @@ use strata_predicate::PredicateKey;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AcctPredicateOverride {
     AlwaysAccept,
+    NativeSchnorr,
     Sp1Groth16,
 }
 
@@ -18,7 +19,8 @@ impl fmt::Display for ParseAcctPredicateError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "invalid account predicate type '{}', expected 'always-accept' or 'sp1-groth16'",
+            "invalid account predicate type '{}', expected 'always-accept', \
+             'native-schnorr', or 'sp1-groth16'",
             self.0
         )
     }
@@ -32,6 +34,7 @@ impl FromStr for AcctPredicateOverride {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "always-accept" => Ok(Self::AlwaysAccept),
+            "native-schnorr" => Ok(Self::NativeSchnorr),
             "sp1-groth16" => Ok(Self::Sp1Groth16),
             _ => Err(ParseAcctPredicateError(s.to_owned())),
         }
@@ -43,9 +46,14 @@ pub(crate) fn resolve_acct_predicate(
 ) -> anyhow::Result<PredicateKey> {
     match override_val {
         Some(AcctPredicateOverride::AlwaysAccept) => Ok(PredicateKey::always_accept()),
+        Some(AcctPredicateOverride::NativeSchnorr) => Ok(resolve_native_schnorr()),
         Some(AcctPredicateOverride::Sp1Groth16) => resolve_sp1_groth16(),
         None => Ok(resolve_default()),
     }
+}
+
+fn resolve_native_schnorr() -> PredicateKey {
+    strata_zkvm_hosts::native::alpen_acct_predicate_key()
 }
 
 fn resolve_sp1_groth16() -> anyhow::Result<PredicateKey> {
@@ -70,7 +78,7 @@ fn resolve_default() -> PredicateKey {
 
     #[cfg(not(feature = "sp1-builder"))]
     {
-        PredicateKey::always_accept()
+        resolve_native_schnorr()
     }
 }
 

--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -150,6 +150,12 @@ pub(crate) struct SubcParams {
 
     #[argh(
         option,
+        description = "add a bridge operator public key (x-only or compressed hex), appended after xpriv-derived keys"
+    )]
+    pub(crate) op_pubkey: Vec<String>,
+
+    #[argh(
+        option,
         description = "read bridge operator keys (master xpriv) by line from file",
         short = 'B'
     )]
@@ -179,7 +185,8 @@ pub(crate) struct SubcParams {
 
     #[argh(
         option,
-        description = "checkpoint predicate type: 'always-accept' or 'sp1-groth16' (default: feature-gated)"
+        description = "checkpoint predicate type: 'always-accept', 'native-schnorr', or \
+                       'sp1-groth16' (default: feature-gated)"
     )]
     pub(crate) checkpoint_predicate: Option<CheckpointPredicateOverride>,
 
@@ -227,6 +234,12 @@ pub(crate) struct SubcAsmParams {
 
     #[argh(
         option,
+        description = "add a bridge operator public key (x-only or compressed hex)"
+    )]
+    pub(crate) op_pubkey: Vec<String>,
+
+    #[argh(
+        option,
         description = "read bridge operator keys (master xpriv) by line from file",
         short = 'B'
     )]
@@ -256,7 +269,14 @@ pub(crate) struct SubcAsmParams {
 
     #[argh(
         option,
-        description = "checkpoint predicate type: 'always-accept' or 'sp1-groth16' (default: feature-gated)"
+        description = "sequencer xpub; when set, ASM checkpoint envelopes must use this pubkey"
+    )]
+    pub(crate) seqkey: Option<String>,
+
+    #[argh(
+        option,
+        description = "checkpoint predicate type: 'always-accept', 'native-schnorr', or \
+                       'sp1-groth16' (default: feature-gated)"
     )]
     pub(crate) checkpoint_predicate: Option<CheckpointPredicateOverride>,
 
@@ -312,7 +332,8 @@ pub(crate) struct SubcOlParams {
 
     #[argh(
         option,
-        description = "alpen snark account predicate type: 'always-accept' or 'sp1-groth16' (default: feature-gated)"
+        description = "alpen snark account predicate type: 'always-accept', \
+                       'native-schnorr', or 'sp1-groth16' (default: feature-gated)"
     )]
     pub(crate) alpen_predicate: Option<AcctPredicateOverride>,
 

--- a/bin/datatool/src/checkpoint_predicate.rs
+++ b/bin/datatool/src/checkpoint_predicate.rs
@@ -10,6 +10,8 @@ use strata_predicate::PredicateKey;
 pub(crate) enum CheckpointPredicateOverride {
     /// Force `AlwaysAccept` regardless of compile-time features.
     AlwaysAccept,
+    /// Use the deterministic native Schnorr predicate.
+    NativeSchnorr,
     /// Use SP1 Groth16 (requires `sp1-builder` feature).
     Sp1Groth16,
 }
@@ -22,7 +24,8 @@ impl fmt::Display for ParseCheckpointPredicateError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "invalid checkpoint predicate type '{}', expected 'always-accept' or 'sp1-groth16'",
+            "invalid checkpoint predicate type '{}', expected 'always-accept', \
+             'native-schnorr', or 'sp1-groth16'",
             self.0
         )
     }
@@ -36,6 +39,7 @@ impl FromStr for CheckpointPredicateOverride {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "always-accept" => Ok(Self::AlwaysAccept),
+            "native-schnorr" => Ok(Self::NativeSchnorr),
             "sp1-groth16" => Ok(Self::Sp1Groth16),
             _ => Err(ParseCheckpointPredicateError(s.to_owned())),
         }
@@ -52,9 +56,15 @@ pub(crate) fn resolve_checkpoint_predicate(
 ) -> anyhow::Result<PredicateKey> {
     match override_val {
         Some(CheckpointPredicateOverride::AlwaysAccept) => Ok(PredicateKey::always_accept()),
+        Some(CheckpointPredicateOverride::NativeSchnorr) => Ok(resolve_native_schnorr()),
         Some(CheckpointPredicateOverride::Sp1Groth16) => resolve_sp1_groth16(),
         None => Ok(resolve_default()),
     }
+}
+
+/// Resolves the deterministic native Schnorr predicate key.
+fn resolve_native_schnorr() -> PredicateKey {
+    strata_zkvm_hosts::native::checkpoint_predicate_key()
 }
 
 /// Resolves the SP1 Groth16 predicate key.
@@ -84,7 +94,7 @@ fn resolve_default() -> PredicateKey {
 
     #[cfg(not(feature = "sp1-builder"))]
     {
-        PredicateKey::always_accept()
+        resolve_native_schnorr()
     }
 }
 

--- a/bin/datatool/src/cmd/asm_params.rs
+++ b/bin/datatool/src/cmd/asm_params.rs
@@ -3,8 +3,8 @@
 use std::{fs, num::NonZero, str::FromStr};
 
 use bitcoin::{
-    bip32::Xpriv,
-    secp256k1::{PublicKey, SECP256K1},
+    bip32::{Xpriv, Xpub},
+    secp256k1::{Parity, PublicKey, XOnlyPublicKey, SECP256K1},
 };
 use strata_asm_params::{
     AdministrationInitConfig, AsmParams, BridgeV1InitConfig, CheckpointInitConfig,
@@ -18,7 +18,8 @@ use strata_crypto::{
 use strata_l1_txfmt::MagicBytes;
 use strata_ol_genesis::build_genesis_artifacts;
 use strata_ol_params::OLParams;
-use strata_predicate::PredicateKey;
+use strata_predicate::{PredicateKey, PredicateTypeId};
+use strata_primitives::buf::Buf32;
 
 use crate::{
     args::{CmdContext, SubcAsmParams},
@@ -84,10 +85,13 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
     }
 
     // Convert xpriv keys to secp256k1 public keys.
-    let pubkeys: Vec<PublicKey> = opkeys
+    let mut pubkeys: Vec<PublicKey> = opkeys
         .iter()
         .map(|xpriv| xpriv.to_keypair(SECP256K1).public_key())
         .collect();
+    for key in cmd.op_pubkey {
+        pubkeys.push(parse_operator_pubkey(&key)?);
+    }
 
     // Build admin subprotocol params using the operator keys for all three admin roles.
     let admin_keys: Vec<CompressedPublicKey> = pubkeys
@@ -125,10 +129,18 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
 
     // Build checkpoint config.
     let checkpoint_predicate = resolve_checkpoint_predicate(cmd.checkpoint_predicate)?;
+    let sequencer_predicate = match cmd.seqkey.as_ref().map(|s| s.trim()) {
+        Some(seqkey) => {
+            let xpub = Xpub::from_str(seqkey)?;
+            let seq_pubkey = Buf32(xpub.to_x_only_pub().serialize());
+            PredicateKey::new(PredicateTypeId::Bip340Schnorr, seq_pubkey.0.to_vec())
+        }
+        None => PredicateKey::always_accept(),
+    };
     let genesis_l1_height = genesis_l1_view.blk.height();
 
     let checkpoint = CheckpointInitConfig {
-        sequencer_predicate: PredicateKey::always_accept(),
+        sequencer_predicate,
         checkpoint_predicate,
         genesis_l1_height,
         genesis_ol_blkid,
@@ -180,4 +192,16 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
     }
 
     Ok(())
+}
+
+fn parse_operator_pubkey(raw: &str) -> anyhow::Result<PublicKey> {
+    let raw = raw.trim();
+    if raw.len() == 64 {
+        let xonly = XOnlyPublicKey::from_str(raw)
+            .map_err(|e| anyhow::anyhow!("invalid x-only operator pubkey {raw}: {e}"))?;
+        return Ok(xonly.public_key(Parity::Even));
+    }
+
+    PublicKey::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("invalid compressed operator pubkey {raw}: {e}"))
 }

--- a/bin/datatool/src/cmd/params.rs
+++ b/bin/datatool/src/cmd/params.rs
@@ -6,7 +6,7 @@ use alloy_genesis::Genesis;
 use alloy_primitives::B256;
 use bitcoin::{
     bip32::{Xpriv, Xpub},
-    secp256k1::SECP256K1,
+    secp256k1::{PublicKey, SECP256K1},
     Amount, XOnlyPublicKey,
 };
 use reth_chainspec::ChainSpec;
@@ -78,6 +78,11 @@ pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> 
         opkeys.push(Xpriv::from_str(&key)?);
     }
 
+    let mut operator_pubkeys = Vec::new();
+    for key in cmd.op_pubkey {
+        operator_pubkeys.push(parse_operator_pubkey(&key)?);
+    }
+
     // Parse the deposit size str.
     let deposit_sats = cmd
         .deposit_sats
@@ -111,6 +116,7 @@ pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> 
         epoch_slots: cmd.epoch_slots.unwrap_or(DEFAULT_EPOCH_SLOTS),
         seqkey,
         opkeys,
+        operator_pubkeys,
         checkpoint_predicate: rollup_vk,
         // TODO make a const
         deposit_sats,
@@ -166,6 +172,8 @@ struct ParamsConfig {
     seqkey: Option<Buf32>,
     /// Operators' master keys.
     opkeys: Vec<Xpriv>,
+    /// Operators' public keys.
+    operator_pubkeys: Vec<XOnlyPublicKey>,
     /// Verifier's key.
     checkpoint_predicate: PredicateKey,
     /// Amount of sats to deposit.
@@ -184,11 +192,12 @@ fn construct_params(config: ParamsConfig) -> Result<RollupParams, KeyError> {
         .map(CredRule::SchnorrKey)
         .unwrap_or(CredRule::Unchecked);
 
-    let opkeys: Vec<XOnlyPublicKey> = config
+    let mut opkeys: Vec<XOnlyPublicKey> = config
         .opkeys
         .iter()
         .map(|o| o.to_keypair(SECP256K1).x_only_public_key().0)
         .collect();
+    opkeys.extend(config.operator_pubkeys);
 
     Ok(RollupParams {
         magic_bytes: config.magic,
@@ -215,6 +224,18 @@ fn construct_params(config: ParamsConfig) -> Result<RollupParams, KeyError> {
         max_deposits_in_block: 16,
         network: config.bitcoin_network,
     })
+}
+
+fn parse_operator_pubkey(raw: &str) -> anyhow::Result<XOnlyPublicKey> {
+    let raw = raw.trim();
+    if raw.len() == 64 {
+        return XOnlyPublicKey::from_str(raw)
+            .map_err(|e| anyhow::anyhow!("invalid x-only operator pubkey {raw}: {e}"));
+    }
+
+    let compressed = PublicKey::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("invalid compressed operator pubkey {raw}: {e}"))?;
+    Ok(compressed.x_only_public_key().0)
 }
 
 pub(super) struct BlockInfo {

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -24,18 +24,15 @@ debug-utils = [
 ]
 prover = [
   "dep:borsh",
-  "dep:strata-ol-state-support-types",
-  "dep:strata-ol-stf",
   "dep:strata-paas",
   "dep:strata-predicate",
   "dep:strata-proofimpl-checkpoint",
+  "dep:strata-zkvm-hosts",
   "dep:zkaleido",
 ]
 sp1 = [
   "prover",
   "strata-paas/remote",
-  "dep:strata-zkvm-hosts",
-  "dep:zkaleido-sp1-host",
   "strata-zkvm-hosts/sp1",
 ]
 
@@ -74,9 +71,7 @@ strata-ol-rpc-api.workspace = true
 strata-ol-rpc-types.workspace = true
 strata-ol-sequencer = { workspace = true, optional = true }
 strata-ol-state-provider = { workspace = true, optional = true }
-strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
-strata-ol-stf = { workspace = true, optional = true }
 strata-paas = { workspace = true, optional = true }
 strata-params.workspace = true
 strata-predicate = { workspace = true, optional = true }
@@ -109,9 +104,6 @@ tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 zkaleido = { workspace = true, optional = true }
-zkaleido-sp1-host = { workspace = true, features = [
-  "remote-prover",
-], optional = true }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -263,6 +263,8 @@ fn expected_backend_for_checkpoint_predicate(
     match checkpoint_predicate_type {
         // SP1 checkpoint predicates require SP1 proofs.
         PredicateTypeId::Sp1Groth16 => Ok(Some(ProverBackend::Sp1)),
+        // Native proofs are Schnorr signatures over checkpoint public values.
+        PredicateTypeId::Bip340Schnorr => Ok(Some(ProverBackend::Native)),
         // AlwaysAccept ignores witness bytes, so proofs are optional.
         PredicateTypeId::AlwaysAccept => Ok(None),
         // Other predicate types are currently unsupported for integrated checkpoint proving.
@@ -638,9 +640,10 @@ mod tests {
 
     #[cfg(feature = "prover")]
     #[test]
-    fn rejects_unsupported_predicate_for_integrated_prover() {
-        let err = super::expected_backend_for_checkpoint_predicate(PredicateTypeId::Bip340Schnorr)
-            .unwrap_err();
-        assert!(matches!(err, InitError::InvalidProverConfig(_)));
+    fn accepts_matching_backend_for_schnorr_predicate() {
+        let result =
+            super::expected_backend_for_checkpoint_predicate(PredicateTypeId::Bip340Schnorr)
+                .unwrap();
+        assert_eq!(result, Some(ProverBackend::Native));
     }
 }

--- a/bin/strata/src/prover/mod.rs
+++ b/bin/strata/src/prover/mod.rs
@@ -16,9 +16,10 @@ use anyhow::{Context, Result};
 use strata_config::{ProverBackend, ProverConfig};
 use strata_identifiers::{Epoch, EpochCommitment};
 use strata_paas::{ProverBuilder, ProverHandle, ProverServiceBuilder, RetryConfig, TaskResult};
-use strata_proofimpl_checkpoint::program::CheckpointProgram;
+use strata_proofimpl_checkpoint::process_ol_stf;
 use strata_storage::CheckpointProofDbManager;
 use strata_tasks::TaskExecutor;
+use strata_zkvm_hosts::native::{DeterministicNativeHost, NativeProofKind};
 use tokio::{sync::watch, time};
 use tracing::{debug, info, warn};
 
@@ -36,6 +37,7 @@ const PROVER_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 /// Default end-to-end deadline applied to the SP1 prover network when
 /// `ProverConfig::sp1_proof_deadline_secs` is not set. Chosen to comfortably
 /// cover checkpoint proofs while still failing fast on stuck requests.
+#[cfg(feature = "sp1")]
 const DEFAULT_SP1_DEADLINE_SECS: u64 = 4 * 60 * 60;
 
 /// Starts the integrated prover service.
@@ -76,23 +78,21 @@ pub(crate) fn start_prover_service(
 
     // Pick native vs. remote strategy at build time.
     let prover = match prover_config.backend {
-        ProverBackend::Native => ProverBuilder::new(spec)
-            .task_store(task_store)
-            .receipt_hook(hook)
-            .retry(RetryConfig::default())
-            .native(CheckpointProgram::native_host()),
+        ProverBackend::Native => {
+            let host = DeterministicNativeHost::new(process_ol_stf, NativeProofKind::Checkpoint);
+            ProverBuilder::new(spec)
+                .task_store(task_store)
+                .receipt_hook(hook)
+                .retry(RetryConfig::default())
+                .native(host)
+        }
         #[cfg(feature = "sp1")]
         ProverBackend::Sp1 => {
-            use strata_zkvm_hosts::sp1::CHECKPOINT_HOST;
-            // prover-core's `.remote(host)` takes the host by value and
-            // re-wraps it in its own Arc inside RemoteStrategy. SP1Host
-            // is Clone (only holds a SP1ProvingKey), so cloning from the
-            // shared static is fine.
-            let mut host: zkaleido_sp1_host::SP1Host = (**CHECKPOINT_HOST).clone();
+            use strata_zkvm_hosts::sp1::checkpoint_host_with_deadline;
             let deadline_secs = prover_config
                 .sp1_proof_deadline_secs
                 .unwrap_or(DEFAULT_SP1_DEADLINE_SECS);
-            host = host.with_deadline(Duration::from_secs(deadline_secs));
+            let host = checkpoint_host_with_deadline(Duration::from_secs(deadline_secs));
             info!(deadline_secs, "sp1 prover deadline configured");
             ProverBuilder::new(spec)
                 .task_store(task_store)

--- a/bin/strata/src/prover/spec.rs
+++ b/bin/strata/src/prover/spec.rs
@@ -9,8 +9,7 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize, io::Error as BorshIoError};
 use strata_identifiers::{Epoch, EpochCommitment};
-use strata_ol_state_support_types::{DaAccumulatingState, MemoryStateBaseLayer};
-use strata_ol_stf::execute_block_batch;
+use strata_ol_checkpoint::compute_epoch_preseal_da_diff;
 use strata_paas::{ProofSpec, ProverError as PaasError, ProverResult};
 use strata_proofimpl_checkpoint::program::{CheckpointProgram, CheckpointProverInput};
 use strata_storage::NodeStorage;
@@ -167,23 +166,8 @@ fn fetch_input_blocking(
 
     blocks.reverse();
 
-    // Compute DA state diff bytes by replaying the epoch blocks through a
-    // [`DaAccumulatingState`] wrapper. This intercepts state mutations to
-    // build the same DA diff that the guest program will verify. Computing
-    // it here (rather than reading a checkpoint entry) ensures the diff
-    // is available before the checkpoint entry is written.
-    let da_state_diff_bytes = {
-        let mut da_state =
-            DaAccumulatingState::new(MemoryStateBaseLayer::new((*start_state).clone()));
-        execute_block_batch(&mut da_state, &blocks, &parent)
-            .map_err(|e| ProverError::DaComputation(e.to_string()))?;
-        da_state
-            .take_completed_epoch_da_blob()
-            .map_err(|e| ProverError::DaComputation(e.to_string()))?
-            .ok_or_else(|| {
-                ProverError::DaComputation("no DA blob produced after epoch replay".to_string())
-            })?
-    };
+    let da_state_diff_bytes = compute_epoch_preseal_da_diff(&start_state, &blocks, &parent)
+        .map_err(|e| ProverError::DaComputation(e.to_string()))?;
 
     debug!(
         %epoch_index,

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/state.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/state.rs
@@ -189,28 +189,37 @@ impl OLChainTrackerState {
             to_slot = max_slot;
         }
 
-        if from_slot > to_slot {
-            let next_inbox_msg_idx = self.next_inbox_msg_idx_at_or_before(to_slot);
-            return Ok(InboxMessages::new_empty(next_inbox_msg_idx));
-        }
-
-        // Blocks are present. `from_idx` is the first block with
-        // slot >= from_slot and `to_idx_exclusive` is the first block after
-        // to_slot.
+        // Blocks are present.
+        // Index of first block with slot >= from_slot.
         let from_idx = self.blocks.partition_point(|b| b.slot() < from_slot);
-        let to_idx_exclusive = self.blocks.partition_point(|b| b.slot() <= to_slot);
 
-        let next_inbox_msg_idx = to_idx_exclusive
+        // Index of the first block with slot > to_slot.
+        let to_idx = self.blocks.partition_point(|b| b.slot() <= to_slot);
+
+        let next_inbox_msg_idx_before_range = from_idx
             .checked_sub(1)
             .and_then(|i| self.blocks.get(i))
             .and_then(|b| self.data.get(b.blkid()))
             .map_or(self.base_block_next_inbox_msg_idx, |d| d.next_inbox_msg_idx);
 
+        if from_idx >= to_idx {
+            return Ok(InboxMessages::new_empty(next_inbox_msg_idx_before_range));
+        }
+
+        // Return the next expected inbox index after the last block in the
+        // returned range.
+        let next_inbox_msg_idx = self
+            .blocks
+            .get(to_idx - 1)
+            .and_then(|b| self.data.get(b.blkid()))
+            .ok_or_else(|| eyre!("missing inbox data for last block in range"))?
+            .next_inbox_msg_idx;
+
         let messages = self
             .blocks
             .iter()
             .skip(from_idx)
-            .take(to_idx_exclusive.saturating_sub(from_idx))
+            .take(to_idx - from_idx)
             .map(|b| {
                 self.data
                     .get(b.blkid())
@@ -228,14 +237,6 @@ impl OLChainTrackerState {
             messages,
             next_inbox_msg_idx,
         })
-    }
-
-    fn next_inbox_msg_idx_at_or_before(&self, slot: u64) -> u64 {
-        let idx = self.blocks.partition_point(|b| b.slot() <= slot);
-        idx.checked_sub(1)
-            .and_then(|i| self.blocks.get(i))
-            .and_then(|b| self.data.get(b.blkid()))
-            .map_or(self.base_block_next_inbox_msg_idx, |d| d.next_inbox_msg_idx)
     }
 }
 
@@ -601,8 +602,8 @@ mod tests {
                 .append_block(make_block(12), vec![make_message(200)], 2)
                 .unwrap();
 
-            // Request range completely above tracked blocks. This returns no
-            // messages, but still reports the latest tracked inbox index.
+            // Request a range completely above tracked blocks. It returns no
+            // messages while preserving the latest tracked inbox index.
             let messages = state.get_inbox_messages(20, 25).unwrap();
             assert!(messages.messages.is_empty());
             assert_eq!(messages.next_inbox_msg_idx(), 2);

--- a/crates/db/tests/src/proof_tests.rs
+++ b/crates/db/tests/src/proof_tests.rs
@@ -46,7 +46,12 @@ fn generate_proof() -> (EpochCommitment, ProofReceiptWithMetadata) {
     let proof = Proof::default();
     let public_values = PublicValues::default();
     let receipt = ProofReceipt::new(proof, public_values);
-    let metadata = ProofMetadata::new(ZkVm::Native, ProgramId([0u8; 32]), "0.1".to_string());
+    let metadata = ProofMetadata::new(
+        ZkVm::Native,
+        ProgramId([0u8; 32]),
+        "0.1".to_string(),
+        zkaleido::ProofType::Core,
+    );
     let proof_receipt = ProofReceiptWithMetadata::new(receipt, metadata);
     (epoch, proof_receipt)
 }

--- a/crates/ol/checkpoint/src/context.rs
+++ b/crates/ol/checkpoint/src/context.rs
@@ -11,7 +11,10 @@ use strata_identifiers::{Epoch, EpochCommitment, OLBlockCommitment};
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLBlockId, OLLog};
 use strata_ol_state_support_types::{DaAccumulatingState, MemoryStateBaseLayer};
 use strata_ol_state_types::OLState;
-use strata_ol_stf::execute_block_batch;
+use strata_ol_stf::{
+    BlockComponents, BlockContext, BlockExecInput, BlockInfo, execute_block_batch,
+    execute_block_inputs,
+};
 use strata_primitives::nonempty_vec::NonEmptyVec;
 use strata_storage::NodeStorage;
 use tracing::{debug, warn};
@@ -357,10 +360,10 @@ fn assert_terminal_commitment_matches(
 /// Replays epoch blocks to produce DA state diff bytes, accumulated logs, and
 /// the terminal header.
 ///
-/// Loads the OL state at the previous terminal block, wraps it in
-/// `DaAccumulatingState` to intercept mutations, then re-executes every block
-/// in the epoch. The DA blob is extracted from the accumulating layer and the
-/// logs are collected from each block's execution output.
+/// Loads the OL state at the previous terminal block and re-executes every
+/// block in the epoch. Full block replay collects logs and validates headers,
+/// while DA accumulation replays only the preseal phases that the checkpoint
+/// proof authenticates against the terminal preseal root.
 fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
     ctx: &C,
     summary: &EpochSummary,
@@ -375,22 +378,60 @@ fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
     let ol_state_raw = ctx
         .get_ol_state(prev_terminal)?
         .ok_or_else(|| anyhow::anyhow!("missing OL state at prev terminal {:?}", prev_terminal))?;
-    let ol_state = MemoryStateBaseLayer::new(ol_state_raw);
 
-    let mut da_state = DaAccumulatingState::new(ol_state);
-
-    let logs = execute_block_batch(&mut da_state, &epoch_blocks, &prev_terminal_header)
+    let mut replay_state = MemoryStateBaseLayer::new(ol_state_raw.clone());
+    let logs = execute_block_batch(&mut replay_state, &epoch_blocks, &prev_terminal_header)
         .map_err(|e| anyhow::anyhow!("epoch block replay failed: {e}"))?;
 
     let terminal_header = epoch_blocks.ensured_last().header().clone();
-
-    // Extract the DA blob from the accumulating layer.
-    let da_bytes = da_state
-        .take_completed_epoch_da_blob()
-        .map_err(|e| anyhow::anyhow!("DA accumulation failed: {e}"))?
-        .ok_or_else(|| anyhow::anyhow!("no DA blob produced after epoch replay"))?;
+    let da_bytes =
+        compute_epoch_preseal_da_diff(&ol_state_raw, &epoch_blocks, &prev_terminal_header)?;
 
     Ok((da_bytes, logs, terminal_header))
+}
+
+/// Computes the epoch DA payload using only preseal block execution.
+///
+/// Manifest processing is proven by full block replay and terminal header
+/// equality. The DA witness is verified against the terminal preseal root, so
+/// L1-derived manifest mutations must not be included in this blob.
+pub fn compute_epoch_preseal_da_diff(
+    start_state: &OLState,
+    blocks: &[OLBlock],
+    initial_parent: &OLBlockHeader,
+) -> anyhow::Result<Vec<u8>> {
+    let mut da_state = DaAccumulatingState::new(MemoryStateBaseLayer::new(start_state.clone()));
+    let mut parent = initial_parent.clone();
+
+    for block in blocks {
+        let block_info = BlockInfo::from_header(block.header());
+        let block_context = BlockContext::new(&block_info, Some(&parent));
+        let block_components = BlockComponents::from_block(block);
+        let tx_segment = block_components.tx_segment().clone();
+        let block_exec_input = BlockExecInput::new(&tx_segment, None);
+
+        let outputs = execute_block_inputs(&mut da_state, block_context, block_exec_input)
+            .map_err(|e| anyhow::anyhow!("preseal DA replay failed: {e}"))?;
+
+        let expected_preseal_root = block
+            .body()
+            .l1_update()
+            .map_or(block.header().state_root(), |update| {
+                update.preseal_state_root()
+            });
+        anyhow::ensure!(
+            outputs.header_post_state_root() == expected_preseal_root,
+            "preseal DA replay root mismatch at slot {}",
+            block.header().slot()
+        );
+
+        parent = block.header().clone();
+    }
+
+    da_state
+        .take_completed_epoch_da_blob()
+        .map_err(|e| anyhow::anyhow!("DA accumulation failed: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("no DA blob produced after epoch replay"))
 }
 
 /// Collects all blocks in an epoch by walking backwards from the terminal block.

--- a/crates/ol/checkpoint/src/lib.rs
+++ b/crates/ol/checkpoint/src/lib.rs
@@ -10,5 +10,5 @@ mod service;
 mod state;
 
 pub use builder::OLCheckpointBuilder;
-pub use context::{ProofNotify, ProverConfig};
+pub use context::{ProofNotify, ProverConfig, compute_epoch_preseal_da_diff};
 pub use handle::OLCheckpointWorkerHandle;

--- a/crates/proof-impl/alpen-acct/src/program.rs
+++ b/crates/proof-impl/alpen-acct/src/program.rs
@@ -95,7 +95,8 @@ impl EeAcctProgram {
         input: &<Self as ZkVmProgram>::Input,
     ) -> ZkVmResult<<Self as ZkVmProgram>::Output> {
         let host = self.native_host();
-        <Self as ZkVmProgram>::execute(input, &host)
+        let execution = <Self as ZkVmProgram>::execute(input, &host)?;
+        Self::process_output::<NativeHost>(execution.public_values())
     }
 }
 

--- a/crates/proof-impl/alpen-chunk/src/program.rs
+++ b/crates/proof-impl/alpen-chunk/src/program.rs
@@ -63,7 +63,8 @@ impl EeChunkProgram {
         input: &<Self as ZkVmProgram>::Input,
     ) -> ZkVmResult<<Self as ZkVmProgram>::Output> {
         let host = Self::native_host();
-        <Self as ZkVmProgram>::execute(input, &host)
+        let execution = <Self as ZkVmProgram>::execute(input, &host)?;
+        Self::process_output::<NativeHost>(execution.public_values())
     }
 }
 

--- a/crates/proof-impl/checkpoint/src/program.rs
+++ b/crates/proof-impl/checkpoint/src/program.rs
@@ -62,7 +62,8 @@ impl CheckpointProgram {
     ) -> ZkVmResult<<Self as ZkVmProgram>::Output> {
         // Get the native host and delegate to the trait's execute method
         let host = Self::native_host();
-        <Self as ZkVmProgram>::execute(input, &host)
+        let execution = <Self as ZkVmProgram>::execute(input, &host)?;
+        Self::process_output::<NativeHost>(execution.public_values())
     }
 }
 
@@ -109,10 +110,7 @@ mod tests {
         let slot_delta_u16 =
             u16::try_from(slot_delta).expect("slot delta exceeds u16::MAX; epoch too long");
         let da_diff = StateDiff::new(
-            GlobalStateDiff::new(
-                DaCounter::new_changed(slot_delta_u16),
-                DaCounter::new_unchanged(),
-            ),
+            GlobalStateDiff::new(DaCounter::new_changed(slot_delta_u16)),
             LedgerDiff::default(),
         );
         let da_state_diff_bytes =
@@ -180,10 +178,7 @@ mod tests {
         let bad_delta = u16::try_from(slot_delta.saturating_sub(1))
             .expect("slot delta exceeds u16::MAX; epoch too long");
         let bad_da_diff = StateDiff::new(
-            GlobalStateDiff::new(
-                DaCounter::new_changed(bad_delta),
-                DaCounter::new_unchanged(),
-            ),
+            GlobalStateDiff::new(DaCounter::new_changed(bad_delta)),
             LedgerDiff::default(),
         );
         input.da_state_diff_bytes =

--- a/crates/proof-impl/evm-ee-stf/src/program.rs
+++ b/crates/proof-impl/evm-ee-stf/src/program.rs
@@ -54,6 +54,7 @@ impl EvmEeProgram {
     ) -> ZkVmResult<<Self as ZkVmProgram>::Output> {
         // Get the native host and delegate to the trait's execute method
         let host = Self::native_host();
-        <Self as ZkVmProgram>::execute(input, &host)
+        let execution = <Self as ZkVmProgram>::execute(input, &host)?;
+        Self::process_output::<NativeHost>(execution.public_values())
     }
 }

--- a/crates/zkvm/hosts/Cargo.toml
+++ b/crates/zkvm/hosts/Cargo.toml
@@ -7,13 +7,19 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+bincode.workspace = true
+k256.workspace = true
+serde.workspace = true
+strata-predicate.workspace = true
+zkaleido.workspace = true
+zkaleido-native-adapter.workspace = true
+
 # sp1
 strata-sp1-guest-builder = { path = "../../../provers/sp1", optional = true }
-zkaleido-sp1-host = { workspace = true, features = [
-  "remote-prover",
-], optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
+zkaleido-sp1-host = { workspace = true, optional = true }
 
 [features]
 default = []
-sp1 = ["dep:zkaleido-sp1-host", "zkaleido-sp1-host/remote-prover"]
+sp1 = ["dep:tokio", "dep:zkaleido-sp1-host"]
 sp1-builder = ["sp1", "strata-sp1-guest-builder/sp1-dev"]

--- a/crates/zkvm/hosts/src/lib.rs
+++ b/crates/zkvm/hosts/src/lib.rs
@@ -6,5 +6,7 @@
 //! its `ProofContext` / `ProofZkVm`) is gone — the integrated prover knows
 //! its host at build time, no runtime dispatch needed.
 
+pub mod native;
+
 #[cfg(feature = "sp1")]
 pub mod sp1;

--- a/crates/zkvm/hosts/src/native.rs
+++ b/crates/zkvm/hosts/src/native.rs
@@ -1,0 +1,262 @@
+//! Deterministic native zkVM hosts used by local functional tests.
+
+use std::{fmt, sync::Arc};
+
+use k256::schnorr::{
+    signature::{Signer, Verifier},
+    Signature, SigningKey,
+};
+use strata_predicate::{PredicateKey, PredicateTypeId};
+use zkaleido::{
+    AggregationInput, DataFormatError, ExecutionSummary, ProgramId, Proof, ProofMetadata,
+    ProofReceipt, ProofReceiptWithMetadata, ProofType, PublicValues, VerifyingKey, ZkVm, ZkVmError,
+    ZkVmExecutor, ZkVmHost, ZkVmInputBuilder, ZkVmInputError, ZkVmInputResult, ZkVmOutputExtractor,
+    ZkVmProofError, ZkVmProver, ZkVmResult, ZkVmTypedVerifier, ZkVmVkProvider,
+};
+use zkaleido_native_adapter::NativeMachine;
+
+type ProcessProofFn = dyn Fn(&NativeMachine) -> ZkVmResult<()> + Send + Sync;
+
+const CHECKPOINT_NATIVE_SECRET: [u8; 32] = [0x11; 32];
+const ALPEN_CHUNK_NATIVE_SECRET: [u8; 32] = [0x22; 32];
+const ALPEN_ACCT_NATIVE_SECRET: [u8; 32] = [0x33; 32];
+
+/// Native proof programs that need stable Schnorr predicate keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeProofKind {
+    /// OL checkpoint proof.
+    Checkpoint,
+    /// Alpen EE chunk proof.
+    AlpenChunk,
+    /// Alpen EE account update proof.
+    AlpenAcct,
+}
+
+impl NativeProofKind {
+    fn secret(self) -> [u8; 32] {
+        match self {
+            Self::Checkpoint => CHECKPOINT_NATIVE_SECRET,
+            Self::AlpenChunk => ALPEN_CHUNK_NATIVE_SECRET,
+            Self::AlpenAcct => ALPEN_ACCT_NATIVE_SECRET,
+        }
+    }
+
+    /// Returns the predicate key that verifies this native proof kind.
+    pub fn predicate_key(self) -> PredicateKey {
+        predicate_key_for_secret(self.secret())
+    }
+}
+
+/// Returns the native Schnorr predicate for OL checkpoint proofs.
+pub fn checkpoint_predicate_key() -> PredicateKey {
+    NativeProofKind::Checkpoint.predicate_key()
+}
+
+/// Returns the native Schnorr predicate for Alpen EE chunk proofs.
+pub fn alpen_chunk_predicate_key() -> PredicateKey {
+    NativeProofKind::AlpenChunk.predicate_key()
+}
+
+/// Returns the native Schnorr predicate for Alpen EE account update proofs.
+pub fn alpen_acct_predicate_key() -> PredicateKey {
+    NativeProofKind::AlpenAcct.predicate_key()
+}
+
+fn signing_key_for_secret(secret: [u8; 32]) -> SigningKey {
+    SigningKey::from_bytes(&secret).expect("native proof secret key must be valid")
+}
+
+fn predicate_key_for_secret(secret: [u8; 32]) -> PredicateKey {
+    let signing_key = signing_key_for_secret(secret);
+    PredicateKey::new(
+        PredicateTypeId::Bip340Schnorr,
+        signing_key.verifying_key().to_bytes().to_vec(),
+    )
+}
+
+/// Native host that signs public values with a stable Schnorr key.
+#[derive(Clone)]
+pub struct DeterministicNativeHost {
+    process_fn: Arc<Box<ProcessProofFn>>,
+    signing_key: SigningKey,
+}
+
+impl DeterministicNativeHost {
+    /// Creates a deterministic native host for the given proof kind.
+    pub fn new<F>(process_fn: F, kind: NativeProofKind) -> Self
+    where
+        F: Fn(&NativeMachine) + Send + Sync + 'static,
+    {
+        Self::new_fallible(
+            move |zkvm| {
+                process_fn(zkvm);
+                Ok(())
+            },
+            kind,
+        )
+    }
+
+    /// Creates a deterministic native host with a fallible process function.
+    pub fn new_fallible<F>(process_fn: F, kind: NativeProofKind) -> Self
+    where
+        F: Fn(&NativeMachine) -> ZkVmResult<()> + Send + Sync + 'static,
+    {
+        Self {
+            process_fn: Arc::new(Box::new(process_fn)),
+            signing_key: signing_key_for_secret(kind.secret()),
+        }
+    }
+
+    /// Returns the predicate key that verifies receipts from this host.
+    pub fn predicate_key(&self) -> PredicateKey {
+        PredicateKey::new(
+            PredicateTypeId::Bip340Schnorr,
+            self.signing_key.verifying_key().to_bytes().to_vec(),
+        )
+    }
+}
+
+impl ZkVmHost for DeterministicNativeHost {
+    fn zkvm(&self) -> ZkVm {
+        ZkVm::Native
+    }
+}
+
+impl ZkVmExecutor for DeterministicNativeHost {
+    type Input<'a> = NativeInputBuilder;
+
+    fn execute<'a>(&self, native_machine: NativeMachine) -> ZkVmResult<ExecutionSummary> {
+        (self.process_fn)(&native_machine)?;
+        let output = native_machine.state.borrow().output.clone();
+        Ok(ExecutionSummary::new(PublicValues::new(output), 0, None))
+    }
+
+    fn get_elf(&self) -> &[u8] {
+        &[]
+    }
+
+    fn save_trace(&self, _trace_name: &str) {}
+
+    fn program_id(&self) -> ProgramId {
+        ProgramId(self.signing_key.verifying_key().to_bytes().into())
+    }
+}
+
+impl ZkVmProver for DeterministicNativeHost {
+    type ZkVmProofReceipt = NativeProofReceipt;
+
+    fn prove_inner<'a>(
+        &self,
+        native_machine: NativeMachine,
+        proof_type: ProofType,
+    ) -> ZkVmResult<NativeProofReceipt> {
+        let execution_result = self.execute(native_machine)?;
+        let public_values = execution_result.into_public_values();
+        let signature: Signature = self.signing_key.sign(public_values.as_bytes());
+        let proof = Proof::new(signature.to_bytes().to_vec());
+        let receipt = ProofReceipt::new(proof, public_values);
+        let metadata = ProofMetadata::new(
+            ZkVm::Native,
+            self.program_id(),
+            env!("CARGO_PKG_VERSION").to_string(),
+            proof_type,
+        );
+        let receipt = ProofReceiptWithMetadata::new(receipt, metadata);
+        Ok(receipt.try_into()?)
+    }
+}
+
+impl ZkVmTypedVerifier for DeterministicNativeHost {
+    type ZkVmProofReceipt = NativeProofReceipt;
+
+    fn verify_inner(&self, proof: &NativeProofReceipt) -> ZkVmResult<()> {
+        let receipt: ProofReceiptWithMetadata = proof
+            .clone()
+            .try_into()
+            .map_err(ZkVmError::InvalidProofReceipt)?;
+        let signature = Signature::try_from(receipt.receipt().proof().as_bytes())
+            .map_err(|e| ZkVmError::ProofVerificationError(format!("invalid signature: {e}")))?;
+        self.signing_key
+            .verifying_key()
+            .verify(receipt.receipt().public_values().as_bytes(), &signature)
+            .map_err(|e| {
+                ZkVmError::ProofVerificationError(format!("signature verification failed: {e}"))
+            })
+    }
+}
+
+impl ZkVmVkProvider for DeterministicNativeHost {
+    fn vk(&self) -> VerifyingKey {
+        VerifyingKey::new(self.signing_key.verifying_key().to_bytes().to_vec())
+    }
+}
+
+impl ZkVmOutputExtractor for DeterministicNativeHost {
+    fn extract_serde_public_output<T: serde::Serialize + serde::de::DeserializeOwned>(
+        public_values_raw: &PublicValues,
+    ) -> ZkVmResult<T> {
+        bincode::deserialize(public_values_raw.as_bytes()).map_err(|e| {
+            ZkVmError::OutputExtractionError {
+                source: DataFormatError::Serde(e.to_string()),
+            }
+        })
+    }
+}
+
+impl fmt::Debug for DeterministicNativeHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "deterministic_native")
+    }
+}
+
+/// Input builder for the deterministic native host.
+#[derive(Debug)]
+pub struct NativeInputBuilder(NativeMachine);
+
+impl ZkVmInputBuilder<'_> for NativeInputBuilder {
+    type Input = NativeMachine;
+    type ZkVmProofReceipt = NativeProofReceipt;
+
+    fn new() -> Self {
+        Self(NativeMachine::new())
+    }
+
+    fn write_buf(&mut self, item: &[u8]) -> ZkVmInputResult<&mut Self> {
+        self.0.write_slice(item.to_vec());
+        Ok(self)
+    }
+
+    fn write_serde<T: serde::Serialize>(&mut self, item: &T) -> ZkVmInputResult<&mut Self> {
+        let slice = bincode::serialize(item)
+            .map_err(|e| ZkVmInputError::DataFormat(DataFormatError::Serde(e.to_string())))?;
+        self.write_buf(&slice)
+    }
+
+    fn write_proof(&mut self, item: &AggregationInput) -> ZkVmInputResult<&mut Self> {
+        self.write_buf(item.receipt().receipt().public_values().as_bytes())
+    }
+
+    fn build(&mut self) -> ZkVmInputResult<Self::Input> {
+        Ok(self.0.clone())
+    }
+}
+
+/// Native proof receipt wrapper.
+#[derive(Debug, Clone)]
+pub struct NativeProofReceipt(ProofReceiptWithMetadata);
+
+impl TryFrom<ProofReceiptWithMetadata> for NativeProofReceipt {
+    type Error = ZkVmProofError;
+
+    fn try_from(value: ProofReceiptWithMetadata) -> Result<Self, Self::Error> {
+        Ok(Self(value))
+    }
+}
+
+impl TryFrom<NativeProofReceipt> for ProofReceiptWithMetadata {
+    type Error = ZkVmProofError;
+
+    fn try_from(value: NativeProofReceipt) -> Result<Self, Self::Error> {
+        Ok(value.0)
+    }
+}

--- a/crates/zkvm/hosts/src/sp1.rs
+++ b/crates/zkvm/hosts/src/sp1.rs
@@ -1,11 +1,12 @@
 use std::{
     env::var,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 #[cfg(feature = "sp1-builder")]
 use strata_sp1_guest_builder::*;
-use zkaleido_sp1_host::SP1Host;
+use zkaleido_sp1_host::{SP1Host, SP1HostConfig};
 
 pub static ELF_BASE_PATH: LazyLock<String> =
     LazyLock::new(|| var("ELF_BASE_PATH").unwrap_or_else(|_| "elfs/sp1".to_string()));
@@ -14,19 +15,87 @@ macro_rules! define_host {
     ($host_name:ident, $guest_const:ident, $elf_file:expr) => {
         #[cfg(feature = "sp1-builder")]
         pub static $host_name: LazyLock<Arc<SP1Host>> =
-            LazyLock::new(|| Arc::new(SP1Host::init(&$guest_const)));
+            LazyLock::new(|| Arc::new(init_host(load_embedded_elf($guest_const), None)));
 
         #[cfg(not(feature = "sp1-builder"))]
-        pub static $host_name: LazyLock<Arc<SP1Host>> = LazyLock::new(|| {
-            let elf_path = format!("{}/{}", *ELF_BASE_PATH, $elf_file);
-            let elf = std::fs::read(&elf_path)
-                .expect(&format!("Failed to read ELF file from {}", elf_path));
-            Arc::new(SP1Host::init(&elf))
-        });
+        pub static $host_name: LazyLock<Arc<SP1Host>> =
+            LazyLock::new(|| Arc::new(init_host(load_elf_file($elf_file), None)));
     };
 }
 
-// Define hosts using the macro
+#[cfg(feature = "sp1-builder")]
+fn load_embedded_elf(embedded: &[u8]) -> Vec<u8> {
+    embedded.to_vec()
+}
+
+#[cfg(not(feature = "sp1-builder"))]
+fn load_elf_file(file_name: &str) -> Vec<u8> {
+    let elf_path = format!("{}/{}", *ELF_BASE_PATH, file_name);
+    std::fs::read(&elf_path).unwrap_or_else(|_| panic!("Failed to read ELF file from {elf_path}"))
+}
+
+fn init_host(elf: Vec<u8>, deadline: Option<Duration>) -> SP1Host {
+    let mut config = SP1HostConfig::from_env();
+    if let Some(deadline) = deadline {
+        config = config.with_deadline(deadline);
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build SP1 host init runtime")
+                .block_on(SP1Host::init_with_config(&elf, config))
+        })
+        .join()
+        .expect("SP1 host init thread panicked")
+    } else {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build SP1 host init runtime")
+            .block_on(SP1Host::init_with_config(&elf, config))
+    }
+}
+
+/// Returns a checkpoint SP1 host with a per-call proof deadline.
+#[cfg(feature = "sp1-builder")]
+pub fn checkpoint_host_with_deadline(deadline: Duration) -> SP1Host {
+    init_host(load_embedded_elf(GUEST_CHECKPOINT_ELF), Some(deadline))
+}
+
+/// Returns a checkpoint SP1 host with a per-call proof deadline.
+#[cfg(not(feature = "sp1-builder"))]
+pub fn checkpoint_host_with_deadline(deadline: Duration) -> SP1Host {
+    init_host(load_elf_file("guest-checkpoint.elf"), Some(deadline))
+}
+
+/// Returns an Alpen chunk SP1 host with a per-call proof deadline.
+#[cfg(feature = "sp1-builder")]
+pub fn alpen_chunk_host_with_deadline(deadline: Duration) -> SP1Host {
+    init_host(load_embedded_elf(GUEST_ALPEN_CHUNK_ELF), Some(deadline))
+}
+
+/// Returns an Alpen chunk SP1 host with a per-call proof deadline.
+#[cfg(not(feature = "sp1-builder"))]
+pub fn alpen_chunk_host_with_deadline(deadline: Duration) -> SP1Host {
+    init_host(load_elf_file("guest-alpen-chunk.elf"), Some(deadline))
+}
+
+/// Returns an Alpen account SP1 host with a per-call proof deadline.
+#[cfg(feature = "sp1-builder")]
+pub fn alpen_acct_host_with_deadline(deadline: Duration) -> SP1Host {
+    init_host(load_embedded_elf(GUEST_ALPEN_ACCT_ELF), Some(deadline))
+}
+
+/// Returns an Alpen account SP1 host with a per-call proof deadline.
+#[cfg(not(feature = "sp1-builder"))]
+pub fn alpen_acct_host_with_deadline(deadline: Duration) -> SP1Host {
+    init_host(load_elf_file("guest-alpen-acct.elf"), Some(deadline))
+}
+
+// Define hosts using the macro.
 define_host!(
     CHECKPOINT_HOST,
     GUEST_CHECKPOINT_ELF,

--- a/functional-tests/common/config/config.py
+++ b/functional-tests/common/config/config.py
@@ -144,6 +144,12 @@ class EpochSealingConfig:
 
 
 @dataclass
+class ProverConfig:
+    backend: str = field(default="native")
+    workers: int = field(default=1)
+
+
+@dataclass
 class StrataConfig:
     client: ClientConfig = field(default_factory=ClientConfig)
     bitcoind: BitcoindConfig = field(default_factory=BitcoindConfig)
@@ -152,6 +158,7 @@ class StrataConfig:
     exec: ExecConfig = field(default_factory=ExecConfig)
     relayer: RelayerConfig = field(default_factory=RelayerConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
+    prover: ProverConfig = field(default_factory=ProverConfig)
 
     def as_toml_string(self) -> str:
         d = asdict(self)

--- a/functional-tests/common/datatool.py
+++ b/functional-tests/common/datatool.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -6,6 +7,15 @@ from pathlib import Path
 from common.config.config import BitcoindConfig
 
 DEFAULT_OL_BLOCK_TIME_MS = 5_000
+DEFAULT_NATIVE_PREDICATE = "native-schnorr"
+
+
+def checkpoint_predicate() -> str:
+    return os.environ.get("ALPEN_CHECKPOINT_PREDICATE", DEFAULT_NATIVE_PREDICATE)
+
+
+def alpen_predicate() -> str:
+    return os.environ.get("ALPEN_ALPEN_PREDICATE", DEFAULT_NATIVE_PREDICATE)
 
 
 def run_datatool(
@@ -79,6 +89,7 @@ class RollupParamsArtifacts:
     params_path: Path
     sequencer_key_path: Path | None
     operator_keys: list[str]
+    sequencer_pubkey: str | None = None
 
 
 def write_sequencer_runtime_config(
@@ -102,6 +113,8 @@ def generate_rollup_params_unchecked(
     datadir: Path,
     bconfig: BitcoindConfig,
     genesis_l1_height: int,
+    operator_pubkeys: list[str] | None = None,
+    chain_config: Path | None = None,
     seq_fname: str = "sequencer_root_key",
 ) -> RollupParamsArtifacts:
     """Generates rollup params with ``CredRule::Unchecked``.
@@ -113,13 +126,15 @@ def generate_rollup_params_unchecked(
     """
     sequencer_key_path = datadir / seq_fname
     ensure_priv_key(sequencer_key_path)
-    operator_xprivs = get_operator_xprivs(datadir, "bridge-operator_keys")
+    operator_xprivs = (
+        [] if operator_pubkeys else get_operator_xprivs(datadir, "bridge-operator_keys")
+    )
     params_path = datadir / "rollup-params.json"
 
     args = [
         "genparams",
         "--checkpoint-predicate",
-        "always-accept",
+        checkpoint_predicate(),
         "--name",
         "ALPN",
         "--genesis-l1-height",
@@ -127,8 +142,12 @@ def generate_rollup_params_unchecked(
         "-o",
         str(params_path),
     ]
+    if chain_config is not None:
+        args.extend(["--chain-config", str(chain_config)])
     for opkey in operator_xprivs:
         args.extend(["--opkey", opkey])
+    for op_pubkey in operator_pubkeys or []:
+        args.extend(["--op-pubkey", op_pubkey])
 
     run_datatool(args, bconfig)
     return RollupParamsArtifacts(
@@ -142,20 +161,24 @@ def generate_rollup_params(
     datadir: Path,
     bconfig: BitcoindConfig,
     genesis_l1_height: int,
+    operator_pubkeys: list[str] | None = None,
+    chain_config: Path | None = None,
     seq_fname="sequencer_root_key",
 ) -> RollupParamsArtifacts:
     # Generate sequencer keys
     sequencer_key_path = datadir / seq_fname
     ensure_priv_key(sequencer_key_path)
     sequencer_pubkey = generate_sequencer_pubkey(sequencer_key_path)
-    operator_xprivs = get_operator_xprivs(datadir, "bridge-operator_keys")
+    operator_xprivs = (
+        [] if operator_pubkeys else get_operator_xprivs(datadir, "bridge-operator_keys")
+    )
 
     params_path = datadir / "rollup-params.json"
 
     args = [
         "genparams",
         "--checkpoint-predicate",
-        "always-accept",
+        checkpoint_predicate(),
         "--name",
         "ALPN",
         "--genesis-l1-height",
@@ -165,11 +188,20 @@ def generate_rollup_params(
         "-o",
         str(params_path),
     ]
+    if chain_config is not None:
+        args.extend(["--chain-config", str(chain_config)])
     for opkey in operator_xprivs:
         args.extend(["--opkey", opkey])
+    for op_pubkey in operator_pubkeys or []:
+        args.extend(["--op-pubkey", op_pubkey])
 
     run_datatool(args, bconfig)
-    return RollupParamsArtifacts(params_path, sequencer_key_path, operator_xprivs)
+    return RollupParamsArtifacts(
+        params_path,
+        sequencer_key_path,
+        operator_xprivs,
+        sequencer_pubkey,
+    )
 
 
 def generate_sequencer_pubkey(sequencer_key_path: Path) -> str:
@@ -184,17 +216,22 @@ def generate_ol_params(
     datadir: Path,
     bconfig: BitcoindConfig,
     genesis_l1_height: int,
+    alpen_chain_config: Path | None = None,
 ) -> Path:
     """Generates OL params via ``strata-datatool gen-ol-params``."""
     params_path = datadir / "ol-params.json"
 
     args = [
         "gen-ol-params",
+        "--alpen-predicate",
+        alpen_predicate(),
         "--genesis-l1-height",
         str(genesis_l1_height),
         "-o",
         str(params_path),
     ]
+    if alpen_chain_config is not None:
+        args.extend(["--alpen-chain-config", str(alpen_chain_config)])
 
     run_datatool(args, bconfig)
     return params_path
@@ -205,15 +242,17 @@ def generate_asm_params(
     bconfig: BitcoindConfig,
     genesis_l1_height: int,
     operator_xprivs: list[str],
+    operator_pubkeys: list[str] | None = None,
     ol_params_path: Path | None = None,
     admin_confirmation_depth: int | None = None,
+    sequencer_pubkey: str | None = None,
 ) -> Path:
     params_path = datadir / "asm-params.json"
 
     args = [
         "gen-asm-params",
         "--checkpoint-predicate",
-        "always-accept",
+        checkpoint_predicate(),
         "--name",
         "ALPN",
         "--genesis-l1-height",
@@ -223,10 +262,14 @@ def generate_asm_params(
     ]
     if ol_params_path is not None:
         args.extend(["--ol-params", str(ol_params_path)])
+    if sequencer_pubkey is not None:
+        args.extend(["--seqkey", sequencer_pubkey])
     if admin_confirmation_depth is not None:
         args.extend(["--confirmation-depth", str(admin_confirmation_depth)])
     for opkey in operator_xprivs:
         args.extend(["--opkey", opkey])
+    for op_pubkey in operator_pubkeys or []:
+        args.extend(["--op-pubkey", op_pubkey])
 
     run_datatool(args, bconfig)
     return params_path

--- a/functional-tests/common/external_bridge.py
+++ b/functional-tests/common/external_bridge.py
@@ -1,0 +1,530 @@
+"""Helpers for running an external strata-bridge checkout in functional tests."""
+
+import json
+import os
+import re
+import select
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+DEFAULT_OPERATOR_COUNT = 2
+DEFAULT_BRIDGE_REPO_CANDIDATES = ("strata-bridge-current", "strata-bridge")
+DEFAULT_BRIDGE_RPC_PORT = 13000
+READY_PREFIX = "BRIDGE_READY "
+STAGE_PREFIX = "BRIDGE_STAGE "
+STARTUP_LOG_PREFIXES = (STAGE_PREFIX, "BRIDGE_ERROR ")
+DEFAULT_FDB_KNOBS = (
+    "-m 2GiB -M 512MiB --cache-memory 256MiB "
+    "--knob-min_available_space 0 "
+    "--knob-min_available_space_ratio 0 "
+    "--knob-min_available_space_ratio_safety_buffer 0 "
+    "--knob-target_available_space_ratio 0 "
+    "--knob-available_space_ratio_cutoff 0"
+)
+
+
+def find_bridge_repo() -> Path:
+    """Resolve the external strata-bridge checkout."""
+    configured = os.environ.get("ALPEN_EXTERNAL_BRIDGE_REPO")
+    if configured:
+        repo = Path(configured).expanduser().resolve()
+        if not (repo / "Cargo.toml").exists():
+            raise RuntimeError(f"ALPEN_EXTERNAL_BRIDGE_REPO is not a Rust repo: {repo}")
+        return repo
+
+    alpen_parent = Path(__file__).resolve().parents[3]
+    for name in DEFAULT_BRIDGE_REPO_CANDIDATES:
+        repo = alpen_parent / name
+        if (repo / "Cargo.toml").exists():
+            return repo
+
+    raise RuntimeError(
+        "External strata-bridge checkout not found. Set ALPEN_EXTERNAL_BRIDGE_REPO."
+    )
+
+
+def load_bridge_operator_pubkeys(repo: Path, count: int = DEFAULT_OPERATOR_COUNT) -> list[str]:
+    """Load MuSig2 operator public keys from the external bridge test artifacts."""
+    keys_path = repo / "functional-tests/artifacts/keys.json"
+    keys = json.loads(keys_path.read_text())
+    if len(keys) < count:
+        raise RuntimeError(f"requested {count} bridge operators, only {len(keys)} keys available")
+    return [entry["MUSIG2_KEY"] for entry in keys[:count]]
+
+
+def compute_bridge_aggregate_pubkey(operator_pubkeys: list[str]) -> str:
+    """Compute the MuSig2 aggregate key used by `alpen deposit`."""
+    result = subprocess.run(
+        [
+            "strata-test-cli",
+            "musig-aggregate-pks",
+            "--pubkeys",
+            json.dumps(operator_pubkeys),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _extract_git_rev(cargo_toml: str, package: str) -> str:
+    pattern = rf"{re.escape(package)}.*rev = \"([^\"]+)\""
+    match = re.search(pattern, cargo_toml)
+    if match is None:
+        raise RuntimeError(f"failed to extract {package} rev from external bridge Cargo.toml")
+    return match.group(1)
+
+
+def build_external_bridge(repo: Path) -> None:
+    """Build external bridge binaries and install auxiliary binaries."""
+    if os.environ.get("ALPEN_EXTERNAL_BRIDGE_BUILD", "1") == "0":
+        return
+
+    env = os.environ.copy()
+    subprocess.run(
+        ["cargo", "build", "--bin", "strata-bridge"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    subprocess.run(
+        ["cargo", "build", "-p", "secret-service", "--bin", "secret-service"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    subprocess.run(["cargo", "build", "--bin", "dev-cli"], cwd=repo, env=env, check=True)
+
+    install_root = repo / "functional-tests/_dd/.bin"
+    bin_dir = install_root / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    cargo_toml = (repo / "Cargo.toml").read_text()
+    mosaic_rev = _extract_git_rev(cargo_toml, "mosaic-rpc-api")
+    asm_rev = _extract_git_rev(cargo_toml, "strata-asm-worker")
+
+    if shutil.which("mosaic", path=str(bin_dir)) is None:
+        subprocess.run(
+            [
+                "cargo",
+                "install",
+                "--locked",
+                "--root",
+                str(install_root),
+                "--git",
+                "https://github.com/alpenlabs/mosaic",
+                "--rev",
+                mosaic_rev,
+                "mosaic",
+            ],
+            check=True,
+        )
+
+    if shutil.which("strata-asm-runner", path=str(bin_dir)) is None:
+        subprocess.run(
+            [
+                "cargo",
+                "install",
+                "--locked",
+                "--root",
+                str(install_root),
+                "--git",
+                "https://github.com/alpenlabs/asm",
+                "--rev",
+                asm_rev,
+                "strata-asm-runner",
+            ],
+            check=True,
+        )
+
+
+def _bridge_process_env(repo: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    ft_root = repo / "functional-tests"
+    bin_paths = [repo / "target/debug", ft_root / "_dd/.bin/bin"]
+    env["PATH"] = os.pathsep.join(str(path) for path in bin_paths) + os.pathsep + env["PATH"]
+
+    fdb_root = ft_root / "_dd/.tools/fdb-7.3.43/root"
+    if fdb_root.exists():
+        env.setdefault("FDBSERVER_PATH", str(fdb_root / "usr/local/libexec/fdbserver"))
+        env.setdefault("FDBCLI_PATH", str(fdb_root / "usr/local/bin/fdbcli"))
+        env.setdefault("FDB_LIBRARY_PATH", str(fdb_root / "usr/local/lib"))
+        dyld_path = env.get("DYLD_LIBRARY_PATH", "")
+        fdb_lib = env["FDB_LIBRARY_PATH"]
+        env["DYLD_LIBRARY_PATH"] = f"{fdb_lib}:{dyld_path}" if dyld_path else fdb_lib
+
+    env.setdefault("FDB_STORAGE_ENGINE", "ssd")
+    env.setdefault("FDBSERVER_EXTRA_ARGS", DEFAULT_FDB_KNOBS)
+    env.setdefault("BRIDGE_FDB_RETRY_LIMIT", "20")
+    env.setdefault("BRIDGE_FDB_RETRY_TIMEOUT_SECS", "120")
+    return env
+
+
+def _jsonrpc(url: str, method: str, params: list[Any] | None = None) -> Any:
+    response = requests.post(
+        url,
+        json={"jsonrpc": "2.0", "method": method, "params": params or [], "id": 1},
+        timeout=5,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if "error" in payload:
+        raise RuntimeError(payload["error"])
+    return payload["result"]
+
+
+@dataclass
+class ExternalBridgeHandle:
+    """Running external bridge daemon."""
+
+    process: subprocess.Popen[str]
+    stop_file: Path
+    rpc_url: str
+    datadir: Path
+
+    def wait_deposit_complete(self, drt_txid: str, timeout: int = 360) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            indices = _jsonrpc(self.rpc_url, "stratabridge_depositIndices")
+            for deposit_idx in indices:
+                info = _jsonrpc(self.rpc_url, "stratabridge_depositInfo", [deposit_idx])
+                if info.get("deposit_request_txid") != drt_txid:
+                    continue
+                if info.get("status", {}).get("status") == "complete":
+                    return info
+            time.sleep(2)
+        raise AssertionError(f"bridge deposit did not complete for DRT {drt_txid}")
+
+    def stop(self) -> None:
+        if self.process.poll() is not None:
+            return
+        self.stop_file.write_text("stop\n")
+        try:
+            self.process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=10)
+
+
+def start_external_bridge(
+    repo: Path,
+    datadir: Path,
+    bitcoind_props: dict[str, Any],
+    genesis_l1_height: int,
+    operator_count: int = DEFAULT_OPERATOR_COUNT,
+    deposit_amount: int = 1_000_000_000,
+) -> ExternalBridgeHandle:
+    """Start bridge operators from an external checkout against the core Bitcoin node."""
+    build_external_bridge(repo)
+
+    bridge_run_dir = datadir / "external_bridge"
+    bridge_run_dir.mkdir(parents=True, exist_ok=True)
+    stop_file = bridge_run_dir / "stop"
+    script_path = bridge_run_dir / "bridge_daemon.py"
+    script_path.write_text(
+        _daemon_script(
+            bridge_run_dir,
+            stop_file,
+            bitcoind_props,
+            genesis_l1_height,
+            operator_count,
+            deposit_amount,
+        )
+    )
+
+    proc = subprocess.Popen(
+        ["uv", "run", "python", str(script_path)],
+        cwd=repo / "functional-tests",
+        env=_bridge_process_env(repo),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdout is not None
+
+    deadline = time.monotonic() + 420
+    captured: list[str] = []
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            output = "".join(captured)
+            raise RuntimeError(f"external bridge exited during startup:\n{output}")
+
+        readable, _, _ = select.select([proc.stdout], [], [], 1)
+        if not readable:
+            continue
+
+        line = proc.stdout.readline()
+        captured.append(line)
+        if line.startswith(READY_PREFIX):
+            info = json.loads(line.removeprefix(READY_PREFIX))
+            return ExternalBridgeHandle(
+                process=proc,
+                stop_file=stop_file,
+                rpc_url=info["rpc_url"],
+                datadir=Path(info["datadir"]),
+            )
+        if line.startswith(STARTUP_LOG_PREFIXES):
+            print(line, end="")
+        if line.startswith(STAGE_PREFIX):
+            info = json.loads(line.removeprefix(STAGE_PREFIX))
+            if info.get("message") in ("ready", "stakes_confirmed"):
+                rpc_url = info.get("rpc_url") or f"http://127.0.0.1:{DEFAULT_BRIDGE_RPC_PORT}"
+                return ExternalBridgeHandle(
+                    process=proc,
+                    stop_file=stop_file,
+                    rpc_url=rpc_url,
+                    datadir=Path(info.get("datadir") or bridge_run_dir),
+                )
+
+    proc.terminate()
+    output = "".join(captured)
+    raise TimeoutError(f"timed out waiting for external bridge readiness:\n{output}")
+
+
+def _daemon_script(
+    run_dir: Path,
+    stop_file: Path,
+    bitcoind_props: dict[str, Any],
+    genesis_l1_height: int,
+    operator_count: int,
+    deposit_amount: int,
+) -> str:
+    return f"""
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import flexitest
+from bitcoinlib.services.bitcoind import BitcoindClient
+
+sys.path.insert(0, str(Path.cwd()))
+
+from constants import BRIDGE_NODE_DIR
+from entry import generate_mtls_credentials
+from envs.base_env import BaseEnv
+from envs.btc_config import BitcoinEnvConfig
+from envs.live_env import StrataLiveEnv
+from factory.asm_rpc import AsmRpcFactory
+from factory.bridge_operator import BridgeOperatorFactory
+from factory.bridge_operator.config_cfg import BridgeConfigParams
+from factory.bridge_operator.params_cfg import BridgeProtocolParams
+from factory.fdb import FdbFactory
+from factory.mosaic import MosaicFactory, MosaicFactoryConfig
+from factory.s2 import S2Factory
+from rpc.client import JsonrpcClient
+from utils.mosaic import get_circuit_path, get_peer_configs
+from utils.network import wait_until_p2p_connected
+from utils.service_names import get_operator_service_name
+from utils.utils import generate_blocks, wait_until, wait_until_bridge_ready
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+BITCOIND_PROPS = {json.dumps(bitcoind_props)}
+RUN_DIR = Path({json.dumps(str(run_dir))})
+STOP_FILE = Path({json.dumps(str(stop_file))})
+GENESIS_L1_HEIGHT = {genesis_l1_height}
+OPERATOR_COUNT = {operator_count}
+DEPOSIT_AMOUNT = {deposit_amount}
+
+
+class ExternalBitcoinService:
+    def __init__(self, props):
+        self.props = props
+
+    def create_rpc(self):
+        return BitcoindClient(base_url=self.props["rpc_url"], network="regtest")
+
+    def healthcheck(self):
+        self.create_rpc().proxy.getblockchaininfo()
+
+    def is_started(self):
+        return True
+
+    def check_status(self):
+        self.healthcheck()
+        return True
+
+    def get_status_msg(self):
+        return None
+
+    def stop(self):
+        return None
+
+
+class ExternalBitcoinBridgeEnv(BaseEnv):
+    def __init__(self):
+        btc_config = BitcoinEnvConfig(auto_mine=True, initial_blocks=GENESIS_L1_HEIGHT)
+        protocol = BridgeProtocolParams(deposit_amount=DEPOSIT_AMOUNT)
+        super().__init__(
+            OPERATOR_COUNT,
+            bridge_protocol_params=protocol,
+            bridge_config_params=BridgeConfigParams(),
+            btc_config=btc_config,
+        )
+        self.initial_blocks = GENESIS_L1_HEIGHT
+
+    def init(self, ectx):
+        svcs = {{"bitcoin": ExternalBitcoinService(BITCOIND_PROPS)}}
+        brpc = svcs["bitcoin"].create_rpc()
+        wallet_addr = brpc.proxy.getnewaddress()
+        miner = generate_blocks(brpc, self.btc_config.block_generation_interval_secs, wallet_addr)
+
+        fdb = self.setup_fdb(ectx, "external-core")
+        svcs["fdb"] = fdb
+
+        mosaic_fac = ectx.get_factory("mosaic")
+        mosaic_factory_config = MosaicFactoryConfig(
+            circuit_path=get_circuit_path(),
+            storage_cluster_file=fdb.props["cluster_file"],
+            fdb_prefix=self.fdb_root_directory_prefix,
+            all_peers=get_peer_configs(self.num_operators),
+        )
+
+        for idx in range(self.num_operators):
+            mosaic_service = mosaic_fac.create_mosaic_service(idx, mosaic_factory_config)
+            s2_service, bridge_node, asm_service = self.create_operator(
+                ectx,
+                idx,
+                BITCOIND_PROPS,
+                brpc,
+                fdb.props,
+                mosaic_service.props["rpc_url"],
+            )
+            self.fund_operator(brpc, bridge_node.props, wallet_addr)
+            wait_until_bridge_ready(bridge_node.create_rpc())
+            svcs[f"s2_{{idx}}"] = s2_service
+            svcs[f"bridge_node_{{idx}}"] = bridge_node
+            svcs["asm_rpc"] = asm_service
+            svcs[f"mosaic_{{idx}}"] = mosaic_service
+
+        return StrataLiveEnv(svcs, miner)
+
+
+class KeepBridgeRunning(flexitest.Test):
+    def __init__(self, ctx):
+        ctx.set_env(ExternalBitcoinBridgeEnv())
+
+    def main(self, ctx):
+        bridge_nodes = [ctx.get_service(f"bridge_node_{{idx}}") for idx in range(OPERATOR_COUNT)]
+        bridge_rpcs = [bridge_node.create_rpc() for bridge_node in bridge_nodes]
+
+        bridge_stage("p2p_wait_start")
+        wait_until_p2p_connected(bridge_rpcs)
+        bridge_stage("p2p_connected")
+
+        bitcoin_rpc = ctx.get_service("bitcoin").create_rpc()
+        confirmed_stakes = wait_for_confirmed_stakes(bridge_rpcs[0], bitcoin_rpc)
+        bridge_stage("stakes_confirmed", stakes=confirmed_stakes)
+
+        rpc_url = "http://127.0.0.1:{DEFAULT_BRIDGE_RPC_PORT}"
+        bridge_stage("ready", rpc_url=rpc_url, datadir=str(RUN_DIR))
+        print(
+            "BRIDGE_READY "
+            + json.dumps({{"rpc_url": rpc_url, "datadir": str(RUN_DIR)}}),
+            flush=True,
+        )
+        while not STOP_FILE.exists():
+            time.sleep(1)
+        return True
+
+
+def bridge_stage(message, **fields):
+    payload = {{"message": message}}
+    payload.update(fields)
+    print("BRIDGE_STAGE " + json.dumps(payload), flush=True)
+
+
+def wait_for_confirmed_stakes(bridge_rpc, bitcoin_rpc):
+    deadline = time.monotonic() + 300
+    last_report = 0
+    last_error = None
+    last_stakes = None
+
+    while time.monotonic() < deadline:
+        try:
+            stakes = bridge_rpc.stratabridge_stakeStatus()
+            last_stakes = stakes
+            now = time.monotonic()
+            if now - last_report >= 5:
+                bridge_stage("stake_status", stakes=stakes)
+                last_report = now
+
+            if len(stakes) < OPERATOR_COUNT:
+                time.sleep(1)
+                continue
+
+            ready = True
+            for stake in stakes:
+                state = stake.get("state")
+                if state not in ("confirmed", "preimage_revealed", "unstaked"):
+                    ready = False
+                    break
+
+                stake_txid = stake.get("stake_txid")
+                if state == "confirmed":
+                    if stake_txid is None:
+                        ready = False
+                        break
+                    tx_info = bitcoin_rpc.proxy.getrawtransaction(stake_txid, True)
+                    if "blockhash" not in tx_info:
+                        ready = False
+                        break
+
+            if ready:
+                return stakes
+        except Exception as exc:
+            last_error = type(exc).__name__ + ": " + str(exc)
+            now = time.monotonic()
+            if now - last_report >= 5:
+                bridge_stage("stake_status_error", error=last_error)
+                last_report = now
+
+        time.sleep(1)
+
+    raise TimeoutError(
+        "bridge operators did not reach confirmed stake status; "
+        + "last_error="
+        + repr(last_error)
+        + "; last_stakes="
+        + repr(last_stakes)
+    )
+
+
+runtime = flexitest.TestRuntime(
+    {{}},
+    str(RUN_DIR / "_dd"),
+    {{
+        "fdb": FdbFactory([12700 + i for i in range(100)]),
+        "s2": S2Factory([12800 + i for i in range(100)]),
+        "bofac": BridgeOperatorFactory([13000 + i for i in range(100)]),
+        "asm_rpc": AsmRpcFactory([12600 + i for i in range(100)]),
+        "mosaic": MosaicFactory([12900 + i for i in range(100)]),
+    }},
+)
+
+gen_s2_tls_script_path = str((Path.cwd().parent / "docker" / "gen_s2_tls.sh").resolve())
+for operator_idx in range(OPERATOR_COUNT):
+    generate_mtls_credentials(gen_s2_tls_script_path, str(RUN_DIR / "_dd"), operator_idx)
+
+runtime.prepare_test("keep_bridge_running", KeepBridgeRunning)
+results = runtime.run_tests(["keep_bridge_running"])
+if results["keep_bridge_running"]["status"] != "OK":
+    print("BRIDGE_ERROR " + json.dumps(results), flush=True)
+    raise SystemExit(json.dumps(results, indent=2))
+"""

--- a/functional-tests/common/services/bitcoin.py
+++ b/functional-tests/common/services/bitcoin.py
@@ -23,6 +23,11 @@ class BitcoinProps(TypedDict):
     rpc_url: str
     datadir: str
     walletname: str
+    zmq_hashblock: int
+    zmq_hashtx: int
+    zmq_rawblock: int
+    zmq_rawtx: int
+    zmq_sequence: int
 
 
 class BitcoinService(RpcService):

--- a/functional-tests/docker/Dockerfile
+++ b/functional-tests/docker/Dockerfile
@@ -24,7 +24,7 @@ COPY provers provers
 COPY tests tests
 COPY benches benches
 
-RUN cargo build -F sequencer -F debug-utils -F test-mode \
+RUN cargo build -F sequencer -F strata/prover -F debug-utils -F test-mode \
     --bin strata --bin alpen-client --bin strata-datatool --bin strata-test-cli \
     && mkdir -p /out \
     && cp target/debug/strata target/debug/alpen-client \

--- a/functional-tests/envconfigs/alpen_client.py
+++ b/functional-tests/envconfigs/alpen_client.py
@@ -43,6 +43,8 @@ class AlpenClientEnv(flexitest.EnvConfig):
         da_magic_bytes: bytes = DEFAULT_DA_MAGIC_BYTES,
         l1_reorg_safe_depth: int = 1,
         batch_sealing_block_count: int = 5,
+        custom_chain: str = "dev",
+        dev_track_finalized_epoch: bool = False,
     ):
         self.fullnode_count = fullnode_count
         self.enable_discovery = enable_discovery
@@ -52,6 +54,8 @@ class AlpenClientEnv(flexitest.EnvConfig):
         self.da_magic_bytes = da_magic_bytes
         self.l1_reorg_safe_depth = l1_reorg_safe_depth
         self.batch_sealing_block_count = batch_sealing_block_count
+        self.custom_chain = custom_chain
+        self.dev_track_finalized_epoch = dev_track_finalized_epoch
         if pure_discovery and not enable_discovery:
             raise ValueError("pure_discovery requires enable_discovery=True")
         if mesh_bootnodes and not enable_discovery:
@@ -70,6 +74,8 @@ class AlpenClientEnv(flexitest.EnvConfig):
             self.da_magic_bytes,
             self.l1_reorg_safe_depth,
             self.batch_sealing_block_count,
+            self.custom_chain,
+            self.dev_track_finalized_epoch,
         )
         return flexitest.LiveEnv(services)
 
@@ -84,9 +90,10 @@ class AlpenClientEnv(flexitest.EnvConfig):
         da_magic_bytes: bytes = b"0000",
         l1_reorg_safe_depth: int = 2,
         batch_sealing_block_count: int = 10,
+        custom_chain: str = "dev",
+        dev_track_finalized_epoch: bool = False,
         bitcoin_service: BitcoinService | None = None,
         ol_endpoint: str | None = None,
-        dev_track_finalized_epoch: bool = False,
     ):
         factory = cast(AlpenClientFactory, ectx.get_factory(ServiceType.AlpenClient))
         privkey, pubkey = generate_sequencer_keypair()
@@ -133,6 +140,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
             enable_discovery=enable_discovery,
             ol_endpoint=ol_endpoint,
             da_config=da_config,
+            custom_chain=custom_chain,
             dev_track_finalized_epoch=dev_track_finalized_epoch,
         )
         sequencer.wait_for_ready(timeout=60)
@@ -160,6 +168,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
                 instance_id=i,
                 sequencer_http=seq_http_url,  # Forward transactions to sequencer
                 ol_endpoint=ol_endpoint,
+                custom_chain=custom_chain,
             )
             fullnode.wait_for_ready(timeout=60)
             fullnodes.append(fullnode)

--- a/functional-tests/envconfigs/el_ol.py
+++ b/functional-tests/envconfigs/el_ol.py
@@ -3,6 +3,7 @@ Alpen-client test environment configurations.
 """
 
 import flexitest
+from pathlib import Path
 
 from common.config.config import EpochSealingConfig
 from common.config.constants import ServiceType
@@ -41,6 +42,9 @@ class EeOLEnv(flexitest.EnvConfig):
         ol_block_time_ms: int | None = None,
         dev_track_finalized_epoch: bool = False,
         batch_sealing_block_count: int = 10,
+        bridge_operator_pubkeys: list[str] | None = None,
+        custom_chain: str = "dev",
+        alpen_chain_config: Path | None = None,
     ):
         self.fullnode_count = fullnode_count
         self.enable_discovery = enable_discovery
@@ -52,6 +56,9 @@ class EeOLEnv(flexitest.EnvConfig):
         self.ol_block_time_ms = ol_block_time_ms
         self.dev_track_finalized_epoch = dev_track_finalized_epoch
         self.batch_sealing_block_count = batch_sealing_block_count
+        self.bridge_operator_pubkeys = bridge_operator_pubkeys
+        self.custom_chain = custom_chain
+        self.alpen_chain_config = alpen_chain_config
         self.epoch_seal_config = (
             EpochSealingConfig.new_fixed_slot(seal_epoch_slots)
             if seal_epoch_slots
@@ -69,6 +76,8 @@ class EeOLEnv(flexitest.EnvConfig):
             fund_test_cli_wallet=self.fund_test_cli_wallet,
             admin_confirmation_depth=self.admin_confirmation_depth,
             ol_block_time_ms=self.ol_block_time_ms,
+            bridge_operator_pubkeys=self.bridge_operator_pubkeys,
+            alpen_chain_config=self.alpen_chain_config,
         )
         strata_services = strata_config._get_services(ectx)
 
@@ -87,6 +96,7 @@ class EeOLEnv(flexitest.EnvConfig):
             ol_endpoint=ol_endpoint,
             dev_track_finalized_epoch=self.dev_track_finalized_epoch,
             batch_sealing_block_count=self.batch_sealing_block_count,
+            custom_chain=self.custom_chain,
         )
 
         services = {**alpen_services, **strata_services}

--- a/functional-tests/envconfigs/real_bridge.py
+++ b/functional-tests/envconfigs/real_bridge.py
@@ -1,0 +1,47 @@
+"""EE/OL environment configured for an external real bridge."""
+
+import json
+from pathlib import Path
+
+import flexitest
+
+from envconfigs.el_ol import EeOLEnv
+
+
+def write_no_prefund_chain_spec(ectx: flexitest.EnvContext) -> Path:
+    """Write an Alpen dev chainspec with no prefunded EVM accounts."""
+    repo_root = Path(__file__).resolve().parents[2]
+    chain_spec_path = repo_root / "crates/reth/chainspec/src/res/alpen-dev-chain.json"
+    chain_spec = json.loads(chain_spec_path.read_text())
+    chain_spec["alloc"] = {}
+
+    output_path = Path(ectx.envdd_path) / "alpen-no-prefund-chain.json"
+    output_path.write_text(json.dumps(chain_spec, indent=2) + "\n")
+    return output_path
+
+
+class RealBridgeEeOLEnv(flexitest.EnvConfig):
+    """Starts Bitcoin, Strata, and Alpen with bridge operator keys from strata-bridge."""
+
+    def __init__(
+        self,
+        bridge_operator_pubkeys: list[str],
+        fullnode_count: int = 1,
+        pre_generate_blocks: int = 110,
+        seal_epoch_slots: int | None = None,
+    ):
+        self.bridge_operator_pubkeys = bridge_operator_pubkeys
+        self.fullnode_count = fullnode_count
+        self.pre_generate_blocks = pre_generate_blocks
+        self.seal_epoch_slots = seal_epoch_slots
+
+    def init(self, ectx: flexitest.EnvContext) -> flexitest.LiveEnv:
+        chain_spec = write_no_prefund_chain_spec(ectx)
+        return EeOLEnv(
+            fullnode_count=self.fullnode_count,
+            pre_generate_blocks=self.pre_generate_blocks,
+            seal_epoch_slots=self.seal_epoch_slots,
+            bridge_operator_pubkeys=self.bridge_operator_pubkeys,
+            custom_chain=str(chain_spec),
+            alpen_chain_config=chain_spec,
+        ).init(ectx)

--- a/functional-tests/envconfigs/strata.py
+++ b/functional-tests/envconfigs/strata.py
@@ -1,6 +1,7 @@
 """Environment configurations."""
 
 import subprocess
+from pathlib import Path
 from typing import cast
 
 import flexitest
@@ -29,6 +30,8 @@ class StrataEnvConfig(flexitest.EnvConfig):
         admin_confirmation_depth: int | None = None,
         strata_env: dict[str, str] | None = None,
         ol_block_time_ms: int | None = None,
+        bridge_operator_pubkeys: list[str] | None = None,
+        alpen_chain_config: Path | None = None,
     ):
         self.pre_generate_blocks = pre_generate_blocks
         self.genesis_accounts = genesis_accounts
@@ -37,6 +40,8 @@ class StrataEnvConfig(flexitest.EnvConfig):
         self.admin_confirmation_depth = admin_confirmation_depth
         self.strata_env = strata_env
         self.ol_block_time_ms = ol_block_time_ms
+        self.bridge_operator_pubkeys = bridge_operator_pubkeys
+        self.alpen_chain_config = alpen_chain_config
 
     def _fund_bdk_wallet(self, btc_rpc) -> None:
         """Pre-fund the strata-test-cli BDK wallet so it can build Bitcoin txs."""
@@ -109,6 +114,8 @@ class StrataEnvConfig(flexitest.EnvConfig):
             admin_confirmation_depth=self.admin_confirmation_depth,
             env=self.strata_env,
             ol_block_time_ms=self.ol_block_time_ms,
+            bridge_operator_pubkeys=self.bridge_operator_pubkeys,
+            alpen_chain_config=self.alpen_chain_config,
         )
         strata.wait_for_ready(timeout=30)
 

--- a/functional-tests/factories/bitcoin.py
+++ b/functional-tests/factories/bitcoin.py
@@ -50,6 +50,11 @@ class BitcoinFactory(flexitest.Factory):
         datadir = ctx.make_service_dir(ServiceType.Bitcoin)
         p2p_port = self.next_port()
         rpc_port = self.next_port()
+        zmq_hashblock = self.next_port()
+        zmq_hashtx = self.next_port()
+        zmq_rawblock = self.next_port()
+        zmq_rawtx = self.next_port()
+        zmq_sequence = self.next_port()
         logfile = os.path.join(datadir, "service.log")
 
         cmd = [
@@ -59,12 +64,21 @@ class BitcoinFactory(flexitest.Factory):
             "-listen=0",
             f"-port={p2p_port}",
             "-printtoconsole",
+            "-server=1",
             "-fallbackfee=0.00001",
             "-minrelaytxfee=0",
+            "-blockmintxfee=0",
+            "-dustrelayfee=0",
+            "-acceptnonstdtxn=1",
             f"-datadir={datadir}",
             f"-rpcport={rpc_port}",
             f"-rpcuser={rpc_user}",
             f"-rpcpassword={rpc_password}",
+            f"-zmqpubhashblock=tcp://0.0.0.0:{zmq_hashblock}",
+            f"-zmqpubhashtx=tcp://0.0.0.0:{zmq_hashtx}",
+            f"-zmqpubrawblock=tcp://0.0.0.0:{zmq_rawblock}",
+            f"-zmqpubrawtx=tcp://0.0.0.0:{zmq_rawtx}",
+            f"-zmqpubsequence=tcp://0.0.0.0:{zmq_sequence}",
         ]
 
         rpc_url = f"http://{rpc_user}:{rpc_password}@localhost:{rpc_port}"
@@ -77,6 +91,11 @@ class BitcoinFactory(flexitest.Factory):
             "rpc_password": rpc_password,
             "datadir": datadir,
             "walletname": "testwallet",
+            "zmq_hashblock": zmq_hashblock,
+            "zmq_hashtx": zmq_hashtx,
+            "zmq_rawblock": zmq_rawblock,
+            "zmq_rawtx": zmq_rawtx,
+            "zmq_sequence": zmq_sequence,
         }
 
         svc = BitcoinService(props, cmd, stdout=logfile, name=ServiceType.Bitcoin)

--- a/functional-tests/factories/strata.py
+++ b/functional-tests/factories/strata.py
@@ -64,6 +64,8 @@ class StrataFactory(flexitest.Factory):
         admin_confirmation_depth: int | None = None,
         env: dict[str, str] | None = None,
         ol_block_time_ms: int | None = None,
+        bridge_operator_pubkeys: list[str] | None = None,
+        alpen_chain_config: Path | None = None,
         **kwargs,
     ) -> CreateNodeResult:
         """
@@ -80,6 +82,8 @@ class StrataFactory(flexitest.Factory):
             admin_confirmation_depth: Optional admin subprotocol confirmation depth.
             env: Additional process environment variables.
             ol_block_time_ms: Optional sequencer OL block time override.
+            bridge_operator_pubkeys: Optional raw bridge operator public keys.
+            alpen_chain_config: Optional EVM genesis chain config used for Alpen account state.
         """
         # Ensured by `with_ectx` decorator. Don't like this though.
         ctx: flexitest.EnvContext = kwargs["ctx"]
@@ -132,16 +136,33 @@ class StrataFactory(flexitest.Factory):
 
         # Generate rollup params via datatool (also produces keys used below).
         if use_unchecked_cred_rule:
-            params_data = generate_rollup_params_unchecked(datadir, bconfig, genesis_l1_height)
+            params_data = generate_rollup_params_unchecked(
+                datadir,
+                bconfig,
+                genesis_l1_height,
+                operator_pubkeys=bridge_operator_pubkeys,
+                chain_config=alpen_chain_config,
+            )
         else:
-            params_data = generate_rollup_params(datadir, bconfig, genesis_l1_height)
+            params_data = generate_rollup_params(
+                datadir,
+                bconfig,
+                genesis_l1_height,
+                operator_pubkeys=bridge_operator_pubkeys,
+                chain_config=alpen_chain_config,
+            )
 
         # Generate or write OL params.
         if ol_params is not None:
             ol_params_path = datadir / "ol-params.json"
             ol_params_path.write_text(ol_params.as_json_string())
         else:
-            ol_params_path = generate_ol_params(datadir, bconfig, genesis_l1_height)
+            ol_params_path = generate_ol_params(
+                datadir,
+                bconfig,
+                genesis_l1_height,
+                alpen_chain_config=alpen_chain_config,
+            )
 
         # Generate ASM params via datatool (computes correct genesis_ol_blkid from OL params).
         asm_params_path = generate_asm_params(
@@ -149,8 +170,10 @@ class StrataFactory(flexitest.Factory):
             bconfig,
             genesis_l1_height,
             params_data.operator_keys,
+            operator_pubkeys=bridge_operator_pubkeys,
             ol_params_path=ol_params_path,
             admin_confirmation_depth=admin_confirmation_depth,
+            sequencer_pubkey=params_data.sequencer_pubkey,
         )
 
         # Build command

--- a/functional-tests/run_tests.sh
+++ b/functional-tests/run_tests.sh
@@ -19,7 +19,7 @@ setup_path() {
 build() {
     # TODO: add conditional builds as we go
     # TODO: different binaries for sequencer and full nodes
-    cargo build  -F sequencer -F debug-utils -F test-mode -F debug-asm --bin strata --bin strata-signer --bin alpen-client --bin strata-datatool --bin strata-test-cli --bin strata-dbtool
+    cargo build  -F sequencer -F strata/prover -F debug-utils -F test-mode -F debug-asm --bin strata --bin strata-signer --bin alpen-client --bin alpen --bin strata-datatool --bin strata-test-cli --bin strata-dbtool
 }
 
 # Runs tests.

--- a/functional-tests/tests/alpen_client/test_ee_predicate_transition.py
+++ b/functional-tests/tests/alpen_client/test_ee_predicate_transition.py
@@ -73,9 +73,9 @@ class TestEePredicateTransition(BaseTest):
             return strata_rpc.strata_getSnarkAccountState(ALPEN_ACCOUNT_ID, "latest")["update_vk"]
 
         initial_vk = strata_rpc.strata_getSnarkAccountState(ALPEN_ACCOUNT_ID, "latest")["update_vk"]
-        if initial_vk != "AlwaysAccept":
+        if not initial_vk.startswith("Bip340Schnorr:"):
             raise AssertionError(
-                f"expected initial update_vk to be AlwaysAccept, got {initial_vk!r}"
+                f"expected initial update_vk to be Bip340Schnorr, got {initial_vk!r}"
             )
 
         for seq_no, target in enumerate(PREDICATE_TRANSITIONS, start=1):

--- a/functional-tests/tests/alpen_client/test_real_bridge_e2e.py
+++ b/functional-tests/tests/alpen_client/test_real_bridge_e2e.py
@@ -1,0 +1,276 @@
+"""Real bridge deposit into an unfunded Alpen EE account."""
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+import flexitest
+
+from common.accounts import ManagedAccount, get_recipient_account
+from common.config.constants import DEV_ADDRESS, DEV_PRIVATE_KEY, SATS_TO_WEI, ServiceType
+from common.evm_utils import get_balance, send_raw_transaction, wait_for_receipt
+from common.external_bridge import (
+    compute_bridge_aggregate_pubkey,
+    find_bridge_repo,
+    load_bridge_operator_pubkeys,
+    start_external_bridge,
+)
+from common.services.alpen_client import AlpenClientService
+from common.services.bitcoin import BitcoinService
+from common.services.strata import StrataService
+from common.wait import wait_until_with_value
+from envconfigs.real_bridge import RealBridgeEeOLEnv
+
+logger = logging.getLogger(__name__)
+
+OPERATOR_COUNT = int(os.environ.get("ALPEN_EXTERNAL_BRIDGE_OPERATORS", "2"))
+CLI_SEED_HEX = "11" * 16
+SPEND_VALUE_WEI = 100_000_000_000_000_000
+
+
+@flexitest.register
+class RealBridgeDepositToEeTest(flexitest.Test):
+    """Deposit through strata-bridge, then spend the bridged EE funds."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        self.bridge_repo = find_bridge_repo()
+        self.operator_pubkeys = load_bridge_operator_pubkeys(self.bridge_repo, OPERATOR_COUNT)
+        ctx.set_env(
+            RealBridgeEeOLEnv(
+                bridge_operator_pubkeys=self.operator_pubkeys,
+                seal_epoch_slots=4,
+            )
+        )
+
+    def premain(self, ctx: flexitest.RunContext):
+        self.runctx = ctx
+
+    def main(self, ctx):
+        alpen_seq: AlpenClientService = ctx.get_service(ServiceType.AlpenSequencer)
+        strata_seq: StrataService = ctx.get_service(ServiceType.Strata)
+        bitcoin: BitcoinService = ctx.get_service(ServiceType.Bitcoin)
+
+        strata_rpc = strata_seq.wait_for_rpc_ready(timeout=30)
+        strata_seq.wait_for_account_genesis_epoch_commitment(
+            "01" * 32,
+            rpc=strata_rpc,
+            timeout=30,
+        )
+        alpen_seq.wait_for_block(3, timeout=60)
+
+        evm_rpc = alpen_seq.create_rpc()
+        initial_balance = get_balance(evm_rpc, DEV_ADDRESS)
+        assert initial_balance == 0, f"expected no prefunded EE balance, got {initial_balance}"
+
+        env_dir = Path(strata_seq.props["datadir"]).parent
+        rollup_params_path = Path(strata_seq.props["datadir"]) / "rollup-params.json"
+        rollup_params = json.loads(rollup_params_path.read_text())
+        deposit_sats = int(rollup_params["deposit_amount"])
+        expected_balance = deposit_sats * SATS_TO_WEI
+        genesis_l1_height = int(rollup_params["genesis_l1_view"]["blk"]["height"])
+
+        bridge = start_external_bridge(
+            self.bridge_repo,
+            env_dir,
+            dict(bitcoin.props),
+            genesis_l1_height,
+            operator_count=OPERATOR_COUNT,
+            deposit_amount=deposit_sats,
+        )
+
+        try:
+            drt_txid = self._send_deposit_with_alpen_cli(
+                bitcoin,
+                alpen_seq,
+                env_dir,
+                rollup_params_path,
+            )
+            logger.info("Broadcasted alpen-cli DRT %s", drt_txid)
+
+            btc_rpc = bitcoin.create_rpc()
+            mine_addr = btc_rpc.proxy.getnewaddress()
+            btc_rpc.proxy.generatetoaddress(2, mine_addr)
+
+            deposit_info = bridge.wait_deposit_complete(drt_txid, timeout=420)
+            logger.info("Bridge deposit completed: %s", deposit_info)
+
+            balance = self._wait_for_ee_deposit(
+                bitcoin,
+                alpen_seq,
+                DEV_ADDRESS,
+                expected_balance,
+            )
+            logger.info("EE balance after bridge deposit: %s", balance)
+
+            self._spend_ee_funds(evm_rpc)
+            confirmed_epoch = self._wait_for_confirmed_epoch(strata_seq, strata_rpc, bitcoin, 6)
+            logger.info("Confirmed epoch after bridge deposit: %s", confirmed_epoch)
+        finally:
+            bridge.stop()
+
+        return True
+
+    def _run_alpen(
+        self,
+        args: list[str],
+        env_dir: Path,
+        env: dict[str, str],
+        include_stderr: bool = False,
+    ) -> str:
+        result = subprocess.run(
+            ["alpen", *args],
+            cwd=env_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"alpen {' '.join(args)} failed with {result.returncode}\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        if include_stderr:
+            return result.stdout + "\n" + result.stderr
+        return result.stdout
+
+    def _send_deposit_with_alpen_cli(
+        self,
+        bitcoin: BitcoinService,
+        alpen_seq: AlpenClientService,
+        env_dir: Path,
+        rollup_params_path: Path,
+    ) -> str:
+        cli_dir = env_dir / "alpen_cli"
+        config_dir = cli_dir / "config"
+        data_dir = cli_dir / "data"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        bridge_pubkey = compute_bridge_aggregate_pubkey(self.operator_pubkeys)
+        config_path = config_dir / "config.toml"
+        config_path.write_text(
+            "\n".join(
+                [
+                    f'bitcoind_rpc_user = "{bitcoin.props["rpc_user"]}"',
+                    f'bitcoind_rpc_pw = "{bitcoin.props["rpc_password"]}"',
+                    f'bitcoind_rpc_endpoint = "http://127.0.0.1:{bitcoin.props["rpc_port"]}"',
+                    f'alpen_endpoint = "{alpen_seq.props["http_url"]}"',
+                    'faucet_endpoint = ""',
+                    f'bridge_pubkey = "{bridge_pubkey}"',
+                    "bridge_fee_sats = 1000",
+                    "finality_depth = 1",
+                    f'rollup_params_path = "{rollup_params_path}"',
+                    f'seed = "{CLI_SEED_HEX}"',
+                    "",
+                ]
+            )
+        )
+
+        env = os.environ.copy()
+        env["CLI_CONFIG"] = str(config_path)
+        env["PROJ_DIRS"] = str(cli_dir)
+        env["STRATA_NETWORK_PARAMS"] = str(rollup_params_path)
+
+        receive_out = self._run_alpen(["receive", "signet"], env_dir, env)
+        receive_address = receive_out.strip().splitlines()[-1]
+        btc_rpc = bitcoin.create_rpc()
+        btc_rpc.proxy.sendtoaddress(receive_address, 11)
+        btc_rpc.proxy.generatetoaddress(8, btc_rpc.proxy.getnewaddress())
+
+        deposit_out = self._run_alpen(
+            ["deposit", DEV_ADDRESS, "--fee-rate", "1"],
+            env_dir,
+            env,
+            include_stderr=True,
+        )
+        transaction_id_match = re.search(r"Transaction ID:\s*([0-9a-f]{64})", deposit_out)
+        if transaction_id_match is not None:
+            return transaction_id_match.group(1)
+
+        recovery_pk_match = re.search(r"Recovery public key:\s*([0-9a-f]{64})", deposit_out)
+        if recovery_pk_match is not None:
+            return self._find_drt_by_recovery_pk(bitcoin, recovery_pk_match.group(1))
+
+        raise RuntimeError(f"failed to parse DRT txid from alpen output:\n{deposit_out}")
+
+    def _find_drt_by_recovery_pk(self, bitcoin: BitcoinService, recovery_pk: str) -> str:
+        btc_rpc = bitcoin.create_rpc()
+        mempool_txids = btc_rpc.proxy.getrawmempool()
+        for txid in mempool_txids:
+            tx = btc_rpc.proxy.getrawtransaction(txid, True)
+            for vout in tx.get("vout", []):
+                script_pubkey = vout.get("scriptPubKey", {})
+                if recovery_pk in script_pubkey.get("asm", ""):
+                    return str(txid)
+
+        raise RuntimeError(f"failed to find DRT with recovery public key {recovery_pk}")
+
+    def _wait_for_ee_deposit(
+        self,
+        bitcoin: BitcoinService,
+        alpen_seq: AlpenClientService,
+        address: str,
+        expected_balance: int,
+    ) -> int:
+        btc_rpc = bitcoin.create_rpc()
+        evm_rpc = alpen_seq.create_rpc()
+        mine_addr = btc_rpc.proxy.getnewaddress()
+
+        def mine_and_check_balance():
+            btc_rpc.proxy.generatetoaddress(2, mine_addr)
+            time.sleep(2)
+            return get_balance(evm_rpc, address)
+
+        return wait_until_with_value(
+            mine_and_check_balance,
+            lambda balance: balance >= expected_balance,
+            error_with=f"EE balance did not reach bridged amount {expected_balance}",
+            timeout=420,
+            step=1,
+        )
+
+    def _spend_ee_funds(self, evm_rpc) -> None:
+        sender = ManagedAccount.from_key(DEV_PRIVATE_KEY)
+        nonce = int(evm_rpc.eth_getTransactionCount(sender.address, "pending"), 16)
+        sender.sync_nonce(nonce)
+        recipient = get_recipient_account()
+        gas_price = int(evm_rpc.eth_gasPrice(), 16)
+        raw_tx = sender.sign_transfer(
+            to=recipient.address,
+            value=SPEND_VALUE_WEI,
+            gas_price=gas_price,
+        )
+        tx_hash = send_raw_transaction(evm_rpc, raw_tx)
+        receipt = wait_for_receipt(evm_rpc, tx_hash, timeout=60)
+        assert int(receipt["status"], 16) == 1, f"spend failed: {receipt}"
+        recipient_balance = get_balance(evm_rpc, recipient.address)
+        assert recipient_balance >= SPEND_VALUE_WEI
+
+    def _wait_for_confirmed_epoch(
+        self,
+        strata_seq: StrataService,
+        strata_rpc,
+        bitcoin: BitcoinService,
+        target_epoch: int,
+    ) -> int:
+        btc_rpc = bitcoin.create_rpc()
+        mine_addr = btc_rpc.proxy.getnewaddress()
+
+        def mine_and_check_epoch():
+            btc_rpc.proxy.generatetoaddress(2, mine_addr)
+            time.sleep(2)
+            status = strata_seq.get_sync_status(strata_rpc)
+            return status["confirmed"]["epoch"]
+
+        return wait_until_with_value(
+            mine_and_check_epoch,
+            lambda epoch: epoch >= target_epoch,
+            error_with=f"confirmed epoch did not reach {target_epoch}",
+            timeout=420,
+            step=1,
+        )

--- a/provers/sp1/guest-alpen-acct/Cargo.toml
+++ b/provers/sp1/guest-alpen-acct/Cargo.toml
@@ -10,7 +10,7 @@ strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "
   "sp1-groth16",
 ] }
 strata-proofimpl-alpen-acct = { path = "../../../crates/proof-impl/alpen-acct" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc25" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.30.0-sp1-5.0.0" }

--- a/provers/sp1/guest-alpen-chunk/Cargo.toml
+++ b/provers/sp1/guest-alpen-chunk/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-alpen-chunk = { path = "../../../crates/proof-impl/alpen-chunk" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc25" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.30.0-sp1-5.0.0" }

--- a/provers/sp1/guest-checkpoint/Cargo.toml
+++ b/provers/sp1/guest-checkpoint/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-checkpoint = { path = "../../../crates/proof-impl/checkpoint" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc25" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", rev = "f287d06b91a140bffff9ab7dbf037296b6915581" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.30.0-sp1-5.0.0" }


### PR DESCRIPTION
## Summary
- add a functional e2e that runs an external strata-bridge checkout against core bitcoind/Strata/Alpen, deposits with alpen-cli into a no-prefund EE chainspec, waits for bridge completion, spends bridged EE funds, and waits through confirmed epoch 6
- add deterministic native Schnorr predicate/prover plumbing for local functional tests, including datatool predicate/operator-key overrides
- fix e2e blockers in core: OL inbox next-index handling for queried ranges and checkpoint DA witness generation from preseal execution

## Why
We need an e2e that uses the real bridge to fund an EE chain with no prefunded balances. This validates the actual DRT -> bridge DT -> ASM deposit -> OL inbox -> EE balance path instead of relying on devchain prefunds or debug deposit paths. Native Schnorr keeps the local harness non-permissive without requiring SP1 proving on a laptop.

## Verification
- python3 -m py_compile on the touched functional-test Python files
- cargo fmt --check on the touched Rust packages
- git diff --check
- cargo check -p strata-zkvm-hosts
- cargo check -p strata-proofimpl-checkpoint -p strata-proofimpl-alpen-acct -p strata-proofimpl-alpen-chunk -p strata-proofimpl-evm-ee-stf
- cargo check -p strata-datatool
- CARGO_INCREMENTAL=0 cargo check -p strata --features prover
- local real bridge e2e passed before final conflict cleanup: DRT 34d543216e426ca26e0dff805366483665cad2a362adfeac47f7e06c4f8370ce, bridge DT 7f2a4009ecdbe741d97b368ef43105cd4439199af63563c517e61051aac17bb1, EE balance 10000000000000000000, spend succeeded, confirmed epoch 6

Note: a later focused sequencer test rerun was blocked by local disk exhaustion while recompiling Reth dependencies, not by a code assertion failure.