### PR TITLE
STR-3252: remove tracked_balance field and bookkeeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16419,7 +16419,6 @@ dependencies = [
  "rkyv",
  "rsp-primitives",
  "ssz",
- "strata-acct-types",
  "strata-codec",
  "strata-ee-acct-runtime",
  "strata-ee-acct-types",

--- a/bin/datatool/src/cmd/ol_params.rs
+++ b/bin/datatool/src/cmd/ol_params.rs
@@ -78,12 +78,6 @@ fn compute_inner_state_from_chain_config(chain_config: Option<&Path>) -> anyhow:
     let genesis_info = get_alpen_ee_genesis_block_info(&genesis_json)?;
     let blockhash = genesis_info.blockhash.0.into();
     let state_root = genesis_info.stateroot.0.into();
-    let ee_state = EeAccountState::new(
-        blockhash,
-        state_root,
-        BitcoinAmount::zero(),
-        Vec::new(),
-        Vec::new(),
-    );
+    let ee_state = EeAccountState::new(blockhash, state_root, Vec::new(), Vec::new());
     Ok(ee_state.compute_state_root())
 }

--- a/bin/prover-perf/src/programs/alpen_acct.rs
+++ b/bin/prover-perf/src/programs/alpen_acct.rs
@@ -12,7 +12,6 @@
 //! (d) pubvals SSZ commit.
 
 use ssz::Encode;
-use strata_acct_types::BitcoinAmount;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_runtime::{ChunkInput, EePrivateInput};
 use strata_ee_acct_types::{EeAccountState, ExecBlock, ExecHeader, UpdateExtraData};
@@ -54,13 +53,8 @@ fn prepare_input() -> EeAcctProofInput {
         .expect("decode tip block")
         .get_header()
         .get_state_root();
-    let initial_state = EeAccountState::new(
-        parent_blkid,
-        parent_state_root,
-        BitcoinAmount::from_sat(0),
-        Vec::new(),
-        Vec::new(),
-    );
+    let initial_state =
+        EeAccountState::new(parent_blkid, parent_state_root, Vec::new(), Vec::new());
     let pre_root = initial_state.compute_state_root();
 
     // 3. Post-state: same EE account but tip advanced to the chunk's output. This is what the acct

--- a/crates/alpen-ee/common/src/traits/storage/account.rs
+++ b/crates/alpen-ee/common/src/traits/storage/account.rs
@@ -107,7 +107,6 @@ macro_rules! storage_tests {
 
 #[cfg(feature = "test-utils")]
 pub mod tests {
-    use strata_acct_types::BitcoinAmount;
     use strata_ee_acct_types::EeAccountState;
     use strata_identifiers::{Buf32, EpochCommitment, OLBlockId};
 
@@ -122,13 +121,7 @@ pub mod tests {
     }
 
     fn create_test_ee_account_state() -> EeAccountState {
-        EeAccountState::new(
-            [0u8; 32].into(),
-            [0u8; 32].into(),
-            BitcoinAmount::ZERO,
-            Vec::new(),
-            Vec::new(),
-        )
+        EeAccountState::new([0u8; 32].into(), [0u8; 32].into(), Vec::new(), Vec::new())
     }
 
     /// Test storing and retrieving EE account state.

--- a/crates/alpen-ee/common/src/traits/storage/exec_block.rs
+++ b/crates/alpen-ee/common/src/traits/storage/exec_block.rs
@@ -355,13 +355,7 @@ pub mod exec_block_storage_test_fns {
 
     /// Helper to create an EeAccountState with a specific block hash
     fn create_account_state(blockhash: Hash) -> EeAccountState {
-        EeAccountState::new(
-            blockhash,
-            Hash::zero(),
-            BitcoinAmount::ZERO,
-            Vec::new(),
-            Vec::new(),
-        )
+        EeAccountState::new(blockhash, Hash::zero(), Vec::new(), Vec::new())
     }
 
     /// Helper to create a test MessageEntry

--- a/crates/alpen-ee/database/src/serialization_types/account_state.rs
+++ b/crates/alpen-ee/database/src/serialization_types/account_state.rs
@@ -31,24 +31,17 @@ impl DBAccountStateAtEpoch {
 pub(crate) struct DBEeAccountState {
     last_exec_blkid: Hash,
     last_exec_state_root: Hash,
-    tracked_balance: DBBitcoinAmount,
     pending_inputs: Vec<DBPendingInputEntry>,
     pending_fincls: Vec<DBPendingFinclEntry>,
 }
 
 impl From<EeAccountState> for DBEeAccountState {
     fn from(value: EeAccountState) -> Self {
-        let (
-            last_exec_blkid,
-            last_exec_state_root,
-            tracked_balance,
-            pending_inputs,
-            pending_fincls,
-        ) = value.into_parts();
+        let (last_exec_blkid, last_exec_state_root, pending_inputs, pending_fincls) =
+            value.into_parts();
         Self {
             last_exec_blkid,
             last_exec_state_root,
-            tracked_balance: tracked_balance.into(),
             pending_inputs: pending_inputs.into_iter().map(Into::into).collect(),
             pending_fincls: pending_fincls.into_iter().map(Into::into).collect(),
         }
@@ -60,7 +53,6 @@ impl From<DBEeAccountState> for EeAccountState {
         Self::new(
             value.last_exec_blkid,
             value.last_exec_state_root,
-            value.tracked_balance.into(),
             value.pending_inputs.into_iter().map(Into::into).collect(),
             value.pending_fincls.into_iter().map(Into::into).collect(),
         )

--- a/crates/alpen-ee/engine/src/sync.rs
+++ b/crates/alpen-ee/engine/src/sync.rs
@@ -305,7 +305,6 @@ mod tests {
         MockExecBlockStorage, StorageError,
     };
     use async_trait::async_trait;
-    use strata_acct_types::BitcoinAmount;
     use strata_ee_acct_types::EeAccountState;
     use strata_ee_chain_types::{ExecBlockCommitment, ExecBlockPackage, ExecInputs, ExecOutputs};
 
@@ -472,13 +471,7 @@ mod tests {
             ExecInputs::new_empty(),
             ExecOutputs::new_empty(),
         );
-        let account_state = EeAccountState::new(
-            block_hash,
-            Hash::zero(),
-            BitcoinAmount::ZERO,
-            vec![],
-            vec![],
-        );
+        let account_state = EeAccountState::new(block_hash, Hash::zero(), vec![], vec![]);
 
         // Create OL block commitment
         let mut ol_block_bytes = [0u8; 32];

--- a/crates/alpen-ee/exec-chain/src/state.rs
+++ b/crates/alpen-ee/exec-chain/src/state.rs
@@ -205,7 +205,6 @@ pub async fn init_exec_chain_state_from_storage<TStorage: ExecBlockStorage>(
 
 #[cfg(test)]
 mod tests {
-    use strata_acct_types::BitcoinAmount;
     use strata_ee_acct_types::EeAccountState;
     use strata_ee_chain_types::{ExecBlockCommitment, ExecBlockPackage, ExecInputs, ExecOutputs};
     use strata_identifiers::{Buf32, OLBlockCommitment};
@@ -218,13 +217,7 @@ mod tests {
         blockhash: Hash,
         parent_blockhash: Hash,
     ) -> ExecBlockRecord {
-        let account_state = EeAccountState::new(
-            blockhash,
-            Hash::zero(),
-            BitcoinAmount::ZERO,
-            Vec::new(),
-            Vec::new(),
-        );
+        let account_state = EeAccountState::new(blockhash, Hash::zero(), Vec::new(), Vec::new());
 
         let package = ExecBlockPackage::new(
             ExecBlockCommitment::new(blockhash, Hash::new([0; 32])),

--- a/crates/alpen-ee/genesis/src/utils.rs
+++ b/crates/alpen-ee/genesis/src/utils.rs
@@ -1,6 +1,6 @@
 use alpen_ee_common::{ExecBlockPayload, ExecBlockRecord};
 use alpen_ee_config::AlpenEeParams;
-use strata_acct_types::{BitcoinAmount, Hash};
+use strata_acct_types::Hash;
 use strata_ee_acct_types::EeAccountState;
 use strata_ee_chain_types::{ExecBlockCommitment, ExecBlockPackage, ExecInputs, ExecOutputs};
 use strata_identifiers::{Buf32, OLBlockCommitment};
@@ -9,7 +9,6 @@ pub fn build_genesis_ee_account_state(params: &AlpenEeParams) -> EeAccountState 
     EeAccountState::new(
         params.genesis_blockhash().0.into(),
         params.genesis_stateroot().0.into(),
-        BitcoinAmount::zero(),
         Vec::new(),
         Vec::new(),
     )

--- a/crates/alpen-ee/ol-tracker/src/task.rs
+++ b/crates/alpen-ee/ol-tracker/src/task.rs
@@ -231,7 +231,6 @@ pub(crate) async fn handle_extend_ee_state<TStorage: Storage>(
 #[cfg(test)]
 mod tests {
     use alpen_ee_common::{MockOLClient, OLChainStatus, OLEpochSummary};
-    use strata_acct_types::BitcoinAmount;
 
     use super::*;
     use crate::test_utils::*;
@@ -245,13 +244,7 @@ mod tests {
         fn test_apply_empty_operations() {
             // Scenario: Apply empty operations list
             // Expected: State unchanged, returns Ok
-            let mut state = EeAccountState::new(
-                Hash::new([0u8; 32]),
-                Hash::zero(),
-                BitcoinAmount::zero(),
-                vec![],
-                vec![],
-            );
+            let mut state = EeAccountState::new(Hash::new([0u8; 32]), Hash::zero(), vec![], vec![]);
             let operations: Vec<UpdateInputData> = vec![];
 
             let result = apply_epoch_operations(&mut state, &operations);

--- a/crates/alpen-ee/ol-tracker/src/test_utils.rs
+++ b/crates/alpen-ee/ol-tracker/src/test_utils.rs
@@ -1,7 +1,6 @@
 use alpen_ee_common::{
     EeAccountStateAtEpoch, MockOLClient, MockStorage, OLBlockOrEpoch, OLClientError, OLEpochSummary,
 };
-use strata_acct_types::BitcoinAmount;
 use strata_ee_acct_types::EeAccountState;
 use strata_identifiers::{Buf32, EpochCommitment, OLBlockCommitment, OLBlockId};
 
@@ -20,13 +19,7 @@ pub(crate) fn make_block_commitment(slot: u64, id: u8) -> OLBlockCommitment {
 }
 
 pub(crate) fn make_ee_state(last_exec_blkid: [u8; 32]) -> EeAccountState {
-    EeAccountState::new(
-        last_exec_blkid.into(),
-        [0u8; 32].into(),
-        BitcoinAmount::zero(),
-        vec![],
-        vec![],
-    )
+    EeAccountState::new(last_exec_blkid.into(), [0u8; 32].into(), vec![], vec![])
 }
 
 pub(crate) fn make_state_at_epoch(

--- a/crates/alpen-ee/sequencer/src/block_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/task.rs
@@ -358,8 +358,7 @@ mod tests {
             ExecInputs::new_empty(),
             ExecOutputs::new_empty(),
         );
-        let account_state =
-            EeAccountState::new(hash, Hash::zero(), BitcoinAmount::ZERO, vec![], vec![]);
+        let account_state = EeAccountState::new(hash, Hash::zero(), vec![], vec![]);
         ExecBlockRecord::new(
             package,
             account_state,

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/test_utils.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/test_utils.rs
@@ -101,8 +101,7 @@ pub(crate) fn create_mock_exec_record(ol_block: OLBlockCommitment) -> ExecBlockR
         ExecOutputs::new_empty(),
     );
 
-    let account_state =
-        EeAccountState::new(hash, Hash::zero(), BitcoinAmount::ZERO, vec![], vec![]);
+    let account_state = EeAccountState::new(hash, Hash::zero(), vec![], vec![]);
 
     ExecBlockRecord::new(
         package,

--- a/crates/ee-acct-runtime/src/ee_program.rs
+++ b/crates/ee-acct-runtime/src/ee_program.rs
@@ -111,13 +111,10 @@ impl<E: ExecutionEnvironment> SnarkAccountProgramVerification for EeSnarkAccount
     fn verify_coinput<'a>(
         &self,
         _state: &Self::State,
-        vstate: &mut Self::VState<'a>,
-        msg: &InputMessage<Self::Msg>,
+        _vstate: &mut Self::VState<'a>,
+        _msg: &InputMessage<Self::Msg>,
         coinput: &[u8],
     ) -> ProgramResult<(), Self::Error> {
-        // Update balance bookkeeping.
-        vstate.accept_funds(msg.meta().value())?;
-
         // For both Valid and Unknown messages, require empty coinput.
         // We don't need any message coinputs for the EE right now.
         if !coinput.is_empty() {
@@ -159,8 +156,7 @@ impl<E: ExecutionEnvironment> SnarkAccountProgramVerification for EeSnarkAccount
     }
 }
 
-/// Processes a single input message, updating tracked balance and applying
-/// decoded message effects.
+/// Processes a single input message, applying decoded message effects.
 ///
 /// This is the shared logic used by both the [`SnarkAccountProgram`]
 /// implementation and block assembly.
@@ -168,11 +164,6 @@ pub(crate) fn process_input_message(
     state: &mut EeAccountState,
     msg: &InputMessage<DecodedEeMessageData>,
 ) -> ProgramResult<(), EnvError> {
-    // Add value to tracked balance, always do this.
-    if !msg.meta().value().is_zero() {
-        state.add_tracked_balance(msg.meta().value());
-    }
-
     // If we recognize it, then we have to do something with it.
     if let Some(decoded_msg) = msg.message() {
         apply_decoded_message(state, decoded_msg, msg.meta().value())?;

--- a/crates/ee-acct-runtime/src/verification_state.rs
+++ b/crates/ee-acct-runtime/src/verification_state.rs
@@ -3,7 +3,7 @@
 //! This module contains the verification state types used during update
 //! processing in SNARK proofs.
 
-use strata_acct_types::{BitcoinAmount, Hash};
+use strata_acct_types::Hash;
 use strata_ee_acct_types::{
     EeAccountState, EnvError, EnvProgramResult, EnvResult, ExecutionEnvironment, PendingInputEntry,
     UpdateExtraData,
@@ -88,18 +88,6 @@ pub struct EeVerificationState<'a, E: ExecutionEnvironment> {
     /// Current verified chain tip.
     cur_verified_exec_blkid: Hash,
 
-    /// Tracks the total value sent in this update.
-    ///
-    /// Not sure why we're doing this after all.
-    total_val_sent: BitcoinAmount,
-
-    /// Tracks current balance.
-    ///
-    /// This is the snark account's balance on the orchestration layer, as an
-    /// additional check to ensure we don't permit invalid updates.  It is still
-    /// incremented when we receive messages we don't understand.
-    cur_balance: BitcoinAmount,
-
     /// Outputs we expect to have.
     expected_outputs: UpdateOutputs,
 
@@ -129,8 +117,6 @@ impl<'a, E: ExecutionEnvironment> EeVerificationState<'a, E> {
             ee,
             chunk_predicate_key,
             cur_verified_exec_blkid: state.last_exec_blkid(),
-            total_val_sent: 0.into(),
-            cur_balance: state.tracked_balance(),
             expected_outputs,
             accumulated_outputs: UpdateOutputs::new_empty(),
             input_chunks,
@@ -152,21 +138,6 @@ impl<'a, E: ExecutionEnvironment> EeVerificationState<'a, E> {
         self.cur_verified_exec_blkid
     }
 
-    pub fn cur_balance(&self) -> BitcoinAmount {
-        self.cur_balance
-    }
-
-    /// Increases our verification state tracked balance.
-    ///
-    /// This is intended for when we accept a message.
-    pub fn accept_funds(&mut self, amt: BitcoinAmount) -> EnvResult<()> {
-        self.cur_balance = self
-            .cur_balance
-            .checked_add(amt)
-            .ok_or(EnvError::BalanceOverflow)?;
-        Ok(())
-    }
-
     /// Returns the raw partial pre-state.
     pub fn raw_partial_pre_state(&self) -> &'a [u8] {
         self.raw_partial_pre_state
@@ -181,22 +152,6 @@ impl<'a, E: ExecutionEnvironment> EeVerificationState<'a, E> {
     /// If this results in overflowing buffers, then returns an error and leaves
     /// us in a dirty state where we should abort anyways.
     pub(crate) fn merge_new_outputs(&mut self, outputs: &ExecOutputs) -> EnvResult<()> {
-        // Annoying thing to do checked summation.
-        let sent_now = BitcoinAmount::sum(
-            outputs.output_transfers().iter().map(|e| e.value()).chain(
-                outputs
-                    .output_messages()
-                    .iter()
-                    .map(|e| e.payload().value()),
-            ),
-        );
-
-        // Update the balance before anything else, throw an error for insufficient funds.
-        self.cur_balance = self
-            .cur_balance
-            .checked_sub(sent_now)
-            .ok_or(EnvError::InsufficientFunds)?;
-
         // Just merge the entries into the buffer. This is a little more
         // complicated than it really is because we have to convert between two
         // sets of similar types that are separately defined to avoid semantic
@@ -218,12 +173,6 @@ impl<'a, E: ExecutionEnvironment> EeVerificationState<'a, E> {
                     .map(|e| OutputMessage::new(e.dest(), e.payload().clone())),
             )
             .map_err(|_| EnvError::OutputOverflow)?;
-
-        // Finally update the total_val_sent field.
-        self.total_val_sent = self
-            .total_val_sent
-            .checked_add(sent_now)
-            .ok_or(EnvError::OutputOverflow)?;
 
         Ok(())
     }
@@ -324,8 +273,6 @@ impl<'a, E: ExecutionEnvironment> Clone for EeVerificationState<'a, E> {
             ee: self.ee,
             chunk_predicate_key: self.chunk_predicate_key,
             cur_verified_exec_blkid: self.cur_verified_exec_blkid,
-            total_val_sent: self.total_val_sent,
-            cur_balance: self.cur_balance,
             expected_outputs: self.expected_outputs.clone(),
             accumulated_outputs: self.accumulated_outputs.clone(),
             input_chunks: self.input_chunks,

--- a/crates/ee-acct-runtime/tests/common/mod.rs
+++ b/crates/ee-acct-runtime/tests/common/mod.rs
@@ -168,13 +168,7 @@ pub fn assert_both_paths_succeed(
 
 /// Creates a simple initial state for testing.
 pub(crate) fn create_initial_state() -> (EeAccountState, SnarkAccountState) {
-    let ee_state = EeAccountState::new(
-        Hash::new([0u8; 32]),
-        Hash::zero(),
-        BitcoinAmount::from(0u64),
-        Vec::new(),
-        Vec::new(),
-    );
+    let ee_state = EeAccountState::new(Hash::new([0u8; 32]), Hash::zero(), Vec::new(), Vec::new());
 
     let snark_state = make_snark_state(&ee_state);
 

--- a/crates/ee-acct-runtime/tests/invalid_updates.rs
+++ b/crates/ee-acct-runtime/tests/invalid_updates.rs
@@ -348,7 +348,6 @@ fn test_deposit_mismatch_in_chunk() {
     let initial_state = strata_ee_acct_types::EeAccountState::new(
         Hash::new([0u8; 32]),
         Hash::zero(),
-        BitcoinAmount::from(0u64),
         vec![PendingInputEntry::Deposit(deposit)],
         Vec::new(),
     );
@@ -391,7 +390,6 @@ fn test_input_count_mismatch() {
     let initial_state = strata_ee_acct_types::EeAccountState::new(
         Hash::new([0u8; 32]),
         Hash::zero(),
-        BitcoinAmount::from(0u64),
         Vec::new(),
         Vec::new(),
     );

--- a/crates/ee-acct-runtime/tests/update_verification.rs
+++ b/crates/ee-acct-runtime/tests/update_verification.rs
@@ -13,9 +13,9 @@ use common::{
     assert_verified_path_succeeds, build_update_operation, create_deposit_message,
     create_initial_state, simple_chunk,
 };
-use strata_acct_types::{AccountId, BitcoinAmount, Hash, MsgPayload, SubjectId};
+use strata_acct_types::{AccountId, BitcoinAmount, Hash, SubjectId};
 use strata_ee_acct_runtime::{EeVerificationInput, UpdateBuilder};
-use strata_ee_chain_types::{ExecOutputs, OutputMessage as ExecOutputMessage};
+use strata_ee_chain_types::ExecOutputs;
 use strata_predicate::PredicateKey;
 use strata_simple_ee::SimpleExecutionEnvironment;
 
@@ -131,47 +131,6 @@ fn test_single_deposit_with_chunk() {
     apply_unconditionally(&initial_state, &operation).expect("unconditional path should succeed");
 
     // Verified path with chunk proof verification should succeed
-    assert_verified_chunks_succeed(&initial_state, &operation, &coinputs, &[chunk], &ee);
-}
-
-#[test]
-fn test_chunk_output_does_not_change_inner_tracked_balance() {
-    let (initial_state, snark_state) = create_initial_state();
-    let ee = SimpleExecutionEnvironment;
-
-    let dest = SubjectId::from([1u8; 32]);
-    let value = BitcoinAmount::from(1000u64);
-    let source = AccountId::from([2u8; 32]);
-    let message = create_deposit_message(dest, value, source, 1);
-
-    let predicate_key = PredicateKey::always_accept();
-    let vinput = EeVerificationInput::new(&ee, &predicate_key, &[], &[]);
-    let mut builder =
-        UpdateBuilder::new(1, snark_state, initial_state.clone(), vinput).expect("create builder");
-
-    builder.add_messages(vec![message]).expect("add message");
-
-    let deposit = match &builder.remaining_pending_inputs()[0] {
-        strata_ee_acct_types::PendingInputEntry::Deposit(d) => d.clone(),
-    };
-
-    let mut outputs = ExecOutputs::new_empty();
-    outputs.add_message(ExecOutputMessage::new(
-        AccountId::from([3u8; 32]),
-        MsgPayload::from_bytes(BitcoinAmount::from(400u64), vec![1, 2, 3])
-            .expect("message payload bytes must fit within SSZ max length"),
-    ));
-
-    let tip = Hash::new([0xDD; 32]);
-    let chunk = simple_chunk(builder.cur_tip_blkid(), tip, vec![deposit], outputs);
-
-    builder
-        .accept_chunk_transition(&chunk)
-        .expect("accept chunk");
-
-    let (operation, coinputs) = builder.build().expect("build");
-
-    apply_unconditionally(&initial_state, &operation).expect("unconditional path should succeed");
     assert_verified_chunks_succeed(&initial_state, &operation, &coinputs, &[chunk], &ee);
 }
 

--- a/crates/ee-acct-types/src/errors.rs
+++ b/crates/ee-acct-types/src/errors.rs
@@ -63,12 +63,6 @@ pub enum EnvError {
     #[error("blocks in a chunk did not match the chunk's attested io")]
     InconsistentChunkIo,
 
-    #[error("insufficient funds")]
-    InsufficientFunds,
-
-    #[error("balance overflow")]
-    BalanceOverflow,
-
     /// Accumulated output transfers or messages exceeded protocol capacity.
     #[error("output overflow")]
     OutputOverflow,

--- a/crates/ee-acct-types/src/state.rs
+++ b/crates/ee-acct-types/src/state.rs
@@ -1,6 +1,5 @@
 //! EE account internal state.
 
-use strata_acct_types::BitcoinAmount;
 use strata_identifiers::Hash;
 use strata_snark_acct_runtime::IInnerState;
 use tree_hash::{Sha256Hasher, TreeHash};
@@ -11,14 +10,12 @@ impl EeAccountState {
     pub fn new(
         last_exec_blkid: Hash,
         last_exec_state_root: Hash,
-        tracked_balance: BitcoinAmount,
         pending_inputs: Vec<PendingInputEntry>,
         pending_fincls: Vec<PendingFinclEntry>,
     ) -> Self {
         Self {
             last_exec_blkid: last_exec_blkid.0.into(),
             last_exec_state_root: last_exec_state_root.0.into(),
-            tracked_balance,
             pending_inputs: pending_inputs
                 .try_into()
                 .expect("pending inputs should not exceed capacity"),
@@ -28,15 +25,7 @@ impl EeAccountState {
         }
     }
 
-    pub fn into_parts(
-        self,
-    ) -> (
-        Hash,
-        Hash,
-        BitcoinAmount,
-        Vec<PendingInputEntry>,
-        Vec<PendingFinclEntry>,
-    ) {
+    pub fn into_parts(self) -> (Hash, Hash, Vec<PendingInputEntry>, Vec<PendingFinclEntry>) {
         (
             self.last_exec_blkid
                 .as_ref()
@@ -46,7 +35,6 @@ impl EeAccountState {
                 .as_ref()
                 .try_into()
                 .expect("FixedBytes<32> should convert to [u8; 32]"),
-            self.tracked_balance,
             self.pending_inputs.into(),
             self.pending_fincls.into(),
         )
@@ -72,18 +60,6 @@ impl EeAccountState {
 
     pub fn set_last_exec_state_root(&mut self, root: Hash) {
         self.last_exec_state_root = root.0.into();
-    }
-
-    pub fn tracked_balance(&self) -> BitcoinAmount {
-        self.tracked_balance
-    }
-
-    /// Adds to the tracked balance, panicking on overflow.
-    pub fn add_tracked_balance(&mut self, amt: BitcoinAmount) {
-        self.tracked_balance = self
-            .tracked_balance
-            .checked_add(amt)
-            .expect("snarkacct: overflowing balance");
     }
 
     pub fn pending_inputs(&self) -> &[PendingInputEntry] {
@@ -231,7 +207,6 @@ mod tests {
             (
                 any::<[u8; 32]>(),
                 any::<[u8; 32]>(),
-                any::<u64>(),
                 prop::collection::vec(pending_input_entry_strategy(), 0..5),
                 prop::collection::vec(
                     (any::<u32>(), any::<[u8; 32]>()).prop_map(|(epoch, hash)| PendingFinclEntry {
@@ -241,21 +216,18 @@ mod tests {
                     0..5,
                 ),
             )
-                .prop_map(
-                    |(last_exec_blkid, last_exec_state_root, balance, inputs, fincls)| {
-                        EeAccountState {
-                            last_exec_blkid: last_exec_blkid.into(),
-                            last_exec_state_root: last_exec_state_root.into(),
-                            tracked_balance: BitcoinAmount::from_sat(balance),
-                            pending_inputs: inputs
-                                .try_into()
-                                .expect("pending inputs should not exceed capacity"),
-                            pending_fincls: fincls
-                                .try_into()
-                                .expect("pending fincls should not exceed capacity"),
-                        }
-                    },
-                )
+                .prop_map(|(last_exec_blkid, last_exec_state_root, inputs, fincls)| {
+                    EeAccountState {
+                        last_exec_blkid: last_exec_blkid.into(),
+                        last_exec_state_root: last_exec_state_root.into(),
+                        pending_inputs: inputs
+                            .try_into()
+                            .expect("pending inputs should not exceed capacity"),
+                        pending_fincls: fincls
+                            .try_into()
+                            .expect("pending fincls should not exceed capacity"),
+                    }
+                },)
         );
 
         #[test]
@@ -263,14 +235,12 @@ mod tests {
             let a = EeAccountState::new(
                 Hash::from([1u8; 32]),
                 Hash::from([2u8; 32]),
-                BitcoinAmount::from_sat(10),
                 Vec::new(),
                 Vec::new(),
             );
             let b = EeAccountState::new(
                 Hash::from([1u8; 32]),
                 Hash::from([3u8; 32]),
-                BitcoinAmount::from_sat(10),
                 Vec::new(),
                 Vec::new(),
             );

--- a/crates/ee-acct-types/ssz/state.ssz
+++ b/crates/ee-acct-types/ssz/state.ssz
@@ -27,9 +27,6 @@ class EeAccountState(Container):
     ### State root of the last execution block that we've processed
     last_exec_state_root: Bytes32
 
-    ### Tracked balance bridged into execution env, according to processed messages
-    tracked_balance: strata_acct_types.BitcoinAmount
-
     ### Pending inputs that haven't been accepted into a block (must be processed in order)
     pending_inputs: List[PendingInputEntry, MAX_PENDING_INPUTS]
 

--- a/crates/proof-impl/alpen-acct/Cargo.toml
+++ b/crates/proof-impl/alpen-acct/Cargo.toml
@@ -19,7 +19,6 @@ zkaleido.workspace = true
 zkaleido-native-adapter.workspace = true
 
 [dev-dependencies]
-strata-acct-types.workspace = true
 strata-codec.workspace = true
 strata-ee-acct-types.workspace = true
 strata-identifiers.workspace = true

--- a/crates/proof-impl/alpen-acct/src/program.rs
+++ b/crates/proof-impl/alpen-acct/src/program.rs
@@ -118,7 +118,6 @@ impl EeAcctProgram {
 mod tests {
     use rsp_primitives::genesis::Genesis;
     use ssz::Encode;
-    use strata_acct_types::BitcoinAmount;
     use strata_codec::encode_to_vec;
     use strata_ee_acct_runtime::EePrivateInput;
     use strata_ee_acct_types::{EeAccountState, UpdateExtraData};
@@ -135,13 +134,8 @@ mod tests {
     fn test_native_acct_execution_zero_chunks() {
         // Build a minimal EE account state.
         let initial_blkid = Hash::zero();
-        let initial_state = EeAccountState::new(
-            initial_blkid,
-            Hash::zero(),
-            BitcoinAmount::from_sat(0),
-            Vec::new(),
-            Vec::new(),
-        );
+        let initial_state =
+            EeAccountState::new(initial_blkid, Hash::zero(), Vec::new(), Vec::new());
         let state_root = initial_state.compute_state_root();
 
         // Extra data: tip stays the same, nothing processed.


### PR DESCRIPTION
## Description

This PR removes the `tracked_balance` field from `EeAccountState` and the associated bookkeeping.  It was not being updated correctly, as was reported in an audit, although it was not actually required for security.  Instead of adding functionality to make it be updated correctly, it's actually more advantageous to remove it.

This PR superscedes #1845 and is the preferred implementation.  This should be merged instead of that one.

Claude was used for most of the tedious work here.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
