### PR TITLE
fix(datatool, provers/sp1): emit borsh-serialized verifier as Sp1Groth16 condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15433,6 +15433,7 @@ dependencies = [
  "argh",
  "bitcoin",
  "bitcoind-async-client",
+ "borsh",
  "rand_core 0.6.4",
  "reth-chainspec",
  "serde_json",
@@ -16709,6 +16710,7 @@ name = "strata-sp1-guest-builder"
 version = "0.3.0-alpha.1"
 dependencies = [
  "bincode",
+ "borsh",
  "cargo_metadata 0.19.2",
  "cfg-if",
  "once_cell",

--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -27,6 +27,7 @@ strata-predicate.workspace = true
 strata-primitives.workspace = true
 strata-snark-acct-runtime.workspace = true
 
+borsh = { workspace = true, optional = true }
 sp1-verifier = { workspace = true, optional = true }
 strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }
 zkaleido-sp1-groth16-verifier = { workspace = true, optional = true }
@@ -48,6 +49,7 @@ default = ["btc-client"]
 btc-client = ["dep:bitcoind-async-client", "dep:tokio"]
 sp1-builder = [
   "strata-sp1-guest-builder/sp1-dev",
+  "dep:borsh",
   "dep:sp1-verifier",
   "dep:zkaleido-sp1-groth16-verifier",
 ]

--- a/bin/datatool/src/acct_predicate.rs
+++ b/bin/datatool/src/acct_predicate.rs
@@ -91,6 +91,9 @@ fn build_sp1_predicate() -> PredicateKey {
         true,
     )
     .expect("Failed to load SP1 Groth16 verifier");
-    let condition_bytes = sp1_verifier.vk.to_uncompressed_bytes();
+    // strata-predicate's Sp1Groth16 verifier expects a borsh-serialized
+    // `SP1Groth16Verifier`, not raw VK bytes.
+    let condition_bytes = borsh::to_vec(&sp1_verifier)
+        .expect("failed to borsh-serialize SP1Groth16Verifier for acct predicate");
     PredicateKey::new(PredicateTypeId::Sp1Groth16, condition_bytes)
 }

--- a/bin/datatool/src/checkpoint_predicate.rs
+++ b/bin/datatool/src/checkpoint_predicate.rs
@@ -107,6 +107,9 @@ fn build_sp1_predicate() -> PredicateKey {
         true,
     )
     .expect("Failed to load SP1 Groth16 verifier");
-    let condition_bytes = sp1_verifier.vk.to_uncompressed_bytes();
+    // strata-predicate's Sp1Groth16 verifier expects a borsh-serialized
+    // `SP1Groth16Verifier`, not raw VK bytes.
+    let condition_bytes = borsh::to_vec(&sp1_verifier)
+        .expect("failed to borsh-serialize SP1Groth16Verifier for checkpoint predicate");
     PredicateKey::new(PredicateTypeId::Sp1Groth16, condition_bytes)
 }

--- a/provers/sp1/Cargo.toml
+++ b/provers/sp1/Cargo.toml
@@ -8,6 +8,7 @@ once_cell = "1.21.4"
 
 [build-dependencies]
 bincode.workspace = true
+borsh.workspace = true
 cargo_metadata = "0.19.1"
 cfg-if.workspace = true
 sha2.workspace = true

--- a/provers/sp1/build.rs
+++ b/provers/sp1/build.rs
@@ -310,10 +310,11 @@ fn get_mock_elf_contents_and_vk_hash() -> ([u32; 8], String, [u8; 32]) {
     )
 }
 
-/// Computes the full Groth16 verifying key condition bytes for the given
-/// BN254 program ID. These bytes are the serialized `Groth16VerifyingKey`
-/// that merges the SP1 circuit VK with the program-specific ID,
-/// suitable for use as the condition in a `PredicateKey::Sp1Groth16`.
+/// Computes the Groth16 verifying key condition bytes for the given BN254
+/// program ID. The output is a borsh-serialized [`SP1Groth16Verifier`] that
+/// the runtime `Sp1Groth16` predicate verifier in `strata-predicate` decodes
+/// via `borsh::from_slice`. The verifier object embeds the SP1 circuit VK
+/// merged with the program-specific ID and the VK root.
 #[cfg(all(feature = "sp1-dev", not(debug_assertions)))]
 fn compute_groth16_condition(program_id: &[u8; 32]) -> Vec<u8> {
     let sp1_verifier = SP1Groth16Verifier::load(
@@ -324,7 +325,7 @@ fn compute_groth16_condition(program_id: &[u8; 32]) -> Vec<u8> {
     )
     .expect("Failed to load SP1 Groth16 verifier");
 
-    sp1_verifier.vk.to_uncompressed_bytes()
+    borsh::to_vec(&sp1_verifier).expect("failed to borsh-serialize SP1Groth16Verifier")
 }
 
 /// Returns empty condition bytes in debug/mock builds.


### PR DESCRIPTION
## Summary

#1809 bumped strata-predicate to rc21, whose `Sp1Groth16Verifier::parse_condition` deserializes a full `SP1Groth16Verifier` via borsh (verifying key + folded program_vk_hash + vk_root + vk_hash_tag + require_success). The producer sites in `bin/datatool` and `provers/sp1/build.rs` still emit `sp1_verifier.vk.to_uncompressed_bytes()`, so the on-chain `Sp1Groth16` predicate condition can't be parsed by the runtime verifier.

Switch the three producer sites to `borsh::to_vec(&sp1_verifier)` and add the borsh dep to `bin/datatool/Cargo.toml` (gated on `sp1-builder`) and to `provers/sp1` build-dependencies.

Validated locally by running `test_real_bridge_alpen_cli_e2e` with `SP1_PROVER=network` against the Succinct reserved cluster: seq_no=0 and seq_no=1 SAUs land on OL with zero `verify_claim_witness` failures. Without the fix, every SAU is rejected at parse_condition.
