### PR TITLE
fix(btcio): defer retryable chunked commit publish errors

### DIFF
--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -62,6 +62,7 @@ pub enum SendRawTransactionMode {
     MissingOrInvalidInput,
     InvalidParameter,
     HttpInternalServerError,
+    ConnectionError,
     GenericError,
 }
 
@@ -272,6 +273,9 @@ impl Broadcaster for TestBitcoinClient {
                 500,
                 "Internal Server Error".to_string(),
             )),
+            SendRawTransactionMode::ConnectionError => {
+                Err(ClientError::Connection("connection refused".to_string()))
+            }
             SendRawTransactionMode::GenericError => Err(ClientError::Server(
                 -1,
                 "generic broadcast failure".to_string(),

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -502,7 +502,7 @@ async fn publish_commit_immediately<R: Broadcaster>(
             warn!(%txid, ?e, "commit broadcast rejected by mempool; will resign");
             Ok(CommitPublishResult::InvalidInputs)
         }
-        Err(e @ ClientError::Status(500, _)) => Ok(CommitPublishResult::Deferred(e.to_string())),
+        Err(e) if e.is_retriable() => Ok(CommitPublishResult::Deferred(e.to_string())),
         Err(e) => Err(e.into()),
     }
 }
@@ -963,7 +963,10 @@ mod tests {
     use strata_primitives::buf::Buf32;
 
     use super::*;
-    use crate::writer::test_utils::{get_broadcast_handle, get_chunked_envelope_ops};
+    use crate::{
+        test_utils::{SendRawTransactionMode, TestBitcoinClient},
+        writer::test_utils::{get_broadcast_handle, get_chunked_envelope_ops},
+    };
 
     fn bytes_from_start(start: u8) -> [u8; 32] {
         let mut bytes = [0u8; 32];
@@ -1211,6 +1214,22 @@ mod tests {
             .collect();
         entry.status = ChunkedEnvelopeStatus::Unpublished;
         entry
+    }
+
+    #[tokio::test]
+    async fn test_publish_commit_immediately_defers_retriable_rpc_errors() {
+        let client = TestBitcoinClient::new(0)
+            .with_send_raw_transaction_mode(SendRawTransactionMode::ConnectionError);
+        let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
+
+        let result = publish_commit_immediately(&client, &commit_tx_entry)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            result,
+            CommitPublishResult::Deferred(reason) if reason.contains("connection refused")
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Treat retryable Bitcoin RPC failures during immediate chunked-envelope commit publication as deferred instead of bubbling them out of the watcher. This keeps the critical EE DA watcher alive and leaves the persisted commit entry for the broadcaster retry loop.

Add regression coverage for a transient connection error.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
