### PR TITLE
ci: add SP1 E2E workflow stub for feature branch testing

### DIFF
--- a/.github/workflows/ci-sp1-e2e.yml
+++ b/.github/workflows/ci-sp1-e2e.yml
@@ -1,0 +1,29 @@
+# SP1 E2E proving test — stub workflow.
+#
+# GitHub only discovers workflow_dispatch triggers from the default branch.
+# This stub exists on main so developers can test the full implementation
+# on their feature branches using:
+#
+#   gh workflow run ci-sp1-e2e.yml --ref <branch> -f image_tag=<tag>
+#
+# Full implementation: feat/sp1-e2e-ci
+
+name: CI — SP1 E2E Proving Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to test"
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  stub:
+    name: SP1 E2E (stub)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "Stub — trigger with --ref pointing to a branch with the full implementation"


### PR DESCRIPTION
## Description
It seems we need ci workflow to be registered in default branch. I need this stub to register this workflow so that I can test sp1-e2e test on my actual development [branch](https://github.com/alpenlabs/alpen/tree/feat/sp1-e2e-ci) before I can open it for review. 
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
