### PR TITLE
refactor(acct-types): make `MsgPayload` byte construction fallible

### DIFF
--- a/bin/alpen-client/src/rpc_client.rs
+++ b/bin/alpen-client/src/rpc_client.rs
@@ -5,6 +5,7 @@ use alpen_ee_common::{
 use async_trait::async_trait;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use ssz::Encode;
+use strata_acct_types::MessageEntry;
 use strata_common::{
     retry::{
         policies::ExponentialBackoff, retry_with_backoff_async, DEFAULT_ENGINE_CALL_MAX_RETRIES,
@@ -142,8 +143,9 @@ impl OLClient for RpcOLClient {
                 let updates: Vec<UpdateInputData> = epoch_summary
                     .update_inputs()
                     .iter()
-                    .map(Into::into)
-                    .collect();
+                    .map(UpdateInputData::try_from)
+                    .collect::<Result<_, _>>()
+                    .map_err(|e| OLClientError::rpc(e.to_string()))?;
 
                 Ok(OLEpochSummary::new(
                     epoch_summary.epoch_commitment(),
@@ -179,16 +181,21 @@ impl SequencerOLClient for RpcOLClient {
 
                 let blocks = block_summaries
                     .into_iter()
-                    .map(|block_summary| OLBlockData {
-                        commitment: block_summary.block_commitment,
-                        inbox_messages: block_summary
+                    .map(|block_summary| {
+                        let inbox_messages = block_summary
                             .new_inbox_messages
                             .into_iter()
-                            .map(Into::into)
-                            .collect(),
-                        next_inbox_msg_idx: block_summary.next_inbox_msg_idx,
+                            .map(MessageEntry::try_from)
+                            .collect::<Result<_, _>>()
+                            .map_err(|e| OLClientError::rpc(e.to_string()))?;
+
+                        Ok(OLBlockData {
+                            commitment: block_summary.block_commitment,
+                            inbox_messages,
+                            next_inbox_msg_idx: block_summary.next_inbox_msg_idx,
+                        })
                     })
-                    .collect();
+                    .collect::<Result<_, OLClientError>>()?;
 
                 Ok(blocks)
             },

--- a/bin/strata-test-cli/src/mock_ee/withdrawal.rs
+++ b/bin/strata-test-cli/src/mock_ee/withdrawal.rs
@@ -42,7 +42,8 @@ pub(crate) fn build_snark_withdrawal_json(
     let owned_msg =
         OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).context("failed to create OwnedMsg")?;
 
-    let msg_payload = MsgPayload::new(BitcoinAmount::from_sat(amount), owned_msg.to_vec());
+    let msg_payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(amount), owned_msg.to_vec())
+        .expect("withdrawal message payload bytes must fit within SSZ max length");
 
     let output_message = OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, msg_payload);
     let outputs = UpdateOutputs::new(vec![], vec![output_message]);
@@ -310,7 +311,9 @@ mod tests {
                 .unwrap();
         let encoded_body = strata_codec::encode_to_vec(&withdrawal_msg_data).unwrap();
         let owned_msg = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).unwrap();
-        let msg_payload = MsgPayload::new(BitcoinAmount::from_sat(100_000_000), owned_msg.to_vec());
+        let msg_payload =
+            MsgPayload::from_bytes(BitcoinAmount::from_sat(100_000_000), owned_msg.to_vec())
+                .expect("withdrawal message payload bytes must fit within SSZ max length");
         let output_message = OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, msg_payload);
         let outputs = UpdateOutputs::new(vec![], vec![output_message]);
         let claim_ssz = sign_claim_ssz(&proof_state, &proof_state, &outputs);

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -460,12 +460,26 @@ fn make_message_entry(
     payload_value_sat: u64,
     payload_buf: Vec<u8>,
 ) -> MessageEntry {
-    let payload = MsgPayload::new(BitcoinAmount::from_sat(payload_value_sat), payload_buf);
+    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(payload_value_sat), payload_buf)
+        .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(source, incl_epoch, payload)
 }
 
 fn rpc_messages_to_entries(messages: &[RpcMessageEntry]) -> Vec<MessageEntry> {
-    messages.iter().cloned().map(Into::into).collect()
+    messages
+        .iter()
+        .cloned()
+        .map(|msg| {
+            msg.try_into()
+                .expect("message payload bytes must fit within SSZ max length")
+        })
+        .collect()
+}
+
+fn rpc_update_to_input(update: RpcUpdateInputData) -> UpdateInputData {
+    update
+        .try_into()
+        .expect("message payload bytes must fit within SSZ max length")
 }
 
 fn inbox_fetch_expect_success(
@@ -1335,7 +1349,7 @@ async fn blocks_summaries_populates_updates_and_new_inbox_messages_from_index() 
     assert_eq!(summaries.len(), 1);
     assert_eq!(summaries[0].updates().len(), 1);
 
-    let update: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let update = rpc_update_to_input(summaries[0].updates()[0].clone());
     assert_eq!(update.seq_no(), 6);
     assert_eq!(update.extra_data(), extra_data.as_slice());
     assert_eq!(update.new_state().inner_state(), final_state_root);
@@ -1424,8 +1438,8 @@ async fn blocks_summaries_slices_processed_messages_from_index_ranges() {
     assert_eq!(summaries.len(), 1);
     assert_eq!(summaries[0].updates().len(), 2);
 
-    let u0: UpdateInputData = summaries[0].updates()[0].clone().into();
-    let u1: UpdateInputData = summaries[0].updates()[1].clone().into();
+    let u0 = rpc_update_to_input(summaries[0].updates()[0].clone());
+    let u1 = rpc_update_to_input(summaries[0].updates()[1].clone());
     assert_eq!(u0.processed_messages(), msgs_1.as_slice());
     assert_eq!(u1.processed_messages(), msgs_2.as_slice());
 }
@@ -1506,8 +1520,8 @@ async fn blocks_summaries_walks_cursor_across_epochs() {
         .expect("summaries");
     assert_eq!(summaries.len(), 2);
 
-    let u_e1: UpdateInputData = summaries[0].updates()[0].clone().into();
-    let u_e2: UpdateInputData = summaries[1].updates()[0].clone().into();
+    let u_e1 = rpc_update_to_input(summaries[0].updates()[0].clone());
+    let u_e2 = rpc_update_to_input(summaries[1].updates()[0].clone());
     assert_eq!(u_e1.processed_messages(), msgs_e1.as_slice());
     assert_eq!(u_e2.processed_messages(), msgs_e2.as_slice());
 }
@@ -1560,7 +1574,7 @@ async fn blocks_summaries_seeds_cursor_to_zero_for_new_account() {
         .expect("summaries");
     assert_eq!(summaries.len(), 1);
 
-    let update: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let update = rpc_update_to_input(summaries[0].updates()[0].clone());
     assert_eq!(update.processed_messages(), msgs.as_slice());
 }
 
@@ -1672,7 +1686,7 @@ async fn blocks_summaries_account_appears_midway_through_range() {
                 1,
                 "epoch {epoch} (account appears)"
             );
-            let update: UpdateInputData = summary.updates()[0].clone().into();
+            let update = rpc_update_to_input(summary.updates()[0].clone());
             assert_eq!(update.processed_messages(), msgs.as_slice());
         } else {
             assert!(
@@ -1767,7 +1781,7 @@ async fn blocks_summaries_out_of_chain_directset_does_not_fail_rpc() {
     assert_eq!(summaries.len(), 1);
     assert_eq!(summaries[0].updates().len(), 1);
 
-    let update: UpdateInputData = summaries[0].updates()[0].clone().into();
+    let update = rpc_update_to_input(summaries[0].updates()[0].clone());
     assert_eq!(update.seq_no(), 2);
     assert_eq!(update.extra_data(), [0xA0]);
 }
@@ -1856,8 +1870,8 @@ async fn blocks_summaries_cursor_passes_checkpoint_sync_row() {
     assert_eq!(summaries.len(), 1);
     assert_eq!(summaries[0].updates().len(), 2);
 
-    let u_a: UpdateInputData = summaries[0].updates()[0].clone().into();
-    let u_c: UpdateInputData = summaries[0].updates()[1].clone().into();
+    let u_a = rpc_update_to_input(summaries[0].updates()[0].clone());
+    let u_c = rpc_update_to_input(summaries[0].updates()[1].clone());
     assert_eq!(u_a.processed_messages(), msgs_a.as_slice());
     assert_eq!(u_c.processed_messages(), msgs_c.as_slice());
 }
@@ -1941,7 +1955,7 @@ proptest! {
         for (rpc_update, (_, seq_no, root, extra_data)) in
             summaries[0].updates().iter().zip(expected_block0.iter())
         {
-            let update: UpdateInputData = rpc_update.clone().into();
+            let update = rpc_update_to_input(rpc_update.clone());
             prop_assert_eq!(update.seq_no(), u64::from(*seq_no));
             prop_assert_eq!(update.extra_data(), extra_data.as_slice());
             prop_assert_eq!(
@@ -1955,7 +1969,7 @@ proptest! {
         for (rpc_update, (_, seq_no, root, extra_data)) in
             summaries[1].updates().iter().zip(expected_block1.iter())
         {
-            let update: UpdateInputData = rpc_update.clone().into();
+            let update = rpc_update_to_input(rpc_update.clone());
             prop_assert_eq!(update.seq_no(), u64::from(*seq_no));
             prop_assert_eq!(update.extra_data(), extra_data.as_slice());
             prop_assert_eq!(

--- a/bin/strata/src/rpc/provider.rs
+++ b/bin/strata/src/rpc/provider.rs
@@ -206,12 +206,14 @@ mod tests {
             MessageEntry::new(
                 test_account_id(2),
                 3,
-                MsgPayload::new(BitcoinAmount::from_sat(10), vec![0xaa]),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(10), vec![0xaa])
+                    .expect("message payload bytes must fit within SSZ max length"),
             ),
             MessageEntry::new(
                 test_account_id(3),
                 3,
-                MsgPayload::new(BitcoinAmount::from_sat(20), vec![0xbb, 0xcc]),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(20), vec![0xbb, 0xcc])
+                    .expect("message payload bytes must fit within SSZ max length"),
             ),
         ];
         let preimages = messages.iter().map(Encode::as_ssz_bytes).collect();

--- a/crates/acct-types/src/effects.rs
+++ b/crates/acct-types/src/effects.rs
@@ -1,6 +1,8 @@
 //! Transaction effects.
 
-use crate::{AccountId, BitcoinAmount, MsgPayload, SentMessage, SentTransfer, TxEffects};
+use crate::{
+    AccountId, BitcoinAmount, MsgPayload, MsgPayloadError, SentMessage, SentTransfer, TxEffects,
+};
 
 impl TxEffects {
     /// Attempts to add a transfer.
@@ -57,9 +59,14 @@ impl TxEffects {
     ///
     /// Constructs a [`SentMessage`] (with [`MsgPayload`]) internally and appends
     /// it.  Returns false if the message list is full.
-    pub fn push_message(&mut self, dest: AccountId, sats: u64, data: Vec<u8>) -> bool {
-        let payload = MsgPayload::new(BitcoinAmount::from_sat(sats), data);
-        self.add_message(SentMessage::new(dest, payload))
+    pub fn push_message(
+        &mut self,
+        dest: AccountId,
+        sats: u64,
+        data: Vec<u8>,
+    ) -> Result<bool, MsgPayloadError> {
+        let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(sats), data)?;
+        Ok(self.add_message(SentMessage::new(dest, payload)))
     }
 
     /// Returns an iterator over the messages.

--- a/crates/acct-types/src/lib.rs
+++ b/crates/acct-types/src/lib.rs
@@ -30,6 +30,7 @@ mod ssz_generated {
 
 pub use constants::SYSTEM_RESERVED_ACCTS;
 pub use errors::{AcctError, AcctResult};
+pub use messages::{MsgPayloadData, MsgPayloadError};
 pub use mmr::{
     CompactMmr64, CompactMmr64Ref, MerkleProof, MerkleProofRef, Mmr64, Mmr64Ref, RawMerkleProof,
     RawMerkleProofRef, StrataHasher,

--- a/crates/acct-types/src/messages.rs
+++ b/crates/acct-types/src/messages.rs
@@ -7,10 +7,24 @@ use tree_hash::TreeHash;
 
 use crate::{
     AccountId, BitcoinAmount, SentTransfer,
-    ssz_generated::ssz::messages::{MessageEntry, MsgPayload, ReceivedMessage, SentMessage},
+    ssz_generated::ssz::messages::{
+        MAX_MSG_PAYLOAD_DATA_BYTES, MessageEntry, MsgPayload, ReceivedMessage, SentMessage,
+    },
 };
 
+/// SSZ-bounded message payload data.
+pub type MsgPayloadData = VariableList<u8, { MAX_MSG_PAYLOAD_DATA_BYTES as usize }>;
+
+/// Error constructing a [`MsgPayload`] from raw bytes.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MsgPayloadError {
+    /// Raw message data exceeds the SSZ maximum length.
+    #[error("message payload data too large (len {len} > max {max})")]
+    DataTooLarge { len: usize, max: usize },
+}
+
 impl SentMessage {
+    /// Creates a new [`SentMessage`] with the given destination and payload.
     pub fn new(dest: AccountId, payload: MsgPayload) -> Self {
         Self { dest, payload }
     }
@@ -25,16 +39,19 @@ impl SentMessage {
         Self::new_dataless(dest, BitcoinAmount::zero())
     }
 
+    /// Returns the destination account ID.
     pub fn dest(&self) -> AccountId {
         self.dest
     }
 
+    /// Returns the message payload.
     pub fn payload(&self) -> &MsgPayload {
         &self.payload
     }
 }
 
 impl SentTransfer {
+    /// Creates a new [`SentTransfer`] with the given destination and value.
     pub fn new(dest: AccountId, value: BitcoinAmount) -> Self {
         Self { dest, value }
     }
@@ -46,16 +63,19 @@ impl SentTransfer {
         Self::new(dest, BitcoinAmount::zero())
     }
 
+    /// Returns the destination account ID.
     pub fn dest(&self) -> AccountId {
         self.dest
     }
 
+    /// Returns the transfer value.
     pub fn value(&self) -> BitcoinAmount {
         self.value
     }
 }
 
 impl ReceivedMessage {
+    /// Creates a new [`ReceivedMessage`] with the given source and payload.
     pub fn new(source: AccountId, payload: MsgPayload) -> Self {
         Self { source, payload }
     }
@@ -70,34 +90,49 @@ impl ReceivedMessage {
         Self::new_dataless(dest, BitcoinAmount::zero())
     }
 
+    /// Returns the source account ID.
     pub fn source(&self) -> AccountId {
         self.source
     }
 
+    /// Returns the message payload.
     pub fn payload(&self) -> &MsgPayload {
         &self.payload
     }
 }
 
 impl MsgPayload {
-    pub fn new(value: BitcoinAmount, data: Vec<u8>) -> Self {
-        Self {
-            value,
-            // FIXME size limits
-            data: data
-                .try_into()
-                .expect("message payload bytes must fit within SSZ max length"),
-        }
+    /// Creates a new [`MsgPayload`] with the given value and data.
+    pub fn new(value: BitcoinAmount, data: MsgPayloadData) -> Self {
+        Self { value, data }
+    }
+
+    /// Creates a new instance from raw data and some value.
+    ///
+    /// If the data exceeds the SSZ maximum length, an error is returned.
+    pub fn from_bytes(value: BitcoinAmount, data: Vec<u8>) -> Result<Self, MsgPayloadError> {
+        let len = data.len();
+        let data = data.try_into().map_err(|_| MsgPayloadError::DataTooLarge {
+            len,
+            max: MAX_MSG_PAYLOAD_DATA_BYTES as usize,
+        })?;
+
+        Ok(Self::new(value, data))
     }
 
     /// Creates a new instance with empty data and some value.
     pub fn new_dataless(value: BitcoinAmount) -> Self {
-        Self::new(value, Vec::new())
+        Self::new(value, MsgPayloadData::default())
     }
 
     /// Creates a new instance with some data and 0 value.
-    pub fn new_valueless(data: Vec<u8>) -> Self {
+    pub fn new_valueless(data: MsgPayloadData) -> Self {
         Self::new(BitcoinAmount::zero(), data)
+    }
+
+    /// Creates a new instance from raw data and 0 value.
+    pub fn from_bytes_valueless(data: Vec<u8>) -> Result<Self, MsgPayloadError> {
+        Self::from_bytes(BitcoinAmount::zero(), data)
     }
 
     /// Creates a new instance with empty data and 0 value.
@@ -208,11 +243,39 @@ mod tests {
 
         #[test]
         fn test_zero_ssz() {
-            let payload = MsgPayload::new(BitcoinAmount::from_sat(0), vec![]);
+            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![])
+                .expect("message payload bytes must fit within SSZ max length");
             let encoded = payload.as_ssz_bytes();
             let decoded = MsgPayload::from_ssz_bytes(&encoded).unwrap();
             assert_eq!(payload.value(), decoded.value());
             assert_eq!(payload.data(), decoded.data());
+        }
+
+        #[test]
+        fn accepts_max_size_payload() {
+            let data = vec![0u8; MAX_MSG_PAYLOAD_DATA_BYTES as usize];
+            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), data)
+                .expect("max size message payload bytes must fit within SSZ max length");
+
+            assert_eq!(payload.data().len(), MAX_MSG_PAYLOAD_DATA_BYTES as usize);
+        }
+
+        #[test]
+        fn rejects_oversized_payload() {
+            let max = MAX_MSG_PAYLOAD_DATA_BYTES as usize;
+            let err = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![0u8; max + 1])
+                .expect_err("oversized message payload bytes must fail");
+
+            assert_eq!(err, MsgPayloadError::DataTooLarge { len: max + 1, max });
+        }
+
+        #[test]
+        fn new_accepts_prebuilt_payload_data() {
+            let data = MsgPayloadData::default();
+            let payload = MsgPayload::new(BitcoinAmount::from_sat(42), data);
+
+            assert_eq!(payload.value(), BitcoinAmount::from_sat(42));
+            assert!(payload.data().is_empty());
         }
     }
 
@@ -243,7 +306,8 @@ mod tests {
         fn test_zero_ssz() {
             let msg = SentMessage::new(
                 AccountId::new([0u8; 32]),
-                MsgPayload::new(BitcoinAmount::from_sat(0), vec![]),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![])
+                    .expect("message payload bytes must fit within SSZ max length"),
             );
             let encoded = msg.as_ssz_bytes();
             let decoded = SentMessage::from_ssz_bytes(&encoded).unwrap();
@@ -278,7 +342,8 @@ mod tests {
         fn test_zero_ssz() {
             let msg = ReceivedMessage::new(
                 AccountId::new([0u8; 32]),
-                MsgPayload::new(BitcoinAmount::from_sat(0), vec![]),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![])
+                    .expect("message payload bytes must fit within SSZ max length"),
             );
             let encoded = msg.as_ssz_bytes();
             let decoded = ReceivedMessage::from_ssz_bytes(&encoded).unwrap();

--- a/crates/alpen-ee/block-assembly/src/package.rs
+++ b/crates/alpen-ee/block-assembly/src/package.rs
@@ -104,7 +104,7 @@ fn create_withdrawal_init_message_payload(
     let msg = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, body).expect("create message");
     let payload_data = msg.to_vec();
 
-    Some(MsgPayload::new(value, payload_data))
+    MsgPayload::from_bytes(value, payload_data).ok()
 }
 
 #[cfg(test)]

--- a/crates/alpen-ee/common/src/traits/storage/exec_block.rs
+++ b/crates/alpen-ee/common/src/traits/storage/exec_block.rs
@@ -367,7 +367,8 @@ pub mod exec_block_storage_test_fns {
     /// Helper to create a test MessageEntry
     pub fn create_message_entry(source_id: u8, epoch: u32, data: Vec<u8>) -> MessageEntry {
         let source = AccountId::from([source_id; 32]);
-        let payload = MsgPayload::new(BitcoinAmount::ZERO, data);
+        let payload = MsgPayload::from_bytes(BitcoinAmount::ZERO, data)
+            .expect("message payload bytes must fit within SSZ max length");
         MessageEntry::new(source, epoch, payload)
     }
 

--- a/crates/alpen-ee/database/src/serialization_types/exec_block.rs
+++ b/crates/alpen-ee/database/src/serialization_types/exec_block.rs
@@ -90,10 +90,11 @@ impl From<DBMessageEntry> for MessageEntry {
         MessageEntry::new(
             value.source.into(),
             value.incl_epoch,
-            MsgPayload::new(
+            MsgPayload::from_bytes(
                 BitcoinAmount::from_sat(value.payload_value_sats),
                 value.payload_data,
-            ),
+            )
+            .expect("database message payload bytes must fit within SSZ max length"),
         )
     }
 }

--- a/crates/alpen-ee/sequencer/src/block_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/task.rs
@@ -410,12 +410,14 @@ mod tests {
             let msg1 = MessageEntry::new(
                 AccountId::new([1u8; 32]),
                 0,
-                MsgPayload::new(BitcoinAmount::from_sat(100), vec![]),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(100), vec![])
+                    .expect("message payload bytes must fit within SSZ max length"),
             );
             let msg2 = MessageEntry::new(
                 AccountId::new([2u8; 32]),
                 0,
-                MsgPayload::new(BitcoinAmount::from_sat(200), vec![]),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(200), vec![])
+                    .expect("message payload bytes must fit within SSZ max length"),
             );
             let messages = vec![msg1.clone(), msg2.clone()];
 

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/test_utils.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/test_utils.rs
@@ -27,7 +27,8 @@ pub(crate) fn make_message(value: u64) -> MessageEntry {
     MessageEntry::new(
         AccountId::new([0u8; 32]),
         0,
-        MsgPayload::new(BitcoinAmount::from_sat(value), vec![]),
+        MsgPayload::from_bytes(BitcoinAmount::from_sat(value), vec![])
+            .expect("message payload bytes must fit within SSZ max length"),
     )
 }
 

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -446,7 +446,9 @@ mod tests {
     }
 
     fn message_entry(source_seed: u8, value_sats: u64) -> MessageEntry {
-        let payload = MsgPayload::new(BitcoinAmount::from_sat(value_sats), vec![source_seed]);
+        let payload =
+            MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), vec![source_seed])
+                .expect("message payload bytes must fit within SSZ max length");
         MessageEntry::new(AccountId::from([source_seed; 32]), 0, payload)
     }
 

--- a/crates/ee-acct-runtime/tests/common/mod.rs
+++ b/crates/ee-acct-runtime/tests/common/mod.rs
@@ -197,7 +197,8 @@ pub(crate) fn create_deposit_message(
     let msg = OwnedMsg::new(DEPOSIT_MSG_TYPE, body).expect("create message");
     let payload_data = msg.to_vec();
 
-    let payload = MsgPayload::new(value, payload_data);
+    let payload = MsgPayload::from_bytes(value, payload_data)
+        .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(source, incl_epoch, payload)
 }
 

--- a/crates/ee-acct-runtime/tests/update_verification.rs
+++ b/crates/ee-acct-runtime/tests/update_verification.rs
@@ -158,7 +158,8 @@ fn test_chunk_output_does_not_change_inner_tracked_balance() {
     let mut outputs = ExecOutputs::new_empty();
     outputs.add_message(ExecOutputMessage::new(
         AccountId::from([3u8; 32]),
-        MsgPayload::new(BitcoinAmount::from(400u64), vec![1, 2, 3]),
+        MsgPayload::from_bytes(BitcoinAmount::from(400u64), vec![1, 2, 3])
+            .expect("message payload bytes must fit within SSZ max length"),
     ));
 
     let tip = Hash::new([0xDD; 32]);

--- a/crates/ee-chain-types/src/io.rs
+++ b/crates/ee-chain-types/src/io.rs
@@ -260,10 +260,11 @@ mod tests {
                         .prop_map(|(dest, sats, data)| {
                             OutputMessage::new(
                                 AccountId::new(dest),
-                                strata_acct_types::MsgPayload::new(
+                                strata_acct_types::MsgPayload::from_bytes(
                                     BitcoinAmount::from_sat(sats),
                                     data,
-                                ),
+                                )
+                                .expect("message payload bytes must fit within SSZ max length"),
                             )
                         }),
                     0..10

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -68,7 +68,8 @@ fn convert_withdrawal_intents_to_messages(
         let msg_data = msg.to_vec();
 
         // Create message to bridge gateway with withdrawal amount and encoded data
-        let payload = MsgPayload::new(BitcoinAmount::from_sat(intent.amt), msg_data);
+        let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(intent.amt), msg_data)
+            .expect("withdrawal message payload bytes must fit within SSZ max length");
         let message = OutputMessage::new(BRIDGE_GATEWAY_ACCOUNT, payload);
         outputs.add_message(message);
     }

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -141,7 +141,8 @@ pub(crate) fn create_test_message(source_id: u8, epoch: u32, value_sats: u64) ->
         .unwrap()
         .current();
     let payload_bytes = sampled_message.payload().data().to_vec();
-    let payload = MsgPayload::new(BitcoinAmount::from_sat(value_sats), payload_bytes);
+    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), payload_bytes)
+        .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(source, epoch, payload)
 }
 
@@ -407,7 +408,8 @@ impl MempoolGamTxBuilder {
     /// Builds the mempool transaction.
     pub(crate) fn build(self) -> OLTransaction {
         OLTransaction::new(
-            OLTransactionData::new_gam(self.target, self.data),
+            OLTransactionData::from_gam_bytes(self.target, self.data)
+                .expect("message payload bytes must fit within SSZ max length"),
             TxProofs::new_empty(),
         )
     }
@@ -423,10 +425,11 @@ pub(crate) fn withdrawal_output_message(
         .expect("valid withdrawal data");
     let encoded_body = encode_to_vec(&withdrawal_data).expect("encode withdrawal body");
     let withdrawal_msg = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).expect("msg format");
-    let payload = MsgPayload::new(
+    let payload = MsgPayload::from_bytes(
         BitcoinAmount::from_sat(amount_sats),
         withdrawal_msg.to_vec(),
-    );
+    )
+    .expect("withdrawal message payload bytes must fit within SSZ max length");
     OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload)
 }
 
@@ -546,7 +549,9 @@ impl MempoolSnarkTxBuilder {
             self.outputs
                 .into_iter()
                 .map(|(dest, value_sats)| {
-                    let payload = MsgPayload::new(BitcoinAmount::from_sat(value_sats), vec![]);
+                    let payload =
+                        MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), vec![])
+                            .expect("message payload bytes must fit within SSZ max length");
                     OutputMessage::new(dest, payload)
                 })
                 .collect()
@@ -554,11 +559,13 @@ impl MempoolSnarkTxBuilder {
 
         let mut effects = strata_acct_types::TxEffects::default();
         for msg in output_messages {
-            effects.push_message(
-                msg.dest(),
-                msg.payload().value().to_sat(),
-                msg.payload().data().to_vec(),
-            );
+            effects
+                .push_message(
+                    msg.dest(),
+                    msg.payload().value().to_sat(),
+                    msg.payload().data().to_vec(),
+                )
+                .expect("message payload bytes must fit within SSZ max length");
         }
 
         let data = OLTransactionData::new(payload, effects);
@@ -682,7 +689,8 @@ pub(crate) fn generate_message_entries(
                 })
                 .collect();
 
-            let payload = MsgPayload::new(BitcoinAmount::from_sat(value_sats), data);
+            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), data)
+                .expect("message payload bytes must fit within SSZ max length");
             MessageEntry::new(source_account, incl_epoch, payload)
         })
         .collect()

--- a/crates/ol/block-assembly/src/tests/messaging.rs
+++ b/crates/ol/block-assembly/src/tests/messaging.rs
@@ -54,12 +54,14 @@ async fn test_multi_sender_attribution() {
     let expected_msg_from_a = MessageEntry::new(
         sender_a,
         epoch,
-        MsgPayload::new(BitcoinAmount::from_sat(100), vec![]),
+        MsgPayload::from_bytes(BitcoinAmount::from_sat(100), vec![])
+            .expect("message payload bytes must fit within SSZ max length"),
     );
     let expected_msg_from_b = MessageEntry::new(
         sender_b,
         epoch,
-        MsgPayload::new(BitcoinAmount::from_sat(250), vec![]),
+        MsgPayload::from_bytes(BitcoinAmount::from_sat(250), vec![])
+            .expect("message payload bytes must fit within SSZ max length"),
     );
     let included_block1 = included_txids(&output_block1.template);
     assert_eq!(

--- a/crates/ol/chain-types/src/transaction.rs
+++ b/crates/ol/chain-types/src/transaction.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use int_enum::IntEnum;
-use strata_acct_types::{AccountId, MessageEntry, TxEffects};
+use strata_acct_types::{AccountId, MessageEntry, MsgPayloadError, TxEffects};
 use strata_identifiers::{Buf32, OLTxId, Slot};
 use tree_hash::{Sha256Hasher, TreeHash};
 
@@ -257,15 +257,15 @@ impl OLTransactionData {
 
     /// Creates a GAM transaction data targeting the given account with a zero-value message
     /// containing the provided payload data.
-    pub fn new_gam(dest: AccountId, data: Vec<u8>) -> Self {
+    pub fn new_gam(dest: AccountId, data: Vec<u8>) -> Result<Self, MsgPayloadError> {
         let payload = TransactionPayload::GenericAccountMessage(GamTxPayload { target: dest });
         let mut effects = TxEffects::default();
-        effects.push_message(dest, 0, data);
-        Self {
+        effects.push_message(dest, 0, data)?;
+        Ok(Self {
             payload,
             constraints: TxConstraints::default(),
             effects,
-        }
+        })
     }
 
     /// Sets the constraints on this transaction data, consuming and returning self.

--- a/crates/ol/chain-types/src/transaction.rs
+++ b/crates/ol/chain-types/src/transaction.rs
@@ -1,7 +1,10 @@
 use std::fmt;
 
 use int_enum::IntEnum;
-use strata_acct_types::{AccountId, MessageEntry, MsgPayloadError, TxEffects};
+use strata_acct_types::{
+    AccountId, BitcoinAmount, MessageEntry, MsgPayload, MsgPayloadData, MsgPayloadError,
+    SentMessage, TxEffects,
+};
 use strata_identifiers::{Buf32, OLTxId, Slot};
 use tree_hash::{Sha256Hasher, TreeHash};
 
@@ -257,15 +260,24 @@ impl OLTransactionData {
 
     /// Creates a GAM transaction data targeting the given account with a zero-value message
     /// containing the provided payload data.
-    pub fn new_gam(dest: AccountId, data: Vec<u8>) -> Result<Self, MsgPayloadError> {
+    pub fn new_gam(dest: AccountId, data: MsgPayloadData) -> Self {
         let payload = TransactionPayload::GenericAccountMessage(GamTxPayload { target: dest });
         let mut effects = TxEffects::default();
-        effects.push_message(dest, 0, data)?;
-        Ok(Self {
+        effects.add_message(SentMessage::new(
+            dest,
+            MsgPayload::new(BitcoinAmount::zero(), data),
+        ));
+        Self {
             payload,
             constraints: TxConstraints::default(),
             effects,
-        })
+        }
+    }
+
+    /// Creates GAM transaction data from raw message payload bytes.
+    pub fn from_gam_bytes(dest: AccountId, data: Vec<u8>) -> Result<Self, MsgPayloadError> {
+        let msg_payload = MsgPayload::from_bytes_valueless(data)?;
+        Ok(Self::new_gam(dest, msg_payload.data))
     }
 
     /// Sets the constraints on this transaction data, consuming and returning self.

--- a/crates/ol/da/src/types/mod.rs
+++ b/crates/ol/da/src/types/mod.rs
@@ -46,10 +46,11 @@ mod tests {
 
     #[test]
     fn test_da_message_entry_decode_rejects_oversize_payload() {
-        let payload = MsgPayload::new(
+        let payload = MsgPayload::from_bytes(
             BitcoinAmount::from_sat(0),
             vec![0u8; MAX_MSG_PAYLOAD_BYTES + 1],
-        );
+        )
+        .expect("message payload bytes must fit within SSZ max length");
         let entry = DaMessageEntry::new(AccountId::from([0u8; 32]), 0, payload);
 
         let encoded = encode_to_vec(&entry).expect("encode da message entry");

--- a/crates/ol/mempool/src/test_utils.rs
+++ b/crates/ol/mempool/src/test_utils.rs
@@ -266,7 +266,9 @@ pub(crate) fn create_test_generic_tx_with_constraints(constraints: TxConstraints
     let mut runner = TestRunner::default();
     let payload_strategy = prop::collection::vec(any::<u8>(), 10..100);
     let payload = payload_strategy.new_tree(&mut runner).unwrap().current();
-    let data = OLTransactionData::new_gam(target, payload).with_constraints(constraints);
+    let data = OLTransactionData::from_gam_bytes(target, payload)
+        .expect("message payload bytes must fit within SSZ max length")
+        .with_constraints(constraints);
     OLTransaction::new(data, TxProofs::new_empty())
 }
 
@@ -288,7 +290,9 @@ pub(crate) fn create_test_generic_tx_with_size(
     let mut runner = TestRunner::default();
     let payload_strategy = prop::collection::vec(any::<u8>(), size..=size);
     let payload = payload_strategy.new_tree(&mut runner).unwrap().current();
-    let data = OLTransactionData::new_gam(target, payload).with_constraints(constraints);
+    let data = OLTransactionData::from_gam_bytes(target, payload)
+        .expect("message payload bytes must fit within SSZ max length")
+        .with_constraints(constraints);
     OLTransaction::new(data, TxProofs::new_empty())
 }
 
@@ -421,7 +425,9 @@ pub(crate) fn create_test_generic_tx_for_account(account_id: u8) -> OLTransactio
     let mut payload = payload_strategy.new_tree(&mut runner).unwrap().current();
     // Prepend account_id to make it deterministic per account
     payload.insert(0, account_id);
-    let data = OLTransactionData::new_gam(target, payload).with_constraints(constraints);
+    let data = OLTransactionData::from_gam_bytes(target, payload)
+        .expect("message payload bytes must fit within SSZ max length")
+        .with_constraints(constraints);
     OLTransaction::new(data, TxProofs::new_empty())
 }
 

--- a/crates/ol/mempool/src/types.rs
+++ b/crates/ol/mempool/src/types.rs
@@ -417,7 +417,9 @@ mod tests {
         let payload = create_test_message_payload();
 
         let tx = OLTransaction::new(
-            OLTransactionData::new_gam(target, payload).with_constraints(constraints.clone()),
+            OLTransactionData::from_gam_bytes(target, payload)
+                .expect("message payload bytes must fit within SSZ max length")
+                .with_constraints(constraints.clone()),
             TxProofs::new_empty(),
         );
 
@@ -456,18 +458,21 @@ mod tests {
         let target = create_test_account_id();
         let payload = create_test_message_payload();
         let tx1 = OLTransaction::new(
-            OLTransactionData::new_gam(target, payload.clone()),
+            OLTransactionData::from_gam_bytes(target, payload.clone())
+                .expect("message payload bytes must fit within SSZ max length"),
             TxProofs::new_empty(),
         );
         let tx2 = OLTransaction::new(
-            OLTransactionData::new_gam(target, payload),
+            OLTransactionData::from_gam_bytes(target, payload)
+                .expect("message payload bytes must fit within SSZ max length"),
             TxProofs::new_empty(),
         );
         assert_eq!(tx1.compute_txid(), tx2.compute_txid());
 
         let different_target = create_test_account_id();
         let tx3 = OLTransaction::new(
-            OLTransactionData::new_gam(different_target, create_test_message_payload()),
+            OLTransactionData::from_gam_bytes(different_target, create_test_message_payload())
+                .expect("message payload bytes must fit within SSZ max length"),
             TxProofs::new_empty(),
         );
         assert_ne!(tx1.compute_txid(), tx3.compute_txid());

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -1,7 +1,7 @@
 //! RPC types for the Orchestration Layer.
 
 use serde::{Deserialize, Serialize};
-use strata_acct_types::{AccountId, BitcoinAmount, MessageEntry, MsgPayload};
+use strata_acct_types::{AccountId, BitcoinAmount, MessageEntry, MsgPayload, MsgPayloadError};
 use strata_identifiers::OLBlockCommitment;
 use strata_primitives::{EpochCommitment, HexBytes, HexBytes32};
 use strata_snark_acct_types::{ProofState, UpdateInputData, UpdateStateData};
@@ -164,19 +164,29 @@ impl From<UpdateInputData> for RpcUpdateInputData {
     }
 }
 
-impl From<RpcUpdateInputData> for UpdateInputData {
-    fn from(rpc: RpcUpdateInputData) -> Self {
-        UpdateInputData::new(
+impl TryFrom<RpcUpdateInputData> for UpdateInputData {
+    type Error = MsgPayloadError;
+
+    fn try_from(rpc: RpcUpdateInputData) -> Result<Self, Self::Error> {
+        let messages = rpc
+            .messages
+            .into_iter()
+            .map(MessageEntry::try_from)
+            .collect::<Result<_, _>>()?;
+
+        Ok(UpdateInputData::new(
             rpc.seq_no,
-            rpc.messages.into_iter().map(Into::into).collect(),
+            messages,
             UpdateStateData::new(rpc.proof_state.into(), rpc.extra_data.0),
-        )
+        ))
     }
 }
 
-impl From<&RpcUpdateInputData> for UpdateInputData {
-    fn from(rpc: &RpcUpdateInputData) -> Self {
-        rpc.clone().into()
+impl TryFrom<&RpcUpdateInputData> for UpdateInputData {
+    type Error = MsgPayloadError;
+
+    fn try_from(rpc: &RpcUpdateInputData) -> Result<Self, Self::Error> {
+        rpc.clone().try_into()
     }
 }
 
@@ -202,13 +212,15 @@ impl From<MessageEntry> for RpcMessageEntry {
     }
 }
 
-impl From<RpcMessageEntry> for MessageEntry {
-    fn from(rpc: RpcMessageEntry) -> Self {
-        MessageEntry::new(
+impl TryFrom<RpcMessageEntry> for MessageEntry {
+    type Error = MsgPayloadError;
+
+    fn try_from(rpc: RpcMessageEntry) -> Result<Self, Self::Error> {
+        Ok(MessageEntry::new(
             AccountId::new(rpc.source.0),
             rpc.incl_epoch,
-            rpc.payload.into(),
-        )
+            rpc.payload.try_into()?,
+        ))
     }
 }
 
@@ -231,9 +243,11 @@ impl From<MsgPayload> for RpcMsgPayload {
     }
 }
 
-impl From<RpcMsgPayload> for MsgPayload {
-    fn from(rpc: RpcMsgPayload) -> Self {
-        MsgPayload::new(BitcoinAmount::from_sat(rpc.value), rpc.data.into())
+impl TryFrom<RpcMsgPayload> for MsgPayload {
+    type Error = MsgPayloadError;
+
+    fn try_from(rpc: RpcMsgPayload) -> Result<Self, Self::Error> {
+        MsgPayload::from_bytes(BitcoinAmount::from_sat(rpc.value), rpc.data.into())
     }
 }
 

--- a/crates/ol/rpc/types/src/tx.rs
+++ b/crates/ol/rpc/types/src/tx.rs
@@ -150,6 +150,10 @@ pub enum RpcTxConversionError {
     /// Too many ASM history claims in snark operation.
     #[error("too many ASM history claims in snark operation")]
     TooManyAsmHistoryClaims,
+
+    /// Message payload data exceeds SSZ limits.
+    #[error("invalid message payload: {0}")]
+    InvalidMessagePayload(#[from] strata_acct_types::MsgPayloadError),
 }
 
 impl TryFrom<RpcOLTransaction> for OLTransaction {
@@ -161,8 +165,8 @@ impl TryFrom<RpcOLTransaction> for OLTransaction {
         match rpc_tx.payload {
             RpcTransactionPayload::GenericAccountMessage(gam) => {
                 let target = AccountId::new(gam.target.0);
-                let tx_data =
-                    OLTransactionData::new_gam(target, gam.payload.0).with_constraints(constraints);
+                let tx_data = OLTransactionData::from_gam_bytes(target, gam.payload.0)?
+                    .with_constraints(constraints);
                 Ok(OLTransaction::new(tx_data, TxProofs::new_empty()))
             }
             RpcTransactionPayload::SnarkAccountUpdate(sau) => {

--- a/crates/ol/state-support-types/src/test_utils.rs
+++ b/crates/ol/state-support-types/src/test_utils.rs
@@ -36,7 +36,8 @@ pub(crate) fn test_snark_account_state(state_root_seed: u8) -> OLSnarkAccountSta
 
 /// Create a test message entry for inbox testing.
 pub(crate) fn test_message_entry(source_seed: u8, epoch: u32, value_sats: u64) -> MessageEntry {
-    let payload = MsgPayload::new(BitcoinAmount::from_sat(value_sats), vec![source_seed]);
+    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), vec![source_seed])
+        .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(test_account_id(source_seed), epoch, payload)
 }
 

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -1043,7 +1043,8 @@ fn test_message_source_missing_is_rejected() {
     let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
     let mut da_state = DaAccumulatingState::new(layer);
 
-    let payload = MsgPayload::new(BitcoinAmount::from_sat(0), vec![0u8; 4]);
+    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![0u8; 4])
+        .expect("message payload bytes must fit within SSZ max length");
     let missing_source = test_account_id(99);
     let msg = MessageEntry::new(missing_source, 0, payload);
     da_state
@@ -1068,7 +1069,8 @@ fn test_special_message_source_is_encoded() {
     let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
     let mut da_state = DaAccumulatingState::new(layer);
 
-    let payload = MsgPayload::new(BitcoinAmount::from_sat(0), vec![0u8; 4]);
+    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![0u8; 4])
+        .expect("message payload bytes must fit within SSZ max length");
     let special_source = AccountId::special(0x10);
     let msg = MessageEntry::new(special_source, 0, payload);
     da_state
@@ -1098,10 +1100,11 @@ fn test_message_payload_size_limit() {
     let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
     let mut da_state = DaAccumulatingState::new(layer);
 
-    let payload = MsgPayload::new(
+    let payload = MsgPayload::from_bytes(
         BitcoinAmount::from_sat(0),
         vec![0u8; MAX_MSG_PAYLOAD_BYTES + 1],
-    );
+    )
+    .expect("message payload bytes must fit within SSZ max length");
     let msg = MessageEntry::new(test_account_id(2), 0, payload);
     da_state
         .update_account(account_id, |acct| {

--- a/crates/ol/stf/src/assembly.rs
+++ b/crates/ol/stf/src/assembly.rs
@@ -216,7 +216,9 @@ impl BlockComponents {
             .map(|p| {
                 let mut effects = TxEffects::default();
                 if let TransactionPayload::GenericAccountMessage(ref gam) = p {
-                    effects.push_message(*gam.target(), 0, vec![]);
+                    effects
+                        .push_message(*gam.target(), 0, vec![])
+                        .expect("message payload bytes must fit within SSZ max length");
                 }
                 let data = OLTransactionData {
                     payload: p,

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -204,7 +204,8 @@ fn process_deposit_log<S: IStateAccessorMut>(
     let deposit_data = OwnedMsg::new(DEPOSIT_MSG_TYPE_ID, deposit_body)
         .expect("deposit message body must fit into msg-fmt envelope")
         .to_vec();
-    let msg_payload = MsgPayload::new(deposit.amount.into(), deposit_data);
+    let msg_payload = MsgPayload::from_bytes(deposit.amount.into(), deposit_data)
+        .expect("deposit message payload bytes must fit within SSZ max length");
 
     debug!(
         %dest_id,

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -246,14 +246,16 @@ pub fn build_chain_with_transactions(
             let msg_entry = MessageEntry::new(
                 crate::SEQUENCER_ACCT_ID,
                 epoch,
-                MsgPayload::new(BitcoinAmount::from_sat(0), msg_data.clone()),
+                MsgPayload::from_bytes(BitcoinAmount::from_sat(0), msg_data.clone())
+                    .expect("message payload bytes must fit within SSZ max length"),
             );
             let proof = inbox_tracker.add_message(&msg_entry);
             pending_msgs.push(msg_entry);
             pending_proofs.push(proof);
 
             let gam_tx = OLTransaction::new(
-                OLTransactionData::new_gam(snark_id, msg_data),
+                OLTransactionData::from_gam_bytes(snark_id, msg_data)
+                    .expect("message payload bytes must fit within SSZ max length"),
                 TxProofs::new_empty(),
             );
             BlockComponents::new_txs_from_ol_transactions(vec![gam_tx])
@@ -272,7 +274,8 @@ pub fn build_chain_with_transactions(
         } else if i % 4 == 2 {
             // GAM to regular target account
             let gam_tx = OLTransaction::new(
-                OLTransactionData::new_gam(gam_target, vec![]),
+                OLTransactionData::from_gam_bytes(gam_target, vec![])
+                    .expect("message payload bytes must fit within SSZ max length"),
                 TxProofs::new_empty(),
             );
             BlockComponents::new_txs_from_ol_transactions(vec![gam_tx])
@@ -644,7 +647,8 @@ pub fn create_empty_account(
 /// Helper to make a GAM transaction targeting the given account with empty payload data.
 pub fn make_gam_tx(dest: AccountId) -> OLTransaction {
     OLTransaction::new(
-        OLTransactionData::new_gam(dest, vec![]),
+        OLTransactionData::from_gam_bytes(dest, vec![])
+            .expect("message payload bytes must fit within SSZ max length"),
         TxProofs::new_empty(),
     )
 }
@@ -731,7 +735,8 @@ impl SnarkUpdateBuilder {
 
     /// Add a single message effect
     pub fn with_output_message(mut self, dest: AccountId, amount: u64, data: Vec<u8>) -> Self {
-        let payload = MsgPayload::new(BitcoinAmount::from_sat(amount), data);
+        let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(amount), data)
+            .expect("message payload bytes must fit within SSZ max length");
         self.effects.add_message(SentMessage::new(dest, payload));
         self
     }

--- a/crates/ol/stf/src/tests/deposit_withdrawal.rs
+++ b/crates/ol/stf/src/tests/deposit_withdrawal.rs
@@ -119,7 +119,8 @@ fn test_snark_account_deposit_and_withdrawal() {
     let deposit_msg_in_inbox = MessageEntry::new(
         BRIDGE_GATEWAY_ACCT_ID,
         0, // genesis epoch
-        MsgPayload::new(BitcoinAmount::from_sat(deposit_amount), deposit_msg_data),
+        MsgPayload::from_bytes(BitcoinAmount::from_sat(deposit_amount), deposit_msg_data)
+            .expect("message payload bytes must fit within SSZ max length"),
     );
 
     // Add the message to the tracker to get a proof

--- a/crates/ol/stf/src/tests/limbo.rs
+++ b/crates/ol/stf/src/tests/limbo.rs
@@ -48,7 +48,8 @@ fn limbo_message_to_nonexistent_account() {
     let context = BasicExecContext::new(block_info, &outputs);
 
     let value = BitcoinAmount::from_sat(2_500_000);
-    let payload = MsgPayload::new(value, vec![]);
+    let payload = MsgPayload::from_bytes(value, vec![])
+        .expect("message payload bytes must fit within SSZ max length");
 
     account_processing::process_message(
         &mut state,

--- a/crates/simple-ee/src/types.rs
+++ b/crates/simple-ee/src/types.rs
@@ -351,7 +351,8 @@ impl SimpleTransaction {
                 msg_data.extend_from_slice(data);
 
                 // Emit message output
-                let payload = MsgPayload::new(BitcoinAmount::from(*value), msg_data);
+                let payload = MsgPayload::from_bytes(BitcoinAmount::from(*value), msg_data)
+                    .map_err(|_| EnvError::InvalidBlockTx)?;
                 let message = OutputMessage::new(*dest_account, payload);
                 outputs.add_message(message);
             }

--- a/crates/snark-acct-runtime/src/program_processing.rs
+++ b/crates/snark-acct-runtime/src/program_processing.rs
@@ -329,7 +329,8 @@ mod tests {
 
     fn make_msg_entry(delta: u64) -> MessageEntry {
         let data = strata_codec::encode_to_vec(&TestMsg { delta }).unwrap();
-        let payload = MsgPayload::new(BitcoinAmount::ZERO, data);
+        let payload = MsgPayload::from_bytes(BitcoinAmount::ZERO, data)
+            .expect("message payload bytes must fit within SSZ max length");
         MessageEntry::new(AccountId::zero(), 0, payload)
     }
 
@@ -409,7 +410,8 @@ mod tests {
         let mut state = TestState { value: 0 };
 
         // Create a message entry with garbage payload data to trigger Unknown
-        let unknown_payload = MsgPayload::new(BitcoinAmount::ZERO, vec![0xff]);
+        let unknown_payload = MsgPayload::from_bytes(BitcoinAmount::ZERO, vec![0xff])
+            .expect("message payload bytes must fit within SSZ max length");
         let unknown_entry = MessageEntry::new(AccountId::zero(), 0, unknown_payload);
 
         // Only valid messages contribute: (5 + 3) * 1 = 8


### PR DESCRIPTION
## Description

Replaces the panicking raw-byte `MsgPayload::new(value, Vec<u8>)` path with Trey D’s suggested split API:

- `MsgPayload::new(value, MsgPayloadData)` now accepts already-bounded SSZ payload data.
- `MsgPayload::from_bytes(value, Vec<u8>)` performs the fallible raw-byte conversion.
- RPC and OL transaction conversion paths now propagate oversized payload errors instead of panicking.

This reuses the generated SSZ `MAX_MSG_PAYLOAD_DATA_BYTES` constant as the source of truth.


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The main API change is that raw `Vec<u8>` construction is now explicit and fallible via `MsgPayload::from_bytes`. Call sites with externally supplied bytes now propagate errors; test/helper paths use `expect` where the payload is locally bounded.

Done with the aid of AI.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3053