### PR TITLE
fix(btcio): tolerate transient Bitcoin RPC outages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6092f4da3f6e25a5c452dc387c13972f03a53c414e4999f9beff555af305e52"
+checksum = "cfbc51226f51642aa07ec276b4b492846ba23e3d01aa4c36c1c3f841d0b39190"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -414,7 +414,7 @@ bitcoin = { version = "0.32.6", features = ["serde"] }
 bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", version = "0.10.0", tag = "v0.10.0", features = [
   "ssz",
 ] }
-bitcoind-async-client = { version = "0.10.5", features = ["29_0", "raw_rpc"] }
+bitcoind-async-client = { version = "0.10.6", features = ["29_0", "raw_rpc"] }
 bitvec = { version = "1.0.1", features = ["serde"] }
 borsh = { version = "1.6.1", features = ["derive"] }
 bytes = "1.11.1"

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -323,13 +323,6 @@ pub(crate) fn start_strata_services(
 ///
 /// Polls Bitcoin for new blocks and submits them to ASM for processing.
 fn start_btcio_reader(nodectx: &NodeContext, asm_handle: Arc<strata_asm_worker::AsmWorkerHandle>) {
-    let expected_l1_anchor = nodectx
-        .storage()
-        .client_state()
-        .fetch_most_recent_state()
-        .expect("startup checks must verify client state storage before starting btcio reader")
-        .map(|_| nodectx.ol_params().last_l1_block);
-
     nodectx.executor().spawn_critical_async(
         "bitcoin_data_reader_task",
         bitcoin_data_reader_task(
@@ -337,7 +330,10 @@ fn start_btcio_reader(nodectx: &NodeContext, asm_handle: Arc<strata_asm_worker::
             nodectx.storage().clone(),
             Arc::new(nodectx.config().btcio.reader.clone()),
             rollup_to_btcio_params(nodectx.params().rollup()),
-            ReaderValidation::new(nodectx.config().bitcoind.network, expected_l1_anchor),
+            ReaderValidation::new(
+                nodectx.config().bitcoind.network,
+                nodectx.ol_params().last_l1_block,
+            ),
             nodectx.status_channel().as_ref().clone(),
             Arc::new(AsmBlockSubmitter::new(asm_handle)),
         ),

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use strata_btcio::reader::query::bitcoin_data_reader_task;
+use strata_btcio::reader::query::{ReaderValidation, bitcoin_data_reader_task};
 use strata_chain_worker_new::start_chain_worker_service_from_ctx;
 use strata_consensus_logic::{
     AsmBlockSubmitter, FcmContext, start_fcm_service,
@@ -323,6 +323,13 @@ pub(crate) fn start_strata_services(
 ///
 /// Polls Bitcoin for new blocks and submits them to ASM for processing.
 fn start_btcio_reader(nodectx: &NodeContext, asm_handle: Arc<strata_asm_worker::AsmWorkerHandle>) {
+    let expected_l1_anchor = nodectx
+        .storage()
+        .client_state()
+        .fetch_most_recent_state()
+        .expect("startup checks must verify client state storage before starting btcio reader")
+        .map(|_| nodectx.ol_params().last_l1_block);
+
     nodectx.executor().spawn_critical_async(
         "bitcoin_data_reader_task",
         bitcoin_data_reader_task(
@@ -330,6 +337,7 @@ fn start_btcio_reader(nodectx: &NodeContext, asm_handle: Arc<strata_asm_worker::
             nodectx.storage().clone(),
             Arc::new(nodectx.config().btcio.reader.clone()),
             rollup_to_btcio_params(nodectx.params().rollup()),
+            ReaderValidation::new(nodectx.config().bitcoind.network, expected_l1_anchor),
             nodectx.status_channel().as_ref().clone(),
             Arc::new(AsmBlockSubmitter::new(asm_handle)),
         ),

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -1,14 +1,16 @@
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use bitcoin::{BlockHash, Network};
-use bitcoind_async_client::{Client, corepc_types::model::GetBlockchainInfo, traits::Reader};
+use bitcoind_async_client::{
+    Client, corepc_types::model::GetBlockchainInfo, error::ClientError, traits::Reader,
+};
 use strata_btc_types::BlockHashExt;
 use strata_identifiers::{EpochCommitment, OLBlockCommitment};
 use strata_node_context::NodeContext;
 use strata_ol_chain_types_new::OLBlock;
 use strata_primitives::L1BlockCommitment;
 use strata_storage::NodeStorage;
-use tracing::info;
+use tracing::{info, warn};
 
 #[async_trait]
 pub(crate) trait StartupBitcoinClient {
@@ -29,14 +31,38 @@ impl StartupBitcoinClient for Client {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StartupBitcoinCheck {
+    Verified,
+    Deferred { reason: String },
+}
+
+fn is_retryable_startup_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<ClientError>()
+            .is_some_and(ClientError::is_retriable)
+    })
+}
+
 pub(crate) async fn run_bitcoin_connectivity_and_network_checks(
     bitcoin_client: &impl StartupBitcoinClient,
     expected_network: Network,
-) -> Result<()> {
-    let chain_info = bitcoin_client
-        .get_blockchain_info_for_startup()
-        .await
-        .context("startup: could not connect to bitcoind via getblockchaininfo")?;
+) -> Result<StartupBitcoinCheck> {
+    let chain_info = match bitcoin_client.get_blockchain_info_for_startup().await {
+        Ok(chain_info) => chain_info,
+        Err(err) if is_retryable_startup_error(&err) => {
+            return Ok(StartupBitcoinCheck::Deferred {
+                reason: format!(
+                    "startup: could not connect to bitcoind via getblockchaininfo: {err}"
+                ),
+            });
+        }
+        Err(err) => {
+            return Err(err)
+                .context("startup: could not connect to bitcoind via getblockchaininfo");
+        }
+    };
 
     if chain_info.chain != expected_network {
         bail!(
@@ -46,22 +72,35 @@ pub(crate) async fn run_bitcoin_connectivity_and_network_checks(
         );
     }
 
-    Ok(())
+    Ok(StartupBitcoinCheck::Verified)
 }
 
 pub(crate) async fn verify_l1_anchor_block(
     bitcoin_client: &impl StartupBitcoinClient,
     expected_l1_block: L1BlockCommitment,
-) -> Result<()> {
-    let actual_hash = bitcoin_client
+) -> Result<StartupBitcoinCheck> {
+    let actual_hash = match bitcoin_client
         .get_block_hash_for_startup(expected_l1_block.height() as u64)
         .await
-        .with_context(|| {
-            format!(
-                "startup: failed to fetch L1 block hash from bitcoind at height {}",
-                expected_l1_block.height()
-            )
-        })?;
+    {
+        Ok(actual_hash) => actual_hash,
+        Err(err) if is_retryable_startup_error(&err) => {
+            return Ok(StartupBitcoinCheck::Deferred {
+                reason: format!(
+                    "startup: failed to fetch L1 block hash from bitcoind at height {}: {err}",
+                    expected_l1_block.height()
+                ),
+            });
+        }
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "startup: failed to fetch L1 block hash from bitcoind at height {}",
+                    expected_l1_block.height()
+                )
+            });
+        }
+    };
 
     let actual_block_id = actual_hash.to_l1_block_id();
     if actual_block_id != *expected_l1_block.blkid() {
@@ -72,7 +111,7 @@ pub(crate) async fn verify_l1_anchor_block(
         );
     }
 
-    Ok(())
+    Ok(StartupBitcoinCheck::Verified)
 }
 
 fn get_ol_genesis_block(storage: &NodeStorage) -> Result<Option<OLBlockCommitment>> {
@@ -227,12 +266,16 @@ fn verify_previous_epoch_summary_for_tip(storage: &NodeStorage, tip_block: &OLBl
 }
 
 pub(crate) fn run_startup_checks(ctx: &NodeContext) -> Result<()> {
-    ctx.executor()
-        .handle()
-        .block_on(run_bitcoin_connectivity_and_network_checks(
-            ctx.bitcoin_client().as_ref(),
-            ctx.config().bitcoind.network,
-        ))?;
+    let bitcoin_network_check =
+        ctx.executor()
+            .handle()
+            .block_on(run_bitcoin_connectivity_and_network_checks(
+                ctx.bitcoin_client().as_ref(),
+                ctx.config().bitcoind.network,
+            ))?;
+    if let StartupBitcoinCheck::Deferred { reason } = bitcoin_network_check {
+        warn!(%reason, "startup: deferring Bitcoin RPC network check");
+    }
 
     let has_client_state = ctx
         .storage()
@@ -245,10 +288,13 @@ pub(crate) fn run_startup_checks(ctx: &NodeContext) -> Result<()> {
     validate_persisted_state_presence(has_client_state, has_ol_genesis)?;
 
     if has_client_state {
-        ctx.executor().handle().block_on(verify_l1_anchor_block(
+        let l1_anchor_check = ctx.executor().handle().block_on(verify_l1_anchor_block(
             ctx.bitcoin_client().as_ref(),
             ctx.ol_params().last_l1_block,
         ))?;
+        if let StartupBitcoinCheck::Deferred { reason } = l1_anchor_check {
+            warn!(%reason, "startup: deferring L1 anchor block check");
+        }
     }
 
     if let Some(genesis_commitment) = genesis_commitment {
@@ -307,38 +353,49 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    enum MockResult<T> {
+        Ok(T),
+        ClientError(ClientError),
+    }
+
+    impl<T: Clone> MockResult<T> {
+        fn to_result(&self) -> Result<T> {
+            match self {
+                Self::Ok(value) => Ok(value.clone()),
+                Self::ClientError(err) => Err(err.clone().into()),
+            }
+        }
+    }
+
     struct MockBitcoinClient {
-        blockchain_info_result: Option<Result<GetBlockchainInfo>>,
-        block_hash_result: Option<Result<BlockHash>>,
+        blockchain_info_result: Option<MockResult<GetBlockchainInfo>>,
+        block_hash_result: Option<MockResult<BlockHash>>,
     }
 
     #[async_trait]
     impl StartupBitcoinClient for MockBitcoinClient {
         async fn get_blockchain_info_for_startup(&self) -> Result<GetBlockchainInfo> {
-            match self.blockchain_info_result.as_ref().unwrap() {
-                Ok(info) => Ok(info.clone()),
-                Err(e) => Err(anyhow::anyhow!("{e}")),
-            }
+            self.blockchain_info_result.as_ref().unwrap().to_result()
         }
 
         async fn get_block_hash_for_startup(&self, _height: u64) -> Result<BlockHash> {
-            match self.block_hash_result.as_ref().unwrap() {
-                Ok(hash) => Ok(*hash),
-                Err(e) => Err(anyhow::anyhow!("{e}")),
-            }
+            self.block_hash_result.as_ref().unwrap().to_result()
         }
     }
 
     fn mock_client_ok(network: Network) -> MockBitcoinClient {
         MockBitcoinClient {
-            blockchain_info_result: Some(Ok(make_blockchain_info(network))),
+            blockchain_info_result: Some(MockResult::Ok(make_blockchain_info(network))),
             block_hash_result: None,
         }
     }
 
     fn mock_client_unreachable() -> MockBitcoinClient {
         MockBitcoinClient {
-            blockchain_info_result: Some(Err(anyhow::anyhow!("connection refused"))),
+            blockchain_info_result: Some(MockResult::ClientError(ClientError::Connection(
+                "connection refused".into(),
+            ))),
             block_hash_result: None,
         }
     }
@@ -346,14 +403,16 @@ mod tests {
     fn mock_client_with_block_hash(hash: BlockHash) -> MockBitcoinClient {
         MockBitcoinClient {
             blockchain_info_result: None,
-            block_hash_result: Some(Ok(hash)),
+            block_hash_result: Some(MockResult::Ok(hash)),
         }
     }
 
     fn mock_client_block_hash_unreachable() -> MockBitcoinClient {
         MockBitcoinClient {
             blockchain_info_result: None,
-            block_hash_result: Some(Err(anyhow::anyhow!("block not found"))),
+            block_hash_result: Some(MockResult::ClientError(ClientError::Connection(
+                "connection refused".into(),
+            ))),
         }
     }
 
@@ -363,12 +422,8 @@ mod tests {
 
         let result = run_bitcoin_connectivity_and_network_checks(&client, Network::Regtest).await;
 
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("could not connect to bitcoind"),
-            "unexpected error: {err}"
-        );
+        let check = result.expect("retryable connection failure should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
     }
 
     #[tokio::test]
@@ -388,7 +443,7 @@ mod tests {
 
         let result = run_bitcoin_connectivity_and_network_checks(&client, Network::Regtest).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), StartupBitcoinCheck::Verified);
     }
 
     fn make_l1_block_commitment(height: u32, hash: BlockHash) -> L1BlockCommitment {
@@ -404,7 +459,7 @@ mod tests {
 
         let result = verify_l1_anchor_block(&client, commitment).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), StartupBitcoinCheck::Verified);
     }
 
     #[tokio::test]
@@ -432,12 +487,8 @@ mod tests {
 
         let result = verify_l1_anchor_block(&client, commitment).await;
 
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("failed to fetch L1 block hash"),
-            "unexpected error: {err}"
-        );
+        let check = result.expect("retryable connection failure should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
     }
 
     fn setup_storage_with_genesis() -> (NodeStorage, OLBlockCommitment) {

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -46,7 +46,7 @@ pub(crate) trait BroadcasterIoContext: Send + Sync + 'static {
     fn get_transaction<'a>(
         &'a self,
         txid: &'a Txid,
-    ) -> impl Future<Output = BroadcasterResult<Option<TxConfirmationInfo>>> + Send + 'a;
+    ) -> impl Future<Output = BroadcasterResult<TxLookupOutcome>> + Send + 'a;
 
     /// Attempts publication and classifies the outcome for retry/state logic.
     fn send_raw_transaction<'a>(
@@ -56,7 +56,7 @@ pub(crate) trait BroadcasterIoContext: Send + Sync + 'static {
 }
 
 /// Minimal transaction view needed by broadcaster confirmation logic.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TxConfirmationInfo {
     pub(crate) confirmations: i64,
     pub(crate) block_hash: Option<Buf32>,
@@ -101,14 +101,14 @@ pub trait WalletTxLookup: Send + Sync + 'static {
     fn get_transaction_confirmation<'a>(
         &'a self,
         txid: &'a Txid,
-    ) -> impl Future<Output = Result<Option<TxConfirmationInfo>, BroadcasterError>> + Send + 'a;
+    ) -> impl Future<Output = Result<TxLookupOutcome, BroadcasterError>> + Send + 'a;
 }
 
 impl WalletTxLookup for Client {
     async fn get_transaction_confirmation<'a>(
         &'a self,
         txid: &'a Txid,
-    ) -> BroadcasterResult<Option<TxConfirmationInfo>> {
+    ) -> BroadcasterResult<TxLookupOutcome> {
         let params = [bitcoind_async_client::to_value(txid.to_string())
             .map_err(|err| BroadcasterError::Rpc(anyhow!(err)))?];
 
@@ -116,10 +116,16 @@ impl WalletTxLookup for Client {
             .call_raw::<WalletTxConfirmationResponse>("gettransaction", &params)
             .await
         {
-            Ok(info) => Ok(Some(info.try_into()?)),
+            Ok(info) => Ok(TxLookupOutcome::Found(info.try_into()?)),
             Err(err) if err.is_tx_not_found() => {
                 debug!(%err, %txid, "get_transaction: tx not found");
-                Ok(None)
+                Ok(TxLookupOutcome::Missing)
+            }
+            Err(err) if err.is_retriable() => {
+                warn!(%err, %txid, "get_transaction hit transient Bitcoin RPC error");
+                Ok(TxLookupOutcome::RetryLater {
+                    reason: err.to_string(),
+                })
             }
             Err(err) => {
                 warn!(%err, %txid, "get_transaction failed");
@@ -140,18 +146,34 @@ mod test_impls {
         async fn get_transaction_confirmation<'a>(
             &'a self,
             txid: &'a Txid,
-        ) -> BroadcasterResult<Option<TxConfirmationInfo>> {
+        ) -> BroadcasterResult<TxLookupOutcome> {
             match Wallet::get_transaction(self, txid).await {
-                Ok(info) => Ok(Some(TxConfirmationInfo {
+                Ok(info) => Ok(TxLookupOutcome::Found(TxConfirmationInfo {
                     confirmations: info.confirmations,
                     block_hash: info.block_hash.map(|h| h.to_buf32()),
                     block_height: info.block_height,
                 })),
-                Err(err) if err.is_tx_not_found() => Ok(None),
+                Err(err) if err.is_tx_not_found() => Ok(TxLookupOutcome::Missing),
+                Err(err) if err.is_retriable() => Ok(TxLookupOutcome::RetryLater {
+                    reason: err.to_string(),
+                }),
                 Err(err) => Err(BroadcasterError::Rpc(anyhow!(err))),
             }
         }
     }
+}
+
+/// Broadcaster-level outcome of looking up a transaction in the wallet.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TxLookupOutcome {
+    /// Transaction was found in the wallet.
+    Found(TxConfirmationInfo),
+
+    /// Transaction is not currently known to the wallet.
+    Missing,
+
+    /// Transient failure; call sites should retry in a later poll pass.
+    RetryLater { reason: String },
 }
 
 /// Broadcaster-level outcome of broadcasting a transaction.
@@ -200,10 +222,7 @@ where
         Ok(())
     }
 
-    async fn get_transaction<'a>(
-        &'a self,
-        txid: &'a Txid,
-    ) -> BroadcasterResult<Option<TxConfirmationInfo>> {
+    async fn get_transaction<'a>(&'a self, txid: &'a Txid) -> BroadcasterResult<TxLookupOutcome> {
         self.rpc_client.get_transaction_confirmation(txid).await
     }
 
@@ -249,8 +268,8 @@ where
                 warn!(%txid, %err, "sendrawtransaction verify-rejected (treated as InvalidInputs)");
                 Ok(PublishTxOutcome::InvalidInputs)
             }
-            Err(err @ ClientError::Status(500, _)) => {
-                warn!(%txid, %err, "sendrawtransaction HTTP 500 (treated as RetryLater)");
+            Err(err) if err.is_retriable() => {
+                warn!(%txid, %err, "sendrawtransaction hit transient Bitcoin RPC error");
                 Ok(PublishTxOutcome::RetryLater {
                     reason: err.to_string(),
                 })

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -4,7 +4,7 @@ use tracing::*;
 
 use super::{
     error::{BroadcasterError, BroadcasterResult},
-    io::{BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo},
+    io::{BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo, TxLookupOutcome},
     state::{BroadcasterState, IndexedEntry},
 };
 use crate::BtcioParams;
@@ -101,11 +101,15 @@ where
     match txinfo_res? {
         // `confirmation_status` returns `Published` for 0-conf, which is the
         // correct sighting for an already-Published entry still in mempool.
-        Some(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
-        None => match publish_tx(io, txentry).await? {
+        TxLookupOutcome::Found(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
+        TxLookupOutcome::Missing => match publish_tx(io, txentry).await? {
             L1TxStatus::InvalidInputs => Ok(L1TxStatus::InvalidInputs),
             _ => Ok(L1TxStatus::Published),
         },
+        TxLookupOutcome::RetryLater { reason } => {
+            warn!(%reason, "transaction lookup should be retried on next poll");
+            Ok(L1TxStatus::Published)
+        }
     }
 }
 
@@ -162,9 +166,13 @@ where
         let reorg_safe_depth: i64 = params.l1_reorg_safe_depth().into();
 
         match txinfo_res? {
-            Some(info) if info.confirmations == 0 => Ok(L1TxStatus::Unpublished),
-            Some(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
-            None => Ok(L1TxStatus::Unpublished),
+            TxLookupOutcome::Found(info) if info.confirmations == 0 => Ok(L1TxStatus::Unpublished),
+            TxLookupOutcome::Found(info) => Ok(confirmation_status(&info, reorg_safe_depth)),
+            TxLookupOutcome::Missing => Ok(L1TxStatus::Unpublished),
+            TxLookupOutcome::RetryLater { reason } => {
+                warn!(%reason, "transaction lookup should be retried on next poll");
+                Ok(txentry.status.clone())
+            }
         }
     }
     .instrument(debug_span!(
@@ -294,7 +302,9 @@ mod test {
 
     use super::*;
     use crate::{
-        broadcaster::io::{BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo},
+        broadcaster::io::{
+            BroadcasterIoContext, PublishTxOutcome, TxConfirmationInfo, TxLookupOutcome,
+        },
         test_utils::gen_l1_tx_entry_with_status,
     };
 
@@ -305,6 +315,7 @@ mod test {
     enum MockTxLookupResult {
         Missing,
         Found(TxConfirmationInfo),
+        RetryLater,
     }
 
     #[derive(Clone, Debug)]
@@ -351,7 +362,7 @@ mod test {
         async fn get_transaction<'a>(
             &'a self,
             txid: &'a Txid,
-        ) -> BroadcasterResult<Option<TxConfirmationInfo>> {
+        ) -> BroadcasterResult<TxLookupOutcome> {
             let result = self
                 .tx_lookup
                 .get(txid)
@@ -359,8 +370,11 @@ mod test {
                 .unwrap_or(MockTxLookupResult::Missing);
 
             match result {
-                MockTxLookupResult::Missing => Ok(None),
-                MockTxLookupResult::Found(info) => Ok(Some(info)),
+                MockTxLookupResult::Missing => Ok(TxLookupOutcome::Missing),
+                MockTxLookupResult::Found(info) => Ok(TxLookupOutcome::Found(info)),
+                MockTxLookupResult::RetryLater => Ok(TxLookupOutcome::RetryLater {
+                    reason: "mock retry".into(),
+                }),
             }
         }
 
@@ -742,6 +756,22 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_published_entry_lookup_retry_later_holds_published() {
+        let (e, txid) = entry_with_txid(L1TxStatus::Published);
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default()
+            .with_tx_lookup(txid, MockTxLookupResult::RetryLater)
+            .with_broadcast_result(txid, MockBroadcastResult::InvalidInputs);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(L1TxStatus::Published),
+            "Published entry must hold on retryable get_transaction failure"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_handle_confirmed_entry_missing_tx_regresses_to_unpublished() {
         // Confirmed entries that go missing on lookup should still regress to
         // Unpublished so the broadcaster re-publishes (e.g. after a reorg
@@ -755,6 +785,21 @@ mod test {
             res,
             Some(L1TxStatus::Unpublished),
             "Confirmed entry that disappears should regress to Unpublished"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_confirmed_entry_lookup_retry_later_holds_confirmed() {
+        let current_status = confirmed_status(1, 1, Buf32::zero());
+        let (e, txid) = entry_with_txid(current_status.clone());
+        let btcio_params = get_test_btcio_params();
+
+        let io = MockIoContext::default().with_tx_lookup(txid, MockTxLookupResult::RetryLater);
+        let res = process_status(&io, &e, &txid, &btcio_params).await;
+        assert_eq!(
+            res,
+            Some(current_status),
+            "Confirmed entry must hold on retryable get_transaction failure"
         );
     }
 

--- a/crates/btcio/src/lib.rs
+++ b/crates/btcio/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod broadcaster;
 pub mod params;
 pub mod reader;
+pub(crate) mod rpc_error;
 pub mod status;
 
 #[cfg(test)]

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::bail;
-use bitcoin::{Block, BlockHash};
+use bitcoin::{Block, BlockHash, Network};
 use bitcoind_async_client::traits::Reader;
 use strata_btc_types::BlockHashExt;
 use strata_config::btcio::ReaderConfig;
@@ -19,6 +19,7 @@ use tracing::*;
 use super::event::L1Event;
 use crate::{
     reader::{event::BlockData, handler::handle_bitcoin_event, state::ReaderState},
+    rpc_error::is_retryable_anyhow_error,
     status::{apply_status_updates, L1StatusUpdate},
     BtcioParams,
 };
@@ -37,8 +38,31 @@ pub(crate) struct ReaderContext<R: Reader> {
     /// Btcio params
     pub btcio_params: BtcioParams,
 
+    /// Expected Bitcoin network.
+    pub expected_network: Network,
+
+    /// Optional L1 anchor block to verify before ingesting reader data.
+    pub expected_l1_anchor: Option<L1BlockCommitment>,
+
     /// Status transmitter
     pub status_channel: StatusChannel,
+}
+
+/// Expected Bitcoin chain properties validated before reader ingestion starts.
+#[derive(Debug, Clone)]
+pub struct ReaderValidation {
+    expected_network: Network,
+    expected_l1_anchor: Option<L1BlockCommitment>,
+}
+
+impl ReaderValidation {
+    /// Creates a validation config for reader startup.
+    pub fn new(expected_network: Network, expected_l1_anchor: Option<L1BlockCommitment>) -> Self {
+        Self {
+            expected_network,
+            expected_l1_anchor,
+        }
+    }
 }
 
 /// The main task that initializes the reader state and starts reading from bitcoin.
@@ -47,6 +71,7 @@ pub async fn bitcoin_data_reader_task<E: BlockSubmitter>(
     storage: Arc<NodeStorage>,
     config: Arc<ReaderConfig>,
     btcio_params: BtcioParams,
+    validation: ReaderValidation,
     status_channel: StatusChannel,
     event_submitter: Arc<E>,
 ) -> anyhow::Result<()> {
@@ -58,6 +83,8 @@ pub async fn bitcoin_data_reader_task<E: BlockSubmitter>(
         storage,
         config,
         btcio_params,
+        expected_network: validation.expected_network,
+        expected_l1_anchor: validation.expected_l1_anchor,
         status_channel,
     };
     do_reader_task(ctx, target_next_block, event_submitter.as_ref()).await
@@ -86,22 +113,35 @@ async fn do_reader_task<R: Reader>(
     info!(%target_next_block, "started L1 reader task!");
 
     let poll_dur = Duration::from_millis(ctx.config.client_poll_dur_ms as u64);
-    let mut state = init_reader_state(&ctx, target_next_block).await?;
-    let best_blkid = state.best_block();
-    info!(%best_blkid, "initialized L1 reader state");
+    let mut state: Option<ReaderState> = None;
 
     loop {
         let mut status_updates: Vec<L1StatusUpdate> = Vec::new();
 
-        match poll_for_new_blocks(&ctx, &mut state, &mut status_updates).await {
-            Err(err) => {
-                handle_poll_error(&err, &mut status_updates);
-            }
-            Ok(events) => {
-                // handle events
-                for ev in events {
-                    handle_bitcoin_event(ev, &ctx, event_submitter).await?;
+        if let Some(reader_state) = state.as_mut() {
+            match poll_for_new_blocks(&ctx, reader_state, &mut status_updates).await {
+                Err(err) => {
+                    handle_poll_error(&err, &mut status_updates);
                 }
+                Ok(events) => {
+                    // handle events
+                    for ev in events {
+                        handle_bitcoin_event(ev, &ctx, event_submitter).await?;
+                    }
+                }
+            }
+        } else {
+            match init_reader_state(&ctx, target_next_block).await {
+                Ok(reader_state) => {
+                    let best_blkid = reader_state.best_block();
+                    info!(%best_blkid, "initialized L1 reader state");
+                    status_updates.push(L1StatusUpdate::RpcConnected(true));
+                    state = Some(reader_state);
+                }
+                Err(err) if is_retryable_anyhow_error(&err) => {
+                    handle_poll_error(&err, &mut status_updates);
+                }
+                Err(err) => return Err(err),
             }
         };
 
@@ -123,10 +163,12 @@ fn handle_poll_error(err: &anyhow::Error, status_updates: &mut Vec<L1StatusUpdat
     warn!(%err, "failed to poll Bitcoin client");
     status_updates.push(L1StatusUpdate::RpcError(err.to_string()));
 
+    if is_retryable_anyhow_error(err) {
+        status_updates.push(L1StatusUpdate::RpcConnected(false));
+        return;
+    }
+
     if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
-        if reqwest_err.is_connect() {
-            status_updates.push(L1StatusUpdate::RpcConnected(false));
-        }
         if reqwest_err.is_builder() {
             panic!("btcio: couldn't build the L1 client");
         }
@@ -149,6 +191,28 @@ async fn init_reader_state<R: Reader>(
 
     // Do some math to figure out where our start and end are.
     let chain_info = client.get_blockchain_info().await?;
+    if chain_info.chain != ctx.expected_network {
+        bail!(
+            "btcio: bitcoind network mismatch: expected {}, got {}",
+            ctx.expected_network,
+            chain_info.chain
+        );
+    }
+
+    if let Some(expected_l1_anchor) = ctx.expected_l1_anchor {
+        let actual_hash = client
+            .get_block_hash(expected_l1_anchor.height() as u64)
+            .await?;
+        let actual_block_id = actual_hash.to_l1_block_id();
+        if actual_block_id != *expected_l1_anchor.blkid() {
+            bail!(
+                "btcio: L1 anchor block hash mismatch at height {height}: expected {expected}, got {actual_block_id}",
+                height = expected_l1_anchor.height(),
+                expected = expected_l1_anchor.blkid(),
+            );
+        }
+    }
+
     let chain_tip = chain_info.blocks as L1Height;
     let start_height = target_next_block
         .saturating_sub(lookback)

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -41,8 +41,8 @@ pub(crate) struct ReaderContext<R: Reader> {
     /// Expected Bitcoin network.
     pub expected_network: Network,
 
-    /// Optional L1 anchor block to verify before ingesting reader data.
-    pub expected_l1_anchor: Option<L1BlockCommitment>,
+    /// L1 anchor block to verify before ingesting reader data.
+    pub expected_l1_anchor: L1BlockCommitment,
 
     /// Status transmitter
     pub status_channel: StatusChannel,
@@ -52,12 +52,12 @@ pub(crate) struct ReaderContext<R: Reader> {
 #[derive(Debug, Clone)]
 pub struct ReaderValidation {
     expected_network: Network,
-    expected_l1_anchor: Option<L1BlockCommitment>,
+    expected_l1_anchor: L1BlockCommitment,
 }
 
 impl ReaderValidation {
     /// Creates a validation config for reader startup.
-    pub fn new(expected_network: Network, expected_l1_anchor: Option<L1BlockCommitment>) -> Self {
+    pub fn new(expected_network: Network, expected_l1_anchor: L1BlockCommitment) -> Self {
         Self {
             expected_network,
             expected_l1_anchor,
@@ -199,18 +199,16 @@ async fn init_reader_state<R: Reader>(
         );
     }
 
-    if let Some(expected_l1_anchor) = ctx.expected_l1_anchor {
-        let actual_hash = client
-            .get_block_hash(expected_l1_anchor.height() as u64)
-            .await?;
-        let actual_block_id = actual_hash.to_l1_block_id();
-        if actual_block_id != *expected_l1_anchor.blkid() {
-            bail!(
-                "btcio: L1 anchor block hash mismatch at height {height}: expected {expected}, got {actual_block_id}",
-                height = expected_l1_anchor.height(),
-                expected = expected_l1_anchor.blkid(),
-            );
-        }
+    let actual_hash = client
+        .get_block_hash(ctx.expected_l1_anchor.height() as u64)
+        .await?;
+    let actual_block_id = actual_hash.to_l1_block_id();
+    if actual_block_id != *ctx.expected_l1_anchor.blkid() {
+        bail!(
+            "btcio: L1 anchor block hash mismatch at height {height}: expected {expected}, got {actual_block_id}",
+            height = ctx.expected_l1_anchor.height(),
+            expected = ctx.expected_l1_anchor.blkid(),
+        );
     }
 
     let chain_tip = chain_info.blocks as L1Height;

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -28,13 +28,6 @@ pub(crate) fn is_retryable_anyhow_error(err: &AnyhowError) -> bool {
 }
 
 /// Returns `true` when an envelope error represents a retryable Bitcoin RPC outage.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "STR-3411 wires this shared classifier into writers in follow-up commits"
-    )
-)]
 pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
     match err {
         EnvelopeError::PrereqFetch(err) | EnvelopeError::Other(err) => {
@@ -52,13 +45,6 @@ pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
 }
 
 /// Formats a retryable error reason for status and logs.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "STR-3411 wires this shared formatter into status reporting in follow-up commits"
-    )
-)]
 pub(crate) fn retryable_reason(err: impl fmt::Display) -> String {
     err.to_string()
 }

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -1,0 +1,127 @@
+use std::fmt;
+
+use anyhow::Error as AnyhowError;
+use bitcoind_async_client::error::ClientError;
+
+use crate::writer::builder::EnvelopeError;
+
+/// Returns `true` when a Bitcoin RPC error may be resolved by retrying later.
+pub(crate) fn is_retryable_client_error(err: &ClientError) -> bool {
+    err.is_retriable()
+}
+
+/// Returns `true` when an [`anyhow::Error`] wraps a retryable Bitcoin RPC error.
+pub(crate) fn is_retryable_anyhow_error(err: &AnyhowError) -> bool {
+    if err.chain().any(|cause| {
+        cause
+            .downcast_ref::<ClientError>()
+            .is_some_and(is_retryable_client_error)
+    }) {
+        return true;
+    }
+
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(|err| err.is_connect() || err.is_timeout())
+    })
+}
+
+/// Returns `true` when an envelope error represents a retryable Bitcoin RPC outage.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "STR-3411 wires this shared classifier into writers in follow-up commits"
+    )
+)]
+pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
+    match err {
+        EnvelopeError::PrereqFetch(err) | EnvelopeError::Other(err) => {
+            is_retryable_anyhow_error(err)
+        }
+        EnvelopeError::SignRawTransaction(err) => is_retryable_client_error(err),
+        EnvelopeError::EmptyPayload
+        | EnvelopeError::NotEnoughUtxos(_, _)
+        | EnvelopeError::MissingEnvelopePubkey
+        | EnvelopeError::Taproot(_)
+        | EnvelopeError::Tag(_)
+        | EnvelopeError::EnvelopeBuild(_)
+        | EnvelopeError::Sighash(_) => false,
+    }
+}
+
+/// Formats a retryable error reason for status and logs.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "STR-3411 wires this shared formatter into status reporting in follow-up commits"
+    )
+)]
+pub(crate) fn retryable_reason(err: impl fmt::Display) -> String {
+    err.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoind_async_client::error::ClientError;
+
+    use super::{
+        is_retryable_anyhow_error, is_retryable_client_error, is_retryable_envelope_error,
+        retryable_reason,
+    };
+    use crate::writer::builder::EnvelopeError;
+
+    #[test]
+    fn client_errors_delegate_to_bitcoind_async_client() {
+        assert!(is_retryable_client_error(&ClientError::Connection(
+            "connection refused".into()
+        )));
+        assert!(!is_retryable_client_error(&ClientError::Server(
+            -25,
+            "bad-txns-inputs-missingorspent".into()
+        )));
+    }
+
+    #[test]
+    fn anyhow_context_preserves_retryable_client_error_classification() {
+        let err = anyhow::Error::from(ClientError::Connection("connection refused".into()))
+            .context("failed to fetch envelope prerequisites");
+
+        assert!(is_retryable_anyhow_error(&err));
+    }
+
+    #[test]
+    fn envelope_prereq_fetch_uses_wrapped_retry_classification() {
+        let source = anyhow::Error::from(ClientError::Timeout).context("network unavailable");
+        let err = EnvelopeError::PrereqFetch(source);
+
+        assert!(is_retryable_envelope_error(&err));
+    }
+
+    #[test]
+    fn envelope_signing_rpc_outages_are_retryable() {
+        let err =
+            EnvelopeError::SignRawTransaction(ClientError::Connection("connection refused".into()));
+
+        assert!(is_retryable_envelope_error(&err));
+    }
+
+    #[test]
+    fn envelope_signing_permanent_failures_are_not_retryable() {
+        let err = EnvelopeError::SignRawTransaction(ClientError::Server(
+            -25,
+            "bad-txns-inputs-missingorspent".into(),
+        ));
+
+        assert!(!is_retryable_envelope_error(&err));
+    }
+
+    #[test]
+    fn retryable_reason_formats_display_value() {
+        let reason = retryable_reason(ClientError::Timeout);
+
+        assert_eq!(reason, "Timeout");
+    }
+}

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -21,6 +21,7 @@ use bitcoin::{
 };
 use bitcoind_async_client::{
     corepc_types::model::ListUnspentItem,
+    error::ClientError,
     traits::{Reader, Signer, Wallet},
 };
 use rand::{rngs::OsRng, RngCore};
@@ -92,7 +93,7 @@ pub enum EnvelopeError {
     NotEnoughUtxos(u64, u64),
 
     #[error("Could not sign raw transaction: {0}")]
-    SignRawTransaction(String),
+    SignRawTransaction(#[source] ClientError),
 
     #[error("envelope_pubkey is required for envelope transactions")]
     MissingEnvelopePubkey,
@@ -205,7 +206,7 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
         .client
         .sign_raw_transaction_with_wallet(&envelope.commit_tx, None)
         .await
-        .map_err(|e| EnvelopeError::SignRawTransaction(e.to_string()))?
+        .map_err(EnvelopeError::SignRawTransaction)?
         .tx;
     envelope.commit_tx = signed_commit;
 

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -31,6 +31,7 @@ use super::{
 };
 use crate::{
     broadcaster::{is_benign_minus25_message, L1BroadcastHandle},
+    rpc_error::{is_retryable_envelope_error, retryable_reason},
     writer::builder::EnvelopeError,
     BtcioParams,
 };
@@ -637,6 +638,10 @@ async fn advance_forward_frontier<R: Reader + Signer + Wallet + Broadcaster>(
             Err(EnvelopeError::NotEnoughUtxos(need, have)) => {
                 warn!(idx, %need, %have, "waiting for sufficient utxos");
             }
+            Err(err) if is_retryable_envelope_error(&err) => {
+                let reason = retryable_reason(&err);
+                warn!(idx, %reason, "retrying chunked envelope signing after Bitcoin RPC error");
+            }
             Err(e) => return Err(e.into()),
         }
 
@@ -929,6 +934,8 @@ fn to_envelope_status(s: &L1TxStatus) -> ChunkedEnvelopeStatus {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use bitcoin::{
         absolute::LockTime, consensus::encode::serialize as btc_serialize, hashes::Hash,
         transaction::Version, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -127,7 +127,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .client
             .sign_raw_transaction_with_wallet(&built.commit_tx, None)
             .await
-            .map_err(|e| EnvelopeError::SignRawTransaction(e.to_string()))?
+            .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
         let commit_txid: Buf32 = signed_commit.compute_txid().to_buf32();
         let commit_wtxid: Buf32 = signed_commit.compute_wtxid().to_buf32();

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -66,7 +66,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .client
             .network()
             .await
-            .map_err(|e| EnvelopeError::Other(e.into()))?;
+            .map_err(|e| EnvelopeError::PrereqFetch(e.into()))?;
 
         // NOTE: passing `min_conf = 0` would also include unconfirmed UTXOs and mitigate the
         // lack-of-UTXO problem, but it complicates fee bumping (RBF/CPFP over chained unconfirmed
@@ -76,7 +76,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .client
             .list_unspent(None, None, None, None, None)
             .await
-            .map_err(|e| EnvelopeError::Other(e.into()))?
+            .map_err(|e| EnvelopeError::PrereqFetch(e.into()))?
             .0;
 
         let spendable_utxo_count = utxos
@@ -92,7 +92,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
 
         let fee_rate = resolve_fee_rate(ctx.client.as_ref(), ctx.config.as_ref())
             .await
-            .map_err(EnvelopeError::Other)?;
+            .map_err(EnvelopeError::PrereqFetch)?;
 
         debug!(
             envelope_idx,

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -43,7 +43,7 @@ pub(crate) async fn create_payload_envelopes<R: Reader + Signer + Wallet>(
             .client
             .sign_raw_transaction_with_wallet(&envelope.commit_tx, None)
             .await
-            .map_err(|e| EnvelopeError::SignRawTransaction(e.to_string()))?
+            .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
         envelope.commit_tx = signed_commit;
 

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -3,7 +3,13 @@
 //! Drives the [`L1BundleStatus`] state machine for the current payload entry
 //! on each timer tick.
 
-use std::{collections::HashMap, future::Future, marker::PhantomData, sync::Arc};
+use std::{
+    collections::HashMap,
+    future::Future,
+    marker::PhantomData,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use serde::Serialize;
@@ -17,6 +23,7 @@ use tracing::*;
 
 use crate::{
     broadcaster::L1BroadcastHandle,
+    rpc_error::{is_retryable_envelope_error, retryable_reason},
     status::{apply_status_updates, L1StatusUpdate},
     writer::{
         builder::{EnvelopeData, EnvelopeError},
@@ -35,39 +42,48 @@ pub(crate) trait WatcherServiceContext: Send + Sync + 'static {
         &self,
         idx: u64,
     ) -> impl Future<Output = anyhow::Result<Option<BundledPayloadEntry>>> + Send;
+
     fn put_payload_entry(
         &self,
         idx: u64,
         entry: BundledPayloadEntry,
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
+
     /// Returns `true` when the node is configured with an external signer
     /// (`CredRule::SchnorrKey`). When `false`, the watcher signs in-process.
     fn needs_external_signing(&self) -> bool;
+
     fn create_envelopes(
         &self,
         idx: u64,
         entry: &BundledPayloadEntry,
     ) -> impl Future<Output = Result<EnvelopeData, EnvelopeError>> + Send;
+
     fn sign_and_broadcast(
         &self,
         idx: u64,
         entry: &BundledPayloadEntry,
     ) -> impl Future<Output = Result<(Buf32, Buf32), EnvelopeError>> + Send;
+
     fn complete_reveal_and_broadcast(
         &self,
         idx: u64,
         envelope: &EnvelopeData,
         sig: &[u8; 64],
     ) -> impl Future<Output = anyhow::Result<Buf32>> + Send;
+
     fn get_tx_status(
         &self,
         txid: Buf32,
     ) -> impl Future<Output = anyhow::Result<Option<L1TxEntry>>> + Send;
+
     fn report_status(
         &self,
         entry: &BundledPayloadEntry,
         status: &L1BundleStatus,
     ) -> impl Future<Output = ()> + Send;
+
+    fn report_rpc_error(&self, reason: String) -> impl Future<Output = ()> + Send;
 }
 
 pub(crate) struct WatcherContextImpl<R: Reader + Signer + Wallet + Send + Sync + 'static> {
@@ -153,6 +169,20 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
 
     async fn report_status(&self, entry: &BundledPayloadEntry, status: &L1BundleStatus) {
         update_l1_status(entry, status, &self.context.status_channel).await;
+    }
+
+    async fn report_rpc_error(&self, reason: String) {
+        let status_updates = [
+            L1StatusUpdate::RpcConnected(false),
+            L1StatusUpdate::RpcError(reason),
+            L1StatusUpdate::LastUpdate(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64,
+            ),
+        ];
+        apply_status_updates(&status_updates, &self.context.status_channel).await;
     }
 }
 
@@ -281,8 +311,13 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
-                e => {
-                    e?;
+                Err(err) if is_retryable_envelope_error(&err) => {
+                    let reason = retryable_reason(&err);
+                    warn!(%reason, "retrying envelope creation after Bitcoin RPC error");
+                    self.ctx.report_rpc_error(reason).await;
+                }
+                Err(err) => {
+                    return Err(err.into());
                 }
             }
         } else {
@@ -305,8 +340,13 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
-                e => {
-                    e?;
+                Err(err) if is_retryable_envelope_error(&err) => {
+                    let reason = retryable_reason(&err);
+                    warn!(%reason, "retrying envelope signing after Bitcoin RPC error");
+                    self.ctx.report_rpc_error(reason).await;
+                }
+                Err(err) => {
+                    return Err(err.into());
                 }
             }
         }
@@ -466,6 +506,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
+    use anyhow::anyhow;
     use bitcoin::{
         absolute::LockTime,
         blockdata::{opcodes, script::Builder as ScriptBuilder},
@@ -476,6 +517,7 @@ mod tests {
         transaction::Version,
         Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
     };
+    use bitcoind_async_client::error::ClientError;
     use strata_csm_types::L1Payload;
     use strata_db_types::types::{BundledPayloadEntry, L1BundleStatus, L1TxEntry};
     use strata_l1_txfmt::TagData;
@@ -493,6 +535,31 @@ mod tests {
 
     const TEST_REQUIRED_SATS: u64 = 4096;
     const TEST_AVAILABLE_SATS: u64 = 2658;
+
+    #[derive(Clone, Copy)]
+    enum MockEnvelopeFailure {
+        NotEnoughUtxos,
+        PrereqFetch,
+        SignRawTransaction,
+        Other,
+    }
+
+    impl MockEnvelopeFailure {
+        fn into_error(self) -> EnvelopeError {
+            match self {
+                Self::NotEnoughUtxos => {
+                    EnvelopeError::NotEnoughUtxos(TEST_REQUIRED_SATS, TEST_AVAILABLE_SATS)
+                }
+                Self::PrereqFetch => EnvelopeError::PrereqFetch(anyhow::Error::from(
+                    ClientError::Connection("mock connection failure".to_string()),
+                )),
+                Self::SignRawTransaction => EnvelopeError::SignRawTransaction(
+                    ClientError::Connection("mock signing failure".to_string()),
+                ),
+                Self::Other => EnvelopeError::Other(anyhow!("mock storage failure")),
+            }
+        }
+    }
 
     fn minimal_envelope_data() -> EnvelopeData {
         let keypair =
@@ -547,8 +614,9 @@ mod tests {
         stored: Mutex<HashMap<u64, BundledPayloadEntry>>,
         broadcast_handle: Arc<L1BroadcastHandle>,
         external_signing: bool,
-        fail_create_not_enough_utxos: bool,
-        fail_sign_not_enough_utxos: bool,
+        create_failure: Option<MockEnvelopeFailure>,
+        sign_failure: Option<MockEnvelopeFailure>,
+        rpc_errors: Mutex<Vec<String>>,
     }
 
     impl MockWatcherContext {
@@ -557,23 +625,43 @@ mod tests {
                 stored: Mutex::new(HashMap::new()),
                 broadcast_handle: get_broadcast_handle(),
                 external_signing,
-                fail_create_not_enough_utxos: false,
-                fail_sign_not_enough_utxos: false,
+                create_failure: None,
+                sign_failure: None,
+                rpc_errors: Mutex::new(Vec::new()),
             }
         }
 
         fn with_create_not_enough_utxos(mut self) -> Self {
-            self.fail_create_not_enough_utxos = true;
+            self.create_failure = Some(MockEnvelopeFailure::NotEnoughUtxos);
             self
         }
 
         fn with_sign_not_enough_utxos(mut self) -> Self {
-            self.fail_sign_not_enough_utxos = true;
+            self.sign_failure = Some(MockEnvelopeFailure::NotEnoughUtxos);
+            self
+        }
+
+        fn with_create_prereq_fetch(mut self) -> Self {
+            self.create_failure = Some(MockEnvelopeFailure::PrereqFetch);
+            self
+        }
+
+        fn with_sign_raw_transaction_failure(mut self) -> Self {
+            self.sign_failure = Some(MockEnvelopeFailure::SignRawTransaction);
+            self
+        }
+
+        fn with_sign_other_failure(mut self) -> Self {
+            self.sign_failure = Some(MockEnvelopeFailure::Other);
             self
         }
 
         fn get_stored(&self, idx: u64) -> Option<BundledPayloadEntry> {
             self.stored.lock().unwrap().get(&idx).cloned()
+        }
+
+        fn rpc_error_count(&self) -> usize {
+            self.rpc_errors.lock().unwrap().len()
         }
     }
 
@@ -600,11 +688,8 @@ mod tests {
             _idx: u64,
             _entry: &BundledPayloadEntry,
         ) -> Result<EnvelopeData, EnvelopeError> {
-            if self.fail_create_not_enough_utxos {
-                return Err(EnvelopeError::NotEnoughUtxos(
-                    TEST_REQUIRED_SATS,
-                    TEST_AVAILABLE_SATS,
-                ));
+            if let Some(failure) = self.create_failure {
+                return Err(failure.into_error());
             }
             Ok(minimal_envelope_data())
         }
@@ -614,11 +699,8 @@ mod tests {
             _idx: u64,
             _entry: &BundledPayloadEntry,
         ) -> Result<(Buf32, Buf32), EnvelopeError> {
-            if self.fail_sign_not_enough_utxos {
-                return Err(EnvelopeError::NotEnoughUtxos(
-                    TEST_REQUIRED_SATS,
-                    TEST_AVAILABLE_SATS,
-                ));
+            if let Some(failure) = self.sign_failure {
+                return Err(failure.into_error());
             }
             Ok((Buf32([1u8; 32]), Buf32([2u8; 32])))
         }
@@ -639,6 +721,10 @@ mod tests {
         }
 
         async fn report_status(&self, _entry: &BundledPayloadEntry, _status: &L1BundleStatus) {}
+
+        async fn report_rpc_error(&self, reason: String) {
+            self.rpc_errors.lock().unwrap().push(reason);
+        }
     }
 
     fn test_unsigned_entry() -> BundledPayloadEntry {
@@ -716,6 +802,63 @@ mod tests {
         assert_eq!(stored.reveal_txid, Buf32::zero());
         assert_eq!(state.curr_payloadidx, 0);
         assert!(state.envelope_cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_schnorr_key_prereq_fetch_keeps_unsigned_for_retry() {
+        let ctx = MockWatcherContext::new(true).with_create_prereq_fetch();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry);
+
+        let mut state = WatcherState::new(ctx, 0);
+        let response = WatcherService::<MockWatcherContext>::process_input(&mut state, ())
+            .await
+            .unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert!(matches!(response, Response::Continue));
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(state.curr_payloadidx, 0);
+        assert!(state.envelope_cache.is_empty());
+        assert_eq!(state.ctx.rpc_error_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_unchecked_sign_raw_transaction_keeps_unsigned_for_retry() {
+        let ctx = MockWatcherContext::new(false).with_sign_raw_transaction_failure();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry);
+
+        let mut state = WatcherState::new(ctx, 0);
+        let response = WatcherService::<MockWatcherContext>::process_input(&mut state, ())
+            .await
+            .unwrap();
+
+        let stored = state.ctx.get_stored(0).unwrap();
+        assert!(matches!(response, Response::Continue));
+        assert_eq!(stored.status, L1BundleStatus::Unsigned);
+        assert_eq!(state.curr_payloadidx, 0);
+        assert!(state.envelope_cache.is_empty());
+        assert_eq!(state.ctx.rpc_error_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_unchecked_other_error_exits_watcher() {
+        let ctx = MockWatcherContext::new(false).with_sign_other_failure();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry);
+
+        let mut state = WatcherState::new(ctx, 0);
+        let err = WatcherService::<MockWatcherContext>::process_input(&mut state, ())
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("mock storage failure"));
+        assert_eq!(
+            state.ctx.get_stored(0).unwrap().status,
+            L1BundleStatus::Unsigned
+        );
+        assert_eq!(state.ctx.rpc_error_count(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Makes BTCIO resilient to temporary Bitcoin node and wallet RPC outages across reader, writer, chunked writer, and broadcaster paths.

This PR classifies retryable Bitcoin RPC errors through `bitcoind-async-client`, defers startup-only Bitcoin checks when the node is temporarily unreachable, retries reader initialization/poll failures, and keeps writer/broadcaster state machines alive across transient RPC failures. It also preserves typed wallet signing errors so only retryable signing failures are retried.


### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Key areas to review:

- Retry classification in `crates/btcio/src/rpc_error.rs`
- Reader startup/deferred validation flow in `crates/btcio/src/reader/query.rs` and `bin/strata/src/startup_checks.rs`
- Writer and chunked writer behavior when prerequisite fetches, wallet signing, or reveal broadcasts fail transiently
- Broadcaster handling of retryable `gettransaction` and `sendrawtransaction` failures

Needs a `bitcoind-async-client` version bump because of https://github.com/alpenlabs/bitcoind-async-client/pull/112 which exposes `is_retriable()` to RPC errors.

AI assistance disclosure: I used OpenAI Codex to help review, implement, test, and draft this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3411
