### PR TITLE
STR-3155: bind snark account updates to specific seqnos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -503,6 +503,8 @@ tree_hash_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.
 # `next_request_id >= readable_request_id` invariant, which fires under
 # concurrent bitcoind RPC traffic in coverage/debug builds. Tracked upstream at
 # https://github.com/rust-bitcoin/corepc/issues/583 (PR #584 unmerged).
+#
+# TODO(STR-3554): remove this when PR merged
 [profile.dev.package.bitreq]
 debug-assertions = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -499,6 +499,13 @@ ssz_types = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
 tree_hash = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
 tree_hash_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
 
+# Disable debug_assertions in bitreq to dodge a known concurrency race in its
+# `next_request_id >= readable_request_id` invariant, which fires under
+# concurrent bitcoind RPC traffic in coverage/debug builds. Tracked upstream at
+# https://github.com/rust-bitcoin/corepc/issues/583 (PR #584 unmerged).
+[profile.dev.package.bitreq]
+debug-assertions = false
+
 # This is needed for custom build of SP1
 [profile.release.build-override]
 opt-level = 3

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -29,7 +29,7 @@ use strata_paas::{ProofSpec, ProverError as PaasError, ProverResult, ReceiptStor
 use strata_proofimpl_alpen_acct::{EeAcctProgram, EeAcctProofInput};
 use strata_snark_acct_runtime::{Coinput, IInnerState, PrivateInput as UpdatePrivateInput};
 use strata_snark_acct_types::{
-    OutputMessage, OutputTransfer, ProofState, UpdateOutputs, UpdateProofPubParams,
+    OutputMessage, OutputTransfer, ProofState, Seqno, UpdateOutputs, UpdateProofPubParams,
 };
 
 use super::ChunkTask;
@@ -372,7 +372,12 @@ impl ProofSpec for AcctSpec {
                 )),
             })?;
 
+        let seq_no = batch.update_seq_no().ok_or_else(|| {
+            PaasError::TransientFailure(format!("batch {batch_id} has no assigned update seq_no"))
+        })?;
+
         let pub_params = UpdateProofPubParams::new(
+            Seqno::new(seq_no),
             cur_state,
             new_state,
             messages,

--- a/bin/prover-perf/src/programs/alpen_acct.rs
+++ b/bin/prover-perf/src/programs/alpen_acct.rs
@@ -19,7 +19,7 @@ use strata_evm_ee::EvmExecutionEnvironment;
 use strata_proofimpl_alpen_acct::{EeAcctProgram, EeAcctProofInput};
 use strata_proofimpl_alpen_chunk::EeChunkProgram;
 use strata_snark_acct_runtime::{IInnerState, PrivateInput as UpdatePrivateInput};
-use strata_snark_acct_types::{LedgerRefs, ProofState, UpdateOutputs, UpdateProofPubParams};
+use strata_snark_acct_types::{LedgerRefs, ProofState, Seqno, UpdateOutputs, UpdateProofPubParams};
 use tracing::info;
 use zkaleido::{ExecutionSummary, ZkVmHost, ZkVmProgram};
 
@@ -71,6 +71,7 @@ fn prepare_input() -> EeAcctProofInput {
     let extra_data_bytes = encode_to_vec(&extra_data).expect("encode extra data");
 
     let pub_params = UpdateProofPubParams::new(
+        Seqno::zero(),
         ProofState::new(pre_root, 0),
         ProofState::new(post_root, 0),
         vec![],

--- a/bin/strata-test-cli/src/mock_ee/withdrawal.rs
+++ b/bin/strata-test-cli/src/mock_ee/withdrawal.rs
@@ -11,7 +11,8 @@ use strata_msg_fmt::{Msg, OwnedMsg};
 use strata_ol_msg_types::{WithdrawalMsgData, WITHDRAWAL_MSG_TYPE_ID};
 use strata_ol_stf::BRIDGE_GATEWAY_ACCT_ID;
 use strata_snark_acct_types::{
-    LedgerRefs, OutputMessage, ProofState, UpdateOperationData, UpdateOutputs, UpdateProofPubParams,
+    LedgerRefs, OutputMessage, ProofState, Seqno, UpdateOperationData, UpdateOutputs,
+    UpdateProofPubParams,
 };
 
 /// Deterministic BIP-340 signing key whose verifying key matches the
@@ -70,7 +71,7 @@ pub(crate) fn build_snark_withdrawal_json(
     //
     // The mock withdrawal does not advance the snark account's inner state
     // or inbox index, so `cur_state == new_state == proof_state`.
-    let claim_ssz = sign_claim_ssz(&proof_state, &proof_state, &outputs);
+    let claim_ssz = sign_claim_ssz(Seqno::new(seq_no), &proof_state, &proof_state, &outputs);
     let signature = bip340_test_sign(&claim_ssz);
     let update_proof_hex = hex::encode(signature);
 
@@ -99,11 +100,13 @@ pub(crate) fn build_snark_withdrawal_json(
 /// Reconstructs the `UpdateProofPubParams` claim the OL builds in
 /// `snark_acct_sys::compute_update_claim` and returns its SSZ encoding.
 fn sign_claim_ssz(
+    seq_no: Seqno,
     cur_state: &ProofState,
     new_state: &ProofState,
     outputs: &UpdateOutputs,
 ) -> Vec<u8> {
     let pub_params = UpdateProofPubParams::new(
+        seq_no,
         cur_state.clone(),
         new_state.clone(),
         Vec::<MessageEntry>::new(),
@@ -316,7 +319,7 @@ mod tests {
                 .expect("withdrawal message payload bytes must fit within SSZ max length");
         let output_message = OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, msg_payload);
         let outputs = UpdateOutputs::new(vec![], vec![output_message]);
-        let claim_ssz = sign_claim_ssz(&proof_state, &proof_state, &outputs);
+        let claim_ssz = sign_claim_ssz(Seqno::new(5), &proof_state, &proof_state, &outputs);
 
         let proof_hex = json["payload"]["update_proof"].as_str().unwrap();
         let proof_bytes = hex::decode(proof_hex).unwrap();

--- a/crates/ee-acct-runtime/src/update_builder.rs
+++ b/crates/ee-acct-runtime/src/update_builder.rs
@@ -11,7 +11,7 @@ use strata_ee_acct_types::{
 use strata_ee_chain_types::ChunkTransition;
 use strata_snark_acct_runtime::{PrivateInput, UpdateBuilder as GenericUpdateBuilder};
 use strata_snark_acct_types::{
-    LedgerRefs, OutputMessage, OutputTransfer, SnarkAccountState, UpdateOperationData,
+    LedgerRefs, OutputMessage, OutputTransfer, Seqno, SnarkAccountState, UpdateOperationData,
     UpdateOutputs,
 };
 
@@ -30,9 +30,6 @@ use crate::{
 #[expect(missing_debug_implementations, reason = "E may not implement Debug")]
 pub struct UpdateBuilder<'i, E: ExecutionEnvironment> {
     inner: GenericUpdateBuilder<'i, EeSnarkAccountProgram<E>>,
-
-    /// Seqno of the update we're proving.
-    seq_no: u64,
 
     /// Current chain tip, advanced as chunks are accepted.
     cur_tip_blkid: Hash,
@@ -57,7 +54,6 @@ impl<'i, E: ExecutionEnvironment> UpdateBuilder<'i, E> {
     /// Initializes with an empty message set. Messages are added incrementally
     /// via [`Self::add_message`] or [`Self::add_messages`].
     pub fn new(
-        seq_no: u64,
         snark_state: SnarkAccountState,
         initial_state: EeAccountState,
         vinput: EeVerificationInput<'i, E>,
@@ -79,13 +75,21 @@ impl<'i, E: ExecutionEnvironment> UpdateBuilder<'i, E> {
 
         Ok(Self {
             inner,
-            seq_no,
             cur_tip_blkid,
             cur_tip_state_root,
             pending_inputs,
             inputs_consumed: 0,
             fincls_processed: 0,
         })
+    }
+
+    /// Overrides the seqno that the finalized update will be tagged with.
+    ///
+    /// By default the inner builder uses the snark account state's expected
+    /// next seqno; set this to build an update bound to a different seqno
+    /// (e.g. when constructing a sequence of updates ahead of submission).
+    pub fn set_override_seq_no(&mut self, seq_no: Option<Seqno>) {
+        self.inner.set_override_seq_no(seq_no);
     }
 
     /// Returns the current account state.
@@ -253,9 +257,7 @@ impl<'i, E: ExecutionEnvironment> UpdateBuilder<'i, E> {
             self.fincls_processed as u32,
         );
 
-        let (op, coinputs) = self
-            .inner
-            .build_operation_data_unverified(self.seq_no, extra_data)?;
+        let (op, coinputs) = self.inner.build_operation_data_unverified(extra_data)?;
         Ok((op, coinputs))
     }
 

--- a/crates/ee-acct-runtime/tests/common/mod.rs
+++ b/crates/ee-acct-runtime/tests/common/mod.rs
@@ -20,10 +20,7 @@ use strata_snark_acct_runtime::{
     ArchivedPrivateInput as ArchivedSnarkPrivateInput, Coinput, IInnerState, InputMessage,
     PrivateInput as SnarkPrivateInput, ProgramResult, SnarkAccountProgram,
 };
-use strata_snark_acct_types::{
-    ProofState, SnarkAccountState, UpdateManifest, UpdateOperationData, UpdateOutputs,
-    UpdateProofPubParams,
-};
+use strata_snark_acct_types::*;
 
 /// Serializes an [`EePrivateInput`] and a [`SnarkPrivateInput`] with rkyv, then
 /// calls `f` with the archived references.
@@ -130,6 +127,7 @@ pub fn verify_update(
     let post_root = post_state.compute_state_root();
 
     let pub_params = UpdateProofPubParams::new(
+        Seqno::new(operation.seq_no()),
         ProofState::new(pre_root, 0),
         ProofState::new(post_root, operation.processed_messages().len() as u64),
         operation.processed_messages().to_vec(),
@@ -281,6 +279,7 @@ pub(crate) fn verify_with_chunks(
     let post_root = post_state.compute_state_root();
 
     let pub_params = UpdateProofPubParams::new(
+        Seqno::new(operation.seq_no()),
         ProofState::new(pre_root, 0),
         ProofState::new(post_root, operation.processed_messages().len() as u64),
         operation.processed_messages().to_vec(),

--- a/crates/ee-acct-runtime/tests/common/mod.rs
+++ b/crates/ee-acct-runtime/tests/common/mod.rs
@@ -199,7 +199,6 @@ pub(crate) fn create_deposit_message(
 /// Accepts messages and chunk transitions. The builder validates chunks
 /// against its internal pending input tracking.
 pub(crate) fn build_update_operation(
-    seq_no: u64,
     messages: Vec<MessageEntry>,
     chunks: &[ChunkTransition],
     initial_state: &EeAccountState,
@@ -209,9 +208,8 @@ pub(crate) fn build_update_operation(
     let predicate_key = PredicateKey::always_accept();
     let vinput = EeVerificationInput::new(ee, &predicate_key, &[], &[]);
 
-    let mut builder =
-        UpdateBuilder::new(seq_no, snark_state.clone(), initial_state.clone(), vinput)
-            .expect("create builder");
+    let mut builder = UpdateBuilder::new(snark_state.clone(), initial_state.clone(), vinput)
+        .expect("create builder");
 
     builder.add_messages(messages).expect("add messages");
 

--- a/crates/ee-acct-runtime/tests/invalid_updates.rs
+++ b/crates/ee-acct-runtime/tests/invalid_updates.rs
@@ -38,7 +38,7 @@ fn test_mismatched_coinput_count() {
     let message = create_deposit_message(dest, value, source, 1);
 
     let (operation, _coinputs, _snark_priv) =
-        build_update_operation(1, vec![message], &[], &initial_state, &snark_state, &ee);
+        build_update_operation(vec![message], &[], &initial_state, &snark_state, &ee);
 
     // Too many coinputs
     let wrong_coinputs = [vec![], vec![]];
@@ -74,7 +74,7 @@ fn test_nonempty_coinput_rejected() {
     let message = create_deposit_message(dest, value, source, 1);
 
     let (operation, _coinputs, _snark_priv) =
-        build_update_operation(1, vec![message], &[], &initial_state, &snark_state, &ee);
+        build_update_operation(vec![message], &[], &initial_state, &snark_state, &ee);
 
     // Non-empty coinput should be rejected (EE requires empty coinputs)
     let nonempty_coinputs = vec![vec![1, 2, 3]];
@@ -170,7 +170,7 @@ fn test_builder_rejects_wrong_parent() {
     let predicate_key = PredicateKey::always_accept();
     let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
     let mut builder =
-        UpdateBuilder::new(1, snark_state, initial_state, vinput).expect("create builder");
+        UpdateBuilder::new(snark_state, initial_state, vinput).expect("create builder");
 
     // Chunk with wrong parent
     let wrong_parent = Hash::new([0xCC; 32]);
@@ -197,7 +197,7 @@ fn test_builder_rejects_wrong_deposit() {
     let predicate_key = PredicateKey::always_accept();
     let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
     let mut builder =
-        UpdateBuilder::new(1, snark_state, initial_state, vinput).expect("create builder");
+        UpdateBuilder::new(snark_state, initial_state, vinput).expect("create builder");
 
     builder.add_messages(vec![message]).expect("add messages");
 
@@ -236,7 +236,7 @@ fn test_builder_advances_tip() {
     let predicate_key = PredicateKey::always_accept();
     let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
     let mut builder =
-        UpdateBuilder::new(1, snark_state, initial_state, vinput).expect("create builder");
+        UpdateBuilder::new(snark_state, initial_state, vinput).expect("create builder");
 
     builder
         .add_messages(vec![msg1, msg2])

--- a/crates/ee-acct-runtime/tests/update_verification.rs
+++ b/crates/ee-acct-runtime/tests/update_verification.rs
@@ -13,9 +13,9 @@ use common::{
     assert_verified_path_succeeds, build_update_operation, create_deposit_message,
     create_initial_state, simple_chunk,
 };
-use strata_acct_types::{AccountId, BitcoinAmount, Hash, SubjectId};
+use strata_acct_types::{AccountId, BitcoinAmount, Hash, MsgPayload, SubjectId};
 use strata_ee_acct_runtime::{EeVerificationInput, UpdateBuilder};
-use strata_ee_chain_types::ExecOutputs;
+use strata_ee_chain_types::{ExecOutputs, OutputMessage};
 use strata_predicate::PredicateKey;
 use strata_simple_ee::SimpleExecutionEnvironment;
 
@@ -25,7 +25,7 @@ fn test_empty_update_no_chunks() {
     let ee = SimpleExecutionEnvironment;
 
     let (operation, coinputs, snark_priv) =
-        build_update_operation(1, vec![], &[], &initial_state, &snark_state, &ee);
+        build_update_operation(vec![], &[], &initial_state, &snark_state, &ee);
 
     assert_both_paths_succeed(&initial_state, &operation, &coinputs, &ee);
     assert_verified_path_succeeds(&snark_priv, &[], &ee);
@@ -42,7 +42,7 @@ fn test_single_deposit_no_chunks() {
     let message = create_deposit_message(dest, value, source, 1);
 
     let (operation, _coinputs, snark_priv) =
-        build_update_operation(1, vec![message], &[], &initial_state, &snark_state, &ee);
+        build_update_operation(vec![message], &[], &initial_state, &snark_state, &ee);
 
     apply_unconditionally(&initial_state, &operation).expect("unconditional path should succeed");
     assert_verified_path_succeeds(&snark_priv, &[], &ee);
@@ -63,7 +63,6 @@ fn test_multiple_deposits_no_chunks() {
     let message2 = create_deposit_message(dest2, value2, source, 1);
 
     let (operation, _coinputs, snark_priv) = build_update_operation(
-        1,
         vec![message1, message2],
         &[],
         &initial_state,
@@ -81,7 +80,7 @@ fn test_empty_update_verified_path() {
     let ee = SimpleExecutionEnvironment;
 
     let (operation, coinputs, snark_priv) =
-        build_update_operation(1, vec![], &[], &initial_state, &snark_state, &ee);
+        build_update_operation(vec![], &[], &initial_state, &snark_state, &ee);
 
     assert_both_paths_succeed(&initial_state, &operation, &coinputs, &ee);
     assert_verified_path_succeeds(&snark_priv, &[], &ee);
@@ -102,7 +101,7 @@ fn test_single_deposit_with_chunk() {
     let predicate_key = PredicateKey::always_accept();
     let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
     let mut builder =
-        UpdateBuilder::new(1, snark_state, initial_state.clone(), vinput).expect("create builder");
+        UpdateBuilder::new(snark_state, initial_state.clone(), vinput).expect("create builder");
 
     builder.add_messages(vec![message]).expect("add messages");
 
@@ -135,6 +134,47 @@ fn test_single_deposit_with_chunk() {
 }
 
 #[test]
+fn test_chunk_output_does_not_change_inner_tracked_balance() {
+    let (initial_state, snark_state) = create_initial_state();
+    let ee = SimpleExecutionEnvironment;
+
+    let dest = SubjectId::from([1u8; 32]);
+    let value = BitcoinAmount::from(1000u64);
+    let source = AccountId::from([2u8; 32]);
+    let message = create_deposit_message(dest, value, source, 1);
+
+    let predicate_key = PredicateKey::always_accept();
+    let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
+    let mut builder =
+        UpdateBuilder::new(snark_state, initial_state.clone(), vinput).expect("create builder");
+
+    builder.add_messages(vec![message]).expect("add message");
+
+    let deposit = match &builder.remaining_pending_inputs()[0] {
+        strata_ee_acct_types::PendingInputEntry::Deposit(d) => d.clone(),
+    };
+
+    let mut outputs = ExecOutputs::new_empty();
+    outputs.add_message(OutputMessage::new(
+        AccountId::from([3u8; 32]),
+        MsgPayload::from_bytes(BitcoinAmount::from(400u64), vec![1, 2, 3])
+            .expect("create payload"),
+    ));
+
+    let tip = Hash::new([0xDD; 32]);
+    let chunk = simple_chunk(builder.cur_tip_blkid(), tip, vec![deposit], outputs);
+
+    builder
+        .accept_chunk_transition(&chunk)
+        .expect("accept chunk");
+
+    let (operation, coinputs) = builder.build().expect("build");
+
+    apply_unconditionally(&initial_state, &operation).expect("unconditional path should succeed");
+    assert_verified_chunks_succeed(&initial_state, &operation, &coinputs, &[chunk], &ee);
+}
+
+#[test]
 fn test_multiple_deposits_multiple_chunks() {
     let (initial_state, snark_state) = create_initial_state();
     let ee = SimpleExecutionEnvironment;
@@ -151,7 +191,7 @@ fn test_multiple_deposits_multiple_chunks() {
     let predicate_key = PredicateKey::always_accept();
     let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
     let mut builder =
-        UpdateBuilder::new(1, snark_state, initial_state.clone(), vinput).expect("create builder");
+        UpdateBuilder::new(snark_state, initial_state.clone(), vinput).expect("create builder");
 
     builder
         .add_messages(vec![msg1, msg2])

--- a/crates/ee-acct-runtime/tests/update_verification.rs
+++ b/crates/ee-acct-runtime/tests/update_verification.rs
@@ -157,8 +157,7 @@ fn test_chunk_output_does_not_change_inner_tracked_balance() {
     let mut outputs = ExecOutputs::new_empty();
     outputs.add_message(OutputMessage::new(
         AccountId::from([3u8; 32]),
-        MsgPayload::from_bytes(BitcoinAmount::from(400u64), vec![1, 2, 3])
-            .expect("create payload"),
+        MsgPayload::from_bytes(BitcoinAmount::from(400u64), vec![1, 2, 3]).expect("create payload"),
     ));
 
     let tip = Hash::new([0xDD; 32]);

--- a/crates/proof-impl/alpen-acct/src/program.rs
+++ b/crates/proof-impl/alpen-acct/src/program.rs
@@ -124,7 +124,9 @@ mod tests {
     use strata_identifiers::Hash;
     use strata_predicate::{PredicateKey, PredicateTypeId};
     use strata_snark_acct_runtime::{IInnerState, PrivateInput as UpdatePrivateInput};
-    use strata_snark_acct_types::{LedgerRefs, ProofState, UpdateOutputs, UpdateProofPubParams};
+    use strata_snark_acct_types::{
+        LedgerRefs, ProofState, Seqno, UpdateOutputs, UpdateProofPubParams,
+    };
 
     use super::*;
 
@@ -145,6 +147,7 @@ mod tests {
 
         // With zero chunks and no state change, pre == post state root.
         let pub_params = UpdateProofPubParams::new(
+            Seqno::zero(),
             ProofState::new(state_root, 0),
             ProofState::new(state_root, 0),
             vec![],

--- a/crates/snark-acct-runtime/src/update_builder.rs
+++ b/crates/snark-acct-runtime/src/update_builder.rs
@@ -377,6 +377,7 @@ impl<P: SnarkAccountProgramVerification> FinalizedUpdate<P> {
         let coinputs = self.coinputs.into_iter().map(Coinput::new).collect();
 
         let pub_params = strata_snark_acct_types::UpdateProofPubParams::new(
+            self.snark_state.seq_no(),
             ProofState::new(self.pre_state.compute_state_root(), pre_inbox_idx),
             new_proof_state,
             self.messages,

--- a/crates/snark-acct-runtime/src/update_builder.rs
+++ b/crates/snark-acct-runtime/src/update_builder.rs
@@ -426,9 +426,7 @@ impl<P: SnarkAccountProgramVerification> FinalizedUpdate<P> {
         ))
     }
 
-    fn into_operation_data(
-        self,
-    ) -> ProgramResult<(UpdateOperationData, Vec<Vec<u8>>), P::Error> {
+    fn into_operation_data(self) -> ProgramResult<(UpdateOperationData, Vec<Vec<u8>>), P::Error> {
         let new_proof_state = self.new_proof_state();
         let extra_data_buf = self.encode_extra_data()?;
 

--- a/crates/snark-acct-runtime/src/update_builder.rs
+++ b/crates/snark-acct-runtime/src/update_builder.rs
@@ -36,6 +36,11 @@ pub struct UpdateBuilder<'i, P: SnarkAccountProgramVerification> {
     next_msg_idx: usize,
     ledger_refs: LedgerRefs,
     outputs: UpdateOutputs,
+    /// If set, overrides the seqno that would otherwise be derived from the
+    /// snark account state.  Used for building updates that target a seqno
+    /// other than the one currently expected on-chain (e.g. when building a
+    /// sequence of updates ahead of submission).
+    override_seq_no: Option<Seqno>,
 }
 
 impl<'i, P: SnarkAccountProgramVerification> UpdateBuilder<'i, P> {
@@ -79,7 +84,23 @@ impl<'i, P: SnarkAccountProgramVerification> UpdateBuilder<'i, P> {
             next_msg_idx: 0,
             ledger_refs,
             outputs,
+            override_seq_no: None,
         })
+    }
+
+    /// Returns the seqno that finalized updates will be tagged with.
+    ///
+    /// Defaults to the snark account state's expected next seqno; returns the
+    /// override if one has been set via [`Self::set_override_seq_no`].
+    pub fn resolved_seq_no(&self) -> Seqno {
+        self.override_seq_no
+            .unwrap_or_else(|| self.snark_state.seq_no())
+    }
+
+    /// Sets an override seqno used in place of the snark account state's
+    /// expected seqno when finalizing.
+    pub fn set_override_seq_no(&mut self, seq_no: Option<Seqno>) {
+        self.override_seq_no = seq_no;
     }
 
     /// Appends a message without processing it.
@@ -243,6 +264,7 @@ impl<'i, P: SnarkAccountProgramVerification> UpdateBuilder<'i, P> {
             coinputs: self.coinputs.clone(),
             ledger_refs: self.ledger_refs.clone(),
             outputs: self.outputs.clone(),
+            seq_no: self.resolved_seq_no(),
         })
     }
 
@@ -277,6 +299,7 @@ impl<'i, P: SnarkAccountProgramVerification> UpdateBuilder<'i, P> {
             coinputs: self.coinputs.clone(),
             ledger_refs: self.ledger_refs.clone(),
             outputs: self.outputs.clone(),
+            seq_no: self.resolved_seq_no(),
         })
     }
 
@@ -312,17 +335,17 @@ impl<'i, P: SnarkAccountProgramVerification> UpdateBuilder<'i, P> {
     /// Builds [`UpdateOperationData`] and raw coinputs.
     ///
     /// Calls `pre_finalize_state`, `finalize_verification`, `finalize_state`.
-    /// Clones internal state so the builder can be reused.
+    /// Tags the operation with [`Self::resolved_seq_no`]. Clones internal state
+    /// so the builder can be reused.
     pub fn build_operation_data(
         &mut self,
-        seq_no: u64,
         extra_data: P::ExtraData,
     ) -> ProgramResult<(UpdateOperationData, Vec<Vec<u8>>), P::Error>
     where
         P::VState<'i>: Clone,
     {
         let finalized = self.finalize_verified(extra_data)?;
-        finalized.into_operation_data(seq_no)
+        finalized.into_operation_data()
     }
 
     /// Builds [`UpdateOperationData`] and raw coinputs without running
@@ -330,15 +353,15 @@ impl<'i, P: SnarkAccountProgramVerification> UpdateBuilder<'i, P> {
     ///
     /// Calls `pre_finalize_state`, `finalize_state` (skips
     /// `finalize_verification`). Useful for the construction side where
-    /// the builder has already validated chunks locally. Clones internal state
-    /// so the builder can be reused.
+    /// the builder has already validated chunks locally. Tags the operation
+    /// with [`Self::resolved_seq_no`]. Clones internal state so the builder can
+    /// be reused.
     pub fn build_operation_data_unverified(
         &mut self,
-        seq_no: u64,
         extra_data: P::ExtraData,
     ) -> ProgramResult<(UpdateOperationData, Vec<Vec<u8>>), P::Error> {
         let finalized = self.finalize_unverified(extra_data)?;
-        finalized.into_operation_data(seq_no)
+        finalized.into_operation_data()
     }
 }
 
@@ -352,6 +375,9 @@ struct FinalizedUpdate<P: SnarkAccountProgramVerification> {
     coinputs: Vec<Vec<u8>>,
     ledger_refs: LedgerRefs,
     outputs: UpdateOutputs,
+    /// Seqno to tag this update with — either the snark account's expected
+    /// next seqno or an explicit override.
+    seq_no: Seqno,
 }
 
 impl<P: SnarkAccountProgramVerification> FinalizedUpdate<P> {
@@ -377,7 +403,7 @@ impl<P: SnarkAccountProgramVerification> FinalizedUpdate<P> {
         let coinputs = self.coinputs.into_iter().map(Coinput::new).collect();
 
         let pub_params = strata_snark_acct_types::UpdateProofPubParams::new(
-            self.snark_state.seq_no(),
+            self.seq_no,
             ProofState::new(self.pre_state.compute_state_root(), pre_inbox_idx),
             new_proof_state,
             self.messages,
@@ -402,13 +428,12 @@ impl<P: SnarkAccountProgramVerification> FinalizedUpdate<P> {
 
     fn into_operation_data(
         self,
-        seq_no: u64,
     ) -> ProgramResult<(UpdateOperationData, Vec<Vec<u8>>), P::Error> {
         let new_proof_state = self.new_proof_state();
         let extra_data_buf = self.encode_extra_data()?;
 
         let op = UpdateOperationData::new(
-            seq_no,
+            *self.seq_no.inner(),
             new_proof_state,
             self.messages,
             self.ledger_refs,

--- a/crates/snark-acct-sys/src/verification.rs
+++ b/crates/snark-acct-sys/src/verification.rs
@@ -168,6 +168,7 @@ fn compute_update_claim(
     let outputs = effects_to_update_outputs(update.effects());
 
     let pub_params = UpdateProofPubParams::new(
+        update.seq_no(),
         cur_state,
         update.new_proof_state().clone(),
         update.processed_messages().to_vec(),

--- a/crates/snark-acct-types/src/proof_interface.rs
+++ b/crates/snark-acct-types/src/proof_interface.rs
@@ -3,12 +3,13 @@
 use strata_acct_types::MessageEntry;
 
 use crate::{
-    LedgerRefs, ProofState, UpdateOutputs,
+    LedgerRefs, ProofState, Seqno, UpdateOutputs,
     ssz_generated::ssz::proof_interface::UpdateProofPubParams,
 };
 
 impl UpdateProofPubParams {
     pub fn new(
+        seq_no: Seqno,
         cur_state: ProofState,
         new_state: ProofState,
         message_inputs: Vec<MessageEntry>,
@@ -17,6 +18,7 @@ impl UpdateProofPubParams {
         extra_data: Vec<u8>,
     ) -> Self {
         Self {
+            seq_no: *seq_no.inner(),
             cur_state,
             new_state,
             message_inputs: message_inputs
@@ -28,6 +30,10 @@ impl UpdateProofPubParams {
                 .try_into()
                 .expect("extra data must fit within SSZ max length"),
         }
+    }
+
+    pub fn seq_no(&self) -> Seqno {
+        Seqno::new(self.seq_no)
     }
 
     pub fn cur_state(&self) -> ProofState {
@@ -58,11 +64,12 @@ impl UpdateProofPubParams {
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
+    use ssz::Encode as _;
     use strata_acct_types::{AccountId, BitcoinAmount, MsgPayload};
     use strata_test_utils_ssz::ssz_proptest;
 
     use super::*;
-    use crate::{AccumulatorClaim, OutputMessage, OutputTransfer};
+    use crate::{AccumulatorClaim, OutputMessage, OutputTransfer, Seqno};
 
     fn proof_state_strategy() -> impl Strategy<Value = ProofState> {
         (any::<[u8; 32]>(), any::<u64>()).prop_map(|(inner_state, next_idx)| ProofState {
@@ -140,6 +147,7 @@ mod tests {
 
     fn update_proof_pub_params_strategy() -> impl Strategy<Value = UpdateProofPubParams> {
         (
+            any::<u64>(),
             proof_state_strategy(),
             proof_state_strategy(),
             prop::collection::vec(message_entry_strategy(), 0..3),
@@ -148,8 +156,17 @@ mod tests {
             prop::collection::vec(any::<u8>(), 0..32),
         )
             .prop_map(
-                |(cur_state, new_state, message_inputs, ledger_refs, outputs, extra_data)| {
+                |(
+                    seq_no,
+                    cur_state,
+                    new_state,
+                    message_inputs,
+                    ledger_refs,
+                    outputs,
+                    extra_data,
+                )| {
                     UpdateProofPubParams {
+                        seq_no,
                         cur_state,
                         new_state,
                         message_inputs: message_inputs
@@ -166,4 +183,32 @@ mod tests {
     }
 
     ssz_proptest!(UpdateProofPubParams, update_proof_pub_params_strategy());
+
+    /// Regression test for the Zellic replay finding: two
+    /// `UpdateProofPubParams` that are otherwise identical but built for
+    /// different `seq_no` values must produce different SSZ encodings.
+    /// `compute_update_claim` (in `strata-snark-acct-sys`) hashes this SSZ
+    /// encoding into the proof claim, so this property is what prevents an
+    /// older proof from being replayed at a later `seq_no`.
+    #[test]
+    fn pub_params_encoding_binds_seq_no() {
+        let proof_state = ProofState::new([0u8; 32].into(), 0);
+        let make = |seq_no: u64| {
+            UpdateProofPubParams::new(
+                Seqno::new(seq_no),
+                proof_state.clone(),
+                proof_state.clone(),
+                Vec::new(),
+                LedgerRefs::new_empty(),
+                UpdateOutputs::new_empty(),
+                Vec::new(),
+            )
+            .as_ssz_bytes()
+        };
+        assert_ne!(
+            make(7),
+            make(8),
+            "claim must differ across seq_no to prevent proof replay"
+        );
+    }
 }

--- a/crates/snark-acct-types/ssz/proof_interface.ssz
+++ b/crates/snark-acct-types/ssz/proof_interface.ssz
@@ -9,6 +9,11 @@ MAX_MESSAGE_ENTRIES = 2 << 10
 ### Public params that we provide as the claim the proof must prove the relate
 ### to each other correctly.
 class UpdateProofPubParams(Container):
+    ### Sequence number this update is authorized under.  Binding this into
+    ### the claim prevents replaying the same proof under a different
+    ### replay-protection counter.
+    seq_no: uint64
+
     ### Current state we're extending.
     cur_state: state.ProofState
 


### PR DESCRIPTION
## Description

This PR fixes an audit finding by adding a `seq_no` field to the snark account update proof interface, binding the proofs to a specific update seqno.

Claude did most of the low-level work with me guiding it to minimize change blast radius.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
