### PR TITLE
chore(btcio): use `RBuf32` and `Debug` for logging

### DIFF
--- a/bin/strata-dbtool/src/cmd/writer.rs
+++ b/bin/strata-dbtool/src/cmd/writer.rs
@@ -1,7 +1,9 @@
 use argh::FromArgs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
-use strata_db_types::traits::{DatabaseBackend, L1WriterDatabase};
-use strata_primitives::buf::Buf32;
+use strata_db_types::{
+    traits::{DatabaseBackend, L1WriterDatabase},
+    types::L1TxId,
+};
 
 use super::checkpoint::{get_checkpoint_at_epoch, get_checkpoint_epoch_range};
 use crate::{
@@ -106,12 +108,12 @@ pub(crate) fn get_writer_payload(
             index: args.index,
             status: payload_entry.status.clone(),
             payload: payload_entry.payload.clone(),
-            commit_txid: if payload_entry.commit_txid == Buf32::zero() {
+            commit_txid: if payload_entry.commit_txid == L1TxId::zero() {
                 None
             } else {
                 Some(payload_entry.commit_txid)
             },
-            reveal_txid: if payload_entry.reveal_txid == Buf32::zero() {
+            reveal_txid: if payload_entry.reveal_txid == L1TxId::zero() {
                 None
             } else {
                 Some(payload_entry.reveal_txid)

--- a/bin/strata-dbtool/src/output/writer.rs
+++ b/bin/strata-dbtool/src/output/writer.rs
@@ -1,8 +1,7 @@
 use serde::Serialize;
 use strata_crypto::hash;
 use strata_csm_types::L1Payload;
-use strata_db_types::types::L1BundleStatus;
-use strata_primitives::buf::Buf32;
+use strata_db_types::types::{L1BundleStatus, L1TxId};
 
 use super::{helpers::porcelain_field, traits::Formattable};
 
@@ -42,9 +41,9 @@ pub(crate) struct WriterPayloadInfo {
     pub(crate) status: L1BundleStatus,
     pub(crate) payload: L1Payload,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) commit_txid: Option<Buf32>,
+    pub(crate) commit_txid: Option<L1TxId>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) reveal_txid: Option<Buf32>,
+    pub(crate) reveal_txid: Option<L1TxId>,
 }
 
 impl Formattable for WriterPayloadInfo {

--- a/crates/alpen-ee/da/src/envelope_provider.rs
+++ b/crates/alpen-ee/da/src/envelope_provider.rs
@@ -12,7 +12,9 @@ use bitcoin::{Txid, Wtxid};
 use eyre::{bail, ensure};
 use strata_btc_types::Buf32BitcoinExt;
 use strata_btcio::writer::chunked_envelope::ChunkedEnvelopeHandle;
-use strata_db_types::types::{ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxStatus};
+use strata_db_types::types::{
+    ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxId, L1TxStatus, L1WtxId,
+};
 use strata_identifiers::{L1BlockCommitment, L1BlockId, L1Height};
 use strata_l1_txfmt::MagicBytes;
 use strata_primitives::buf::Buf32;
@@ -51,6 +53,18 @@ struct FinalizedRevealTx {
 
 /// Groups commit + reveal txs by L1 block for [`L1DaBlockRef`] construction.
 type BlockMap = HashMap<(Buf32, L1Height), BlockTxs>;
+
+fn to_raw_buf32(txid: L1TxId) -> Buf32 {
+    Buf32(txid.0)
+}
+
+fn txid_to_bitcoin(txid: L1TxId) -> Txid {
+    to_raw_buf32(txid).to_txid()
+}
+
+fn wtxid_to_bitcoin(wtxid: L1WtxId) -> Wtxid {
+    Buf32(wtxid.0).to_wtxid()
+}
 
 /// [`BatchDaProvider`] that posts DA via chunked envelope inscription.
 pub struct ChunkedEnvelopeDaProvider {
@@ -178,8 +192,10 @@ impl ChunkedEnvelopeDaProvider {
         // Commit tx (carries the EE DA magic/version OP_RETURN).
         let (commit_block_hash, commit_block_height) =
             self.lookup_finalized(entry.commit_txid).await?;
-        let commit_tx =
-            FinalizedTxRef::new(entry.commit_txid.to_txid(), entry.commit_wtxid.to_wtxid());
+        let commit_tx = FinalizedTxRef::new(
+            txid_to_bitcoin(entry.commit_txid),
+            wtxid_to_bitcoin(entry.commit_wtxid),
+        );
         block_map
             .entry((commit_block_hash, commit_block_height))
             .or_default()
@@ -194,7 +210,10 @@ impl ChunkedEnvelopeDaProvider {
                 .reveals
                 .push(FinalizedRevealTx {
                     vout_index: reveal.vout_index,
-                    tx: FinalizedTxRef::new(reveal.txid.to_txid(), reveal.wtxid.to_wtxid()),
+                    tx: FinalizedTxRef::new(
+                        txid_to_bitcoin(reveal.txid),
+                        wtxid_to_bitcoin(reveal.wtxid),
+                    ),
                 });
         }
 
@@ -221,9 +240,13 @@ impl ChunkedEnvelopeDaProvider {
     }
 
     /// Looks up a tx in the broadcast DB and returns the finalized L1 block.
-    async fn lookup_finalized(&self, txid: Buf32) -> eyre::Result<(Buf32, L1Height)> {
-        let Some(tx_entry) = self.broadcast_ops.get_tx_entry_by_id_async(txid).await? else {
-            bail!("broadcast entry for txid {txid} not found");
+    async fn lookup_finalized(&self, txid: L1TxId) -> eyre::Result<(Buf32, L1Height)> {
+        let Some(tx_entry) = self
+            .broadcast_ops
+            .get_tx_entry_by_id_async(to_raw_buf32(txid))
+            .await?
+        else {
+            bail!("broadcast entry for txid {txid:?} not found");
         };
         match tx_entry.status {
             L1TxStatus::Finalized {
@@ -231,7 +254,10 @@ impl ChunkedEnvelopeDaProvider {
                 block_height,
                 ..
             } => Ok((block_hash, block_height)),
-            other => bail!("expected Finalized status for txid {txid}, got {:?}", other),
+            other => bail!(
+                "expected Finalized status for txid {txid:?}, got {:?}",
+                other
+            ),
         }
     }
 }
@@ -305,15 +331,15 @@ mod tests {
             DA_BLOB_VERSION,
         );
         entry.status = status;
-        entry.commit_txid = Buf32::from([0x11; 32]);
-        entry.commit_wtxid = Buf32::from([0x12; 32]);
+        entry.commit_txid = L1TxId::from([0x11; 32]);
+        entry.commit_wtxid = L1WtxId::from([0x12; 32]);
         entry.reveals = heights
             .iter()
             .enumerate()
             .map(|(i, _)| RevealTxMeta {
                 vout_index: (i + 1) as u32,
-                txid: Buf32::from([(0x20 + i as u8); 32]),
-                wtxid: Buf32::from([(0x30 + i as u8); 32]),
+                txid: L1TxId::from([(0x20 + i as u8); 32]),
+                wtxid: L1WtxId::from([(0x30 + i as u8); 32]),
                 tx_bytes: btc_serialize(&make_test_tx()),
             })
             .collect();
@@ -406,15 +432,15 @@ mod tests {
             .unwrap();
         // Commit landed at height 99 (before either reveal).
         broadcast_ops
-            .put_tx_entry_async(entry.commit_txid, finalized_tx_entry(99))
+            .put_tx_entry_async(to_raw_buf32(entry.commit_txid), finalized_tx_entry(99))
             .await
             .unwrap();
         broadcast_ops
-            .put_tx_entry_async(entry.reveals[0].txid, finalized_tx_entry(101))
+            .put_tx_entry_async(to_raw_buf32(entry.reveals[0].txid), finalized_tx_entry(101))
             .await
             .unwrap();
         broadcast_ops
-            .put_tx_entry_async(entry.reveals[1].txid, finalized_tx_entry(100))
+            .put_tx_entry_async(to_raw_buf32(entry.reveals[1].txid), finalized_tx_entry(100))
             .await
             .unwrap();
 
@@ -431,22 +457,25 @@ mod tests {
         // Block 99 holds only the commit tx.
         assert_eq!(
             refs[0].txns,
-            vec![(entry.commit_txid.to_txid(), entry.commit_wtxid.to_wtxid())]
+            vec![(
+                txid_to_bitcoin(entry.commit_txid),
+                wtxid_to_bitcoin(entry.commit_wtxid)
+            )]
         );
 
         // Blocks 100 and 101 each hold one reveal tx.
         assert_eq!(
             refs[1].txns,
             vec![(
-                entry.reveals[1].txid.to_txid(),
-                entry.reveals[1].wtxid.to_wtxid()
+                txid_to_bitcoin(entry.reveals[1].txid),
+                wtxid_to_bitcoin(entry.reveals[1].wtxid)
             )]
         );
         assert_eq!(
             refs[2].txns,
             vec![(
-                entry.reveals[0].txid.to_txid(),
-                entry.reveals[0].wtxid.to_wtxid()
+                txid_to_bitcoin(entry.reveals[0].txid),
+                wtxid_to_bitcoin(entry.reveals[0].wtxid)
             )]
         );
     }

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -17,7 +17,7 @@ use bitcoind_async_client::{
 };
 use strata_config::btcio::WriterConfig;
 use strata_db_types::types::{
-    ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxEntry, L1TxStatus, RevealTxMeta,
+    ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxEntry, L1TxId, L1TxStatus, RevealTxMeta,
 };
 use strata_primitives::buf::Buf32;
 use strata_storage::ops::chunked_envelope::ChunkedEnvelopeOps;
@@ -74,13 +74,17 @@ enum ChunkedEnvelopeWatcherError {
 
     /// A commit tx disappeared after the envelope reached reveal tracking.
     #[error(
-        "chunked envelope {envelope_idx} commit {commit_txid} missing from broadcast db in status {status:?}"
+        "chunked envelope {envelope_idx} commit {commit_txid:?} missing from broadcast db in status {status:?}"
     )]
     CommitMissingAfterRevealTracking {
         envelope_idx: u64,
-        commit_txid: Buf32,
+        commit_txid: L1TxId,
         status: ChunkedEnvelopeStatus,
     },
+}
+
+fn to_raw_buf32(txid: L1TxId) -> Buf32 {
+    Buf32(txid.0)
 }
 
 /// Handle for submitting chunked envelope entries.
@@ -235,28 +239,28 @@ fn format_reveal_refs(entry: &ChunkedEnvelopeEntry) -> Vec<String> {
     entry
         .reveals
         .iter()
-        .map(|reveal| format!("{}/{}", reveal.txid, reveal.wtxid))
+        .map(|reveal| format!("{:?}/{:?}", reveal.txid, reveal.wtxid))
         .collect()
 }
 
-fn format_tx_status(txid: Buf32, status: &L1TxStatus) -> String {
+fn format_tx_status(txid: L1TxId, status: &L1TxStatus) -> String {
     match status {
-        L1TxStatus::Unpublished => format!("{txid}:unpublished"),
-        L1TxStatus::Published => format!("{txid}:published"),
-        L1TxStatus::InvalidInputs => format!("{txid}:invalid_inputs"),
+        L1TxStatus::Unpublished => format!("{txid:?}:unpublished"),
+        L1TxStatus::Published => format!("{txid:?}:published"),
+        L1TxStatus::InvalidInputs => format!("{txid:?}:invalid_inputs"),
         L1TxStatus::Confirmed {
             confirmations,
             block_hash,
             block_height,
         } => {
-            format!("{txid}:confirmed@{block_height}/{block_hash} ({confirmations} confs)")
+            format!("{txid:?}:confirmed@{block_height}/{block_hash} ({confirmations} confs)")
         }
         L1TxStatus::Finalized {
             confirmations,
             block_hash,
             block_height,
         } => {
-            format!("{txid}:finalized@{block_height}/{block_hash} ({confirmations} confs)")
+            format!("{txid:?}:finalized@{block_height}/{block_hash} ({confirmations} confs)")
         }
     }
 }
@@ -438,7 +442,7 @@ async fn reconcile_active_entries(
             let reveal_refs = format_reveal_refs(&entry);
             debug!(
                 envelope_idx = idx,
-                commit_txid = %entry.commit_txid,
+                commit_txid = ?entry.commit_txid,
                 ?reveal_refs,
                 old_status = ?entry.status,
                 ?new_status,
@@ -519,12 +523,12 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
     ops.put_chunked_envelope_entry_async(envelope_idx, entry.clone())
         .await?;
     let commit_broadcast_idx = broadcast_handle
-        .put_tx_entry(entry.commit_txid, commit_tx_entry.clone())
+        .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_tx_entry.clone())
         .await?;
     debug!(
         envelope_idx,
-        commit_txid = %entry.commit_txid,
-        commit_wtxid = %entry.commit_wtxid,
+        commit_txid = ?entry.commit_txid,
+        commit_wtxid = ?entry.commit_wtxid,
         reveal_count = entry.reveals.len(),
         "persisted signed chunked envelope before commit broadcast"
     );
@@ -536,7 +540,7 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
                 .put_tx_entry_by_idx(commit_broadcast_idx, commit_tx_entry)
                 .await?;
             let commit = broadcast_handle
-                .get_tx_entry_by_id_async(entry.commit_txid)
+                .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
                 .await?
                 .expect("commit tx was just stored");
             try_enqueue_reveals_if_policy_safe(envelope_idx, &entry, &commit, broadcast_handle)
@@ -546,7 +550,7 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
                 .await?;
             info!(
                 envelope_idx,
-                commit_txid = %entry.commit_txid,
+                commit_txid = ?entry.commit_txid,
                 reveal_count = entry.reveals.len(),
                 "chunked envelope commit published"
             );
@@ -561,7 +565,7 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
                 .await?;
             warn!(
                 envelope_idx,
-                commit_txid = %entry.commit_txid,
+                commit_txid = ?entry.commit_txid,
                 "chunked envelope commit has invalid inputs; entry needs resign"
             );
         }
@@ -623,7 +627,7 @@ async fn advance_forward_frontier<R: Reader + Signer + Wallet + Broadcaster>(
                 let reveal_refs = format_reveal_refs(&updated);
                 debug!(
                     envelope_idx = idx,
-                    commit_txid = %updated.commit_txid,
+                    commit_txid = ?updated.commit_txid,
                     ?reveal_refs,
                     ?signed_status,
                     "entry signed successfully"
@@ -669,10 +673,13 @@ async fn check_commit_and_enqueue_reveals(
     entry: &ChunkedEnvelopeEntry,
     bcast: &L1BroadcastHandle,
 ) -> anyhow::Result<ChunkedEnvelopeStatus> {
-    let Some(commit) = bcast.get_tx_entry_by_id_async(entry.commit_txid).await? else {
+    let Some(commit) = bcast
+        .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+        .await?
+    else {
         warn!(
             envelope_idx,
-            commit_txid = %entry.commit_txid,
+            commit_txid = ?entry.commit_txid,
             "commit tx missing from broadcast db, will re-sign"
         );
         return Ok(ChunkedEnvelopeStatus::Unsigned);
@@ -682,7 +689,7 @@ async fn check_commit_and_enqueue_reveals(
         L1TxStatus::InvalidInputs => {
             warn!(
                 envelope_idx,
-                commit_txid = %entry.commit_txid,
+                commit_txid = ?entry.commit_txid,
                 "chunked envelope commit has invalid inputs during status check"
             );
             return Ok(ChunkedEnvelopeStatus::NeedsResign);
@@ -690,7 +697,7 @@ async fn check_commit_and_enqueue_reveals(
         L1TxStatus::Unpublished => {
             debug!(
                 envelope_idx,
-                commit_txid = %entry.commit_txid,
+                commit_txid = ?entry.commit_txid,
                 "chunked envelope commit still unpublished"
             );
             return Ok(ChunkedEnvelopeStatus::Unpublished);
@@ -700,7 +707,7 @@ async fn check_commit_and_enqueue_reveals(
 
     debug!(
         envelope_idx,
-        commit_txid = %entry.commit_txid,
+        commit_txid = ?entry.commit_txid,
         commit_status = ?commit.status,
         reveal_count = entry.reveals.len(),
         "chunked envelope commit publication observed"
@@ -739,7 +746,7 @@ async fn try_enqueue_reveals_if_policy_safe(
     if !reveal_enqueue_is_policy_safe(entry, commit)? {
         debug!(
             envelope_idx,
-            commit_txid = %entry.commit_txid,
+            commit_txid = ?entry.commit_txid,
             commit_status = ?commit.status,
             reveal_count = entry.reveals.len(),
             "reveal enqueue waiting for commit confirmation or smaller package"
@@ -749,7 +756,7 @@ async fn try_enqueue_reveals_if_policy_safe(
     let reveal_refs = format_reveal_refs(entry);
     info!(
         envelope_idx,
-        commit_txid = %entry.commit_txid,
+        commit_txid = ?entry.commit_txid,
         commit_status = ?commit.status,
         reveal_count = entry.reveals.len(),
         ?reveal_refs,
@@ -762,7 +769,7 @@ async fn try_enqueue_reveals_if_policy_safe(
 
     info!(
         envelope_idx,
-        commit_txid = %entry.commit_txid,
+        commit_txid = ?entry.commit_txid,
         reveal_count = entry.reveals.len(),
         ?reveal_refs,
         "enqueued reveal transactions for broadcaster retry tracking"
@@ -777,10 +784,14 @@ async fn ensure_reveal_tx_entry(
     reveal: &RevealTxMeta,
     bcast: &L1BroadcastHandle,
 ) -> anyhow::Result<()> {
-    if bcast.get_tx_entry_by_id_async(reveal.txid).await?.is_some() {
+    if bcast
+        .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+        .await?
+        .is_some()
+    {
         debug!(
             envelope_idx,
-            txid = %reveal.txid,
+            txid = ?reveal.txid,
             "reveal tx already tracked by broadcaster"
         );
         return Ok(());
@@ -789,13 +800,13 @@ async fn ensure_reveal_tx_entry(
     let tx = btc_deserialize(&reveal.tx_bytes)
         .map_err(|e| anyhow::anyhow!("failed to deserialize reveal tx: {}", e))?;
     bcast
-        .put_tx_entry(reveal.txid, L1TxEntry::from_tx(&tx))
+        .put_tx_entry(to_raw_buf32(reveal.txid), L1TxEntry::from_tx(&tx))
         .await
         .map_err(|e| anyhow::anyhow!("failed to store reveal tx: {}", e))?;
 
     debug!(
         envelope_idx,
-        txid = %reveal.txid,
+        txid = ?reveal.txid,
         "reveal tx enqueued in broadcaster"
     );
     Ok(())
@@ -811,10 +822,13 @@ async fn check_full_broadcast_status(
     entry: &ChunkedEnvelopeEntry,
     bcast: &L1BroadcastHandle,
 ) -> anyhow::Result<ChunkedEnvelopeStatus> {
-    let Some(commit) = bcast.get_tx_entry_by_id_async(entry.commit_txid).await? else {
+    let Some(commit) = bcast
+        .get_tx_entry_by_id_async(to_raw_buf32(entry.commit_txid))
+        .await?
+    else {
         error!(
             envelope_idx,
-            commit_txid = %entry.commit_txid,
+            commit_txid = ?entry.commit_txid,
             status = ?entry.status,
             "commit tx missing from broadcast db after reveals were expected to be tracked"
         );
@@ -835,11 +849,14 @@ async fn check_full_broadcast_status(
     let mut min_progress = commit.status.clone();
     let mut reveal_l1_statuses = Vec::with_capacity(entry.reveals.len());
     for reveal in &entry.reveals {
-        let Some(rtx) = bcast.get_tx_entry_by_id_async(reveal.txid).await? else {
+        let Some(rtx) = bcast
+            .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+            .await?
+        else {
             if !can_enqueue_missing_reveals {
                 debug!(
                     envelope_idx,
-                    txid = %reveal.txid,
+                    txid = ?reveal.txid,
                     commit_status = ?commit.status,
                     "reveal tx not enqueued yet; waiting for commit confirmation or smaller package"
                 );
@@ -847,7 +864,7 @@ async fn check_full_broadcast_status(
             }
             warn!(
                 envelope_idx,
-                txid = %reveal.txid,
+                txid = ?reveal.txid,
                 "reveal tx missing from broadcast db, restoring from persisted reveal bytes"
             );
             ensure_reveal_tx_entry(envelope_idx, reveal, bcast).await?;
@@ -860,7 +877,7 @@ async fn check_full_broadcast_status(
             // but handle it gracefully by re-signing.
             warn!(
                 envelope_idx,
-                txid = %reveal.txid,
+                txid = ?reveal.txid,
                 "reveal has InvalidInputs despite commit being published"
             );
             return Ok(ChunkedEnvelopeStatus::NeedsResign);
@@ -879,7 +896,7 @@ async fn check_full_broadcast_status(
         let commit_l1_status = format_tx_status(entry.commit_txid, &commit.status);
         info!(
             envelope_idx,
-            commit_txid = %entry.commit_txid,
+            commit_txid = ?entry.commit_txid,
             ?envelope_status,
             commit_l1_status = %commit_l1_status,
             ?reveal_l1_statuses,
@@ -941,12 +958,28 @@ mod tests {
         transaction::Version, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
         Witness,
     };
-    use strata_db_types::types::RevealTxMeta;
+    use strata_db_types::types::{L1TxId, L1WtxId, RevealTxMeta};
     use strata_l1_txfmt::MagicBytes;
     use strata_primitives::buf::Buf32;
 
     use super::*;
     use crate::writer::test_utils::{get_broadcast_handle, get_chunked_envelope_ops};
+
+    fn bytes_from_start(start: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        for (idx, byte) in bytes.iter_mut().enumerate() {
+            *byte = start.wrapping_add(idx as u8);
+        }
+        bytes
+    }
+
+    fn reversed_hex(bytes: [u8; 32]) -> String {
+        bytes
+            .into_iter()
+            .rev()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
 
     fn make_recovery_entry(
         status: ChunkedEnvelopeStatus,
@@ -962,12 +995,23 @@ mod tests {
         if signed {
             entry.reveals = vec![RevealTxMeta {
                 vout_index: 0,
-                txid: Buf32::from([idx_tag; 32]),
-                wtxid: Buf32::from([idx_tag.wrapping_add(1); 32]),
+                txid: L1TxId::from([idx_tag; 32]),
+                wtxid: L1WtxId::from([idx_tag.wrapping_add(1); 32]),
                 tx_bytes: vec![idx_tag],
             }];
         }
         entry
+    }
+
+    #[test]
+    fn format_tx_status_uses_full_reversed_txid() {
+        let txid_bytes = bytes_from_start(0x10);
+        let status = L1TxStatus::Published;
+
+        assert_eq!(
+            format_tx_status(L1TxId::from(txid_bytes), &status),
+            format!("{}:published", reversed_hex(txid_bytes))
+        );
     }
 
     #[test]
@@ -1153,14 +1197,14 @@ mod tests {
             MagicBytes::new([0x01, 0x02, 0x03, 0x04]),
             1,
         );
-        entry.commit_txid = Buf32::from([0x11; 32]);
+        entry.commit_txid = L1TxId::from([0x11; 32]);
         entry.reveals = (0..n)
             .map(|i| {
                 let tx = make_test_tx();
                 RevealTxMeta {
                     vout_index: i as u32,
-                    txid: Buf32::from([(0x20 + i as u8); 32]),
-                    wtxid: Buf32::from([(0x30 + i as u8); 32]),
+                    txid: L1TxId::from([(0x20 + i as u8); 32]),
+                    wtxid: L1WtxId::from([(0x30 + i as u8); 32]),
                     tx_bytes: btc_serialize(&tx),
                 }
             })
@@ -1177,7 +1221,7 @@ mod tests {
         // Store commit with Unpublished status — reveals should NOT be broadcast.
         let commit_entry = L1TxEntry::from_tx(&make_test_tx());
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1192,7 +1236,10 @@ mod tests {
 
         // Ensure reveals are not inserted in broadcast DB before commit is published.
         for reveal in &entry.reveals {
-            let rtx = bcast.get_tx_entry_by_id_async(reveal.txid).await.unwrap();
+            let rtx = bcast
+                .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+                .await
+                .unwrap();
             assert!(
                 rtx.is_none(),
                 "reveal should not be stored before commit publish"
@@ -1224,7 +1271,7 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = L1TxStatus::InvalidInputs;
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1247,7 +1294,7 @@ mod tests {
             block_height: 100,
         };
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1263,7 +1310,7 @@ mod tests {
         // Reveals enter the broadcaster as Unpublished so its retry loop owns sendrawtransaction.
         for reveal in &entry.reveals {
             let rtx = bcast
-                .get_tx_entry_by_id_async(reveal.txid)
+                .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
                 .await
                 .unwrap()
                 .expect("reveal should be in broadcast DB");
@@ -1283,7 +1330,7 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = L1TxStatus::Published;
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1293,7 +1340,7 @@ mod tests {
         assert_eq!(result, ChunkedEnvelopeStatus::CommitPublished);
 
         let rtx = bcast
-            .get_tx_entry_by_id_async(entry.reveals[0].txid)
+            .get_tx_entry_by_id_async(to_raw_buf32(entry.reveals[0].txid))
             .await
             .unwrap()
             .expect("single reveal should be queued under the descendant-size limit");
@@ -1308,7 +1355,7 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = L1TxStatus::Published;
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1318,7 +1365,10 @@ mod tests {
         assert_eq!(result, ChunkedEnvelopeStatus::CommitPublished);
 
         for reveal in &entry.reveals {
-            let rtx = bcast.get_tx_entry_by_id_async(reveal.txid).await.unwrap();
+            let rtx = bcast
+                .get_tx_entry_by_id_async(to_raw_buf32(reveal.txid))
+                .await
+                .unwrap();
             assert!(
                 rtx.is_none(),
                 "multi-reveal tx should wait until commit confirmation"
@@ -1341,7 +1391,7 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = finalized.clone();
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1349,7 +1399,10 @@ mod tests {
         for reveal in &entry.reveals {
             let mut rtx = L1TxEntry::from_tx(&make_test_tx());
             rtx.status = finalized.clone();
-            bcast.put_tx_entry(reveal.txid, rtx).await.unwrap();
+            bcast
+                .put_tx_entry(to_raw_buf32(reveal.txid), rtx)
+                .await
+                .unwrap();
         }
 
         let result = check_full_broadcast_status(0, &entry, &bcast)
@@ -1373,24 +1426,33 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = confirmed.clone();
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
         // Reveal 0: Confirmed.
         let mut r0 = L1TxEntry::from_tx(&make_test_tx());
         r0.status = confirmed.clone();
-        bcast.put_tx_entry(entry.reveals[0].txid, r0).await.unwrap();
+        bcast
+            .put_tx_entry(to_raw_buf32(entry.reveals[0].txid), r0)
+            .await
+            .unwrap();
 
         // Reveal 1: Published (least progressed).
         let mut r1 = L1TxEntry::from_tx(&make_test_tx());
         r1.status = L1TxStatus::Published;
-        bcast.put_tx_entry(entry.reveals[1].txid, r1).await.unwrap();
+        bcast
+            .put_tx_entry(to_raw_buf32(entry.reveals[1].txid), r1)
+            .await
+            .unwrap();
 
         // Reveal 2: Confirmed.
         let mut r2 = L1TxEntry::from_tx(&make_test_tx());
         r2.status = confirmed;
-        bcast.put_tx_entry(entry.reveals[2].txid, r2).await.unwrap();
+        bcast
+            .put_tx_entry(to_raw_buf32(entry.reveals[2].txid), r2)
+            .await
+            .unwrap();
 
         let result = check_full_broadcast_status(0, &entry, &bcast)
             .await
@@ -1433,14 +1495,17 @@ mod tests {
             block_height: 100,
         };
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
         // Store only first reveal.
         let mut r0 = L1TxEntry::from_tx(&make_test_tx());
         r0.status = L1TxStatus::Published;
-        bcast.put_tx_entry(entry.reveals[0].txid, r0).await.unwrap();
+        bcast
+            .put_tx_entry(to_raw_buf32(entry.reveals[0].txid), r0)
+            .await
+            .unwrap();
 
         // Second reveal is missing.
         let result = check_full_broadcast_status(0, &entry, &bcast)
@@ -1453,7 +1518,7 @@ mod tests {
         );
 
         let restored = bcast
-            .get_tx_entry_by_id_async(entry.reveals[1].txid)
+            .get_tx_entry_by_id_async(to_raw_buf32(entry.reveals[1].txid))
             .await
             .unwrap()
             .expect("missing reveal should be restored in broadcast DB");
@@ -1469,19 +1534,25 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = L1TxStatus::Published;
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
         // Reveal 0 is fine.
         let mut r0 = L1TxEntry::from_tx(&make_test_tx());
         r0.status = L1TxStatus::Published;
-        bcast.put_tx_entry(entry.reveals[0].txid, r0).await.unwrap();
+        bcast
+            .put_tx_entry(to_raw_buf32(entry.reveals[0].txid), r0)
+            .await
+            .unwrap();
 
         // Reveal 1 has invalid inputs.
         let mut r1 = L1TxEntry::from_tx(&make_test_tx());
         r1.status = L1TxStatus::InvalidInputs;
-        bcast.put_tx_entry(entry.reveals[1].txid, r1).await.unwrap();
+        bcast
+            .put_tx_entry(to_raw_buf32(entry.reveals[1].txid), r1)
+            .await
+            .unwrap();
 
         let result = check_full_broadcast_status(0, &entry, &bcast)
             .await
@@ -1502,7 +1573,7 @@ mod tests {
         let mut commit_entry = L1TxEntry::from_tx(&make_test_tx());
         commit_entry.status = L1TxStatus::Published;
         bcast
-            .put_tx_entry(entry.commit_txid, commit_entry)
+            .put_tx_entry(to_raw_buf32(entry.commit_txid), commit_entry)
             .await
             .unwrap();
 
@@ -1510,7 +1581,10 @@ mod tests {
         for reveal in &entry.reveals {
             let rtx = L1TxEntry::from_tx(&make_test_tx());
             // from_tx creates with Unpublished status by default
-            bcast.put_tx_entry(reveal.txid, rtx).await.unwrap();
+            bcast
+                .put_tx_entry(to_raw_buf32(reveal.txid), rtx)
+                .await
+                .unwrap();
         }
 
         let result = check_full_broadcast_status(0, &entry, &bcast)

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -14,9 +14,8 @@ use bitcoin::consensus::encode::serialize as btc_serialize;
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::{TxidExt, WtxidExt};
 use strata_db_types::types::{
-    ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxEntry, RevealTxMeta,
+    ChunkedEnvelopeEntry, ChunkedEnvelopeStatus, L1TxEntry, L1TxId, L1WtxId, RevealTxMeta,
 };
-use strata_primitives::buf::Buf32;
 use tracing::*;
 
 use super::{builder::build_chunked_envelope_txs, context::ChunkedWriterContext};
@@ -28,8 +27,16 @@ use crate::writer::{
 fn format_reveal_refs(reveals: &[RevealTxMeta]) -> Vec<String> {
     reveals
         .iter()
-        .map(|reveal| format!("{}/{}", reveal.txid, reveal.wtxid))
+        .map(|reveal| format!("{:?}/{:?}", reveal.txid, reveal.wtxid))
         .collect()
+}
+
+fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
+    L1TxId::from(txid.to_buf32().0)
+}
+
+fn to_l1_wtxid(wtxid: bitcoin::Wtxid) -> L1WtxId {
+    L1WtxId::from(wtxid.to_buf32().0)
 }
 
 /// Signed chunked-envelope metadata ready for lifecycle persistence.
@@ -129,15 +136,15 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .await
             .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
-        let commit_txid: Buf32 = signed_commit.compute_txid().to_buf32();
-        let commit_wtxid: Buf32 = signed_commit.compute_wtxid().to_buf32();
+        let commit_txid = to_l1_txid(signed_commit.compute_txid());
+        let commit_wtxid = to_l1_wtxid(signed_commit.compute_wtxid());
 
         // Store reveal metadata and raw bytes locally. They'll be added to broadcast
         // DB by the watcher after commit is published.
         let mut reveals = Vec::with_capacity(built.reveal_txs.len());
         for (i, reveal_tx) in built.reveal_txs.iter().enumerate() {
-            let txid: Buf32 = reveal_tx.compute_txid().to_buf32();
-            let wtxid: Buf32 = reveal_tx.compute_wtxid().to_buf32();
+            let txid = to_l1_txid(reveal_tx.compute_txid());
+            let wtxid = to_l1_wtxid(reveal_tx.compute_wtxid());
             let tx_bytes = btc_serialize(reveal_tx);
 
             // vout_index is i+1 because vout 0 is the commit OP_RETURN.
@@ -151,8 +158,8 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
 
         let reveal_refs = format_reveal_refs(&reveals);
         debug!(
-            %commit_txid,
-            %commit_wtxid,
+            ?commit_txid,
+            ?commit_wtxid,
             reveal_count = reveals.len(),
             ?reveal_refs,
             "signed chunked envelope, ready for persistence"
@@ -170,4 +177,48 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
     }
     .instrument(sign_chunked_envelope_span)
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_db_types::types::RevealTxMeta;
+
+    use super::*;
+
+    fn bytes_from_start(start: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        for (idx, byte) in bytes.iter_mut().enumerate() {
+            *byte = start.wrapping_add(idx as u8);
+        }
+        bytes
+    }
+
+    fn reversed_hex(bytes: [u8; 32]) -> String {
+        bytes
+            .into_iter()
+            .rev()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    #[test]
+    fn format_reveal_refs_uses_full_reversed_hex() {
+        let txid_bytes = bytes_from_start(0x10);
+        let wtxid_bytes = bytes_from_start(0x40);
+        let reveals = vec![RevealTxMeta {
+            vout_index: 1,
+            txid: L1TxId::from(txid_bytes),
+            wtxid: L1WtxId::from(wtxid_bytes),
+            tx_bytes: Vec::new(),
+        }];
+
+        assert_eq!(
+            format_reveal_refs(&reveals),
+            vec![format!(
+                "{}/{}",
+                reversed_hex(txid_bytes),
+                reversed_hex(wtxid_bytes)
+            )]
+        );
+    }
 }

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_btc_types::TxidExt;
-use strata_db_types::types::{BundledPayloadEntry, L1TxEntry};
+use strata_db_types::types::{BundledPayloadEntry, L1TxEntry, L1TxId};
 use strata_primitives::buf::Buf32;
 use tracing::*;
 
@@ -14,6 +14,14 @@ use super::{
     context::WriterContext,
 };
 use crate::broadcaster::L1BroadcastHandle;
+
+fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
+    L1TxId::from(txid.to_buf32().0)
+}
+
+fn to_raw_buf32(txid: L1TxId) -> Buf32 {
+    Buf32(txid.0)
+}
 
 /// Builds envelope transactions for a payload entry.
 ///
@@ -64,7 +72,7 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
     payloadentry: &BundledPayloadEntry,
     ctx: Arc<WriterContext<R>>,
     broadcast_handle: &L1BroadcastHandle,
-) -> Result<(Buf32, Buf32), EnvelopeError> {
+) -> Result<(L1TxId, L1TxId), EnvelopeError> {
     let span = debug_span!(
         "btcio_payload_envelope_unchecked",
         component = "btcio_writer_signer",
@@ -74,19 +82,19 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
     async {
         let envelope = build_and_sign_envelope_txs(&payloadentry.payload, ctx.as_ref()).await?;
 
-        let cid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
+        let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(cid, L1TxEntry::from_tx(&envelope.commit_tx))
+            .put_tx_entry(to_raw_buf32(cid), L1TxEntry::from_tx(&envelope.commit_tx))
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
 
-        let rid: Buf32 = envelope.reveal_tx.compute_txid().to_buf32();
+        let rid = to_l1_txid(envelope.reveal_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(rid, L1TxEntry::from_tx(&envelope.reveal_tx))
+            .put_tx_entry(to_raw_buf32(rid), L1TxEntry::from_tx(&envelope.reveal_tx))
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
 
-        info!(%cid, reveal_txid = %rid, "envelope signed and stored for broadcast");
+        info!(?cid, reveal_txid = ?rid, "envelope signed and stored for broadcast");
         Ok((cid, rid))
     }
     .instrument(span)
@@ -103,7 +111,7 @@ pub(crate) async fn complete_reveal_and_broadcast(
     envelope: &EnvelopeData,
     signature: &[u8; 64],
     broadcast_handle: &L1BroadcastHandle,
-) -> Result<Buf32, EnvelopeError> {
+) -> Result<L1TxId, EnvelopeError> {
     let span = debug_span!(
         "btcio_payload_reveal",
         component = "btcio_writer_signer",
@@ -122,19 +130,19 @@ pub(crate) async fn complete_reveal_and_broadcast(
         )
         .map_err(EnvelopeError::Other)?;
 
-        let cid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
+        let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(cid, L1TxEntry::from_tx(&envelope.commit_tx))
+            .put_tx_entry(to_raw_buf32(cid), L1TxEntry::from_tx(&envelope.commit_tx))
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
 
-        let rid: Buf32 = reveal_tx.compute_txid().to_buf32();
+        let rid = to_l1_txid(reveal_tx.compute_txid());
         broadcast_handle
-            .put_tx_entry(rid, L1TxEntry::from_tx(&reveal_tx))
+            .put_tx_entry(to_raw_buf32(rid), L1TxEntry::from_tx(&reveal_tx))
             .await
             .map_err(|e| EnvelopeError::Other(e.into()))?;
 
-        info!(%cid, reveal_txid = %rid, "commit and reveal stored for broadcast");
+        info!(?cid, reveal_txid = ?rid, "commit and reveal stored for broadcast");
         Ok(rid)
     }
     .instrument(span)
@@ -174,8 +182,8 @@ mod test {
         let entry = unsigned_test_entry();
 
         assert_eq!(entry.status, L1BundleStatus::Unsigned);
-        assert_eq!(entry.commit_txid, Buf32::zero());
-        assert_eq!(entry.reveal_txid, Buf32::zero());
+        assert_eq!(entry.commit_txid, L1TxId::zero());
+        assert_eq!(entry.reveal_txid, L1TxId::zero());
 
         iops.put_payload_entry_async(0, entry.clone())
             .await
@@ -209,17 +217,17 @@ mod test {
             .unwrap();
 
         // Both txids should be non-zero
-        assert_ne!(cid, Buf32::zero());
-        assert_ne!(rid, Buf32::zero());
+        assert_ne!(cid, L1TxId::zero());
+        assert_ne!(rid, L1TxId::zero());
 
         // Both commit and reveal should be stored in broadcaster DB immediately
         assert!(bcast_handle
-            .get_tx_entry_by_id_async(cid)
+            .get_tx_entry_by_id_async(to_raw_buf32(cid))
             .await
             .unwrap()
             .is_some());
         assert!(bcast_handle
-            .get_tx_entry_by_id_async(rid)
+            .get_tx_entry_by_id_async(to_raw_buf32(rid))
             .await
             .unwrap()
             .is_some());

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -14,7 +14,7 @@ use std::{
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use serde::Serialize;
 use strata_btc_types::{Buf32BitcoinExt, TxidExt};
-use strata_db_types::types::{BundledPayloadEntry, L1BundleStatus, L1TxEntry, L1TxStatus};
+use strata_db_types::types::{BundledPayloadEntry, L1BundleStatus, L1TxEntry, L1TxId, L1TxStatus};
 use strata_primitives::buf::Buf32;
 use strata_service::{AsyncService, Response, Service, ServiceState};
 use strata_status::StatusChannel;
@@ -34,6 +34,14 @@ use crate::{
         },
     },
 };
+
+fn to_l1_txid(txid: bitcoin::Txid) -> L1TxId {
+    L1TxId::from(txid.to_buf32().0)
+}
+
+fn to_raw_buf32(txid: L1TxId) -> Buf32 {
+    Buf32(txid.0)
+}
 
 /// Abstracts the external dependencies of the watcher so that `process_input` can be
 /// tested without a real Bitcoin node, database, or broadcast infrastructure.
@@ -63,18 +71,16 @@ pub(crate) trait WatcherServiceContext: Send + Sync + 'static {
         &self,
         idx: u64,
         entry: &BundledPayloadEntry,
-    ) -> impl Future<Output = Result<(Buf32, Buf32), EnvelopeError>> + Send;
-
+    ) -> impl Future<Output = Result<(L1TxId, L1TxId), EnvelopeError>> + Send;
     fn complete_reveal_and_broadcast(
         &self,
         idx: u64,
         envelope: &EnvelopeData,
         sig: &[u8; 64],
-    ) -> impl Future<Output = anyhow::Result<Buf32>> + Send;
-
+    ) -> impl Future<Output = anyhow::Result<L1TxId>> + Send;
     fn get_tx_status(
         &self,
-        txid: Buf32,
+        txid: L1TxId,
     ) -> impl Future<Output = anyhow::Result<Option<L1TxEntry>>> + Send;
 
     fn report_status(
@@ -139,7 +145,7 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
         &self,
         idx: u64,
         entry: &BundledPayloadEntry,
-    ) -> Result<(Buf32, Buf32), EnvelopeError> {
+    ) -> Result<(L1TxId, L1TxId), EnvelopeError> {
         sign_and_broadcast_payload_envelopes(
             idx,
             entry,
@@ -154,15 +160,15 @@ impl<R: Reader + Signer + Wallet + Send + Sync + 'static> WatcherServiceContext
         idx: u64,
         envelope: &EnvelopeData,
         sig: &[u8; 64],
-    ) -> anyhow::Result<Buf32> {
+    ) -> anyhow::Result<L1TxId> {
         complete_reveal_and_broadcast(idx, envelope, sig, &self.broadcast_handle)
             .await
             .map_err(Into::into)
     }
 
-    async fn get_tx_status(&self, txid: Buf32) -> anyhow::Result<Option<L1TxEntry>> {
+    async fn get_tx_status(&self, txid: L1TxId) -> anyhow::Result<Option<L1TxEntry>> {
         self.broadcast_handle
-            .get_tx_entry_by_id_async(txid)
+            .get_tx_entry_by_id_async(Buf32(txid.0))
             .await
             .map_err(Into::into)
     }
@@ -291,8 +297,8 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 .await
             {
                 Ok(envelope) => {
-                    let cid: Buf32 = envelope.commit_tx.compute_txid().to_buf32();
-                    let rid: Buf32 = envelope.reveal_tx.compute_txid().to_buf32();
+                    let cid = to_l1_txid(envelope.commit_tx.compute_txid());
+                    let rid = to_l1_txid(envelope.reveal_tx.compute_txid());
                     let sighash = envelope.sighash;
 
                     let mut updated_entry = payloadentry.clone();
@@ -335,7 +341,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                         .put_payload_entry(self.curr_payloadidx, updated_entry)
                         .await?;
 
-                    debug!(%cid, reveal_txid = %rid, "envelope signed and queued for broadcast");
+                    debug!(?cid, reveal_txid = ?rid, "envelope signed and queued for broadcast");
                 }
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
@@ -419,8 +425,8 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     debug!(
                         component = "btcio_writer",
                         payload_idx = self.curr_payloadidx,
-                        commit_txid = %payloadentry.commit_txid,
-                        reveal_txid = %payloadentry.reveal_txid,
+                        commit_txid = ?payloadentry.commit_txid,
+                        reveal_txid = ?payloadentry.reveal_txid,
                         payload_status = ?new_status,
                         commit_l1_status = ?ctx.status,
                         reveal_l1_status = ?rtx.status,
@@ -467,7 +473,7 @@ async fn update_l1_status(
         || *new_status == L1BundleStatus::Finalized
     {
         let status_updates = [
-            L1StatusUpdate::LastPublishedTxid(payloadentry.reveal_txid.to_txid()),
+            L1StatusUpdate::LastPublishedTxid(to_raw_buf32(payloadentry.reveal_txid).to_txid()),
             L1StatusUpdate::IncrementPublishedRevealCount,
         ];
         apply_status_updates(&status_updates, status_channel).await;
@@ -519,7 +525,7 @@ mod tests {
     };
     use bitcoind_async_client::error::ClientError;
     use strata_csm_types::L1Payload;
-    use strata_db_types::types::{BundledPayloadEntry, L1BundleStatus, L1TxEntry};
+    use strata_db_types::types::{BundledPayloadEntry, L1BundleStatus, L1TxEntry, L1TxId};
     use strata_l1_txfmt::TagData;
     use strata_primitives::buf::{Buf32, Buf64};
 
@@ -698,11 +704,11 @@ mod tests {
             &self,
             _idx: u64,
             _entry: &BundledPayloadEntry,
-        ) -> Result<(Buf32, Buf32), EnvelopeError> {
+        ) -> Result<(L1TxId, L1TxId), EnvelopeError> {
             if let Some(failure) = self.sign_failure {
                 return Err(failure.into_error());
             }
-            Ok((Buf32([1u8; 32]), Buf32([2u8; 32])))
+            Ok((L1TxId::from([1u8; 32]), L1TxId::from([2u8; 32])))
         }
 
         async fn complete_reveal_and_broadcast(
@@ -710,13 +716,13 @@ mod tests {
             idx: u64,
             envelope: &EnvelopeData,
             sig: &[u8; 64],
-        ) -> anyhow::Result<Buf32> {
+        ) -> anyhow::Result<L1TxId> {
             complete_reveal_and_broadcast(idx, envelope, sig, &self.broadcast_handle)
                 .await
                 .map_err(Into::into)
         }
 
-        async fn get_tx_status(&self, _txid: Buf32) -> anyhow::Result<Option<L1TxEntry>> {
+        async fn get_tx_status(&self, _txid: L1TxId) -> anyhow::Result<Option<L1TxEntry>> {
             Ok(None)
         }
 
@@ -744,8 +750,8 @@ mod tests {
 
         let stored = state.ctx.get_stored(0).unwrap();
         assert_eq!(stored.status, L1BundleStatus::Unpublished);
-        assert_eq!(stored.commit_txid, Buf32([1u8; 32]));
-        assert_eq!(stored.reveal_txid, Buf32([2u8; 32]));
+        assert_eq!(stored.commit_txid, L1TxId::from([1u8; 32]));
+        assert_eq!(stored.reveal_txid, L1TxId::from([2u8; 32]));
         // No cache entry — ephemeral path does not use the envelope cache
         assert!(state.envelope_cache.is_empty());
     }
@@ -762,8 +768,8 @@ mod tests {
         let stored = state.ctx.get_stored(0).unwrap();
         assert_eq!(stored.status, L1BundleStatus::Unsigned);
         // Unsigned entries use zero txids as sentinels because no txs have been built yet.
-        assert_eq!(stored.commit_txid, Buf32::zero());
-        assert_eq!(stored.reveal_txid, Buf32::zero());
+        assert_eq!(stored.commit_txid, L1TxId::zero());
+        assert_eq!(stored.reveal_txid, L1TxId::zero());
         assert_eq!(state.curr_payloadidx, 0);
         assert!(state.envelope_cache.is_empty());
     }
@@ -798,8 +804,8 @@ mod tests {
         let stored = state.ctx.get_stored(0).unwrap();
         assert_eq!(stored.status, L1BundleStatus::Unsigned);
         // Unsigned entries use zero txids as sentinels because no txs have been built yet.
-        assert_eq!(stored.commit_txid, Buf32::zero());
-        assert_eq!(stored.reveal_txid, Buf32::zero());
+        assert_eq!(stored.commit_txid, L1TxId::zero());
+        assert_eq!(stored.reveal_txid, L1TxId::zero());
         assert_eq!(state.curr_payloadidx, 0);
         assert!(state.envelope_cache.is_empty());
     }

--- a/crates/db/types/src/types.rs
+++ b/crates/db/types/src/types.rs
@@ -12,7 +12,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_checkpoint_types::{BatchInfo, Checkpoint, CheckpointSidecar};
 use strata_csm_types::{CheckpointL1Ref, L1Payload, PayloadIntent};
-use strata_identifiers::{Buf32, Buf64, OLTxId};
+use strata_identifiers::{Buf32, Buf64, OLTxId, RBuf32};
 use strata_l1_txfmt::MagicBytes;
 use strata_ol_chainstate_types::Chainstate;
 use strata_primitives::L1Height;
@@ -20,6 +20,12 @@ use zkaleido::Proof;
 
 /// Taproot script-spend sighash for the reveal transaction.
 pub type Sighash = Buf32;
+
+/// Bitcoin transaction ID displayed in Bitcoin byte order.
+pub type L1TxId = RBuf32;
+
+/// Bitcoin witness transaction ID displayed in Bitcoin byte order.
+pub type L1WtxId = RBuf32;
 
 /// Represents an intent to publish to some DA, which will be bundled for efficiency.
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
@@ -62,8 +68,8 @@ pub enum IntentStatus {
 #[derive(Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
 pub struct BundledPayloadEntry {
     pub payload: L1Payload,
-    pub commit_txid: Buf32,
-    pub reveal_txid: Buf32,
+    pub commit_txid: L1TxId,
+    pub reveal_txid: L1TxId,
     pub status: L1BundleStatus,
     /// Schnorr signature provided by the external signer for envelope reveal tx.
     ///
@@ -74,8 +80,8 @@ pub struct BundledPayloadEntry {
 impl BundledPayloadEntry {
     pub fn new(
         payload: L1Payload,
-        commit_txid: Buf32,
-        reveal_txid: Buf32,
+        commit_txid: L1TxId,
+        reveal_txid: L1TxId,
         status: L1BundleStatus,
     ) -> Self {
         Self {
@@ -93,65 +99,34 @@ impl BundledPayloadEntry {
     ///   Because it is better to defer gathering utxos as late as possible to prevent being spent
     ///   by others. Those will be created and signed in a single step.
     pub fn new_unsigned(payload: L1Payload) -> Self {
-        let cid = Buf32::zero();
-        let rid = Buf32::zero();
+        let cid = L1TxId::zero();
+        let rid = L1TxId::zero();
         Self::new(payload, cid, rid, L1BundleStatus::Unsigned)
     }
 }
 
-// Custom debug implementation to print commit_txid and reveal_txid in little endian
+// Custom debug implementation to print commit_txid and reveal_txid in Bitcoin order.
 impl fmt::Debug for BundledPayloadEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let commit_txid_le = {
-            let mut bytes = self.commit_txid.0;
-            bytes.reverse();
-            bytes
-                .iter()
-                .map(|b| format!("{:02x}", b))
-                .collect::<String>()
-        };
-        let reveal_txid_le = {
-            let mut bytes = self.reveal_txid.0;
-            bytes.reverse();
-            bytes
-                .iter()
-                .map(|b| format!("{:02x}", b))
-                .collect::<String>()
-        };
+        let commit_txid = format!("{:?}", self.commit_txid);
+        let reveal_txid = format!("{:?}", self.reveal_txid);
 
         f.debug_struct("BundledPayloadEntry")
             .field("payload", &self.payload)
-            .field("commit_txid", &commit_txid_le)
-            .field("reveal_txid", &reveal_txid_le)
+            .field("commit_txid", &commit_txid)
+            .field("reveal_txid", &reveal_txid)
             .field("status", &self.status)
             .finish()
     }
 }
 
-// Custom display implementation to print commit_txid and reveal_txid in little endian
+// Custom display implementation to print commit_txid and reveal_txid in Bitcoin order.
 impl fmt::Display for BundledPayloadEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let commit_txid_le = {
-            let mut bytes = self.commit_txid.0;
-            bytes.reverse();
-            bytes
-                .iter()
-                .map(|b| format!("{:02x}", b))
-                .collect::<String>()
-        };
-        let reveal_txid_le = {
-            let mut bytes = self.reveal_txid.0;
-            bytes.reverse();
-            bytes
-                .iter()
-                .map(|b| format!("{:02x}", b))
-                .collect::<String>()
-        };
-
         write!(
             f,
-            "BundledPayloadEntry {{ payload: {:?}, commit_txid: {}, reveal_txid: {}, status: {:?} }}",
-            self.payload, commit_txid_le, reveal_txid_le, self.status
+            "BundledPayloadEntry {{ payload: {:?}, commit_txid: {:?}, reveal_txid: {:?}, status: {:?} }}",
+            self.payload, self.commit_txid, self.reveal_txid, self.status
         )
     }
 }
@@ -451,9 +426,9 @@ pub struct ChunkedEnvelopeEntry {
     /// DA blob version carried in the commit OP_RETURN.
     pub da_blob_version: u32,
     /// Commit transaction ID. Zero if unsigned.
-    pub commit_txid: Buf32,
+    pub commit_txid: L1TxId,
     /// Witness transaction ID of the commit. Zero if unsigned.
-    pub commit_wtxid: Buf32,
+    pub commit_wtxid: L1WtxId,
     /// Per-reveal metadata, ordered by output index. Empty if unsigned.
     pub reveals: Vec<RevealTxMeta>,
     /// Lifecycle status.
@@ -474,8 +449,8 @@ impl ChunkedEnvelopeEntry {
             chunk_data,
             magic_bytes,
             da_blob_version,
-            commit_txid: Buf32::zero(),
-            commit_wtxid: Buf32::zero(),
+            commit_txid: L1TxId::zero(),
+            commit_wtxid: L1WtxId::zero(),
             reveals: Vec::new(),
             status: ChunkedEnvelopeStatus::Unsigned,
         }
@@ -486,7 +461,7 @@ impl fmt::Display for ChunkedEnvelopeEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "ChunkedEnvelopeEntry(status={}, chunk_count={}, commit_txid={}, reveals=[",
+            "ChunkedEnvelopeEntry(status={}, chunk_count={}, commit_txid={:?}, reveals=[",
             self.status,
             self.chunk_data.len(),
             self.commit_txid
@@ -509,9 +484,9 @@ pub struct RevealTxMeta {
     /// Output index in the commit tx that this reveal spends.
     pub vout_index: u32,
     /// Reveal transaction ID.
-    pub txid: Buf32,
+    pub txid: L1TxId,
     /// Reveal witness transaction ID.
-    pub wtxid: Buf32,
+    pub wtxid: L1WtxId,
     /// Raw signed reveal transaction bytes (consensus-encoded).
     /// Stored here until the commit is published, then added to broadcast DB.
     pub tx_bytes: Vec<u8>,
@@ -519,7 +494,7 @@ pub struct RevealTxMeta {
 
 impl fmt::Display for RevealTxMeta {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/{}", self.txid, self.wtxid)
+        write!(f, "{:?}/{:?}", self.txid, self.wtxid)
     }
 }
 
@@ -577,6 +552,7 @@ mod tests {
     };
     use serde_json;
     use strata_identifiers::test_utils::{buf32_strategy, l1_block_commitment_strategy};
+    use strata_l1_txfmt::TagData;
 
     use super::*;
 
@@ -625,27 +601,73 @@ mod tests {
         assert_eq!(status.to_string(), "confirmed@42/000000..000000 (12 confs)");
     }
 
+    fn bytes_from_start(start: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        for (idx, byte) in bytes.iter_mut().enumerate() {
+            *byte = start.wrapping_add(idx as u8);
+        }
+        bytes
+    }
+
+    fn reversed_hex(bytes: [u8; 32]) -> String {
+        bytes
+            .into_iter()
+            .rev()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    #[test]
+    fn bundled_payload_entry_formats_full_reversed_txids() {
+        let commit_bytes = bytes_from_start(0x10);
+        let reveal_bytes = bytes_from_start(0x40);
+        let payload = L1Payload::new(vec![vec![1, 2, 3]], TagData::new(1, 1, vec![]).unwrap());
+        let entry = BundledPayloadEntry::new(
+            payload,
+            L1TxId::from(commit_bytes),
+            L1TxId::from(reveal_bytes),
+            L1BundleStatus::Unpublished,
+        );
+
+        let display = entry.to_string();
+        let debug = format!("{entry:?}");
+        let expected_commit = reversed_hex(commit_bytes);
+        let expected_reveal = reversed_hex(reveal_bytes);
+
+        assert!(display.contains(&expected_commit));
+        assert!(display.contains(&expected_reveal));
+        assert!(!display.contains(".."));
+        assert!(debug.contains(&expected_commit));
+        assert!(debug.contains(&expected_reveal));
+        assert!(!debug.contains(".."));
+    }
+
     #[test]
     fn display_chunked_envelope_entry_includes_commit_and_reveals() {
+        let commit_bytes = bytes_from_start(0x01);
+        let commit_witness_bytes = bytes_from_start(0x21);
+        let reveal_bytes = bytes_from_start(0x41);
+        let reveal_witness_bytes = bytes_from_start(0x61);
         let entry = ChunkedEnvelopeEntry {
             chunk_data: vec![vec![1], vec![2]],
             magic_bytes: MagicBytes::new([0; 4]),
             da_blob_version: 1,
-            commit_txid: Buf32::from([1; 32]),
-            commit_wtxid: Buf32::from([4; 32]),
+            commit_txid: L1TxId::from(commit_bytes),
+            commit_wtxid: L1WtxId::from(commit_witness_bytes),
             reveals: vec![RevealTxMeta {
                 vout_index: 0,
-                txid: Buf32::from([2; 32]),
-                wtxid: Buf32::from([3; 32]),
+                txid: L1TxId::from(reveal_bytes),
+                wtxid: L1WtxId::from(reveal_witness_bytes),
                 tx_bytes: Vec::new(),
             }],
             status: ChunkedEnvelopeStatus::Published,
         };
 
-        assert_eq!(
-            entry.to_string(),
-            "ChunkedEnvelopeEntry(status=published, chunk_count=2, commit_txid=010101..010101, reveals=[020202..020202/030303..030303])"
-        );
+        let display = entry.to_string();
+        assert!(display.contains(&reversed_hex(commit_bytes)));
+        assert!(display.contains(&reversed_hex(reveal_bytes)));
+        assert!(display.contains(&reversed_hex(reveal_witness_bytes)));
+        assert!(!display.contains(".."));
     }
 
     #[test]


### PR DESCRIPTION
## Description

L1 transactions and block hashes in BTCIO uses `Buf32` that do not reverse the hex string that Bitcoin transaction IDs/block hashes are supposed to be. Hence we need to move them to `RBuf32`. Also, using the `Display` implementation for logging trims the transaction ID and block hashes (`aaaa....bbbb`), making it difficult to find them in a block explorer. Hence we should move to use the `Debug` implementation for logging. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3416
