### PR TITLE
fix(ol): correct checkpoint DA and inbox indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13927,7 +13927,6 @@ dependencies = [
  "strata-ol-state-provider",
  "strata-ol-state-support-types",
  "strata-ol-state-types",
- "strata-ol-stf",
  "strata-paas",
  "strata-params",
  "strata-predicate",

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -24,8 +24,6 @@ debug-utils = [
 ]
 prover = [
   "dep:borsh",
-  "dep:strata-ol-state-support-types",
-  "dep:strata-ol-stf",
   "dep:strata-paas",
   "dep:strata-predicate",
   "dep:strata-proofimpl-checkpoint",
@@ -74,9 +72,7 @@ strata-ol-rpc-api.workspace = true
 strata-ol-rpc-types.workspace = true
 strata-ol-sequencer = { workspace = true, optional = true }
 strata-ol-state-provider = { workspace = true, optional = true }
-strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
-strata-ol-stf = { workspace = true, optional = true }
 strata-paas = { workspace = true, optional = true }
 strata-params.workspace = true
 strata-predicate = { workspace = true, optional = true }

--- a/bin/strata/src/prover/spec.rs
+++ b/bin/strata/src/prover/spec.rs
@@ -9,8 +9,7 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize, io::Error as BorshIoError};
 use strata_identifiers::{Epoch, EpochCommitment};
-use strata_ol_state_support_types::{DaAccumulatingState, MemoryStateBaseLayer};
-use strata_ol_stf::execute_block_batch;
+use strata_ol_checkpoint::compute_epoch_preseal_da_diff;
 use strata_paas::{ProofSpec, ProverError as PaasError, ProverResult};
 use strata_proofimpl_checkpoint::program::{CheckpointProgram, CheckpointProverInput};
 use strata_storage::NodeStorage;
@@ -167,23 +166,8 @@ fn fetch_input_blocking(
 
     blocks.reverse();
 
-    // Compute DA state diff bytes by replaying the epoch blocks through a
-    // [`DaAccumulatingState`] wrapper. This intercepts state mutations to
-    // build the same DA diff that the guest program will verify. Computing
-    // it here (rather than reading a checkpoint entry) ensures the diff
-    // is available before the checkpoint entry is written.
-    let da_state_diff_bytes = {
-        let mut da_state =
-            DaAccumulatingState::new(MemoryStateBaseLayer::new((*start_state).clone()));
-        execute_block_batch(&mut da_state, &blocks, &parent)
-            .map_err(|e| ProverError::DaComputation(e.to_string()))?;
-        da_state
-            .take_completed_epoch_da_blob()
-            .map_err(|e| ProverError::DaComputation(e.to_string()))?
-            .ok_or_else(|| {
-                ProverError::DaComputation("no DA blob produced after epoch replay".to_string())
-            })?
-    };
+    let da_state_diff_bytes = compute_epoch_preseal_da_diff(&start_state, &blocks, &parent)
+        .map_err(|e| ProverError::DaComputation(e.to_string()))?;
 
     debug!(
         %epoch_index,

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/state.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/state.rs
@@ -189,28 +189,37 @@ impl OLChainTrackerState {
             to_slot = max_slot;
         }
 
-        if from_slot > to_slot {
-            let next_inbox_msg_idx = self.next_inbox_msg_idx_at_or_before(to_slot);
-            return Ok(InboxMessages::new_empty(next_inbox_msg_idx));
-        }
-
-        // Blocks are present. `from_idx` is the first block with
-        // slot >= from_slot and `to_idx_exclusive` is the first block after
-        // to_slot.
+        // Blocks are present.
+        // Index of first block with slot >= from_slot.
         let from_idx = self.blocks.partition_point(|b| b.slot() < from_slot);
-        let to_idx_exclusive = self.blocks.partition_point(|b| b.slot() <= to_slot);
 
-        let next_inbox_msg_idx = to_idx_exclusive
+        // Index of the first block with slot > to_slot.
+        let to_idx = self.blocks.partition_point(|b| b.slot() <= to_slot);
+
+        let next_inbox_msg_idx_before_range = from_idx
             .checked_sub(1)
             .and_then(|i| self.blocks.get(i))
             .and_then(|b| self.data.get(b.blkid()))
             .map_or(self.base_block_next_inbox_msg_idx, |d| d.next_inbox_msg_idx);
 
+        if from_idx >= to_idx {
+            return Ok(InboxMessages::new_empty(next_inbox_msg_idx_before_range));
+        }
+
+        // Return the next expected inbox index after the last block in the
+        // returned range.
+        let next_inbox_msg_idx = self
+            .blocks
+            .get(to_idx - 1)
+            .and_then(|b| self.data.get(b.blkid()))
+            .ok_or_else(|| eyre!("missing inbox data for last block in range"))?
+            .next_inbox_msg_idx;
+
         let messages = self
             .blocks
             .iter()
             .skip(from_idx)
-            .take(to_idx_exclusive.saturating_sub(from_idx))
+            .take(to_idx - from_idx)
             .map(|b| {
                 self.data
                     .get(b.blkid())
@@ -228,14 +237,6 @@ impl OLChainTrackerState {
             messages,
             next_inbox_msg_idx,
         })
-    }
-
-    fn next_inbox_msg_idx_at_or_before(&self, slot: u64) -> u64 {
-        let idx = self.blocks.partition_point(|b| b.slot() <= slot);
-        idx.checked_sub(1)
-            .and_then(|i| self.blocks.get(i))
-            .and_then(|b| self.data.get(b.blkid()))
-            .map_or(self.base_block_next_inbox_msg_idx, |d| d.next_inbox_msg_idx)
     }
 }
 
@@ -601,8 +602,8 @@ mod tests {
                 .append_block(make_block(12), vec![make_message(200)], 2)
                 .unwrap();
 
-            // Request range completely above tracked blocks. This returns no
-            // messages, but still reports the latest tracked inbox index.
+            // Request a range completely above tracked blocks. It returns no
+            // messages while preserving the latest tracked inbox index.
             let messages = state.get_inbox_messages(20, 25).unwrap();
             assert!(messages.messages.is_empty());
             assert_eq!(messages.next_inbox_msg_idx(), 2);

--- a/crates/ol/checkpoint/src/context.rs
+++ b/crates/ol/checkpoint/src/context.rs
@@ -8,10 +8,12 @@ use std::{
 use strata_asm_proto_checkpoint_types::CheckpointPayload;
 use strata_checkpoint_types::EpochSummary;
 use strata_identifiers::{Epoch, EpochCommitment, OLBlockCommitment};
-use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLBlockId, OLLog};
+use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLBlockId, OLLog, OLTxSegment};
 use strata_ol_state_support_types::{DaAccumulatingState, MemoryStateBaseLayer};
 use strata_ol_state_types::OLState;
-use strata_ol_stf::execute_block_batch;
+use strata_ol_stf::{
+    BlockContext, BlockExecInput, BlockInfo, execute_block_batch, execute_block_inputs,
+};
 use strata_primitives::nonempty_vec::NonEmptyVec;
 use strata_storage::NodeStorage;
 use tracing::{debug, warn};
@@ -357,10 +359,10 @@ fn assert_terminal_commitment_matches(
 /// Replays epoch blocks to produce DA state diff bytes, accumulated logs, and
 /// the terminal header.
 ///
-/// Loads the OL state at the previous terminal block, wraps it in
-/// `DaAccumulatingState` to intercept mutations, then re-executes every block
-/// in the epoch. The DA blob is extracted from the accumulating layer and the
-/// logs are collected from each block's execution output.
+/// Loads the OL state at the previous terminal block and re-executes every
+/// block in the epoch. Full block replay collects logs and validates headers,
+/// while DA accumulation replays only the preseal phases that the checkpoint
+/// proof authenticates against the terminal preseal root.
 fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
     ctx: &C,
     summary: &EpochSummary,
@@ -375,22 +377,75 @@ fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
     let ol_state_raw = ctx
         .get_ol_state(prev_terminal)?
         .ok_or_else(|| anyhow::anyhow!("missing OL state at prev terminal {:?}", prev_terminal))?;
-    let ol_state = MemoryStateBaseLayer::new(ol_state_raw);
 
-    let mut da_state = DaAccumulatingState::new(ol_state);
-
-    let logs = execute_block_batch(&mut da_state, &epoch_blocks, &prev_terminal_header)
+    let mut replay_state = MemoryStateBaseLayer::new(ol_state_raw.clone());
+    let logs = execute_block_batch(&mut replay_state, &epoch_blocks, &prev_terminal_header)
         .map_err(|e| anyhow::anyhow!("epoch block replay failed: {e}"))?;
 
     let terminal_header = epoch_blocks.ensured_last().header().clone();
-
-    // Extract the DA blob from the accumulating layer.
-    let da_bytes = da_state
-        .take_completed_epoch_da_blob()
-        .map_err(|e| anyhow::anyhow!("DA accumulation failed: {e}"))?
-        .ok_or_else(|| anyhow::anyhow!("no DA blob produced after epoch replay"))?;
+    let da_bytes =
+        compute_epoch_preseal_da_diff(&ol_state_raw, &epoch_blocks, &prev_terminal_header)?;
 
     Ok((da_bytes, logs, terminal_header))
+}
+
+/// Computes the epoch DA payload using only preseal block execution.
+///
+/// Manifest processing is proven by full block replay and terminal header
+/// equality. The DA witness is verified against the terminal preseal root, so
+/// L1-derived manifest mutations must not be included in this blob.
+pub fn compute_epoch_preseal_da_diff(
+    start_state: &OLState,
+    blocks: &[OLBlock],
+    initial_parent: &OLBlockHeader,
+) -> anyhow::Result<Vec<u8>> {
+    let terminal = blocks
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("cannot compute checkpoint DA diff without epoch blocks"))?;
+    anyhow::ensure!(
+        terminal.header().is_terminal(),
+        "cannot compute checkpoint DA diff: terminal block is not marked terminal"
+    );
+    anyhow::ensure!(
+        terminal.body().l1_update().is_some(),
+        "cannot compute checkpoint DA diff: terminal block is missing L1 update"
+    );
+
+    let mut da_state = DaAccumulatingState::new(MemoryStateBaseLayer::new(start_state.clone()));
+    let mut parent = initial_parent.clone();
+    let empty_tx_segment =
+        OLTxSegment::new(Vec::new()).expect("empty transaction segment is valid");
+
+    for block in blocks {
+        let block_info = BlockInfo::from_header(block.header());
+        let block_context = BlockContext::new(&block_info, Some(&parent));
+        let tx_segment = block.body().tx_segment().unwrap_or(&empty_tx_segment);
+        let block_exec_input = BlockExecInput::new(tx_segment, None);
+
+        let outputs = execute_block_inputs(&mut da_state, block_context, block_exec_input)
+            .map_err(|e| anyhow::anyhow!("preseal DA replay failed: {e}"))?;
+
+        let expected_preseal_root = block
+            .body()
+            .l1_update()
+            .map_or(block.header().state_root(), |update| {
+                update.preseal_state_root()
+            });
+        anyhow::ensure!(
+            outputs.header_post_state_root() == expected_preseal_root,
+            "preseal DA replay root mismatch at slot {}: expected {:?}, got {:?}",
+            block.header().slot(),
+            expected_preseal_root,
+            outputs.header_post_state_root()
+        );
+
+        parent = block.header().clone();
+    }
+
+    da_state
+        .take_completed_epoch_da_blob()
+        .map_err(|e| anyhow::anyhow!("DA accumulation failed: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("no DA blob produced after preseal DA replay"))
 }
 
 /// Collects all blocks in an epoch by walking backwards from the terminal block.

--- a/crates/ol/checkpoint/src/lib.rs
+++ b/crates/ol/checkpoint/src/lib.rs
@@ -10,5 +10,5 @@ mod service;
 mod state;
 
 pub use builder::OLCheckpointBuilder;
-pub use context::{ProofNotify, ProverConfig};
+pub use context::{ProofNotify, ProverConfig, compute_epoch_preseal_da_diff};
 pub use handle::OLCheckpointWorkerHandle;


### PR DESCRIPTION
## Summary
- compute checkpoint DA witness bytes from preseal-only OL block execution, matching the state root authenticated by checkpoint proofs
- keep full epoch replay for logs/header validation so manifest processing is still checked separately
- fix OL chain tracker inbox range bookkeeping so non-empty ranges report the next inbox index after the last returned block, while empty ranges preserve the before-range index
- remove stale direct `strata` prover dependencies that became unused after sharing the checkpoint DA helper

## Bug / context
This addresses the Slack-reported OL prover failure:

`DA witness does not match authenticated preseal state root: ChainIntegrity`

The checkpoint proof authenticates the terminal block's `preseal_state_root`. That root is taken after normal OL block execution and before L1 manifest processing. The old prover input path built DA by replaying full OL blocks through `DaAccumulatingState`, which also includes terminal manifest processing. When a manifest mutates DA-tracked state, the witness describes the wrong transition:

```text
expected by proof: epoch_start -> preseal_state_root
old DA witness:    epoch_start -> post-manifest state
```

This is intermittent because empty manifests do not add extra writes. Real bridge activity makes the issue easier to hit because deposits, malformed deposits routed to limbo, and predicate-key updates can all change manifest-side OL state.

