### PR TITLE
feat!(btcio): promote max retry count to u16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1646,7 +1646,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2812,7 +2812,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2830,7 +2830,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2987,14 +2987,14 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbc51226f51642aa07ec276b4b492846ba23e3d01aa4c36c1c3f841d0b39190"
+checksum = "6dce5a07efe5a418df899e6ba925efb0a2434043de2f26396af19430236cfe0f"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
  "bitreq",
- "corepc-types",
+ "corepc-types 0.12.0",
  "hex-conservative",
  "secp256k1 0.29.1",
  "serde",
@@ -3589,7 +3589,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3794,7 +3794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7755b8b9219b23d166a5897b5e2d8266cbdd0de5861d351b96f6db26bcf415f3"
 dependencies = [
  "bitcoin",
- "corepc-types",
+ "corepc-types 0.10.1",
  "jsonrpc",
  "log",
  "serde",
@@ -3820,6 +3820,17 @@ name = "corepc-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22db78b0223b66f82f92b14345f06307078f76d94b18280431ea9bc6cd9cbb6"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583872320eb2ac629c36753023fd072f1ca1b3b74b20cc62bab055b54278789"
 dependencies = [
  "bitcoin",
  "serde",
@@ -4317,7 +4328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4620,7 +4631,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4933,7 +4944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6064,7 +6075,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -7540,7 +7551,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7706,7 +7717,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9101,7 +9112,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9138,7 +9149,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -12572,7 +12583,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13881,7 +13892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17302,7 +17313,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18661,7 +18672,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -414,7 +414,7 @@ bitcoin = { version = "0.32.6", features = ["serde"] }
 bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", version = "0.10.0", tag = "v0.10.0", features = [
   "ssz",
 ] }
-bitcoind-async-client = { version = "0.10.6", features = ["29_0", "raw_rpc"] }
+bitcoind-async-client = { version = "0.10.7", features = ["29_0", "raw_rpc"] }
 bitvec = { version = "1.0.1", features = ["serde"] }
 borsh = { version = "1.6.1", features = ["derive"] }
 bytes = "1.11.1"

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -1025,7 +1025,7 @@ pub struct AdditionalConfig {
     /// Max retries for Bitcoin RPC requests.
     #[cfg(feature = "sequencer")]
     #[arg(long, default_value_t = DEFAULT_BTCIO_RETRY_COUNT)]
-    pub btcio_retry_count: u8,
+    pub btcio_retry_count: u16,
 
     /// Bitcoin RPC retry interval in ms.
     #[cfg(feature = "sequencer")]
@@ -1157,7 +1157,7 @@ fn sequencer_bitcoin_keypair(privkey: &Buf32) -> eyre::Result<Keypair> {
 
 // Mirrors `bitcoind-async-client`'s upstream defaults.
 #[cfg(feature = "sequencer")]
-const DEFAULT_BTCIO_RETRY_COUNT: u8 = 3;
+const DEFAULT_BTCIO_RETRY_COUNT: u16 = 3;
 #[cfg(feature = "sequencer")]
 const DEFAULT_BTCIO_RETRY_INTERVAL_MS: u64 = 1_000;
 

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -51,7 +51,7 @@ pub struct TestBitcoinClient {
     /// Behavior for `send_raw_transaction`.
     pub send_raw_transaction_mode: SendRawTransactionMode,
     /// Value returned by the mock wallet UTXO.
-    pub utxo_amount_sats: i64,
+    pub utxo_amount_sats: u64,
 }
 
 /// Configures how [`TestBitcoinClient`] responds to `send_raw_transaction`.
@@ -82,7 +82,7 @@ impl TestBitcoinClient {
         self
     }
 
-    pub fn with_utxo_amount_sats(mut self, sats: i64) -> Self {
+    pub fn with_utxo_amount_sats(mut self, sats: u64) -> Self {
         self.utxo_amount_sats = sats;
         self
     }
@@ -249,6 +249,8 @@ impl Reader for TestBitcoinClient {
             incremental_relay_fee: None,
             unbroadcast_count: Some(0),
             full_rbf: None,
+            permit_bare_multisig: None,
+            max_data_carrier_size: None,
         })
     }
 }
@@ -377,7 +379,7 @@ impl Wallet for TestBitcoinClient {
             label: "test".to_string(),
             script_pubkey: ScriptBuf::from_hex("001478a93a5b649de9deabd9494ae9bc41f3c9c13837")
                 .unwrap(),
-            amount: SignedAmount::from_sat(self.utxo_amount_sats),
+            amount: Amount::from_sat(self.utxo_amount_sats),
             confirmations: self.confs as u32,
             spendable: true,
             solvable: true,

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -373,7 +373,7 @@ pub(crate) fn choose_utxos(
 ) -> Result<(Vec<ListUnspentItem>, u64), EnvelopeError> {
     let mut bigger_utxos: Vec<&ListUnspentItem> = utxos
         .iter()
-        .filter(|utxo| utxo.amount.to_sat() >= amount as i64)
+        .filter(|utxo| utxo.amount.to_sat() >= amount)
         .collect();
     let mut sum: u64 = 0;
 
@@ -384,13 +384,13 @@ pub(crate) fn choose_utxos(
         // single utxo will be enough
         // so return the transaction
         let utxo = bigger_utxos[0];
-        sum += utxo.amount.to_sat() as u64;
+        sum += utxo.amount.to_sat();
 
         Ok((vec![utxo.clone()], sum))
     } else {
         let mut smaller_utxos: Vec<&ListUnspentItem> = utxos
             .iter()
-            .filter(|utxo| utxo.amount.to_sat() < amount as i64)
+            .filter(|utxo| utxo.amount.to_sat() < amount)
             .collect();
 
         // sort vec by amount (large first)
@@ -399,7 +399,7 @@ pub(crate) fn choose_utxos(
         let mut chosen_utxos: Vec<ListUnspentItem> = vec![];
 
         for utxo in smaller_utxos {
-            sum += utxo.amount.to_sat() as u64;
+            sum += utxo.amount.to_sat();
             chosen_utxos.push(utxo.clone());
 
             if sum >= amount {
@@ -436,9 +436,7 @@ fn build_commit_transaction(
 
     let utxos: Vec<ListUnspentItem> = utxos
         .iter()
-        .filter(|utxo| {
-            utxo.spendable && utxo.solvable && utxo.amount.to_sat() > BITCOIN_DUST_LIMIT as i64
-        })
+        .filter(|utxo| utxo.spendable && utxo.solvable && utxo.amount.to_sat() > BITCOIN_DUST_LIMIT)
         .cloned()
         .collect();
 
@@ -667,7 +665,7 @@ mod tests {
     use bitcoin::{
         absolute::LockTime, script, secp256k1::constants::SCHNORR_SIGNATURE_SIZE,
         taproot::ControlBlock, transaction::Version, Address, Network, OutPoint, ScriptBuf,
-        Sequence, SignedAmount, Transaction, TxIn, TxOut, Witness,
+        Sequence, Transaction, TxIn, TxOut, Witness,
     };
     use bitcoind_async_client::corepc_types::model::ListUnspentItem;
     use strata_l1_txfmt::{MagicBytes, TagData, TagDataRef};
@@ -697,7 +695,7 @@ mod tests {
                 vout: 0,
                 address: address.as_unchecked().clone(),
                 script_pubkey: ScriptBuf::new(),
-                amount: SignedAmount::from_btc(100.0).unwrap(),
+                amount: Amount::from_btc(100.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
                 solvable: true,
@@ -714,7 +712,7 @@ mod tests {
                 vout: 0,
                 address: address.as_unchecked().clone(),
                 script_pubkey: ScriptBuf::new(),
-                amount: SignedAmount::from_btc(50.0).unwrap(),
+                amount: Amount::from_btc(50.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
                 solvable: true,
@@ -731,7 +729,7 @@ mod tests {
                 vout: 0,
                 address: address.as_unchecked().clone(),
                 script_pubkey: ScriptBuf::new(),
-                amount: SignedAmount::from_btc(10.0).unwrap(),
+                amount: Amount::from_btc(10.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
                 solvable: true,
@@ -796,7 +794,7 @@ mod tests {
         }];
 
         let outputs = vec![TxOut {
-            value: utxo.amount.to_unsigned().unwrap(),
+            value: utxo.amount,
             script_pubkey: utxo.address.clone().assume_checked().script_pubkey(),
         }];
 

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -192,7 +192,7 @@ fn build_multi_output_commit(
 ) -> Result<Transaction, EnvelopeError> {
     let spendable: Vec<ListUnspentItem> = utxos
         .into_iter()
-        .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT as i64)
+        .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT)
         .collect();
 
     let p2tr_outputs: Vec<TxOut> = artifacts
@@ -280,7 +280,7 @@ mod tests {
     use bitcoin::{
         opcodes::all::OP_RETURN,
         secp256k1::{rand, Keypair, Secp256k1},
-        Network, ScriptBuf, SignedAmount, Txid,
+        Network, ScriptBuf, Txid,
     };
     use bitcoind_async_client::corepc_types::model::ListUnspentItem;
 
@@ -308,7 +308,7 @@ mod tests {
                 vout: 0,
                 address: address.as_unchecked().clone(),
                 script_pubkey: ScriptBuf::new(),
-                amount: SignedAmount::from_btc(100.0).unwrap(),
+                amount: Amount::from_btc(100.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
                 solvable: true,
@@ -325,7 +325,7 @@ mod tests {
                 vout: 0,
                 address: address.as_unchecked().clone(),
                 script_pubkey: ScriptBuf::new(),
-                amount: SignedAmount::from_btc(50.0).unwrap(),
+                amount: Amount::from_btc(50.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
                 solvable: true,
@@ -416,7 +416,7 @@ mod tests {
             vout: 0,
             address: address.as_unchecked().clone(),
             script_pubkey: ScriptBuf::new(),
-            amount: SignedAmount::from_sat(1000),
+            amount: Amount::from_sat(1_000),
             confirmations: 100,
             spendable: true,
             solvable: true,

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -88,12 +88,12 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
 
         let spendable_utxo_count = utxos
             .iter()
-            .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT as i64)
+            .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT)
             .count();
 
-        let spendable_value_sats: i64 = utxos
+        let spendable_value_sats: u64 = utxos
             .iter()
-            .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT as i64)
+            .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT)
             .map(|u| u.amount.to_sat())
             .sum();
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -317,7 +317,7 @@ pub struct BitcoindConfig {
     pub rpc_password: String,
     pub network: Network,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_count: Option<u8>,
+    pub retry_count: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_interval: Option<u64>,
 }


### PR DESCRIPTION
## Description

We will have issues with BTCIO max retries being capped at 255, which is the maximum `u8` size. This bumps to more than 65,000 by promoting it to a `u16`. 

Needed a bump in `bitcoind-async-client` which had to do some fixes. These are contained to self-explanatory commits in this PR.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

The new version of `bitcoind-async-client`, also bumps `corepc-types` internally, which get rid of some inconsistencies of using `SignedAmount`s instead of `Amount`s. There was some internal refactor to adjust to these inconsistencies, which are way more consistent now by only using `Amount`s. 

No AI was used.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3550
