### PR TITLE
feat(datatool): accept pubkeys instead of privkeys for params generation

### DIFF
--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -156,7 +156,7 @@ pub(crate) struct SubcParams {
 
     #[argh(
         option,
-        description = "add a bridge operator compressed public key (33-byte hex, 02/03 prefix)",
+        description = "add a bridge operator compressed public key (33-byte hex with a parity `02`/`03` prefix)",
         short = 'b'
     )]
     pub(crate) op_pk: Vec<String>,
@@ -240,7 +240,7 @@ pub(crate) struct SubcAsmParams {
 
     #[argh(
         option,
-        description = "add a bridge operator compressed public key (33-byte hex, 02/03 prefix)",
+        description = "add a bridge operator compressed public key (33-byte hex with a parity `02`/`03` prefix)",
         short = 'b'
     )]
     pub(crate) op_pk: Vec<String>,

--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -53,6 +53,7 @@ pub(crate) enum Subcommand {
     Xpriv(SubcXpriv),
     SeqPubkey(SubcSeqPubkey),
     SeqPrivkey(SubcSeqPrivkey),
+    OpPubkey(SubcOpPubkey),
     Params(SubcParams),
     AsmParams(SubcAsmParams),
     OlParams(SubcOlParams),
@@ -112,6 +113,18 @@ pub(crate) struct SubcSeqPrivkey {
     pub(crate) key_from_env: bool,
 }
 
+/// Derive the operator compressed public key from a master xpriv.
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(
+    subcommand,
+    name = "genoppubkey",
+    description = "derives an operator compressed public key from a master xpriv"
+)]
+pub(crate) struct SubcOpPubkey {
+    #[argh(option, description = "reads key from specified file", short = 'f')]
+    pub(crate) key_file: PathBuf,
+}
+
 /// Generate a network's param file from inputs.
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(
@@ -136,24 +149,24 @@ pub(crate) struct SubcParams {
 
     #[argh(
         option,
-        description = "sequencer pubkey (default unchecked)",
+        description = "sequencer x-only public key, 32-byte hex (default unchecked)",
         short = 's'
     )]
-    pub(crate) seqkey: Option<String>,
+    pub(crate) seq_pk: Option<String>,
 
     #[argh(
         option,
-        description = "add a bridge operator key (master xpriv, must be at least one, appended after file keys)",
+        description = "add a bridge operator compressed public key (33-byte hex, 02/03 prefix)",
         short = 'b'
     )]
-    pub(crate) opkey: Vec<String>,
+    pub(crate) op_pk: Vec<String>,
 
     #[argh(
         option,
-        description = "read bridge operator keys (master xpriv) by line from file",
+        description = "read bridge operator compressed public keys by line from file",
         short = 'B'
     )]
-    pub(crate) opkeys: Option<PathBuf>,
+    pub(crate) op_pks: Option<PathBuf>,
 
     #[argh(option, description = "deposit amount in sats (default \"10 BTC\")")]
     pub(crate) deposit_sats: Option<String>,
@@ -220,24 +233,24 @@ pub(crate) struct SubcAsmParams {
 
     #[argh(
         option,
-        description = "sequencer pubkey (default unchecked)",
+        description = "sequencer x-only public key, 32-byte hex (default unchecked)",
         short = 's'
     )]
-    pub(crate) seqkey: Option<String>,
+    pub(crate) seq_pk: Option<String>,
 
     #[argh(
         option,
-        description = "add a bridge operator key (master xpriv)",
+        description = "add a bridge operator compressed public key (33-byte hex, 02/03 prefix)",
         short = 'b'
     )]
-    pub(crate) opkey: Vec<String>,
+    pub(crate) op_pk: Vec<String>,
 
     #[argh(
         option,
-        description = "read bridge operator keys (master xpriv) by line from file",
+        description = "read bridge operator compressed public keys by line from file",
         short = 'B'
     )]
-    pub(crate) opkeys: Option<PathBuf>,
+    pub(crate) op_pks: Option<PathBuf>,
 
     #[argh(option, description = "deposit amount in sats (default \"10 BTC\")")]
     pub(crate) deposit_sats: Option<String>,

--- a/bin/datatool/src/cmd/asm_params.rs
+++ b/bin/datatool/src/cmd/asm_params.rs
@@ -2,10 +2,7 @@
 
 use std::{fs, num::NonZero, str::FromStr};
 
-use bitcoin::{
-    bip32::{Xpriv, Xpub},
-    secp256k1::{PublicKey, SECP256K1},
-};
+use bitcoin::{secp256k1::PublicKey, XOnlyPublicKey};
 use strata_asm_params::{
     AdministrationInitConfig, AsmParams, BridgeV1InitConfig, CheckpointInitConfig,
     ConfirmationDepths, SubprotocolInstance,
@@ -64,30 +61,24 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
         ctx,
     )?;
 
-    // Parse operator keys.
-    let mut opkeys = Vec::new();
+    // Parse operator public keys.
+    let mut pubkeys: Vec<PublicKey> = Vec::new();
 
-    if let Some(opkeys_path) = cmd.opkeys {
-        let opkeys_str = fs::read_to_string(opkeys_path)?;
+    if let Some(pks_path) = cmd.op_pks {
+        let pks_str = fs::read_to_string(pks_path)?;
 
-        for line in opkeys_str.lines() {
+        for line in pks_str.lines() {
             if line.trim().is_empty() || line.starts_with('#') {
                 continue;
             }
 
-            opkeys.push(Xpriv::from_str(line)?);
+            pubkeys.push(PublicKey::from_str(line.trim())?);
         }
     }
 
-    for key in cmd.opkey {
-        opkeys.push(Xpriv::from_str(&key)?);
+    for key in &cmd.op_pk {
+        pubkeys.push(PublicKey::from_str(key.trim())?);
     }
-
-    // Convert xpriv keys to secp256k1 public keys.
-    let pubkeys: Vec<PublicKey> = opkeys
-        .iter()
-        .map(|xpriv| xpriv.to_keypair(SECP256K1).public_key())
-        .collect();
 
     // Build admin subprotocol params using the operator keys for all three admin roles.
     let admin_keys: Vec<CompressedPublicKey> = pubkeys
@@ -136,7 +127,7 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
     let genesis_ol_blkid = *genesis_artifacts.commitment.blkid();
 
     // Build checkpoint config.
-    let sequencer_predicate = resolve_sequencer_predicate(cmd.seqkey.as_deref())?;
+    let sequencer_predicate = resolve_sequencer_predicate(cmd.seq_pk.as_deref())?;
     let checkpoint_predicate = resolve_checkpoint_predicate(cmd.checkpoint_predicate)?;
     let genesis_l1_height = genesis_l1_view.blk.height();
 
@@ -195,25 +186,26 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
     Ok(())
 }
 
-fn resolve_sequencer_predicate(seqkey: Option<&str>) -> anyhow::Result<PredicateKey> {
-    let Some(seqkey) = seqkey.map(str::trim) else {
+fn resolve_sequencer_predicate(seq_pk: Option<&str>) -> anyhow::Result<PredicateKey> {
+    let Some(pk_hex) = seq_pk.map(str::trim) else {
         return Ok(PredicateKey::always_accept());
     };
 
-    let xpub = Xpub::from_str(seqkey)?;
+    let xonly = XOnlyPublicKey::from_str(pk_hex)?;
     Ok(PredicateKey::new(
         PredicateTypeId::Bip340Schnorr,
-        xpub.to_x_only_pub().serialize().to_vec(),
+        xonly.serialize().to_vec(),
     ))
 }
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::bip32::Xpub;
-
     use super::*;
 
-    const TEST_SEQUENCER_XPUB: &str = "tpubDASVk1m5cxpmUbwVEZEQb8maDVx9kDxBhSLCqsKHJJmZ8htSegpHx7G3RFudZCdDLtNKTosQiBLbbFsVA45MemurWenzn16Y1ft7NkQekcD";
+    /// X-only pubkey hex derived from the test xpriv
+    /// `tprv8ZgxMBicQKsPd4arFr7sKjSnKFDVMR2JHw9Y8L9nXN4kiok4u28LpHijEudH3mMYoL4pM5UL9Bgdz2M4Cy8EzfErmU9m86ZTw6hCzvFeTg7`
+    /// via `genseqpubkey`.
+    const TEST_SEQ_PK: &str = "14ebfa9a90fee3020686b5334b297b675a9f29282f44b6c3a4ab1f0582021839";
 
     #[test]
     fn sequencer_predicate_defaults_to_always_accept() {
@@ -225,9 +217,9 @@ mod tests {
     #[test]
     fn sequencer_predicate_uses_bip340_schnorr_pubkey() {
         let predicate =
-            resolve_sequencer_predicate(Some(TEST_SEQUENCER_XPUB)).expect("xpub should parse");
-        let xpub = Xpub::from_str(TEST_SEQUENCER_XPUB).expect("xpub should parse");
-        let expected_pubkey = xpub.to_x_only_pub().serialize();
+            resolve_sequencer_predicate(Some(TEST_SEQ_PK)).expect("x-only hex should parse");
+        let xonly = XOnlyPublicKey::from_str(TEST_SEQ_PK).expect("x-only hex should parse");
+        let expected_pubkey = xonly.serialize();
 
         assert_eq!(predicate.id(), PredicateTypeId::Bip340Schnorr.as_u8());
         assert_eq!(predicate.condition(), expected_pubkey.as_slice());

--- a/bin/datatool/src/cmd/mod.rs
+++ b/bin/datatool/src/cmd/mod.rs
@@ -4,6 +4,7 @@ mod asm_params;
 #[cfg(feature = "btc-client")]
 mod l1_view;
 mod ol_params;
+mod op_pubkey;
 mod params;
 mod seq_privkey;
 mod seq_pubkey;
@@ -17,6 +18,7 @@ pub(crate) fn exec_subc(cmd: Subcommand, ctx: &mut CmdContext) -> anyhow::Result
         Subcommand::Xpriv(subc) => xpriv::exec(subc, ctx),
         Subcommand::SeqPubkey(subc) => seq_pubkey::exec(subc, ctx),
         Subcommand::SeqPrivkey(subc) => seq_privkey::exec(subc, ctx),
+        Subcommand::OpPubkey(subc) => op_pubkey::exec(subc, ctx),
         Subcommand::Params(subc) => params::exec(subc, ctx),
         Subcommand::AsmParams(subc) => asm_params::exec(subc, ctx),
         Subcommand::OlParams(subc) => ol_params::exec(subc, ctx),

--- a/bin/datatool/src/cmd/op_pubkey.rs
+++ b/bin/datatool/src/cmd/op_pubkey.rs
@@ -9,7 +9,7 @@ use crate::args::{CmdContext, SubcOpPubkey};
 /// Executes the `genoppubkey` subcommand.
 ///
 /// Reads a master [`Xpriv`] from the specified file and prints the corresponding
-/// compressed public key (33-byte hex) to stdout.
+/// compressed [`PublicKey`](bitcoin::PublicKey) (33-byte hex) to stdout.
 pub(super) fn exec(cmd: SubcOpPubkey, _ctx: &mut CmdContext) -> anyhow::Result<()> {
     let xpriv = Xpriv::from_str(fs::read_to_string(&cmd.key_file)?.trim())?;
     let pubkey = xpriv.to_keypair(SECP256K1).public_key();

--- a/bin/datatool/src/cmd/op_pubkey.rs
+++ b/bin/datatool/src/cmd/op_pubkey.rs
@@ -1,0 +1,19 @@
+//! `genoppubkey` subcommand: derives an operator compressed public key from a master xpriv.
+
+use std::{fs, str::FromStr};
+
+use bitcoin::{bip32::Xpriv, secp256k1::SECP256K1};
+
+use crate::args::{CmdContext, SubcOpPubkey};
+
+/// Executes the `genoppubkey` subcommand.
+///
+/// Reads a master [`Xpriv`] from the specified file and prints the corresponding
+/// compressed public key (33-byte hex) to stdout.
+pub(super) fn exec(cmd: SubcOpPubkey, _ctx: &mut CmdContext) -> anyhow::Result<()> {
+    let xpriv = Xpriv::from_str(fs::read_to_string(&cmd.key_file)?.trim())?;
+    let pubkey = xpriv.to_keypair(SECP256K1).public_key();
+    println!("{pubkey}");
+
+    Ok(())
+}

--- a/bin/datatool/src/cmd/params.rs
+++ b/bin/datatool/src/cmd/params.rs
@@ -159,7 +159,7 @@ struct ParamsConfig {
     genesis_l1_view: GenesisL1View,
     /// Sequencer's key.
     seqkey: Option<Buf32>,
-    /// Operators' compressed public keys.
+    /// Operators' compressed [`PublicKey`](bitcoin::PublicKey)s.
     opkeys: Vec<PublicKey>,
     /// Verifier's key.
     checkpoint_predicate: PredicateKey,

--- a/bin/datatool/src/cmd/params.rs
+++ b/bin/datatool/src/cmd/params.rs
@@ -4,13 +4,8 @@ use std::{fs, path::Path, str::FromStr};
 
 use alloy_genesis::Genesis;
 use alloy_primitives::B256;
-use bitcoin::{
-    bip32::{Xpriv, Xpub},
-    secp256k1::SECP256K1,
-    Amount, XOnlyPublicKey,
-};
+use bitcoin::{secp256k1::PublicKey, Amount, XOnlyPublicKey};
 use reth_chainspec::ChainSpec;
-use strata_key_derivation::error::KeyError;
 use strata_l1_txfmt::MagicBytes;
 use strata_params::{CredRule, ProofPublishMode, RollupParams};
 use strata_predicate::PredicateKey;
@@ -43,10 +38,10 @@ const DEFAULT_EPOCH_SLOTS: u32 = 64;
 /// Either writes to a file or prints to stdout depending on the provided options.
 pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> {
     // Parse the sequencer key, trimming whitespace for convenience.
-    let seqkey = match cmd.seqkey.as_ref().map(|s| s.trim()) {
-        Some(seqkey) => {
-            let xpub = Xpub::from_str(seqkey)?;
-            Some(Buf32(xpub.to_x_only_pub().serialize()))
+    let seqkey = match cmd.seq_pk.as_ref().map(|s| s.trim()) {
+        Some(pk_hex) => {
+            let xonly = XOnlyPublicKey::from_str(pk_hex)?;
+            Some(Buf32(xonly.serialize()))
         }
         None => None,
     };
@@ -58,10 +53,10 @@ pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> 
         ctx,
     )?;
 
-    // Parse each of the operator keys.
+    // Parse each of the operator public keys.
     let mut opkeys = Vec::new();
 
-    if let Some(opkeys_path) = cmd.opkeys {
+    if let Some(opkeys_path) = cmd.op_pks {
         let opkeys_str = fs::read_to_string(opkeys_path)?;
 
         for line in opkeys_str.lines() {
@@ -70,12 +65,12 @@ pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> 
                 continue;
             }
 
-            opkeys.push(Xpriv::from_str(line)?);
+            opkeys.push(PublicKey::from_str(line.trim())?);
         }
     }
 
-    for key in cmd.opkey {
-        opkeys.push(Xpriv::from_str(&key)?);
+    for key in &cmd.op_pk {
+        opkeys.push(PublicKey::from_str(key.trim())?);
     }
 
     // Parse the deposit size str.
@@ -164,8 +159,8 @@ struct ParamsConfig {
     genesis_l1_view: GenesisL1View,
     /// Sequencer's key.
     seqkey: Option<Buf32>,
-    /// Operators' master keys.
-    opkeys: Vec<Xpriv>,
+    /// Operators' compressed public keys.
+    opkeys: Vec<PublicKey>,
     /// Verifier's key.
     checkpoint_predicate: PredicateKey,
     /// Amount of sats to deposit.
@@ -178,7 +173,7 @@ struct ParamsConfig {
 
 /// Constructs the parameters for a Strata network.
 // TODO convert this to also initialize the sync params
-fn construct_params(config: ParamsConfig) -> Result<RollupParams, KeyError> {
+fn construct_params(config: ParamsConfig) -> anyhow::Result<RollupParams> {
     let cr = config
         .seqkey
         .map(CredRule::SchnorrKey)
@@ -187,7 +182,7 @@ fn construct_params(config: ParamsConfig) -> Result<RollupParams, KeyError> {
     let opkeys: Vec<XOnlyPublicKey> = config
         .opkeys
         .iter()
-        .map(|o| o.to_keypair(SECP256K1).x_only_public_key().0)
+        .map(|pk| pk.x_only_public_key().0)
         .collect();
 
     Ok(RollupParams {

--- a/bin/datatool/src/cmd/seq_pubkey.rs
+++ b/bin/datatool/src/cmd/seq_pubkey.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Executes the `genseqpubkey` subcommand.
 ///
-/// Derives the sequencer x-only public key (32-byte hex) from the provided
+/// Derives the sequencer [`XOnlyPublicKey`](bitcoin::XOnlyPublicKey) (32-byte hex) from the provided
 /// master [`Xpriv`](bitcoin::bip32::Xpriv) and prints it to stdout.
 pub(super) fn exec(cmd: SubcSeqPubkey, _ctx: &mut CmdContext) -> anyhow::Result<()> {
     let Some(xpriv) = resolve_xpriv(&cmd.key_file, cmd.key_from_env, SEQKEY_ENVVAR)? else {

--- a/bin/datatool/src/cmd/seq_pubkey.rs
+++ b/bin/datatool/src/cmd/seq_pubkey.rs
@@ -1,4 +1,4 @@
-//! `genseqpubkey` subcommand: generates a sequencer pubkey from a master xpriv.
+//! `genseqpubkey` subcommand: derives the sequencer x-only public key from a master xpriv.
 
 use strata_key_derivation::sequencer::SequencerKeys;
 
@@ -9,16 +9,16 @@ use crate::{
 
 /// Executes the `genseqpubkey` subcommand.
 ///
-/// Generates the sequencer [`Xpub`](bitcoin::bip32::Xpub) from the provided
-/// [`Xpriv`](bitcoin::bip32::Xpriv) and prints it to stdout.
+/// Derives the sequencer x-only public key (32-byte hex) from the provided
+/// master [`Xpriv`](bitcoin::bip32::Xpriv) and prints it to stdout.
 pub(super) fn exec(cmd: SubcSeqPubkey, _ctx: &mut CmdContext) -> anyhow::Result<()> {
     let Some(xpriv) = resolve_xpriv(&cmd.key_file, cmd.key_from_env, SEQKEY_ENVVAR)? else {
         anyhow::bail!("privkey unset");
     };
 
     let seq_keys = SequencerKeys::new(&xpriv)?;
-    let seq_xpub = seq_keys.derived_xpub();
-    println!("{seq_xpub}");
+    let xonly = seq_keys.derived_xpub().to_x_only_pub();
+    println!("{xonly}");
 
     Ok(())
 }

--- a/bin/datatool/src/cmd/seq_pubkey.rs
+++ b/bin/datatool/src/cmd/seq_pubkey.rs
@@ -9,8 +9,8 @@ use crate::{
 
 /// Executes the `genseqpubkey` subcommand.
 ///
-/// Derives the sequencer [`XOnlyPublicKey`](bitcoin::XOnlyPublicKey) (32-byte hex) from the provided
-/// master [`Xpriv`](bitcoin::bip32::Xpriv) and prints it to stdout.
+/// Derives the sequencer [`XOnlyPublicKey`](bitcoin::XOnlyPublicKey) (32-byte hex) from the
+/// provided master [`Xpriv`](bitcoin::bip32::Xpriv) and prints it to stdout.
 pub(super) fn exec(cmd: SubcSeqPubkey, _ctx: &mut CmdContext) -> anyhow::Result<()> {
     let Some(xpriv) = resolve_xpriv(&cmd.key_file, cmd.key_from_env, SEQKEY_ENVVAR)? else {
         anyhow::bail!("privkey unset");

--- a/docker/init-network.sh
+++ b/docker/init-network.sh
@@ -193,9 +193,9 @@ if [ "${MODE}" = "sequencer" ]; then
         "${DATATOOL_PATH}" -b "${BITCOIN_NETWORK}" genxpriv "${OPERATOR_KEY}"
         echo "generated ${OPERATOR_KEY}"
     fi
-    OPERATOR_XPRIV=$(cat "${OPERATOR_KEY}")
+    OPERATOR_PK=$("${DATATOOL_PATH}" -b "${BITCOIN_NETWORK}" genoppubkey -f "${OPERATOR_KEY}")
 
-    SEQ_XPUB=$("${DATATOOL_PATH}" -b "${BITCOIN_NETWORK}" genseqpubkey -f "${SEQ_ROOT_KEY}")
+    SEQ_PK=$("${DATATOOL_PATH}" -b "${BITCOIN_NETWORK}" genseqpubkey -f "${SEQ_ROOT_KEY}")
 
     GENESIS_L1_VIEW="${OUTPUT_DIR}/genesis-l1-view.json"
     if [ ! -f "${GENESIS_L1_VIEW}" ]; then
@@ -242,8 +242,8 @@ GEOF
             genparams \
             -o "${ROLLUP_PARAMS}" \
             -n ALPN \
-            -s "${SEQ_XPUB}" \
-            -b "${OPERATOR_XPRIV}" \
+            -s "${SEQ_PK}" \
+            -b "${OPERATOR_PK}" \
             -g "${GENESIS_L1_HEIGHT}" \
             --proof-timeout 30 \
             --genesis-l1-view-file "${GENESIS_L1_VIEW}" \
@@ -270,8 +270,8 @@ GEOF
             gen-asm-params \
             -o "${ASM_PARAMS}" \
             -n ALPN \
-            -s "${SEQ_XPUB}" \
-            -b "${OPERATOR_XPRIV}" \
+            -s "${SEQ_PK}" \
+            -b "${OPERATOR_PK}" \
             -g "${GENESIS_L1_HEIGHT}" \
             --genesis-l1-view-file "${GENESIS_L1_VIEW}" \
             --ol-params "${OL_PARAMS}" \

--- a/functional-tests/common/datatool.py
+++ b/functional-tests/common/datatool.py
@@ -65,13 +65,15 @@ def ensure_priv_key(path: Path) -> None:
     )
 
 
-def get_operator_xprivs(datadir, operator_fname) -> list[str]:
-    # Generate operator keys
+def get_operator_pubkeys(datadir, operator_fname) -> list[str]:
+    """Generates an operator xpriv and returns the derived compressed public keys."""
     operator_key_path = datadir / operator_fname
     ensure_priv_key(operator_key_path)
-    operator_xpriv = operator_key_path.read_text().strip()
-    operator_xprivs = [operator_xpriv]
-    return operator_xprivs
+    res = run_datatool(["genoppubkey", "-f", str(operator_key_path)])
+    pubkey = res.stdout.strip()
+    if not pubkey:
+        raise RuntimeError("strata-datatool genoppubkey returned empty output")
+    return [pubkey]
 
 
 @dataclass
@@ -114,7 +116,7 @@ def generate_rollup_params_unchecked(
     """
     sequencer_key_path = datadir / seq_fname
     ensure_priv_key(sequencer_key_path)
-    operator_xprivs = get_operator_xprivs(datadir, "bridge-operator_keys")
+    operator_pubkeys = get_operator_pubkeys(datadir, "bridge-operator_keys")
     params_path = datadir / "rollup-params.json"
 
     args = [
@@ -128,15 +130,15 @@ def generate_rollup_params_unchecked(
         "-o",
         str(params_path),
     ]
-    for opkey in operator_xprivs:
-        args.extend(["--opkey", opkey])
+    for pk in operator_pubkeys:
+        args.extend(["--op-pk", pk])
 
     run_datatool(args, bconfig)
     return RollupParamsArtifacts(
         params_path=params_path,
         sequencer_key_path=sequencer_key_path,
         sequencer_pubkey=None,
-        operator_keys=operator_xprivs,
+        operator_keys=operator_pubkeys,
     )
 
 
@@ -150,7 +152,7 @@ def generate_rollup_params(
     sequencer_key_path = datadir / seq_fname
     ensure_priv_key(sequencer_key_path)
     sequencer_pubkey = generate_sequencer_pubkey(sequencer_key_path)
-    operator_xprivs = get_operator_xprivs(datadir, "bridge-operator_keys")
+    operator_pubkeys = get_operator_pubkeys(datadir, "bridge-operator_keys")
 
     params_path = datadir / "rollup-params.json"
 
@@ -162,16 +164,18 @@ def generate_rollup_params(
         "ALPN",
         "--genesis-l1-height",
         str(genesis_l1_height),
-        "--seqkey",
+        "--seq-pk",
         sequencer_pubkey,
         "-o",
         str(params_path),
     ]
-    for opkey in operator_xprivs:
-        args.extend(["--opkey", opkey])
+    for pk in operator_pubkeys:
+        args.extend(["--op-pk", pk])
 
     run_datatool(args, bconfig)
-    return RollupParamsArtifacts(params_path, sequencer_key_path, sequencer_pubkey, operator_xprivs)
+    return RollupParamsArtifacts(
+        params_path, sequencer_key_path, sequencer_pubkey, operator_pubkeys
+    )
 
 
 def generate_sequencer_pubkey(sequencer_key_path: Path) -> str:
@@ -208,7 +212,7 @@ def generate_asm_params(
     datadir: Path,
     bconfig: BitcoindConfig,
     genesis_l1_height: int,
-    operator_xprivs: list[str],
+    operator_pubkeys: list[str],
     ol_params_path: Path | None = None,
     sequencer_pubkey: str | None = None,
     admin_confirmation_depth: int | None = None,
@@ -229,11 +233,11 @@ def generate_asm_params(
     if ol_params_path is not None:
         args.extend(["--ol-params", str(ol_params_path)])
     if sequencer_pubkey is not None:
-        args.extend(["--seqkey", sequencer_pubkey])
+        args.extend(["--seq-pk", sequencer_pubkey])
     if admin_confirmation_depth is not None:
         args.extend(["--confirmation-depth", str(admin_confirmation_depth)])
-    for opkey in operator_xprivs:
-        args.extend(["--opkey", opkey])
+    for pk in operator_pubkeys:
+        args.extend(["--op-pk", pk])
 
     run_datatool(args, bconfig)
     return params_path


### PR DESCRIPTION
## Description

Datatool's `genparams` and `gen-asm-params` previously required bridge operator master xprivs, meaning whoever generates params must know all operator private keys — defeating the bridge's multi-party security model. This PR changes both commands to accept only public keys, enabling params generation without access to secrets (e.g. in CI).

**Changes:**
- Operator keys: `--opkey`/`--opkeys` (xprivs) → `--op-pk`/`--op-pks` (compressed pubkeys, 33-byte hex)
- Sequencer key: `--seqkey` (xpub) → `--seq-pk` (x-only pubkey, 32-byte hex)
- `genseqpubkey`: now outputs x-only hex instead of xpub string
- New `genoppubkey` command: derives compressed pubkey from an operator xpriv file
- Functional tests updated to derive and pass pubkeys to datatool

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is a breaking change to the datatool CLI interface — flag names and expected input formats have changed. Any scripts or CI that call `genparams` / `gen-asm-params` with `--opkey` / `--seqkey` will need updating.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

**AI Assistance Notice:** This PR was developed with assistance from Claude Code (Anthropic).

## Related Issues

Resolves [STR-3462](https://alpenlabs.atlassian.net/browse/STR-3462)

[STR-3462]: https://alpenlabs.atlassian.net/browse/STR-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ