### PR TITLE
STR 3036 api to get a range of inbox messages for account from index mmr db

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -1,6 +1,7 @@
 //! OL RPC server implementation for a strata node.
 use std::{
     collections::{HashMap, HashSet},
+    ops::Range,
     sync::Arc,
 };
 
@@ -50,6 +51,47 @@ pub(crate) struct OLRpcServer<P: OLRpcProvider> {
 struct AccountRecords {
     updates_by_block: HashMap<OLBlockCommitment, Vec<UpdateInputData>>,
     inbox: Vec<InboxMessageRecord>,
+}
+
+fn local_inbox_message_range(
+    account_id: AccountId,
+    start_idx: u64,
+    end_idx_exclusive: u64,
+    fetched_start_idx: u64,
+) -> RpcResult<Range<usize>> {
+    let local_start = start_idx.checked_sub(fetched_start_idx).ok_or_else(|| {
+        internal_error(format!(
+            "account {account_id} inbox range [{start_idx}, {end_idx_exclusive}) \
+                 starts before fetched range start {fetched_start_idx}"
+        ))
+    })?;
+    let local_end = end_idx_exclusive
+        .checked_sub(fetched_start_idx)
+        .ok_or_else(|| {
+            internal_error(format!(
+                "account {account_id} inbox range [{start_idx}, {end_idx_exclusive}) \
+                 ends before fetched range start {fetched_start_idx}"
+            ))
+        })?;
+    if local_end < local_start {
+        return Err(internal_error(format!(
+            "account {account_id} inbox range has reversed bounds: \
+             [{start_idx}, {end_idx_exclusive})"
+        )));
+    }
+
+    let local_start = usize::try_from(local_start).map_err(|_| {
+        internal_error(format!(
+            "account {account_id} inbox range start offset {local_start} does not fit in usize"
+        ))
+    })?;
+    let local_end = usize::try_from(local_end).map_err(|_| {
+        internal_error(format!(
+            "account {account_id} inbox range end offset {local_end} does not fit in usize"
+        ))
+    })?;
+
+    Ok(local_start..local_end)
 }
 
 impl<P: OLRpcProvider> OLRpcServer<P> {
@@ -334,9 +376,9 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
             };
 
             for p in pending {
-                let local_start = (p.cursor_start - min_start) as usize;
-                let local_end = (p.cursor_end - min_start) as usize;
-                let messages = messages_in_range[local_start..local_end].to_vec();
+                let message_range =
+                    local_inbox_message_range(account_id, p.cursor_start, p.cursor_end, min_start)?;
+                let messages = messages_in_range[message_range].to_vec();
                 updates_by_block
                     .entry(p.block_commitment)
                     .or_default()
@@ -512,8 +554,20 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                     .map_or(0, |s| s.next_inbox_msg_idx())
             };
 
-            let mut out = Vec::with_capacity(records.len());
+            struct Pending {
+                seq_no: u64,
+                final_state_root: Hash,
+                extra_data: Vec<u8>,
+                cursor_start: u64,
+                cursor_end: u64,
+            }
+
+            let mut pending = Vec::with_capacity(records.len());
             for r in &records {
+                let cursor_start = cursor;
+                let cursor_end = r.next_inbox_idx();
+                cursor = cursor_end;
+
                 let meta = r.update_meta().ok_or_else(|| {
                     internal_error(format!(
                         "record for account {account_id} epoch {epoch} missing update_meta \
@@ -530,21 +584,43 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                     })?
                     .to_vec();
 
+                pending.push(Pending {
+                    seq_no: r.seq_no(),
+                    final_state_root: meta.final_state_root(),
+                    extra_data,
+                    cursor_start,
+                    cursor_end,
+                });
+            }
+
+            let min_start = pending.iter().map(|p| p.cursor_start).min().unwrap_or(0);
+            let max_end = pending.iter().map(|p| p.cursor_end).max().unwrap_or(0);
+            let messages_in_range = if skip_fetch || max_end <= min_start {
+                Vec::new()
+            } else {
+                self.provider
+                    .get_account_inbox_messages(account_id, min_start, max_end)
+                    .await
+                    .map_err(db_error)?
+            };
+
+            let mut out = Vec::with_capacity(pending.len());
+            for p in pending {
                 let messages = if skip_fetch {
                     Vec::new()
                 } else {
-                    self.provider
-                        .get_account_inbox_messages(account_id, cursor, r.next_inbox_idx())
-                        .await
-                        .map_err(db_error)?
+                    let message_range = local_inbox_message_range(
+                        account_id,
+                        p.cursor_start,
+                        p.cursor_end,
+                        min_start,
+                    )?;
+                    messages_in_range[message_range].to_vec()
                 };
-                cursor = r.next_inbox_idx();
-
                 out.push(RpcUpdateInputData {
-                    seq_no: r.seq_no(),
-                    proof_state: ProofState::new(meta.final_state_root(), r.next_inbox_idx())
-                        .into(),
-                    extra_data: extra_data.into(),
+                    seq_no: p.seq_no,
+                    proof_state: ProofState::new(p.final_state_root, p.cursor_end).into(),
+                    extra_data: p.extra_data.into(),
                     messages: messages.into_iter().map(Into::into).collect(),
                 });
             }

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashMap,
-    slice,
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, slice, sync::Arc};
 
 use async_trait::async_trait;
 use proptest::prelude::*;
@@ -483,26 +479,6 @@ fn inbox_fetch_expect_success(
         assert_eq!(start_idx, expected_start_idx);
         assert_eq!(end_idx_exclusive, expected_end_idx_exclusive);
         Ok(messages_to_return.clone())
-    }
-}
-
-/// Each entry in `expected` is `(start, end_exclusive, messages_to_return)`,
-/// asserted in call order.
-fn inbox_fetch_expect_sequence(
-    expected_account_id: AccountId,
-    expected: Vec<(u64, u64, Vec<MessageEntry>)>,
-) -> impl Fn(AccountId, u64, u64) -> DbResult<Vec<MessageEntry>> + Send + Sync + 'static {
-    let calls = Mutex::new(0usize);
-    move |queried_account_id, start_idx, end_idx_exclusive| {
-        let mut idx = calls.lock().unwrap();
-        let (exp_start, exp_end, msgs) = expected
-            .get(*idx)
-            .unwrap_or_else(|| panic!("unexpected extra inbox fetch call #{}", *idx));
-        assert_eq!(queried_account_id, expected_account_id);
-        assert_eq!(start_idx, *exp_start, "call #{}: start mismatch", *idx);
-        assert_eq!(end_idx_exclusive, *exp_end, "call #{}: end mismatch", *idx);
-        *idx += 1;
-        Ok(msgs.clone())
     }
 }
 
@@ -2260,13 +2236,15 @@ async fn epoch_summary_multi_record_slices_messages_per_update() {
             prev_next_inbox_msg_idx,
         )
         .with_account_update_records(account_id, epoch, records)
-        .with_inbox_fetch_fn(inbox_fetch_expect_sequence(
+        .with_inbox_fetch_fn(inbox_fetch_expect_success(
             account_id,
-            vec![
-                (2, 4, msgs_1.clone()),
-                (4, 4, Vec::new()),
-                (4, 7, msgs_3.clone()),
-            ],
+            2,
+            7,
+            msgs_1
+                .iter()
+                .chain(msgs_3.iter())
+                .cloned()
+                .collect::<Vec<_>>(),
         ));
     let rpc = make_rpc(provider);
 
@@ -2279,10 +2257,12 @@ async fn epoch_summary_multi_record_slices_messages_per_update() {
 
     assert_eq!(updates[0].seq_no, 10);
     assert_eq!(updates[0].messages.len(), 2);
+    assert_eq!(rpc_messages_to_entries(&updates[0].messages), msgs_1);
     assert_eq!(updates[1].seq_no, 11);
     assert!(updates[1].messages.is_empty());
     assert_eq!(updates[2].seq_no, 12);
     assert_eq!(updates[2].messages.len(), 3);
+    assert_eq!(rpc_messages_to_entries(&updates[2].messages), msgs_3);
 }
 
 #[tokio::test]

--- a/bin/strata/src/rpc/provider.rs
+++ b/bin/strata/src/rpc/provider.rs
@@ -43,6 +43,25 @@ impl NodeRpcProvider {
     }
 }
 
+fn decode_inbox_messages(
+    account_id: AccountId,
+    start_idx: u64,
+    preimages: Vec<Vec<u8>>,
+) -> DbResult<Vec<MessageEntry>> {
+    preimages
+        .into_iter()
+        .enumerate()
+        .map(|(offset, preimage)| {
+            let idx = start_idx + offset as u64;
+            MessageEntry::from_ssz_bytes(&preimage).map_err(|e| {
+                DbError::Other(format!(
+                    "failed to decode account inbox message at index {idx} for account {account_id}: {e}"
+                ))
+            })
+        })
+        .collect()
+}
+
 #[async_trait]
 impl OLRpcProvider for NodeRpcProvider {
     async fn get_canonical_block_at(&self, height: u64) -> DbResult<Option<OLBlockCommitment>> {
@@ -134,18 +153,8 @@ impl OLRpcProvider for NodeRpcProvider {
             .as_ref()
             .get_handle(MmrId::SnarkMsgInbox(account_id));
 
-        let mut messages = Vec::with_capacity((end_idx_exclusive - start_idx) as usize);
-        for idx in start_idx..end_idx_exclusive {
-            let preimage = mmr_handle.get(idx).await?;
-            let message = MessageEntry::from_ssz_bytes(&preimage).map_err(|e| {
-                DbError::Other(format!(
-                    "failed to decode account inbox message at index {idx} for account {account_id}: {e}"
-                ))
-            })?;
-            messages.push(message);
-        }
-
-        Ok(messages)
+        let preimages = mmr_handle.get_range(start_idx, end_idx_exclusive).await?;
+        decode_inbox_messages(account_id, start_idx, preimages)
     }
 
     async fn get_account_creation_epoch(&self, account_id: AccountId) -> DbResult<Option<Epoch>> {
@@ -175,5 +184,53 @@ impl OLRpcProvider for NodeRpcProvider {
 
     async fn submit_transaction(&self, tx: OLTransaction) -> OLMempoolResult<OLTxId> {
         self.mempool_handle.submit_transaction(tx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ssz::Encode;
+    use strata_acct_types::{BitcoinAmount, MsgPayload};
+    use strata_identifiers::AccountId;
+
+    use super::*;
+
+    fn test_account_id(index: u8) -> AccountId {
+        AccountId::new([index; 32])
+    }
+
+    #[test]
+    fn decode_inbox_messages_round_trips_ssz_entries() {
+        let account_id = test_account_id(1);
+        let messages = vec![
+            MessageEntry::new(
+                test_account_id(2),
+                3,
+                MsgPayload::new(BitcoinAmount::from_sat(10), vec![0xaa]),
+            ),
+            MessageEntry::new(
+                test_account_id(3),
+                3,
+                MsgPayload::new(BitcoinAmount::from_sat(20), vec![0xbb, 0xcc]),
+            ),
+        ];
+        let preimages = messages.iter().map(Encode::as_ssz_bytes).collect();
+
+        let decoded =
+            decode_inbox_messages(account_id, 7, preimages).expect("decode valid messages");
+
+        assert_eq!(decoded, messages);
+    }
+
+    #[test]
+    fn decode_inbox_messages_errors_on_malformed_preimage() {
+        let err = decode_inbox_messages(test_account_id(1), 9, vec![vec![0xff]])
+            .expect_err("malformed preimage should fail");
+
+        assert!(matches!(
+            err,
+            DbError::Other(msg)
+                if msg.contains("index 9") && msg.contains(&test_account_id(1).to_string())
+        ));
     }
 }

--- a/crates/db/store-sled/src/mmr_index/db.rs
+++ b/crates/db/store-sled/src/mmr_index/db.rs
@@ -36,6 +36,46 @@ impl MmrIndexDatabase for MmrIndexDb {
         Ok(self.preimage_tree.get(&(mmr_id, pos))?)
     }
 
+    /// Returns optional leaf preimages for `[start, end_exclusive)`.
+    ///
+    /// All reads are executed in one sled transaction so the returned range is
+    /// assembled from a single consistent snapshot.
+    fn get_preimage_range(
+        &self,
+        mmr_id: RawMmrId,
+        start: LeafPos,
+        end_exclusive: LeafPos,
+    ) -> DbResult<Vec<Option<Vec<u8>>>> {
+        let start_idx = start.index();
+        let end_idx = end_exclusive.index();
+        let len = end_idx
+            .checked_sub(start_idx)
+            .ok_or(DbError::MmrInvalidRange {
+                start: start_idx,
+                end: end_idx,
+            })?;
+
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+
+        let capacity = usize::try_from(len).map_err(|_| DbError::MmrInvalidRange {
+            start: start_idx,
+            end: end_idx,
+        })?;
+
+        self.config.with_retry(
+            (&self.preimage_tree,),
+            |(pt,): (SledTransactionalTree<MmrIndexPreimageSchema>,)| {
+                let mut out = Vec::with_capacity(capacity);
+                for idx in start_idx..end_idx {
+                    out.push(pt.get(&(mmr_id.clone(), LeafPos::new(idx)))?);
+                }
+                Ok(out)
+            },
+        )
+    }
+
     /// Returns current leaf count for a namespace.
     ///
     /// Absent entries are treated as zero leaves.

--- a/crates/db/tests/src/mmr_index_tests.rs
+++ b/crates/db/tests/src/mmr_index_tests.rs
@@ -1,5 +1,5 @@
 use proptest::{collection::vec, prelude::*};
-use strata_db_types::{traits::MmrIndexDatabase, LeafPos, MmrBatchWrite, NodePos};
+use strata_db_types::{traits::MmrIndexDatabase, DbError, LeafPos, MmrBatchWrite, NodePos};
 use strata_identifiers::Hash;
 
 pub fn raw_mmr_id_strategy() -> impl Strategy<Value = Vec<u8>> {
@@ -331,6 +331,60 @@ pub fn test_mmr_index_leaf_count_cas_conflict_rolls_back(
     assert_eq!(db.get_node(mmr_id, pos).expect("node after conflict"), None);
 }
 
+pub fn test_mmr_index_preimage_range_empty(db: &impl MmrIndexDatabase, mmr_id: Vec<u8>) {
+    assert_eq!(
+        db.get_preimage_range(mmr_id, LeafPos::new(3), LeafPos::new(3))
+            .expect("empty range"),
+        Vec::<Option<Vec<u8>>>::new()
+    );
+}
+
+pub fn test_mmr_index_preimage_range_single_and_multi(db: &impl MmrIndexDatabase, mmr_id: Vec<u8>) {
+    let payloads = [vec![0x11], vec![0x22], vec![0x33]];
+    let mut batch = MmrBatchWrite::default();
+    {
+        let mmr_batch = batch.entry(mmr_id.clone());
+        for (idx, payload) in payloads.iter().enumerate() {
+            mmr_batch.put_preimage(LeafPos::new(idx as u64 + 1), payload.clone());
+        }
+    }
+    db.apply_update(batch).expect("seed preimages");
+
+    assert_eq!(
+        db.get_preimage_range(mmr_id.clone(), LeafPos::new(2), LeafPos::new(3))
+            .expect("single range"),
+        vec![Some(payloads[1].clone())]
+    );
+    assert_eq!(
+        db.get_preimage_range(mmr_id, LeafPos::new(1), LeafPos::new(4))
+            .expect("multi range"),
+        payloads.into_iter().map(Some).collect::<Vec<_>>()
+    );
+}
+
+pub fn test_mmr_index_preimage_range_missing_slot(db: &impl MmrIndexDatabase, mmr_id: Vec<u8>) {
+    let mut batch = MmrBatchWrite::default();
+    {
+        let mmr_batch = batch.entry(mmr_id.clone());
+        mmr_batch.put_preimage(LeafPos::new(1), vec![0x11]);
+        mmr_batch.put_preimage(LeafPos::new(3), vec![0x33]);
+    }
+    db.apply_update(batch).expect("seed sparse preimages");
+
+    assert_eq!(
+        db.get_preimage_range(mmr_id, LeafPos::new(1), LeafPos::new(4))
+            .expect("range with missing slot"),
+        vec![Some(vec![0x11]), None, Some(vec![0x33])]
+    );
+}
+
+pub fn test_mmr_index_preimage_range_invalid_bounds(db: &impl MmrIndexDatabase, mmr_id: Vec<u8>) {
+    let err = db
+        .get_preimage_range(mmr_id, LeafPos::new(4), LeafPos::new(2))
+        .expect_err("invalid range should fail");
+    assert!(matches!(err, DbError::MmrInvalidRange { start: 4, end: 2 }));
+}
+
 #[macro_export]
 macro_rules! mmr_index_db_tests {
     ($setup_expr:expr) => {
@@ -495,6 +549,38 @@ macro_rules! mmr_index_db_tests {
                 $crate::mmr_index_tests::test_mmr_index_leaf_count_cas_conflict_rolls_back(
                     &db, mmr_id, pos, hash
                 );
+            }
+
+            #[test]
+            fn test_mmr_index_preimage_range_empty_contract(
+                mmr_id in $crate::mmr_index_tests::raw_mmr_id_strategy(),
+            ) {
+                let db = $setup_expr;
+                $crate::mmr_index_tests::test_mmr_index_preimage_range_empty(&db, mmr_id);
+            }
+
+            #[test]
+            fn test_mmr_index_preimage_range_single_and_multi_contract(
+                mmr_id in $crate::mmr_index_tests::raw_mmr_id_strategy(),
+            ) {
+                let db = $setup_expr;
+                $crate::mmr_index_tests::test_mmr_index_preimage_range_single_and_multi(&db, mmr_id);
+            }
+
+            #[test]
+            fn test_mmr_index_preimage_range_missing_slot_contract(
+                mmr_id in $crate::mmr_index_tests::raw_mmr_id_strategy(),
+            ) {
+                let db = $setup_expr;
+                $crate::mmr_index_tests::test_mmr_index_preimage_range_missing_slot(&db, mmr_id);
+            }
+
+            #[test]
+            fn test_mmr_index_preimage_range_invalid_bounds_contract(
+                mmr_id in $crate::mmr_index_tests::raw_mmr_id_strategy(),
+            ) {
+                let db = $setup_expr;
+                $crate::mmr_index_tests::test_mmr_index_preimage_range_invalid_bounds(&db, mmr_id);
             }
         }
     };

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -570,6 +570,20 @@ pub trait MmrIndexDatabase: Send + Sync + 'static {
     /// Returns optional preimage bytes for a namespace and leaf position.
     fn get_preimage(&self, mmr_id: RawMmrId, pos: LeafPos) -> DbResult<Option<Vec<u8>>>;
 
+    /// Returns optional preimage bytes for a namespace and leaf range.
+    ///
+    /// The returned vector has one slot per leaf in `[start, end_exclusive)`.
+    /// Missing preimages are returned as `None`.
+    ///
+    /// Empty ranges return an empty vector. Backends must reject reversed
+    /// ranges with [`crate::DbError::MmrInvalidRange`].
+    fn get_preimage_range(
+        &self,
+        mmr_id: RawMmrId,
+        start: LeafPos,
+        end_exclusive: LeafPos,
+    ) -> DbResult<Vec<Option<Vec<u8>>>>;
+
     /// Returns the current leaf count for a namespace.
     ///
     /// Implementations should return `0` when the namespace has no leaves.

--- a/crates/storage/src/managers/mmr_index.rs
+++ b/crates/storage/src/managers/mmr_index.rs
@@ -429,6 +429,37 @@ impl MmrIndexHandle {
             .ok_or(DbError::MmrPayloadNotFound(LeafPos::new(index)))
     }
 
+    /// Reads raw preimage bytes for `[start, end_exclusive)`.
+    pub fn get_range_blocking(&self, start: u64, end_exclusive: u64) -> DbResult<Vec<Vec<u8>>> {
+        let len = end_exclusive
+            .checked_sub(start)
+            .ok_or(DbError::MmrInvalidRange {
+                start,
+                end: end_exclusive,
+            })?;
+
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+
+        let capacity = usize::try_from(len).map_err(|_| DbError::MmrInvalidRange {
+            start,
+            end: end_exclusive,
+        })?;
+
+        let preimages = self.ops.get_preimage_range_blocking(
+            self.mmr_id_bytes(),
+            LeafPos::new(start),
+            LeafPos::new(end_exclusive),
+        )?;
+        let mut out = Vec::with_capacity(capacity);
+        for (offset, preimage) in preimages.into_iter().enumerate() {
+            let idx = start + offset as u64;
+            out.push(preimage.ok_or(DbError::MmrPayloadNotFound(LeafPos::new(idx)))?);
+        }
+        Ok(out)
+    }
+
     /// Reads raw preimage bytes by leaf index.
     pub async fn get(&self, index: u64) -> DbResult<Vec<u8>> {
         let this = self.clone();
@@ -439,6 +470,14 @@ impl MmrIndexHandle {
         })
         .await
         .map_err(|_| DbError::WorkerFailedStrangely)?
+    }
+
+    /// Reads raw preimage bytes for `[start, end_exclusive)`.
+    pub async fn get_range(&self, start: u64, end_exclusive: u64) -> DbResult<Vec<Vec<u8>>> {
+        let this = self.clone();
+        spawn_blocking(move || this.get_range_blocking(start, end_exclusive))
+            .await
+            .map_err(|_| DbError::WorkerFailedStrangely)?
     }
 
     /// Generates contiguous proofs with leaf-hash validation from one prefetch snapshot.
@@ -599,5 +638,97 @@ impl MmrIndexHandle {
 
     pub fn mmr_id(&self) -> &MmrId {
         &self.mmr_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+
+    use super::*;
+
+    fn setup_handle() -> MmrIndexHandle {
+        let pool = ThreadPool::new(1);
+        let backend = get_test_sled_backend();
+        let manager = MmrIndexManager::new(pool, backend.mmr_index_db());
+        manager.get_handle(MmrId::Asm)
+    }
+
+    #[test]
+    fn get_range_blocking_returns_contiguous_preimages() {
+        let handle = setup_handle();
+        let payloads = [vec![0x11], vec![0x22], vec![0x33]];
+
+        for payload in payloads.iter().cloned() {
+            handle.append_blocking(payload).expect("append preimage");
+        }
+
+        assert_eq!(
+            handle.get_range_blocking(0, 3).expect("get full range"),
+            payloads
+        );
+        assert_eq!(
+            handle.get_range_blocking(1, 2).expect("get single range"),
+            vec![payloads[1].clone()]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_range_returns_contiguous_preimages() {
+        let handle = setup_handle();
+        let payloads = [vec![0xaa], vec![0xbb]];
+
+        for payload in payloads.iter().cloned() {
+            handle.append_blocking(payload).expect("append preimage");
+        }
+
+        assert_eq!(
+            handle.get_range(0, 2).await.expect("get async range"),
+            payloads
+        );
+    }
+
+    #[test]
+    fn get_range_blocking_empty_range_returns_empty_vec() {
+        let handle = setup_handle();
+
+        assert_eq!(
+            handle
+                .get_range_blocking(7, 7)
+                .expect("empty range should succeed"),
+            Vec::<Vec<u8>>::new()
+        );
+    }
+
+    #[test]
+    fn get_range_blocking_missing_preimage_errors() {
+        let handle = setup_handle();
+        handle
+            .append_blocking(vec![0x11])
+            .expect("append preimage at 0");
+        handle
+            .append_leaf_blocking(Hash::from([0x22; 32]))
+            .expect("append leaf without preimage at 1");
+        handle
+            .append_blocking(vec![0x33])
+            .expect("append preimage at 2");
+
+        let err = handle
+            .get_range_blocking(0, 3)
+            .expect_err("missing preimage should fail");
+        assert!(matches!(
+            err,
+            DbError::MmrPayloadNotFound(pos) if pos == LeafPos::new(1)
+        ));
+    }
+
+    #[test]
+    fn get_range_blocking_invalid_bounds_errors() {
+        let handle = setup_handle();
+
+        let err = handle
+            .get_range_blocking(4, 2)
+            .expect_err("invalid range should fail");
+        assert!(matches!(err, DbError::MmrInvalidRange { start: 4, end: 2 }));
     }
 }

--- a/crates/storage/src/ops/mmr_index.rs
+++ b/crates/storage/src/ops/mmr_index.rs
@@ -11,6 +11,7 @@ inst_ops_simple! {
     (<D: MmrIndexDatabase> => MmrIndexOps, component = components::STORAGE_MMR_INDEX) {
         get_node(mmr_id: RawMmrId, pos: NodePos) => Option<Hash>;
         get_preimage(mmr_id: RawMmrId, pos: LeafPos) => Option<Vec<u8>>;
+        get_preimage_range(mmr_id: RawMmrId, start: LeafPos, end_exclusive: LeafPos) => Vec<Option<Vec<u8>>>;
         get_leaf_count(mmr_id: RawMmrId) => u64;
         fetch_node_paths(nodes: Vec<MmrNodePos>, preimages: bool) => MmrNodeTable;
         apply_update(batch: MmrBatchWrite) => ();


### PR DESCRIPTION
## Description

Adds ranged inbox-message fetching for snark account inbox MMRs.

- Adds `get_preimage_range` through the DB trait, sled backend, storage ops, and `MmrIndexHandle`.
- Uses one range fetch in `NodeRpcProvider::get_account_inbox_messages` instead of one MMR lookup per message.
- Batches `getAccountEpochSummary` inbox message loading into one covering range, then slices messages per update locally.
- Preserves existing RPC/provider API shape.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
