### PR TITLE
fix(docker): install libprotobuf-dev for SP1 v6 well-known protos

### DIFF
--- a/docker/alpen-client/Dockerfile
+++ b/docker/alpen-client/Dockerfile
@@ -11,7 +11,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler && \
+      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cargo-chef once (cached layer)

--- a/docker/alpen-client/Dockerfile.local
+++ b/docker/alpen-client/Dockerfile.local
@@ -11,7 +11,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler && \
+      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cargo-chef once (cached layer)

--- a/docker/strata-signer/Dockerfile
+++ b/docker/strata-signer/Dockerfile
@@ -11,7 +11,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler && \
+      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cargo-chef once (cached layer)

--- a/docker/strata/Dockerfile
+++ b/docker/strata/Dockerfile
@@ -11,7 +11,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler && \
+      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cargo-chef (cached layer)

--- a/docker/strata/Dockerfile.local
+++ b/docker/strata/Dockerfile.local
@@ -31,7 +31,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler && \
+      build-essential ca-certificates clang libclang-dev pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cargo-chef (cached layer)


### PR DESCRIPTION
## Summary

- After [ce07c2ae8](https://github.com/alpenlabs/alpen/commit/ce07c2ae8) (SP1 v6 bump), all three image builds in [ci-build.yml](.github/workflows/ci-build.yml) fail during `cargo chef cook` with: `protoc failed: google/protobuf/empty.proto: File not found`.
- Root cause: `sp1-prover-types v6.1.0`'s `build.rs` invokes `protoc` on a `worker.proto` that imports the well-known `google/protobuf/empty.proto`. On Debian, that file ships in `libprotobuf-dev` — separate from the `protobuf-compiler` package that provides the `protoc` binary. The Dockerfiles installed the latter but not the former.
- Fix: add `libprotobuf-dev` to the apt-get install line in all five Dockerfiles (alpen-client, strata, strata-signer + their `.local` variants). Affects every workspace-cooking image because `cargo chef cook` cooks the full workspace dep graph regardless of which binary the image ships.

## Why this only surfaced in the Docker builds

The `build-sp1-artifacts` runner job uses `arduino/setup-protoc`, which installs the upstream protobuf release tarball — that bundle ships `protoc` *and* `include/google/protobuf/*.proto` together, so the well-known imports resolve out of the box. Debian splits those into a separate package. Different packaging, same upstream source — different "did I get the well-known protos?" outcome.

## Test plan

- [ ] CI build job succeeds for `alpen-client`, `strata`, `strata-signer`
- [ ] `just docker` succeeds locally (covers the `.local` variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)