### PR TITLE
fix: parameterize bridge denom and withdrawal cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15109,6 +15109,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "serde",
+ "serde_json",
  "ssz",
  "ssz_derive",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1046,6 +1046,7 @@ dependencies = [
  "shrex",
  "sled",
  "strata-asm-proto-bridge-v1-txs",
+ "strata-bridge-params",
  "strata-cli-common",
  "strata-identifiers",
  "strata-l1-txfmt",
@@ -1108,6 +1109,7 @@ dependencies = [
  "rsp-primitives",
  "ssz",
  "strata-acct-types",
+ "strata-bridge-params",
  "strata-btcio",
  "strata-codec",
  "strata-common",
@@ -1420,6 +1422,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "secp256k1 0.29.1",
+ "strata-bridge-params",
  "strata-crypto",
  "strata-identifiers",
  "strata-ol-bridge-types",
@@ -2790,7 +2793,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3581,7 +3584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7864,9 +7867,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -7901,9 +7904,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -9014,7 +9017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -9034,7 +9037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9047,7 +9050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15101,6 +15104,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-bridge-params"
+version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "serde",
+ "ssz",
+ "ssz_derive",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "strata-btc-types"
 version = "0.1.0"
 source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
@@ -15205,6 +15219,7 @@ dependencies = [
  "sled",
  "ssz",
  "strata-acct-types",
+ "strata-bridge-params",
  "strata-checkpoint-types",
  "strata-db-store-sled",
  "strata-db-types",
@@ -16008,6 +16023,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-manifest-types",
  "strata-asm-proto-checkpoint-types",
+ "strata-bridge-params",
  "strata-btc-verification",
  "strata-codec",
  "strata-common",
@@ -16121,6 +16137,7 @@ dependencies = [
  "proptest",
  "serde",
  "strata-asm-proto-checkpoint-types",
+ "strata-bridge-params",
  "strata-checkpoint-types",
  "strata-db-store-sled",
  "strata-identifiers",
@@ -16233,6 +16250,7 @@ dependencies = [
  "arbitrary",
  "serde",
  "serde_json",
+ "strata-bridge-params",
  "strata-btc-types",
  "strata-identifiers",
  "strata-predicate",
@@ -16385,6 +16403,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-proto-checkpoint-types",
+ "strata-bridge-params",
  "strata-codec",
  "strata-identifiers",
  "strata-ledger-types",
@@ -16492,11 +16511,13 @@ dependencies = [
 name = "strata-proofimpl-alpen-acct"
 version = "0.1.0"
 dependencies = [
+ "alpen-reth-evm",
  "k256",
  "reth-chainspec",
  "rkyv",
  "rsp-primitives",
  "ssz",
+ "strata-bridge-params",
  "strata-codec",
  "strata-ee-acct-runtime",
  "strata-ee-acct-types",
@@ -16513,6 +16534,7 @@ dependencies = [
 name = "strata-proofimpl-alpen-chunk"
 version = "0.1.0"
 dependencies = [
+ "alpen-reth-evm",
  "k256",
  "reth-chainspec",
  "reth-primitives-traits",
@@ -16523,6 +16545,7 @@ dependencies = [
  "serde_json",
  "ssz",
  "strata-acct-types",
+ "strata-bridge-params",
  "strata-codec",
  "strata-ee-acct-types",
  "strata-ee-chain-types",
@@ -16542,6 +16565,7 @@ dependencies = [
  "ssz_primitives",
  "strata-asm-manifest-types",
  "strata-asm-proto-checkpoint-types",
+ "strata-bridge-params",
  "strata-codec",
  "strata-crypto",
  "strata-da-framework",
@@ -16603,6 +16627,7 @@ dependencies = [
 name = "strata-provers-perf"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "alpen-reth-evm",
  "anyhow",
  "argh",
  "num-format",
@@ -16615,6 +16640,7 @@ dependencies = [
  "sp1-sdk",
  "ssz",
  "strata-acct-types",
+ "strata-bridge-params",
  "strata-codec",
  "strata-da-framework",
  "strata-ee-acct-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
   "crates/paas",
   "crates/prover-core",
   "crates/params",
+  "crates/bridge-params",
   "crates/primitives",
   "crates/proof-impl/evm-ee-stf",
   "crates/proof-impl/alpen-chunk",
@@ -159,6 +160,7 @@ alpen-reth-rpc = { path = "crates/reth/rpc" }
 alpen-reth-statediff = { path = "crates/reth/statediff" }
 alpen-reth-witness = { path = "crates/reth/witness" }
 strata-acct-types = { path = "crates/acct-types" }
+strata-bridge-params = { path = "crates/bridge-params" }
 strata-btcio = { path = "crates/btcio" }
 strata-chain-worker = { path = "crates/chain-worker" }
 strata-chain-worker-new = { path = "crates/chain-worker-new" }

--- a/bin/alpen-cli/Cargo.toml
+++ b/bin/alpen-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 alpen-reth-primitives.workspace = true
 strata-asm-proto-bridge-v1-txs.workspace = true
+strata-bridge-params.workspace = true
 strata-cli-common.workspace = true
 strata-identifiers.workspace = true
 strata-l1-txfmt.workspace = true

--- a/bin/alpen-cli/src/cmd/withdraw.rs
+++ b/bin/alpen-cli/src/cmd/withdraw.rs
@@ -11,6 +11,7 @@ use bdk_wallet::{
     KeychainKind,
 };
 use indicatif::ProgressBar;
+use strata_bridge_params::BridgeParams;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_ol_bridge_types::OperatorSelection;
 use strata_primitives::bitcoin_bosd::Descriptor;
@@ -86,8 +87,7 @@ pub async fn withdraw(
         }
     };
 
-    let denomination = settings.params.deposit_amount;
-    let bridge_out_amount = resolve_withdrawal_amount(args.amount, denomination)?;
+    let bridge_out_amount = resolve_withdrawal_amount(args.amount, &settings.bridge_params)?;
     println!("Bridging out {} to {address}", bridge_out_amount);
 
     let bosd: Descriptor = address
@@ -127,63 +127,74 @@ pub async fn withdraw(
     Ok(())
 }
 
-/// Resolves the withdrawal amount from an optional user-provided value and the denomination.
+/// Resolves the withdrawal amount from an optional user-provided value.
 ///
-/// Returns the validated amount, or a [`DisplayedError`] if the amount is invalid.
+/// Defaults to one denomination if no amount is provided.
 fn resolve_withdrawal_amount(
     amount_sats: Option<u64>,
-    denomination: Amount,
+    bridge_params: &BridgeParams,
 ) -> Result<Amount, DisplayedError> {
-    match amount_sats {
-        Some(sats) => {
-            if sats == 0 || !sats.is_multiple_of(denomination.to_sat()) {
-                return Err(DisplayedError::UserError(
-                    format!("Amount must be a positive multiple of {denomination}"),
-                    Box::new(()),
-                ));
-            }
-            Ok(Amount::from_sat(sats))
+    let sats = amount_sats.unwrap_or(bridge_params.denomination());
+    if !bridge_params.validate_withdrawal_amount(sats) {
+        let denom = bridge_params.denomination();
+        let mut msg = format!("Amount must be a positive multiple of {denom} sats");
+        if let Some(max) = bridge_params.max_withdrawal_amount() {
+            msg.push_str(&format!(" and at most {max} sats"));
         }
-        None => Ok(denomination),
+        return Err(DisplayedError::UserError(msg, Box::new(())));
     }
+    Ok(Amount::from_sat(sats))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const DENOM: Amount = Amount::from_sat(100_000_000); // 1 BTC
+    fn params() -> BridgeParams {
+        BridgeParams::new(100_000_000, Some(1_000_000_000)).unwrap()
+    }
 
     #[test]
     fn test_none_defaults_to_denomination() {
-        let result = resolve_withdrawal_amount(None, DENOM).unwrap();
-        assert_eq!(result, DENOM);
+        let result = resolve_withdrawal_amount(None, &params()).unwrap();
+        assert_eq!(result, Amount::from_sat(100_000_000));
     }
 
     #[test]
     fn test_exact_denomination_accepted() {
-        let result = resolve_withdrawal_amount(Some(100_000_000), DENOM).unwrap();
+        let result = resolve_withdrawal_amount(Some(100_000_000), &params()).unwrap();
         assert_eq!(result, Amount::from_sat(100_000_000));
     }
 
     #[test]
     fn test_exact_multiple_accepted() {
-        let result = resolve_withdrawal_amount(Some(300_000_000), DENOM).unwrap();
+        let result = resolve_withdrawal_amount(Some(300_000_000), &params()).unwrap();
         assert_eq!(result, Amount::from_sat(300_000_000));
     }
 
     #[test]
     fn test_zero_rejected() {
-        assert!(resolve_withdrawal_amount(Some(0), DENOM).is_err());
+        assert!(resolve_withdrawal_amount(Some(0), &params()).is_err());
     }
 
     #[test]
     fn test_non_multiple_rejected() {
-        assert!(resolve_withdrawal_amount(Some(150_000_000), DENOM).is_err());
+        assert!(resolve_withdrawal_amount(Some(150_000_000), &params()).is_err());
     }
 
     #[test]
     fn test_below_denomination_rejected() {
-        assert!(resolve_withdrawal_amount(Some(50_000_000), DENOM).is_err());
+        assert!(resolve_withdrawal_amount(Some(50_000_000), &params()).is_err());
+    }
+
+    #[test]
+    fn test_exceeds_cap_rejected() {
+        assert!(resolve_withdrawal_amount(Some(1_100_000_000), &params()).is_err());
+    }
+
+    #[test]
+    fn test_at_cap_accepted() {
+        let result = resolve_withdrawal_amount(Some(1_000_000_000), &params()).unwrap();
+        assert_eq!(result, Amount::from_sat(1_000_000_000));
     }
 }

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -10,6 +10,9 @@ pub const DEFAULT_FINALITY_DEPTH: u32 = 6;
 
 pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 
+/// Default denomination in satoshis (1 BTC).
+pub const DEFAULT_DENOMINATION_SATS: u64 = 100_000_000;
+
 /// Fee to cover the mining fees for creating the deposit transaction from the deposit request
 /// transaction. This includes the cost for the bridge to spend the deposit request output into the
 /// federation.

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -10,8 +10,7 @@ pub const DEFAULT_FINALITY_DEPTH: u32 = 6;
 
 pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 
-/// Default denomination in satoshis (1 BTC).
-pub const DEFAULT_DENOMINATION_SATS: u64 = 100_000_000;
+pub use strata_bridge_params::{DEFAULT_DENOMINATION_SATS, DEFAULT_MAX_WITHDRAWAL_SATS};
 
 /// Fee to cover the mining fees for creating the deposit transaction from the deposit request
 /// transaction. This includes the cost for the bridge to spend the deposit request output into the

--- a/bin/alpen-cli/src/settings.rs
+++ b/bin/alpen-cli/src/settings.rs
@@ -21,10 +21,7 @@ use terrors::OneOf;
 #[cfg(feature = "test-mode")]
 use crate::{constants::SEED_LEN, seed::Seed};
 use crate::{
-    constants::{
-        DEFAULT_BRIDGE_ALPEN_ADDRESS, DEFAULT_BRIDGE_FEE, DEFAULT_DENOMINATION_SATS,
-        DEFAULT_FINALITY_DEPTH,
-    },
+    constants::*,
     signet::{backend::SignetBackend, EsploraClient},
 };
 

--- a/bin/alpen-cli/src/settings.rs
+++ b/bin/alpen-cli/src/settings.rs
@@ -14,13 +14,17 @@ use config::Config;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use shrex::Hex;
+use strata_bridge_params::BridgeParams;
 use strata_params::RollupParams;
 use terrors::OneOf;
 
 #[cfg(feature = "test-mode")]
 use crate::{constants::SEED_LEN, seed::Seed};
 use crate::{
-    constants::{DEFAULT_BRIDGE_ALPEN_ADDRESS, DEFAULT_BRIDGE_FEE, DEFAULT_FINALITY_DEPTH},
+    constants::{
+        DEFAULT_BRIDGE_ALPEN_ADDRESS, DEFAULT_BRIDGE_FEE, DEFAULT_DENOMINATION_SATS,
+        DEFAULT_FINALITY_DEPTH,
+    },
     signet::{backend::SignetBackend, EsploraClient},
 };
 
@@ -53,6 +57,10 @@ pub struct SettingsFromFile {
     pub bridge_fee_sats: Option<u64>,
     /// The number of confirmations to consider a Bitcoin transaction final.
     pub finality_depth: Option<u32>,
+    /// Denomination in satoshis. Defaults to 100_000_000 (1 BTC).
+    pub withdrawal_denomination_sats: Option<u64>,
+    /// Maximum withdrawal amount in satoshis. Defaults to 1_000_000_000 (10 BTC).
+    pub max_withdrawal_amount_sats: Option<u64>,
     /// Path to the rollup params JSON file.
     pub rollup_params_path: Option<PathBuf>,
     /// Seed that can be passed directly for functional test.
@@ -78,6 +86,7 @@ pub struct Settings {
     pub signet_backend: Arc<dyn SignetBackend>,
     pub bridge_fee: Amount,
     pub finality_depth: u32,
+    pub bridge_params: BridgeParams,
     pub params: RollupParams,
     #[cfg(feature = "test-mode")]
     pub seed: Seed,
@@ -177,6 +186,13 @@ impl Settings {
                 .map(Amount::from_sat)
                 .unwrap_or(DEFAULT_BRIDGE_FEE),
             finality_depth: from_file.finality_depth.unwrap_or(DEFAULT_FINALITY_DEPTH),
+            bridge_params: BridgeParams::new(
+                from_file
+                    .withdrawal_denomination_sats
+                    .unwrap_or(DEFAULT_DENOMINATION_SATS),
+                from_file.max_withdrawal_amount_sats,
+            )
+            .expect("invalid withdrawal params in config"),
             params,
             #[cfg(feature = "test-mode")]
             seed: Seed::from_file(from_file.seed),

--- a/bin/alpen-cli/src/settings.rs
+++ b/bin/alpen-cli/src/settings.rs
@@ -187,7 +187,9 @@ impl Settings {
                 from_file
                     .withdrawal_denomination_sats
                     .unwrap_or(DEFAULT_DENOMINATION_SATS),
-                from_file.max_withdrawal_amount_sats,
+                from_file
+                    .max_withdrawal_amount_sats
+                    .or(Some(DEFAULT_MAX_WITHDRAWAL_SATS)),
             )
             .expect("invalid withdrawal params in config"),
             params,

--- a/bin/alpen-client/Cargo.toml
+++ b/bin/alpen-client/Cargo.toml
@@ -13,7 +13,6 @@ sequencer = [
   "dep:alpen-ee-exec-chain",
   "dep:alpen-ee-sequencer",
   "dep:alpen-reth-exex",
-  "dep:alpen-reth-evm",
   "dep:alloy-eips",
   "dep:alloy-rpc-types-engine",
   "dep:bitcoind-async-client",
@@ -43,13 +42,14 @@ alpen-ee-genesis.workspace = true
 alpen-ee-ol-tracker.workspace = true
 alpen-ee-rpc-server.workspace = true
 alpen-ee-sequencer = { workspace = true, optional = true }
-alpen-reth-evm = { workspace = true, optional = true }
+alpen-reth-evm.workspace = true
 alpen-reth-exex = { workspace = true, optional = true }
 alpen-reth-node.workspace = true
 alpen-reth-witness.workspace = true
 bitcoind-async-client = { workspace = true, optional = true }
 ssz.workspace = true
 strata-acct-types.workspace = true
+strata-bridge-params.workspace = true
 strata-btcio = { workspace = true, optional = true }
 strata-codec.workspace = true
 strata-common = { workspace = true, features = ["async"] }

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -164,6 +164,14 @@ fn main() {
 
             // --- CONFIGS ---
 
+            // Resolve withdrawal cap: --no-withdrawal-cap → None,
+            // --max-withdrawal-amount X → Some(X), neither → default 10 BTC.
+            let resolved_max_withdrawal = if ext.no_withdrawal_cap {
+                None
+            } else {
+                Some(ext.max_withdrawal_amount.unwrap_or(1_000_000_000))
+            };
+
             let datadir = builder.config().datadir().data_dir().to_path_buf();
 
             // TODO: read config, params from file
@@ -358,7 +366,7 @@ fn main() {
             .map_err(|e| eyre::eyre!("failed to start ol tracker service: {e}"))?;
 
             let evm_factory = AlpenEvmFactory::from_bridge_params(
-                &BridgeParams::new(ext.bridge_denomination, ext.max_withdrawal_amount)
+                &BridgeParams::new(ext.bridge_denomination, resolved_max_withdrawal)
                     .expect("invalid withdrawal params"),
             );
             let node_args = AlpenNodeArgs {
@@ -710,7 +718,7 @@ fn main() {
                 };
 
                 let bridge_params =
-                    BridgeParams::new(ext.bridge_denomination, ext.max_withdrawal_amount)
+                    BridgeParams::new(ext.bridge_denomination, resolved_max_withdrawal)
                         .expect("invalid withdrawal params");
 
                 let chunk_builder = ProverBuilder::new(ChunkSpec::new(
@@ -1011,6 +1019,10 @@ pub struct AdditionalConfig {
     /// Maximum withdrawal amount in satoshis. Defaults to 1_000_000_000 (10 BTC).
     #[arg(long)]
     pub max_withdrawal_amount: Option<u64>,
+
+    /// Disable the withdrawal cap entirely.
+    #[arg(long)]
+    pub no_withdrawal_cap: bool,
 
     /// Use the zkaleido `NativeHost` for the EE chunk + acct provers
     /// instead of the SP1 remote host.

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -61,7 +61,7 @@ use reth_network::{protocol::IntoRlpxSubProtocol, NetworkProtocols};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_provider::CanonStateSubscriptions;
 use strata_acct_types::AccountId;
-use strata_bridge_params::BridgeParams;
+use strata_bridge_params::{BridgeParams, DEFAULT_DENOMINATION_SATS, DEFAULT_MAX_WITHDRAWAL_SATS};
 #[cfg(feature = "sequencer")]
 use strata_btcio::{
     broadcaster::BroadcasterBuilder, writer::chunked_envelope::create_chunked_envelope_task,
@@ -164,12 +164,11 @@ fn main() {
 
             // --- CONFIGS ---
 
-            // Resolve withdrawal cap: --no-withdrawal-cap → None,
-            // --max-withdrawal-amount X → Some(X), neither → default 10 BTC.
-            let resolved_max_withdrawal = if ext.no_withdrawal_cap {
-                None
-            } else {
-                Some(ext.max_withdrawal_amount.unwrap_or(1_000_000_000))
+            // Resolve withdrawal cap: 0 → no cap, omitted → default 10 BTC.
+            let resolved_max_withdrawal = match ext.max_withdrawal_amount {
+                Some(0) => None,
+                Some(v) => Some(v),
+                None => Some(DEFAULT_MAX_WITHDRAWAL_SATS),
             };
 
             let datadir = builder.config().datadir().data_dir().to_path_buf();
@@ -1012,17 +1011,18 @@ pub struct AdditionalConfig {
     #[arg(long, default_value = "100")]
     pub batch_sealing_block_count: u64,
 
-    /// Bridge denomination in satoshis. Defaults to 100_000_000 (1 BTC).
-    #[arg(long, default_value = "100000000")]
+    /// Bridge denomination in satoshis (1 BTC default).
+    #[arg(long, default_value_t = DEFAULT_DENOMINATION_SATS)]
     pub bridge_denomination: u64,
 
-    /// Maximum withdrawal amount in satoshis. Defaults to 1_000_000_000 (10 BTC).
+    /// Maximum withdrawal amount in satoshis.
+    ///
+    /// When omitted, defaults to 1_000_000_000 (10 BTC) at runtime.
+    /// Pass 0 to disable the cap entirely. Kept as `Option` (no
+    /// `default_value`) so we can distinguish "not set" (→ safe default)
+    /// from an explicit value.
     #[arg(long)]
     pub max_withdrawal_amount: Option<u64>,
-
-    /// Disable the withdrawal cap entirely.
-    #[arg(long)]
-    pub no_withdrawal_cap: bool,
 
     /// Use the zkaleido `NativeHost` for the EE chunk + acct provers
     /// instead of the SP1 remote host.

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -36,6 +36,7 @@ use alpen_ee_sequencer::{
     block_builder_task, build_ol_chain_tracker, init_ol_chain_tracker_state, BlockBuilderConfig,
 };
 use alpen_ee_sequencer::{init_batch_builder_state, init_lifecycle_state};
+use alpen_reth_evm::evm::AlpenEvmFactory;
 #[cfg(feature = "sequencer")]
 use alpen_reth_exex::{AccessedStateGenerator, StateDiffGenerator};
 use alpen_reth_node::{
@@ -60,6 +61,7 @@ use reth_network::{protocol::IntoRlpxSubProtocol, NetworkProtocols};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_provider::CanonStateSubscriptions;
 use strata_acct_types::AccountId;
+use strata_bridge_params::BridgeParams;
 #[cfg(feature = "sequencer")]
 use strata_btcio::{
     broadcaster::BroadcasterBuilder, writer::chunked_envelope::create_chunked_envelope_task,
@@ -355,8 +357,13 @@ fn main() {
             .await
             .map_err(|e| eyre::eyre!("failed to start ol tracker service: {e}"))?;
 
+            let evm_factory = AlpenEvmFactory::from_bridge_params(
+                &BridgeParams::new(ext.bridge_denomination, ext.max_withdrawal_amount)
+                    .expect("invalid withdrawal params"),
+            );
             let node_args = AlpenNodeArgs {
                 sequencer_http: ext.sequencer_http.clone(),
+                evm_factory,
             };
 
             let consensus_watcher = ol_tracker.consensus_watcher();
@@ -702,10 +709,15 @@ fn main() {
                     ext.custom_chain.genesis().config.clone().into_rsp()
                 };
 
+                let bridge_params =
+                    BridgeParams::new(ext.bridge_denomination, ext.max_withdrawal_amount)
+                        .expect("invalid withdrawal params");
+
                 let chunk_builder = ProverBuilder::new(ChunkSpec::new(
                     batch_storage_dyn.clone(),
                     storage.clone(),
                     genesis.clone(),
+                    bridge_params,
                 ))
                 .task_store(task_store.clone())
                 .receipt_store(chunk_receipts.clone())
@@ -718,6 +730,7 @@ fn main() {
                     storage.clone(),
                     ol_client.clone(),
                     genesis,
+                    bridge_params,
                 ))
                 .task_store(task_store)
                 .receipt_hook(AcctReceiptHook::new(
@@ -990,6 +1003,14 @@ pub struct AdditionalConfig {
     /// Lower values seal batches more frequently (useful for testing).
     #[arg(long, default_value = "100")]
     pub batch_sealing_block_count: u64,
+
+    /// Bridge denomination in satoshis. Defaults to 100_000_000 (1 BTC).
+    #[arg(long, default_value = "100000000")]
+    pub bridge_denomination: u64,
+
+    /// Maximum withdrawal amount in satoshis. Defaults to 1_000_000_000 (10 BTC).
+    #[arg(long)]
+    pub max_withdrawal_amount: Option<u64>,
 
     /// Use the zkaleido `NativeHost` for the EE chunk + acct provers
     /// instead of the SP1 remote host.

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use rsp_primitives::genesis::Genesis;
 use ssz::{Decode, Encode as _};
 use strata_acct_types::Hash;
+use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_runtime::{ChunkInput, EePrivateInput};
 use strata_ee_acct_types::UpdateExtraData;
@@ -150,6 +151,7 @@ pub(crate) struct AcctSpec {
     storage: Arc<EeNodeStorage>,
     ol_client: Arc<dyn SequencerOLClient + Send + Sync>,
     genesis: Genesis,
+    bridge_params: BridgeParams,
 }
 
 impl AcctSpec {
@@ -159,6 +161,7 @@ impl AcctSpec {
         storage: Arc<EeNodeStorage>,
         ol_client: Arc<dyn SequencerOLClient + Send + Sync>,
         genesis: Genesis,
+        bridge_params: BridgeParams,
     ) -> Self {
         Self {
             chunk_receipts,
@@ -166,6 +169,7 @@ impl AcctSpec {
             storage,
             ol_client,
             genesis,
+            bridge_params,
         }
     }
 }
@@ -396,6 +400,7 @@ impl ProofSpec for AcctSpec {
             genesis: self.genesis.clone(),
             ee_private_input,
             update_private_input,
+            bridge_params: self.bridge_params,
         })
     }
 }

--- a/bin/alpen-client/src/prover/spec_chunk.rs
+++ b/bin/alpen-client/src/prover/spec_chunk.rs
@@ -15,6 +15,7 @@ use reth_primitives::Block;
 use reth_primitives_traits::Block as _;
 use rsp_primitives::genesis::Genesis;
 use strata_acct_types::Hash;
+use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::{ExecBlock, ExecHeader};
 use strata_ee_chain_types::{
@@ -109,6 +110,7 @@ pub(crate) struct ChunkSpec {
     batch_storage: Arc<dyn BatchStorage>,
     storage: Arc<EeNodeStorage>,
     genesis: Genesis,
+    bridge_params: BridgeParams,
 }
 
 impl ChunkSpec {
@@ -116,11 +118,13 @@ impl ChunkSpec {
         batch_storage: Arc<dyn BatchStorage>,
         storage: Arc<EeNodeStorage>,
         genesis: Genesis,
+        bridge_params: BridgeParams,
     ) -> Self {
         Self {
             batch_storage,
             storage,
             genesis,
+            bridge_params,
         }
     }
 }
@@ -290,6 +294,7 @@ impl ProofSpec for ChunkSpec {
         Ok(EeChunkProofInput {
             genesis: self.genesis.clone(),
             private_input,
+            bridge_params: self.bridge_params,
         })
     }
 }

--- a/bin/datatool/src/cmd/asm_params.rs
+++ b/bin/datatool/src/cmd/asm_params.rs
@@ -23,8 +23,8 @@ use crate::{
     util::parse_abbr_amt,
 };
 
-/// The default deposit amount in sats (10 BTC).
-const DEFAULT_DEPOSIT_SATS: u64 = 1_000_000_000;
+/// The default deposit amount in sats (1 BTC).
+const DEFAULT_DEPOSIT_SATS: u64 = 100_000_000;
 
 /// The default assignment duration in blocks.
 const DEFAULT_ASSIGNMENT_DURATION: u16 = 64;

--- a/bin/datatool/src/cmd/params.rs
+++ b/bin/datatool/src/cmd/params.rs
@@ -78,7 +78,7 @@ pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> 
         .deposit_sats
         .map(|s| parse_abbr_amt(&s))
         .transpose()?
-        .unwrap_or(1_000_000_000);
+        .unwrap_or(100_000_000);
 
     // Parse the checkpoint verification key.
     let rollup_vk = resolve_checkpoint_predicate(cmd.checkpoint_predicate)?;

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+alpen-reth-evm.workspace = true
 ssz.workspace = true
 zkaleido.workspace = true
 
@@ -16,6 +17,7 @@ strata-proofimpl-alpen-chunk.workspace = true
 strata-proofimpl-checkpoint.workspace = true
 
 strata-acct-types.workspace = true
+strata-bridge-params.workspace = true
 strata-codec.workspace = true
 strata-da-framework.workspace = true
 strata-ee-acct-runtime.workspace = true

--- a/bin/prover-perf/src/programs/alpen_acct.rs
+++ b/bin/prover-perf/src/programs/alpen_acct.rs
@@ -12,6 +12,7 @@
 //! (d) pubvals SSZ commit.
 
 use ssz::Encode;
+use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_runtime::{ChunkInput, EePrivateInput};
 use strata_ee_acct_types::{EeAccountState, ExecBlock, ExecHeader, UpdateExtraData};
@@ -91,6 +92,7 @@ fn prepare_input() -> EeAcctProofInput {
         genesis,
         ee_private_input,
         update_private_input,
+        bridge_params: BridgeParams::default(),
     }
 }
 

--- a/bin/prover-perf/src/programs/alpen_chunk.rs
+++ b/bin/prover-perf/src/programs/alpen_chunk.rs
@@ -6,10 +6,12 @@
 
 use std::{fs, path::PathBuf, sync::Arc};
 
+use alpen_reth_evm::evm::AlpenEvmFactory;
 use reth_primitives_traits::Block as _;
 use rsp_client_executor::io::EthClientExecutorInput;
 use serde::Deserialize;
 use strata_acct_types::Hash;
+use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::{ExecBlock, ExecHeader, ExecPayload, ExecutionEnvironment};
 use strata_ee_chain_types::ExecInputs;
@@ -73,7 +75,7 @@ pub(super) fn prepare_input() -> EeChunkProofInput {
 
     let chain_spec: Arc<reth_chainspec::ChainSpec> =
         Arc::new((&witness.genesis).try_into().unwrap());
-    let ee = EvmExecutionEnvironment::new(chain_spec);
+    let ee = EvmExecutionEnvironment::new(chain_spec, AlpenEvmFactory::default());
     let exec_payload = ExecPayload::new(&header, block.get_body());
     let inputs = ExecInputs::new_empty();
     let output = ee
@@ -101,6 +103,7 @@ pub(super) fn prepare_input() -> EeChunkProofInput {
     EeChunkProofInput {
         genesis: witness.genesis,
         private_input,
+        bridge_params: BridgeParams::default(),
     }
 }
 

--- a/bin/prover-perf/src/programs/checkpoint.rs
+++ b/bin/prover-perf/src/programs/checkpoint.rs
@@ -11,6 +11,7 @@
 //!
 //! Until then, empty blocks with a slot-delta-only DA payload keep the proof correct.
 
+use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_da_framework::DaCounter;
 use strata_identifiers::Buf64;
@@ -68,6 +69,7 @@ fn prepare_checkpoint_input() -> CheckpointProverInput {
         blocks,
         parent,
         da_state_diff_bytes,
+        bridge_params: BridgeParams::default(),
     }
 }
 

--- a/bin/strata-test-cli/src/constants.rs
+++ b/bin/strata-test-cli/src/constants.rs
@@ -6,8 +6,8 @@ use strata_l1_txfmt::MagicBytes;
 /// Magic bytes to add to the metadata output in transactions to help identify them.
 pub(crate) const MAGIC_BYTES: MagicBytes = MagicBytes::new(*b"ALPN");
 
-/// Bridge outs are enforced to be exactly 10 BTC
-pub(crate) const BRIDGE_OUT_AMOUNT: Amount = Amount::from_int_btc(10);
+/// Bridge denomination: 1 BTC.
+pub(crate) const BRIDGE_OUT_AMOUNT: Amount = Amount::from_int_btc(1);
 
 /// An xpriv that is good enough for testing purposes.
 ///

--- a/bin/strata/src/prover/mod.rs
+++ b/bin/strata/src/prover/mod.rs
@@ -66,7 +66,8 @@ pub(crate) fn start_prover_service(
     // Build the spec + hook. The backend choice is fixed here at build
     // time rather than being part of task identity — the new paas erases
     // the host type inside the prove strategy.
-    let spec = CheckpointSpec::new(storage.clone());
+    let bridge_params = *runctx.ol_params().bridge_params();
+    let spec = CheckpointSpec::new(storage.clone(), bridge_params);
     let hook = CheckpointReceiptHook::new(proof_db.clone(), proof_notify);
 
     // Task store: the node's `ProverTaskDbManager` implements

--- a/bin/strata/src/prover/spec.rs
+++ b/bin/strata/src/prover/spec.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 pub(crate) use strata_checkpoint_types::CheckpointProofTask as CheckpointTask;
 use strata_identifiers::{Epoch, EpochCommitment};
+use strata_ol_params::BridgeParams;
 use strata_ol_state_support_types::{DaAccumulatingState, MemoryStateBaseLayer};
 use strata_ol_stf::execute_block_batch_preseal;
 use strata_paas::{ProofSpec, ProverError as PaasError, ProverResult};
@@ -23,11 +24,15 @@ use super::errors::ProverError;
 #[derive(Clone)]
 pub(crate) struct CheckpointSpec {
     storage: Arc<NodeStorage>,
+    bridge_params: BridgeParams,
 }
 
 impl CheckpointSpec {
-    pub(crate) fn new(storage: Arc<NodeStorage>) -> Self {
-        Self { storage }
+    pub(crate) fn new(storage: Arc<NodeStorage>, bridge_params: BridgeParams) -> Self {
+        Self {
+            storage,
+            bridge_params,
+        }
     }
 }
 
@@ -40,9 +45,10 @@ impl ProofSpec for CheckpointSpec {
         let commitment = task.0;
         debug!(epoch = %commitment.epoch, "fetching checkpoint proof input");
         let storage = Arc::clone(&self.storage);
+        let bridge_params = self.bridge_params;
         // All storage access is blocking; hop to a blocking thread so we
         // don't stall the async runtime while reading blocks and state.
-        spawn_blocking(move || fetch_input_blocking(storage, commitment))
+        spawn_blocking(move || fetch_input_blocking(storage, commitment, bridge_params))
             .await
             .map_err(|e| PaasError::TransientFailure(format!("input fetch join: {e}")))?
             .map_err(PaasError::from)
@@ -52,6 +58,7 @@ impl ProofSpec for CheckpointSpec {
 fn fetch_input_blocking(
     storage: Arc<NodeStorage>,
     task_commitment: EpochCommitment,
+    bridge_params: BridgeParams,
 ) -> Result<CheckpointProverInput, ProverError> {
     let epoch: Epoch = task_commitment.epoch;
     let epoch_index = u64::from(epoch);
@@ -147,7 +154,7 @@ fn fetch_input_blocking(
     let da_state_diff_bytes = {
         let mut da_state =
             DaAccumulatingState::new(MemoryStateBaseLayer::new((*start_state).clone()));
-        execute_block_batch_preseal(&mut da_state, &blocks, &parent)
+        execute_block_batch_preseal(&mut da_state, &blocks, &parent, bridge_params)
             .map_err(|e| ProverError::DaComputation(e.to_string()))?;
         da_state
             .take_completed_epoch_da_blob()
@@ -169,5 +176,6 @@ fn fetch_input_blocking(
         blocks,
         parent,
         da_state_diff_bytes,
+        bridge_params,
     })
 }

--- a/bin/strata/src/run_context.rs
+++ b/bin/strata/src/run_context.rs
@@ -53,6 +53,11 @@ impl RunContext {
         self.common.params()
     }
 
+    #[cfg(feature = "prover")]
+    pub(crate) fn ol_params(&self) -> &Arc<strata_ol_params::OLParams> {
+        self.common.ol_params()
+    }
+
     /// Returns the storage.
     pub(crate) fn storage(&self) -> &Arc<NodeStorage> {
         self.common.storage()

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -186,6 +186,7 @@ mod sequencer_services {
 
         nodectx.task_manager().handle().block_on(async {
             BlockasmBuilder::new(
+                nodectx.ol_params().clone(),
                 blockasm_config,
                 nodectx.storage().clone(),
                 mempool_provider,

--- a/crates/bridge-params/Cargo.toml
+++ b/crates/bridge-params/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "strata-bridge-params"
+version = "0.1.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+arbitrary = { workspace = true, optional = true }
+serde.workspace = true
+ssz.workspace = true
+ssz_derive.workspace = true
+thiserror.workspace = true
+
+[features]
+arbitrary = ["dep:arbitrary"]

--- a/crates/bridge-params/Cargo.toml
+++ b/crates/bridge-params/Cargo.toml
@@ -13,5 +13,8 @@ ssz.workspace = true
 ssz_derive.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [features]
 arbitrary = ["dep:arbitrary"]

--- a/crates/bridge-params/src/lib.rs
+++ b/crates/bridge-params/src/lib.rs
@@ -59,11 +59,17 @@ impl BridgeParams {
     }
 }
 
+/// Default bridge denomination: 1 BTC in satoshis.
+pub const DEFAULT_DENOMINATION_SATS: u64 = 100_000_000;
+
+/// Default maximum withdrawal amount: 10 BTC in satoshis.
+pub const DEFAULT_MAX_WITHDRAWAL_SATS: u64 = 1_000_000_000;
+
 impl Default for BridgeParams {
     fn default() -> Self {
         Self {
-            denomination: 100_000_000,                  // 1 BTC
-            max_withdrawal_amount: Some(1_000_000_000), // 10 BTC
+            denomination: DEFAULT_DENOMINATION_SATS,
+            max_withdrawal_amount: Some(DEFAULT_MAX_WITHDRAWAL_SATS),
         }
     }
 }

--- a/crates/bridge-params/src/lib.rs
+++ b/crates/bridge-params/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as DeError};
 use ssz_derive::{Decode, Encode};
 use thiserror::Error;
 
@@ -11,11 +11,42 @@ use thiserror::Error;
 /// Constructed via [`BridgeParams::new`] which validates the invariants:
 /// - `denomination` must be non-zero
 /// - If `max_withdrawal_amount` is set, it must be `>= denomination` and a multiple of it
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Encode)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BridgeParams {
     denomination: u64,
     max_withdrawal_amount: Option<u64>,
+}
+
+/// Raw mirror for deserialization. Serde and SSZ decode into this first,
+/// then validate via [`BridgeParams::new`].
+#[derive(Deserialize, Decode)]
+struct BridgeParamsRaw {
+    denomination: u64,
+    max_withdrawal_amount: Option<u64>,
+}
+
+impl<'de> Deserialize<'de> for BridgeParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = BridgeParamsRaw::deserialize(deserializer)?;
+        Self::new(raw.denomination, raw.max_withdrawal_amount).map_err(DeError::custom)
+    }
+}
+
+impl ssz::Decode for BridgeParams {
+    fn is_ssz_fixed_len() -> bool {
+        BridgeParamsRaw::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        BridgeParamsRaw::ssz_fixed_len()
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let raw = BridgeParamsRaw::from_ssz_bytes(bytes)?;
+        Self::new(raw.denomination, raw.max_withdrawal_amount)
+            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
+    }
 }
 
 impl BridgeParams {
@@ -129,5 +160,33 @@ mod tests {
         let w = BridgeParams::new(100_000_000, Some(100_000_000)).unwrap();
         assert!(w.validate_withdrawal_amount(100_000_000));
         assert!(!w.validate_withdrawal_amount(200_000_000));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let bp = BridgeParams::new(100_000_000, Some(1_000_000_000)).unwrap();
+        let json = serde_json::to_string(&bp).unwrap();
+        let decoded: BridgeParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(bp, decoded);
+    }
+
+    #[test]
+    fn serde_rejects_zero_denomination() {
+        let json = r#"{"denomination":0,"max_withdrawal_amount":null}"#;
+        assert!(serde_json::from_str::<BridgeParams>(json).is_err());
+    }
+
+    #[test]
+    fn serde_rejects_invalid_cap() {
+        let json = r#"{"denomination":100000000,"max_withdrawal_amount":150000000}"#;
+        assert!(serde_json::from_str::<BridgeParams>(json).is_err());
+    }
+
+    #[test]
+    fn ssz_roundtrip() {
+        let bp = BridgeParams::new(100_000_000, Some(1_000_000_000)).unwrap();
+        let encoded = ssz::Encode::as_ssz_bytes(&bp);
+        let decoded = <BridgeParams as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(bp, decoded);
     }
 }

--- a/crates/bridge-params/src/lib.rs
+++ b/crates/bridge-params/src/lib.rs
@@ -1,0 +1,127 @@
+//! Bridge denomination and cap parameters.
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use thiserror::Error;
+
+/// Bridge denomination and optional maximum withdrawal amount, in satoshis.
+///
+/// Constructed via [`BridgeParams::new`] which validates the invariants:
+/// - `denomination` must be non-zero
+/// - If `max_withdrawal_amount` is set, it must be `>= denomination` and a multiple of it
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BridgeParams {
+    denomination: u64,
+    max_withdrawal_amount: Option<u64>,
+}
+
+impl BridgeParams {
+    /// Creates a new [`BridgeParams`] after validating invariants.
+    pub fn new(
+        denomination: u64,
+        max_withdrawal_amount: Option<u64>,
+    ) -> Result<Self, BridgeParamsError> {
+        if denomination == 0 {
+            return Err(BridgeParamsError::ZeroDenomination);
+        }
+        if let Some(max) = max_withdrawal_amount {
+            if max < denomination {
+                return Err(BridgeParamsError::MaxBelowDenomination { denomination, max });
+            }
+            if max % denomination != 0 {
+                return Err(BridgeParamsError::MaxNotMultiple { denomination, max });
+            }
+        }
+        Ok(Self {
+            denomination,
+            max_withdrawal_amount,
+        })
+    }
+
+    pub fn denomination(&self) -> u64 {
+        self.denomination
+    }
+
+    pub fn max_withdrawal_amount(&self) -> Option<u64> {
+        self.max_withdrawal_amount
+    }
+
+    /// Returns whether a withdrawal amount (in sats) is valid.
+    pub fn validate_withdrawal_amount(&self, amount_sats: u64) -> bool {
+        amount_sats > 0
+            && amount_sats.is_multiple_of(self.denomination)
+            && self
+                .max_withdrawal_amount
+                .is_none_or(|cap| amount_sats <= cap)
+    }
+}
+
+impl Default for BridgeParams {
+    fn default() -> Self {
+        Self {
+            denomination: 100_000_000,                  // 1 BTC
+            max_withdrawal_amount: Some(1_000_000_000), // 10 BTC
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum BridgeParamsError {
+    #[error("denomination must not be zero")]
+    ZeroDenomination,
+
+    #[error("max_withdrawal_amount ({max}) is below denomination ({denomination})")]
+    MaxBelowDenomination { denomination: u64, max: u64 },
+
+    #[error("max_withdrawal_amount ({max}) is not a multiple of denomination ({denomination})")]
+    MaxNotMultiple { denomination: u64, max: u64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_no_cap() {
+        let w = BridgeParams::new(100_000_000, None).unwrap();
+        assert!(w.validate_withdrawal_amount(100_000_000));
+        assert!(w.validate_withdrawal_amount(300_000_000));
+        assert!(!w.validate_withdrawal_amount(0));
+        assert!(!w.validate_withdrawal_amount(150_000_000));
+    }
+
+    #[test]
+    fn valid_with_cap() {
+        let w = BridgeParams::new(100_000_000, Some(1_000_000_000)).unwrap();
+        assert!(w.validate_withdrawal_amount(100_000_000));
+        assert!(w.validate_withdrawal_amount(1_000_000_000));
+        assert!(!w.validate_withdrawal_amount(1_100_000_000));
+        assert!(!w.validate_withdrawal_amount(0));
+        assert!(!w.validate_withdrawal_amount(150_000_000));
+    }
+
+    #[test]
+    fn zero_denomination_rejected() {
+        assert!(BridgeParams::new(0, None).is_err());
+    }
+
+    #[test]
+    fn max_below_denomination_rejected() {
+        assert!(BridgeParams::new(100_000_000, Some(50_000_000)).is_err());
+    }
+
+    #[test]
+    fn max_not_multiple_rejected() {
+        assert!(BridgeParams::new(100_000_000, Some(150_000_000)).is_err());
+    }
+
+    #[test]
+    fn max_equals_denomination_accepted() {
+        let w = BridgeParams::new(100_000_000, Some(100_000_000)).unwrap();
+        assert!(w.validate_withdrawal_amount(100_000_000));
+        assert!(!w.validate_withdrawal_amount(200_000_000));
+    }
+}

--- a/crates/chain-worker-new/Cargo.toml
+++ b/crates/chain-worker-new/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 strata-acct-types.workspace = true
+strata-bridge-params.workspace = true
 strata-checkpoint-types.workspace = true
 strata-db-types.workspace = true
 strata-identifiers.workspace = true

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -7,6 +7,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use ssz::Encode;
 use strata_acct_types::{MessageEntry, tree_hash::TreeHash};
+use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::{
     errors::DbError,
@@ -66,6 +67,9 @@ pub struct ChainWorkerContextImpl {
     /// Rollup params
     params: Arc<Params>,
 
+    /// Withdrawal denomination and cap.
+    bridge_params: BridgeParams,
+
     /// Runtime handle
     handle: Handle,
 }
@@ -83,6 +87,7 @@ impl ChainWorkerContextImpl {
             status_channel: nodectx.status_channel().clone(),
             epoch_summary_tx,
             params: nodectx.params().clone(),
+            bridge_params: *nodectx.ol_params().bridge_params(),
             handle: nodectx.executor().handle().clone(),
         }
     }
@@ -97,6 +102,10 @@ impl ChainWorkerContextImpl {
 
     pub fn params(&self) -> &Params {
         &self.params
+    }
+
+    pub fn bridge_params(&self) -> BridgeParams {
+        self.bridge_params
     }
 
     pub fn handle(&self) -> &Handle {

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -9,6 +9,7 @@
 //! even though both must live in [`ChainWorkerServiceState`] due to the current
 //! service framework design.
 
+use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::errors::DbError;
 use strata_identifiers::OLBlockCommitment;
@@ -243,8 +244,12 @@ impl ChainWorkerServiceState {
         let parent_state = MemoryStateBaseLayer::new(parent_state_raw);
 
         // Execute and extract outputs
-        let (write_batch, indexer_writes) =
-            Self::run_stf_verification(&parent_state, block, parent_header)?;
+        let (write_batch, indexer_writes) = Self::run_stf_verification(
+            &parent_state,
+            block,
+            parent_header,
+            self.ctx.bridge_params(),
+        )?;
 
         // Apply write batch to parent state to get new state
         let mut new_state = parent_state;
@@ -282,6 +287,7 @@ impl ChainWorkerServiceState {
         parent_state: &MemoryStateBaseLayer,
         block: &OLBlock,
         parent_header: Option<&OLBlockHeader>,
+        bridge_params: BridgeParams,
     ) -> WorkerResult<(WriteBatch<OLAccountState>, IndexerWrites)> {
         // Build the state stack: IndexerState<WriteTrackingState<&MemoryStateBaseLayer>>
         let tracking_state = WriteTrackingState::new_empty(parent_state);
@@ -292,6 +298,7 @@ impl ChainWorkerServiceState {
             block.header(),
             parent_header,
             block.body(),
+            bridge_params,
         )?;
 
         // Extract outputs

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -244,7 +244,7 @@ impl ChainWorkerServiceState {
         let parent_state = MemoryStateBaseLayer::new(parent_state_raw);
 
         // Execute and extract outputs
-        let (write_batch, indexer_writes) = Self::run_stf_verification(
+        let (write_batch, indexer_writes) = run_stf_verification(
             &parent_state,
             block,
             parent_header,
@@ -269,43 +269,6 @@ impl ChainWorkerServiceState {
             OLBlockExecutionOutput::new(computed_state_root, write_batch, indexer_writes),
             new_state,
         ))
-    }
-
-    /// Runs the STF verification on a block.
-    ///
-    /// This is a pure function that builds the state stack and executes the STF.
-    #[instrument(
-        skip_all,
-        fields(
-            slot = block.header().slot(),
-            epoch = block.header().epoch(),
-            is_terminal = block.header().is_terminal(),
-        ),
-        err,
-    )]
-    fn run_stf_verification(
-        parent_state: &MemoryStateBaseLayer,
-        block: &OLBlock,
-        parent_header: Option<&OLBlockHeader>,
-        bridge_params: BridgeParams,
-    ) -> WorkerResult<(WriteBatch<OLAccountState>, IndexerWrites)> {
-        // Build the state stack: IndexerState<WriteTrackingState<&MemoryStateBaseLayer>>
-        let tracking_state = WriteTrackingState::new_empty(parent_state);
-        let mut indexer_state = IndexerState::new(tracking_state);
-
-        verify_block(
-            &mut indexer_state,
-            block.header(),
-            parent_header,
-            block.body(),
-            bridge_params,
-        )?;
-
-        // Extract outputs
-        let (tracking_state, indexer_writes) = indexer_state.into_parts();
-        let write_batch: WriteBatch<OLAccountState> = tracking_state.into_batch();
-
-        Ok((write_batch, indexer_writes))
     }
 
     /// Persists the execution output and state to storage.
@@ -386,6 +349,43 @@ impl ServiceState for ChainWorkerServiceState {
     fn name(&self) -> &str {
         "chain_worker_new"
     }
+}
+
+/// Runs the STF verification on a block.
+///
+/// This is a pure function that builds the state stack and executes the STF.
+#[instrument(
+    skip_all,
+    fields(
+        slot = block.header().slot(),
+        epoch = block.header().epoch(),
+        is_terminal = block.header().is_terminal(),
+    ),
+    err,
+)]
+fn run_stf_verification(
+    parent_state: &MemoryStateBaseLayer,
+    block: &OLBlock,
+    parent_header: Option<&OLBlockHeader>,
+    bridge_params: BridgeParams,
+) -> WorkerResult<(WriteBatch<OLAccountState>, IndexerWrites)> {
+    // Build the state stack: IndexerState<WriteTrackingState<&MemoryStateBaseLayer>>
+    let tracking_state = WriteTrackingState::new_empty(parent_state);
+    let mut indexer_state = IndexerState::new(tracking_state);
+
+    verify_block(
+        &mut indexer_state,
+        block.header(),
+        parent_header,
+        block.body(),
+        bridge_params,
+    )?;
+
+    // Extract outputs
+    let (tracking_state, indexer_writes) = indexer_state.into_parts();
+    let write_batch: WriteBatch<OLAccountState> = tracking_state.into_batch();
+
+    Ok((write_batch, indexer_writes))
 }
 
 /// Builds the [`EpochSummary`] for a completed epoch from the terminal block,

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -350,7 +350,7 @@ mod tests {
             serde_json::from_str(&json_content).expect("Failed to parse test data");
 
         let chain_spec: Arc<ChainSpec> = Arc::new((&test_data.witness.genesis).try_into().unwrap());
-        let env = EvmExecutionEnvironment::new(chain_spec);
+        let env = EvmExecutionEnvironment::new(chain_spec, AlpenEvmFactory::default());
         let header = test_data.witness.current_block.header().clone();
         let evm_header = EvmHeader::new(header.clone());
         let mut state = EvmPartialState::new(

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -76,9 +76,10 @@ fn convert_withdrawal_intents_to_messages(
 }
 
 impl EvmExecutionEnvironment {
-    /// Creates a new EvmExecutionEnvironment with the given chain specification.
-    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        let evm_config = EthEvmConfig::new_with_evm_factory(chain_spec, AlpenEvmFactory::default());
+    /// Creates a new EvmExecutionEnvironment with the given chain specification
+    /// and EVM factory.
+    pub fn new(chain_spec: Arc<ChainSpec>, evm_factory: AlpenEvmFactory) -> Self {
+        let evm_config = EthEvmConfig::new_with_evm_factory(chain_spec, evm_factory);
         Self { evm_config }
     }
 }
@@ -401,7 +402,7 @@ mod tests {
 
         // Create execution environment
         let chain_spec: Arc<ChainSpec> = Arc::new((&test_data.witness.genesis).try_into().unwrap());
-        let env = EvmExecutionEnvironment::new(chain_spec);
+        let env = EvmExecutionEnvironment::new(chain_spec, AlpenEvmFactory::default());
 
         // Use the pre-state directly from witness data (it already has all the proofs!)
         let pre_state = EvmPartialState::new(

--- a/crates/evm-ee/src/types/tests.rs
+++ b/crates/evm-ee/src/types/tests.rs
@@ -343,6 +343,7 @@ fn test_evm_partial_state_rejects_invalid_ancestor_parent_hash() {
 fn test_evm_partial_state_codec_roundtrip_execution() {
     use std::sync::Arc;
 
+    use alpen_reth_evm::evm::AlpenEvmFactory;
     use reth_chainspec::ChainSpec;
     use reth_primitives_traits::Block as _;
     use strata_ee_acct_types::{ExecBlock, ExecPayload, ExecutionEnvironment};
@@ -364,7 +365,7 @@ fn test_evm_partial_state_codec_roundtrip_execution() {
     let block = EvmBlock::new(EvmHeader::new(header.clone()), body);
 
     let chain_spec: Arc<ChainSpec> = Arc::new((&witness.genesis).try_into().unwrap());
-    let ee = EvmExecutionEnvironment::new(chain_spec);
+    let ee = EvmExecutionEnvironment::new(chain_spec, AlpenEvmFactory::default());
     let payload = ExecPayload::new(&header, block.get_body());
     let inputs = ExecInputs::new_empty();
 

--- a/crates/node-context/src/lib.rs
+++ b/crates/node-context/src/lib.rs
@@ -109,6 +109,7 @@ impl NodeContext {
                 params: self.params,
                 blockasm_config: self.blockasm_config,
                 asm_params: self.asm_params,
+                ol_params: self.ol_params,
                 config: self.config,
                 storage: self.storage,
                 status_channel: self.status_channel,
@@ -127,6 +128,7 @@ pub struct CommonContext {
     params: Arc<Params>,
     blockasm_config: Option<Arc<BlockAssemblyConfig>>,
     asm_params: Arc<AsmParams>,
+    ol_params: Arc<OLParams>,
     config: Config,
     storage: Arc<NodeStorage>,
     status_channel: Arc<StatusChannel>,
@@ -147,6 +149,10 @@ impl CommonContext {
 
     pub fn asm_params(&self) -> &Arc<AsmParams> {
         &self.asm_params
+    }
+
+    pub fn ol_params(&self) -> &Arc<OLParams> {
+        &self.ol_params
     }
 
     pub fn config(&self) -> &Config {

--- a/crates/ol/block-assembly/Cargo.toml
+++ b/crates/ol/block-assembly/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 strata-acct-types.workspace = true
 strata-asm-manifest-types.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
+strata-bridge-params.workspace = true
 strata-common = { workspace = true, optional = true }
 strata-config.workspace = true
 strata-db-types.workspace = true
@@ -17,6 +18,7 @@ strata-identifiers.workspace = true
 strata-ledger-types.workspace = true
 strata-ol-chain-types-new.workspace = true
 strata-ol-mempool.workspace = true
+strata-ol-params.workspace = true
 strata-ol-state-provider.workspace = true
 strata-ol-state-support-types.workspace = true
 strata-ol-state-types.workspace = true
@@ -54,5 +56,6 @@ strata-msg-fmt.workspace = true
 strata-ol-chain-types-new = { workspace = true, features = ["test-utils"] }
 strata-ol-msg-types.workspace = true
 strata-ol-params.workspace = true
+strata-predicate.workspace = true
 strata-state.workspace = true
 threadpool.workspace = true

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -6,6 +6,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use strata_bridge_params::BridgeParams;
 use strata_config::SequencerConfig;
 use strata_db_types::errors::DbError;
 use strata_identifiers::{Epoch, OLBlockCommitment, OLTxId, Slot};
@@ -160,6 +161,7 @@ pub(crate) async fn generate_block_template_inner<C, E>(
     sequencer_config: &SequencerConfig,
     block_generation_config: BlockGenerationConfig,
     parent_da: AccumulatedDaData,
+    bridge_params: BridgeParams,
 ) -> BlockAssemblyResult<BlockTemplateResult>
 where
     C: BlockAssemblyAnchorContext + AccumulatorProofGenerator + MempoolProvider,
@@ -198,6 +200,7 @@ where
         block_epoch,
         mempool_txs,
         parent_da,
+        bridge_params,
     )
     .await?;
 
@@ -257,6 +260,7 @@ pub(crate) async fn construct_block<C, E>(
     block_epoch: Epoch,
     mempool_txs: Vec<(OLTxId, OLTransaction)>,
     parent_da: AccumulatedDaData,
+    bridge_params: BridgeParams,
 ) -> BlockAssemblyResult<ConstructBlockOutput<C::State>>
 where
     C: BlockAssemblyAnchorContext + AccumulatorProofGenerator,
@@ -307,6 +311,7 @@ where
         accumulated_batch,
         mempool_txs,
         accumulated_da,
+        bridge_params,
     );
 
     // Phase 3: Seal the epoch if the policy says so or the checkpoint payload is near the
@@ -431,6 +436,7 @@ where
     skip_all,
     fields(component = "ol_block_assembly", tx_count = mempool_txs.len())
 )]
+#[expect(clippy::too_many_arguments, reason = "all arguments are required")]
 fn process_transactions<P, S>(
     proof_gen: &P,
     block_context: &BlockContext<'_>,
@@ -439,6 +445,7 @@ fn process_transactions<P, S>(
     accumulated_batch: WriteBatch<S::AccountState>,
     mempool_txs: Vec<(OLTxId, OLTransaction)>,
     accumulated_da: AccumulatedDaData,
+    bridge_params: BridgeParams,
 ) -> ProcessTransactionsOutput<S>
 where
     P: AccumulatorProofGenerator,
@@ -513,7 +520,8 @@ where
         // Step 3: Create per-tx output buffer and execute transaction.
         // Logs are only merged into main buffer on success; on failure they're discarded.
         let tx_buffer = ExecOutputBuffer::new_empty();
-        let basic_ctx = BasicExecContext::new(*block_context.block_info(), &tx_buffer);
+        let basic_ctx = BasicExecContext::new(*block_context.block_info(), &tx_buffer)
+            .with_bridge_params(bridge_params);
         let tx_ctx = TxExecContext::new(&basic_ctx, block_context.parent_header());
 
         debug!(%txid, kind = %tx.payload().type_id(), "processing transaction");
@@ -2567,6 +2575,7 @@ mod tests {
             accumulated_batch,
             vec![(txid, tx)],
             AccumulatedDaData::new_empty(),
+            BridgeParams::default(),
         );
 
         assert!(
@@ -2623,6 +2632,7 @@ mod tests {
             accumulated_batch,
             vec![(tx_fill_id, tx_fill), (tx_overflow_id, tx_overflow)],
             AccumulatedDaData::new_empty(),
+            BridgeParams::default(),
         );
 
         assert_eq!(
@@ -2667,6 +2677,7 @@ mod tests {
             accumulated_batch,
             vec![(txid, tx)],
             AccumulatedDaData::new_empty(),
+            BridgeParams::default(),
         );
 
         assert!(
@@ -2706,6 +2717,7 @@ mod tests {
             accumulated_batch,
             mempool_txs,
             seeded_da,
+            BridgeParams::default(),
         )
     }
 

--- a/crates/ol/block-assembly/src/builder.rs
+++ b/crates/ol/block-assembly/src/builder.rs
@@ -7,6 +7,7 @@ use std::{
 
 use strata_config::{BlockAssemblyConfig, SequencerConfig};
 use strata_ledger_types::{IAccountStateMut, IStateAccessor, IStateAccessorMut};
+use strata_ol_params::OLParams;
 use strata_ol_state_provider::StateProvider;
 use strata_predicate::PredicateKey;
 use strata_service::ServiceBuilder;
@@ -27,6 +28,7 @@ where
     E: EpochSealingPolicy,
     P: StateProvider,
 {
+    ol_params: Arc<OLParams>,
     blockasm_config: Arc<BlockAssemblyConfig>,
     storage: Arc<NodeStorage>,
     mempool_provider: M,
@@ -43,7 +45,12 @@ where
     E: EpochSealingPolicy,
     P: StateProvider,
 {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "params can be removed once RollupParams is phased out"
+    )]
     pub fn new(
+        ol_params: Arc<OLParams>,
         blockasm_config: Arc<BlockAssemblyConfig>,
         storage: Arc<NodeStorage>,
         mempool_provider: M,
@@ -53,6 +60,7 @@ where
         sequencer_predicate: PredicateKey,
     ) -> Self {
         Self {
+            ol_params,
             blockasm_config,
             storage,
             mempool_provider,
@@ -89,6 +97,7 @@ where
         ));
 
         let state = BlockasmServiceState::new(
+            self.ol_params,
             self.blockasm_config,
             self.sequencer_config,
             self.sequencer_predicate,

--- a/crates/ol/block-assembly/src/builder.rs
+++ b/crates/ol/block-assembly/src/builder.rs
@@ -45,10 +45,7 @@ where
     E: EpochSealingPolicy,
     P: StateProvider,
 {
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "params can be removed once RollupParams is phased out"
-    )]
+    #[expect(clippy::too_many_arguments, reason = "service builder wiring")]
     pub fn new(
         ol_params: Arc<OLParams>,
         blockasm_config: Arc<BlockAssemblyConfig>,

--- a/crates/ol/block-assembly/src/da_tracker.rs
+++ b/crates/ol/block-assembly/src/da_tracker.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::{Epoch, OLBlockCommitment, OLBlockId};
 use strata_ledger_types::{IAccountStateMut, IStateAccessorMut};
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLLog};
@@ -113,6 +114,7 @@ async fn collect_epoch_blocks_until<C: BlockAssemblyAnchorContext>(
 pub(crate) async fn rebuild_accumulated_da_upto<C: BlockAssemblyAnchorContext>(
     blkid: OLBlockCommitment,
     epoch: Epoch,
+    bridge_params: BridgeParams,
     ctx: &C,
 ) -> Result<AccumulatedDaData, BlockAssemblyError>
 where
@@ -129,6 +131,7 @@ where
         &mut da_state,
         &epoch_blocks.blocks,
         &epoch_blocks.epoch_parent,
+        bridge_params,
     )
     .map_err(|e| BlockAssemblyError::Other(format!("epoch block replay failed: {e}")))?;
 
@@ -276,9 +279,10 @@ mod tests {
         env.put_block(boundary).await;
         env.put_block(target).await;
 
-        let err = rebuild_accumulated_da_upto(target_commitment, 2, env.ctx())
-            .await
-            .expect_err("missing boundary state should fail rebuild");
+        let err =
+            rebuild_accumulated_da_upto(target_commitment, 2, BridgeParams::default(), env.ctx())
+                .await
+                .expect_err("missing boundary state should fail rebuild");
         assert!(
             matches!(err, BlockAssemblyError::EpochBoundaryStateNotFound(_)),
             "expected EpochBoundaryStateNotFound(_), got: {err:?}"

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -129,6 +129,7 @@ where
         state.sequencer_config(),
         config,
         parent_da,
+        *state.ol_params().bridge_params(),
     )
     .await?;
 
@@ -233,6 +234,7 @@ mod tests {
     use strata_identifiers::{Buf32, Buf64};
     use strata_ol_chain_types_new::test_utils::schnorr_predicate;
     use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
+    use strata_ol_params::OLParams;
     use strata_ol_state_provider::OLStateManagerProviderImpl;
     use strata_predicate::PredicateKey;
     use strata_primitives::utils::get_test_schnorr_keys;
@@ -282,6 +284,7 @@ mod tests {
         let mempool = env.mempool_arc();
 
         let state = BlockasmServiceState::new(
+            Arc::new(OLParams::default()),
             Arc::new(BlockAssemblyConfig::new(TEST_BLOCK_TEMPLATE_TTL)),
             env.sequencer_config().clone(),
             sequencer_predicate,

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -10,6 +10,7 @@ use std::{
 use strata_config::{BlockAssemblyConfig, SequencerConfig};
 use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use strata_ledger_types::{IAccountStateMut, IStateAccessorMut};
+use strata_ol_params::OLParams;
 use strata_ol_state_provider::StateProvider;
 use strata_predicate::PredicateKey;
 use strata_service::ServiceState;
@@ -196,6 +197,7 @@ impl BlockAssemblyState {
 
 /// Combined state for the service (context + mutable state).
 pub(crate) struct BlockasmServiceState<M: MempoolProvider, E: EpochSealingPolicy, S> {
+    ol_params: Arc<OLParams>,
     blockasm_config: Arc<BlockAssemblyConfig>,
     sequencer_config: SequencerConfig,
     sequencer_predicate: PredicateKey,
@@ -221,6 +223,7 @@ impl<M: MempoolProvider, E: EpochSealingPolicy, S> Debug for BlockasmServiceStat
 impl<M: MempoolProvider, E: EpochSealingPolicy, S> BlockasmServiceState<M, E, S> {
     /// Create new block assembly service state.
     pub(crate) fn new(
+        ol_params: Arc<OLParams>,
         blockasm_config: Arc<BlockAssemblyConfig>,
         sequencer_config: SequencerConfig,
         sequencer_predicate: PredicateKey,
@@ -229,6 +232,7 @@ impl<M: MempoolProvider, E: EpochSealingPolicy, S> BlockasmServiceState<M, E, S>
     ) -> Self {
         let ttl = Duration::from_secs(sequencer_config.block_template_ttl_secs);
         Self {
+            ol_params,
             blockasm_config,
             sequencer_config,
             sequencer_predicate,
@@ -237,6 +241,10 @@ impl<M: MempoolProvider, E: EpochSealingPolicy, S> BlockasmServiceState<M, E, S>
             state: BlockAssemblyState::new(ttl),
             epoch_da_tracker: EpochDaTracker::new_empty(),
         }
+    }
+
+    pub(crate) fn ol_params(&self) -> &OLParams {
+        &self.ol_params
     }
 
     pub(crate) fn sequencer_config(&self) -> &SequencerConfig {
@@ -302,7 +310,15 @@ where
                 .get_accumulated_da(parent_blkid.blkid)
             {
                 Some(da) => Ok(da.clone()),
-                None => rebuild_accumulated_da_upto(parent_blkid, cur_epoch, self.context()).await,
+                None => {
+                    rebuild_accumulated_da_upto(
+                        parent_blkid,
+                        cur_epoch,
+                        *self.ol_params().bridge_params(),
+                        self.context(),
+                    )
+                    .await
+                }
             }
         }
     }
@@ -361,6 +377,7 @@ mod tests {
         let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         let state = BlockasmServiceState::new(
+            Arc::new(OLParams::default()),
             Arc::new(BlockAssemblyConfig::new(TEST_BLOCK_TEMPLATE_TTL)),
             env.sequencer_config().clone(),
             PredicateKey::always_accept(),
@@ -577,6 +594,7 @@ mod tests {
             env.sequencer_config(),
             config,
             AccumulatedDaData::new_empty(),
+            *state.ol_params().bridge_params(),
         )
         .await
         .expect("child block generation should succeed");

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -42,7 +42,7 @@ use strata_ol_chain_types_new::{
 };
 use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
 use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, WithdrawalMsgData};
-use strata_ol_params::OLParams;
+use strata_ol_params::{BridgeParams, OLParams};
 use strata_ol_state_provider::{OLStateManagerProviderImpl, StateProvider};
 use strata_ol_state_support_types::{EpochDaAccumulator, MemoryStateBaseLayer};
 use strata_ol_state_types::{MMR_SENTINEL_DUMMY_LEAF_HASH, OLState};
@@ -624,8 +624,13 @@ pub(crate) fn create_test_parent_header() -> strata_ol_chain_types_new::OLBlockH
     let mut temp_state = create_test_genesis_state();
     let genesis_context = BlockContext::new(&genesis_info, None);
     let genesis_components = BlockComponents::new_empty();
-    let genesis_output =
-        stf_construct_block(&mut temp_state, genesis_context, genesis_components).unwrap();
+    let genesis_output = stf_construct_block(
+        &mut temp_state,
+        genesis_context,
+        genesis_components,
+        BridgeParams::default(),
+    )
+    .unwrap();
     genesis_output.completed_block().header().clone()
 }
 
@@ -994,6 +999,7 @@ impl TestEnv {
             self.sequencer_config(),
             config,
             parent_da,
+            BridgeParams::default(),
         )
         .await
     }
@@ -1263,8 +1269,13 @@ impl TestStorageFixtureBuilder {
                 let components = BlockComponents::new_manifests(vec![genesis_manifest]);
 
                 let block_context = BlockContext::new(&block_info, None);
-                let construct_output = stf_construct_block(&mut state, block_context, components)
-                    .expect("Genesis block execution should succeed");
+                let construct_output = stf_construct_block(
+                    &mut state,
+                    block_context,
+                    components,
+                    BridgeParams::default(),
+                )
+                .expect("Genesis block execution should succeed");
 
                 let completed_block = construct_output.completed_block();
                 let header = completed_block.header().clone();
@@ -1485,6 +1496,7 @@ pub(crate) async fn assemble_block_with_txs(
         block_epoch,
         txs,
         parent_da,
+        BridgeParams::default(),
     )
     .await
 }

--- a/crates/ol/block-assembly/src/tests/da.rs
+++ b/crates/ol/block-assembly/src/tests/da.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::OLBlockCommitment;
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
 use strata_ol_state_support_types::{
@@ -113,9 +114,13 @@ async fn test_da_incremental_matches_replay() {
 
     let owned_blocks: Vec<OLBlock> = blocks.into_iter().cloned().collect();
     let mut replay_da_state = DaAccumulatingState::new(Arc::unwrap_or_clone(genesis_state));
-    let replay_logs =
-        execute_block_batch_preseal(&mut replay_da_state, &owned_blocks, parent_header)
-            .expect("replay should succeed");
+    let replay_logs = execute_block_batch_preseal(
+        &mut replay_da_state,
+        &owned_blocks,
+        parent_header,
+        BridgeParams::default(),
+    )
+    .expect("replay should succeed");
 
     let (replay_acc, replay_inner) = replay_da_state.into_parts();
     let replay_blob = finalize_da_to_bytes(replay_acc, replay_inner);
@@ -284,9 +289,10 @@ async fn test_rebuild_da_matches_incremental() {
 
     // Rebuild DA from scratch using the production code path.
     let epoch = artifacts[0].0.header().epoch();
-    let rebuilt_da = rebuild_accumulated_da_upto(final_commitment, epoch, env.ctx())
-        .await
-        .expect("rebuild_accumulated_da_upto should succeed");
+    let rebuilt_da =
+        rebuild_accumulated_da_upto(final_commitment, epoch, BridgeParams::default(), env.ctx())
+            .await
+            .expect("rebuild_accumulated_da_upto should succeed");
 
     let (rebuilt_acc, rebuilt_logs) = rebuilt_da.into_parts();
     let rebuilt_blob = finalize_da_to_bytes(rebuilt_acc, last_post_state.clone());

--- a/crates/ol/block-assembly/src/tests/mempool.rs
+++ b/crates/ol/block-assembly/src/tests/mempool.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use strata_bridge_params::BridgeParams;
 use strata_config::SequencerConfig;
 use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
 use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
@@ -40,6 +41,7 @@ async fn test_missing_parent_fails() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect_err("missing parent state should fail");
@@ -68,6 +70,7 @@ async fn test_state_provider_failure_propagates() {
         &sequencer_config,
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect_err("state provider error should fail");
@@ -91,6 +94,7 @@ async fn test_get_transactions_failure_propagates() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect_err("mempool get failure should fail");
@@ -130,6 +134,7 @@ async fn test_generation_stage_does_not_report_invalid_txs() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("inner assembly should not call report_invalid_transactions");
@@ -162,6 +167,7 @@ async fn test_no_report_when_all_txs_valid() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("valid tx block assembly should succeed");
@@ -201,6 +207,7 @@ async fn test_exact_failed_txs_payload() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("assembly should succeed with invalid tx filtered");
@@ -249,6 +256,7 @@ async fn test_mixed_failures_keep_order_and_reason() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("assembly should succeed with failed tx filtering");
@@ -291,6 +299,7 @@ async fn test_max_txs_returns_only_fetched_failures() {
         &sequencer_config,
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("assembly should succeed with limited tx fetch");
@@ -327,6 +336,7 @@ async fn test_exec_failure_maps_to_failed() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("assembly should succeed with failed execution filtered");
@@ -360,6 +370,7 @@ async fn test_duplicate_txid_one_fails() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("assembly should succeed");
@@ -396,6 +407,7 @@ async fn test_duplicate_txid_both_fail() {
         env.sequencer_config(),
         config,
         AccumulatedDaData::new_empty(),
+        BridgeParams::default(),
     )
     .await
     .expect("assembly should succeed with both txs filtered");

--- a/crates/ol/checkpoint/Cargo.toml
+++ b/crates/ol/checkpoint/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 metrics.workspace = true
 serde.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
+strata-bridge-params.workspace = true
 strata-checkpoint-types.workspace = true
 strata-identifiers.workspace = true
 strata-node-context.workspace = true

--- a/crates/ol/checkpoint/src/builder.rs
+++ b/crates/ol/checkpoint/src/builder.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
+use strata_bridge_params::BridgeParams;
 use strata_node_context::NodeContext;
 use strata_primitives::epoch::EpochCommitment;
 use strata_service::{ServiceBuilder, SyncAsyncInput, TokioWatchInput};
@@ -22,6 +23,7 @@ use crate::{
 /// Builder for constructing and launching an OL checkpoint service.
 pub struct OLCheckpointBuilder {
     storage: Option<Arc<NodeStorage>>,
+    bridge_params: BridgeParams,
     epoch_summary_rx: Option<watch::Receiver<Option<EpochCommitment>>>,
     prover: Option<ProverConfig>,
 }
@@ -31,14 +33,16 @@ impl OLCheckpointBuilder {
     pub fn new() -> Self {
         Self {
             storage: None,
+            bridge_params: BridgeParams::default(),
             epoch_summary_rx: None,
             prover: None,
         }
     }
 
-    /// Set storage from [`NodeContext`].
+    /// Set storage and withdrawal params from [`NodeContext`].
     pub fn with_node_context(mut self, nodectx: &NodeContext) -> Self {
         self.storage = Some(nodectx.storage().clone());
+        self.bridge_params = *nodectx.ol_params().bridge_params();
         self
     }
 
@@ -75,8 +79,10 @@ impl OLCheckpointBuilder {
         let input = SyncAsyncInput::new(input, runtime_handle);
 
         let ctx = match self.prover {
-            Some(prover) => CheckpointWorkerContextImpl::with_prover(storage, prover),
-            None => CheckpointWorkerContextImpl::new(storage),
+            Some(prover) => {
+                CheckpointWorkerContextImpl::with_prover(storage, self.bridge_params, prover)
+            }
+            None => CheckpointWorkerContextImpl::new(storage, self.bridge_params),
         };
         let state = OLCheckpointServiceState::new(ctx);
         let builder = ServiceBuilder::<OLCheckpointService<CheckpointWorkerContextImpl>, _>::new()

--- a/crates/ol/checkpoint/src/context.rs
+++ b/crates/ol/checkpoint/src/context.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use strata_asm_proto_checkpoint_types::CheckpointPayload;
+use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
 use strata_identifiers::{Epoch, EpochCommitment, OLBlockCommitment};
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLBlockId, OLLog};
@@ -146,6 +147,7 @@ pub struct ProverConfig {
 /// for the prover to deliver them. Without it, returns empty proofs.
 pub(crate) struct CheckpointWorkerContextImpl {
     storage: Arc<NodeStorage>,
+    bridge_params: BridgeParams,
     /// When present, a prover is running and `get_proof` waits for proofs.
     /// When absent, `get_proof` returns empty immediately.
     prover: Option<ProverConfig>,
@@ -155,17 +157,23 @@ impl CheckpointWorkerContextImpl {
     /// Creates a new context without a prover.
     ///
     /// `get_proof` always returns empty bytes.
-    pub(crate) fn new(storage: Arc<NodeStorage>) -> Self {
+    pub(crate) fn new(storage: Arc<NodeStorage>, bridge_params: BridgeParams) -> Self {
         Self {
             storage,
+            bridge_params,
             prover: None,
         }
     }
 
     /// Creates a new context with an integrated prover.
-    pub(crate) fn with_prover(storage: Arc<NodeStorage>, prover: ProverConfig) -> Self {
+    pub(crate) fn with_prover(
+        storage: Arc<NodeStorage>,
+        bridge_params: BridgeParams,
+        prover: ProverConfig,
+    ) -> Self {
         Self {
             storage,
+            bridge_params,
             prover: Some(prover),
         }
     }
@@ -329,7 +337,8 @@ impl CheckpointWorkerContext for CheckpointWorkerContextImpl {
         &self,
         summary: &EpochSummary,
     ) -> anyhow::Result<(StateDiffRaw, Vec<OLLog>)> {
-        let (statediff, logs, terminal_header) = replay_epoch_and_compute_da(self, summary)?;
+        let (statediff, logs, terminal_header) =
+            replay_epoch_and_compute_da(self, summary, self.bridge_params)?;
         assert_terminal_commitment_matches(&terminal_header, summary.terminal())?;
         Ok((statediff, logs))
     }
@@ -364,6 +373,7 @@ fn assert_terminal_commitment_matches(
 fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
     ctx: &C,
     summary: &EpochSummary,
+    bridge_params: BridgeParams,
 ) -> anyhow::Result<(Vec<u8>, Vec<OLLog>, OLBlockHeader)> {
     let epoch_blocks = collect_epoch_blocks(summary, ctx)?;
 
@@ -379,8 +389,13 @@ fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
 
     let mut da_state = DaAccumulatingState::new(ol_state);
 
-    let logs = execute_block_batch_preseal(&mut da_state, &epoch_blocks, &prev_terminal_header)
-        .map_err(|e| anyhow::anyhow!("epoch block replay failed: {e}"))?;
+    let logs = execute_block_batch_preseal(
+        &mut da_state,
+        &epoch_blocks,
+        &prev_terminal_header,
+        bridge_params,
+    )
+    .map_err(|e| anyhow::anyhow!("epoch block replay failed: {e}"))?;
 
     let terminal_header = epoch_blocks.ensured_last().header().clone();
 

--- a/crates/ol/checkpoint/src/state.rs
+++ b/crates/ol/checkpoint/src/state.rs
@@ -195,6 +195,7 @@ mod tests {
     use strata_asm_proto_checkpoint_types::{
         CheckpointPayload, CheckpointTip, test_utils::checkpoint_sidecar_strategy,
     };
+    use strata_bridge_params::BridgeParams;
     use strata_checkpoint_types::EpochSummary;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::{
@@ -243,7 +244,7 @@ mod tests {
             stub_ol_logs: Vec<OLLog>,
         ) -> Self {
             Self {
-                inner: CheckpointWorkerContextImpl::new(storage),
+                inner: CheckpointWorkerContextImpl::new(storage, BridgeParams::default()),
                 stub_state_diff,
                 stub_ol_logs,
             }
@@ -369,7 +370,7 @@ mod tests {
                     .expect("put checkpoint");
             }
 
-            let ctx = CheckpointWorkerContextImpl::new(storage);
+            let ctx = CheckpointWorkerContextImpl::new(storage, BridgeParams::default());
             let mut state = OLCheckpointServiceState::new(ctx);
             state.initialize();
 

--- a/crates/ol/genesis/src/lib.rs
+++ b/crates/ol/genesis/src/lib.rs
@@ -76,8 +76,12 @@ pub fn build_genesis_artifacts(params: &OLParams) -> Result<GenesisArtifacts> {
 
     // Execute genesis block through the OL STF.
     let block_context = BlockContext::new(&genesis_info, None);
-    let genesis_block =
-        execute_and_complete_block(&mut ol_state, block_context, genesis_components)?;
+    let genesis_block = execute_and_complete_block(
+        &mut ol_state,
+        block_context,
+        genesis_components,
+        *params.bridge_params(),
+    )?;
     let ol_state = ol_state.into_inner();
 
     // Create signed header (genesis uses zero signature).

--- a/crates/ol/params/Cargo.toml
+++ b/crates/ol/params/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 workspace = true
 
 [dependencies]
+strata-bridge-params.workspace = true
 strata-btc-types.workspace = true
 strata-identifiers.workspace = true
 strata-predicate.workspace = true
@@ -18,4 +19,8 @@ serde.workspace = true
 serde_json.workspace = true
 
 [features]
-arbitrary = ["dep:arbitrary", "strata-predicate/arbitrary"]
+arbitrary = [
+  "dep:arbitrary",
+  "strata-predicate/arbitrary",
+  "strata-bridge-params/arbitrary",
+]

--- a/crates/ol/params/src/lib.rs
+++ b/crates/ol/params/src/lib.rs
@@ -13,6 +13,7 @@ pub use account::GenesisSnarkAccountData;
 use arbitrary::Arbitrary;
 pub use header::GenesisHeaderParams;
 use serde::{Deserialize, Serialize};
+pub use strata_bridge_params::BridgeParams;
 use strata_identifiers::{AccountId, EpochCommitment, L1BlockCommitment};
 
 /// Top-level OL genesis parameters.
@@ -33,6 +34,10 @@ pub struct OLParams {
     /// Last L1 block known at genesis time, treated as the initial verified L1 tip.
     #[serde(default)]
     pub last_l1_block: L1BlockCommitment,
+
+    /// Withdrawal denomination and optional cap.
+    #[serde(default)]
+    pub bridge_params: BridgeParams,
 }
 
 impl OLParams {
@@ -42,7 +47,12 @@ impl OLParams {
             header: GenesisHeaderParams::default(),
             accounts: BTreeMap::new(),
             last_l1_block,
+            ..Default::default()
         }
+    }
+
+    pub fn bridge_params(&self) -> &BridgeParams {
+        &self.bridge_params
     }
 
     /// Builds an [`EpochCommitment`] from the genesis header parameters.
@@ -94,6 +104,7 @@ mod tests {
             header: serde_json::from_str("{}").unwrap(),
             accounts,
             last_l1_block: L1BlockCommitment::default(),
+            ..Default::default()
         }
     }
 

--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -9,6 +9,7 @@ ssz_types = { workspace = true, optional = true }
 strata-acct-types.workspace = true
 strata-asm-common.workspace = true
 strata-asm-logs.workspace = true
+strata-bridge-params.workspace = true
 strata-codec.workspace = true
 strata-identifiers.workspace = true
 strata-ledger-types.workspace = true

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -148,7 +148,7 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     let dest = withdrawal_data.into_dest_desc();
     let dest_desc_len = dest.len();
     let log_data = SimpleWithdrawalIntentLogData {
-        amt: amt_raw.into(),
+        amt: amt_raw,
         selected_operator,
         dest,
     };

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -132,16 +132,12 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
         return Ok(());
     };
 
-    // 2. Check if the withdrawal amount is a positive exact multiple of the denomination
-    let withdrawal_amt = payload.value();
-
-    // TODO(STR-2974) move to params struct
-    let withdrawal_denom: u64 = 100_000_000;
-
-    // 3. Verify the amount is a positive exact multiple of the denomination.
-    let amt_raw: u64 = withdrawal_amt.into();
-    if amt_raw == 0 || !amt_raw.is_multiple_of(withdrawal_denom) {
-        // Sweep to limbo.
+    // 2. Validate the withdrawal amount against params.
+    let amt_raw: u64 = payload.value().into();
+    let valid = context
+        .bridge_params()
+        .is_some_and(|wp| wp.validate_withdrawal_amount(amt_raw));
+    if !valid {
         warn!(%sender, %amt_raw, "limboing bad amount sent to bridge gateway acct");
         handle_misplaced_funds(state, coin)?;
         return Ok(());
@@ -152,7 +148,7 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     let dest = withdrawal_data.into_dest_desc();
     let dest_desc_len = dest.len();
     let log_data = SimpleWithdrawalIntentLogData {
-        amt: withdrawal_amt.into(),
+        amt: amt_raw.into(),
         selected_operator,
         dest,
     };

--- a/crates/ol/stf/src/assembly.rs
+++ b/crates/ol/stf/src/assembly.rs
@@ -448,7 +448,13 @@ pub fn execute_block_batch_preseal<S: IStateAccessorMut>(
     let mut batch_logs = Vec::with_capacity(blocks.len());
 
     for block in blocks {
-        let logs = verify_block_preseal(state, block.header(), Some(&parent), block.body(), bridge_params)?;
+        let logs = verify_block_preseal(
+            state,
+            block.header(),
+            Some(&parent),
+            block.body(),
+            bridge_params,
+        )?;
         parent = block.header().clone();
         batch_logs.push(logs);
     }

--- a/crates/ol/stf/src/assembly.rs
+++ b/crates/ol/stf/src/assembly.rs
@@ -2,6 +2,7 @@
 
 use strata_acct_types::TxEffects;
 use strata_asm_common::AsmManifest;
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::Buf32;
 use strata_ledger_types::IStateAccessorMut;
 use strata_merkle::{BinaryMerkleTree, Sha256Hasher};
@@ -126,6 +127,7 @@ pub fn execute_block_inputs<S: IStateAccessorMut>(
     state: &mut S,
     block_context: BlockContext<'_>,
     block_exec_input: BlockExecInput<'_>,
+    bridge_params: BridgeParams,
 ) -> ExecResult<BlockExecOutputs> {
     // 0. Construct the block exec context for tracking verification state
     // across phases.
@@ -138,7 +140,8 @@ pub fn execute_block_inputs<S: IStateAccessorMut>(
     execute_block_start(state, &block_context)?;
 
     // 3. Call process_block_tx_segment for every block as usual.
-    let basic_ctx = BasicExecContext::new(*block_context.block_info(), &output);
+    let basic_ctx = BasicExecContext::new(*block_context.block_info(), &output)
+        .with_bridge_params(bridge_params);
     let tx_ctx = TxExecContext::new(&basic_ctx, block_context.parent_header());
     execute_block_tx_segment(state, block_exec_input.tx_segment(), &tx_ctx)?;
     // Defense-in-depth: `emit_logs` enforces the cap at insertion time, and this
@@ -337,10 +340,11 @@ pub fn construct_block<S: IStateAccessorMut>(
     state: &mut S,
     block_context: BlockContext<'_>,
     block_components: BlockComponents,
+    bridge_params: BridgeParams,
 ) -> ExecResult<ConstructBlockOutput> {
     // 1. First just execute the block with the inputs.
     let block_exec_input = block_components.to_exec_input();
-    let exec_outputs = execute_block_inputs(state, block_context, block_exec_input)?;
+    let exec_outputs = execute_block_inputs(state, block_context, block_exec_input, bridge_params)?;
 
     // 2. Take the inputs and outputs and compute the commitments for the header.
 
@@ -391,8 +395,9 @@ pub fn execute_and_complete_block<S: IStateAccessorMut>(
     state: &mut S,
     block_context: BlockContext<'_>,
     block_components: BlockComponents,
+    bridge_params: BridgeParams,
 ) -> ExecResult<CompletedBlock> {
-    let construct_output = construct_block(state, block_context, block_components)?;
+    let construct_output = construct_block(state, block_context, block_components, bridge_params)?;
     Ok(construct_output.completed_block)
 }
 
@@ -407,12 +412,19 @@ pub fn execute_block_batch<S: IStateAccessorMut>(
     state: &mut S,
     blocks: &[OLBlock],
     initial_parent: &OLBlockHeader,
+    bridge_params: BridgeParams,
 ) -> ExecResult<Vec<OLLog>> {
     let mut parent = initial_parent.clone();
     let mut batch_logs = Vec::with_capacity(blocks.len());
 
     for block in blocks {
-        let logs = verify_block(state, block.header(), Some(&parent), block.body())?;
+        let logs = verify_block(
+            state,
+            block.header(),
+            Some(&parent),
+            block.body(),
+            bridge_params,
+        )?;
         parent = block.header().clone();
         batch_logs.push(logs);
     }

--- a/crates/ol/stf/src/assembly.rs
+++ b/crates/ol/stf/src/assembly.rs
@@ -442,12 +442,13 @@ pub fn execute_block_batch_preseal<S: IStateAccessorMut>(
     state: &mut S,
     blocks: &[OLBlock],
     initial_parent: &OLBlockHeader,
+    bridge_params: BridgeParams,
 ) -> ExecResult<Vec<OLLog>> {
     let mut parent = initial_parent.clone();
     let mut batch_logs = Vec::with_capacity(blocks.len());
 
     for block in blocks {
-        let logs = verify_block_preseal(state, block.header(), Some(&parent), block.body())?;
+        let logs = verify_block_preseal(state, block.header(), Some(&parent), block.body(), bridge_params)?;
         parent = block.header().clone();
         batch_logs.push(logs);
     }

--- a/crates/ol/stf/src/context.rs
+++ b/crates/ol/stf/src/context.rs
@@ -8,6 +8,7 @@
 //! ensuring that we don't box ourselves into a design corner where we can't do
 //! DA-based state reconstruction.
 
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::{Epoch, OLBlockHeader, OLLog, Slot};
 
@@ -207,10 +208,15 @@ impl EpochInitialContext {
 }
 
 /// Basic execution context which can be used for tracking outputs.
+///
+/// Optionally carries withdrawal parameters for transaction processing paths
+/// that validate withdrawal amounts. Manifest processing paths leave this as
+/// `None`.
 #[derive(Debug)]
 pub struct BasicExecContext<'b> {
     block_info: BlockInfo,
     output_buffer: &'b ExecOutputBuffer,
+    bridge_params: Option<BridgeParams>,
 }
 
 impl<'b> BasicExecContext<'b> {
@@ -218,7 +224,13 @@ impl<'b> BasicExecContext<'b> {
         Self {
             block_info,
             output_buffer,
+            bridge_params: None,
         }
+    }
+
+    pub fn with_bridge_params(mut self, bridge_params: BridgeParams) -> Self {
+        self.bridge_params = Some(bridge_params);
+        self
     }
 
     fn block_info(&self) -> &BlockInfo {
@@ -235,6 +247,10 @@ impl<'b> BasicExecContext<'b> {
 
     pub fn epoch(&self) -> Epoch {
         self.block_info.epoch()
+    }
+
+    pub fn bridge_params(&self) -> Option<&BridgeParams> {
+        self.bridge_params.as_ref()
     }
 }
 

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -82,7 +82,7 @@ use strata_ol_msg_types::{
     DEFAULT_OPERATOR_FEE, DEPOSIT_MSG_TYPE_ID, DepositMsgData, WITHDRAWAL_MSG_TYPE_ID,
     WithdrawalMsgData,
 };
-use strata_ol_params::OLParams;
+use strata_ol_params::{BridgeParams, OLParams};
 use strata_ol_state_support_types::MemoryStateBaseLayer;
 use strata_ol_state_types::{
     MMR_SENTINEL_DUMMY_LEAF, OLAccountState, OLSnarkAccountState, OLState,
@@ -116,6 +116,29 @@ pub const TEST_NONEXISTENT_ID: u32 = 999;
 /// Builds a state root with predictable bytes.
 pub fn make_state_root(variant: u8) -> Hash {
     Hash::from([variant; 32])
+}
+
+/// Execute a block with the given block info and return the completed block.
+pub fn execute_block(
+    state: &mut MemoryStateBaseLayer,
+    block_info: &BlockInfo,
+    parent_header: Option<&OLBlockHeader>,
+    components: BlockComponents,
+) -> ExecResult<CompletedBlock> {
+    let block_context = BlockContext::new(block_info, parent_header);
+    execute_and_complete_block(state, block_context, components, BridgeParams::default())
+}
+
+/// Execute a block and return the construct output which includes both the completed block and
+/// execution outputs. This is useful for tests that need to inspect the logs.
+pub fn execute_block_with_outputs(
+    state: &mut MemoryStateBaseLayer,
+    block_info: &BlockInfo,
+    parent_header: Option<&OLBlockHeader>,
+    components: BlockComponents,
+) -> ExecResult<ConstructBlockOutput> {
+    let block_context = BlockContext::new(block_info, parent_header);
+    construct_block(state, block_context, components, BridgeParams::default())
 }
 
 /// Builds proof bytes with predictable contents.
@@ -545,7 +568,13 @@ pub fn assert_verification_succeeds<S: IStateAccessorMut>(
     parent_header: Option<OLBlockHeader>,
     body: &strata_ol_chain_types_new::OLBlockBody,
 ) {
-    let result = verify_block(state, header, parent_header.as_ref(), body);
+    let result = verify_block(
+        state,
+        header,
+        parent_header.as_ref(),
+        body,
+        BridgeParams::default(),
+    );
     assert!(
         result.is_ok(),
         "Block verification failed when it should have succeeded: {:?}",
@@ -561,7 +590,13 @@ pub fn assert_verification_fails_with(
     body: &strata_ol_chain_types_new::OLBlockBody,
     error_matcher: impl Fn(&ExecError) -> bool,
 ) {
-    let result = verify_block(state, header, parent_header.as_ref(), body);
+    let result = verify_block(
+        state,
+        header,
+        parent_header.as_ref(),
+        body,
+        BridgeParams::default(),
+    );
     assert!(
         result.is_err(),
         "Block verification succeeded when it should have failed"

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -118,29 +118,6 @@ pub fn make_state_root(variant: u8) -> Hash {
     Hash::from([variant; 32])
 }
 
-/// Execute a block with the given block info and return the completed block.
-pub fn execute_block(
-    state: &mut MemoryStateBaseLayer,
-    block_info: &BlockInfo,
-    parent_header: Option<&OLBlockHeader>,
-    components: BlockComponents,
-) -> ExecResult<CompletedBlock> {
-    let block_context = BlockContext::new(block_info, parent_header);
-    execute_and_complete_block(state, block_context, components, BridgeParams::default())
-}
-
-/// Execute a block and return the construct output which includes both the completed block and
-/// execution outputs. This is useful for tests that need to inspect the logs.
-pub fn execute_block_with_outputs(
-    state: &mut MemoryStateBaseLayer,
-    block_info: &BlockInfo,
-    parent_header: Option<&OLBlockHeader>,
-    components: BlockComponents,
-) -> ExecResult<ConstructBlockOutput> {
-    let block_context = BlockContext::new(block_info, parent_header);
-    construct_block(state, block_context, components, BridgeParams::default())
-}
-
 /// Builds proof bytes with predictable contents.
 pub fn make_proof(variant: u8) -> Vec<u8> {
     vec![variant; 100]
@@ -472,7 +449,7 @@ pub fn execute_block(
     components: BlockComponents,
 ) -> ExecResult<CompletedBlock> {
     let block_context = BlockContext::new(block_info, parent_header);
-    execute_and_complete_block(state, block_context, components)
+    execute_and_complete_block(state, block_context, components, BridgeParams::default())
 }
 
 /// Executes a block and returns the construct output, which includes both the completed block and
@@ -484,7 +461,7 @@ pub fn execute_block_with_outputs(
     components: BlockComponents,
 ) -> ExecResult<ConstructBlockOutput> {
     let block_context = BlockContext::new(block_info, parent_header);
-    construct_block(state, block_context, components)
+    construct_block(state, block_context, components, BridgeParams::default())
 }
 
 /// Executes a transaction in a non-genesis block.

--- a/crates/ol/stf/src/tests/da_preseal_correctness.rs
+++ b/crates/ol/stf/src/tests/da_preseal_correctness.rs
@@ -4,6 +4,7 @@
 
 use strata_acct_types::BitcoinAmount;
 use strata_asm_common::AsmManifest;
+use strata_bridge_params::BridgeParams;
 use strata_codec::decode_buf_exact;
 use strata_identifiers::{Buf64, OLBlockCommitment, SubjectId};
 use strata_ledger_types::IStateAccessor;
@@ -156,8 +157,13 @@ fn rebuild_da_blob(
     prev_terminal_header: &OLBlockHeader,
 ) -> Vec<u8> {
     let mut da = DaAccumulatingState::new(pre_epoch_state.clone());
-    execute_block_batch_preseal(&mut da, blocks, prev_terminal_header)
-        .expect("execute_block_batch_preseal");
+    execute_block_batch_preseal(
+        &mut da,
+        blocks,
+        prev_terminal_header,
+        BridgeParams::default(),
+    )
+    .expect("execute_block_batch_preseal");
     da.take_completed_epoch_da_blob()
         .expect("finalize DA")
         .expect("DA blob")

--- a/crates/ol/stf/src/tests/partial_execution.rs
+++ b/crates/ol/stf/src/tests/partial_execution.rs
@@ -1,6 +1,7 @@
 //! Tests that pin mid-block failure semantics (no rollback + TxExec context wrapping).
 
 use strata_acct_types::{AccountId, BitcoinAmount, TxEffects};
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::Buf32;
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_ol_chain_types_new::{
@@ -178,7 +179,13 @@ fn test_verify_block_mid_failure_returns_txexec() {
         Buf32::zero(),
     );
 
-    let result = verify_block(&mut state, &header, Some(parent_block.header()), &body);
+    let result = verify_block(
+        &mut state,
+        &header,
+        Some(parent_block.header()),
+        &body,
+        BridgeParams::default(),
+    );
 
     match result {
         Err(ExecError::TxExec(txid, idx, inner)) => {

--- a/crates/ol/stf/src/tests/sau_sequences.rs
+++ b/crates/ol/stf/src/tests/sau_sequences.rs
@@ -1,6 +1,7 @@
 //! Multi-block sequence tests for dependent snark account updates.
 
 use strata_acct_types::{BitcoinAmount, Hash};
+use strata_bridge_params::BridgeParams;
 use strata_ledger_types::ISnarkAccountState;
 use strata_ol_chain_types_new::OLBlockHeader;
 
@@ -49,6 +50,7 @@ fn test_dependent_snark_updates_advance_across_blocks() {
             block.header(),
             Some(&parent_header),
             block.body(),
+            BridgeParams::default(),
         )
         .expect("dependent snark update block should verify");
 

--- a/crates/ol/stf/src/tests/staging_layers.rs
+++ b/crates/ol/stf/src/tests/staging_layers.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeSet;
 
 use strata_acct_types::{AccountId, AcctError, BitcoinAmount, MsgPayload};
+use strata_bridge_params::BridgeParams;
 use strata_ledger_types::{
     IAccountState, ISnarkAccountState, IStateAccessor, IStateAccessorMut, NewAccountData,
     NewAccountTypeState,
@@ -565,6 +566,7 @@ fn test_assembly_and_verify_write_tracking_reach_same_state() {
         block.header(),
         Some(&genesis_header),
         block.body(),
+        BridgeParams::default(),
     )
     .expect("assembled block should verify through staging layers");
 
@@ -627,6 +629,7 @@ fn test_verify_block_tracks_snark_inbox_writes() {
         block.header(),
         Some(&genesis_header),
         block.body(),
+        BridgeParams::default(),
     )
     .expect("GAM block should verify");
 
@@ -666,8 +669,14 @@ fn test_verify_block_through_write_tracking_stack() {
         let tracking = WriteTrackingState::new_empty(&verify_base);
         let mut indexer = IndexerState::new(tracking);
 
-        verify_block(&mut indexer, genesis.header(), None, genesis.body())
-            .expect("Genesis verification through write-tracking stack should succeed");
+        verify_block(
+            &mut indexer,
+            genesis.header(),
+            None,
+            genesis.body(),
+            BridgeParams::default(),
+        )
+        .expect("Genesis verification through write-tracking stack should succeed");
     }
 
     // Apply genesis writes to get post-genesis state for next block
@@ -676,8 +685,14 @@ fn test_verify_block_through_write_tracking_stack() {
         let tracking = WriteTrackingState::new_empty(&post_genesis);
         let mut indexer = IndexerState::new(tracking);
 
-        verify_block(&mut indexer, genesis.header(), None, genesis.body())
-            .expect("Genesis verification should succeed");
+        verify_block(
+            &mut indexer,
+            genesis.header(),
+            None,
+            genesis.body(),
+            BridgeParams::default(),
+        )
+        .expect("Genesis verification should succeed");
 
         let (tracking, _writes) = indexer.into_parts();
         post_genesis
@@ -695,6 +710,7 @@ fn test_verify_block_through_write_tracking_stack() {
             block1.header(),
             Some(genesis.header()),
             block1.body(),
+            BridgeParams::default(),
         )
         .expect("Block 1 verification through write-tracking stack should succeed");
     }
@@ -733,7 +749,7 @@ fn test_verify_terminal_block_through_write_tracking_stack() {
         let tracking = WriteTrackingState::new_empty(&verify_base);
         let mut indexer = IndexerState::new(tracking);
 
-        verify_block(&mut indexer, block.header(), parent_header.as_ref(), block.body()).unwrap_or_else(
+        verify_block(&mut indexer, block.header(), parent_header.as_ref(), block.body(), BridgeParams::default()).unwrap_or_else(
             |e| {
                 panic!(
                     "Block {} (slot {}, terminal={}) verification through write-tracking stack failed: {:?}",

--- a/crates/ol/stf/src/tests/stress.rs
+++ b/crates/ol/stf/src/tests/stress.rs
@@ -3,6 +3,7 @@
 //! Covers large transaction, inbox, and proof batches.
 
 use strata_acct_types::{BitcoinAmount, MessageEntry, MsgPayload};
+use strata_bridge_params::BridgeParams;
 use strata_ledger_types::ISnarkAccountState;
 
 use crate::{SEQUENCER_ACCT_ID, test_utils::*, verify_block};
@@ -123,6 +124,7 @@ fn test_stress_processes_large_inbox_proof_batch() {
         sau_block.completed_block().header(),
         Some(&parent_header),
         sau_block.completed_block().body(),
+        BridgeParams::default(),
     )
     .expect("large-message SAU should verify");
 

--- a/crates/ol/stf/src/verification.rs
+++ b/crates/ol/stf/src/verification.rs
@@ -4,6 +4,7 @@
 //! assembly as they perform all of the block validation checks including
 //! outputs (corresponding with headers/checkpoints/etc).
 
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::Buf32;
 use strata_ledger_types::*;
 use strata_merkle::{BinaryMerkleTree, Sha256Hasher};
@@ -155,6 +156,7 @@ pub fn verify_block<S: IStateAccessorMut>(
     header: &OLBlockHeader,
     parent_header: Option<&OLBlockHeader>,
     body: &OLBlockBody,
+    bridge_params: BridgeParams,
 ) -> ExecResult<Vec<OLLog>> {
     let exp = BlockExecExpectations::from_block_parts(header, body);
 
@@ -216,7 +218,8 @@ pub fn verify_block_preseal<S: IStateAccessorMut>(
 
     // 3. Call process_block_tx_segment for every block as usual.
     let output_buffer = ExecOutputBuffer::new_empty();
-    let basic_ctx = BasicExecContext::new(block_info, &output_buffer);
+    let basic_ctx =
+        BasicExecContext::new(block_info, &output_buffer).with_bridge_params(bridge_params);
     let tx_ctx = TxExecContext::new(&basic_ctx, parent_header);
     if let Some(tx_segment) = body.tx_segment() {
         transaction_processing::process_block_tx_segment(state, tx_segment, &tx_ctx)?;

--- a/crates/ol/stf/src/verification.rs
+++ b/crates/ol/stf/src/verification.rs
@@ -160,7 +160,7 @@ pub fn verify_block<S: IStateAccessorMut>(
 ) -> ExecResult<Vec<OLLog>> {
     let exp = BlockExecExpectations::from_block_parts(header, body);
 
-    let mut logs = verify_block_preseal(state, header, parent_header, body)?;
+    let mut logs = verify_block_preseal(state, header, parent_header, body, bridge_params)?;
     logs.extend(apply_block_manifests(state, header, body)?);
 
     // Verify logs size.
@@ -197,6 +197,7 @@ pub fn verify_block_preseal<S: IStateAccessorMut>(
     header: &OLBlockHeader,
     parent_header: Option<&OLBlockHeader>,
     body: &OLBlockBody,
+    bridge_params: BridgeParams,
 ) -> ExecResult<Vec<OLLog>> {
     // 0. Do preliminary sanity checks.
     verify_header_continuity(header, parent_header)?;

--- a/crates/proof-impl/alpen-acct/Cargo.toml
+++ b/crates/proof-impl/alpen-acct/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+alpen-reth-evm.workspace = true
+strata-bridge-params.workspace = true
 strata-ee-acct-runtime.workspace = true
 strata-evm-ee.workspace = true
 strata-predicate.workspace = true

--- a/crates/proof-impl/alpen-acct/src/lib.rs
+++ b/crates/proof-impl/alpen-acct/src/lib.rs
@@ -2,9 +2,12 @@
 
 use std::sync::Arc;
 
+use alpen_reth_evm::evm::AlpenEvmFactory;
 use reth_chainspec::ChainSpec;
 use rkyv::rancor::Error as RkyvError;
 use rsp_primitives::genesis::Genesis;
+use ssz::Decode;
+use strata_bridge_params::BridgeParams;
 use strata_ee_acct_runtime::ArchivedEePrivateInput;
 use strata_evm_ee::EvmExecutionEnvironment;
 use strata_predicate::PredicateKey;
@@ -38,7 +41,11 @@ pub fn process_ee_acct_update(zkvm: &impl ZkVmEnvSerde, chunk_predicate_key: &Pr
         rkyv::access::<ArchivedUpdatePrivateInput, RkyvError>(&upd_buf)
             .expect("failed to access rkyv update archive");
 
-    let ee = EvmExecutionEnvironment::new(chain_spec);
+    let withdrawal_ssz = zkvm.read_buf();
+    let bridge_params = BridgeParams::from_ssz_bytes(&withdrawal_ssz)
+        .expect("failed to deserialize withdrawal params");
+    let evm_factory = AlpenEvmFactory::from_bridge_params(&bridge_params);
+    let ee = EvmExecutionEnvironment::new(chain_spec, evm_factory);
 
     strata_ee_acct_runtime::verify_and_process_update(
         &ee,

--- a/crates/proof-impl/alpen-acct/src/program.rs
+++ b/crates/proof-impl/alpen-acct/src/program.rs
@@ -1,7 +1,8 @@
 use k256::schnorr::SigningKey;
 use rkyv::rancor::Error as RkyvError;
 use rsp_primitives::genesis::Genesis;
-use ssz::Decode;
+use ssz::{Decode, Encode};
+use strata_bridge_params::BridgeParams;
 use strata_ee_acct_runtime::EePrivateInput;
 use strata_predicate::{PredicateKey, PredicateTypeId};
 use strata_snark_acct_runtime::PrivateInput as UpdatePrivateInput;
@@ -34,6 +35,7 @@ pub struct EeAcctProofInput {
     pub genesis: Genesis,
     pub ee_private_input: EePrivateInput,
     pub update_private_input: UpdatePrivateInput,
+    pub bridge_params: BridgeParams,
 }
 
 #[derive(Debug)]
@@ -75,6 +77,7 @@ impl ZkVmProgram for EeAcctProgram {
         let upd_rkyv_bytes = rkyv::to_bytes::<RkyvError>(&input.update_private_input)
             .map_err(|e| ZkVmInputError::InputBuild(e.to_string()))?;
         builder.write_buf(&upd_rkyv_bytes)?;
+        builder.write_buf(&input.bridge_params.as_ssz_bytes())?;
 
         builder.build()
     }
@@ -165,6 +168,7 @@ mod tests {
             genesis,
             ee_private_input,
             update_private_input,
+            bridge_params: BridgeParams::default(),
         };
 
         // Predicate is carried through but never evaluated in this

--- a/crates/proof-impl/alpen-chunk/Cargo.toml
+++ b/crates/proof-impl/alpen-chunk/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+alpen-reth-evm.workspace = true
+strata-bridge-params.workspace = true
 strata-ee-chain-types.workspace = true
 strata-ee-chunk-runtime.workspace = true
 strata-evm-ee.workspace = true

--- a/crates/proof-impl/alpen-chunk/src/lib.rs
+++ b/crates/proof-impl/alpen-chunk/src/lib.rs
@@ -2,9 +2,12 @@
 
 use std::sync::Arc;
 
+use alpen_reth_evm::evm::AlpenEvmFactory;
 use reth_chainspec::ChainSpec;
 use rkyv::rancor::Error as RkyvError;
 use rsp_primitives::genesis::Genesis;
+use ssz::Decode;
+use strata_bridge_params::BridgeParams;
 use strata_ee_chunk_runtime::ArchivedPrivateInput;
 use strata_evm_ee::EvmExecutionEnvironment;
 use zkaleido::ZkVmEnvSerde;
@@ -27,7 +30,11 @@ pub fn process_ee_chunk(zkvm: &impl ZkVmEnvSerde) {
     let input: &ArchivedPrivateInput = rkyv::access::<ArchivedPrivateInput, RkyvError>(&buf)
         .expect("failed to access rkyv archive");
 
-    let ee = EvmExecutionEnvironment::new(chain_spec);
+    let withdrawal_ssz = zkvm.read_buf();
+    let bridge_params = BridgeParams::from_ssz_bytes(&withdrawal_ssz)
+        .expect("failed to deserialize withdrawal params");
+    let evm_factory = AlpenEvmFactory::from_bridge_params(&bridge_params);
+    let ee = EvmExecutionEnvironment::new(chain_spec, evm_factory);
 
     strata_ee_chunk_runtime::verify_input(&ee, input).expect("chunk verification failed");
 

--- a/crates/proof-impl/alpen-chunk/src/program.rs
+++ b/crates/proof-impl/alpen-chunk/src/program.rs
@@ -1,7 +1,8 @@
 use k256::schnorr::SigningKey;
 use rkyv::rancor::Error as RkyvError;
 use rsp_primitives::genesis::Genesis;
-use ssz::Decode;
+use ssz::{Decode, Encode};
+use strata_bridge_params::BridgeParams;
 use strata_ee_chain_types::ChunkTransition;
 use strata_ee_chunk_runtime::PrivateInput;
 use strata_predicate::{PredicateKey, PredicateTypeId};
@@ -21,6 +22,7 @@ fn test_signing_key() -> SigningKey {
 pub struct EeChunkProofInput {
     pub genesis: Genesis,
     pub private_input: PrivateInput,
+    pub bridge_params: BridgeParams,
 }
 
 #[derive(Debug)]
@@ -47,6 +49,7 @@ impl ZkVmProgram for EeChunkProgram {
         let rkyv_bytes = rkyv::to_bytes::<RkyvError>(&input.private_input)
             .map_err(|e| ZkVmInputError::InputBuild(e.to_string()))?;
         builder.write_buf(&rkyv_bytes)?;
+        builder.write_buf(&input.bridge_params.as_ssz_bytes())?;
         builder.build()
     }
 
@@ -85,6 +88,7 @@ impl EeChunkProgram {
 mod tests {
     use std::{fs, path::PathBuf, sync::Arc};
 
+    use alpen_reth_evm::evm::AlpenEvmFactory;
     use reth_primitives_traits::Block as _;
     use rsp_client_executor::io::EthClientExecutorInput;
     use serde::Deserialize;
@@ -149,7 +153,7 @@ mod tests {
         // Execute the block to get outputs.
         let chain_spec: Arc<reth_chainspec::ChainSpec> =
             Arc::new((&witness.genesis).try_into().unwrap());
-        let ee = EvmExecutionEnvironment::new(chain_spec);
+        let ee = EvmExecutionEnvironment::new(chain_spec, AlpenEvmFactory::default());
         let exec_payload = ExecPayload::new(&header, block.get_body());
         let inputs = ExecInputs::new_empty();
         let output = ee
@@ -179,6 +183,7 @@ mod tests {
         let proof_input = EeChunkProofInput {
             genesis: witness.genesis,
             private_input,
+            bridge_params: BridgeParams::default(),
         };
 
         // Run the full native execution pipeline.

--- a/crates/proof-impl/checkpoint/Cargo.toml
+++ b/crates/proof-impl/checkpoint/Cargo.toml
@@ -11,6 +11,7 @@ ssz.workspace = true
 ssz_primitives.workspace = true
 strata-asm-manifest-types.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
+strata-bridge-params.workspace = true
 strata-crypto.workspace = true
 strata-ledger-types.workspace = true
 strata-ol-chain-types-new.workspace = true

--- a/crates/proof-impl/checkpoint/src/program.rs
+++ b/crates/proof-impl/checkpoint/src/program.rs
@@ -1,6 +1,7 @@
 use k256::schnorr::SigningKey;
 use ssz::{Decode, Encode};
 use strata_asm_proto_checkpoint_types::CheckpointClaim;
+use strata_bridge_params::BridgeParams;
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
 use strata_ol_state_types::OLState;
 use strata_predicate::{PredicateKey, PredicateTypeId};
@@ -19,6 +20,7 @@ pub struct CheckpointProverInput {
     pub blocks: Vec<OLBlock>,
     pub parent: OLBlockHeader,
     pub da_state_diff_bytes: Vec<u8>,
+    pub bridge_params: BridgeParams,
 }
 
 #[derive(Debug)]
@@ -45,6 +47,7 @@ impl ZkVmProgram for CheckpointProgram {
         input_builder.write_buf(&input.blocks.as_ssz_bytes())?;
         input_builder.write_buf(&input.parent.as_ssz_bytes())?;
         input_builder.write_buf(&input.da_state_diff_bytes)?;
+        input_builder.write_buf(&input.bridge_params.as_ssz_bytes())?;
         input_builder.build()
     }
 
@@ -85,6 +88,7 @@ mod tests {
     use std::panic::catch_unwind;
 
     use strata_asm_proto_checkpoint_types::TerminalHeaderComplement;
+    use strata_bridge_params::BridgeParams;
     use strata_codec::encode_to_vec;
     use strata_crypto::hash;
     use strata_da_framework::DaCounter;
@@ -137,6 +141,7 @@ mod tests {
             blocks,
             parent,
             da_state_diff_bytes,
+            bridge_params: BridgeParams::default(),
         }
     }
 

--- a/crates/proof-impl/checkpoint/src/statements.rs
+++ b/crates/proof-impl/checkpoint/src/statements.rs
@@ -7,6 +7,7 @@ use ssz::{Decode, Encode};
 use ssz_primitives::FixedBytes;
 use strata_asm_manifest_types::{AsmManifestRangeHash, compute_asm_manifests_hash};
 use strata_asm_proto_checkpoint_types::{CheckpointClaim, L2BlockRange, TerminalHeaderComplement};
+use strata_bridge_params::BridgeParams;
 use strata_crypto::hash;
 use strata_ledger_types::IStateAccessor;
 use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLLog, OLTxSegment};
@@ -59,8 +60,13 @@ pub fn process_ol_stf(zkvm: &impl ZkVmEnv) {
     // Read DA diff witness bytes from zkVM input
     let da_state_diff_bytes = zkvm.read_buf();
 
+    // Read withdrawal params from zkVM input
+    let withdrawal_ssz_bytes = zkvm.read_buf();
+    let bridge_params = BridgeParams::from_ssz_bytes(&withdrawal_ssz_bytes)
+        .expect("failed to deserialize withdrawal params from SSZ bytes");
+
     // Execute the core STF logic to get the claim
-    let claim = process_ol_stf_core(state, blocks, parent, da_state_diff_bytes);
+    let claim = process_ol_stf_core(state, blocks, parent, da_state_diff_bytes, bridge_params);
 
     // Serialize and commit the checkpoint claim to the zkVM as public output
     let claim_ssz_bytes = claim.as_ssz_bytes();
@@ -90,6 +96,7 @@ pub fn process_ol_stf_core(
     blocks: Vec<OLBlock>,
     parent: OLBlockHeader,
     da_state_diff_bytes: Vec<u8>,
+    bridge_params: BridgeParams,
 ) -> CheckpointClaim {
     // Wrap OLState in MemoryStateBaseLayer to satisfy IStateAccessor requirements.
     let mut state = MemoryStateBaseLayer::new(state);
@@ -140,7 +147,7 @@ pub fn process_ol_stf_core(
     // Execute all blocks in the batch and collect execution artifacts.
     // Header equality checks inside execution bind manifests/preseal commitments via body_root.
     let (logs, asm_manifests_hash, terminal_header) =
-        execute_block_batch(&mut state, &blocks, &parent);
+        execute_block_batch(&mut state, &blocks, &parent, bridge_params);
 
     let start = parent.compute_block_commitment();
     let end = terminal_header.compute_block_commitment();
@@ -235,6 +242,7 @@ fn execute_block_batch(
     state: &mut MemoryStateBaseLayer,
     blocks: &[OLBlock],
     initial_parent: &OLBlockHeader,
+    bridge_params: BridgeParams,
 ) -> (Vec<OLLog>, AsmManifestRangeHash, OLBlockHeader) {
     // Exactly one block per epoch must carry an L1 update (the terminal block).
     // The manifest hash is computed by overwriting a single `Option` in the loop
@@ -288,7 +296,7 @@ fn execute_block_batch(
 
         // Execute the block's state transition function.
         // This applies transactions, processes manifests, and updates state.
-        let output = construct_block(state, context, components).expect(
+        let output = construct_block(state, context, components, bridge_params).expect(
             "block execution failed; all blocks in proof input must be valid and executable",
         );
 

--- a/crates/reth/evm/Cargo.toml
+++ b/crates/reth/evm/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 alpen-reth-primitives.workspace = true
+strata-bridge-params.workspace = true
 strata-crypto.workspace = true
 strata-identifiers.workspace = true
 strata-ol-bridge-types.workspace = true

--- a/crates/reth/evm/src/constants.rs
+++ b/crates/reth/evm/src/constants.rs
@@ -1,6 +1,4 @@
-use revm::primitives::{address, Address, U256};
-
-use crate::utils::{u256_from, WEI_PER_BTC};
+use revm::primitives::{address, Address};
 
 /// The address for the Bridgeout precompile contract.
 pub const BRIDGEOUT_PRECOMPILE_ADDRESS: Address =
@@ -15,9 +13,6 @@ pub const SCHNORR_PRECOMPILE_ADDRESS: Address =
 
 /// Custom PrecompileId for the Schnorr precompile contract.
 pub const SCHNORR_PRECOMPILE_PRECOMPILE_ID: &str = "alpen-schnorr-precompile";
-
-/// The fixed withdrawal denomination in wei (1 BTC equivalent).
-pub const FIXED_WITHDRAWAL_WEI: U256 = u256_from(WEI_PER_BTC);
 
 /// The address to send transaction basefee to instead of burning.
 pub const BASEFEE_ADDRESS: Address = address!("5400000000000000000000000000000000000010");

--- a/crates/reth/evm/src/evm.rs
+++ b/crates/reth/evm/src/evm.rs
@@ -10,14 +10,53 @@ use revm::{
     interpreter::interpreter::EthInterpreter,
     Context, Inspector, MainBuilder, MainContext,
 };
-use revm_primitives::hardfork::SpecId;
+use revm_primitives::{hardfork::SpecId, U256};
+use strata_bridge_params::BridgeParams;
 
-use crate::{apis::AlpenAlloyEvm, precompiles::factory};
+use crate::{
+    apis::AlpenAlloyEvm,
+    precompiles::factory,
+    utils::{u256_from, WEI_PER_BTC, WEI_PER_SAT},
+};
 
 /// Custom EVM configuration.
-#[derive(Debug, Clone, Default)]
-#[non_exhaustive]
-pub struct AlpenEvmFactory;
+///
+/// Carries withdrawal denomination and optional cap (in wei) for bridge
+/// precompile validation. Use [`AlpenEvmFactory::new`] to construct, or
+/// [`Default`] for the standard 1 BTC denomination / 10 BTC cap.
+#[derive(Debug, Clone)]
+pub struct AlpenEvmFactory {
+    denomination_wei: U256,
+    max_withdrawal_wei: Option<U256>,
+}
+
+impl Default for AlpenEvmFactory {
+    fn default() -> Self {
+        Self {
+            denomination_wei: u256_from(WEI_PER_BTC),
+            max_withdrawal_wei: Some(u256_from(WEI_PER_BTC * 10)),
+        }
+    }
+}
+
+impl AlpenEvmFactory {
+    pub fn new(denomination_wei: U256, max_withdrawal_wei: Option<U256>) -> Self {
+        Self {
+            denomination_wei,
+            max_withdrawal_wei,
+        }
+    }
+
+    /// Creates an [`AlpenEvmFactory`] from [`BridgeParams`] (sats-denominated),
+    /// converting to wei.
+    pub fn from_bridge_params(bp: &BridgeParams) -> Self {
+        let denom_wei = U256::from(bp.denomination()) * WEI_PER_SAT;
+        let max_wei = bp
+            .max_withdrawal_amount()
+            .map(|m| U256::from(m) * WEI_PER_SAT);
+        Self::new(denom_wei, max_wei)
+    }
+}
 
 impl EvmFactory for AlpenEvmFactory {
     type Evm<DB: Database, I: Inspector<EthEvmContext<DB>, EthInterpreter>> = AlpenAlloyEvm<DB, I>;
@@ -30,7 +69,11 @@ impl EvmFactory for AlpenEvmFactory {
     type Precompiles = PrecompilesMap;
 
     fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
-        let precompiles = factory::create_precompiles_map(input.cfg_env.spec);
+        let precompiles = factory::create_precompiles_map(
+            input.cfg_env.spec,
+            self.denomination_wei,
+            self.max_withdrawal_wei,
+        );
 
         let evm = Context::mainnet()
             .with_db(db)

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -4,10 +4,7 @@ use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 use revm_primitives::{Bytes, Log, LogData, U256};
 use strata_primitives::bitcoin_bosd::Descriptor;
 
-use crate::{
-    constants::{BRIDGEOUT_PRECOMPILE_ADDRESS, FIXED_WITHDRAWAL_WEI},
-    utils::wei_to_sats,
-};
+use crate::{constants::BRIDGEOUT_PRECOMPILE_ADDRESS, utils::wei_to_sats};
 
 /// Custom precompile to burn rollup native token and add bridge out intent of equal amount.
 /// Bridge out intent is created during block payload generation.
@@ -16,7 +13,11 @@ use crate::{
 /// Calldata format: `[4 bytes: selected_operator (big-endian u32)][BOSD bytes]`
 /// - `u32::MAX` (`0xFFFFFFFF`): no operator selection
 /// - Any other value: operator index
-pub(crate) fn bridge_context_call(mut input: PrecompileInput<'_>) -> PrecompileResult {
+pub(crate) fn bridge_context_call(
+    mut input: PrecompileInput<'_>,
+    denomination_wei: U256,
+    max_withdrawal_wei: Option<U256>,
+) -> PrecompileResult {
     let calldata = WithdrawalCalldata::decode(input.data).ok_or_else(|| {
         PrecompileError::other(
             "Calldata too short: expected at least 5 bytes (4 operator + 1 BOSD)",
@@ -29,7 +30,7 @@ pub(crate) fn bridge_context_call(mut input: PrecompileInput<'_>) -> PrecompileR
     let withdrawal_amount = input.value;
 
     // Verify that the transaction value is a positive exact multiple of the withdrawal denomination
-    validate_withdrawal_amount(withdrawal_amount)?;
+    validate_withdrawal_amount(withdrawal_amount, denomination_wei, max_withdrawal_wei)?;
 
     // Convert wei to satoshis
     let (sats, _) = wei_to_sats(withdrawal_amount);
@@ -67,12 +68,24 @@ pub(crate) fn bridge_context_call(mut input: PrecompileInput<'_>) -> PrecompileR
     Ok(PrecompileOutput::new(gas_cost, Bytes::new()))
 }
 
-/// Validates that the withdrawal amount is a positive exact multiple of the denomination.
-fn validate_withdrawal_amount(amount: U256) -> Result<(), PrecompileError> {
-    if amount.is_zero() || !(amount % FIXED_WITHDRAWAL_WEI).is_zero() {
+/// Validates that the withdrawal amount is a positive exact multiple of the denomination
+/// and within the optional cap.
+fn validate_withdrawal_amount(
+    amount: U256,
+    denomination_wei: U256,
+    max_withdrawal_wei: Option<U256>,
+) -> Result<(), PrecompileError> {
+    if amount.is_zero() || !(amount % denomination_wei).is_zero() {
         return Err(PrecompileError::other(format!(
-            "Invalid withdrawal value: must be a positive exact multiple of {FIXED_WITHDRAWAL_WEI} wei",
+            "Invalid withdrawal value: must be a positive exact multiple of {denomination_wei} wei",
         )));
+    }
+    if let Some(max) = max_withdrawal_wei {
+        if amount > max {
+            return Err(PrecompileError::other(format!(
+                "Withdrawal value {amount} exceeds maximum allowed {max} wei",
+            )));
+        }
     }
     Ok(())
 }
@@ -89,6 +102,10 @@ mod tests {
     use strata_ol_bridge_types::OperatorSelection;
 
     use super::*;
+    use crate::utils::{u256_from, WEI_PER_BTC};
+
+    /// Test-only denomination constant (1 BTC in wei).
+    const FIXED_WITHDRAWAL_WEI: U256 = u256_from(WEI_PER_BTC);
 
     /// Valid P2WPKH descriptor: type tag (0x03) + 20-byte hash160.
     const VALID_P2WPKH_BOSD: &[u8; 21] = &{
@@ -163,28 +180,84 @@ mod tests {
 
     // --- withdrawal amount validation tests ---
 
+    fn max_withdrawal() -> Option<U256> {
+        Some(FIXED_WITHDRAWAL_WEI * U256::from(10))
+    }
+
     #[test]
     fn test_validate_withdrawal_exact_denomination() {
-        assert!(validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI).is_ok());
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI,
+            FIXED_WITHDRAWAL_WEI,
+            max_withdrawal()
+        )
+        .is_ok());
     }
 
     #[test]
     fn test_validate_withdrawal_exact_multiple() {
-        assert!(validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI * U256::from(3)).is_ok());
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI * U256::from(3),
+            FIXED_WITHDRAWAL_WEI,
+            max_withdrawal()
+        )
+        .is_ok());
     }
 
     #[test]
     fn test_validate_withdrawal_zero_rejected() {
-        assert!(validate_withdrawal_amount(U256::ZERO).is_err());
+        assert!(
+            validate_withdrawal_amount(U256::ZERO, FIXED_WITHDRAWAL_WEI, max_withdrawal()).is_err()
+        );
     }
 
     #[test]
     fn test_validate_withdrawal_non_multiple_rejected() {
-        assert!(validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI + U256::from(1)).is_err());
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI + U256::from(1),
+            FIXED_WITHDRAWAL_WEI,
+            max_withdrawal()
+        )
+        .is_err());
     }
 
     #[test]
     fn test_validate_withdrawal_below_denomination_rejected() {
-        assert!(validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI - U256::from(1)).is_err());
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI - U256::from(1),
+            FIXED_WITHDRAWAL_WEI,
+            max_withdrawal()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_validate_withdrawal_exceeds_cap() {
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI * U256::from(11),
+            FIXED_WITHDRAWAL_WEI,
+            max_withdrawal()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_validate_withdrawal_at_cap() {
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI * U256::from(10),
+            FIXED_WITHDRAWAL_WEI,
+            max_withdrawal()
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_withdrawal_no_cap() {
+        assert!(validate_withdrawal_amount(
+            FIXED_WITHDRAWAL_WEI * U256::from(100),
+            FIXED_WITHDRAWAL_WEI,
+            None
+        )
+        .is_ok());
     }
 }

--- a/crates/reth/evm/src/precompiles/factory.rs
+++ b/crates/reth/evm/src/precompiles/factory.rs
@@ -1,6 +1,6 @@
 use reth_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use revm::precompile::PrecompileId;
-use revm_primitives::hardfork::SpecId;
+use revm_primitives::{hardfork::SpecId, U256};
 
 use crate::{
     constants::{BRIDGEOUT_PRECOMPILE_ADDRESS, BRIDGEOUT_PRECOMPILE_ID},
@@ -8,14 +8,19 @@ use crate::{
 };
 
 /// Creates a precompiles map with Alpen-specific precompiles, including the bridge precompile.
-pub fn create_precompiles_map(spec: SpecId) -> PrecompilesMap {
+pub fn create_precompiles_map(
+    spec: SpecId,
+    denomination_wei: U256,
+    max_withdrawal_wei: Option<U256>,
+) -> PrecompilesMap {
     let mut precompiles = PrecompilesMap::from_static(AlpenEvmPrecompiles::new(spec).precompiles());
 
-    // Add bridge precompile using DynPrecompile for compatibility
+    // Add bridge precompile using DynPrecompile for compatibility.
+    // The closure captures withdrawal params so the precompile can validate amounts.
     precompiles.apply_precompile(&BRIDGEOUT_PRECOMPILE_ADDRESS, |_| {
         Some(DynPrecompile::new_stateful(
             PrecompileId::custom(BRIDGEOUT_PRECOMPILE_ID),
-            bridge_context_call,
+            move |input| bridge_context_call(input, denomination_wei, max_withdrawal_wei),
         ))
     });
 

--- a/crates/reth/node/src/args.rs
+++ b/crates/reth/node/src/args.rs
@@ -1,4 +1,7 @@
+use alpen_reth_evm::evm::AlpenEvmFactory;
+
 #[derive(Debug, Clone, Default)]
 pub struct AlpenNodeArgs {
     pub sequencer_http: Option<String>,
+    pub evm_factory: AlpenEvmFactory,
 }

--- a/crates/reth/node/src/evm.rs
+++ b/crates/reth/node/src/evm.rs
@@ -8,9 +8,16 @@ use reth_node_builder::{components::ExecutorBuilder, BuilderContext};
 use reth_primitives::EthPrimitives;
 
 /// Builds a regular ethereum block executor that uses the custom EVM.
-#[derive(Debug, Default, Clone, Copy)]
-#[non_exhaustive]
-pub struct AlpenExecutorBuilder;
+#[derive(Debug, Clone, Default)]
+pub struct AlpenExecutorBuilder {
+    evm_factory: AlpenEvmFactory,
+}
+
+impl AlpenExecutorBuilder {
+    pub fn new(evm_factory: AlpenEvmFactory) -> Self {
+        Self { evm_factory }
+    }
+}
 
 impl<Node> ExecutorBuilder<Node> for AlpenExecutorBuilder
 where
@@ -19,8 +26,7 @@ where
     type EVM = EthEvmConfig<ChainSpec, AlpenEvmFactory>;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let evm_config =
-            EthEvmConfig::new_with_evm_factory(ctx.chain_spec(), AlpenEvmFactory::default());
+        let evm_config = EthEvmConfig::new_with_evm_factory(ctx.chain_spec(), self.evm_factory);
         Ok(evm_config.clone())
     }
 }

--- a/crates/reth/node/src/node.rs
+++ b/crates/reth/node/src/node.rs
@@ -74,7 +74,7 @@ where
         ComponentsBuilder::default()
             .node_types::<N>()
             .pool(AlpenEthereumPoolBuilder::default())
-            .executor(AlpenExecutorBuilder::default())
+            .executor(AlpenExecutorBuilder::new(self.args.evm_factory.clone()))
             .payload(BasicPayloadServiceBuilder::default())
             .network(EthereumNetworkBuilder::default())
             .consensus(EthereumConsensusBuilder::default())

--- a/docker/alpen-client/entrypoint.sh
+++ b/docker/alpen-client/entrypoint.sh
@@ -45,6 +45,8 @@ exec alpen-client \
     --btc-rpc-password "${BITCOIND_RPC_PASSWORD}" \
     --l1-reorg-safe-depth "${L1_REORG_SAFE_DEPTH:-4}" \
     --batch-sealing-block-count "${BATCH_SEALING_BLOCK_COUNT:-120}" \
+    --bridge-denomination "${BRIDGE_DENOMINATION:-100000000}" \
+    ${MAX_WITHDRAWAL_AMOUNT:+--max-withdrawal-amount "$MAX_WITHDRAWAL_AMOUNT"} \
     --txpool.minimal-protocol-fee "${TXPOOL_MIN_PROTOCOL_FEE:-0}" \
     --genesis-l1-height "${GENESIS_L1_HEIGHT:?GENESIS_L1_HEIGHT must be set}" \
     "$@"

--- a/functional-tests/factories/alpen_client.py
+++ b/functional-tests/factories/alpen_client.py
@@ -68,6 +68,8 @@ class AlpenClientFactory(flexitest.Factory):
         ol_submit_token: str | None = None,
         da_config: EeDaConfig | None = None,
         dev_track_latest_epoch: bool = False,
+        bridge_denomination: int = 100_000_000,
+        max_withdrawal_amount: int | None = 1_000_000_000,
         **kwargs,
     ) -> AlpenClientService:
         """
@@ -154,6 +156,11 @@ class AlpenClientFactory(flexitest.Factory):
             # Disable all discovery - peers connect via admin_addPeer or --trusted-peers
             cmd.append("-d")
 
+        # Withdrawal denomination and cap (bridge params)
+        cmd.extend(["--bridge-denomination", str(bridge_denomination)])
+        if max_withdrawal_amount is not None:
+            cmd.extend(["--max-withdrawal-amount", str(max_withdrawal_amount)])
+
         # DA pipeline configuration
         if da_config is not None:
             # fmt: off
@@ -217,6 +224,8 @@ class AlpenClientFactory(flexitest.Factory):
         datadir_override: str | None = None,
         sequencer_http: str | None = None,
         ol_endpoint: str | None = None,
+        bridge_denomination: int = 100_000_000,
+        max_withdrawal_amount: int | None = 1_000_000_000,
         **kwargs,
     ) -> AlpenClientService:
         """
@@ -304,6 +313,11 @@ class AlpenClientFactory(flexitest.Factory):
         else:
             # Disable all discovery - peers connect via admin_addPeer or --trusted-peers
             cmd.append("-d")
+
+        # Withdrawal denomination and cap (bridge params)
+        cmd.extend(["--bridge-denomination", str(bridge_denomination)])
+        if max_withdrawal_amount is not None:
+            cmd.extend(["--max-withdrawal-amount", str(max_withdrawal_amount)])
 
         http_url = f"http://127.0.0.1:{http_port}"
 

--- a/functional-tests/tests/alpen_client/precompiles/test_bridgeout_cap.py
+++ b/functional-tests/tests/alpen_client/precompiles/test_bridgeout_cap.py
@@ -1,0 +1,109 @@
+"""Verify the bridgeout precompile enforces the withdrawal cap.
+
+Sends two transactions to the bridgeout precompile:
+  1. Over-cap amount (11 BTC) -> expects revert
+  2. At-cap amount (10 BTC) -> expects success
+
+Uses the dev account which has a large pre-funded balance.
+"""
+
+import logging
+
+import flexitest
+from eth_account import Account
+from eth_utils import to_checksum_address
+
+from common.base_test import BaseTest
+from common.config.constants import DEV_CHAIN_ID, DEV_PRIVATE_KEY, ServiceType
+from common.evm import DEV_ACCOUNT_ADDRESS
+from common.precompile import PRECOMPILE_BRIDGEOUT_ADDRESS, wait_for_receipt
+from common.services import AlpenClientService
+from envconfigs.alpen_client import AlpenClientEnv
+
+logger = logging.getLogger(__name__)
+
+SATS_TO_WEI = 10**10
+DENOMINATION_SATS = 100_000_000  # 1 BTC
+MAX_WITHDRAWAL_SATS = 1_000_000_000  # 10 BTC
+
+# Bridgeout calldata: [4 bytes: selected_operator (u32 big-endian)][BOSD bytes]
+# 0xFFFFFFFF = no operator preference
+# 0x03 + 20 bytes = valid P2WPKH BOSD descriptor
+NO_OP_HEX = "ffffffff"
+VALID_P2WPKH_BOSD_HEX = "03" + "14" * 20
+
+
+def build_bridgeout_tx(rpc, amount_sats: int, nonce: int) -> dict:
+    """Build a bridgeout precompile transaction."""
+    gas_price = int(rpc.eth_gasPrice(), 16)
+    return {
+        "nonce": nonce,
+        "gasPrice": gas_price,
+        "gas": 200_000,
+        "to": to_checksum_address(PRECOMPILE_BRIDGEOUT_ADDRESS),
+        "value": amount_sats * SATS_TO_WEI,
+        "data": bytes.fromhex(NO_OP_HEX + VALID_P2WPKH_BOSD_HEX),
+        "chainId": DEV_CHAIN_ID,
+    }
+
+
+@flexitest.register
+class TestBridgeoutWithdrawalCap(BaseTest):
+    """Bridgeout precompile: over-cap reverts, at-cap succeeds."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(AlpenClientEnv(fullnode_count=0, enable_l1_da=True))
+
+    def main(self, ctx) -> bool:
+        sequencer: AlpenClientService = self.get_service(ServiceType.AlpenSequencer)
+        rpc = sequencer.create_rpc()
+
+        nonce = int(rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
+
+        # --- Test 1: Over-cap (11 BTC) should revert ---
+        over_cap_sats = 11 * DENOMINATION_SATS
+        logger.info(f"Test 1: bridgeout {over_cap_sats} sats (over cap, expect revert)")
+
+        tx = build_bridgeout_tx(rpc, over_cap_sats, nonce)
+        signed = Account.sign_transaction(tx, DEV_PRIVATE_KEY)
+        tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
+        receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
+
+        assert receipt["status"] in (0, "0x0"), (
+            f"Over-cap bridgeout should revert, got status {receipt['status']}"
+        )
+        logger.info("  Over-cap bridgeout reverted as expected")
+        nonce += 1
+
+        # --- Test 2: Non-multiple of denomination (0.5 BTC) should revert ---
+        non_multiple_sats = 50_000_000  # 0.5 BTC
+        logger.info(f"Test 2: bridgeout {non_multiple_sats} sats (non-multiple, expect revert)")
+
+        tx = build_bridgeout_tx(rpc, non_multiple_sats, nonce)
+        signed = Account.sign_transaction(tx, DEV_PRIVATE_KEY)
+        tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
+        receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
+
+        assert receipt["status"] in (0, "0x0"), (
+            f"Non-multiple bridgeout should revert, got status {receipt['status']}"
+        )
+        logger.info("  Non-multiple bridgeout reverted as expected")
+        nonce += 1
+
+        # --- Test 3: At-cap (10 BTC) should succeed ---
+        at_cap_sats = MAX_WITHDRAWAL_SATS
+        logger.info(f"Test 2: bridgeout {at_cap_sats} sats (at cap, expect success)")
+
+        tx = build_bridgeout_tx(rpc, at_cap_sats, nonce)
+        signed = Account.sign_transaction(tx, DEV_PRIVATE_KEY)
+        tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
+        receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
+
+        assert receipt["status"] in (1, "0x1"), (
+            f"At-cap bridgeout should succeed, got status {receipt['status']}"
+        )
+        assert len(receipt["logs"]) > 0, "At-cap bridgeout should emit WithdrawalIntentEvent"
+        logger.info("  At-cap bridgeout succeeded with withdrawal intent log")
+
+        logger.info("Bridgeout cap tests passed")
+        return True

--- a/functional-tests/tests/alpen_client/test_real_bridge_deposit_withdraw.py
+++ b/functional-tests/tests/alpen_client/test_real_bridge_deposit_withdraw.py
@@ -608,4 +608,52 @@ class TestRealBridgeDepositWithdraw(BaseTest):
             recipient_btc_balance_before=recipient_btc_balance_before,
         )
 
+        # --- Withdrawal cap enforcement ---
+        # Use the genesis-prefunded dev account (large balance) to test
+        # precompile rejection without worrying about insufficient funds.
+        from common.config.constants import DEV_PRIVATE_KEY
+        from common.evm import DEV_ACCOUNT_ADDRESS
+
+        chain_id = int(alpen_rpc.eth_chainId(), 16)
+        gas_price = int(alpen_rpc.eth_gasPrice(), 16)
+        dev_nonce = int(alpen_rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
+        calldata_hex = NO_OPERATOR_SELECTION_HEX + recipient_bosd_hex
+
+        # Over-cap: 11 × denomination exceeds the 10 BTC default cap.
+        over_cap_sats = 11 * bridge_denom_sats
+        logger.info("bridgeout cap test: %d sats (over cap, expect revert)", over_cap_sats)
+        overcap_tx = {
+            "nonce": dev_nonce,
+            "gasPrice": gas_price,
+            "gas": 200_000,
+            "to": PRECOMPILE_BRIDGEOUT_ADDRESS,
+            "value": over_cap_sats * SATS_TO_WEI,
+            "data": bytes.fromhex(calldata_hex),
+            "chainId": chain_id,
+        }
+        signed = Account.sign_transaction(overcap_tx, DEV_PRIVATE_KEY)
+        h = alpen_rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
+        r = wait_for_receipt(alpen_rpc, h, timeout=30)
+        assert r["status"] in (0, "0x0"), f"over-cap bridgeout should revert: {r['status']}"
+        logger.info("  over-cap bridgeout reverted as expected")
+        dev_nonce += 1
+
+        # Non-multiple: half a denomination is not a valid multiple.
+        half_denom_sats = bridge_denom_sats // 2
+        logger.info("bridgeout cap test: %d sats (non-multiple, expect revert)", half_denom_sats)
+        nonmult_tx = {
+            "nonce": dev_nonce,
+            "gasPrice": gas_price,
+            "gas": 200_000,
+            "to": PRECOMPILE_BRIDGEOUT_ADDRESS,
+            "value": half_denom_sats * SATS_TO_WEI,
+            "data": bytes.fromhex(calldata_hex),
+            "chainId": chain_id,
+        }
+        signed = Account.sign_transaction(nonmult_tx, DEV_PRIVATE_KEY)
+        h = alpen_rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
+        r = wait_for_receipt(alpen_rpc, h, timeout=30)
+        assert r["status"] in (0, "0x0"), f"non-multiple bridgeout should revert: {r['status']}"
+        logger.info("  non-multiple bridgeout reverted as expected")
+
         return True


### PR DESCRIPTION
## Parameterize bridge denomination and withdrawal cap

**Problem:** Bridge denomination (1 BTC) was hardcoded across the EE precompile, OL STF, and proof guests and max withdrawal amount (10 BTC) is new and requires changes in the same files as denomination. Changing/introducing these values required touching constants scattered across multiple crates.

**Solution:** Introduce a `BridgeParams` struct that flows from configuration through all three validation points:

1. **EE precompile** — `AlpenEvmFactory` carries denomination/cap in wei; the bridgeout precompile validates `msg.value` against both.
2. **OL STF** — `ExecContext::bridge_params()` supplies params to withdrawal processing in block assembly and verification.
3. **Proof guests** — checkpoint, alpen-acct, and alpen-chunk guests receive `BridgeParams` via input buffer.

**Config sources:**
- `ol-params.json` (`bridge_params` field) — used by OL STF and provers
- `alpen-client --bridge-denomination / --max-withdrawal-amount` — used by the EE reth executor
- `alpen-cli config.toml` — used by the wallet CLI

Also updates the default bridge denomination from 10 BTC to 1 BTC across datatool and strata-test-cli.

### Commits

| Commit | Scope |
|--------|-------|
| `feat(bridge-params)` | New `BridgeParams` crate with sat/wei conversions and validation |
| `feat(evm)` | `AlpenEvmFactory` parameterized; precompile validates denomination + cap |
| `feat(ol)` | Thread through OL STF, block assembly, checkpoint, chain-worker |
| `feat(provers)` | Proof guests receive `BridgeParams` via input buffer |
| `feat(alpen-client)` | CLI args, `AlpenExecutorBuilder`, docker entrypoint, alpen-cli settings |
| `chore` | Default denomination 10 BTC → 1 BTC |
| `test` | Factory passes args; E2E cap + denomination rejection tests |

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers
Its vibe coded with the help of Claude. I tried thinking in lots of different ways to make this solution cleaner but could not do that for the scope of this task.
<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
STR-3196
<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
