### PR TITLE
fix(alpen-ee): build LedgerRefs from DA refs in prover instead of empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "bincode",
  "bitcoin",
  "eyre",
+ "futures",
  "mockall",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -4,11 +4,17 @@
 //! `fetch_input` reads chunk receipts (from the shared paas
 //! `ReceiptStore`) and the prior batch's end-state, then assembles
 //! `ee_acct_runtime::PrivateInput` + `snark_acct_runtime::PrivateInput`.
-use std::{collections::HashMap, fmt, sync::Arc};
+//!
+//! `LedgerRefs` are derived from the batch's DA refs using the same
+//! canonical L1 header commitment and MMR-index mapping as the OL
+//! submitter — they must be byte-identical for the verifier-side claim
+//! reconstruction to match the prover-committed pub-params SSZ.
+
+use std::{fmt, sync::Arc};
 
 use alpen_ee_common::{
-    BatchId, BatchStatus, BatchStorage, ExecBlockStorage, L1DaBlockRef, OLClientError,
-    SequencerOLClient, Storage,
+    build_ledger_refs_from_da, BatchId, BatchStatus, BatchStorage, ExecBlockStorage, L1DaBlockRef,
+    LedgerRefsError, SequencerOLClient, Storage,
 };
 use alpen_ee_database::EeNodeStorage;
 use async_trait::async_trait;
@@ -24,8 +30,7 @@ use strata_paas::{ProofSpec, ProverError as PaasError, ProverResult, ReceiptStor
 use strata_proofimpl_alpen_acct::{EeAcctProgram, EeAcctProofInput};
 use strata_snark_acct_runtime::{Coinput, IInnerState, PrivateInput as UpdatePrivateInput};
 use strata_snark_acct_types::{
-    AccumulatorClaim, LedgerRefs, OutputMessage, OutputTransfer, ProofState, UpdateOutputs,
-    UpdateProofPubParams,
+    OutputMessage, OutputTransfer, ProofState, UpdateOutputs, UpdateProofPubParams,
 };
 
 use super::ChunkTask;
@@ -115,19 +120,6 @@ enum AcctProofInputError {
         batch_id: BatchId,
         status: &'static str,
     },
-
-    #[error("failed to get L1 header commitment (height {height}, {source})")]
-    GetL1HeaderCommitment {
-        height: L1Height,
-        #[source]
-        source: OLClientError,
-    },
-
-    #[error("missing L1 header commitment (height {height})")]
-    MissingL1HeaderCommitment { height: L1Height },
-
-    #[error("L1 height before MMR start offset (height {height}, offset {mmr_offset})")]
-    L1HeightBeforeMmrStart { height: L1Height, mmr_offset: u64 },
 }
 
 impl From<AcctProofInputError> for PaasError {
@@ -136,14 +128,9 @@ impl From<AcctProofInputError> for PaasError {
         match error {
             AcctProofInputError::ReadParentExecBlock { .. }
             | AcctProofInputError::ReadBestEeAccountState { .. } => PaasError::Storage(message),
-            AcctProofInputError::L1HeightBeforeMmrStart { .. } => {
-                PaasError::PermanentFailure(message)
-            }
             AcctProofInputError::NoEeAccountState
             | AcctProofInputError::EePreStateUnavailable { .. }
-            | AcctProofInputError::BatchMissingDaRefs { .. }
-            | AcctProofInputError::GetL1HeaderCommitment { .. }
-            | AcctProofInputError::MissingL1HeaderCommitment { .. } => {
+            | AcctProofInputError::BatchMissingDaRefs { .. } => {
                 PaasError::TransientFailure(message)
             }
         }
@@ -379,7 +366,16 @@ impl ProofSpec for AcctSpec {
         let extra_data_bytes = encode_to_vec(&extra_data)
             .map_err(|e| PaasError::PermanentFailure(format!("encode extra data: {e}")))?;
         let ledger_refs =
-            build_ledger_refs(&da_refs, self.ol_client.as_ref(), self.genesis_l1_height).await?;
+            build_ledger_refs_from_da(&da_refs, self.ol_client.as_ref(), self.genesis_l1_height)
+                .await
+                .map_err(|e| match e {
+                    LedgerRefsError::FetchCommitment { .. } => PaasError::TransientFailure(
+                        format!("build ledger refs for batch {batch_id}: {e}"),
+                    ),
+                    LedgerRefsError::OffsetUnderflow { .. } => PaasError::PermanentFailure(
+                        format!("build ledger refs for batch {batch_id}: {e}"),
+                    ),
+                })?;
 
         let pub_params = UpdateProofPubParams::new(
             cur_state,
@@ -430,46 +426,6 @@ fn da_refs_from_status(batch_id: BatchId, status: BatchStatus) -> ProverResult<V
         }
         .into()),
     }
-}
-
-async fn build_ledger_refs(
-    da_refs: &[L1DaBlockRef],
-    ol_client: &(dyn SequencerOLClient + Send + Sync),
-    genesis_l1_height: L1Height,
-) -> ProverResult<LedgerRefs> {
-    let mut heights: Vec<L1Height> = da_refs.iter().map(|da_ref| da_ref.block.height()).collect();
-    heights.sort_unstable();
-    heights.dedup();
-
-    let mut l1_header_commitments = HashMap::with_capacity(heights.len());
-    for height in heights {
-        let hash = ol_client
-            .get_l1_header_commitment(height)
-            .await
-            .map_err(|source| AcctProofInputError::GetL1HeaderCommitment { height, source })?;
-        l1_header_commitments.insert(height, hash);
-    }
-
-    let mmr_offset = genesis_l1_height as u64 + 1;
-    let mut l1_header_refs = da_refs
-        .iter()
-        .map(|da_ref| {
-            let height = da_ref.block.height();
-            let hash = l1_header_commitments
-                .get(&height)
-                .copied()
-                .ok_or_else(|| AcctProofInputError::MissingL1HeaderCommitment { height })?;
-            let mmr_idx = (height as u64).checked_sub(mmr_offset).ok_or_else(|| {
-                AcctProofInputError::L1HeightBeforeMmrStart { height, mmr_offset }
-            })?;
-
-            Ok(AccumulatorClaim::new(mmr_idx, *hash.as_ref()))
-        })
-        .collect::<ProverResult<Vec<_>>>()?;
-    l1_header_refs.sort_by_key(|claim| claim.idx());
-    l1_header_refs.dedup_by_key(|claim| claim.idx());
-
-    Ok(LedgerRefs::new(l1_header_refs))
 }
 
 /// Decodes a `ChunkInput`'s transition bytes. `PermanentFailure` on malformed.

--- a/crates/alpen-ee/common/Cargo.toml
+++ b/crates/alpen-ee/common/Cargo.toml
@@ -29,6 +29,7 @@ async-trait.workspace = true
 bincode.workspace = true
 bitcoin.workspace = true
 eyre.workspace = true
+futures.workspace = true
 mockall = { workspace = true, optional = true }
 reth-ethereum-engine-primitives.workspace = true
 reth-ethereum-primitives.workspace = true

--- a/crates/alpen-ee/common/src/lib.rs
+++ b/crates/alpen-ee/common/src/lib.rs
@@ -51,4 +51,5 @@ pub use types::{
 pub use utils::{
     clock::{Clock, SystemClock},
     conversions::sats_to_gwei,
+    ledger_refs::{build_ledger_refs_from_da, LedgerRefsError},
 };

--- a/crates/alpen-ee/common/src/utils/ledger_refs.rs
+++ b/crates/alpen-ee/common/src/utils/ledger_refs.rs
@@ -41,25 +41,23 @@ pub enum LedgerRefsError {
 /// `ol_client`, maps it to its MMR leaf index using `genesis_l1_height + 1`
 /// as the offset, then sorts and dedups by index (multiple DA txns may
 /// land in one L1 block).
-pub async fn build_ledger_refs_from_da<C>(
+///
+/// The `?Sized` relaxation on the `impl SequencerOLClient` bound is
+/// required so that callers may pass a `&dyn SequencerOLClient`; the
+/// implicit `Sized` bound on `impl Trait` would otherwise reject it.
+pub async fn build_ledger_refs_from_da(
     da_refs: &[L1DaBlockRef],
-    ol_client: &C,
+    ol_client: &(impl SequencerOLClient + ?Sized),
     genesis_l1_height: L1Height,
-) -> Result<LedgerRefs, LedgerRefsError>
-where
-    C: SequencerOLClient + Send + Sync + ?Sized,
-{
+) -> Result<LedgerRefs, LedgerRefsError> {
     let l1_header_commitments = fetch_l1_header_commitments_by_height(da_refs, ol_client).await?;
     build_ledger_refs(da_refs, &l1_header_commitments, genesis_l1_height)
 }
 
-async fn fetch_l1_header_commitments_by_height<C>(
+async fn fetch_l1_header_commitments_by_height(
     da_refs: &[L1DaBlockRef],
-    ol_client: &C,
-) -> Result<HashMap<L1Height, Hash>, LedgerRefsError>
-where
-    C: SequencerOLClient + Send + Sync + ?Sized,
-{
+    ol_client: &(impl SequencerOLClient + ?Sized),
+) -> Result<HashMap<L1Height, Hash>, LedgerRefsError> {
     let mut heights: Vec<L1Height> = da_refs.iter().map(|da_ref| da_ref.block.height()).collect();
     heights.sort_unstable();
     heights.dedup();

--- a/crates/alpen-ee/common/src/utils/ledger_refs.rs
+++ b/crates/alpen-ee/common/src/utils/ledger_refs.rs
@@ -1,0 +1,106 @@
+//! Canonical [`LedgerRefs`] construction from a batch's DA refs.
+//!
+//! Used by both the OL submitter (when building the on-chain SAU
+//! transaction) and the prover (when assembling pub-params for the
+//! update proof). The two paths MUST produce byte-identical
+//! [`LedgerRefs`] — otherwise the verifier's claim reconstruction won't
+//! match the prover-committed pub-params SSZ and Groth16 verification
+//! will fail.
+
+use std::collections::HashMap;
+
+use futures::future::try_join_all;
+use strata_acct_types::Hash;
+use strata_identifiers::L1Height;
+use strata_snark_acct_types::{AccumulatorClaim, LedgerRefs};
+
+use crate::{
+    traits::ol_client::{OLClientError, SequencerOLClient},
+    types::batch::L1DaBlockRef,
+};
+
+/// Errors produced when building [`LedgerRefs`] from a batch's DA refs.
+#[derive(Debug, thiserror::Error)]
+pub enum LedgerRefsError {
+    /// Failed to fetch the canonical L1 header commitment for a given height.
+    #[error("get_l1_header_commitment({height}): {source}")]
+    FetchCommitment {
+        height: L1Height,
+        #[source]
+        source: OLClientError,
+    },
+
+    /// An L1 height in the DA refs is before the configured MMR start offset.
+    #[error("L1 height {height} is before MMR start offset {mmr_offset}")]
+    OffsetUnderflow { height: L1Height, mmr_offset: u64 },
+}
+
+/// Builds canonical [`LedgerRefs`] from `da_refs`.
+///
+/// Resolves each L1 height to its canonical L1 header commitment via
+/// `ol_client`, maps it to its MMR leaf index using `genesis_l1_height + 1`
+/// as the offset, then sorts and dedups by index (multiple DA txns may
+/// land in one L1 block).
+pub async fn build_ledger_refs_from_da<C>(
+    da_refs: &[L1DaBlockRef],
+    ol_client: &C,
+    genesis_l1_height: L1Height,
+) -> Result<LedgerRefs, LedgerRefsError>
+where
+    C: SequencerOLClient + Send + Sync + ?Sized,
+{
+    let l1_header_commitments = fetch_l1_header_commitments_by_height(da_refs, ol_client).await?;
+    build_ledger_refs(da_refs, &l1_header_commitments, genesis_l1_height)
+}
+
+async fn fetch_l1_header_commitments_by_height<C>(
+    da_refs: &[L1DaBlockRef],
+    ol_client: &C,
+) -> Result<HashMap<L1Height, Hash>, LedgerRefsError>
+where
+    C: SequencerOLClient + Send + Sync + ?Sized,
+{
+    let mut heights: Vec<L1Height> = da_refs.iter().map(|da_ref| da_ref.block.height()).collect();
+    heights.sort_unstable();
+    heights.dedup();
+
+    let pairs = try_join_all(heights.into_iter().map(|height| async move {
+        let hash = ol_client
+            .get_l1_header_commitment(height)
+            .await
+            .map_err(|source| LedgerRefsError::FetchCommitment { height, source })?;
+        Ok::<_, LedgerRefsError>((height, hash))
+    }))
+    .await?;
+
+    Ok(pairs.into_iter().collect())
+}
+
+fn build_ledger_refs(
+    da_refs: &[L1DaBlockRef],
+    l1_header_commitments: &HashMap<L1Height, Hash>,
+    genesis_l1_height: L1Height,
+) -> Result<LedgerRefs, LedgerRefsError> {
+    let mmr_offset = genesis_l1_height as u64 + 1;
+    let mut l1_header_refs: Vec<AccumulatorClaim> = da_refs
+        .iter()
+        .map(|da_ref| {
+            let height = da_ref.block.height();
+            // `fetch_l1_header_commitments_by_height` populates an entry for
+            // every height present in `da_refs`, so a miss here is a bug, not
+            // a transient error — leave it as an `expect` to surface that.
+            let hash = *l1_header_commitments
+                .get(&height)
+                .expect("commitment map covers every DA-ref height");
+            let mmr_idx = (height as u64)
+                .checked_sub(mmr_offset)
+                .ok_or(LedgerRefsError::OffsetUnderflow { height, mmr_offset })?;
+            Ok(AccumulatorClaim::new(mmr_idx, *hash.as_ref()))
+        })
+        .collect::<Result<Vec<_>, LedgerRefsError>>()?;
+
+    l1_header_refs.sort_by_key(|c| c.idx());
+    l1_header_refs.dedup_by_key(|c| c.idx());
+
+    Ok(LedgerRefs::new(l1_header_refs))
+}

--- a/crates/alpen-ee/common/src/utils/mod.rs
+++ b/crates/alpen-ee/common/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod clock;
 pub(crate) mod conversions;
+pub(crate) mod ledger_refs;

--- a/crates/alpen-ee/sequencer/src/update_submitter/task.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/task.rs
@@ -69,7 +69,7 @@ pub async fn create_update_submitter_task<C, S, ES, P>(
     mut ol_status_rx: watch::Receiver<OLFinalizedStatus>,
     genesis_l1_height: L1Height,
 ) where
-    C: SequencerOLClient,
+    C: SequencerOLClient + Send + Sync,
     S: BatchStorage,
     ES: ExecBlockStorage,
     P: BatchProver,
@@ -133,7 +133,7 @@ pub async fn create_update_submitter_task<C, S, ES, P>(
 /// batches in storage starting from the next expected sequence number. For each
 /// batch in `ProofReady` state, it builds and submits an update.
 async fn process_ready_batches(
-    ol_client: &impl SequencerOLClient,
+    ol_client: &(impl SequencerOLClient + Send + Sync),
     batch_storage: &impl BatchStorage,
     exec_storage: &impl ExecBlockStorage,
     prover: &impl BatchProver,

--- a/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use alpen_ee_common::{
-    Batch, BatchProver, ExecBlockRecord, ExecBlockStorage, L1DaBlockRef, ProofId, SequencerOLClient,
+    build_ledger_refs_from_da, Batch, BatchProver, ExecBlockRecord, ExecBlockStorage,
+    L1DaBlockRef, ProofId, SequencerOLClient,
 };
 use eyre::{eyre, OptionExt, Result};
 use futures::{future::try_join_all, FutureExt};
@@ -10,7 +9,7 @@ use strata_codec::encode_to_vec;
 use strata_ee_acct_types::UpdateExtraData;
 use strata_identifiers::L1Height;
 use strata_snark_acct_types::{
-    AccumulatorClaim, LedgerRefs, OutputMessage, OutputTransfer, ProofState, SnarkAccountUpdate,
+    LedgerRefs, OutputMessage, OutputTransfer, ProofState, SnarkAccountUpdate,
     UpdateOperationData, UpdateOutputs,
 };
 use tree_hash::{Sha256Hasher, TreeHash};
@@ -20,7 +19,7 @@ pub(super) async fn build_update_from_batch(
     batch: &Batch,
     da_refs: &[L1DaBlockRef],
     proof_id: &ProofId,
-    ol_client: &impl SequencerOLClient,
+    ol_client: &(impl SequencerOLClient + Send + Sync),
     exec_storage: &impl ExecBlockStorage,
     prover: &impl BatchProver,
     genesis_l1_height: L1Height,
@@ -47,14 +46,10 @@ pub(super) async fn build_update_from_batch(
         .checked_sub(1)
         .ok_or_else(|| eyre!("cannot build update for genesis batch"))?;
 
-    let l1_header_commitments = fetch_l1_header_commitments_by_height(da_refs, ol_client).await?;
-    let update_operation = build_update_operation(
-        seq_no,
-        da_refs,
-        &l1_header_commitments,
-        blocks,
-        genesis_l1_height,
-    )?;
+    // Ledger refs MUST be byte-identical to what the prover commits — see
+    // `build_ledger_refs_from_da` in alpen-ee-common.
+    let ledger_refs = build_ledger_refs_from_da(da_refs, ol_client, genesis_l1_height).await?;
+    let update_operation = build_update_operation(seq_no, ledger_refs, blocks)?;
 
     // Should we re-check that proof is valid ?
 
@@ -64,35 +59,11 @@ pub(super) async fn build_update_from_batch(
     ))
 }
 
-async fn fetch_l1_header_commitments_by_height(
-    da_refs: &[L1DaBlockRef],
-    ol_client: &impl SequencerOLClient,
-) -> Result<HashMap<L1Height, Hash>> {
-    let mut heights: Vec<L1Height> = da_refs.iter().map(|da_ref| da_ref.block.height()).collect();
-    heights.sort_unstable();
-    heights.dedup();
-
-    let l1_header_commitments = try_join_all(
-        heights
-            .into_iter()
-            .map(|height| async move {
-                let hash = ol_client.get_l1_header_commitment(height).await?;
-                Ok::<_, eyre::Error>((height, hash))
-            })
-            .collect::<Vec<_>>(),
-    )
-    .await?;
-
-    Ok(l1_header_commitments.into_iter().collect())
-}
-
 /// Build an [`UpdateOperationData`] from data in a batch.
 fn build_update_operation(
     seq_no: u64,
-    da_refs: &[L1DaBlockRef],
-    l1_header_commitments: &HashMap<L1Height, Hash>,
+    ledger_refs: LedgerRefs,
     blocks: Vec<ExecBlockRecord>,
-    genesis_l1_height: L1Height,
 ) -> Result<UpdateOperationData> {
     // 1. Get info from final block
     let (inner_state, new_tip_blkid, next_inbox_msg_idx) = {
@@ -136,31 +107,7 @@ fn build_update_operation(
     let extra_data = UpdateExtraData::new(new_tip_blkid, processed_inputs as u32, 0);
     let extra_data_buf = encode_to_vec(&extra_data)?;
 
-    // 4. Build ledger refs from DA block references. The claim idx must be the MMR leaf index (not
-    //    the raw L1 height), since the OL STF verifier uses it directly as the position in the ASM
-    //    manifests MMR. The offset is `genesis_l1_height + 1` (the first manifest is for the block
-    //    after genesis).
-    let mmr_offset = genesis_l1_height as u64 + 1;
-    let mut l1_header_refs: Vec<AccumulatorClaim> = da_refs
-        .iter()
-        .map(|da_ref| {
-            let height = da_ref.block.height();
-            let hash = l1_header_commitments
-                .get(&height)
-                .copied()
-                .ok_or_else(|| eyre!("missing L1 header commitment for L1 height {height}"))?;
-            let mmr_idx = (height as u64).checked_sub(mmr_offset).ok_or_else(|| {
-                eyre!("L1 height {height} is before MMR start offset {mmr_offset}")
-            })?;
-            Ok(AccumulatorClaim::new(mmr_idx, *hash.as_ref()))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    // Canonicalize by MMR index before dedup: multiple DA txns may land in the same L1 block.
-    l1_header_refs.sort_by_key(|c| c.idx());
-    l1_header_refs.dedup_by_key(|c| c.idx());
-    let ledger_refs = LedgerRefs::new(l1_header_refs);
-
-    // 5. Build update operation
+    // 4. Build update operation
     let update = UpdateOperationData::new(
         seq_no,
         ProofState::new(inner_state, next_inbox_msg_idx),

--- a/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
+++ b/crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs
@@ -1,6 +1,6 @@
 use alpen_ee_common::{
-    build_ledger_refs_from_da, Batch, BatchProver, ExecBlockRecord, ExecBlockStorage,
-    L1DaBlockRef, ProofId, SequencerOLClient,
+    build_ledger_refs_from_da, Batch, BatchProver, ExecBlockRecord, ExecBlockStorage, L1DaBlockRef,
+    ProofId, SequencerOLClient,
 };
 use eyre::{eyre, OptionExt, Result};
 use futures::{future::try_join_all, FutureExt};
@@ -9,8 +9,8 @@ use strata_codec::encode_to_vec;
 use strata_ee_acct_types::UpdateExtraData;
 use strata_identifiers::L1Height;
 use strata_snark_acct_types::{
-    LedgerRefs, OutputMessage, OutputTransfer, ProofState, SnarkAccountUpdate,
-    UpdateOperationData, UpdateOutputs,
+    LedgerRefs, OutputMessage, OutputTransfer, ProofState, SnarkAccountUpdate, UpdateOperationData,
+    UpdateOutputs,
 };
 use tree_hash::{Sha256Hasher, TreeHash};
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
Fixes the prover's `AcctSpec::fetch_input` to actually populate `LedgerRefs` from the batch's DA refs. Previously it submitted an empty `LedgerRefs`, so the OL STF verifier's claim reconstruction could not match the prover-committed pub-params SSZ and Groth16 verification failed for any batch with DA refs.
- Extracts the canonical construction (DA refs → L1 header commitments → MMR-indexed `AccumulatorClaim`s, sorted/deduped by index) into a new shared helper `build_ledger_refs_from_da` in [`alpen-ee-common`](crates/alpen-ee/common/src/utils/ledger_refs.rs), and routes both the prover ([`spec_acct.rs`](bin/alpen-client/src/prover/spec_acct.rs)) and the OL update submitter ([`update_builder.rs`](crates/alpen-ee/sequencer/src/update_submitter/update_builder.rs)) through it, so the two paths cannot drift again.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
