### PR TITLE
chore: remove debug macros from production code

### DIFF
--- a/crates/alpen-ee/sequencer/src/batch_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/task.rs
@@ -246,9 +246,9 @@ where
         // Try to get block data (non-blocking check)
         let Some(block_data) = ctx.block_data_provider.get_block_data(block.hash()).await? else {
             // Data not ready yet, stop processing
-            println!(
-                "processing pending blocks, block data not yet ready {:?}",
-                block.hash()
+            debug!(
+                hash = %block.hash(),
+                "processing pending blocks, block data not yet ready"
             );
             break;
         };

--- a/crates/consensus-logic/src/checkpoint_verification.rs
+++ b/crates/consensus-logic/src/checkpoint_verification.rs
@@ -85,7 +85,7 @@ pub fn verify_proof(
             .map_err(|_| CheckpointError::MalformedTransition)?;
 
     if expected_public_output != &actual_public_output {
-        dbg!(actual_public_output, expected_public_output);
+        warn!(%checkpoint_idx, "checkpoint proof public output does not match batch info");
         return Err(CheckpointError::TransitionMismatch);
     }
 


### PR DESCRIPTION
Replace dbg! and println! in production code with structured warn! and debug! via tracing.