### PR TITLE
Revert "fix(docker): adds `alpen` HTTP API options ENV var"

### DIFF
--- a/docker/alpen-client/entrypoint.sh
+++ b/docker/alpen-client/entrypoint.sh
@@ -31,7 +31,7 @@ exec alpen-client \
     --http \
     --http.addr 0.0.0.0 \
     --http.port "${HTTP_PORT:-8545}" \
-    --http.api "${HTTP_API:-eth,alpen,net,web3,txpool,admin,debug}" \
+    --http.api "${HTTP_API:-eth,net,web3,txpool,admin,debug}" \
     --ws \
     --ws.addr 0.0.0.0 \
     --ws.port "${WS_PORT:-8546}" \


### PR DESCRIPTION
Reverts alpenlabs/alpen#1863

It is a fix that we don't need. IT already works

```sh
curl -sS https://alpen-staging.testnet-v2.alpenlabs.io/ \
                                                 -H 'content-type: application/json' \
                                                 -d "{\"jsonrpc\":\"2.0\",\"method\":\"alpen_getBlockStatus\",\"params\":[\"0xc7ea6703ea97c2318574076cc26214d4eb4ec261531e9b29789eb5d9c529b6f0\"],\"id\":1}"

{"jsonrpc":"2.0","id":1,"result":{"status":"pending"}}
```