### PR TITLE
fix(csm): reshape L1Checkpoint and fix ClientState finality (STR-2438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15399,10 +15399,12 @@ dependencies = [
  "bitcoin",
  "borsh",
  "serde",
+ "strata-asm-proto-checkpoint-types",
  "strata-btc-types",
  "strata-checkpoint-types",
  "strata-identifiers",
  "strata-primitives",
+ "strata-test-utils",
 ]
 
 [[package]]

--- a/crates/consensus-logic/src/checkpoint_verification.rs
+++ b/crates/consensus-logic/src/checkpoint_verification.rs
@@ -1,25 +1,23 @@
 //! General handling around checkpoint verification.
 
+use strata_asm_proto_checkpoint_types::CheckpointTip;
 use strata_chaintsn::transition::verify_checkpoint_proof;
 use strata_checkpoint_types::{BatchInfo, Checkpoint};
-use strata_csm_types::L1Checkpoint;
 use strata_params::RollupParams;
 use tracing::*;
 use zkaleido::ProofReceipt;
 
 use crate::errors::CheckpointError;
 
-/// Verifies if a checkpoint if valid, given the context of a previous checkpoint.
+/// Verifies if a checkpoint is valid, given the context of a previous checkpoint.
 ///
 /// If this is the first checkpoint we verify, then there is no checkpoint to
 /// check against.
 ///
 /// This does NOT check the signature.
-// TODO reduce this to actually just passing in the core information we really
-// need, not like the height
 pub fn verify_checkpoint(
     checkpoint: &Checkpoint,
-    prev_checkpoint: Option<&L1Checkpoint>,
+    prev_tip: Option<&CheckpointTip>,
     params: &RollupParams,
 ) -> Result<(), CheckpointError> {
     // First thing obviously is to verify the proof.  No sense in continuing if
@@ -28,7 +26,7 @@ pub fn verify_checkpoint(
     verify_proof(checkpoint, &proof_receipt, params)?;
 
     // And check that we're building upon the previous state correctly.
-    if let Some(prev) = prev_checkpoint {
+    if let Some(prev) = prev_tip {
         verify_checkpoint_extends(checkpoint, prev, params)?;
     } else {
         // If it's the first checkpoint we want it to be the initial epoch.
@@ -43,11 +41,11 @@ pub fn verify_checkpoint(
 /// Verifies that the a checkpoint extends the state of a previous checkpoint.
 fn verify_checkpoint_extends(
     checkpoint: &Checkpoint,
-    prev: &L1Checkpoint,
+    prev: &CheckpointTip,
     _params: &RollupParams,
 ) -> Result<(), CheckpointError> {
     let epoch = checkpoint.batch_info().epoch();
-    let prev_epoch = prev.batch_info.epoch();
+    let prev_epoch = prev.epoch;
 
     // Check that the epoch numbers line up.
     if epoch != prev_epoch + 1 {

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -161,4 +161,14 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
             .ol_checkpoint()
             .get_checkpoint_l1_ref_blocking(commitment)?)
     }
+
+    fn get_checkpoint_payload(
+        &self,
+        commitment: EpochCommitment,
+    ) -> anyhow::Result<Option<CheckpointPayload>> {
+        Ok(self
+            .storage
+            .ol_checkpoint()
+            .get_checkpoint_l1_observed_payload_blocking(commitment)?)
+    }
 }

--- a/crates/csm-types/Cargo.toml
+++ b/crates/csm-types/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+strata-asm-proto-checkpoint-types.workspace = true
 strata-btc-types.workspace = true
 strata-checkpoint-types.workspace = true
 strata-identifiers.workspace = true
@@ -18,6 +19,7 @@ serde.workspace = true
 
 [dev-dependencies]
 bitcoin.workspace = true
+strata-test-utils.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/csm-types/src/client_state.rs
+++ b/crates/csm-types/src/client_state.rs
@@ -64,7 +64,7 @@ impl ClientState {
     pub fn get_last_epoch(&self) -> Option<EpochCommitment> {
         self.last_seen_checkpoint
             .as_ref()
-            .map(epoch_commitment_for_tip)
+            .map(EpochCommitment::from)
     }
 
     /// Gets the last checkpoint that has already been finalized.
@@ -76,7 +76,7 @@ impl ClientState {
     pub fn get_declared_final_epoch(&self) -> Option<EpochCommitment> {
         self.last_finalized_checkpoint
             .as_ref()
-            .map(epoch_commitment_for_tip)
+            .map(EpochCommitment::from)
     }
 
     /// Gets the next epoch we expect to be confirmed.
@@ -86,10 +86,6 @@ impl ClientState {
             .map(|ck| ck.tip.epoch + 1)
             .unwrap_or(0u32)
     }
-}
-
-fn epoch_commitment_for_tip(checkpoint: &L1Checkpoint) -> EpochCommitment {
-    EpochCommitment::from_terminal(checkpoint.tip.epoch, checkpoint.tip.l2_commitment)
 }
 
 /// A [`ClientState`] wrapper used in StatusChannel.
@@ -171,6 +167,12 @@ impl fmt::Display for L1Checkpoint {
 impl L1Checkpoint {
     pub fn new(tip: CheckpointTip, l1_reference: CheckpointL1Ref) -> Self {
         Self { tip, l1_reference }
+    }
+}
+
+impl From<&L1Checkpoint> for EpochCommitment {
+    fn from(checkpoint: &L1Checkpoint) -> Self {
+        EpochCommitment::from_terminal(checkpoint.tip.epoch, checkpoint.tip.l2_commitment)
     }
 }
 

--- a/crates/csm-types/src/client_state.rs
+++ b/crates/csm-types/src/client_state.rs
@@ -4,11 +4,16 @@
 
 use core::fmt;
 
-use arbitrary::Arbitrary;
-use borsh::{BorshDeserialize, BorshSerialize};
+use arbitrary::{Arbitrary, Unstructured};
+use borsh::{
+    io::{Read, Result as BorshIoResult, Write},
+    BorshDeserialize, BorshSerialize,
+};
 use serde::{Deserialize, Serialize};
-use strata_checkpoint_types::BatchInfo;
-use strata_identifiers::{Epoch, EpochCommitment, L1BlockCommitment, L1BlockId, L1Height, RBuf32};
+use strata_asm_proto_checkpoint_types::CheckpointTip;
+use strata_identifiers::{
+    Epoch, EpochCommitment, L1BlockCommitment, L1BlockId, L1Height, OLBlockCommitment, RBuf32,
+};
 
 /// High level client's checkpoint view of the network. This is local to the client, not
 /// coordinated as part of the L2 chain.
@@ -59,7 +64,7 @@ impl ClientState {
     pub fn get_last_epoch(&self) -> Option<EpochCommitment> {
         self.last_seen_checkpoint
             .as_ref()
-            .map(|c| c.batch_info.get_epoch_commitment())
+            .map(epoch_commitment_for_tip)
     }
 
     /// Gets the last checkpoint that has already been finalized.
@@ -71,16 +76,20 @@ impl ClientState {
     pub fn get_declared_final_epoch(&self) -> Option<EpochCommitment> {
         self.last_finalized_checkpoint
             .as_ref()
-            .map(|ckpt| ckpt.batch_info.get_epoch_commitment())
+            .map(epoch_commitment_for_tip)
     }
 
     /// Gets the next epoch we expect to be confirmed.
     pub fn get_next_expected_epoch_conf(&self) -> Epoch {
         self.last_seen_checkpoint
             .as_ref()
-            .map(|ck| ck.batch_info.get_epoch_commitment().epoch() + 1)
+            .map(|ck| ck.tip.epoch + 1)
             .unwrap_or(0u32)
     }
+}
+
+fn epoch_commitment_for_tip(checkpoint: &L1Checkpoint) -> EpochCommitment {
+    EpochCommitment::from_terminal(checkpoint.tip.epoch, checkpoint.tip.l2_commitment)
 }
 
 /// A [`ClientState`] wrapper used in StatusChannel.
@@ -136,14 +145,20 @@ impl CheckpointL1Ref {
     }
 }
 
-#[derive(
-    Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Deserialize, Serialize)]
 pub struct L1Checkpoint {
-    /// The inner checkpoint batch info.
-    pub batch_info: BatchInfo,
+    /// Tip published by the ASM checkpoint subprotocol for this checkpoint.
+    ///
+    /// `tip.l1_height` is the L1 view consumed by the OL for this epoch — distinct
+    /// from `l1_reference.l1_commitment`, which records where the checkpoint
+    /// envelope was observed on L1.
+    #[borsh(
+        serialize_with = "borsh_serialize_checkpoint_tip",
+        deserialize_with = "borsh_deserialize_checkpoint_tip"
+    )]
+    pub tip: CheckpointTip,
 
-    /// L1 reference for this checkpoint.
+    /// L1 reference for the envelope that carried this checkpoint.
     pub l1_reference: CheckpointL1Ref,
 }
 
@@ -154,10 +169,61 @@ impl fmt::Display for L1Checkpoint {
 }
 
 impl L1Checkpoint {
-    pub fn new(batch_info: BatchInfo, l1_reference: CheckpointL1Ref) -> Self {
-        Self {
-            batch_info,
-            l1_reference,
-        }
+    pub fn new(tip: CheckpointTip, l1_reference: CheckpointL1Ref) -> Self {
+        Self { tip, l1_reference }
+    }
+}
+
+// `CheckpointTip` lives in an external crate and doesn't derive `Arbitrary`.
+// Construct one field-by-field; the orphan rule prevents impl-ing `Arbitrary`
+// directly on `CheckpointTip`.
+impl<'a> Arbitrary<'a> for L1Checkpoint {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let tip = CheckpointTip {
+            epoch: Epoch::arbitrary(u)?,
+            l1_height: L1Height::arbitrary(u)?,
+            l2_commitment: OLBlockCommitment::arbitrary(u)?,
+        };
+        let l1_reference = CheckpointL1Ref::arbitrary(u)?;
+        Ok(Self { tip, l1_reference })
+    }
+}
+
+// Field-level Borsh codec for `CheckpointTip`: the external SSZ-generated type
+// has no Borsh derive and the orphan rule blocks adding one. Order matches the
+// struct definition.
+fn borsh_serialize_checkpoint_tip<W: Write>(
+    tip: &CheckpointTip,
+    writer: &mut W,
+) -> BorshIoResult<()> {
+    BorshSerialize::serialize(&tip.epoch, writer)?;
+    BorshSerialize::serialize(&tip.l1_height, writer)?;
+    BorshSerialize::serialize(&tip.l2_commitment, writer)?;
+    Ok(())
+}
+
+fn borsh_deserialize_checkpoint_tip<R: Read>(reader: &mut R) -> BorshIoResult<CheckpointTip> {
+    let epoch = BorshDeserialize::deserialize_reader(reader)?;
+    let l1_height = BorshDeserialize::deserialize_reader(reader)?;
+    let l2_commitment = BorshDeserialize::deserialize_reader(reader)?;
+    Ok(CheckpointTip {
+        epoch,
+        l1_height,
+        l2_commitment,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_test_utils::ArbitraryGenerator;
+
+    use super::*;
+
+    #[test]
+    fn l1_checkpoint_borsh_roundtrip() {
+        let original: L1Checkpoint = ArbitraryGenerator::new().generate();
+        let bytes = borsh::to_vec(&original).expect("borsh encode");
+        let decoded: L1Checkpoint = borsh::from_slice(&bytes).expect("borsh decode");
+        assert_eq!(decoded, original);
     }
 }

--- a/crates/csm-types/src/client_state.rs
+++ b/crates/csm-types/src/client_state.rs
@@ -5,10 +5,7 @@
 use core::fmt;
 
 use arbitrary::{Arbitrary, Unstructured};
-use borsh::{
-    io::{Read, Result as BorshIoResult, Write},
-    BorshDeserialize, BorshSerialize,
-};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_asm_proto_checkpoint_types::CheckpointTip;
 use strata_identifiers::{
@@ -148,10 +145,10 @@ pub struct L1Checkpoint {
     /// `tip.l1_height` is the L1 view consumed by the OL for this epoch — distinct
     /// from `l1_reference.l1_commitment`, which records where the checkpoint
     /// envelope was observed on L1.
-    #[borsh(
-        serialize_with = "borsh_serialize_checkpoint_tip",
-        deserialize_with = "borsh_deserialize_checkpoint_tip"
-    )]
+    ///
+    /// `CheckpointTip` is SSZ-defined; its Borsh impl is provided by
+    /// `impl_borsh_via_ssz_fixed!` in `strata-asm-proto-checkpoint-types`, so a
+    /// plain Borsh derive on the parent works without field-level codecs.
     pub tip: CheckpointTip,
 
     /// L1 reference for the envelope that carried this checkpoint.
@@ -176,9 +173,9 @@ impl From<&L1Checkpoint> for EpochCommitment {
     }
 }
 
-// `CheckpointTip` lives in an external crate and doesn't derive `Arbitrary`.
-// Construct one field-by-field; the orphan rule prevents impl-ing `Arbitrary`
-// directly on `CheckpointTip`.
+// `CheckpointTip` is an SSZ-generated type in an external crate and doesn't
+// derive `Arbitrary`; the orphan rule blocks adding it there, so we provide
+// the `Arbitrary` impl on the wrapper.
 impl<'a> Arbitrary<'a> for L1Checkpoint {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let tip = CheckpointTip {
@@ -189,30 +186,6 @@ impl<'a> Arbitrary<'a> for L1Checkpoint {
         let l1_reference = CheckpointL1Ref::arbitrary(u)?;
         Ok(Self { tip, l1_reference })
     }
-}
-
-// Field-level Borsh codec for `CheckpointTip`: the external SSZ-generated type
-// has no Borsh derive and the orphan rule blocks adding one. Order matches the
-// struct definition.
-fn borsh_serialize_checkpoint_tip<W: Write>(
-    tip: &CheckpointTip,
-    writer: &mut W,
-) -> BorshIoResult<()> {
-    BorshSerialize::serialize(&tip.epoch, writer)?;
-    BorshSerialize::serialize(&tip.l1_height, writer)?;
-    BorshSerialize::serialize(&tip.l2_commitment, writer)?;
-    Ok(())
-}
-
-fn borsh_deserialize_checkpoint_tip<R: Read>(reader: &mut R) -> BorshIoResult<CheckpointTip> {
-    let epoch = BorshDeserialize::deserialize_reader(reader)?;
-    let l1_height = BorshDeserialize::deserialize_reader(reader)?;
-    let l2_commitment = BorshDeserialize::deserialize_reader(reader)?;
-    Ok(CheckpointTip {
-        epoch,
-        l1_height,
-        l2_commitment,
-    })
 }
 
 #[cfg(test)]

--- a/crates/csm-worker/Cargo.toml
+++ b/crates/csm-worker/Cargo.toml
@@ -13,7 +13,6 @@ strata-asm-proto-checkpoint.workspace = true
 strata-asm-proto-checkpoint-txs.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
 strata-asm-worker.workspace = true
-strata-checkpoint-types.workspace = true
 strata-checkpoint-verification.workspace = true
 strata-common.workspace = true
 strata-csm-types.workspace = true
@@ -29,6 +28,7 @@ serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+strata-checkpoint-types.workspace = true
 strata-test-utils.workspace = true
 strata-db-store-sled = { workspace = true, features = ["test_utils"] }
 strata-asm-proto-checkpoint-types = { workspace = true, features = [

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -82,4 +82,12 @@ pub trait CsmWorkerContext: Send + Sync {
         &self,
         commitment: EpochCommitment,
     ) -> anyhow::Result<Option<CheckpointL1Ref>>;
+
+    /// Returns the L1-observed checkpoint payload at `commitment` (carries the
+    /// tip the checkpoint declared). Paired with [`Self::get_checkpoint_l1_ref`]
+    /// to reconstruct the full observation record at bootstrap.
+    fn get_checkpoint_payload(
+        &self,
+        commitment: EpochCommitment,
+    ) -> anyhow::Result<Option<CheckpointPayload>>;
 }

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -29,7 +29,7 @@ pub(crate) struct PendingCsmUpdate {
 
     /// Checkpoint observations made during this block, applied to the worker's
     /// finality cursors only after a successful commit.
-    pub(crate) observations: Vec<(EpochCommitment, CheckpointL1Ref)>,
+    pub(crate) observations: Vec<L1Checkpoint>,
 
     /// Per-block verification fixtures, built once on the first checkpoint tip log.
     pub(crate) ckpt_verification_ctx: Option<CheckpointVerificationContext>,
@@ -99,10 +99,9 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             );
         }
 
-        let observation =
+        let new_checkpoint =
             self.mark_ol_checkpoint_l1_observed(pending, checkpoint_tip_update, asm_block)?;
-        let new_checkpoint = L1Checkpoint::new(*checkpoint_tip_update.tip(), observation);
-        pending.cur_state = next_client_state(&pending.cur_state, new_checkpoint, epoch);
+        pending.cur_state = next_client_state(&pending.cur_state, new_checkpoint);
 
         pending.last_processed_epoch = Some(epoch);
         Ok(())
@@ -155,8 +154,10 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
     /// Folds checkpoint observations made during a successfully committed block
     /// into the worker's finality cursors.
-    fn apply_observations(&mut self, observations: Vec<(EpochCommitment, CheckpointL1Ref)>) {
-        for (commitment, observation) in observations {
+    fn apply_observations(&mut self, observations: Vec<L1Checkpoint>) {
+        for checkpoint in observations {
+            let commitment = epoch_commitment_for(&checkpoint);
+
             // Update cached confirmed epoch monotonically.
             if self
                 .confirmed_epoch
@@ -172,10 +173,9 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
                 && !self
                     .observed_checkpoints
                     .iter()
-                    .any(|(epoch, _)| *epoch == commitment)
+                    .any(|existing| epoch_commitment_for(existing) == commitment)
             {
-                self.observed_checkpoints
-                    .push_back((commitment, observation));
+                self.observed_checkpoints.push_back(checkpoint);
             }
         }
     }
@@ -183,12 +183,20 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     /// Walks the observation queue and advances `finalized_epoch` for every
     /// candidate buried at least `finality_depth` deep under `current_l1_tip`.
     ///
-    /// Returns `true` if `finalized_epoch` advanced.
-    pub(crate) fn advance_finalization(&mut self, current_l1_tip: L1Height) -> bool {
+    /// Returns the most recently finalized `L1Checkpoint` if `finalized_epoch`
+    /// advanced, else `None`. The caller uses the returned record to refresh
+    /// `ClientState.last_finalized_checkpoint` so it reflects depth-driven
+    /// finality rather than the (since-removed) observation heuristic.
+    pub(crate) fn advance_finalization(
+        &mut self,
+        current_l1_tip: L1Height,
+    ) -> Option<L1Checkpoint> {
         let prev_finalized = self.finalized_epoch;
         let finality_depth = self.ctx.l1_reorg_safe_depth().max(1);
+        let mut latest_finalized: Option<L1Checkpoint> = None;
 
-        while let Some((commitment, observation)) = self.observed_checkpoints.front() {
+        while let Some(candidate) = self.observed_checkpoints.front() {
+            let commitment = epoch_commitment_for(candidate);
             if self
                 .finalized_epoch
                 .is_some_and(|current| commitment.epoch() <= current.epoch())
@@ -198,23 +206,30 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             }
 
             let confirmations = current_l1_tip
-                .saturating_sub(observation.l1_commitment.height())
+                .saturating_sub(candidate.l1_reference.l1_commitment.height())
                 .saturating_add(1);
             if confirmations < finality_depth {
                 break;
             }
 
-            let epoch = *commitment;
-            self.observed_checkpoints.pop_front();
+            let finalized = self
+                .observed_checkpoints
+                .pop_front()
+                .expect("front returned Some above");
             if self
                 .finalized_epoch
-                .is_none_or(|current| epoch.epoch() > current.epoch())
+                .is_none_or(|current| commitment.epoch() > current.epoch())
             {
-                self.finalized_epoch = Some(epoch);
+                self.finalized_epoch = Some(commitment);
             }
+            latest_finalized = Some(finalized);
         }
 
-        self.finalized_epoch != prev_finalized
+        if self.finalized_epoch != prev_finalized {
+            latest_finalized
+        } else {
+            None
+        }
     }
 
     /// Processes `asm_block` and its logs, first replaying any ASM blocks skipped
@@ -321,7 +336,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         pending: &mut PendingCsmUpdate,
         checkpoint_tip_update: &CheckpointTipUpdate,
         asm_block: &L1BlockCommitment,
-    ) -> anyhow::Result<CheckpointL1Ref> {
+    ) -> anyhow::Result<L1Checkpoint> {
         let tip = checkpoint_tip_update.tip();
         let _span = info_span!("mark_ol_checkpoint_l1_observed", epoch = tip.epoch).entered();
         let commitment = EpochCommitment::from_terminal(tip.epoch, *tip.l2_commitment());
@@ -351,55 +366,36 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             observation.clone(),
         )?;
 
-        pending.observations.push((commitment, observation.clone()));
+        let checkpoint = L1Checkpoint::new(*tip, observation);
+        pending.observations.push(checkpoint.clone());
 
         debug!(
             ?commitment,
             l1_height = asm_block.height(),
-            txid = ?extracted.txid,
-            wtxid = ?extracted.wtxid,
+            txid = ?checkpoint.l1_reference.txid,
+            wtxid = ?checkpoint.l1_reference.wtxid,
             "Recorded OL checkpoint L1 ref from tip update"
         );
-        Ok(observation)
+        Ok(checkpoint)
     }
 }
 
-/// Returns the next client state after folding `new_checkpoint` for `epoch`
-/// into `prev`.
-fn next_client_state(
-    prev: &ClientState,
-    new_checkpoint: L1Checkpoint,
-    epoch: Epoch,
-) -> Arc<ClientState> {
-    // Slot the new checkpoint into `ClientState`'s two-slot view.
-    //
-    // `last_seen_checkpoint` holds the most recent tip we've observed on L1.
-    // `last_finalized_checkpoint` is set to the *previous* `last_seen` once a
-    // successor's tip is observed — i.e. a heuristic, not depth-based finality.
-    //
-    // FIXME: This is not real finality. Actual depth-driven finalization lives
-    // in `CsmWorkerState::finalized_epoch` and the observed-checkpoint queue.
-    // The two coexisting notions can diverge. The recent/finalized split here
-    // should be removed and consumers should read finality from the persisted
-    // observation facts (or `CsmWorkerState`) directly. Out of scope for the
-    // STR-2438 shape refactor.
-    let (last_finalized, recent) = match prev.get_last_checkpoint() {
-        Some(existing) => {
-            // If the new checkpoint is for a later epoch, it becomes recent
-            if epoch > existing.tip.epoch {
-                (Some(existing.clone()), Some(new_checkpoint))
-            } else {
-                // Otherwise keep existing
-                (Some(existing.clone()), None)
-            }
-        }
-        None => {
-            // New checkpoint is the first checkpoint, and it is marked recent
-            (None, Some(new_checkpoint))
-        }
-    };
+/// Derives the [`EpochCommitment`] for a checkpoint from its tip.
+pub(crate) fn epoch_commitment_for(checkpoint: &L1Checkpoint) -> EpochCommitment {
+    EpochCommitment::from_terminal(checkpoint.tip.epoch, checkpoint.tip.l2_commitment)
+}
 
-    Arc::new(ClientState::new(last_finalized, recent))
+/// Returns the next client state after recording `new_checkpoint` as the most
+/// recently observed L1 checkpoint.
+///
+/// `last_finalized_checkpoint` is untouched here; it is refreshed separately
+/// by the service loop once `advance_finalization` declares a new finalized
+/// epoch based on L1 depth.
+fn next_client_state(prev: &ClientState, new_checkpoint: L1Checkpoint) -> Arc<ClientState> {
+    Arc::new(ClientState::new(
+        prev.get_last_finalized_checkpoint(),
+        Some(new_checkpoint),
+    ))
 }
 
 /// Returns the parent L1 commitment derived from `block`'s header.
@@ -439,7 +435,7 @@ mod tests {
     };
     use strata_asm_logs::constants::DEPOSIT_LOG_TYPE_ID;
     use strata_btc_verification::L1Anchor;
-    use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput};
+    use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::RBuf32;
     use strata_l1_txfmt::MagicBytes;
@@ -450,6 +446,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
+    use super::epoch_commitment_for;
     use crate::{state::CsmWorkerState, test_utils::StubCtx};
 
     /// Builds a minimal `AsmState` carrying `logs`. The anchor state itself is
@@ -953,21 +950,23 @@ mod tests {
     }
 
     /// Builds an observation queue entry at `epoch` anchored to L1 `height`.
-    fn observation_at(epoch: u32, l1_height: L1Height) -> (EpochCommitment, CheckpointL1Ref) {
-        let commitment = EpochCommitment::from_terminal(
-            epoch,
-            OLBlockCommitment::new(
-                epoch as u64 * 10,
-                OLBlockId::from(Buf32::from([epoch as u8; 32])),
-            ),
+    fn observation_at(epoch: u32, l1_height: L1Height) -> L1Checkpoint {
+        let l2_commitment = OLBlockCommitment::new(
+            epoch as u64 * 10,
+            OLBlockId::from(Buf32::from([epoch as u8; 32])),
         );
+        let tip = strata_asm_proto_checkpoint_types::CheckpointTip {
+            epoch,
+            l1_height,
+            l2_commitment,
+        };
         let l1_block = L1BlockCommitment::new(l1_height, block_id_at(l1_height));
         let l1_ref = CheckpointL1Ref::new(
             l1_block,
             RBuf32::from([epoch as u8; 32]),
             RBuf32::from([epoch as u8; 32]),
         );
-        (commitment, l1_ref)
+        L1Checkpoint::new(tip, l1_ref)
     }
 
     /// Empty queue is a trivial no-op and never advances `finalized_epoch`.
@@ -976,20 +975,19 @@ mod tests {
         let (mut state, _) = create_test_state();
         assert!(state.observed_checkpoints.is_empty());
 
-        let changed = state.advance_finalization(1_000);
-        assert!(!changed);
+        let finalized = state.advance_finalization(1_000);
+        assert!(finalized.is_none());
         assert_eq!(state.finalized_epoch, None);
     }
 
     #[test]
     fn advance_finalization_below_depth_does_not_advance() {
         let (mut state, _) = create_test_state();
-        let obs = observation_at(1, 100);
-        state.observed_checkpoints.push_back(obs.clone());
+        state.observed_checkpoints.push_back(observation_at(1, 100));
 
         // tip at 101 has 2 confirmations, below threshold of 3.
-        let changed = state.advance_finalization(101);
-        assert!(!changed);
+        let finalized = state.advance_finalization(101);
+        assert!(finalized.is_none());
         assert_eq!(state.finalized_epoch, None);
         assert_eq!(state.observed_checkpoints.len(), 1);
     }
@@ -997,12 +995,13 @@ mod tests {
     #[test]
     fn advance_finalization_single_advance() {
         let (mut state, _) = create_test_state();
-        let (commitment, _) = observation_at(1, 100);
-        state.observed_checkpoints.push_back(observation_at(1, 100));
+        let candidate = observation_at(1, 100);
+        let commitment = epoch_commitment_for(&candidate);
+        state.observed_checkpoints.push_back(candidate.clone());
 
         // tip at 102 has 3 confirmations = depth threshold.
-        let changed = state.advance_finalization(102);
-        assert!(changed);
+        let finalized = state.advance_finalization(102);
+        assert_eq!(finalized.as_ref(), Some(&candidate));
         assert_eq!(state.finalized_epoch, Some(commitment));
         assert!(state.observed_checkpoints.is_empty());
     }
@@ -1010,14 +1009,15 @@ mod tests {
     #[test]
     fn advance_finalization_multi_advance_in_one_call() {
         let (mut state, _) = create_test_state();
-        let (_, _) = observation_at(1, 100);
-        let (commitment_2, _) = observation_at(2, 101);
-        state.observed_checkpoints.push_back(observation_at(1, 100));
-        state.observed_checkpoints.push_back(observation_at(2, 101));
+        let candidate_1 = observation_at(1, 100);
+        let candidate_2 = observation_at(2, 101);
+        let commitment_2 = epoch_commitment_for(&candidate_2);
+        state.observed_checkpoints.push_back(candidate_1);
+        state.observed_checkpoints.push_back(candidate_2.clone());
 
         // tip at 103 so both candidates have ≥ 3 confirmations.
-        let changed = state.advance_finalization(103);
-        assert!(changed);
+        let finalized = state.advance_finalization(103);
+        assert_eq!(finalized.as_ref(), Some(&candidate_2));
         assert_eq!(state.finalized_epoch, Some(commitment_2));
         assert!(state.observed_checkpoints.is_empty());
     }
@@ -1025,17 +1025,19 @@ mod tests {
     #[test]
     fn advance_finalization_stops_at_shallow_candidate() {
         let (mut state, _) = create_test_state();
-        let (commitment_1, _) = observation_at(1, 100);
-        state.observed_checkpoints.push_back(observation_at(1, 100));
-        state.observed_checkpoints.push_back(observation_at(2, 102));
+        let candidate_1 = observation_at(1, 100);
+        let commitment_1 = epoch_commitment_for(&candidate_1);
+        let candidate_2 = observation_at(2, 102);
+        state.observed_checkpoints.push_back(candidate_1.clone());
+        state.observed_checkpoints.push_back(candidate_2.clone());
 
         // tip at 102 so epoch 1 has 3 confirmations (buried), epoch 2 has 1.
-        let changed = state.advance_finalization(102);
-        assert!(changed);
+        let finalized = state.advance_finalization(102);
+        assert_eq!(finalized.as_ref(), Some(&candidate_1));
         assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert_eq!(state.observed_checkpoints.len(), 1);
         assert_eq!(
-            state.observed_checkpoints.front().map(|(e, _)| *e),
+            state.observed_checkpoints.front().map(epoch_commitment_for),
             Some(EpochCommitment::from_terminal(
                 2,
                 OLBlockCommitment::new(20, OLBlockId::from(Buf32::from([2u8; 32])))
@@ -1046,14 +1048,15 @@ mod tests {
     #[test]
     fn advance_finalization_pops_already_finalized() {
         let (mut state, _) = create_test_state();
-        let (commitment_1, _) = observation_at(1, 100);
+        let candidate = observation_at(1, 100);
+        let commitment_1 = epoch_commitment_for(&candidate);
         state.finalized_epoch = Some(commitment_1);
         // Stale entry for an epoch ≤ finalized.
-        state.observed_checkpoints.push_back(observation_at(1, 100));
+        state.observed_checkpoints.push_back(candidate);
 
-        let changed = state.advance_finalization(200);
+        let finalized = state.advance_finalization(200);
         assert!(
-            !changed,
+            finalized.is_none(),
             "popping a stale entry must not register as an advance"
         );
         assert_eq!(state.finalized_epoch, Some(commitment_1));

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -160,29 +160,37 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
     /// Folds checkpoint observations made during a successfully committed block
     /// into the worker's finality cursors.
-    fn apply_observations(&mut self, observations: Vec<L1Checkpoint>) {
+    fn apply_observations(&mut self, observations: impl IntoIterator<Item = L1Checkpoint>) {
         for checkpoint in observations {
-            let commitment = EpochCommitment::from(&checkpoint);
+            self.apply_checkpoint_observation(checkpoint);
+        }
+    }
 
-            // Update cached confirmed epoch monotonically.
-            if self
-                .confirmed_epoch
-                .is_none_or(|current| commitment.epoch() > current.epoch())
-            {
-                self.confirmed_epoch = Some(commitment);
-            }
+    /// Folds a single checkpoint observation into the worker's finality
+    /// cursors: bumps `confirmed_epoch` monotonically and queues the
+    /// observation for incremental depth-driven finalization if it's still
+    /// ahead of `finalized_epoch` and not already present.
+    fn apply_checkpoint_observation(&mut self, checkpoint: L1Checkpoint) {
+        let commitment = EpochCommitment::from(&checkpoint);
 
-            // Queue only non-finalized candidates and avoid duplicates.
-            if self
-                .finalized_epoch
-                .is_none_or(|current| commitment.epoch() > current.epoch())
-                && !self
-                    .observed_checkpoints
-                    .iter()
-                    .any(|existing| EpochCommitment::from(existing) == commitment)
-            {
-                self.observed_checkpoints.push_back(checkpoint);
-            }
+        // Update cached confirmed epoch monotonically.
+        if self
+            .confirmed_epoch
+            .is_none_or(|current| commitment.epoch() > current.epoch())
+        {
+            self.confirmed_epoch = Some(commitment);
+        }
+
+        // Queue only non-finalized candidates and avoid duplicates.
+        if self
+            .finalized_epoch
+            .is_none_or(|current| commitment.epoch() > current.epoch())
+            && !self
+                .observed_checkpoints
+                .iter()
+                .any(|existing| EpochCommitment::from(existing) == commitment)
+        {
+            self.observed_checkpoints.push_back(checkpoint);
         }
     }
 

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -7,7 +7,6 @@ use bitcoin::hashes::Hash;
 use strata_asm_common::{AsmLogEntry, Subprotocol, VerifiedAuxData};
 use strata_asm_logs::{CheckpointTipUpdate, constants::CHECKPOINT_TIP_UPDATE_LOG_TYPE};
 use strata_asm_proto_checkpoint::{CheckpointState, CheckpointSubprotocol};
-use strata_checkpoint_types::BatchInfo;
 use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
 use strata_identifiers::Epoch;
 use strata_primitives::prelude::*;
@@ -102,14 +101,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         let observation =
             self.mark_ol_checkpoint_l1_observed(pending, checkpoint_tip_update, asm_block)?;
-        // Tip logs do not contain full batch transition details.
-        // CSM only needs epoch progression for finalized-epoch signaling, so we
-        // synthesize a minimal checkpoint view from the tip.
-        // TODO(STR-2438): Remove this synthetic mapping once CSM persists/consumes
-        // these fields directly without legacy L1Checkpoint shape coupling.
-        let synthetic_checkpoint =
-            checkpoint_from_tip_update(checkpoint_tip_update, asm_block, observation);
-        pending.cur_state = next_client_state(&pending.cur_state, synthetic_checkpoint, epoch);
+        let new_checkpoint = L1Checkpoint::new(*checkpoint_tip_update.tip(), observation);
+        pending.cur_state = next_client_state(&pending.cur_state, new_checkpoint, epoch);
 
         pending.last_processed_epoch = Some(epoch);
         Ok(())
@@ -378,19 +371,22 @@ fn next_client_state(
     new_checkpoint: L1Checkpoint,
     epoch: Epoch,
 ) -> Arc<ClientState> {
-    // Determine if this checkpoint should be the last finalized or just recent.
-
-    // TODO(STR-2438): This comes from the legacy design currently and will be
-    // simplified in the future.
-    // Currently, `last_finalized` is the buried checkpoint and recent and the last be observed
-    // (the checkpoint that makes the the finalized one to be buried).
-    // It's better to store `L1Checkpoint` separately, move the
-    // logic of "recent/finalized" to the DbManager (that can actually fetches
-    // actual persisted data and doesn't rely on the current state).
+    // Slot the new checkpoint into `ClientState`'s two-slot view.
+    //
+    // `last_seen_checkpoint` holds the most recent tip we've observed on L1.
+    // `last_finalized_checkpoint` is set to the *previous* `last_seen` once a
+    // successor's tip is observed — i.e. a heuristic, not depth-based finality.
+    //
+    // FIXME: This is not real finality. Actual depth-driven finalization lives
+    // in `CsmWorkerState::finalized_epoch` and the observed-checkpoint queue.
+    // The two coexisting notions can diverge. The recent/finalized split here
+    // should be removed and consumers should read finality from the persisted
+    // observation facts (or `CsmWorkerState`) directly. Out of scope for the
+    // STR-2438 shape refactor.
     let (last_finalized, recent) = match prev.get_last_checkpoint() {
         Some(existing) => {
             // If the new checkpoint is for a later epoch, it becomes recent
-            if epoch > existing.batch_info.epoch() {
+            if epoch > existing.tip.epoch {
                 (Some(existing.clone()), Some(new_checkpoint))
             } else {
                 // Otherwise keep existing
@@ -404,27 +400,6 @@ fn next_client_state(
     };
 
     Arc::new(ClientState::new(last_finalized, recent))
-}
-
-/// Build a compatibility synthetic [`L1Checkpoint`] from a checkpoint tip update.
-fn checkpoint_from_tip_update(
-    checkpoint_tip_update: &CheckpointTipUpdate,
-    asm_block: &L1BlockCommitment,
-    l1_reference: CheckpointL1Ref,
-) -> L1Checkpoint {
-    let tip = checkpoint_tip_update.tip();
-
-    // TODO(STR-2438): This `BatchInfo` synthesis is semantically incorrect
-    // for checkpoint tip updates (start/end L1 and L2 commitments are
-    // duplicated placeholders). Replace with native checkpoint data flow
-    // and remove legacy `BatchInfo` construction.
-    let batch_info = BatchInfo::new(
-        tip.epoch,
-        (*asm_block, *asm_block),
-        (*tip.l2_commitment(), *tip.l2_commitment()),
-    );
-
-    L1Checkpoint::new(batch_info, l1_reference)
 }
 
 /// Returns the parent L1 commitment derived from `block`'s header.

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -101,7 +101,13 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         let new_checkpoint =
             self.mark_ol_checkpoint_l1_observed(pending, checkpoint_tip_update, asm_block)?;
-        pending.cur_state = next_client_state(&pending.cur_state, new_checkpoint);
+        // `last_finalized_checkpoint` is left as the previous value here; the
+        // service loop refreshes it once `advance_finalization` declares a new
+        // finalized epoch based on L1 depth.
+        pending.cur_state = Arc::new(ClientState::new(
+            pending.cur_state.get_last_finalized_checkpoint(),
+            Some(new_checkpoint),
+        ));
 
         pending.last_processed_epoch = Some(epoch);
         Ok(())
@@ -156,7 +162,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     /// into the worker's finality cursors.
     fn apply_observations(&mut self, observations: Vec<L1Checkpoint>) {
         for checkpoint in observations {
-            let commitment = epoch_commitment_for(&checkpoint);
+            let commitment = EpochCommitment::from(&checkpoint);
 
             // Update cached confirmed epoch monotonically.
             if self
@@ -173,7 +179,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
                 && !self
                     .observed_checkpoints
                     .iter()
-                    .any(|existing| epoch_commitment_for(existing) == commitment)
+                    .any(|existing| EpochCommitment::from(existing) == commitment)
             {
                 self.observed_checkpoints.push_back(checkpoint);
             }
@@ -196,7 +202,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let mut latest_finalized: Option<L1Checkpoint> = None;
 
         while let Some(candidate) = self.observed_checkpoints.front() {
-            let commitment = epoch_commitment_for(candidate);
+            let commitment = EpochCommitment::from(candidate);
             if self
                 .finalized_epoch
                 .is_some_and(|current| commitment.epoch() <= current.epoch())
@@ -380,24 +386,6 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     }
 }
 
-/// Derives the [`EpochCommitment`] for a checkpoint from its tip.
-pub(crate) fn epoch_commitment_for(checkpoint: &L1Checkpoint) -> EpochCommitment {
-    EpochCommitment::from_terminal(checkpoint.tip.epoch, checkpoint.tip.l2_commitment)
-}
-
-/// Returns the next client state after recording `new_checkpoint` as the most
-/// recently observed L1 checkpoint.
-///
-/// `last_finalized_checkpoint` is untouched here; it is refreshed separately
-/// by the service loop once `advance_finalization` declares a new finalized
-/// epoch based on L1 depth.
-fn next_client_state(prev: &ClientState, new_checkpoint: L1Checkpoint) -> Arc<ClientState> {
-    Arc::new(ClientState::new(
-        prev.get_last_finalized_checkpoint(),
-        Some(new_checkpoint),
-    ))
-}
-
 /// Returns the parent L1 commitment derived from `block`'s header.
 ///
 /// Fails for the genesis block where no parent exists; that case isn't
@@ -446,7 +434,6 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::epoch_commitment_for;
     use crate::{state::CsmWorkerState, test_utils::StubCtx};
 
     /// Builds a minimal `AsmState` carrying `logs`. The anchor state itself is
@@ -996,7 +983,7 @@ mod tests {
     fn advance_finalization_single_advance() {
         let (mut state, _) = create_test_state();
         let candidate = observation_at(1, 100);
-        let commitment = epoch_commitment_for(&candidate);
+        let commitment = EpochCommitment::from(&candidate);
         state.observed_checkpoints.push_back(candidate.clone());
 
         // tip at 102 has 3 confirmations = depth threshold.
@@ -1011,7 +998,7 @@ mod tests {
         let (mut state, _) = create_test_state();
         let candidate_1 = observation_at(1, 100);
         let candidate_2 = observation_at(2, 101);
-        let commitment_2 = epoch_commitment_for(&candidate_2);
+        let commitment_2 = EpochCommitment::from(&candidate_2);
         state.observed_checkpoints.push_back(candidate_1);
         state.observed_checkpoints.push_back(candidate_2.clone());
 
@@ -1026,7 +1013,7 @@ mod tests {
     fn advance_finalization_stops_at_shallow_candidate() {
         let (mut state, _) = create_test_state();
         let candidate_1 = observation_at(1, 100);
-        let commitment_1 = epoch_commitment_for(&candidate_1);
+        let commitment_1 = EpochCommitment::from(&candidate_1);
         let candidate_2 = observation_at(2, 102);
         state.observed_checkpoints.push_back(candidate_1.clone());
         state.observed_checkpoints.push_back(candidate_2.clone());
@@ -1037,7 +1024,10 @@ mod tests {
         assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert_eq!(state.observed_checkpoints.len(), 1);
         assert_eq!(
-            state.observed_checkpoints.front().map(epoch_commitment_for),
+            state
+                .observed_checkpoints
+                .front()
+                .map(EpochCommitment::from),
             Some(EpochCommitment::from_terminal(
                 2,
                 OLBlockCommitment::new(20, OLBlockId::from(Buf32::from([2u8; 32])))
@@ -1049,7 +1039,7 @@ mod tests {
     fn advance_finalization_pops_already_finalized() {
         let (mut state, _) = create_test_state();
         let candidate = observation_at(1, 100);
-        let commitment_1 = epoch_commitment_for(&candidate);
+        let commitment_1 = EpochCommitment::from(&candidate);
         state.finalized_epoch = Some(commitment_1);
         // Stale entry for an epoch ≤ finalized.
         state.observed_checkpoints.push_back(candidate);

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -53,16 +53,8 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
 
         let prev_confirmed_epoch = state.confirmed_epoch;
 
-        // Process `asm_block` and any blocks that might have been skipped.
-        //
-        // On error we bail out before touching finality: `advance_finalization`
-        // and `refresh_finalized_checkpoint` would otherwise persist a
-        // `ClientState` row keyed on the failed block, and bootstrap
-        // (`fetch_most_recent_client_state`) would treat that as committed on
-        // restart — silently dropping the retry the gap-fill path is meant to
-        // guarantee. Per-block intermediate progress from successful gap-fill
-        // commits is already persisted and published by `commit_block`, so
-        // skipping the trailing finality work here doesn't lose it.
+        // Bail before touching finality: persisting a `ClientState` row at a
+        // failed block would make bootstrap skip the retry gap-fill guarantees.
         if let Err(e) = state.process_asm_block(asm_block, asm_status.logs()) {
             error!(%asm_block, err = ?e, "Failed to process ASM block");
             return Ok(Response::Continue);

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -1,8 +1,10 @@
 //! CSM worker service implementation.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 use strata_asm_worker::AsmWorkerStatus;
+use strata_csm_types::{ClientState, ClientUpdateOutput, L1Checkpoint};
+use strata_primitives::l1::L1BlockCommitment;
 use strata_service::{Response, Service, SyncService};
 use tracing::*;
 
@@ -59,12 +61,22 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
             error!(%asm_block, err = ?e, "Failed to process ASM block");
         }
 
-        let finalized_changed = state.advance_finalization(asm_block.height());
+        let newly_finalized = state.advance_finalization(asm_block.height());
         let confirmed_changed = state.confirmed_epoch != prev_confirmed_epoch;
+
+        // If depth-driven finality advanced, refresh ClientState's
+        // `last_finalized_checkpoint` so persisted state matches the worker's
+        // depth-derived view. ClientState is the only thing downstream consumers
+        // (fork choice, chain worker, RPC) can see, so it has to carry the truth.
+        if let Some(finalized) = newly_finalized.as_ref()
+            && let Err(e) = refresh_finalized_checkpoint(state, asm_block, finalized.clone())
+        {
+            error!(%asm_block, err = ?e, "Failed to persist refreshed finalized checkpoint");
+        }
 
         // FCM listens on checkpoint-state updates. Emit when checkpoint status changed
         // even if client-state object itself did not change (tip-only L1 movement).
-        if confirmed_changed || finalized_changed {
+        if confirmed_changed || newly_finalized.is_some() {
             state
                 .ctx
                 .publish_client_state(state.last_committed_state.as_ref().clone(), asm_block);
@@ -72,4 +84,22 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
 
         Ok(Response::Continue)
     }
+}
+
+/// Rewrites the committed `ClientState` so its `last_finalized_checkpoint`
+/// matches the depth-finalized `L1Checkpoint`, then re-persists it under
+/// `asm_block`. The publish happens in the caller alongside other status edges.
+fn refresh_finalized_checkpoint<C: CsmWorkerContext>(
+    state: &mut CsmWorkerState<C>,
+    asm_block: L1BlockCommitment,
+    finalized: L1Checkpoint,
+) -> anyhow::Result<()> {
+    let last_seen = state.last_committed_state.get_last_checkpoint();
+    let refreshed = ClientState::new(Some(finalized), last_seen);
+    state.ctx.put_client_state_update(
+        &asm_block,
+        ClientUpdateOutput::new(refreshed.clone(), vec![]),
+    )?;
+    state.last_committed_state = Arc::new(refreshed);
+    Ok(())
 }

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -55,10 +55,17 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
 
         // Process `asm_block` and any blocks that might have been skipped.
         //
-        // Errors here are intentionally swallowed: gap-fill is idempotent and
-        // the next ASM status update will retry the missed blocks.
+        // On error we bail out before touching finality: `advance_finalization`
+        // and `refresh_finalized_checkpoint` would otherwise persist a
+        // `ClientState` row keyed on the failed block, and bootstrap
+        // (`fetch_most_recent_client_state`) would treat that as committed on
+        // restart — silently dropping the retry the gap-fill path is meant to
+        // guarantee. Per-block intermediate progress from successful gap-fill
+        // commits is already persisted and published by `commit_block`, so
+        // skipping the trailing finality work here doesn't lose it.
         if let Err(e) = state.process_asm_block(asm_block, asm_status.logs()) {
             error!(%asm_block, err = ?e, "Failed to process ASM block");
+            return Ok(Response::Continue);
         }
 
         let newly_finalized = state.advance_finalization(asm_block.height());
@@ -102,4 +109,187 @@ fn refresh_finalized_checkpoint<C: CsmWorkerContext>(
     )?;
     state.last_committed_state = Arc::new(refreshed);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use strata_asm_logs::CheckpointTipUpdate;
+    use strata_asm_proto_checkpoint_types::CheckpointTip;
+    use strata_asm_worker::{AsmState, AsmWorkerStatus};
+    use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_identifiers::{Buf32, L1BlockId, OLBlockId, RBuf32};
+    use strata_primitives::prelude::*;
+    use strata_service::{Response, SyncService};
+    use strata_status::StatusChannel;
+    use strata_storage::create_node_storage;
+    use strata_test_utils::ArbitraryGenerator;
+
+    use super::CsmWorkerService;
+    use crate::{state::CsmWorkerState, test_utils::StubCtx};
+
+    /// Builds a worker state with an already-seeded finalizable observation in
+    /// the queue, anchored to `last` at height `last_height`. `finality_depth`
+    /// controls when the queued observation counts as finalized.
+    fn state_with_pending_finalization(
+        last_height: L1Height,
+        finality_depth: u32,
+    ) -> (
+        CsmWorkerState<StubCtx>,
+        Arc<strata_storage::NodeStorage>,
+        L1BlockCommitment,
+    ) {
+        let params = strata_test_utils_l2::gen_params();
+        let db = get_test_sled_backend();
+        let pool = threadpool::ThreadPool::new(4);
+        let storage = Arc::new(create_node_storage(db, pool).expect("create storage"));
+
+        // Seed the genesis ClientState row keyed at `last`, so bootstrap
+        // resolves `last_asm_block = last` and the worker has no prior finality
+        // — the refresh path can only fire because of the queued observation.
+        let last = L1BlockCommitment::new(last_height, L1BlockId::from(Buf32::from([7; 32])));
+        storage
+            .client_state()
+            .put_update_blocking(
+                &last,
+                ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
+            )
+            .expect("seed client state");
+
+        let mut arbgen = ArbitraryGenerator::new();
+        let status_channel = Arc::new(StatusChannel::new(
+            arbgen.generate(),
+            params.rollup.genesis_l1_view.blk,
+            arbgen.generate(),
+            None,
+            None,
+        ));
+
+        // L1-fetch failure pins the failure to the checkpoint-tip log path;
+        // any other error type could mask the property we want to assert.
+        let ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            finality_depth,
+            params.rollup.magic_bytes,
+            params.rollup.genesis_l1_view.blk,
+        )
+        .with_l1_fetch_failure();
+
+        let mut state = CsmWorkerState::new(ctx).expect("bootstrap state");
+
+        // Inject a queued observation deep enough that any
+        // `advance_finalization` call would advance finality.
+        let epoch = 1u32;
+        let obs_height = last_height - 1;
+        let l2_commitment = OLBlockCommitment::new(
+            epoch as u64 * 10,
+            OLBlockId::from(Buf32::from([epoch as u8; 32])),
+        );
+        let tip = CheckpointTip {
+            epoch,
+            l1_height: obs_height,
+            l2_commitment,
+        };
+        let obs_block = L1BlockCommitment::new(
+            obs_height,
+            L1BlockId::from(Buf32::from([obs_height as u8; 32])),
+        );
+        let l1_ref = CheckpointL1Ref::new(obs_block, RBuf32::from([1; 32]), RBuf32::from([2; 32]));
+        state
+            .observed_checkpoints
+            .push_back(L1Checkpoint::new(tip, l1_ref));
+
+        (state, storage, last)
+    }
+
+    /// Build an `AsmWorkerStatus` for `block` carrying a single checkpoint-tip
+    /// log. With `with_l1_fetch_failure`, that log triggers the failure path
+    /// in `process_asm_block`.
+    fn status_with_tip_log(block: L1BlockCommitment, epoch: u32) -> AsmWorkerStatus {
+        let l2_commitment = OLBlockCommitment::new(
+            epoch as u64 * 10,
+            OLBlockId::from(Buf32::from([epoch as u8; 32])),
+        );
+        let tip = CheckpointTip {
+            epoch,
+            l1_height: block.height(),
+            l2_commitment,
+        };
+        let log = strata_asm_common::AsmLogEntry::from_log(&CheckpointTipUpdate::new(tip))
+            .expect("tip log");
+        let anchor = make_anchor();
+        let asm_state = AsmState::new(anchor, vec![log]);
+        AsmWorkerStatus {
+            is_initialized: true,
+            cur_block: Some(block),
+            cur_state: Some(asm_state),
+        }
+    }
+
+    fn make_anchor() -> strata_asm_common::AnchorState {
+        use bitcoin::Network;
+        use strata_asm_common::{
+            AnchorState, AsmHistoryAccumulatorState, ChainViewState, HeaderVerificationState,
+        };
+        use strata_btc_verification::L1Anchor;
+        use strata_l1_txfmt::MagicBytes;
+
+        let anchor = L1Anchor {
+            block: L1BlockCommitment::default(),
+            next_target: 0,
+            epoch_start_timestamp: 0,
+            network: Network::Bitcoin,
+        };
+        AnchorState {
+            magic: AnchorState::magic_ssz(MagicBytes::from(*b"ALPN")),
+            chain_view: ChainViewState {
+                pow_state: HeaderVerificationState::init(anchor),
+                history_accumulator: AsmHistoryAccumulatorState::new(0),
+            },
+            sections: Default::default(),
+        }
+    }
+
+    /// When `process_asm_block` fails, neither finality advancement nor the
+    /// resulting `ClientState` refresh should run — otherwise we'd persist a
+    /// row keyed on a block that was never actually committed, and bootstrap
+    /// would treat it as committed on restart.
+    #[test]
+    fn process_input_skips_finalization_when_process_asm_block_fails() {
+        let last_height: L1Height = 100;
+        let finality_depth: u32 = 3;
+        let (mut state, storage, last) =
+            state_with_pending_finalization(last_height, finality_depth);
+
+        // Target one block ahead — the queued observation at height 99 will
+        // have 3 confirmations relative to this tip, so without the gate the
+        // refresh path would persist at the failing block.
+        let target = L1BlockCommitment::new(last_height + 1, L1BlockId::from(Buf32::from([8; 32])));
+        let status = status_with_tip_log(target, /* epoch */ 1);
+
+        let response =
+            <CsmWorkerService<StubCtx> as SyncService>::process_input(&mut state, status)
+                .expect("process_input never errors — failures are swallowed");
+        assert!(matches!(response, Response::Continue));
+
+        // Finality must not have moved in-memory.
+        assert_eq!(
+            state.finalized_epoch, None,
+            "finalized_epoch must not advance when process_asm_block failed"
+        );
+        // The cursor must stay pinned at the last committed block.
+        assert_eq!(state.last_asm_block, Some(last));
+        // No ClientState row may exist at the failed block.
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&target)
+                .expect("query client state")
+                .is_none(),
+            "no ClientState row should be persisted at the failed block"
+        );
+    }
 }

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -181,9 +181,7 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
 
 /// Returns the latest observation whose L1 ref meets the depth threshold.
 ///
-/// Iterates forward; the last match wins (latest finalized). Returns the
-/// borrowed checkpoint so callers can both derive `EpochCommitment::from(&_)`
-/// and reconstruct the durable `ClientState` finality field from it.
+/// Iterates forward; the last match wins (latest finalized).
 fn derive_finalized_checkpoint<'a, I>(
     observed: I,
     current_l1_tip: L1Height,

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -2,12 +2,12 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use strata_csm_types::{CheckpointL1Ref, ClientState};
+use strata_csm_types::{ClientState, L1Checkpoint};
 use strata_identifiers::Epoch;
 use strata_primitives::prelude::*;
 use strata_service::ServiceState;
 
-use crate::{constants, context::CsmWorkerContext};
+use crate::{constants, context::CsmWorkerContext, processor::epoch_commitment_for};
 
 /// State for the CSM worker service.
 ///
@@ -44,7 +44,7 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
     ///
     /// Items are appended after a successful block commit and consumed as
     /// finalized depth progresses.
-    pub(crate) observed_checkpoints: VecDeque<(EpochCommitment, CheckpointL1Ref)>,
+    pub(crate) observed_checkpoints: VecDeque<L1Checkpoint>,
 }
 
 // TODO(STR-3491): Use typed errors instead of `anyhow!`
@@ -79,14 +79,14 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         // observations after finalized, fall back to finalized when no newer observed entry exists.
         let confirmed_epoch = observed_checkpoints
             .back()
-            .map(|(epoch, _)| *epoch)
+            .map(epoch_commitment_for)
             .or(finalized_epoch);
 
         // Keep only non-finalized candidates for incremental tip-driven advancement.
         if let Some(finalized) = finalized_epoch {
             while observed_checkpoints
                 .front()
-                .is_some_and(|(epoch, _)| epoch.epoch() <= finalized.epoch())
+                .is_some_and(|checkpoint| checkpoint.tip.epoch <= finalized.epoch())
             {
                 observed_checkpoints.pop_front();
             }
@@ -112,13 +112,15 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 /// Loads observed checkpoint candidates from the OL checkpoint DB via `ctx`,
 /// starting from `start_epoch`.
 ///
-/// Only epochs with both a canonical commitment and an L1 ref are included.
-/// Used at startup to populate the incremental finalization queue.
+/// Only epochs with both a canonical commitment and a complete observation
+/// (payload + L1 ref) are included. Used at startup to populate the
+/// incremental finalization queue and reconstruct the latest finalized
+/// `L1Checkpoint` view of `ClientState`.
 fn load_observed_checkpoints<C: CsmWorkerContext>(
     ctx: &C,
     start_epoch: Epoch,
     current_l1_tip: L1Height,
-) -> anyhow::Result<VecDeque<(EpochCommitment, CheckpointL1Ref)>> {
+) -> anyhow::Result<VecDeque<L1Checkpoint>> {
     let Some(last_l1_ref_commitment) = ctx.get_last_checkpoint_l1_ref_epoch()? else {
         return Ok(VecDeque::new());
     };
@@ -132,12 +134,15 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
         let Some(observation) = ctx.get_checkpoint_l1_ref(commitment)? else {
             continue;
         };
+        let Some(payload) = ctx.get_checkpoint_payload(commitment)? else {
+            continue;
+        };
 
         if observation.l1_commitment.height() > current_l1_tip {
             continue;
         }
 
-        observed.push_back((commitment, observation));
+        observed.push_back(L1Checkpoint::new(*payload.new_tip(), observation));
     }
 
     Ok(observed)
@@ -152,17 +157,17 @@ fn derive_finalized_epoch<'a, I>(
     finality_depth: u32,
 ) -> Option<EpochCommitment>
 where
-    I: Iterator<Item = &'a (EpochCommitment, CheckpointL1Ref)>,
+    I: Iterator<Item = &'a L1Checkpoint>,
 {
     let mut latest_finalized = None;
     let finality_depth = finality_depth.max(1);
 
-    for (commitment, observation) in observed {
+    for checkpoint in observed {
         let confirmations = current_l1_tip
-            .saturating_sub(observation.l1_commitment.height())
+            .saturating_sub(checkpoint.l1_reference.l1_commitment.height())
             .saturating_add(1);
         if confirmations >= finality_depth {
-            latest_finalized = Some(*commitment);
+            latest_finalized = Some(epoch_commitment_for(checkpoint));
         }
     }
 
@@ -203,7 +208,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::CsmWorkerState;
+    use super::{CsmWorkerState, epoch_commitment_for};
     use crate::test_utils::StubCtx;
 
     fn create_test_params() -> Arc<Params> {
@@ -307,7 +312,7 @@ mod tests {
         assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert_eq!(state.observed_checkpoints.len(), 1);
         assert_eq!(
-            state.observed_checkpoints.front().map(|(epoch, _)| *epoch),
+            state.observed_checkpoints.front().map(epoch_commitment_for),
             Some(commitment_2)
         );
     }

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use strata_csm_types::{ClientState, L1Checkpoint};
+use strata_csm_types::{ClientState, ClientUpdateOutput, L1Checkpoint};
 use strata_identifiers::Epoch;
 use strata_primitives::prelude::*;
 use strata_service::ServiceState;
@@ -70,10 +70,16 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let mut observed_checkpoints =
             load_observed_checkpoints(&ctx, observation_start_epoch, current_l1_tip)?;
 
-        let finalized_from_l1_refs =
-            derive_finalized_epoch(observed_checkpoints.iter(), current_l1_tip, finality_depth);
+        let finalized_from_l1_refs = derive_finalized_checkpoint(
+            observed_checkpoints.iter(),
+            current_l1_tip,
+            finality_depth,
+        )
+        .cloned();
+        let finalized_from_l1_refs_epoch =
+            finalized_from_l1_refs.as_ref().map(EpochCommitment::from);
         let finalized_epoch =
-            max_epoch_commitment(baseline_finalized_epoch, finalized_from_l1_refs);
+            max_epoch_commitment(baseline_finalized_epoch, finalized_from_l1_refs_epoch);
 
         // Confirmed means "observed on L1" and may be finalized. If we only loaded
         // observations after finalized, fall back to finalized when no newer observed entry exists.
@@ -81,6 +87,31 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             .back()
             .map(EpochCommitment::from)
             .or(finalized_epoch);
+
+        // If derived finality outpaces what's persisted, refresh ClientState
+        // before pruning so downstream readers (chain worker, RPC, status
+        // channel) don't lag the worker's view. Without this, a restart that
+        // happens after the observation was committed but before
+        // `refresh_finalized_checkpoint` durably landed would prune the
+        // candidate here and leave `ClientState::get_declared_final_epoch`
+        // behind until a later epoch finalized.
+        let last_committed_state = if let Some(newly_finalized) = finalized_from_l1_refs.as_ref()
+            && baseline_finalized_epoch
+                .is_none_or(|baseline| baseline.epoch() < newly_finalized.tip.epoch)
+        {
+            let refreshed = ClientState::new(
+                Some(newly_finalized.clone()),
+                cur_state.get_last_checkpoint(),
+            );
+            ctx.put_client_state_update(
+                &cur_block,
+                ClientUpdateOutput::new(refreshed.clone(), vec![]),
+            )?;
+            ctx.publish_client_state(refreshed.clone(), cur_block);
+            Arc::new(refreshed)
+        } else {
+            Arc::new(cur_state)
+        };
 
         // Keep only non-finalized candidates for incremental tip-driven advancement.
         if let Some(finalized) = finalized_epoch {
@@ -95,7 +126,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         Ok(Self {
             ctx,
             last_asm_block: Some(cur_block),
-            last_committed_state: Arc::new(cur_state),
+            last_committed_state,
             last_processed_epoch: None,
             confirmed_epoch,
             finalized_epoch,
@@ -148,14 +179,16 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
     Ok(observed)
 }
 
-/// Returns the latest epoch commitment whose observation meets the depth threshold.
+/// Returns the latest observation whose L1 ref meets the depth threshold.
 ///
-/// Iterates forward; the last match wins (latest finalized).
-fn derive_finalized_epoch<'a, I>(
+/// Iterates forward; the last match wins (latest finalized). Returns the
+/// borrowed checkpoint so callers can both derive `EpochCommitment::from(&_)`
+/// and reconstruct the durable `ClientState` finality field from it.
+fn derive_finalized_checkpoint<'a, I>(
     observed: I,
     current_l1_tip: L1Height,
     finality_depth: u32,
-) -> Option<EpochCommitment>
+) -> Option<&'a L1Checkpoint>
 where
     I: Iterator<Item = &'a L1Checkpoint>,
 {
@@ -167,7 +200,7 @@ where
             .saturating_sub(checkpoint.l1_reference.l1_commitment.height())
             .saturating_add(1);
         if confirmations >= finality_depth {
-            latest_finalized = Some(EpochCommitment::from(checkpoint));
+            latest_finalized = Some(checkpoint);
         }
     }
 
@@ -199,7 +232,7 @@ mod tests {
 
     use strata_asm_proto_checkpoint_types::test_utils::create_test_checkpoint_payload;
     use strata_checkpoint_types::EpochSummary;
-    use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput};
+    use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::{Buf32, L1BlockId, RBuf32};
     use strata_params::Params;
@@ -317,6 +350,112 @@ mod tests {
                 .front()
                 .map(EpochCommitment::from),
             Some(commitment_2)
+        );
+
+        // The in-memory `last_committed_state` must reflect the refreshed
+        // finality so downstream readers (chain worker, RPC) immediately see
+        // the worker's view rather than the stale on-disk value.
+        assert_eq!(
+            state.last_committed_state.get_declared_final_epoch(),
+            Some(commitment_1),
+            "bootstrap must refresh in-memory ClientState to the derived finality"
+        );
+
+        // The same refreshed state must be persisted at `cur_block` so the
+        // next restart loads finality consistent with the worker's view —
+        // without it, `fetch_most_recent_client_state` would return the stale
+        // pre-refresh state and the candidate (already pruned from the queue)
+        // could never be re-derived.
+        let (persisted_block, persisted_state) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        let cur_block = L1BlockCommitment::new(20, L1BlockId::default());
+        assert_eq!(
+            persisted_block, cur_block,
+            "refreshed ClientState must be keyed on the same cur_block"
+        );
+        assert_eq!(
+            persisted_state.get_declared_final_epoch(),
+            Some(commitment_1)
+        );
+    }
+
+    /// Bootstrap must not rewrite ClientState when the on-disk state already
+    /// matches (or exceeds) the depth-derived finality — otherwise restarts
+    /// would churn the storage with redundant rows.
+    #[test]
+    fn test_state_new_does_not_refresh_when_baseline_matches() {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+        let ol_checkpoint = storage.ol_checkpoint();
+
+        let payload_1 = create_test_checkpoint_payload(1);
+        let ol_terminal_1 = *payload_1.new_tip().l2_commitment();
+        let summary_1 = EpochSummary::new(
+            1,
+            ol_terminal_1,
+            L2BlockCommitment::new(0, L2BlockId::default()),
+            L1BlockCommitment::new(17, L1BlockId::default()),
+            Buf32::zero(),
+        );
+        let commitment_1 = summary_1.get_epoch_commitment();
+        ol_checkpoint
+            .insert_epoch_summary_blocking(summary_1)
+            .expect("insert epoch 1 summary");
+        let l1_ref_1 = CheckpointL1Ref::new(
+            L1BlockCommitment::new(17, L1BlockId::default()),
+            RBuf32::from([1; 32]),
+            RBuf32::from([2; 32]),
+        );
+        ol_checkpoint
+            .put_checkpoint_l1_observation_blocking(
+                commitment_1,
+                payload_1.clone(),
+                l1_ref_1.clone(),
+            )
+            .expect("insert epoch 1 observation");
+
+        // Seed the on-disk ClientState so its `last_finalized_checkpoint`
+        // already reflects epoch 1 — bootstrap should observe this and skip
+        // the refresh path.
+        let baseline = ClientState::new(
+            Some(L1Checkpoint::new(*payload_1.new_tip(), l1_ref_1)),
+            None,
+        );
+        let baseline_block = L1BlockCommitment::new(20, L1BlockId::default());
+        storage
+            .client_state()
+            .put_update_blocking(
+                &baseline_block,
+                ClientUpdateOutput::new(baseline.clone(), vec![]),
+            )
+            .expect("seed baseline client state");
+
+        let ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            4,
+            params.rollup.magic_bytes,
+            params.rollup.genesis_l1_view.blk,
+        );
+        let state = CsmWorkerState::new(ctx).expect("state init");
+
+        assert_eq!(state.finalized_epoch, Some(commitment_1));
+        assert_eq!(
+            state.last_committed_state.get_declared_final_epoch(),
+            Some(commitment_1)
+        );
+
+        let (_, persisted_state) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        assert_eq!(
+            persisted_state, baseline,
+            "bootstrap must not rewrite ClientState when baseline already matches"
         );
     }
 }

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -7,7 +7,7 @@ use strata_identifiers::Epoch;
 use strata_primitives::prelude::*;
 use strata_service::ServiceState;
 
-use crate::{constants, context::CsmWorkerContext, processor::epoch_commitment_for};
+use crate::{constants, context::CsmWorkerContext};
 
 /// State for the CSM worker service.
 ///
@@ -79,7 +79,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         // observations after finalized, fall back to finalized when no newer observed entry exists.
         let confirmed_epoch = observed_checkpoints
             .back()
-            .map(epoch_commitment_for)
+            .map(EpochCommitment::from)
             .or(finalized_epoch);
 
         // Keep only non-finalized candidates for incremental tip-driven advancement.
@@ -167,7 +167,7 @@ where
             .saturating_sub(checkpoint.l1_reference.l1_commitment.height())
             .saturating_add(1);
         if confirmations >= finality_depth {
-            latest_finalized = Some(epoch_commitment_for(checkpoint));
+            latest_finalized = Some(EpochCommitment::from(checkpoint));
         }
     }
 
@@ -208,7 +208,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::{CsmWorkerState, epoch_commitment_for};
+    use super::CsmWorkerState;
     use crate::test_utils::StubCtx;
 
     fn create_test_params() -> Arc<Params> {
@@ -312,7 +312,10 @@ mod tests {
         assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert_eq!(state.observed_checkpoints.len(), 1);
         assert_eq!(
-            state.observed_checkpoints.front().map(epoch_commitment_for),
+            state
+                .observed_checkpoints
+                .front()
+                .map(EpochCommitment::from),
             Some(commitment_2)
         );
     }

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -206,4 +206,14 @@ impl CsmWorkerContext for StubCtx {
             .ol_checkpoint()
             .get_checkpoint_l1_ref_blocking(commitment)?)
     }
+
+    fn get_checkpoint_payload(
+        &self,
+        commitment: EpochCommitment,
+    ) -> anyhow::Result<Option<CheckpointPayload>> {
+        Ok(self
+            .storage
+            .ol_checkpoint()
+            .get_checkpoint_l1_observed_payload_blocking(commitment)?)
+    }
 }


### PR DESCRIPTION
## Description

Fixes [STR-2438](https://alpenlabs.atlassian.net/browse/STR-2438). The CSM's `L1Checkpoint` carried a `BatchInfo` field that didn't reflect the data the CSM actually receives, and `ClientState` carried a `last_finalized_checkpoint` populated by an observation heuristic that could diverge from the depth-driven truth tracked in `CsmWorkerState`. This PR realigns the types with the real inputs and makes the depth-derived value the single source of finality.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor

## Notes to Reviewers

Best reviewed commit-by-commit. The first commit is type plumbing only; the second is the behavioral fix; the third is dead-code cleanup made possible by the second.

Is this PR addressing any specification, design doc or external reference document?

- [ ] Yes
- [x] No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance disclosure: Claude Code was used to help draft commits and this PR description; all changes were human-reviewed.

## Related Issues

[STR-2438]: https://alpenlabs.atlassian.net/browse/STR-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ