### PR TITLE
fix(ol-stf): enable SP1 Groth16 predicate verification

### DIFF
--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -21,7 +21,7 @@ strata-ol-msg-types.workspace = true
 strata-ol-params = { workspace = true, optional = true }
 strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
-strata-predicate = { workspace = true, features = ["sp1-groth16"] }
+strata-predicate = { workspace = true, features = ["all"] }
 strata-snark-acct-sys.workspace = true
 strata-snark-acct-types.workspace = true
 

--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -21,7 +21,7 @@ strata-ol-msg-types.workspace = true
 strata-ol-params = { workspace = true, optional = true }
 strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
-strata-predicate.workspace = true
+strata-predicate = { workspace = true, features = ["sp1-groth16"] }
 strata-snark-acct-sys.workspace = true
 strata-snark-acct-types.workspace = true
 

--- a/crates/ol/stf/src/proof_verification.rs
+++ b/crates/ol/stf/src/proof_verification.rs
@@ -219,6 +219,7 @@ mod tests {
     use strata_ol_chain_types_new::{
         ProofSatisfier, ProofSatisfierList, RawMerkleProofList, TxProofs,
     };
+    use strata_predicate::{PredicateError, PredicateKey, PredicateTypeId};
 
     use super::*;
 
@@ -298,5 +299,24 @@ mod tests {
         // Incrementing past the end returns NoNextProof.
         let err = tracker.inc_next_pred_proof().unwrap_err();
         assert!(matches!(err, ProofVerifyError::NoNextProof));
+    }
+
+    #[test]
+    fn sp1_groth16_predicate_verifier_is_available() {
+        let predicate_key = PredicateKey::new(PredicateTypeId::Sp1Groth16, Vec::new());
+        let err = predicate_key
+            .verify_claim_witness(&[], &[])
+            .expect_err("empty condition is invalid, but verifier must be compiled in");
+
+        assert!(
+            !matches!(
+                err,
+                PredicateError::UnsupportedPredicateType {
+                    id: PredicateTypeId::Sp1Groth16,
+                    ..
+                }
+            ),
+            "Sp1Groth16 verifier feature must be enabled for OL STF replay"
+        );
     }
 }


### PR DESCRIPTION
## Description

Enable the sp1-groth16 feature for strata-predicate in the OL STF
dependency path so checkpoint proof replay can verify snark-account
updates that use PredicateTypeId::Sp1Groth16.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
