### PR TITLE
fix(btcio): ensure minimum fee rate of 1 sat/vB

### DIFF
--- a/crates/btcio/src/writer/fees.rs
+++ b/crates/btcio/src/writer/fees.rs
@@ -90,27 +90,35 @@ pub(crate) async fn resolve_fee_rate<R: Reader>(
     config: &WriterConfig,
 ) -> anyhow::Result<u64> {
     let fee_rate = match config.fee_policy() {
-        FeePolicy::BitcoinD { conf_target } => client
-            .estimate_smart_fee(*conf_target)
-            .await
-            .context("failed to estimate smart fee"),
+        // NOTE(STR-2545, STR-2433): fee estimation is currently being doubled since we don't fully
+        //                           support fee bumping ostensive mechanisms for making sure
+        //                           transactions confirm in a timely manner. This is a temporary
+        //                           measure until we implement more robust fee bumping strategies,
+        //                           at which point we can remove the doubling and rely on the fee
+        //                           policies to provide accurate fee rates.
+        // NOTE(STR-2018): ensure fee is at least 1 sat/vB to avoid zero fee transactions.
+        //                 This will be revised once we support sub 1 sat/vB fee rates.
+        FeePolicy::BitcoinD { conf_target } => {
+            let fee_estimate = client
+                .estimate_smart_fee(*conf_target)
+                .await
+                .context("failed to estimate smart fee")?;
+            u64::max(fee_estimate, 1) * 2
+        }
         FeePolicy::MempoolExplorer {
             policy,
             mempool_base_url,
             fallback_conf_target,
         } => {
-            resolve_mempool_fee_rate(client, mempool_base_url, *fallback_conf_target, *policy).await
+            let fee_estimate =
+                resolve_mempool_fee_rate(client, mempool_base_url, *fallback_conf_target, *policy)
+                    .await?;
+            u64::max(fee_estimate, 1) * 2
         }
-        FeePolicy::Fixed { fee_rate } => Ok(*fee_rate),
-    }?;
+        FeePolicy::Fixed { fee_rate } => *fee_rate,
+    };
 
-    // NOTE(STR-2545, STR-2433): fee estimation is currently being doubled since we don't fully
-    //                           support fee bumping ostensive mechanisms for making sure
-    //                           transactions confirm in a timely manner. This is a temporary
-    //                           measure until we implement more robust fee bumping strategies,
-    //                           at which point we can remove the doubling and rely on the fee
-    //                           policies to provide accurate fee rates.
-    Ok(fee_rate * 2)
+    Ok(fee_rate)
 }
 
 /// Resolves the fee rate using the mempool explorer recommended fees endpoint, falling back to


### PR DESCRIPTION
## Description

Ensures that btcio writer when estimating fees from mempool explorer or bitcoin core (`bitcoind`’s `estimatesmartfee`) returns at least 1 sat/vB.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This also corrects an incorrect doubling of the fee estimate when using the fixed fee policy.

No AI was used

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues