### PR TITLE
feat(strata): expose prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1636,7 +1636,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1647,7 +1647,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2790,7 +2790,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -2813,7 +2813,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2831,7 +2831,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3581,7 +3581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4621,7 +4621,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4849,6 +4849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enr"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4934,7 +4940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7177,11 +7183,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
  "indexmap 2.13.0",
+ "ipnet",
  "metrics",
  "metrics-util 0.19.1",
  "quanta",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7222,10 +7234,12 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "metrics",
+ "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -7493,6 +7507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7541,7 +7564,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7707,7 +7730,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8980,7 +9003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -9000,7 +9023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9013,7 +9036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9170,6 +9193,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rancor"
@@ -12573,7 +12606,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13882,7 +13915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14646,6 +14679,7 @@ dependencies = [
  "strata-identifiers",
  "strata-ledger-types",
  "strata-logging",
+ "strata-metrics",
  "strata-node-context",
  "strata-ol-block-assembly",
  "strata-ol-chain-types-new",
@@ -15855,10 +15889,8 @@ dependencies = [
 [[package]]
 name = "strata-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc22#7eaaf489b26e0d673a77491a295e568af2e9092b"
 dependencies = [
- "metrics",
- "metrics-exporter-otel",
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -15886,6 +15918,24 @@ dependencies = [
  "thiserror 2.0.18",
  "tree_hash 0.15.0",
  "tree_hash_derive 0.15.0",
+]
+
+[[package]]
+name = "strata-metrics"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc22#7eaaf489b26e0d673a77491a295e568af2e9092b"
+dependencies = [
+ "metrics",
+ "metrics-exporter-otel",
+ "metrics-exporter-prometheus",
+ "metrics-util 0.20.1",
+ "opentelemetry 0.31.0",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -16049,6 +16099,7 @@ name = "strata-ol-checkpoint"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "metrics",
  "proptest",
  "serde",
  "strata-asm-proto-checkpoint-types",
@@ -16118,6 +16169,7 @@ name = "strata-ol-mempool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "metrics",
  "proptest",
  "serde",
  "ssz",
@@ -16217,6 +16269,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "metrics",
  "proptest",
  "serde",
  "ssz",
@@ -16695,6 +16748,7 @@ dependencies = [
  "strata-crypto",
  "strata-key-derivation",
  "strata-logging",
+ "strata-metrics",
  "strata-primitives",
  "strata-signer",
  "strata-tasks",
@@ -16855,6 +16909,7 @@ dependencies = [
  "async-trait",
  "borsh",
  "futures",
+ "metrics",
  "strata-common",
  "strata-consensus-logic",
  "strata-db-types",
@@ -17305,7 +17360,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,8 @@ strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.
 strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
 strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
 strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
+strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc22" }
+strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc22" }
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "legacy_compact",
 ], tag = "v0.1.0-alpha-rc21" }

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -880,11 +880,9 @@ pub struct AdditionalConfig {
 
     /// OTLP gRPC endpoint for the OpenTelemetry collector.
     ///
-    /// When set, `strata-logging` builds an `SdkMeterProvider` and a
-    /// tracer provider against this endpoint and installs a
-    /// `metrics`-crate recorder bridge. Every `metrics::*!` call
-    /// (including reth's), span busy/idle histograms, and service
-    /// framework instrumentation flow over OTLP gRPC to the collector.
+    /// When set, `strata-logging` builds a tracer provider against this
+    /// endpoint. Metrics stay on Reth's native recorder and Prometheus
+    /// endpoint; use Reth's `--metrics` flag for `/metrics`.
     /// Falls back to the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var
     /// when the flag isn't passed.
     #[arg(long, env = "OTEL_EXPORTER_OTLP_ENDPOINT")]
@@ -1092,15 +1090,13 @@ where
     }
 
     // Build the tokio runtime ourselves so logging init can run inside its
-    // context, then hand it to CliRunner. strata-logging's OTLP exporters
-    // spawn periodic export tasks that require an active tokio handle when
-    // they're built.
+    // context, then hand it to CliRunner. The OTLP tracing exporter requires
+    // an active tokio handle when it is built.
     let rt = tokio_runtime()?;
 
     {
         let _g = rt.handle().enter();
 
-        let metrics_enabled = command.ext.otlp_url.is_some();
         let mut extra_filter_directives =
             vec!["sp1_core_executor=warn", "jsonrpsee_server::server=warn"];
         if let Some(verbosity_filter) = command.ext.verbosity_filter_directive() {
@@ -1115,7 +1111,6 @@ where
             log_file_prefix: None,
             json_format: None,
             default_log_prefix: "alpen-client",
-            enable_metrics_layer: metrics_enabled,
             extra_filter_directives: &extra_filter_directives,
         });
     }
@@ -1131,7 +1126,7 @@ where
         )
     });
 
-    // Flush OTLP buffers (spans + metrics) before the process exits.
+    // Flush OTLP tracing buffers before the process exits.
     strata_logging::finalize();
 
     result

--- a/bin/strata-signer/Cargo.toml
+++ b/bin/strata-signer/Cargo.toml
@@ -17,6 +17,7 @@ strata-common.workspace = true
 strata-crypto.workspace = true
 strata-key-derivation.workspace = true
 strata-logging.workspace = true
+strata-metrics.workspace = true
 strata-primitives.workspace = true
 strata-tasks.workspace = true
 

--- a/bin/strata-signer/src/config.rs
+++ b/bin/strata-signer/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the signer, loaded from a TOML file.
 
-use std::{fmt, path::PathBuf};
+use std::{fmt, net::IpAddr, path::PathBuf};
 
 use serde::Deserialize;
 
@@ -78,6 +78,16 @@ pub(crate) struct LoggingConfig {
     /// Use JSON format for logs instead of compact format.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) json_format: Option<bool>,
+
+    /// Host for the Prometheus `/metrics` HTTP endpoint.
+    ///
+    /// Defaults to `127.0.0.1` when `metrics_port` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) metrics_host: Option<IpAddr>,
+
+    /// Port for the Prometheus `/metrics` HTTP endpoint. Disabled if not set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) metrics_port: Option<u16>,
 }
 
 const fn default_duty_poll_interval() -> u64 {
@@ -137,6 +147,26 @@ mod tests {
         let config = toml::from_str::<SignerConfig>(config).unwrap();
         assert_eq!(config.health_check_host, "127.0.0.1");
         assert_eq!(config.health_check_port, 18_080);
+    }
+
+    #[test]
+    fn test_signer_config_parses_metrics_port() {
+        let config = r#"
+            sequencer_key = "/tmp/sequencer.key"
+            sequencer_admin_endpoint = "ws://127.0.0.1:8434"
+            sequencer_admin_bearer_token = "test-token"
+
+            [logging]
+            metrics_host = "0.0.0.0"
+            metrics_port = 9615
+        "#;
+
+        let config = toml::from_str::<SignerConfig>(config).unwrap();
+        assert_eq!(
+            config.logging.metrics_host,
+            Some(IpAddr::from([0, 0, 0, 0]))
+        );
+        assert_eq!(config.logging.metrics_port, Some(9615));
     }
 
     #[test]

--- a/bin/strata-signer/src/main.rs
+++ b/bin/strata-signer/src/main.rs
@@ -8,8 +8,14 @@ mod config;
 mod constants;
 mod helpers;
 
-use std::{fs, sync::Arc, time::Duration};
+use std::{
+    fs,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 
+use anyhow::Context;
 use args::Args;
 use config::SignerConfig;
 use constants::SHUTDOWN_TIMEOUT_MS;
@@ -19,7 +25,10 @@ use strata_common::{
     healthz::{start_health_check_server, HealthCheckState},
     ws_client::{ManagedWsClient, WsClientConfig},
 };
-use strata_logging::{init_logging_from_config, LoggingInitConfig};
+use strata_logging::{
+    format_service_name, init_logging_from_config_with_layers, LoggingInitConfig,
+};
+use strata_metrics::{MetricsConfig, MetricsInitConfig, MetricsLayer};
 use strata_signer::SignerBuilder;
 use strata_tasks::TaskManager;
 use tokio::runtime::Builder;
@@ -43,23 +52,46 @@ fn main() -> anyhow::Result<()> {
         .enable_all()
         .thread_name("signer-rt")
         .build()
-        .expect("failed to build tokio runtime");
+        .context("failed to build signer tokio runtime")?;
 
     let handle = runtime.handle();
 
-    // Init logging. Need runtime context for async OTLP setup.
+    // Init logging and metrics. Need runtime context for async exporter setup.
     let _g = handle.enter();
-    init_logging_from_config(LoggingInitConfig {
-        service_base_name: "strata-signer",
-        service_label: config.logging.service_label.as_deref(),
-        otlp_url: config.logging.otlp_url.as_deref(),
-        log_dir: config.logging.log_dir.as_ref(),
-        log_file_prefix: config.logging.log_file_prefix.as_deref(),
-        json_format: config.logging.json_format,
-        default_log_prefix: "signer",
-        enable_metrics_layer: config.logging.otlp_url.is_some(),
-        extra_filter_directives: &["sp1_core_executor=warn", "jsonrpsee_server::server=warn"],
+    let prometheus_listen_addr = config.logging.metrics_port.map(|port| {
+        let host = config
+            .logging
+            .metrics_host
+            .unwrap_or(IpAddr::from([127, 0, 0, 1]));
+        SocketAddr::from((host, port))
     });
+    let metrics_config =
+        MetricsConfig::from_exporters(config.logging.otlp_url.clone(), prometheus_listen_addr);
+    let metrics_enabled = metrics_config.is_explicitly_enabled();
+    let service_name =
+        format_service_name("strata-signer", config.logging.service_label.as_deref());
+
+    let mut extra_layers = Vec::new();
+    if metrics_enabled {
+        extra_layers.push(Box::new(MetricsLayer) as strata_logging::BoxedLayer);
+    }
+
+    init_logging_from_config_with_layers(
+        LoggingInitConfig {
+            service_base_name: "strata-signer",
+            service_label: config.logging.service_label.as_deref(),
+            otlp_url: config.logging.otlp_url.as_deref(),
+            log_dir: config.logging.log_dir.as_ref(),
+            log_file_prefix: config.logging.log_file_prefix.as_deref(),
+            json_format: config.logging.json_format,
+            default_log_prefix: "signer",
+            extra_filter_directives: &["sp1_core_executor=warn", "jsonrpsee_server::server=warn"],
+        },
+        extra_layers,
+    );
+
+    let metrics_init = MetricsInitConfig::new(service_name).with_metrics_config(metrics_config);
+    strata_metrics::init(metrics_init, handle).context("failed to initialize process metrics")?;
 
     let health_check_state = HealthCheckState::new();
     let health_check_addr = format!("{}:{}", config.health_check_host, config.health_check_port);
@@ -95,6 +127,9 @@ fn main() -> anyhow::Result<()> {
     task_manager.start_signal_listeners();
     task_manager.monitor(Some(Duration::from_millis(SHUTDOWN_TIMEOUT_MS)))?;
 
+    info!("exiting strata signer");
+    strata_metrics::finalize();
+    strata_logging::finalize();
     Ok(())
 }
 

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -63,6 +63,7 @@ strata-db-types.workspace = true
 strata-identifiers.workspace = true
 strata-ledger-types.workspace = true
 strata-logging.workspace = true
+strata-metrics.workspace = true
 strata-node-context.workspace = true
 strata-ol-block-assembly = { workspace = true, optional = true }
 strata-ol-chain-types-new.workspace = true

--- a/bin/strata/src/main.rs
+++ b/bin/strata/src/main.rs
@@ -1,12 +1,18 @@
 //! Strata client binary entrypoint.
 
-use std::time::Duration;
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 use anyhow::{Context, Result, anyhow};
 use argh::from_env;
 use strata_common::healthz::{HealthCheckState, start_health_check_server};
 use strata_db_types as _;
-use strata_logging::{LoggingInitConfig, init_logging_from_config};
+use strata_logging::{
+    LoggingInitConfig, format_service_name, init_logging_from_config_with_layers,
+};
+use strata_metrics::{MetricsConfig, MetricsInitConfig, MetricsLayer};
 #[cfg(test)]
 use strata_ol_state_types as _;
 #[cfg(test)]
@@ -51,13 +57,9 @@ fn main() -> Result<()> {
         .build()
         .map_err(InitError::RuntimeBuild)?;
 
-    // Initialize logging. When otlp_url is configured, strata-logging also
-    // builds an OpenTelemetry meter provider, sets it as global, and installs
-    // a metrics-crate recorder bridge. After that, every metrics::counter! /
-    // gauge! / histogram! call (including reth's, MetricsLayer's span
-    // busy/idle histograms, and our domain instrumentation) flows via OTLP
-    // gRPC to the collector.
-    init_logging(rt.handle(), &config);
+    // Initialize logging and metrics. strata-logging owns tracing subscriber
+    // setup; strata-metrics owns the process metrics recorder and exporters.
+    init_logging(rt.handle(), &config)?;
 
     // Validate sequencer flag isn't used when sequencer feature is disabled.
     #[cfg(not(feature = "sequencer"))]
@@ -119,21 +121,48 @@ fn main() -> Result<()> {
     runctx.task_manager.monitor(Some(Duration::from_secs(5)))?;
 
     info!("Exiting strata");
+    strata_metrics::finalize();
+    strata_logging::finalize();
     Ok(())
 }
 
-fn init_logging(rt: &Handle, config: &strata_config::Config) {
+fn init_logging(rt: &Handle, config: &strata_config::Config) -> Result<()> {
     // Need to set the runtime context for async OTLP setup
     let _g = rt.enter();
-    init_logging_from_config(LoggingInitConfig {
-        service_base_name: "strata-client",
-        service_label: config.logging.service_label.as_deref(),
-        otlp_url: config.logging.otlp_url.as_deref(),
-        log_dir: config.logging.log_dir.as_ref(),
-        log_file_prefix: config.logging.log_file_prefix.as_deref(),
-        json_format: config.logging.json_format,
-        default_log_prefix: "alpen",
-        enable_metrics_layer: config.logging.otlp_url.is_some(),
-        extra_filter_directives: &["sp1_core_executor=warn", "jsonrpsee_server::server=warn"],
+    let prometheus_listen_addr = config.logging.metrics_port.map(|port| {
+        let host = config
+            .logging
+            .metrics_host
+            .unwrap_or(IpAddr::from([127, 0, 0, 1]));
+        SocketAddr::from((host, port))
     });
+    let metrics_config =
+        MetricsConfig::from_exporters(config.logging.otlp_url.clone(), prometheus_listen_addr);
+    let metrics_enabled = metrics_config.is_explicitly_enabled();
+    let service_name =
+        format_service_name("strata-client", config.logging.service_label.as_deref());
+
+    let mut extra_layers = Vec::new();
+    if metrics_enabled {
+        extra_layers.push(Box::new(MetricsLayer) as strata_logging::BoxedLayer);
+    }
+
+    init_logging_from_config_with_layers(
+        LoggingInitConfig {
+            service_base_name: "strata-client",
+            service_label: config.logging.service_label.as_deref(),
+            otlp_url: config.logging.otlp_url.as_deref(),
+            log_dir: config.logging.log_dir.as_ref(),
+            log_file_prefix: config.logging.log_file_prefix.as_deref(),
+            json_format: config.logging.json_format,
+            default_log_prefix: "alpen",
+            extra_filter_directives: &["sp1_core_executor=warn", "jsonrpsee_server::server=warn"],
+        },
+        extra_layers,
+    );
+
+    let metrics_init = MetricsInitConfig::new(service_name).with_metrics_config(metrics_config);
+    strata_metrics::init(metrics_init, rt).context("failed to initialize process metrics")?;
+
+    Ok(())
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,4 +1,4 @@
-use std::{fmt, path::PathBuf, time::Duration};
+use std::{fmt, net::IpAddr, path::PathBuf, time::Duration};
 
 use bitcoin::Network;
 use serde::{Deserialize, Serialize};
@@ -436,6 +436,16 @@ pub struct LoggingConfig {
     /// Use JSON format for logs instead of compact format.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_format: Option<bool>,
+
+    /// Host for the Prometheus `/metrics` HTTP endpoint.
+    ///
+    /// Defaults to `127.0.0.1` when `metrics_port` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics_host: Option<IpAddr>,
+
+    /// Port for the Prometheus `/metrics` HTTP endpoint. Disabled if not set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -732,6 +742,23 @@ mod test {
         let with_deadline: ProverConfig = toml::from_str(r#"sp1_proof_deadline_secs = 3600"#)
             .expect("prover config with deadline should parse");
         assert_eq!(with_deadline.sp1_proof_deadline_secs, Some(3600));
+    }
+
+    #[test]
+    fn test_logging_config_metrics_port_defaults_and_parses() {
+        let default_config: LoggingConfig =
+            toml::from_str("").expect("empty logging config parses");
+        assert_eq!(default_config.metrics_port, None);
+
+        let config: LoggingConfig = toml::from_str(
+            r#"
+            metrics_host = "0.0.0.0"
+            metrics_port = 9615
+        "#,
+        )
+        .expect("metrics config should parse");
+        assert_eq!(config.metrics_host, Some(IpAddr::from([0, 0, 0, 0])));
+        assert_eq!(config.metrics_port, Some(9615));
     }
 
     #[test]

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -1,6 +1,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use anyhow::anyhow;
+use metrics::{counter, histogram};
 use serde::Serialize;
 use strata_csm_types::CheckpointState;
 use strata_db_types::traits::BlockStatus;
@@ -207,6 +208,11 @@ async fn process_fc_message<C: FcmContext>(
             };
 
             fcm_state.ctx().set_block_status(*blkid, status).await?;
+            if ok {
+                counter!("strata_fcm_blocks_accepted_total").increment(1);
+            } else {
+                counter!("strata_fcm_blocks_rejected_total").increment(1);
+            }
         }
     }
 
@@ -495,7 +501,8 @@ async fn apply_tip_update<C: FcmContext>(
             let pivot_slot = fcm_state.get_block_slot(pivot_blkid).await?;
             let pivot_block = OLBlockCommitment::new(pivot_slot, pivot_blkid);
             let cur_best = fcm_state.cur_best_block();
-            let reverts_blocks = reorg.revert_iter().next().is_some();
+            let reorg_depth = reorg.revert_iter().count();
+            let reverts_blocks = reorg_depth > 0;
 
             // We probably need to roll back to an earlier block and update our
             // in-memory state first.
@@ -526,6 +533,9 @@ async fn apply_tip_update<C: FcmContext>(
             }
 
             // TODO any cleanup?
+
+            counter!("strata_fcm_reorgs_total").increment(1);
+            histogram!("strata_fcm_reorg_depth").record(reorg_depth as f64);
 
             Ok(())
         }

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -1,6 +1,7 @@
 use std::{collections::VecDeque, sync::Arc, time};
 
 use anyhow::anyhow;
+use metrics::{counter, gauge};
 use strata_ol_state_types::OLState;
 use strata_predicate::PredicateKey;
 use strata_primitives::{EpochCommitment, L2BlockCommitment, OLBlockCommitment, OLBlockId};
@@ -60,6 +61,7 @@ impl<C: FcmContext> FcmServiceState<C> {
         self.inner_state
             .epochs_pending_finalization
             .push_back(epoch);
+        self.record_pending_epochs();
 
         true
     }
@@ -83,7 +85,7 @@ impl<C: FcmContext> FcmServiceState<C> {
     ) -> anyhow::Result<()> {
         self.inner_state.cur_best_block = block;
         self.inner_state.cur_olstate = state;
-        metrics::gauge!("strata_ol_tip_slot").set(block.slot() as f64);
+        gauge!("strata_ol_tip_slot").set(block.slot() as f64);
         self.ctx().update_safe_tip(block).await
     }
 
@@ -127,6 +129,10 @@ impl<C: FcmContext> FcmServiceState<C> {
         // Clear out old pending entries.
         self.clear_pending_epochs(epoch)?;
 
+        counter!("strata_fcm_epochs_finalized_total").increment(1);
+        gauge!("strata_fcm_finalized_epoch").set(epoch.epoch() as f64);
+        gauge!("strata_fcm_finalized_slot").set(epoch.last_slot() as f64);
+
         Ok(())
     }
 
@@ -140,7 +146,13 @@ impl<C: FcmContext> FcmServiceState<C> {
                 .pop_front()
                 .ok_or(anyhow!("pop on empty epoch_pending dequeue"))?;
         }
+        self.record_pending_epochs();
         Ok(())
+    }
+
+    fn record_pending_epochs(&self) {
+        gauge!("strata_fcm_pending_epochs")
+            .set(self.inner_state.epochs_pending_finalization.len() as f64);
     }
 
     pub(crate) async fn get_block_slot(&self, blkid: OLBlockId) -> anyhow::Result<u64> {
@@ -256,6 +268,10 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
         .ok_or(Error::MissingOLState(tip_blkid))?;
 
     let fcm_inner = FcmInnerState::new(chain_tracker, cur_tip_block, ol_state);
+    gauge!("strata_ol_tip_slot").set(cur_tip_block.slot() as f64);
+    gauge!("strata_fcm_finalized_epoch").set(finalized_epoch.epoch() as f64);
+    gauge!("strata_fcm_finalized_slot").set(finalized_epoch.last_slot() as f64);
+    gauge!("strata_fcm_pending_epochs").set(0.0);
 
     // Actually assemble the forkchoice manager state.
     Ok(FcmServiceState::new(

--- a/crates/ol/checkpoint/Cargo.toml
+++ b/crates/ol/checkpoint/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+metrics.workspace = true
 serde.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
 strata-checkpoint-types.workspace = true

--- a/crates/ol/checkpoint/src/state.rs
+++ b/crates/ol/checkpoint/src/state.rs
@@ -1,5 +1,6 @@
 //! Service state for OL checkpoint builder.
 
+use metrics::{counter, gauge};
 use strata_asm_proto_checkpoint_types::{
     CheckpointPayload, CheckpointSidecar, CheckpointTip, OLLog as CheckpointOLLog,
     TerminalHeaderComplement,
@@ -106,6 +107,8 @@ impl<C: CheckpointWorkerContext> OLCheckpointServiceState<C> {
 
         let payload = build_checkpoint_payload(commitment, &summary, &self.ctx)?;
         self.ctx.put_checkpoint_payload(commitment, payload)?;
+        counter!("strata_checkpoint_created_total").increment(1);
+        gauge!("strata_checkpoint_last_created_epoch").set(epoch as f64);
 
         info!(
             component = "ol_checkpoint",

--- a/crates/ol/mempool/Cargo.toml
+++ b/crates/ol/mempool/Cargo.toml
@@ -23,6 +23,7 @@ strata-storage.workspace = true
 strata-tasks.workspace = true
 
 anyhow.workspace = true
+metrics.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/ol/mempool/src/state.rs
+++ b/crates/ol/mempool/src/state.rs
@@ -7,6 +7,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use metrics::{counter, gauge};
 use ssz::{Decode, Encode};
 use strata_acct_types::AccountId;
 use strata_db_types::types::MempoolTxData;
@@ -166,14 +167,17 @@ impl<P: StateProvider> MempoolServiceState<P> {
                 OLMempoolError::StateProvider(format!("State not found for tip {:?}", tip))
             })?;
 
-        Ok(Self {
+        let state = Self {
             ctx,
             entries: HashMap::new(),
             ordering_index: BTreeMap::new(),
             account_state: HashMap::new(),
             state_accessor,
             stats: OLMempoolStats::default(),
-        })
+        };
+        state.record_mempool_gauges();
+
+        Ok(state)
     }
 
     /// Load existing transactions from database.
@@ -429,6 +433,9 @@ impl<P: StateProvider> MempoolServiceState<P> {
         // Validate transaction using STF validation helpers
         // This checks: slot bounds, account existence, sequence number validity
         if let Err(e) = validate_transaction(txid, &tx, &self.state_accessor, &self.account_state) {
+            if let Some(reason) = OLMempoolRejectReason::from_error(&e) {
+                self.update_stats_on_reject(reason);
+            }
             debug!(?txid, error = ?e, "rejecting transaction: validation failed");
             return Err(e);
         }
@@ -459,6 +466,7 @@ impl<P: StateProvider> MempoolServiceState<P> {
 
         // Add to in-memory state
         self.add_tx_to_in_memory_state(txid, entry);
+        counter!("strata_mempool_enqueued_total").increment(1);
 
         debug!(
             ?txid,
@@ -666,18 +674,26 @@ impl<P: StateProvider> MempoolServiceState<P> {
         self.stats.mempool_size += 1;
         self.stats.total_bytes += tx_size;
         self.stats.enqueues_accepted += 1;
+        self.record_mempool_gauges();
     }
 
     /// Update stats when a transaction is removed.
     fn update_stats_on_remove(&mut self, tx_size: usize) {
         self.stats.mempool_size -= 1;
         self.stats.total_bytes -= tx_size;
+        self.record_mempool_gauges();
     }
 
     /// Update stats when a transaction is rejected.
     fn update_stats_on_reject(&mut self, reason: OLMempoolRejectReason) {
         self.stats.enqueues_rejected += 1;
         self.stats.rejects_by_reason.increment(reason);
+        counter!("strata_mempool_rejected_total", "reason" => reason.as_str()).increment(1);
+    }
+
+    fn record_mempool_gauges(&self) {
+        gauge!("strata_mempool_tx_count").set(self.stats.mempool_size() as f64);
+        gauge!("strata_mempool_size_bytes").set(self.stats.total_bytes() as f64);
     }
 
     /// Revalidates all transactions in the mempool against the current state.

--- a/crates/ol/mempool/src/types.rs
+++ b/crates/ol/mempool/src/types.rs
@@ -305,6 +305,21 @@ pub enum OLMempoolRejectReason {
 }
 
 impl OLMempoolRejectReason {
+    /// Returns the stable label value for metrics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MempoolFull => "mempool_full",
+            Self::AccountDoesNotExist => "account_does_not_exist",
+            Self::AccountTypeMismatch => "account_type_mismatch",
+            Self::TransactionTooLarge => "transaction_too_large",
+            Self::UsedSequenceNumber => "used_sequence_number",
+            Self::SequenceNumberGap => "sequence_number_gap",
+            Self::TransactionExpired => "transaction_expired",
+            Self::TransactionNotMature => "transaction_not_mature",
+            Self::Duplicate => "duplicate",
+        }
+    }
+
     /// Try to extract a rejection reason from an [`OLMempoolError`].
     ///
     /// Returns `Some(reason)` if the error represents a transaction rejection

--- a/crates/ol/sequencer/Cargo.toml
+++ b/crates/ol/sequencer/Cargo.toml
@@ -29,6 +29,7 @@ strata-tasks.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
+metrics.workspace = true
 serde.workspace = true
 ssz.workspace = true
 thiserror.workspace = true

--- a/crates/ol/sequencer/src/service.rs
+++ b/crates/ol/sequencer/src/service.rs
@@ -3,9 +3,10 @@
 //! After the signer extraction, this service is a pure template-generation
 //! worker.  All signing is handled externally by `strata-signer` via RPC.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
+use metrics::{counter, histogram};
 use serde::Serialize;
 use strata_db_types::errors::DbError;
 use strata_ol_block_assembly::BlockAssemblyError;
@@ -104,7 +105,12 @@ impl<C: SequencerContext> AsyncService for SequencerService<C> {
 async fn process_generation_tick<C: SequencerContext>(state: &mut SequencerServiceState<C>) {
     debug!(last_seen_tip = ?state.last_seen_tip, "generation tick fired");
 
-    let generated_tip = match state.context.generate_template_for_tip().await {
+    let generation_started = Instant::now();
+    let generation_result = state.context.generate_template_for_tip().await;
+    histogram!("strata_sequencer_template_generation_duration_us")
+        .record(generation_started.elapsed().as_micros() as f64);
+
+    let generated_tip = match generation_result {
         Ok(tip) => tip,
         Err(err) => {
             error!(%err, "failed to generate template on generation tick");
@@ -121,6 +127,7 @@ async fn process_generation_tick<C: SequencerContext>(state: &mut SequencerServi
 
     if previous_tip != state.last_seen_tip {
         state.templates_generated += 1;
+        counter!("strata_sequencer_templates_generated_total").increment(1);
         debug!(?previous_tip, current_tip = ?state.last_seen_tip, "sequencer tip changed");
     }
 }

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -19,6 +19,7 @@ strata-storage.workspace = true
 async-trait.workspace = true
 borsh.workspace = true
 futures.workspace = true
+metrics.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -1,3 +1,4 @@
+use metrics::gauge;
 use strata_consensus_logic::unfinalized_tracker::UnfinalizedBlockTracker;
 use strata_ol_chain_types::{L2BlockId, L2Header, SignedL2BlockHeader};
 use strata_primitives::{epoch::EpochCommitment, l2::L2BlockCommitment};
@@ -33,6 +34,7 @@ impl L2SyncState {
             .chain_tip_blocks_iter()
             .max_by_key(|bc| bc.slot())
             .expect("sync: picking new tip");
+        gauge!("strata_l2_sync_tip_slot").set(self.tip_block.slot() as f64);
 
         Ok(())
     }
@@ -42,6 +44,8 @@ impl L2SyncState {
         epoch: EpochCommitment,
     ) -> Result<(), L2SyncError> {
         self.tracker.update_finalized_epoch(&epoch)?;
+        gauge!("strata_l2_finalized_slot").set(epoch.last_slot() as f64);
+        gauge!("strata_l2_finalized_epoch").set(epoch.epoch() as f64);
         Ok(())
     }
 
@@ -94,6 +98,9 @@ pub(crate) async fn initialize_from_db(
         .expect("sync: missing init chain tip");
 
     debug!(?tip_block, "sync state initialized");
+    gauge!("strata_l2_sync_tip_slot").set(tip_block.slot() as f64);
+    gauge!("strata_l2_finalized_slot").set(finalized_epoch.last_slot() as f64);
+    gauge!("strata_l2_finalized_epoch").set(finalized_epoch.epoch() as f64);
 
     let state = L2SyncState { tip_block, tracker };
 

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
+use metrics::counter;
 #[cfg(feature = "debug-utils")]
 use strata_common::{check_and_pause_debug_async, WorkerType};
 use strata_consensus_logic::{message::ForkChoiceMessage, sync_manager::SyncManager};
@@ -243,6 +244,7 @@ async fn handle_new_block<T: SyncClient>(
             .sync_manager
             .submit_chain_tip_msg_async(ForkChoiceMessage::NewBlock(block.header().get_blockid()))
             .await;
+        counter!("strata_sync_blocks_received_total").increment(1);
         debug!(%block_idx, "l2 sync: sending chain tip sent");
     }
     Ok(())

--- a/docker/compose-ol-el-seq.yml
+++ b/docker/compose-ol-el-seq.yml
@@ -32,6 +32,7 @@ services:
     ports:
       - "8432:8432"
       - "8435:8435"
+      - "9615:9615"
     networks:
       - alpen_network
     entrypoint: ["/usr/local/bin/entrypoint.sh"]

--- a/docker/configs/config.seq.toml
+++ b/docker/configs/config.seq.toml
@@ -14,6 +14,10 @@ datadir = "data"
 db_retry_count = 5
 is_sequencer = true
 
+[logging]
+metrics_host = "0.0.0.0"
+metrics_port = 9615
+
 [bitcoind]
 rpc_url = "bitcoind:18443/wallet/default"
 rpc_user = "rpcuser"

--- a/docker/configs/strata-signer/config.toml
+++ b/docker/configs/strata-signer/config.toml
@@ -11,3 +11,5 @@ health_check_port = 8080
 # log_dir = "/var/log/strata-signer"
 # log_file_prefix = "signer"
 # json_format = true
+# metrics_host = "127.0.0.1"
+# metrics_port = 9615

--- a/example_config.toml
+++ b/example_config.toml
@@ -10,6 +10,9 @@ datadir = "/path/to/data/directory"
 db_retry_count = 5
 max_headers_range = 5_000
 
+[logging]
+metrics_port = 9615
+
 [bitcoind]
 rpc_url = "localhost:18332"
 rpc_user = "alpen"

--- a/functional-tests/common/config/config.py
+++ b/functional-tests/common/config/config.py
@@ -91,6 +91,7 @@ class LoggingConfig:
     log_dir: str | None = field(default=None)
     log_file_prefix: str | None = field(default=None)
     json_format: bool | None = field(default=None)
+    metrics_host: str | None = field(default=None)
     metrics_port: int | None = field(default=None)
 
 


### PR DESCRIPTION
## Summary
- wire `strata` and `strata-signer` to `strata-metrics` so `logging.metrics_port` starts a Prometheus `/metrics` endpoint
- add config/docker defaults for the Strata metrics listener and keep `alpen-client` on Reth native metrics
- add explicit infra/domain metrics for sync, fork choice, checkpoint creation, mempool, and sequencer template generation

## Dependency note
- depends on `strata-common` PR #104 / commit `f654f9f` for the `strata-metrics` API
- `strata-service` stays on `v0.1.0-alpha-rc21` in this PR because the current ASM tag also depends on that source; bumping it here creates duplicate `ServiceMonitor`/`TaskExecutor` types. Service-framework Prometheus coverage for ASM needs the ASM dependency aligned separately.

## Validation
- `cargo fmt --check`
- `cargo check -p strata -p strata-signer`
- `cargo check -p strata-signer-bin`
- `cargo test -p strata-config test_logging_config_metrics_port_defaults_and_parses`
- `cargo test -p strata-signer-bin test_signer_config_parses_metrics_port`