### PR TITLE
fix(exec-chain): retry finalized updates after orphan attachment

### DIFF
--- a/bin/alpen-client/src/services/exec_chain.rs
+++ b/bin/alpen-client/src/services/exec_chain.rs
@@ -37,6 +37,12 @@ where
 
     builder.launch_async("exec_chain", executor).await?;
 
+    let initial_update = consensus_watcher.borrow_and_update().clone();
+    handle
+        .new_consensus_state(initial_update)
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to send initial consensus state: {err:?}"))?;
+
     // Spawn consensus forwarder: bridges watch channel -> command channel.
     let forwarder_handle = handle.clone();
     tokio::spawn(async move {

--- a/crates/alpen-ee/exec-chain/src/state.rs
+++ b/crates/alpen-ee/exec-chain/src/state.rs
@@ -40,6 +40,8 @@ pub struct ExecChainState {
     unfinalized: UnfinalizedTracker,
     /// Orphan blocks waiting for their parent to arrive
     orphans: OrphanTracker,
+    /// Latest finalized block that is known but not connected to the finalized chain yet.
+    pending_finalized: Option<Hash>,
     /// Cached block data for quick access
     blocks: HashMap<Hash, ExecBlockRecord>,
 }
@@ -50,6 +52,7 @@ impl ExecChainState {
         Self {
             unfinalized: UnfinalizedTracker::new_empty((&finalized_block).into()),
             orphans: OrphanTracker::new_empty(),
+            pending_finalized: None,
             blocks: HashMap::from([(finalized_block.blockhash(), finalized_block)]),
         }
     }
@@ -141,6 +144,21 @@ impl ExecChainState {
     /// Checks if a block exists in the orphan tracker.
     pub(crate) fn contains_orphan_block(&self, hash: &Hash) -> bool {
         self.orphans.has_block(hash)
+    }
+
+    /// Returns the latest finalized block that could not be applied yet.
+    pub(crate) fn pending_finalized_blockhash(&self) -> Option<Hash> {
+        self.pending_finalized
+    }
+
+    /// Stores a finalized block that is waiting for its parent chain to arrive.
+    pub(crate) fn set_pending_finalized(&mut self, hash: Hash) {
+        self.pending_finalized = Some(hash);
+    }
+
+    /// Clears any pending finalized block.
+    pub(crate) fn clear_pending_finalized(&mut self) {
+        self.pending_finalized = None;
     }
 
     /// Checks if a block is on the canonical chain.

--- a/crates/alpen-ee/exec-chain/src/task.rs
+++ b/crates/alpen-ee/exec-chain/src/task.rs
@@ -46,6 +46,10 @@ pub(crate) async fn handle_new_block<TStorage: ExecBlockStorage>(
             .map_err(|_| ChainTrackerError::PreconfChannelClosed)?;
     }
 
+    if let Some(finalized) = state.pending_finalized_blockhash() {
+        handle_finalized_update(state, finalized, storage, preconf_tx).await?;
+    }
+
     Ok(())
 }
 
@@ -61,6 +65,15 @@ pub(crate) async fn handle_ol_update<TStorage: ExecBlockStorage>(
     // we only care about reorgs on the finalized state
     let finalized = *status.finalized();
 
+    handle_finalized_update(state, finalized, storage, preconf_tx).await
+}
+
+async fn handle_finalized_update<TStorage: ExecBlockStorage>(
+    state: &mut ExecChainState,
+    finalized: Hash,
+    storage: &TStorage,
+    preconf_tx: &watch::Sender<BlockNumHash>,
+) -> Result<(), ChainTrackerError> {
     if finalized == state.finalized_blockhash() {
         // no need to do anything
         return Ok(());
@@ -76,6 +89,7 @@ pub(crate) async fn handle_ol_update<TStorage: ExecBlockStorage>(
         state
             .prune_finalized(finalized)
             .expect("finalized exists in unfinalized blocks");
+        state.clear_pending_finalized();
         let new_best = state.tip_blockhash();
 
         if prev_best != new_best {
@@ -90,7 +104,8 @@ pub(crate) async fn handle_ol_update<TStorage: ExecBlockStorage>(
 
     if state.contains_orphan_block(&finalized) {
         // finalized block is a known but unconnected block
-        // TODO: store the finalized state and retry later
+        // Keep it around so future parent arrivals can retry finalization.
+        state.set_pending_finalized(finalized);
         return Ok(());
     }
 
@@ -154,5 +169,52 @@ mod tests {
         assert_eq!(state.finalized_blockhash(), hash3);
         assert_eq!(state.finalized_blocknum(), 3);
         assert_eq!(state.tip_blockhash(), hash3);
+    }
+
+    #[tokio::test]
+    async fn handle_new_block_retries_pending_orphan_finalized_head() {
+        let hash0 = hash_from_u8(0);
+        let hash1 = hash_from_u8(1);
+        let hash2 = hash_from_u8(2);
+
+        let block0 = create_exec_block(0, Hash::default(), hash0, 0);
+        let block1 = create_exec_block(1, hash0, hash1, 1);
+        let block2 = create_exec_block(2, hash1, hash2, 2);
+
+        let mut state = ExecChainState::new_empty(block0);
+        state.append_block(block2).unwrap();
+
+        let (preconf_tx, _preconf_rx) = watch::channel(state.tip_blocknumhash());
+        let mut storage = MockExecBlockStorage::new();
+
+        let heads = ConsensusHeads {
+            confirmed: hash2,
+            confirmed_epoch: 1,
+            finalized: hash2,
+            finalized_epoch: 1,
+        };
+
+        handle_ol_update(&mut state, heads, &storage, &preconf_tx)
+            .await
+            .unwrap();
+        assert_eq!(state.pending_finalized_blockhash(), Some(hash2));
+
+        storage
+            .expect_get_exec_block()
+            .withf(move |hash| *hash == hash1)
+            .times(1)
+            .returning(move |_| Ok(Some(block1.clone())));
+        storage
+            .expect_extend_finalized_chain()
+            .withf(move |hash| *hash == hash2)
+            .times(1)
+            .returning(|_| Ok(()));
+
+        handle_new_block(&mut state, hash1, &storage, &preconf_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(state.finalized_blockhash(), hash2);
+        assert_eq!(state.finalized_blocknum(), 2);
     }
 }


### PR DESCRIPTION
## Description

Fixes an exec-chain liveness bug when OL reports a finalized EE block before its missing parent arrives locally.

Before this change, `handle_ol_update` finalized immediately if the block was already in the unfinalized tree, but treated an orphan-only finalized block as a no-op. If the parent arrived later, exec-chain would attach the orphan but never retry finalization unless OL emitted another consensus update.

This patch stores that orphan-only finalized hash as pending state and retries it from `handle_new_block` after attachment. It also sends the current `ConsensusHeads` into exec-chain once at startup so the initial finalized state does not wait for the next watch update.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The new state is `pending_finalized: Option<Hash>` on `ExecChainState`. The behavioral change is limited to the orphan-finalized path and the initial consensus push from `alpen-client` startup.

Added regression coverage for `handle_new_block_retries_pending_orphan_finalized_head`.

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues
