### PR TITLE
fix(ee): preserve blockhash witness lookups

### DIFF
--- a/crates/ee-acct-types/src/traits.rs
+++ b/crates/ee-acct-types/src/traits.rs
@@ -106,6 +106,20 @@ pub trait ExecutionEnvironment: Sized + 'static {
         state: &mut Self::PartialState,
         wb: &Self::WriteBatch,
     ) -> EnvResult<()>;
+
+    /// Updates partial state with data derived from a successfully executed block.
+    ///
+    /// Execution environments that expose per-block lookups to later blocks in
+    /// the same chunk must override this method. The default no-op is only safe
+    /// when no post-block metadata, such as block hashes, is needed by subsequent
+    /// executions.
+    fn update_partial_state_after_block(
+        &self,
+        _state: &mut Self::PartialState,
+        _header: &<Self::Block as ExecBlock>::Header,
+    ) -> EnvResult<()> {
+        Ok(())
+    }
 }
 
 /// Block assembly trait for constructing complete headers from execution outputs.

--- a/crates/ee-chunk-runtime/src/chunk_processing.rs
+++ b/crates/ee-chunk-runtime/src/chunk_processing.rs
@@ -32,6 +32,7 @@ pub fn process_block<E: ExecutionEnvironment>(
 
     // Merge the changes and return the outputs.
     ee.merge_write_into_state(state, exec_outp.write_batch())?;
+    ee.update_partial_state_after_block(state, eb.get_header())?;
 
     Ok(())
 }

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -17,7 +17,7 @@ use rsp_client_executor::BlockValidator;
 use strata_acct_types::{AccountId, BitcoinAmount, MsgPayload};
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::{
-    BlockAssembler, EnvError, EnvResult, ExecBlockOutput, ExecPartialState, ExecPayload,
+    BlockAssembler, EnvError, EnvResult, ExecBlock, ExecBlockOutput, ExecPartialState, ExecPayload,
     ExecutionEnvironment,
 };
 use strata_ee_chain_types::{ExecInputs, ExecOutputs, OutputMessage};
@@ -212,6 +212,15 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
 
         Ok(())
     }
+
+    fn update_partial_state_after_block(
+        &self,
+        state: &mut Self::PartialState,
+        header: &<Self::Block as ExecBlock>::Header,
+    ) -> EnvResult<()> {
+        state.add_executed_block(header.header().clone());
+        Ok(())
+    }
 }
 
 impl BlockAssembler for EvmExecutionEnvironment {
@@ -256,6 +265,12 @@ impl BlockAssembler for EvmExecutionEnvironment {
 mod tests {
     use std::{fs, path::PathBuf};
 
+    use alloy_consensus::Sealable;
+    use reth_primitives_traits::Block as RethBlockTrait;
+    use revm::DatabaseRef;
+    use revm_primitives::B256;
+    use rsp_client_executor::io::EthClientExecutorInput;
+    use serde::Deserialize;
     use strata_ee_acct_types::ExecBlock;
     use strata_msg_fmt::{Msg, MsgRef};
     use strata_ol_bridge_types::OperatorSelection;
@@ -304,13 +319,58 @@ mod tests {
         assert_eq!(withdrawal.dest_desc(), destination_bytes.as_slice());
     }
 
+    #[test]
+    fn update_partial_state_after_block_adds_block_hash_for_subsequent_blocks() {
+        #[derive(Deserialize, Debug)]
+        struct TestData {
+            witness: EthClientExecutorInput,
+        }
+
+        let test_data_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("test-utils/data/evm_ee/witness_params.json");
+
+        let json_content = fs::read_to_string(&test_data_path)
+            .expect("Failed to read witness_params.json from test-utils/data/evm_ee");
+
+        let test_data: TestData =
+            serde_json::from_str(&json_content).expect("Failed to parse test data");
+
+        let chain_spec: Arc<ChainSpec> = Arc::new((&test_data.witness.genesis).try_into().unwrap());
+        let env = EvmExecutionEnvironment::new(chain_spec);
+        let header = test_data.witness.current_block.header().clone();
+        let evm_header = EvmHeader::new(header.clone());
+        let mut state = EvmPartialState::new(
+            test_data.witness.parent_state,
+            test_data.witness.bytecodes,
+            test_data.witness.ancestor_headers,
+        );
+
+        assert_eq!(
+            state
+                .create_witness_db()
+                .block_hash_ref(header.number)
+                .expect("block hash lookup must succeed"),
+            B256::ZERO
+        );
+
+        env.update_partial_state_after_block(&mut state, &evm_header)
+            .expect("post-block state update should succeed");
+
+        assert_eq!(
+            state
+                .create_witness_db()
+                .block_hash_ref(header.number)
+                .expect("block hash lookup must succeed"),
+            header.seal_slow().hash()
+        );
+    }
+
     /// Test with real witness data from the reference implementation.
     /// This is an integration test that validates the full execution flow with real block data.
     #[test]
     fn test_with_witness_params() {
-        use rsp_client_executor::io::EthClientExecutorInput;
-        use serde::Deserialize;
-
         #[derive(Deserialize, Debug)]
         struct TestData {
             witness: EthClientExecutorInput,
@@ -344,7 +404,6 @@ mod tests {
         let evm_header = EvmHeader::new(header.clone());
 
         // Get transactions from the block
-        use reth_primitives_traits::Block as RethBlockTrait;
         let block_body = test_data.witness.current_block.body().clone();
         let evm_body = EvmBlockBody::from_alloy_body(block_body);
 

--- a/crates/evm-ee/src/types/partial_state.rs
+++ b/crates/evm-ee/src/types/partial_state.rs
@@ -22,7 +22,7 @@ use crate::{
 /// Partial state for EVM block execution.
 ///
 /// Contains the witness data needed to execute a block: the sparse Merkle Patricia Trie
-/// state, contract bytecodes, and ancestor block headers for BLOCKHASH opcode support.
+/// state, contract bytecodes, and ancestor block headers for `BLOCKHASH` opcode support.
 ///
 /// This struct pre-computes expensive operations (header hashing, block hash map) during
 /// construction to avoid repeated work when preparing witness databases.
@@ -36,7 +36,7 @@ pub struct EvmPartialState {
     /// Ancestor block headers with pre-computed hashes, indexed by block number.
     /// Headers are sealed once during construction to avoid repeated hash computations.
     ancestor_headers: BTreeMap<u64, Sealed<Header>>,
-    /// Pre-computed block hash lookup map for BLOCKHASH opcode.
+    /// Pre-computed block hash lookup map for `BLOCKHASH` opcode.
     /// Built once during construction from sealed ancestor headers.
     block_hashes: HashMap<u64, B256>,
 }
@@ -75,31 +75,7 @@ impl EvmPartialState {
             })
             .collect();
 
-        // Validate header chain and build block_hashes map once
-        let mut block_hashes: HashMap<u64, B256> = HashMap::with_hasher(Default::default());
-        for (child_sealed, parent_sealed) in ancestor_headers.values().tuple_windows() {
-            // Validate block number continuity
-            assert_eq!(
-                parent_sealed.number() + 1,
-                child_sealed.number(),
-                "Invalid header block number: expected {}, got {}",
-                parent_sealed.number() + 1,
-                child_sealed.number()
-            );
-
-            // Validate parent hash matches
-            let parent_hash = parent_sealed.hash();
-            assert_eq!(
-                parent_hash,
-                child_sealed.parent_hash(),
-                "Invalid header parent hash: expected {}, got {}",
-                parent_hash,
-                child_sealed.parent_hash()
-            );
-
-            // Insert parent's hash into block_hashes map
-            block_hashes.insert(parent_sealed.number(), child_sealed.parent_hash());
-        }
+        let block_hashes = build_block_hashes(&ancestor_headers);
 
         Self {
             ethereum_state,
@@ -146,7 +122,7 @@ impl EvmPartialState {
     /// Adds a newly executed block's header to the witness state.
     ///
     /// This is called after executing a block in a batch to make its hash
-    /// available for BLOCKHASH opcode in subsequent blocks.
+    /// available for `BLOCKHASH` opcode in subsequent blocks.
     // NOTE: not sure we we should be adding this in proof generation flow. Looks like we can
     // prepare all of this for whole batch while generating witness.
     pub fn add_executed_block(&mut self, header: Header) {
@@ -247,31 +223,7 @@ impl Codec for EvmPartialState {
             .map(|sealed| (sealed.number(), sealed))
             .collect();
 
-        // Validate header chain and build block_hashes map
-        let mut block_hashes: HashMap<u64, B256> = HashMap::with_hasher(Default::default());
-        for (child_sealed, parent_sealed) in ancestor_headers.values().tuple_windows() {
-            // Validate block number continuity
-            assert_eq!(
-                parent_sealed.number() + 1,
-                child_sealed.number(),
-                "Invalid header block number: expected {}, got {}",
-                parent_sealed.number() + 1,
-                child_sealed.number()
-            );
-
-            // Validate parent hash matches
-            let parent_hash = parent_sealed.hash();
-            assert_eq!(
-                parent_hash,
-                child_sealed.parent_hash(),
-                "Invalid header parent hash: expected {}, got {}",
-                parent_hash,
-                child_sealed.parent_hash()
-            );
-
-            // Insert parent's hash into block_hashes map
-            block_hashes.insert(parent_sealed.number(), child_sealed.parent_hash());
-        }
+        let block_hashes = build_block_hashes(&ancestor_headers);
 
         Ok(Self {
             ethereum_state,
@@ -280,4 +232,34 @@ impl Codec for EvmPartialState {
             block_hashes,
         })
     }
+}
+
+/// Validates ancestor header continuity and builds the `BLOCKHASH` lookup map.
+///
+/// The lookup map stores every ancestor block number with that header's own hash,
+/// matching EVM `BLOCKHASH(n)` semantics.
+fn build_block_hashes(ancestor_headers: &BTreeMap<u64, Sealed<Header>>) -> HashMap<u64, B256> {
+    for (parent_sealed, child_sealed) in ancestor_headers.values().tuple_windows() {
+        assert_eq!(
+            parent_sealed.number() + 1,
+            child_sealed.number(),
+            "Invalid header block number: expected {}, got {}",
+            parent_sealed.number() + 1,
+            child_sealed.number()
+        );
+
+        let parent_hash = parent_sealed.hash();
+        assert_eq!(
+            parent_hash,
+            child_sealed.parent_hash(),
+            "Invalid header parent hash: expected {}, got {}",
+            parent_hash,
+            child_sealed.parent_hash()
+        );
+    }
+
+    ancestor_headers
+        .values()
+        .map(|sealed_header| (sealed_header.number(), sealed_header.hash()))
+        .collect()
 }

--- a/crates/evm-ee/src/types/tests.rs
+++ b/crates/evm-ee/src/types/tests.rs
@@ -2,7 +2,8 @@
 
 use std::{fs::read_to_string, path::PathBuf};
 
-use alloy_consensus::Header;
+use alloy_consensus::{Header, Sealable};
+use revm::DatabaseRef;
 use revm_primitives::alloy_primitives::{Address, B256, Bloom, Bytes, U256};
 use rsp_client_executor::io::EthClientExecutorInput;
 use serde::Deserialize;
@@ -59,6 +60,44 @@ fn create_test_header() -> Header {
         excess_blob_gas: None,
         parent_beacon_block_root: None,
         requests_hash: None,
+    }
+}
+
+fn create_test_header_at(number: u64, parent_hash: B256) -> Header {
+    let mut header = create_test_header();
+    header.parent_hash = parent_hash;
+    header.number = number;
+    header.timestamp += number;
+    header.extra_data = Bytes::from(number.to_be_bytes().to_vec());
+    header
+}
+
+fn create_test_ancestor_headers() -> Vec<Header> {
+    let parent = create_test_header_at(100, B256::from([42u8; 32]));
+    let child = create_test_header_at(101, parent.clone().seal_slow().hash());
+    let grandchild = create_test_header_at(102, child.clone().seal_slow().hash());
+
+    vec![parent, child, grandchild]
+}
+
+fn assert_block_hashes_match_headers(partial_state: &EvmPartialState, headers: &[Header]) {
+    let witness_db = partial_state.create_witness_db();
+
+    assert_eq!(partial_state.block_hashes().len(), headers.len());
+
+    for header in headers {
+        let sealed = header.clone().seal_slow();
+
+        assert_eq!(
+            partial_state.block_hashes().get(&header.number).copied(),
+            Some(sealed.hash())
+        );
+        assert_eq!(
+            witness_db
+                .block_hash_ref(header.number)
+                .expect("block hash lookup must succeed"),
+            sealed.hash()
+        );
     }
 }
 
@@ -216,6 +255,64 @@ fn test_evm_partial_state_codec_roundtrip() {
 
     // Verify ancestor headers match
     assert_eq!(decoded.ancestor_headers(), partial_state.ancestor_headers());
+}
+
+#[test]
+fn test_evm_partial_state_block_hashes_include_single_ancestor() {
+    let witness = load_witness_test_data();
+    let ancestor_headers = vec![
+        create_test_ancestor_headers()
+            .into_iter()
+            .next()
+            .expect("test ancestor"),
+    ];
+    let partial_state =
+        EvmPartialState::new(witness.parent_state, vec![], ancestor_headers.clone());
+
+    assert_block_hashes_match_headers(&partial_state, &ancestor_headers);
+}
+
+#[test]
+fn test_evm_partial_state_block_hashes_include_all_ancestors() {
+    let witness = load_witness_test_data();
+    let ancestor_headers = create_test_ancestor_headers();
+    let partial_state =
+        EvmPartialState::new(witness.parent_state, vec![], ancestor_headers.clone());
+
+    assert_block_hashes_match_headers(&partial_state, &ancestor_headers);
+}
+
+#[test]
+fn test_evm_partial_state_block_hashes_survive_codec_roundtrip() {
+    let witness = load_witness_test_data();
+    let ancestor_headers = create_test_ancestor_headers();
+    let partial_state =
+        EvmPartialState::new(witness.parent_state, vec![], ancestor_headers.clone());
+
+    let encoded = encode_to_vec(&partial_state).expect("encode failed");
+    let decoded: EvmPartialState = decode_buf_exact(&encoded).expect("decode failed");
+
+    assert_block_hashes_match_headers(&decoded, &ancestor_headers);
+}
+
+#[test]
+#[should_panic(expected = "Invalid header block number")]
+fn test_evm_partial_state_rejects_non_contiguous_ancestor_headers() {
+    let witness = load_witness_test_data();
+    let parent = create_test_header_at(100, B256::from([42u8; 32]));
+    let child = create_test_header_at(102, parent.clone().seal_slow().hash());
+
+    EvmPartialState::new(witness.parent_state, vec![], vec![parent, child]);
+}
+
+#[test]
+#[should_panic(expected = "Invalid header parent hash")]
+fn test_evm_partial_state_rejects_invalid_ancestor_parent_hash() {
+    let witness = load_witness_test_data();
+    let mut ancestor_headers = create_test_ancestor_headers();
+    ancestor_headers[1].parent_hash = B256::from([99u8; 32]);
+
+    EvmPartialState::new(witness.parent_state, vec![], ancestor_headers);
 }
 
 /// Verifies that a codec-roundtripped EvmPartialState can still execute blocks.


### PR DESCRIPTION
## Description

Fixes `BLOCKHASH(n)` witness handling across both pre-chunk ancestor headers and blocks executed earlier in the same chunk.

Ancestor headers are stored in a `BTreeMap`, so iteration is ascending by block number. The previous tuple-window validation treated `(parent, child)` as `(child, parent)`, causing multi-header ancestor witnesses to panic. The old pairwise map construction would also omit the highest ancestor header.

This PR now builds `block_hashes` with the direct invariant:

`block_hashes[n] = hash(header n)`

It also wires chunk execution to update the EVM partial state after each successfully executed block, so later blocks in the same chunk can resolve `BLOCKHASH` for earlier same-chunk block numbers instead of seeing the default zero hash.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The serialized `EvmPartialState` format is unchanged. The behavioral changes are:

- Ancestor header validation now follows parent-child ordering.
- Every included ancestor header contributes its own block hash to the witness lookup map.
- Chunk execution calls a post-block partial-state hook after successful merges.
- EVM partial state uses that hook to record executed block headers for subsequent same-chunk `BLOCKHASH` lookups.

Added tests cover:

- Single-ancestor witnesses populate the block hash map.
- Multi-header ancestor witnesses no longer panic.
- Every ancestor block number maps to that header’s own hash.
- Codec roundtrip preserves the complete `BLOCKHASH` lookup map.
- Invalid ancestor chains still panic during validation.
- The EVM post-block hook makes an executed block hash available for subsequent blocks.

Used AI to assist in the PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3495