### PR TITLE
fix unbound decode allocation

### DIFF
--- a/crates/acct-types/src/messages.rs
+++ b/crates/acct-types/src/messages.rs
@@ -159,7 +159,11 @@ impl Codec for MsgPayload {
         let value = BitcoinAmount::decode(dec)?;
 
         let len_vi = Varint::decode(dec)?;
-        let mut buf = vec![0; len_vi.inner() as usize];
+        let len = len_vi.inner() as usize;
+        if len > MAX_MSG_PAYLOAD_DATA_BYTES as usize {
+            return Err(CodecError::OverflowContainer);
+        }
+        let mut buf = vec![0; len];
         dec.read_buf(&mut buf)?;
         let data = VariableList::new(buf).map_err(|_| CodecError::OverflowContainer)?;
 

--- a/crates/codec-utils/src/borsh_shim.rs
+++ b/crates/codec-utils/src/borsh_shim.rs
@@ -3,6 +3,9 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_codec::{Codec, CodecError, Decoder, Encoder, Varint};
 
+/// Maximum byte length for a single Borsh-encoded object (16 MiB).
+const MAX_BORSH_OBJECT_BYTES: usize = 16 << 20;
+
 /// Wraps a Borsh type so that it can be transparently [`Codec`]ed.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, BorshSerialize, BorshDeserialize)]
 pub struct CodecBorsh<T: BorshSerialize + BorshDeserialize>(pub T);
@@ -27,6 +30,10 @@ impl<T: BorshSerialize + BorshDeserialize> Codec for CodecBorsh<T> {
         let len = Varint::decode(dec)?;
         let len_usize = len.inner() as usize;
 
+        if len_usize > MAX_BORSH_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
+
         // Read a buffer of that size.
         let mut buffer = vec![0u8; len_usize];
         dec.read_buf(&mut buffer)?;
@@ -40,6 +47,10 @@ impl<T: BorshSerialize + BorshDeserialize> Codec for CodecBorsh<T> {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         // Encode convert the inner value to Borsh.
         let bytes = borsh::to_vec(&self.0).map_err(|_| CodecError::MalformedField("borsh"))?;
+
+        if bytes.len() > MAX_BORSH_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
 
         // First encode the length as a varint.
         let len = Varint::new_usize(bytes.len()).ok_or(CodecError::OverflowContainer)?;

--- a/crates/codec-utils/src/ssz_shim.rs
+++ b/crates/codec-utils/src/ssz_shim.rs
@@ -4,6 +4,9 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use strata_codec::{Codec, CodecError, Decoder, Encoder, Varint};
 
+/// Maximum byte length for a single SSZ-encoded object (16 MiB).
+const MAX_SSZ_OBJECT_BYTES: usize = 16 << 20;
+
 /// Wraps an SSZ type so that it can be transparently [`Codec`]ed.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Decode, Encode)]
 #[ssz(struct_behaviour = "transparent")]
@@ -33,6 +36,10 @@ impl<T: Decode + Encode> Codec for CodecSsz<T> {
         let len = Varint::decode(dec)?;
         let len_usize = len.inner() as usize;
 
+        if len_usize > MAX_SSZ_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
+
         // Read a buffer of that size.
         let mut buffer = vec![0u8; len_usize];
         dec.read_buf(&mut buffer)?;
@@ -46,6 +53,10 @@ impl<T: Decode + Encode> Codec for CodecSsz<T> {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         // Encode convert the inner value to SSZ.
         let bytes = self.0.as_ssz_bytes();
+
+        if bytes.len() > MAX_SSZ_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
 
         // First encode the length as a varint.
         let len = Varint::new_usize(bytes.len()).ok_or(CodecError::OverflowContainer)?;

--- a/crates/da-framework/src/codec.rs
+++ b/crates/da-framework/src/codec.rs
@@ -10,6 +10,9 @@ pub use strata_codec::{
 // Create type alias for Result
 pub type CodecResult<T> = Result<T, CodecError>;
 
+/// Maximum collection size for encode/decode (1M entries).
+const MAX_COLLECTION_COUNT: usize = 1_000_000;
+
 // Std collections encoding/decoding helpers
 
 /// Encodes a BTreeMap where both key and value implement [`Codec`].
@@ -17,6 +20,9 @@ pub fn encode_map<K: Codec, V: Codec>(
     map: &BTreeMap<K, V>,
     enc: &mut impl Encoder,
 ) -> Result<(), CodecError> {
+    if map.len() > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     (map.len() as u32).encode(enc)?;
     for (k, v) in map {
         k.encode(enc)?;
@@ -30,6 +36,9 @@ pub fn decode_map<K: Codec + Ord, V: Codec>(
     dec: &mut impl Decoder,
 ) -> Result<BTreeMap<K, V>, CodecError> {
     let count = u32::decode(dec)? as usize;
+    if count > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     let mut map = BTreeMap::new();
     for _ in 0..count {
         let k = K::decode(dec)?;
@@ -41,6 +50,9 @@ pub fn decode_map<K: Codec + Ord, V: Codec>(
 
 /// Encodes a Vec where elements implement [`Codec`].
 pub fn encode_vec<T: Codec>(vec: &[T], enc: &mut impl Encoder) -> Result<(), CodecError> {
+    if vec.len() > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     (vec.len() as u32).encode(enc)?;
     for item in vec {
         item.encode(enc)?;
@@ -51,6 +63,9 @@ pub fn encode_vec<T: Codec>(vec: &[T], enc: &mut impl Encoder) -> Result<(), Cod
 /// Decodes a Vec where elements implement [`Codec`].
 pub fn decode_vec<T: Codec>(dec: &mut impl Decoder) -> Result<Vec<T>, CodecError> {
     let count = u32::decode(dec)? as usize;
+    if count > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     let mut vec = Vec::with_capacity(count);
     for _ in 0..count {
         vec.push(T::decode(dec)?);
@@ -71,6 +86,9 @@ where
     CK: Codec,
     CV: Codec,
 {
+    if map.len() > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     (map.len() as u32).encode(enc)?;
     for (k, v) in map {
         encode_key(k).encode(enc)?;
@@ -93,6 +111,9 @@ where
     CV: Codec,
 {
     let count = u32::decode(dec)? as usize;
+    if count > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     let mut map = BTreeMap::new();
     for _ in 0..count {
         let k = decode_key(CK::decode(dec)?);
@@ -111,6 +132,9 @@ pub fn encode_vec_with<T, CT>(
 where
     CT: Codec,
 {
+    if vec.len() > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     (vec.len() as u32).encode(enc)?;
     for item in vec {
         encode_elem(item).encode(enc)?;
@@ -127,6 +151,9 @@ where
     CT: Codec,
 {
     let count = u32::decode(dec)? as usize;
+    if count > MAX_COLLECTION_COUNT {
+        return Err(CodecError::OverflowContainer);
+    }
     let mut vec = Vec::with_capacity(count);
     for _ in 0..count {
         vec.push(decode_elem(CT::decode(dec)?));

--- a/crates/ee-acct-types/src/messages.rs
+++ b/crates/ee-acct-types/src/messages.rs
@@ -1,11 +1,15 @@
 //! Definitions for EE message types.
 
-use strata_acct_types::SubjectId;
+use strata_acct_types::{MAX_MSG_PAYLOAD_DATA_BYTES, SubjectId};
 use strata_codec::{Codec, VarVec, decode_buf_exact, impl_type_flat_struct};
 use strata_msg_fmt::{Msg, MsgRef, TypeId};
 use strata_snark_acct_runtime::IAcctMsg;
 
 use crate::{MessageDecodeError, MessageDecodeResult};
+
+/// Maximum byte length for subject transfer data, derived from
+/// `MAX_MSG_PAYLOAD_DATA_BYTES` in the acct-types SSZ spec.
+const MAX_TRANSFER_DATA_BYTES: u32 = MAX_MSG_PAYLOAD_DATA_BYTES as u32;
 
 /// Message type ID for deposit messages.
 pub const DEPOSIT_MSG_TYPE: TypeId = 0x02;
@@ -85,7 +89,7 @@ impl_type_flat_struct! {
     pub struct SubjTransferMsgData {
         source_subject: SubjectId,
         dest_subject: SubjectId,
-        transfer_data: VarVec<u8>,
+        transfer_data: VarVec<u8, { MAX_TRANSFER_DATA_BYTES }>,
     }
 }
 

--- a/crates/ol/chain-types/src/log_payloads.rs
+++ b/crates/ol/chain-types/src/log_payloads.rs
@@ -2,7 +2,14 @@
 
 use strata_codec::{Codec, VarVec};
 
-use crate::SauTxUpdateData;
+use crate::{SAU_MAX_EXTRA_DATA_BYTES, SauTxUpdateData};
+
+/// Maximum byte length for a withdrawal destination BOSD descriptor.
+const MAX_DEST_BYTES: u32 = 255;
+
+/// Maximum byte length for snark account update extra data (matches
+/// `SAU_MAX_EXTRA_DATA_BYTES` from the SSZ spec).
+const MAX_EXTRA_DATA_BYTES: u32 = SAU_MAX_EXTRA_DATA_BYTES as u32;
 
 /// Payload for a simple withdrawal intent log.
 ///
@@ -14,7 +21,7 @@ pub struct SimpleWithdrawalIntentLogData {
     pub amt: u64,
 
     /// Destination BOSD.
-    pub dest: VarVec<u8>,
+    pub dest: VarVec<u8, { MAX_DEST_BYTES }>,
 
     /// User's selected operator index for withdrawal assignment.
     // TODO(STR-1861): encode as varint to reduce DA cost in checkpoint payloads.
@@ -54,7 +61,7 @@ pub struct SnarkAccountUpdateLogData {
     pub new_msg_idx: u64,
 
     /// Extra data from the update operation.
-    pub extra_data: VarVec<u8>,
+    pub extra_data: VarVec<u8, { MAX_EXTRA_DATA_BYTES }>,
 }
 
 impl SnarkAccountUpdateLogData {

--- a/crates/ol/chain-types/src/log_payloads.rs
+++ b/crates/ol/chain-types/src/log_payloads.rs
@@ -11,6 +11,12 @@ const MAX_DEST_BYTES: u32 = 255;
 /// `SAU_MAX_EXTRA_DATA_BYTES` from the SSZ spec).
 const MAX_EXTRA_DATA_BYTES: u32 = SAU_MAX_EXTRA_DATA_BYTES as u32;
 
+/// Bounded [`VarVec`] holding SAU extra data.
+pub type ExtraDataBufVec = VarVec<u8, { MAX_EXTRA_DATA_BYTES }>;
+
+/// Bounded [`VarVec`] holding withdrawal intent destination BOSD.
+pub type DestinationBufVec = VarVec<u8, { MAX_DEST_BYTES }>;
+
 /// Payload for a simple withdrawal intent log.
 ///
 /// Emitted by the OL STF when a withdrawal message is processed at the bridge
@@ -21,7 +27,7 @@ pub struct SimpleWithdrawalIntentLogData {
     pub amt: u64,
 
     /// Destination BOSD.
-    pub dest: VarVec<u8, { MAX_DEST_BYTES }>,
+    pub dest: DestinationBufVec,
 
     /// User's selected operator index for withdrawal assignment.
     // TODO(STR-1861): encode as varint to reduce DA cost in checkpoint payloads.
@@ -61,7 +67,7 @@ pub struct SnarkAccountUpdateLogData {
     pub new_msg_idx: u64,
 
     /// Extra data from the update operation.
-    pub extra_data: VarVec<u8, { MAX_EXTRA_DATA_BYTES }>,
+    pub extra_data: ExtraDataBufVec,
 }
 
 impl SnarkAccountUpdateLogData {

--- a/crates/ol/msg-types/src/withdrawal.rs
+++ b/crates/ol/msg-types/src/withdrawal.rs
@@ -18,6 +18,9 @@ pub const MAX_WITHDRAWAL_DESC_LEN: u32 = 255;
 // TODO: allow users to specify operator fee
 pub const DEFAULT_OPERATOR_FEE: u32 = 0;
 
+/// Bounded [`VarVec`] holding destination descriptor.
+pub type DestDescBufVec = VarVec<u8, { MAX_WITHDRAWAL_DESC_LEN }>;
+
 /// Message data for withdrawal initiation to the bridge gateway account.
 ///
 /// This message type is sent by accounts that want to trigger a withdrawal.
@@ -34,7 +37,7 @@ pub struct WithdrawalMsgData {
     selected_operator: u32,
 
     /// Bitcoin Output Script Descriptor describing the withdrawal output.
-    dest_desc: VarVec<u8, { MAX_WITHDRAWAL_DESC_LEN }>,
+    dest_desc: DestDescBufVec,
 }
 
 impl WithdrawalMsgData {
@@ -64,7 +67,7 @@ impl WithdrawalMsgData {
     }
 
     /// Takes out the inner destination descriptor as a `VarVec`.
-    pub fn into_dest_desc(self) -> VarVec<u8, { MAX_WITHDRAWAL_DESC_LEN }> {
+    pub fn into_dest_desc(self) -> DestDescBufVec {
         self.dest_desc
     }
 

--- a/crates/ol/msg-types/src/withdrawal.rs
+++ b/crates/ol/msg-types/src/withdrawal.rs
@@ -13,7 +13,7 @@ pub const WITHDRAWAL_FEE_BUMP_MSG_TYPE_ID: u16 = 0x04;
 pub const WITHDRAWAL_REJECTION_MSG_TYPE_ID: u16 = 0x05;
 
 /// Maximum length for withdrawal destination descriptor.
-pub const MAX_WITHDRAWAL_DESC_LEN: usize = 255;
+pub const MAX_WITHDRAWAL_DESC_LEN: u32 = 255;
 
 // TODO: allow users to specify operator fee
 pub const DEFAULT_OPERATOR_FEE: u32 = 0;
@@ -34,15 +34,14 @@ pub struct WithdrawalMsgData {
     selected_operator: u32,
 
     /// Bitcoin Output Script Descriptor describing the withdrawal output.
-    // TODO idk why, but I can't make the MAX_WITHDRAWAL_DESC_LEN const generic work
-    dest_desc: VarVec<u8>,
+    dest_desc: VarVec<u8, { MAX_WITHDRAWAL_DESC_LEN }>,
 }
 
 impl WithdrawalMsgData {
     /// Creates a new withdrawal message data instance.
     pub fn new(fees: u32, dest_desc: Vec<u8>, selected_operator: u32) -> Option<Self> {
         // Ensure the destination descriptor isn't too long.
-        if dest_desc.len() > MAX_WITHDRAWAL_DESC_LEN {
+        if dest_desc.len() > MAX_WITHDRAWAL_DESC_LEN as usize {
             return None;
         }
 
@@ -65,7 +64,7 @@ impl WithdrawalMsgData {
     }
 
     /// Takes out the inner destination descriptor as a `VarVec`.
-    pub fn into_dest_desc(self) -> VarVec<u8> {
+    pub fn into_dest_desc(self) -> VarVec<u8, { MAX_WITHDRAWAL_DESC_LEN }> {
         self.dest_desc
     }
 

--- a/crates/reth/statediff/src/batch/diff.rs
+++ b/crates/reth/statediff/src/batch/diff.rs
@@ -7,6 +7,9 @@ use revm_primitives::{Address, B256};
 use strata_codec::{Codec, CodecError, Decoder, Encoder};
 use strata_da_framework::{decode_map_with, encode_map_with};
 
+/// Maximum size for encoded bytes (2 MiB).
+const MAX_CODEC_BYTES: usize = 2 << 20;
+
 use super::{AccountChange, StorageDiff};
 use crate::codec::{CodecAddress, CodecB256};
 
@@ -44,6 +47,9 @@ struct CodecBytes(Bytes);
 
 impl Codec for CodecBytes {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
+        if self.0.len() > MAX_CODEC_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
         // Encode length as u32, then raw bytes
         (self.0.len() as u32).encode(enc)?;
         enc.write_buf(&self.0)?;
@@ -52,6 +58,9 @@ impl Codec for CodecBytes {
 
     fn decode(dec: &mut impl Decoder) -> Result<Self, CodecError> {
         let len = u32::decode(dec)? as usize;
+        if len > MAX_CODEC_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
         let mut buf = vec![0u8; len];
         dec.read_buf(&mut buf)?;
         Ok(Self(Bytes::from(buf)))


### PR DESCRIPTION
## Description
Multiple decode paths allocate memory based on untrusted length values before validating input size. A crafted input with a large length prefix can trigger massive allocations (up to ~4 GiB from a single u32), causing OOM before any data is actually read.

Changes
- codec-utils: Cap CodecSsz and CodecBorsh decode allocations at 16 MiB
- da-framework: Add 1M entry cap to all collection encode/decode helpers (decode_vec, decode_map, decode_map_with, decode_vec_with and their encode counterparts)
- reth-statediff: Cap CodecBytes::decode at 2 MiB
- acct-types: Move MsgPayload::decode length check before allocation (the bound existed but was checked after vec![])
- codec: Tighten VarVec BOUND generics at declaration sites (WithdrawalMsgData, SimpleWithdrawalIntentLogData, SnarkAccountUpdateLogData, SubjTransferMsgData)

Note: Instead of sprinkling bound checks across all length-prefix serialization, should we consider add max bounds in the types themselves, similar to VarVec, etc and have the types explicitly decide max bounds, for all collection types we expect to use ? Adding checks just during serialization can potentially be incompatible with other parts of the code that create them, like block builder, etc.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers
- VarVec from strata-common has a default bound of u32::MAX. This has been overridden in usages here, but we should consider if we should start with safer default instead. @delbonis ?
- Please check the max limits added here, if they are incompatible for our use cases.

This PR does not make changes in similar patterns used in the following locations:
- `evm-ee` codec impls: only used internally
-   `U16LenList` : type limits it to 65k entries, and a better approach would be to add const generic for max allowed size similar to VarVec
- `SimpleTransaction`: only used inside tests
- `alpen_reth_statediff::storage::BatchStateDiff` / `alpen_reth_statediff::storage::StorageDiff` : Not really possible to enforce meaningful limits without making more significant changes. Limits here will also need to be either large enough for any realistic batches, or factored into batch sealing logic. Will handle this one separately.
 
AI usage: refactors and change reviews.

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
