### PR TITLE
fix(ci): prevent transitive skip propagation in ci-build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -192,6 +192,7 @@ jobs:
   build-and-push:
     name: "Build ${{ matrix.program }}"
     needs: [prepare, build-sp1-artifacts]
+    if: always() && needs.prepare.result == 'success' && needs.build-sp1-artifacts.result == 'success'
     runs-on: ubuntu-latest
     environment: prod
     permissions:
@@ -329,6 +330,7 @@ jobs:
   dispatch-cd:
     name: Dispatch CD to deployments
     needs: [build-and-push]
+    if: always() && needs.build-and-push.result == 'success'
     runs-on: ubuntu-latest
     permissions: {}
     environment: prod


### PR DESCRIPTION
## Summary

- On `workflow_dispatch`, `check-new-commits` is skipped (schedule-only). `prepare` and `build-sp1-artifacts` handle this with `if: always()`, but `build-and-push` and `dispatch-cd` inherited the transitive skip since they lacked the guard.
- Add explicit `if: always()` with success checks on direct dependencies so downstream jobs run when their inputs succeed regardless of upstream skips.

## Test plan

- [x] Trigger `ci-build.yml` via `workflow_dispatch` — `build-and-push` should no longer be skipped
- [ ] Verify scheduled runs still skip when `check-new-commits` says no new commits