### PR TITLE
STR 3378 Update epoch sealing in block assembly to correctly fetch ASM manifests

### DIFF
--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -353,9 +353,8 @@ where
 
 /// Fetches ASM manifests for a terminal block using `BlockAssemblyAnchorContext`.
 ///
-/// Terminal blocks need to include all L1 blocks processed since the last terminal block.
-/// This function fetches manifests from `parent_state.last_l1_height() + 1` up to the latest
-/// available L1 block.
+/// Terminal blocks include up to [`MAX_SEALING_MANIFEST_COUNT`] L1 blocks processed since the
+/// last terminal block.
 async fn fetch_asm_manifests_for_terminal_block<
     C: BlockAssemblyAnchorContext,
     S: IStateAccessor,
@@ -364,10 +363,14 @@ async fn fetch_asm_manifests_for_terminal_block<
     parent_state: &S,
 ) -> BlockAssemblyResult<Option<OLL1ManifestContainer>> {
     let last_l1_height = parent_state.last_l1_height();
-    let start_height = last_l1_height + 1;
+    let start_height = last_l1_height
+        .checked_add(1)
+        .ok_or_else(|| BlockAssemblyError::Other("l1 height overflow".to_string()))?;
 
     // Fetch manifests using BlockAssemblyAnchorContext trait
-    let manifests = ctx.fetch_asm_manifests_from(start_height).await?;
+    let manifests = ctx
+        .fetch_asm_manifests_from(start_height, MAX_SEALING_MANIFEST_COUNT as u32)
+        .await?;
 
     let total_logs: usize = manifests.iter().map(|m| m.logs().len()).sum();
     debug!(
@@ -828,14 +831,16 @@ mod tests {
 
     use strata_acct_types::*;
     use strata_asm_proto_checkpoint_types::MAX_OL_LOGS_PER_CHECKPOINT;
-    use strata_identifiers::{Buf32, L1Height, OLBlockId};
-    use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, OLLog};
+    use strata_identifiers::{Buf32, L1BlockId, L1Height, OLBlockId};
+    use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, MAX_SEALING_MANIFEST_COUNT, OLLog};
     use strata_ol_state_support_types::MemoryStateBaseLayer;
 
     use super::*;
     use crate::test_utils::*;
 
     type OlWriteBatch = WriteBatch<<MemoryStateBaseLayer as IStateAccessor>::AccountState>;
+
+    const SEALING_MANIFEST_CAP: L1Height = MAX_SEALING_MANIFEST_COUNT as L1Height;
 
     async fn build_process_tx_env(account_id: AccountId) -> TestEnv {
         let env_builder = TestStorageFixtureBuilder::new()
@@ -1561,6 +1566,129 @@ mod tests {
         check_block_slot_epoch(&block_template, 10, 1);
         // After genesis processes manifest 1, only manifests 2 and 3 remain
         check_terminal_block_with_manifests(&block_template, &[2, 3]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_block_below_max_sealing_manifests() {
+        let manifest_count = SEALING_MANIFEST_CAP - 1;
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_genesis_parent_and_l1_manifest_count(manifest_count);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let parent_l1_height = env.parent_last_l1_height().await;
+        let output = env
+            .construct_empty_block()
+            .await
+            .expect("terminal block generation should succeed");
+
+        let expected_heights: Vec<L1Height> =
+            ((parent_l1_height + 1)..=(parent_l1_height + manifest_count)).collect();
+        check_terminal_block_with_manifests(&output.template, &expected_heights);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_block_caps_at_max_sealing_manifests() {
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP + 1);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let parent_l1_height = env.parent_last_l1_height().await;
+        let output = env
+            .construct_empty_block()
+            .await
+            .expect("terminal block generation should succeed");
+
+        let expected_heights: Vec<L1Height> =
+            ((parent_l1_height + 1)..=(parent_l1_height + SEALING_MANIFEST_CAP)).collect();
+        check_terminal_block_with_manifests(&output.template, &expected_heights);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_block_at_exact_max_boundary() {
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let parent_l1_height = env.parent_last_l1_height().await;
+        let output = env
+            .construct_empty_block()
+            .await
+            .expect("terminal block generation should succeed");
+
+        let expected_heights: Vec<L1Height> =
+            ((parent_l1_height + 1)..=(parent_l1_height + SEALING_MANIFEST_CAP)).collect();
+        check_terminal_block_with_manifests(&output.template, &expected_heights);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_consecutive_terminal_blocks_drain_backlog() {
+        let rollover_count: L1Height = 2;
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP + rollover_count);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let first_parent_l1_height = env.parent_last_l1_height().await;
+        let first_output = env
+            .construct_empty_block()
+            .await
+            .expect("first terminal block generation should succeed");
+        let first_expected_heights: Vec<L1Height> = ((first_parent_l1_height + 1)
+            ..=(first_parent_l1_height + SEALING_MANIFEST_CAP))
+            .collect();
+        check_terminal_block_with_manifests(&first_output.template, &first_expected_heights);
+        env.persist(&first_output).await;
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 20).await;
+        let second_parent_l1_height = env.parent_last_l1_height().await;
+        let second_output = env
+            .construct_empty_block()
+            .await
+            .expect("second terminal block generation should succeed");
+        let second_expected_heights: Vec<L1Height> =
+            ((second_parent_l1_height + 1)..=(second_parent_l1_height + rollover_count)).collect();
+        check_terminal_block_with_manifests(&second_output.template, &second_expected_heights);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminal_fetch_stops_at_cap() {
+        let env_builder = TestStorageFixtureBuilder::new()
+            .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP + 1);
+        let (fixture, parent_commitment) = env_builder.build_fixture().await;
+        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+        let parent_l1_height = env.parent_last_l1_height().await;
+        let first_height_past_cap = parent_l1_height + SEALING_MANIFEST_CAP + 1;
+
+        let missing_manifest_blkid = L1BlockId::from(Buf32::from([0xCD; 32]));
+        env.storage()
+            .l1()
+            .revert_canonical_chain_async(first_height_past_cap - 1)
+            .await
+            .expect("revert L1 canonical chain to cap boundary");
+        env.storage()
+            .l1()
+            .extend_canonical_chain_async(&missing_manifest_blkid, first_height_past_cap)
+            .await
+            .expect("insert missing-manifest canonical entry past cap");
+        // ASM tip still points at the original height's blkid; the fetch path only reads its
+        // height.
+
+        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let output = env
+            .construct_empty_block()
+            .await
+            .expect("terminal block generation should not read past cap");
+
+        let expected_heights: Vec<L1Height> =
+            ((parent_l1_height + 1)..=(parent_l1_height + SEALING_MANIFEST_CAP)).collect();
+        check_terminal_block_with_manifests(&output.template, &expected_heights);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -71,10 +71,11 @@ pub trait BlockAssemblyAnchorContext: Send + Sync + 'static {
         tip: OLBlockCommitment,
     ) -> BlockAssemblyResult<Option<Arc<Self::State>>>;
 
-    /// Fetch ASM manifests from `start_height` to latest (ascending).
+    /// Fetch ASM manifests from `start_height`, returning at most `max_count` in ascending order.
     async fn fetch_asm_manifests_from(
         &self,
         start_height: L1Height,
+        max_count: u32,
     ) -> BlockAssemblyResult<Vec<AsmManifest>>;
 }
 
@@ -177,8 +178,13 @@ where
     async fn fetch_asm_manifests_from(
         &self,
         start_height: L1Height,
+        max_count: u32,
     ) -> BlockAssemblyResult<Vec<AsmManifest>> {
-        let end_height = match self
+        if max_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let asm_tip_height = match self
             .storage
             .asm()
             .fetch_most_recent_state()
@@ -187,6 +193,7 @@ where
             Some((commitment, _)) => commitment.height(),
             None => return Ok(Vec::new()),
         };
+        let end_height = asm_tip_height.min(start_height.saturating_add(max_count - 1));
 
         if start_height > end_height {
             return Ok(Vec::new());

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -795,6 +795,8 @@ pub(crate) struct TestStorageFixture {
     inbox_message_claims: Vec<(AccountId, Vec<AccumulatorClaim>)>,
 }
 
+const GENESIS_L1_MANIFEST_HEIGHT: L1Height = 1;
+
 impl TestStorageFixture {
     /// Creates a new fixture from storage.
     pub(crate) fn new(storage: Arc<NodeStorage>) -> Self {
@@ -877,6 +879,16 @@ impl TestEnv {
     /// Returns parent commitment used by default assembly entrypoints.
     pub(crate) fn parent_commitment(&self) -> OLBlockCommitment {
         self.parent_commitment
+    }
+
+    /// Returns the current parent state's last processed L1 height.
+    pub(crate) async fn parent_last_l1_height(&self) -> L1Height {
+        self.ctx()
+            .fetch_state_for_tip(self.parent_commitment())
+            .await
+            .expect("fetch parent state")
+            .expect("parent state exists")
+            .last_l1_height()
     }
 
     /// Returns storage handle for storage-backed test setup helpers.
@@ -1109,6 +1121,14 @@ impl TestStorageFixtureBuilder {
         self
     }
 
+    /// Uses the slot-0 genesis parent and seeds `count` L1 manifests after it.
+    pub(crate) fn with_genesis_parent_and_l1_manifest_count(mut self, count: L1Height) -> Self {
+        self.parent_slot = Some(0);
+        self.l1_manifest_height_range =
+            Some(GENESIS_L1_MANIFEST_HEIGHT..=GENESIS_L1_MANIFEST_HEIGHT + count);
+        self
+    }
+
     /// Seeds L1 header refs for the provided L1 heights.
     pub(crate) fn with_l1_header_refs(
         mut self,
@@ -1246,9 +1266,9 @@ impl TestStorageFixtureBuilder {
                 // Slot 0 is genesis - create terminal block
                 let block_info = BlockInfo::new_genesis(1000000);
 
-                // Create genesis manifest at height 1 (when last_l1_height is 0)
+                // Create genesis manifest when last_l1_height is 0.
                 let genesis_manifest = AsmManifest::new(
-                    1,
+                    GENESIS_L1_MANIFEST_HEIGHT,
                     L1BlockId::from(Buf32::zero()),
                     WtxidsRoot::from(Buf32::zero()),
                     vec![],

--- a/crates/ol/chain-types/ssz/block.ssz
+++ b/crates/ol/chain-types/ssz/block.ssz
@@ -5,7 +5,7 @@ import block_flags
 
 MAX_TXS_PER_BLOCK = 1 << 16
 MAX_LOGS_PER_BLOCK = 1 << 12
-MAX_SEALING_MANIFEST_COUNT = 144
+MAX_SEALING_MANIFEST_COUNT = 2048
 
 ### OL Block header without signature.
 ###


### PR DESCRIPTION
## Description

Terminal block assembly now bounds ASM manifest fetching to `MAX_SEALING_MANIFEST_COUNT` before constructing `OLL1ManifestContainer`.

This prevents large L1 backlogs from causing terminal block assembly to fail with `TooManyManifests`; backlog manifests now drain over subsequent epochs.

Changes:
- Adds a `max_count` bound to `BlockAssemblyAnchorContext::fetch_asm_manifests_from`.
- Caps terminal block manifest fetches at `MAX_SEALING_MANIFEST_COUNT` set to 2048.
- Handles L1 height overflow defensively.
- Keeps `OLL1ManifestContainer::new` as the final cap check.
- Adds tests for cap behavior, exact boundary behavior, backlog rollover, bounded storage reads, and non-empty deposit manifest processing.
- Updates the epoch manifest plan/risks doc.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3378](https://alpenlabs.atlassian.net/browse/STR-3378)

[STR-3378]: https://alpenlabs.atlassian.net/browse/STR-3378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ