### PR TITLE
fix(evm-ee): preserve bytecode code-hash keys in chunk witnesses

### DIFF
--- a/bin/prover-perf/src/programs/alpen_chunk.rs
+++ b/bin/prover-perf/src/programs/alpen_chunk.rs
@@ -53,7 +53,15 @@ pub(super) fn prepare_input() -> EeChunkProofInput {
 
     let pre_state = EvmPartialState::new(
         witness.parent_state.clone(),
-        witness.bytecodes.clone(),
+        // This RSP fixture stores bytecodes as a Vec without original code-hash
+        // keys. Re-hashing keeps the fixture behavior; production range
+        // witnesses preserve the AccessedStateGenerator keys instead.
+        witness
+            .bytecodes
+            .clone()
+            .into_iter()
+            .map(|bytecode| (bytecode.hash_slow(), bytecode))
+            .collect(),
         witness.ancestor_headers.clone(),
     );
 

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -264,11 +264,11 @@ impl BlockAssembler for EvmExecutionEnvironment {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::PathBuf};
+    use std::{collections::BTreeMap, fs, path::PathBuf};
 
     use alloy_consensus::Sealable;
     use reth_primitives_traits::Block as RethBlockTrait;
-    use revm::DatabaseRef;
+    use revm::{DatabaseRef, state::Bytecode};
     use revm_primitives::B256;
     use rsp_client_executor::io::EthClientExecutorInput;
     use serde::Deserialize;
@@ -280,6 +280,16 @@ mod tests {
 
     use super::*;
     use crate::types::{EvmBlock, EvmBlockBody, EvmHeader, EvmPartialState};
+
+    fn rehashed_fixture_bytecodes(bytecodes: Vec<Bytecode>) -> BTreeMap<B256, Bytecode> {
+        // The RSP fixture stores bytecodes as a Vec without the original code-hash
+        // keys. Re-hashing here preserves the old fixture behavior; production
+        // range witnesses pass keyed bytecodes from AccessedStateGenerator.
+        bytecodes
+            .into_iter()
+            .map(|bytecode| (bytecode.hash_slow(), bytecode))
+            .collect()
+    }
 
     #[test]
     fn withdrawal_messages_are_sent_to_bridge_gateway_with_msg_envelope() {
@@ -344,7 +354,7 @@ mod tests {
         let evm_header = EvmHeader::new(header.clone());
         let mut state = EvmPartialState::new(
             test_data.witness.parent_state,
-            test_data.witness.bytecodes,
+            rehashed_fixture_bytecodes(test_data.witness.bytecodes),
             test_data.witness.ancestor_headers,
         );
 
@@ -396,7 +406,7 @@ mod tests {
         // Use the pre-state directly from witness data (it already has all the proofs!)
         let pre_state = EvmPartialState::new(
             test_data.witness.parent_state,
-            test_data.witness.bytecodes,
+            rehashed_fixture_bytecodes(test_data.witness.bytecodes),
             test_data.witness.ancestor_headers,
         );
 

--- a/crates/evm-ee/src/types/partial_state.rs
+++ b/crates/evm-ee/src/types/partial_state.rs
@@ -45,7 +45,6 @@ impl EvmPartialState {
     /// Creates a new EvmPartialState from an EthereumState with witness data.
     ///
     /// This performs expensive one-time operations optimized for zkVM execution:
-    /// - Hashes all bytecodes once
     /// - Seals all ancestor headers (computes their hashes once)
     /// - Validates header chain integrity
     /// - Builds block_hashes lookup map once
@@ -57,15 +56,9 @@ impl EvmPartialState {
     /// Panics if the header chain is invalid (block numbers or parent hashes don't match).
     pub fn new(
         ethereum_state: EthereumState,
-        bytecodes: Vec<Bytecode>,
+        bytecodes: BTreeMap<B256, Bytecode>,
         ancestor_headers: Vec<Header>,
     ) -> Self {
-        // Index bytecodes by their hash for O(log n) lookup
-        let bytecodes = bytecodes
-            .into_iter()
-            .map(|code| (code.hash_slow(), code))
-            .collect();
-
         // Seal ancestor headers once (compute hashes) and index by block number
         let ancestor_headers: BTreeMap<u64, Sealed<Header>> = ancestor_headers
             .into_iter()
@@ -111,10 +104,8 @@ impl EvmPartialState {
     }
 
     // NOTE: same comment as `add_executed_block`
-    pub fn add_bytecodes(&mut self, new_bytecodes: Vec<Bytecode>) {
-        for bytecode in new_bytecodes {
-            let hash = bytecode.hash_slow(); // Hash once
-            // BTreeMap insert only adds if key doesn't exist
+    pub fn add_bytecodes(&mut self, new_bytecodes: BTreeMap<B256, Bytecode>) {
+        for (hash, bytecode) in new_bytecodes {
             self.bytecodes.entry(hash).or_insert(bytecode);
         }
     }

--- a/crates/evm-ee/src/types/tests.rs
+++ b/crates/evm-ee/src/types/tests.rs
@@ -1,9 +1,9 @@
 //! Tests for EVM types Codec implementations.
 
-use std::{fs::read_to_string, path::PathBuf};
+use std::{collections::BTreeMap, fs::read_to_string, path::PathBuf};
 
 use alloy_consensus::{Header, Sealable};
-use revm::DatabaseRef;
+use revm::{DatabaseRef, state::Bytecode};
 use revm_primitives::alloy_primitives::{Address, B256, Bloom, Bytes, U256};
 use rsp_client_executor::io::EthClientExecutorInput;
 use serde::Deserialize;
@@ -32,6 +32,16 @@ fn load_witness_test_data() -> EthClientExecutorInput {
         serde_json::from_str(&json_content).expect("Failed to parse test data");
 
     test_data.witness
+}
+
+fn rehashed_fixture_bytecodes(bytecodes: Vec<Bytecode>) -> BTreeMap<B256, Bytecode> {
+    // The RSP fixture stores bytecodes as a Vec without the original code-hash
+    // keys. Re-hashing here preserves the old fixture behavior; production
+    // range witnesses pass keyed bytecodes from AccessedStateGenerator.
+    bytecodes
+        .into_iter()
+        .map(|bytecode| (bytecode.hash_slow(), bytecode))
+        .collect()
 }
 
 /// Helper function to create a test header with realistic values
@@ -227,7 +237,7 @@ fn test_evm_partial_state_codec_roundtrip() {
     let witness = load_witness_test_data();
     let partial_state = EvmPartialState::new(
         witness.parent_state,
-        witness.bytecodes,
+        rehashed_fixture_bytecodes(witness.bytecodes),
         witness.ancestor_headers,
     );
 
@@ -266,8 +276,11 @@ fn test_evm_partial_state_block_hashes_include_single_ancestor() {
             .next()
             .expect("test ancestor"),
     ];
-    let partial_state =
-        EvmPartialState::new(witness.parent_state, vec![], ancestor_headers.clone());
+    let partial_state = EvmPartialState::new(
+        witness.parent_state,
+        BTreeMap::new(),
+        ancestor_headers.clone(),
+    );
 
     assert_block_hashes_match_headers(&partial_state, &ancestor_headers);
 }
@@ -276,8 +289,11 @@ fn test_evm_partial_state_block_hashes_include_single_ancestor() {
 fn test_evm_partial_state_block_hashes_include_all_ancestors() {
     let witness = load_witness_test_data();
     let ancestor_headers = create_test_ancestor_headers();
-    let partial_state =
-        EvmPartialState::new(witness.parent_state, vec![], ancestor_headers.clone());
+    let partial_state = EvmPartialState::new(
+        witness.parent_state,
+        BTreeMap::new(),
+        ancestor_headers.clone(),
+    );
 
     assert_block_hashes_match_headers(&partial_state, &ancestor_headers);
 }
@@ -286,8 +302,11 @@ fn test_evm_partial_state_block_hashes_include_all_ancestors() {
 fn test_evm_partial_state_block_hashes_survive_codec_roundtrip() {
     let witness = load_witness_test_data();
     let ancestor_headers = create_test_ancestor_headers();
-    let partial_state =
-        EvmPartialState::new(witness.parent_state, vec![], ancestor_headers.clone());
+    let partial_state = EvmPartialState::new(
+        witness.parent_state,
+        BTreeMap::new(),
+        ancestor_headers.clone(),
+    );
 
     let encoded = encode_to_vec(&partial_state).expect("encode failed");
     let decoded: EvmPartialState = decode_buf_exact(&encoded).expect("decode failed");
@@ -302,7 +321,7 @@ fn test_evm_partial_state_rejects_non_contiguous_ancestor_headers() {
     let parent = create_test_header_at(100, B256::from([42u8; 32]));
     let child = create_test_header_at(102, parent.clone().seal_slow().hash());
 
-    EvmPartialState::new(witness.parent_state, vec![], vec![parent, child]);
+    EvmPartialState::new(witness.parent_state, BTreeMap::new(), vec![parent, child]);
 }
 
 #[test]
@@ -312,7 +331,7 @@ fn test_evm_partial_state_rejects_invalid_ancestor_parent_hash() {
     let mut ancestor_headers = create_test_ancestor_headers();
     ancestor_headers[1].parent_hash = B256::from([99u8; 32]);
 
-    EvmPartialState::new(witness.parent_state, vec![], ancestor_headers);
+    EvmPartialState::new(witness.parent_state, BTreeMap::new(), ancestor_headers);
 }
 
 /// Verifies that a codec-roundtripped EvmPartialState can still execute blocks.
@@ -336,7 +355,7 @@ fn test_evm_partial_state_codec_roundtrip_execution() {
     // Build partial state and verify execution works on the original.
     let partial_state = EvmPartialState::new(
         witness.parent_state,
-        witness.bytecodes,
+        rehashed_fixture_bytecodes(witness.bytecodes),
         witness.ancestor_headers,
     );
 

--- a/crates/proof-impl/alpen-chunk/src/program.rs
+++ b/crates/proof-impl/alpen-chunk/src/program.rs
@@ -128,7 +128,14 @@ mod tests {
         // Build partial pre-state from witness data.
         let pre_state = EvmPartialState::new(
             witness.parent_state,
-            witness.bytecodes,
+            // This RSP fixture stores bytecodes as a Vec without original code-hash
+            // keys. Re-hashing keeps the fixture behavior; production range
+            // witnesses preserve the AccessedStateGenerator keys instead.
+            witness
+                .bytecodes
+                .into_iter()
+                .map(|bytecode| (bytecode.hash_slow(), bytecode))
+                .collect(),
             witness.ancestor_headers,
         );
 

--- a/crates/reth/exex/src/accessed_state_exex.rs
+++ b/crates/reth/exex/src/accessed_state_exex.rs
@@ -287,6 +287,8 @@ fn hash_from_b256(hash: B256) -> Hash {
 
 #[cfg(test)]
 mod tests {
+    use std::iter::once;
+
     use alloy_primitives::Bytes;
 
     use super::*;
@@ -300,8 +302,7 @@ mod tests {
         assert_eq!(bytecode.original_bytes(), runtime);
         assert_ne!(bytecode.bytes(), runtime);
 
-        let entries =
-            bytecode_entries_from_accessed_contracts(std::iter::once((&code_hash, &bytecode)));
+        let entries = bytecode_entries_from_accessed_contracts(once((&code_hash, &bytecode)));
 
         assert_eq!(entries, vec![(hash_from_b256(code_hash), runtime.to_vec())]);
     }

--- a/crates/reth/exex/src/accessed_state_exex.rs
+++ b/crates/reth/exex/src/accessed_state_exex.rs
@@ -24,6 +24,7 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
 use alpen_ee_common::{AccessedAccount, AccessedStateRecord, AccessedStateStore};
 use futures_util::TryStreamExt;
 use reth_evm::{
@@ -35,7 +36,7 @@ use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives::{Block, EthPrimitives};
 use reth_primitives_traits::Block as _;
 use reth_provider::{BlockReader, Chain, StateProviderFactory};
-use reth_revm::db::CacheDB;
+use reth_revm::{db::CacheDB, state::Bytecode};
 use strata_acct_types::Hash;
 use tokio::task;
 use tracing::{debug, error, warn};
@@ -267,15 +268,41 @@ where
         ancestor_block_numbers,
     };
 
-    let bytecodes: Vec<BytecodeEntry> = accessed
-        .accessed_contracts()
-        .iter()
-        .map(|(hash, code)| (hash_from_b256(*hash), code.bytes().to_vec()))
-        .collect();
+    let bytecodes = bytecode_entries_from_accessed_contracts(accessed.accessed_contracts().iter());
 
     Ok((record, bytecodes))
 }
 
-fn hash_from_b256(hash: alloy_primitives::B256) -> Hash {
+fn bytecode_entries_from_accessed_contracts<'a>(
+    bytecodes: impl Iterator<Item = (&'a B256, &'a Bytecode)>,
+) -> Vec<BytecodeEntry> {
+    bytecodes
+        .map(|(hash, code)| (hash_from_b256(*hash), code.original_bytes().to_vec()))
+        .collect()
+}
+
+fn hash_from_b256(hash: B256) -> Hash {
     Hash::from(hash.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Bytes;
+
+    use super::*;
+
+    #[test]
+    fn bytecode_entries_preserve_original_runtime_bytes() {
+        let code_hash = B256::from([0x12; 32]);
+        let runtime = Bytes::from_static(&[0x60, 0x01, 0x5f, 0x55]);
+        let bytecode = Bytecode::new_raw(runtime.clone());
+
+        assert_eq!(bytecode.original_bytes(), runtime);
+        assert_ne!(bytecode.bytes(), runtime);
+
+        let entries =
+            bytecode_entries_from_accessed_contracts(std::iter::once((&code_hash, &bytecode)));
+
+        assert_eq!(entries, vec![(hash_from_b256(code_hash), runtime.to_vec())]);
+    }
 }

--- a/crates/reth/witness/src/range_witness_extractor.rs
+++ b/crates/reth/witness/src/range_witness_extractor.rs
@@ -6,7 +6,10 @@
 //! and runs the two pre/post multiproofs. No block re-execution happens
 //! here — that work happens once per produced block inside the exex.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 use alloy_consensus::Header;
 use alloy_primitives::{
@@ -239,7 +242,7 @@ where
         post_state: &P,
         start_state_root: B256,
         accessed: &AccumulatedState,
-    ) -> Result<(EthereumState, Vec<Bytecode>)>
+    ) -> Result<(EthereumState, BTreeMap<B256, Bytecode>)>
     where
         P: StateProvider,
     {
@@ -287,7 +290,17 @@ where
 
         let state =
             EthereumState::from_transition_proofs(start_state_root, &pre_proofs, &post_proofs)?;
-        let bytecodes: Vec<Bytecode> = accessed.bytecodes.values().cloned().collect();
+
+        // Preserve the code-hash key recorded by AccessedStateGenerator.
+        // Re-hashing bytes after they pass through revm representations can produce
+        // a different key if legacy-analysis padding was materialized as input.
+        // In revm, "legacy" is the normal non-EIP-7702 contract bytecode path.
+        // https://github.com/bluealloy/revm/blob/main/crates/bytecode/src/legacy/analysis.rs#L42-L47
+        let bytecodes = accessed
+            .bytecodes
+            .iter()
+            .map(|(hash, bytecode)| (*hash, bytecode.clone()))
+            .collect();
         Ok((state, bytecodes))
     }
 


### PR DESCRIPTION
## Description
Accessed-state records already identify bytecodes by the account `code_hash`, but range witness assembly dropped that key and rebuilt the `EvmPartialState` bytecode map by hashing materialized Bytecode values.

That is incorrect when the stored Bytecode contains revm legacy-analysis padding: 
the replay witness can be keyed by `keccak(runtime + padding)` instead of the account's real `keccak(runtime)`, causing chunk replay to miss bytecode that was actually accessed.


<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
