### PR TITLE
STR 3422 Sequencer signs two blocks per slot when two `GenerationTick`s race

### DIFF
--- a/bin/strata-dbtool/README.md
+++ b/bin/strata-dbtool/README.md
@@ -187,6 +187,24 @@ strata-dbtool get-ol-summary <slot_from> [OPTIONS]
 strata-dbtool get-ol-summary 100
 ```
 
+### `get-ol-blocks-at-slot`
+Shows all OL block IDs stored for a slot.
+
+```bash
+strata-dbtool get-ol-blocks-at-slot <slot> [OPTIONS]
+```
+
+**Arguments:**
+- `slot` - OL slot
+
+**Options:**
+- `-o, --output-format <format>` - Output format (default: porcelain)
+
+**Example:**
+```bash
+strata-dbtool get-ol-blocks-at-slot 100
+```
+
 ### `get-ol-block`
 Shows detailed information about a specific OL block.
 

--- a/bin/strata-dbtool/src/cli.rs
+++ b/bin/strata-dbtool/src/cli.rs
@@ -20,7 +20,7 @@ use crate::cmd::{
         EeDeleteAcctProofArgs, EeDeleteChunkReceiptArgs, EeGetAcctProofArgs, EeGetChunkReceiptArgs,
     },
     l1::{GetL1BlockArgs, GetL1SummaryArgs},
-    ol::{GetOLBlockArgs, GetOLSummaryArgs},
+    ol::{GetOLBlockArgs, GetOLBlocksAtSlotArgs, GetOLSummaryArgs},
     ol_state::{GetOLStateArgs, RevertOLStateArgs},
     prover_task::{
         AbandonProverTaskArgs, AbandonProverTasksArgs, BackfillCheckpointProofTaskArgs,
@@ -57,6 +57,7 @@ pub(crate) enum Command {
     GetBroadcasterSummary(GetBroadcasterSummaryArgs),
     GetBroadcasterTx(GetBroadcasterTxArgs),
     GetOlBlock(GetOLBlockArgs),
+    GetOlBlocksAtSlot(GetOLBlocksAtSlotArgs),
     GetOlSummary(GetOLSummaryArgs),
     GetClientStateUpdate(GetClientStateUpdateArgs),
     GetCheckpoint(GetCheckpointArgs),

--- a/bin/strata-dbtool/src/cmd/ol.rs
+++ b/bin/strata-dbtool/src/cmd/ol.rs
@@ -9,7 +9,7 @@ use crate::{
     cli::OutputFormat,
     cmd::checkpoint::get_last_ol_checkpoint_epoch,
     output::{
-        ol::{OLBlockInfo, OLSummaryInfo},
+        ol::{OLBlockInfo, OLBlocksAtSlotInfo, OLSummaryInfo},
         output,
     },
     utils::block_id::parse_ol_block_id,
@@ -35,6 +35,19 @@ pub(crate) struct GetOLSummaryArgs {
     /// slot to start scanning OL summary from
     #[argh(positional)]
     pub(crate) slot_from: Slot,
+
+    /// output format: "porcelain" (default) or "json"
+    #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
+    pub(crate) output_format: OutputFormat,
+}
+
+/// Get all OL block IDs stored for a slot.
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "get-ol-blocks-at-slot")]
+pub(crate) struct GetOLBlocksAtSlotArgs {
+    /// OL slot
+    #[argh(positional)]
+    pub(crate) slot: Slot,
 
     /// output format: "porcelain" (default) or "json"
     #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
@@ -148,6 +161,25 @@ pub(crate) fn get_ol_summary(
 
     // Use the output utility
     output(&summary_info, args.output_format)
+}
+
+/// Gets all OL block IDs stored for a slot.
+pub(crate) fn get_ol_blocks_at_slot(
+    db: &impl DatabaseBackend,
+    args: GetOLBlocksAtSlotArgs,
+) -> Result<(), DisplayedError> {
+    let block_ids = db
+        .ol_block_db()
+        .get_blocks_at_height(args.slot)
+        .internal_error(format!("Failed to get blocks at slot {}", args.slot))?;
+
+    let info = OLBlocksAtSlotInfo {
+        slot: args.slot,
+        count: block_ids.len(),
+        block_ids: &block_ids,
+    };
+
+    output(&info, args.output_format)
 }
 
 fn get_chain_tip_ol_block_id(db: &impl DatabaseBackend) -> Result<OLBlockId, DisplayedError> {

--- a/bin/strata-dbtool/src/cmd/ol_state.rs
+++ b/bin/strata-dbtool/src/cmd/ol_state.rs
@@ -123,6 +123,7 @@ pub(crate) fn revert_ol_state(
                 Box::new(target_block_id),
             )
         })?;
+    let target_commitment = OLBlockCommitment::new(target_slot, target_block_id);
 
     let target_block = db
         .ol_block_db()
@@ -181,6 +182,11 @@ pub(crate) fn revert_ol_state(
     let mut commitments_to_delete = Vec::new();
     let mut blocks_to_mark_unchecked = Vec::new();
     let mut blocks_to_delete = Vec::new();
+    let high_watermark_to_rollback = db
+        .ol_block_db()
+        .get_block_high_watermark()
+        .internal_error("Failed to get OL block high-watermark")?
+        .filter(|high_watermark| high_watermark.slot() > target_slot);
 
     for slot in target_slot + 1..=chain_tip_slot {
         let block_ids = db
@@ -231,11 +237,12 @@ pub(crate) fn revert_ol_state(
     };
 
     if !dry_run {
-        revert_indexing(
-            db,
-            target_epoch,
-            OLBlockCommitment::new(target_slot, target_block_id),
-        )?;
+        revert_indexing(db, target_epoch, target_commitment)?;
+        if high_watermark_to_rollback.is_some() {
+            db.ol_block_db()
+                .rollback_block_high_watermark(target_commitment)
+                .internal_error("Failed to roll back OL block high-watermark")?;
+        }
     }
 
     let mut checkpoints_to_delete = Vec::new();
@@ -281,6 +288,9 @@ pub(crate) fn revert_ol_state(
         blocks_to_mark_unchecked.len()
     );
     println!("Blocks to delete: {}", blocks_to_delete.len());
+    if let Some(high_watermark) = high_watermark_to_rollback {
+        println!("Block high-watermark rollback: {high_watermark} -> {target_commitment}");
+    }
     println!("Checkpoints to delete: {}", checkpoints_to_delete.len());
     println!(
         "Epoch summaries to delete: {}",

--- a/bin/strata-dbtool/src/main.rs
+++ b/bin/strata-dbtool/src/main.rs
@@ -30,7 +30,7 @@ use crate::{
             ee_delete_acct_proof, ee_delete_chunk_receipt, ee_get_acct_proof, ee_get_chunk_receipt,
         },
         l1::{get_l1_block, get_l1_summary},
-        ol::{get_ol_block, get_ol_summary},
+        ol::{get_ol_block, get_ol_blocks_at_slot, get_ol_summary},
         ol_state::{get_ol_state, revert_ol_state},
         prover_task::{
             abandon_prover_task, abandon_prover_tasks, backfill_checkpoint_proof_task,
@@ -57,6 +57,9 @@ fn main() {
         Command::GetOLState(args) => with_ol_db(&datadir, |db| get_ol_state(db, args)),
         Command::RevertOLState(args) => with_ol_db(&datadir, |db| revert_ol_state(db, args)),
         Command::GetOlBlock(args) => with_ol_db(&datadir, |db| get_ol_block(db, args)),
+        Command::GetOlBlocksAtSlot(args) => {
+            with_ol_db(&datadir, |db| get_ol_blocks_at_slot(db, args))
+        }
         Command::GetOlSummary(args) => with_ol_db(&datadir, |db| get_ol_summary(db, args)),
         Command::GetL1Block(args) => with_ol_db(&datadir, |db| get_l1_block(db, args)),
         Command::GetL1Summary(args) => with_ol_db(&datadir, |db| get_l1_summary(db, args)),

--- a/bin/strata-dbtool/src/output/ol.rs
+++ b/bin/strata-dbtool/src/output/ol.rs
@@ -38,6 +38,14 @@ pub(crate) struct OLSummaryInfo<'a> {
     pub(crate) missing_slots: Vec<Slot>,
 }
 
+/// OL block IDs for one slot.
+#[derive(serde::Serialize)]
+pub(crate) struct OLBlocksAtSlotInfo<'a> {
+    pub(crate) slot: Slot,
+    pub(crate) count: usize,
+    pub(crate) block_ids: &'a [OLBlockId],
+}
+
 impl<'a> Formattable for OLBlockInfo<'a> {
     fn format_porcelain(&self) -> String {
         let mut output = Vec::new();
@@ -118,5 +126,50 @@ impl<'a> Formattable for OLSummaryInfo<'a> {
         }
 
         output.join("\n")
+    }
+}
+
+impl Formattable for OLBlocksAtSlotInfo<'_> {
+    fn format_porcelain(&self) -> String {
+        let mut output = Vec::new();
+
+        output.push(porcelain_field("slot", self.slot));
+        output.push(porcelain_field("count", self.count));
+
+        for (index, block_id) in self.block_ids.iter().enumerate() {
+            output.push(porcelain_field(
+                &format!("block_ids.{index}"),
+                format!("{block_id:?}"),
+            ));
+        }
+
+        output.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_identifiers::Buf32;
+
+    use super::*;
+
+    #[test]
+    fn blocks_at_slot_porcelain_lists_indexed_block_ids() {
+        let block_ids = [
+            OLBlockId::from(Buf32::from([0x11; 32])),
+            OLBlockId::from(Buf32::from([0x22; 32])),
+        ];
+        let info = OLBlocksAtSlotInfo {
+            slot: 7,
+            count: block_ids.len(),
+            block_ids: &block_ids,
+        };
+
+        let output = info.format_porcelain();
+
+        assert!(output.contains("slot: 7"));
+        assert!(output.contains("count: 2"));
+        assert!(output.contains("block_ids.0:"));
+        assert!(output.contains("block_ids.1:"));
     }
 }

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -110,6 +110,7 @@ zkaleido-sp1-host = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
+strata-ol-block-assembly = { workspace = true, features = ["test-utils"] }
 strata-ol-chain-types-new = { workspace = true, features = ["test-utils"] }
 strata-ol-params.workspace = true
 strata-ol-state-support-types.workspace = true

--- a/bin/strata/src/fcm.rs
+++ b/bin/strata/src/fcm.rs
@@ -98,6 +98,13 @@ impl FcmStorage for StrataFcmContext {
             .await
     }
 
+    async fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool> {
+        self.storage
+            .ol_block()
+            .clear_block_high_watermark_async(expected)
+            .await
+    }
+
     async fn get_toplevel_ol_state(
         &self,
         commitment: OLBlockCommitment,

--- a/bin/strata/src/sequencer/block_producer.rs
+++ b/bin/strata/src/sequencer/block_producer.rs
@@ -2,10 +2,15 @@
 
 use std::{sync::Arc, time::Duration};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
+use strata_consensus_logic::{FcmServiceHandle, message::ForkChoiceMessage};
+use strata_db_types::traits::BlockStatus;
+use strata_identifiers::{OLBlockCommitment, OLBlockId};
+use strata_ol_chain_types_new::OLBlock;
 use strata_ol_sequencer::{SequencerBuilder, SequencerServiceStatus};
 use strata_service::ServiceMonitor;
-use tracing::info;
+use strata_storage::NodeStorage;
+use tracing::{error, info};
 
 use super::node_context::NodeSequencerContext;
 use crate::run_context::RunContext;
@@ -25,6 +30,14 @@ pub(crate) fn start_block_producer(
         .ok_or_else(|| anyhow!("sequencer config required when block producer is enabled"))?
         .ol_block_time_ms;
 
+    runctx
+        .task_manager()
+        .handle()
+        .block_on(process_startup_high_watermark_block(
+            runctx.storage().as_ref(),
+            runctx.fcm_handle().as_ref(),
+        ))?;
+
     let context = Arc::new(NodeSequencerContext::new(
         handles.blockasm_handle().clone(),
         runctx.storage().clone(),
@@ -41,4 +54,234 @@ pub(crate) fn start_block_producer(
     info!(%ol_block_interval_ms, "block producer service started");
 
     Ok(service_monitor)
+}
+
+async fn process_startup_high_watermark_block(
+    storage: &NodeStorage,
+    fcm_handle: &FcmServiceHandle,
+) -> Result<()> {
+    let high_watermark = storage
+        .ol_block()
+        .get_block_high_watermark_async()
+        .await
+        .context("failed to get OL block high-watermark")?;
+
+    let Some(high_watermark) = high_watermark else {
+        return Ok(());
+    };
+
+    let block_id = *high_watermark.blkid();
+    let block = storage
+        .ol_block()
+        .get_block_data_async(block_id)
+        .await
+        .context("failed to get high-watermark OL block")?;
+
+    let status = storage
+        .ol_block()
+        .get_block_status_async(block_id)
+        .await
+        .context("failed to get high-watermark OL block status")?;
+
+    match decide_startup_high_watermark_block_action(high_watermark, block.as_ref(), status)? {
+        HighWatermarkBlockAction::Skip => {
+            info!(
+                block_id = %block_id,
+                slot = high_watermark.slot(),
+                "high-watermark OL block already processed by FCM"
+            );
+            Ok(())
+        }
+        HighWatermarkBlockAction::Clear => {
+            let cleared = storage
+                .ol_block()
+                .clear_block_high_watermark_async(high_watermark)
+                .await
+                .inspect_err(|err| {
+                    error!(
+                        block_id = %block_id,
+                        slot = high_watermark.slot(),
+                        %err,
+                        "failed to clear invalid high-watermark OL block on startup; replacement generation for this slot remains blocked"
+                    );
+                })
+                .context("failed to clear invalid high-watermark OL block on startup")?;
+
+            if cleared {
+                info!(
+                    block_id = %block_id,
+                    slot = high_watermark.slot(),
+                    "cleared invalid high-watermark OL block on startup"
+                );
+            }
+
+            Ok(())
+        }
+        HighWatermarkBlockAction::Resubmit(block_id) => {
+            let submitted = fcm_handle
+                .submit_chain_tip_msg_async(ForkChoiceMessage::NewBlock(block_id))
+                .await;
+            if !submitted {
+                bail!("failed to resubmit high-watermark OL block {block_id} to FCM");
+            }
+
+            info!(
+                block_id = %block_id,
+                slot = high_watermark.slot(),
+                "resubmitted high-watermark OL block to FCM"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Startup action for the OL block recorded by the local high-watermark.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum HighWatermarkBlockAction {
+    Skip,
+    Clear,
+    Resubmit(OLBlockId),
+}
+
+fn decide_startup_high_watermark_block_action(
+    high_watermark: OLBlockCommitment,
+    block: Option<&OLBlock>,
+    status: Option<BlockStatus>,
+) -> Result<HighWatermarkBlockAction> {
+    let block_id = *high_watermark.blkid();
+    let block = block.ok_or_else(|| anyhow!("high-watermark OL block {block_id} is missing"))?;
+
+    if block.header().slot() != high_watermark.slot() {
+        bail!(
+            "high-watermark OL block {block_id} has slot {}, expected {}",
+            block.header().slot(),
+            high_watermark.slot()
+        );
+    }
+
+    Ok(match status {
+        Some(BlockStatus::Valid) => HighWatermarkBlockAction::Skip,
+        Some(BlockStatus::Invalid) => {
+            // TODO(STR-2141): `BlockStatus::Invalid` also represents local execution failures.
+            // Revisit high-watermark clearing once FCM distinguishes consensus-invalid blocks
+            // from transient execution failures.
+            HighWatermarkBlockAction::Clear
+        }
+        Some(BlockStatus::Unchecked) | None => HighWatermarkBlockAction::Resubmit(block_id),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_identifiers::{Buf32, Buf64};
+    use strata_ol_chain_types_new::{
+        BlockFlags, OLBlockBody, OLBlockHeader, OLTxSegment, SignedOLBlockHeader,
+    };
+
+    use super::*;
+
+    fn block_at_slot(slot: u64) -> OLBlock {
+        let header = OLBlockHeader::new(
+            0,
+            BlockFlags::from(0),
+            slot,
+            0,
+            OLBlockId::from(Buf32::from([0x11; 32])),
+            Buf32::zero(),
+            Buf32::zero(),
+            Buf32::zero(),
+        );
+        let signed_header = SignedOLBlockHeader::new(header, Buf64::zero());
+        let body = OLBlockBody::new_common(OLTxSegment::new(vec![]).expect("empty tx segment"));
+        OLBlock::new(signed_header, body)
+    }
+
+    fn commitment_for(block: &OLBlock) -> OLBlockCommitment {
+        OLBlockCommitment::new(block.header().slot(), block.header().compute_blkid())
+    }
+
+    #[test]
+    fn startup_action_resubmits_unprocessed_statuses() {
+        let block = block_at_slot(7);
+        let high_watermark = commitment_for(&block);
+        let block_id = *high_watermark.blkid();
+
+        let unchecked = decide_startup_high_watermark_block_action(
+            high_watermark,
+            Some(&block),
+            Some(BlockStatus::Unchecked),
+        )
+        .expect("unchecked high-watermark block should resubmit");
+        assert_eq!(unchecked, HighWatermarkBlockAction::Resubmit(block_id));
+
+        let missing_status =
+            decide_startup_high_watermark_block_action(high_watermark, Some(&block), None)
+                .expect("missing status high-watermark block should resubmit");
+        assert_eq!(missing_status, HighWatermarkBlockAction::Resubmit(block_id));
+    }
+
+    #[test]
+    fn startup_action_clears_invalid_status() {
+        let block = block_at_slot(7);
+        let high_watermark = commitment_for(&block);
+        let invalid = decide_startup_high_watermark_block_action(
+            high_watermark,
+            Some(&block),
+            Some(BlockStatus::Invalid),
+        )
+        .expect("invalid high-watermark block should clear");
+        assert_eq!(invalid, HighWatermarkBlockAction::Clear);
+    }
+
+    #[test]
+    fn startup_action_skips_valid_status() {
+        let block = block_at_slot(8);
+        let high_watermark = commitment_for(&block);
+
+        let valid = decide_startup_high_watermark_block_action(
+            high_watermark,
+            Some(&block),
+            Some(BlockStatus::Valid),
+        )
+        .expect("valid high-watermark block should skip");
+        assert_eq!(valid, HighWatermarkBlockAction::Skip);
+    }
+
+    #[test]
+    fn startup_action_errors_when_recorded_block_is_missing() {
+        let block = block_at_slot(9);
+        let high_watermark = commitment_for(&block);
+        let err = decide_startup_high_watermark_block_action(
+            high_watermark,
+            None,
+            Some(BlockStatus::Unchecked),
+        )
+        .expect_err("missing high-watermark block should error");
+
+        assert!(
+            err.to_string().contains("high-watermark OL block"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            err.to_string().contains("is missing"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn startup_action_errors_when_recorded_block_slot_mismatches() {
+        let block = block_at_slot(10);
+        let high_watermark = OLBlockCommitment::new(11, block.header().compute_blkid());
+        let err = decide_startup_high_watermark_block_action(
+            high_watermark,
+            Some(&block),
+            Some(BlockStatus::Unchecked),
+        )
+        .expect_err("slot-mismatched high-watermark block should error");
+
+        assert!(
+            err.to_string().contains("has slot 10, expected 11"),
+            "unexpected error: {err:#}"
+        );
+    }
 }

--- a/bin/strata/src/sequencer/node_context.rs
+++ b/bin/strata/src/sequencer/node_context.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use strata_identifiers::OLBlockId;
+use strata_db_types::traits::BlockStatus;
+use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use strata_ol_block_assembly::{BlockAssemblyError, BlockasmHandle};
 use strata_ol_sequencer::{BlockGenerationConfig, SequencerContext, SequencerContextError};
 use strata_status::StatusChannel;
@@ -54,6 +55,25 @@ impl SequencerContext for NodeSequencerContext {
             return Ok(None);
         };
         let tip_blkid = *parent_commitment.blkid();
+        let target_slot = parent_commitment.slot().saturating_add(1);
+
+        let high_watermark = self
+            .storage
+            .ol_block()
+            .get_block_high_watermark_async()
+            .await
+            .map_err(SequencerContextError::Db)?;
+        if target_slot_at_or_below_high_watermark(target_slot, high_watermark.as_ref()) {
+            let high_watermark = high_watermark
+                .expect("target slot can only be below high-watermark when high-watermark exists");
+            debug!(
+                tip_blkid = ?tip_blkid,
+                target_slot,
+                high_watermark = %high_watermark,
+                "template generation skipped: target slot is at or below block high-watermark"
+            );
+            return Ok(None);
+        }
 
         debug!(tip_blkid = ?tip_blkid, "template generation attempt");
 
@@ -98,12 +118,65 @@ impl SequencerContext for NodeSequencerContext {
             "submitting template generation request"
         );
 
-        match self.blockasm_handle.generate_block_template(config).await {
+        match self
+            .blockasm_handle
+            .generate_block_template(config.clone())
+            .await
+        {
             Ok(_) => {}
             Err(BlockAssemblyError::TemplateAlreadyCompletedForParent { parent, block })
                 if parent == tip_blkid =>
             {
-                debug!(tip_blkid = ?tip_blkid, completed_block = %block, "template generation skipped: parent already completed");
+                let status = self
+                    .storage
+                    .ol_block()
+                    .get_block_status_async(*block.blkid())
+                    .await
+                    .map_err(SequencerContextError::Db)?;
+
+                if should_release_completed_tombstone(status) {
+                    let released = self
+                        .blockasm_handle
+                        .release_completed_template_status(parent, block)
+                        .await
+                        .map_err(|source| SequencerContextError::TemplateGeneration {
+                            tip_blkid,
+                            source,
+                        })?;
+
+                    if released {
+                        debug!(
+                            tip_blkid = ?tip_blkid,
+                            completed_block = %block,
+                            "released invalid completed-template tombstone; retrying generation"
+                        );
+                        self.blockasm_handle
+                            .generate_block_template(config)
+                            .await
+                            .map_err(|source| SequencerContextError::TemplateGeneration {
+                                tip_blkid,
+                                source,
+                            })?;
+                    } else {
+                        debug!(
+                            tip_blkid = ?tip_blkid,
+                            completed_block = %block,
+                            "template generation skipped: completed-template tombstone was already changed"
+                        );
+                        return Ok(None);
+                    }
+                } else {
+                    debug!(
+                        tip_blkid = ?tip_blkid,
+                        completed_block = %block,
+                        ?status,
+                        "template generation skipped: parent already completed"
+                    );
+                    return Ok(None);
+                }
+            }
+            Err(BlockAssemblyError::TemplateAlreadyCompletedForParent { parent, block }) => {
+                debug!(tip_blkid = ?tip_blkid, completed_parent = ?parent, completed_block = %block, "template generation skipped: parent already completed");
                 return Ok(None);
             }
             Err(source) => {
@@ -114,5 +187,180 @@ impl SequencerContext for NodeSequencerContext {
         debug!(tip_blkid = ?tip_blkid, "template generation request completed");
 
         Ok(Some(tip_blkid))
+    }
+}
+
+fn target_slot_at_or_below_high_watermark(
+    target_slot: u64,
+    high_watermark: Option<&OLBlockCommitment>,
+) -> bool {
+    high_watermark.is_some_and(|high_watermark| target_slot <= high_watermark.slot())
+}
+
+fn should_release_completed_tombstone(status: Option<BlockStatus>) -> bool {
+    matches!(status, Some(BlockStatus::Invalid))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use strata_config::{BlockAssemblyConfig, SequencerConfig};
+    use strata_csm_types::{ClientState, L1Status};
+    use strata_identifiers::{Buf32, Buf64, L1BlockCommitment, L1BlockId};
+    use strata_ol_block_assembly::{
+        BlockCompletionData, BlockasmBuilder, FixedSlotSealing,
+        test_utils::{MockMempoolProvider, TestStorageFixtureBuilder},
+    };
+    use strata_ol_params::OLParams;
+    use strata_ol_state_provider::OLStateManagerProviderImpl;
+    use strata_predicate::PredicateKey;
+    use strata_storage::NodeStorage;
+    use strata_tasks::TaskManager;
+    use tokio::runtime::Handle;
+
+    use super::*;
+
+    fn high_watermark(slot: u64) -> OLBlockCommitment {
+        OLBlockCommitment::new(slot, OLBlockId::from(Buf32::from([slot as u8; 32])))
+    }
+
+    async fn start_test_blockasm(storage: Arc<NodeStorage>) -> (TaskManager, Arc<BlockasmHandle>) {
+        let task_manager = TaskManager::new(Handle::current());
+        let executor = task_manager.create_executor();
+        let state_provider = OLStateManagerProviderImpl::new(storage.ol_state().clone());
+        let blockasm = BlockasmBuilder::new(
+            Arc::new(OLParams::new_empty(L1BlockCommitment::default())),
+            Arc::new(BlockAssemblyConfig::new(Duration::from_millis(1_000))),
+            storage,
+            Arc::new(MockMempoolProvider::new()),
+            FixedSlotSealing::new(10),
+            state_provider,
+            SequencerConfig::default(),
+            PredicateKey::always_accept(),
+            0,
+        )
+        .launch(&executor)
+        .await
+        .expect("test: launch block assembly service");
+
+        (task_manager, Arc::new(blockasm))
+    }
+
+    fn test_status_channel() -> Arc<StatusChannel> {
+        let l1_block = L1BlockCommitment::new(0, L1BlockId::from(Buf32::zero()));
+        Arc::new(StatusChannel::new(
+            ClientState::default(),
+            l1_block,
+            L1Status::default(),
+            None,
+            None,
+        ))
+    }
+
+    #[test]
+    fn target_slot_filter_respects_high_watermark() {
+        assert!(!target_slot_at_or_below_high_watermark(5, None));
+
+        let high_watermark = high_watermark(5);
+        assert!(target_slot_at_or_below_high_watermark(
+            4,
+            Some(&high_watermark)
+        ));
+        assert!(target_slot_at_or_below_high_watermark(
+            5,
+            Some(&high_watermark)
+        ));
+        assert!(!target_slot_at_or_below_high_watermark(
+            6,
+            Some(&high_watermark)
+        ));
+    }
+
+    #[test]
+    fn completed_tombstone_release_requires_invalid_status() {
+        assert!(!should_release_completed_tombstone(None));
+        assert!(!should_release_completed_tombstone(Some(
+            BlockStatus::Unchecked
+        )));
+        assert!(!should_release_completed_tombstone(Some(
+            BlockStatus::Valid
+        )));
+        assert!(should_release_completed_tombstone(Some(
+            BlockStatus::Invalid
+        )));
+    }
+
+    #[tokio::test]
+    async fn generation_releases_invalid_completed_tombstone_and_retries() {
+        let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
+            .with_genesis_parent_and_l1_manifest_count(0)
+            .build_fixture()
+            .await;
+        let storage = fixture.storage().clone();
+        storage
+            .ol_block()
+            .set_block_status_async(*parent_commitment.blkid(), BlockStatus::Valid)
+            .await
+            .expect("test: mark parent block valid");
+        let (_task_manager, blockasm_handle) = start_test_blockasm(storage.clone()).await;
+
+        let stale_template = blockasm_handle
+            .generate_block_template(
+                BlockGenerationConfig::new(parent_commitment).with_ts(1_000_000),
+            )
+            .await
+            .expect("test: generate stale template");
+        let stale_template_id = stale_template.get_blockid();
+
+        let stale_block = blockasm_handle
+            .complete_block_template(
+                stale_template_id,
+                BlockCompletionData::from_signature(Buf64::zero()),
+            )
+            .await
+            .expect("test: complete stale template");
+        let stale_block_commitment = storage
+            .ol_block()
+            .put_block_data_with_high_watermark_async(stale_block)
+            .await
+            .expect("test: persist stale block");
+        blockasm_handle
+            .record_persisted_block(stale_template_id)
+            .await
+            .expect("test: record stale block");
+        storage
+            .ol_block()
+            .set_block_status_async(stale_template_id, BlockStatus::Invalid)
+            .await
+            .expect("test: mark stale block invalid");
+        storage
+            .ol_block()
+            .clear_block_high_watermark_async(stale_block_commitment)
+            .await
+            .expect("test: clear stale block high-watermark");
+
+        let sequencer_context = NodeSequencerContext::new(
+            blockasm_handle.clone(),
+            storage,
+            test_status_channel(),
+            SequencerConfig::default().ol_block_time_ms,
+        );
+
+        let generated_parent = sequencer_context
+            .generate_template_for_tip()
+            .await
+            .expect("test: retry generation after invalid completed tombstone");
+        assert_eq!(generated_parent, Some(*parent_commitment.blkid()));
+
+        let replacement_template = blockasm_handle
+            .get_block_template(*parent_commitment.blkid())
+            .await
+            .expect("test: replacement template is pending");
+        assert_eq!(
+            replacement_template.header().slot(),
+            parent_commitment.slot() + 1
+        );
+        assert_ne!(replacement_template.get_blockid(), stale_template_id);
     }
 }

--- a/bin/strata/src/sequencer/node_context.rs
+++ b/bin/strata/src/sequencer/node_context.rs
@@ -98,10 +98,18 @@ impl SequencerContext for NodeSequencerContext {
             "submitting template generation request"
         );
 
-        self.blockasm_handle
-            .generate_block_template(config)
-            .await
-            .map_err(|source| SequencerContextError::TemplateGeneration { tip_blkid, source })?;
+        match self.blockasm_handle.generate_block_template(config).await {
+            Ok(_) => {}
+            Err(BlockAssemblyError::TemplateAlreadyCompletedForParent { parent, block })
+                if parent == tip_blkid =>
+            {
+                debug!(tip_blkid = ?tip_blkid, completed_block = %block, "template generation skipped: parent already completed");
+                return Ok(None);
+            }
+            Err(source) => {
+                return Err(SequencerContextError::TemplateGeneration { tip_blkid, source });
+            }
+        }
 
         debug!(tip_blkid = ?tip_blkid, "template generation request completed");
 

--- a/bin/strata/src/sequencer/rpc.rs
+++ b/bin/strata/src/sequencer/rpc.rs
@@ -107,13 +107,26 @@ impl OLSequencerRpcServer for OLSeqRpcServer {
             .await
             .map_err(|e| internal_error(e.to_string()))?;
 
-        let blkid = block.header().compute_blkid();
-
-        self.storage
+        let commitment = self
+            .storage
             .ol_block()
-            .put_block_data_async(block)
+            .put_block_data_with_high_watermark_async(block)
             .await
             .map_err(db_error)?;
+        let blkid = *commitment.blkid();
+
+        if let Err(error) = self
+            .blockasm_handle
+            .record_persisted_block(template_id)
+            .await
+        {
+            warn!(
+                %blkid,
+                ?template_id,
+                error = %error,
+                "failed to mark block template completed after durable storage commit"
+            );
+        }
 
         let submitted = self
             .fcm_handle

--- a/crates/consensus-logic/src/fcm/context.rs
+++ b/crates/consensus-logic/src/fcm/context.rs
@@ -28,6 +28,8 @@ pub trait CsmStatusReader: Send + Sync {
 pub trait FcmStorage: UnfinalizedOLBlockSource {
     async fn set_block_status(&self, blkid: OLBlockId, status: BlockStatus) -> DbResult<bool>;
 
+    async fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool>;
+
     async fn get_toplevel_ol_state(
         &self,
         commitment: OLBlockCommitment,

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, sync::Arc};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use metrics::{counter, histogram};
 use serde::Serialize;
 use strata_csm_types::CheckpointState;
@@ -207,7 +207,8 @@ async fn process_fc_message<C: FcmContext>(
                 BlockStatus::Invalid
             };
 
-            fcm_state.ctx().set_block_status(*blkid, status).await?;
+            let block = OLBlockCommitment::new(slot, *blkid);
+            set_block_status_and_clear_invalid_high_watermark(fcm_state, block, status).await?;
             if ok {
                 counter!("strata_fcm_blocks_accepted_total").increment(1);
             } else {
@@ -217,6 +218,40 @@ async fn process_fc_message<C: FcmContext>(
     }
 
     Ok(())
+}
+
+async fn set_block_status_and_clear_invalid_high_watermark<C: FcmContext>(
+    fcm_state: &FcmServiceState<C>,
+    block: OLBlockCommitment,
+    status: BlockStatus,
+) -> anyhow::Result<bool> {
+    let updated = fcm_state
+        .ctx()
+        .set_block_status(*block.blkid(), status)
+        .await?;
+
+    if matches!(status, BlockStatus::Invalid) {
+        // TODO(STR-2141): `BlockStatus::Invalid` also represents local execution failures.
+        // Revisit high-watermark clearing once FCM distinguishes consensus-invalid blocks
+        // from transient execution failures.
+        let cleared = fcm_state
+            .ctx()
+            .clear_block_high_watermark(block)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    %block,
+                    %err,
+                    "failed to clear high-watermark for invalid OL block; replacement generation for this slot remains blocked"
+                );
+            })
+            .context("failed to clear invalid OL block high-watermark")?;
+        if cleared {
+            info!(%block, "cleared invalid OL block high-watermark");
+        }
+    }
+
+    Ok(updated)
 }
 
 async fn handle_new_state_update<C: FcmContext>(
@@ -284,9 +319,7 @@ async fn handle_new_block<C: FcmContext>(
             .set_block_status(*blkid, BlockStatus::Valid)
             .await?;
     } else {
-        fcm_state
-            .ctx()
-            .set_block_status(*blkid, BlockStatus::Invalid)
+        set_block_status_and_clear_invalid_high_watermark(fcm_state, bc, BlockStatus::Invalid)
             .await?;
         return Ok(false);
     }
@@ -653,6 +686,7 @@ mod tests {
         statuses: HashMap<OLBlockId, BlockStatus>,
         blocks_by_slot: BTreeMap<Slot, Vec<OLBlockId>>,
         canonical_blocks: HashMap<Slot, OLBlockCommitment>,
+        block_high_watermark: Option<OLBlockCommitment>,
         states: HashMap<OLBlockCommitment, Arc<OLState>>,
         canonical_epochs: HashMap<Epoch, EpochCommitment>,
     }
@@ -717,6 +751,14 @@ mod tests {
                 .unwrap()
                 .canonical_epochs
                 .insert(epoch.epoch(), epoch);
+        }
+
+        fn set_block_high_watermark(&self, block: OLBlockCommitment) {
+            self.inner.lock().unwrap().block_high_watermark = Some(block);
+        }
+
+        fn block_high_watermark(&self) -> Option<OLBlockCommitment> {
+            self.inner.lock().unwrap().block_high_watermark
         }
     }
 
@@ -800,6 +842,16 @@ mod tests {
             Ok(block_exists)
         }
 
+        async fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool> {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.block_high_watermark != Some(expected) {
+                return Ok(false);
+            }
+
+            inner.block_high_watermark = None;
+            Ok(true)
+        }
+
         async fn get_toplevel_ol_state(
             &self,
             commitment: OLBlockCommitment,
@@ -878,6 +930,10 @@ mod tests {
     impl FcmStorage for StubFcmContext {
         async fn set_block_status(&self, blkid: OLBlockId, status: BlockStatus) -> DbResult<bool> {
             self.storage.set_block_status(blkid, status).await
+        }
+
+        async fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool> {
+            self.storage.clear_block_high_watermark(expected).await
         }
 
         async fn get_toplevel_ol_state(
@@ -1502,6 +1558,46 @@ mod tests {
         assert_eq!(statuses[0].prev_epoch, genesis_epoch);
         assert_eq!(statuses[0].confirmed_epoch, genesis_epoch);
         assert_eq!(statuses[0].finalized_epoch, genesis_epoch);
+    }
+
+    #[tokio::test]
+    async fn process_fc_message_clears_high_watermark_for_invalid_block() -> anyhow::Result<()> {
+        let keypair = make_keypair();
+        let genesis = make_storage_block(0, OLBlockId::from(Buf32::zero()));
+        let genesis_blkid = genesis.header().compute_blkid();
+        let genesis_commitment = OLBlockCommitment::new(genesis.header().slot(), genesis_blkid);
+        let genesis_epoch = EpochCommitment::new(0, genesis_commitment.slot(), genesis_blkid);
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(genesis_epoch))
+                .with_last_confirmed_epoch(Some(genesis_epoch)),
+        );
+
+        let block = make_storage_block(1, genesis_blkid);
+        let blkid = block.header().compute_blkid();
+        let block_commitment = OLBlockCommitment::new(block.header().slot(), blkid);
+
+        ctx.storage().put_executed_block(
+            genesis,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        ctx.storage().put_ol_block(block);
+        ctx.storage().set_block_high_watermark(block_commitment);
+        ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+
+        let mut fcm_state =
+            init_fcm_service_state(schnorr_predicate(&keypair.pk), ctx.clone()).await?;
+
+        process_fc_message(&ForkChoiceMessage::NewBlock(blkid), &mut fcm_state).await?;
+
+        assert_eq!(
+            ctx.storage().get_block_status(blkid).await?,
+            Some(BlockStatus::Invalid)
+        );
+        assert_eq!(ctx.storage().block_high_watermark(), None);
+
+        Ok(())
     }
 
     #[test]

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -1,21 +1,28 @@
+use sled::transaction::ConflictableTransactionError;
 use strata_db_types::{
     DbError, DbResult,
     traits::{BlockStatus, OLBlockDatabase},
 };
-use strata_identifiers::{OLBlockId, Slot};
+use strata_identifiers::{OLBlockCommitment, OLBlockId, Slot};
 use strata_ol_chain_types_new::OLBlock;
+use typed_sled::error::Error as TSledError;
 
-use super::schemas::{OLBlockHeightSchema, OLBlockSchema, OLBlockStatusSchema};
+use super::schemas::{
+    OLBlockHeightSchema, OLBlockHighWatermarkSchema, OLBlockSchema, OLBlockStatusSchema,
+};
 use crate::{
     define_sled_database,
     utils::{first, to_db_error},
 };
+
+const OL_BLOCK_HIGH_WATERMARK_KEY: u8 = 0;
 
 define_sled_database!(
     pub struct OLBlockDBSled {
         blk_tree: OLBlockSchema,
         blk_status_tree: OLBlockStatusSchema,
         blk_height_tree: OLBlockHeightSchema,
+        blk_high_watermark_tree: OLBlockHighWatermarkSchema,
     }
 );
 
@@ -46,6 +53,73 @@ impl OLBlockDatabase for OLBlockDBSled {
             )
             .map_err(to_db_error)?;
         Ok(())
+    }
+
+    fn get_block_high_watermark(&self) -> DbResult<Option<OLBlockCommitment>> {
+        Ok(self
+            .blk_high_watermark_tree
+            .get(&OL_BLOCK_HIGH_WATERMARK_KEY)?)
+    }
+
+    fn put_block_data_with_high_watermark(&self, block: OLBlock) -> DbResult<OLBlockCommitment> {
+        let slot = block.header().slot();
+        let block_id = block.header().compute_blkid();
+        let commitment = OLBlockCommitment::new(slot, block_id);
+
+        self.config.with_retry(
+            (
+                &self.blk_tree,
+                &self.blk_status_tree,
+                &self.blk_height_tree,
+                &self.blk_high_watermark_tree,
+            ),
+            |(bt, bst, bht, hwt)| {
+                if let Some(current) = hwt.get(&OL_BLOCK_HIGH_WATERMARK_KEY)?
+                    && commitment.slot() <= current.slot()
+                {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::BlockHighWatermarkConflict {
+                            attempted: commitment,
+                            current,
+                        },
+                    )));
+                }
+
+                let mut blocks_at_slot = bht.get(&slot)?.unwrap_or(Vec::new());
+                let is_new = !blocks_at_slot.contains(&block_id);
+
+                if is_new {
+                    blocks_at_slot.push(block_id);
+                    bht.insert(&slot, &blocks_at_slot)?;
+
+                    // Only set status to Unchecked for new blocks.
+                    // This preserves Valid/Invalid status if block is re-inserted.
+                    bst.insert(&block_id, &BlockStatus::Unchecked)?;
+                }
+
+                bt.insert(&block_id, &block)?;
+                hwt.insert(&OL_BLOCK_HIGH_WATERMARK_KEY, &commitment)?;
+
+                Ok(commitment)
+            },
+        )
+    }
+
+    fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool> {
+        self.config
+            .with_retry((&self.blk_high_watermark_tree,), |(hwt,)| {
+                let Some(current) = hwt.get(&OL_BLOCK_HIGH_WATERMARK_KEY)? else {
+                    return Ok(false);
+                };
+
+                if current != expected {
+                    return Ok(false);
+                }
+
+                hwt.remove(&OL_BLOCK_HIGH_WATERMARK_KEY)?;
+                Ok(true)
+            })
+            .map_err(to_db_error)
     }
 
     fn get_block_data(&self, id: OLBlockId) -> DbResult<Option<OLBlock>> {

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -122,6 +122,37 @@ impl OLBlockDatabase for OLBlockDBSled {
             .map_err(to_db_error)
     }
 
+    fn rollback_block_high_watermark(&self, target: OLBlockCommitment) -> DbResult<bool> {
+        self.config.with_retry(
+            (&self.blk_tree, &self.blk_high_watermark_tree),
+            |(bt, hwt)| {
+                let target_block_id = *target.blkid();
+                let Some(target_block) = bt.get(&target_block_id)? else {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::NonExistentEntry,
+                    )));
+                };
+
+                if target_block.header().slot() != target.slot() {
+                    return Err(ConflictableTransactionError::Abort(TSledError::abort(
+                        DbError::InvalidArgument,
+                    )));
+                }
+
+                let Some(current) = hwt.get(&OL_BLOCK_HIGH_WATERMARK_KEY)? else {
+                    return Ok(false);
+                };
+
+                if current.slot() <= target.slot() {
+                    return Ok(false);
+                }
+
+                hwt.insert(&OL_BLOCK_HIGH_WATERMARK_KEY, &target)?;
+                Ok(true)
+            },
+        )
+    }
+
     fn get_block_data(&self, id: OLBlockId) -> DbResult<Option<OLBlock>> {
         Ok(self.blk_tree.get(&id)?)
     }

--- a/crates/db/store-sled/src/ol/schemas.rs
+++ b/crates/db/store-sled/src/ol/schemas.rs
@@ -2,12 +2,13 @@ use borsh::{BorshDeserialize, to_vec};
 use sled::IVec;
 use ssz::{Decode, Encode};
 use strata_db_types::traits::BlockStatus;
-use strata_identifiers::OLBlockId;
+use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::OLBlock;
 use typed_sled::codec::{CodecError, KeyCodec, ValueCodec};
 
 use crate::{
     define_table_with_default_codec, define_table_with_integer_key, define_table_without_codec,
+    impl_codec_value_codec,
 };
 
 define_table_without_codec!(
@@ -35,6 +36,13 @@ define_table_with_integer_key!(
     /// A table to store OL Block IDs by slot. Maps slot to Vec<OLBlockId>
     (OLBlockHeightSchema) u64 => Vec<OLBlockId>
 );
+
+define_table_without_codec!(
+    /// Stores the latest OL block committed through the high-watermark path.
+    (OLBlockHighWatermarkSchema) u8 => OLBlockCommitment
+);
+
+impl_codec_value_codec!(OLBlockHighWatermarkSchema, OLBlockCommitment);
 
 // OLBlock is SSZ-generated, so we use SSZ serialization instead of Borsh
 impl ValueCodec<OLBlockSchema> for OLBlock {

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -1,5 +1,8 @@
-use strata_db_types::traits::{BlockStatus, OLBlockDatabase};
-use strata_identifiers::{Buf32, OLBlockId};
+use strata_db_types::{
+    traits::{BlockStatus, OLBlockDatabase},
+    DbError,
+};
+use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::OLBlock;
 
 pub fn test_get_nonexistent_block(db: &impl OLBlockDatabase) {
@@ -45,6 +48,13 @@ pub fn test_get_blocks_at_empty_height(db: &impl OLBlockDatabase) {
     assert!(block_ids.is_empty());
 }
 
+pub fn test_get_empty_block_high_watermark(db: &impl OLBlockDatabase) {
+    let high_watermark = db
+        .get_block_high_watermark()
+        .expect("test: get block high-watermark");
+    assert!(high_watermark.is_none());
+}
+
 // Proptest-based tests for random block data
 pub fn proptest_put_and_get_random_block(db: &impl OLBlockDatabase, block: OLBlock) {
     let block_id = block.header().compute_blkid();
@@ -77,6 +87,209 @@ pub fn proptest_put_twice_idempotent(db: &impl OLBlockDatabase, block: OLBlock) 
         .expect("test: get blocks at height");
     assert_eq!(blocks.len(), 1);
     assert!(blocks.contains(&block_id));
+}
+
+pub fn proptest_put_block_data_does_not_advance_high_watermark(
+    db: &impl OLBlockDatabase,
+    block: OLBlock,
+) {
+    db.put_block_data(block)
+        .expect("test: put block without high-watermark");
+
+    let high_watermark = db
+        .get_block_high_watermark()
+        .expect("test: get block high-watermark");
+    assert!(high_watermark.is_none());
+}
+
+pub fn proptest_put_block_data_with_high_watermark(
+    db: &impl OLBlockDatabase,
+    mut block1: OLBlock,
+    mut block2: OLBlock,
+) {
+    let slot = 10u64;
+    block1.signed_header.header.slot = slot;
+    block1.signed_header.header.timestamp = 1;
+    block2.signed_header.header.slot = slot;
+    block2.signed_header.header.timestamp = 2;
+
+    let block1_id = block1.header().compute_blkid();
+    let block2_id = block2.header().compute_blkid();
+    let block1_commitment = OLBlockCommitment::new(slot, block1_id);
+
+    let applied = db
+        .put_block_data_with_high_watermark(block1.clone())
+        .expect("test: put block with high-watermark");
+    assert_eq!(applied, block1_commitment);
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get block high-watermark"),
+        Some(block1_commitment)
+    );
+    assert_eq!(
+        db.get_block_status(block1_id)
+            .expect("test: get block status"),
+        Some(BlockStatus::Unchecked)
+    );
+
+    let err = db
+        .put_block_data_with_high_watermark(block2.clone())
+        .expect_err("test: same-slot block should not advance high-watermark");
+    match err {
+        DbError::BlockHighWatermarkConflict { attempted, current } => {
+            assert_eq!(attempted, OLBlockCommitment::new(slot, block2_id));
+            assert_eq!(current, block1_commitment);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    assert!(db
+        .get_block_data(block2_id)
+        .expect("test: get rejected block")
+        .is_none());
+    assert_eq!(
+        db.get_blocks_at_height(slot)
+            .expect("test: get blocks at rejected slot"),
+        vec![block1_id]
+    );
+
+    let next_slot = slot + 1;
+    block2.signed_header.header.slot = next_slot;
+    let block2_next_id = block2.header().compute_blkid();
+    let block2_next_commitment = OLBlockCommitment::new(next_slot, block2_next_id);
+
+    let applied = db
+        .put_block_data_with_high_watermark(block2)
+        .expect("test: put next-slot block with high-watermark");
+    assert_eq!(applied, block2_next_commitment);
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get advanced block high-watermark"),
+        Some(block2_next_commitment)
+    );
+}
+
+pub fn proptest_clear_block_high_watermark(
+    db: &impl OLBlockDatabase,
+    mut block1: OLBlock,
+    mut block2: OLBlock,
+) {
+    let slot = 10u64;
+    block1.signed_header.header.slot = slot;
+    block1.signed_header.header.timestamp = 1;
+    block2.signed_header.header.slot = slot;
+    block2.signed_header.header.timestamp = 2;
+
+    let block1_id = block1.header().compute_blkid();
+    let block2_id = block2.header().compute_blkid();
+    let block1_commitment = OLBlockCommitment::new(slot, block1_id);
+    let block2_commitment = OLBlockCommitment::new(slot, block2_id);
+
+    let cleared = db
+        .clear_block_high_watermark(block1_commitment)
+        .expect("test: clear empty block high-watermark");
+    assert!(!cleared);
+
+    db.put_block_data_with_high_watermark(block1.clone())
+        .expect("test: put block with high-watermark");
+
+    let cleared = db
+        .clear_block_high_watermark(block2_commitment)
+        .expect("test: clear mismatched block high-watermark");
+    assert!(!cleared);
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get block high-watermark"),
+        Some(block1_commitment)
+    );
+
+    let cleared = db
+        .clear_block_high_watermark(block1_commitment)
+        .expect("test: clear current block high-watermark");
+    assert!(cleared);
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get cleared block high-watermark"),
+        None
+    );
+    assert_eq!(
+        db.get_block_data(block1_id)
+            .expect("test: get block after high-watermark clear")
+            .map(|block| block.header().compute_blkid()),
+        Some(block1_id)
+    );
+    assert_eq!(
+        db.get_block_status(block1_id)
+            .expect("test: get block status after high-watermark clear"),
+        Some(BlockStatus::Unchecked)
+    );
+    assert_eq!(
+        db.get_blocks_at_height(slot)
+            .expect("test: get blocks at slot after high-watermark clear"),
+        vec![block1_id]
+    );
+
+    db.put_block_data_with_high_watermark(block2)
+        .expect("test: put same-slot replacement after high-watermark clear");
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get replacement block high-watermark"),
+        Some(block2_commitment)
+    );
+    assert_eq!(
+        db.get_blocks_at_height(slot)
+            .expect("test: get blocks at replacement slot")
+            .len(),
+        2
+    );
+}
+
+pub fn proptest_high_watermark_monotonic_under_mixed_puts(
+    db: &impl OLBlockDatabase,
+    ops: Vec<(u8, OLBlock)>,
+) {
+    let mut expected_high_watermark: Option<OLBlockCommitment> = None;
+
+    for (op_selector, block) in ops {
+        let use_high_watermark = op_selector % 2 == 0;
+        let slot = block.header().slot();
+        let block_id = block.header().compute_blkid();
+        let commitment = OLBlockCommitment::new(slot, block_id);
+
+        if use_high_watermark {
+            match expected_high_watermark {
+                Some(expected_current) if slot <= expected_current.slot() => {
+                    let err = db
+                        .put_block_data_with_high_watermark(block)
+                        .expect_err("test: non-advancing guarded put should fail");
+                    match err {
+                        DbError::BlockHighWatermarkConflict { attempted, current } => {
+                            assert_eq!(attempted, commitment);
+                            assert_eq!(current, expected_current);
+                        }
+                        other => panic!("unexpected error: {other:?}"),
+                    }
+                }
+                _ => {
+                    let applied = db
+                        .put_block_data_with_high_watermark(block)
+                        .expect("test: advancing guarded put should succeed");
+                    assert_eq!(applied, commitment);
+                    expected_high_watermark = Some(commitment);
+                }
+            }
+        } else {
+            db.put_block_data(block)
+                .expect("test: unguarded put should succeed");
+        }
+
+        assert_eq!(
+            db.get_block_high_watermark()
+                .expect("test: get block high-watermark"),
+            expected_high_watermark,
+            "high-watermark should equal the max successful guarded slot"
+        );
+    }
 }
 
 pub fn proptest_delete_random_block(db: &impl OLBlockDatabase, block: OLBlock) {
@@ -206,6 +419,12 @@ macro_rules! ol_block_db_tests {
             $crate::ol_block_tests::test_get_blocks_at_empty_height(&db);
         }
 
+        #[test]
+        fn test_get_empty_block_high_watermark() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_get_empty_block_high_watermark(&db);
+        }
+
         proptest::proptest! {
             #[test]
             fn proptest_put_and_get_random_block(block in ol_test_utils::ol_block_strategy()) {
@@ -217,6 +436,32 @@ macro_rules! ol_block_db_tests {
             fn proptest_put_twice_idempotent(block in ol_test_utils::ol_block_strategy()) {
                 let db = $setup_expr;
                 $crate::ol_block_tests::proptest_put_twice_idempotent(&db, block);
+            }
+
+            #[test]
+            fn proptest_put_block_data_does_not_advance_high_watermark(block in ol_test_utils::ol_block_strategy()) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::proptest_put_block_data_does_not_advance_high_watermark(&db, block);
+            }
+
+            #[test]
+            fn proptest_put_block_data_with_high_watermark(block1 in ol_test_utils::ol_block_strategy(), block2 in ol_test_utils::ol_block_strategy()) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::proptest_put_block_data_with_high_watermark(&db, block1, block2);
+            }
+
+            #[test]
+            fn proptest_clear_block_high_watermark(block1 in ol_test_utils::ol_block_strategy(), block2 in ol_test_utils::ol_block_strategy()) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::proptest_clear_block_high_watermark(&db, block1, block2);
+            }
+
+            #[test]
+            fn proptest_high_watermark_monotonic_under_mixed_puts(
+                ops in proptest::collection::vec((0u8..=1, ol_test_utils::ol_block_strategy()), 0..32)
+            ) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::proptest_high_watermark_monotonic_under_mixed_puts(&db, ops);
             }
 
             #[test]

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -292,6 +292,57 @@ pub fn proptest_high_watermark_monotonic_under_mixed_puts(
     }
 }
 
+pub fn proptest_rollback_block_high_watermark(
+    db: &impl OLBlockDatabase,
+    mut block1: OLBlock,
+    mut block2: OLBlock,
+) {
+    block1.signed_header.header.slot = 10;
+    block2.signed_header.header.slot = 11;
+
+    let block1_commitment = db
+        .put_block_data_with_high_watermark(block1)
+        .expect("test: put target block with high-watermark");
+    let block2_commitment = db
+        .put_block_data_with_high_watermark(block2)
+        .expect("test: put later block with high-watermark");
+
+    let rolled_back = db
+        .rollback_block_high_watermark(block1_commitment)
+        .expect("test: roll back block high-watermark");
+    assert!(rolled_back);
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get rolled-back block high-watermark"),
+        Some(block1_commitment)
+    );
+
+    let unchanged = db
+        .rollback_block_high_watermark(block2_commitment)
+        .expect("test: non-rollback target above current high-watermark");
+    assert!(!unchanged);
+    assert_eq!(
+        db.get_block_high_watermark()
+            .expect("test: get unchanged block high-watermark"),
+        Some(block1_commitment)
+    );
+}
+
+pub fn proptest_rollback_block_high_watermark_missing_target(
+    db: &impl OLBlockDatabase,
+    mut block: OLBlock,
+) {
+    block.signed_header.header.slot = 10;
+    db.put_block_data_with_high_watermark(block)
+        .expect("test: put block with high-watermark");
+
+    let missing_target = OLBlockCommitment::new(9, OLBlockId::from(Buf32::from([0xeeu8; 32])));
+    let err = db
+        .rollback_block_high_watermark(missing_target)
+        .expect_err("test: missing rollback target should fail");
+    assert!(matches!(err, DbError::NonExistentEntry));
+}
+
 pub fn proptest_delete_random_block(db: &impl OLBlockDatabase, block: OLBlock) {
     let block_id = block.header().compute_blkid();
 
@@ -462,6 +513,21 @@ macro_rules! ol_block_db_tests {
             ) {
                 let db = $setup_expr;
                 $crate::ol_block_tests::proptest_high_watermark_monotonic_under_mixed_puts(&db, ops);
+            }
+
+            #[test]
+            fn proptest_rollback_block_high_watermark(
+                block1 in ol_test_utils::ol_block_strategy(),
+                block2 in ol_test_utils::ol_block_strategy()
+            ) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::proptest_rollback_block_high_watermark(&db, block1, block2);
+            }
+
+            #[test]
+            fn proptest_rollback_block_high_watermark_missing_target(block in ol_test_utils::ol_block_strategy()) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::proptest_rollback_block_high_watermark_missing_target(&db, block);
             }
 
             #[test]

--- a/crates/db/types/src/errors.rs
+++ b/crates/db/types/src/errors.rs
@@ -193,6 +193,14 @@ pub enum DbError {
         last_applied: OLBlockCommitment,
     },
 
+    /// `put_block_data_with_high_watermark` was called for a block whose slot does not strictly
+    /// advance past the current high-watermark.
+    #[error("block high-watermark conflict: attempted {attempted}, current {current}")]
+    BlockHighWatermarkConflict {
+        attempted: OLBlockCommitment,
+        current: OLBlockCommitment,
+    },
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -702,6 +702,25 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// status to "unchecked" if this is a new block.
     fn put_block_data(&self, block: OLBlock) -> DbResult<()>;
 
+    /// Returns the latest OL block committed through the high-watermark path, if any.
+    ///
+    /// This is not the highest block in the OL block database. Plain
+    /// [`Self::put_block_data`] does not read or update it.
+    fn get_block_high_watermark(&self) -> DbResult<Option<OLBlockCommitment>>;
+
+    /// Stores an OL block and advances the block high-watermark atomically.
+    ///
+    /// Block persistence semantics match [`Self::put_block_data`]. If the block's slot is not
+    /// strictly greater than the current high-watermark slot, this writes nothing and returns
+    /// [`DbError::BlockHighWatermarkConflict`](crate::DbError::BlockHighWatermarkConflict).
+    fn put_block_data_with_high_watermark(&self, block: OLBlock) -> DbResult<OLBlockCommitment>;
+
+    /// Clears the block high-watermark if it currently equals `expected`.
+    ///
+    /// This does not delete block data, block status, or height-index entries.
+    /// Returns `true` when the high-watermark was cleared.
+    fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool>;
+
     /// Retrieves an OL block for a given block ID.
     fn get_block_data(&self, id: OLBlockId) -> DbResult<Option<OLBlock>>;
 

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -721,6 +721,13 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Returns `true` when the high-watermark was cleared.
     fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool>;
 
+    /// Rolls the block high-watermark back to an existing target block.
+    ///
+    /// This is for explicit recovery paths that revert OL state. If the current high-watermark is
+    /// already at or below `target`, this is a no-op and returns `false`. Otherwise, the
+    /// high-watermark is set to `target` and this returns `true`.
+    fn rollback_block_high_watermark(&self, target: OLBlockCommitment) -> DbResult<bool>;
+
     /// Retrieves an OL block for a given block ID.
     fn get_block_data(&self, id: OLBlockId) -> DbResult<Option<OLBlock>>;
 

--- a/crates/ol/block-assembly/Cargo.toml
+++ b/crates/ol/block-assembly/Cargo.toml
@@ -8,16 +8,23 @@ workspace = true
 
 [dependencies]
 strata-acct-types.workspace = true
+strata-asm-common = { workspace = true, optional = true }
 strata-asm-manifest-types.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
 strata-bridge-params.workspace = true
+strata-btc-verification = { workspace = true, optional = true }
+strata-codec = { workspace = true, optional = true }
 strata-common = { workspace = true, optional = true }
 strata-config.workspace = true
+strata-db-store-sled = { workspace = true, optional = true }
 strata-db-types.workspace = true
 strata-identifiers.workspace = true
+strata-l1-txfmt = { workspace = true, optional = true }
 strata-ledger-types.workspace = true
+strata-msg-fmt = { workspace = true, optional = true }
 strata-ol-chain-types-new.workspace = true
 strata-ol-mempool.workspace = true
+strata-ol-msg-types = { workspace = true, optional = true }
 strata-ol-params.workspace = true
 strata-ol-state-provider.workspace = true
 strata-ol-state-support-types.workspace = true
@@ -27,20 +34,39 @@ strata-predicate.workspace = true
 strata-primitives.workspace = true
 strata-service.workspace = true
 strata-snark-acct-types.workspace = true
+strata-state = { workspace = true, optional = true }
 strata-storage.workspace = true
 strata-tasks.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
+bitcoin = { workspace = true, optional = true }
+proptest = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde.workspace = true
 thiserror.workspace = true
+threadpool = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 
 [features]
 debug-utils = ["dep:strata-common", "strata-common/debug-utils"]
 jsonschema = ["dep:schemars", "strata-identifiers/jsonschema"]
+test-utils = [
+  "dep:bitcoin",
+  "dep:proptest",
+  "dep:strata-asm-common",
+  "dep:strata-btc-verification",
+  "dep:strata-codec",
+  "dep:strata-db-store-sled",
+  "dep:strata-l1-txfmt",
+  "dep:strata-msg-fmt",
+  "dep:strata-ol-msg-types",
+  "dep:strata-state",
+  "dep:threadpool",
+  "strata-db-store-sled/test_utils",
+  "strata-ol-chain-types-new/test-utils",
+]
 
 [dev-dependencies]
 bitcoin.workspace = true
@@ -55,7 +81,6 @@ strata-l1-txfmt.workspace = true
 strata-msg-fmt.workspace = true
 strata-ol-chain-types-new = { workspace = true, features = ["test-utils"] }
 strata-ol-msg-types.workspace = true
-strata-ol-params.workspace = true
 strata-predicate.workspace = true
 strata-state.workspace = true
 threadpool.workspace = true

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -116,6 +116,7 @@ fn block_assembly_error_to_mempool_reason(err: &BlockAssemblyError) -> MempoolTx
         | BlockAssemblyError::Mempool(_)
         | BlockAssemblyError::StateProvider(_)
         | BlockAssemblyError::NoPendingTemplateForParent(_)
+        | BlockAssemblyError::TemplateAlreadyCompletedForParent { .. }
         | BlockAssemblyError::Other(_)
         | BlockAssemblyError::RequestChannelClosed
         | BlockAssemblyError::ResponseChannelClosed

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -140,7 +140,10 @@ pub(crate) struct ConstructBlockOutput<S> {
     pub(crate) failed_txs: Vec<FailedMempoolTx>,
     /// The post state after applying all transactions.
     // Used by tests to chain blocks without re-executing through STF.
-    #[cfg_attr(not(test), expect(dead_code, reason = "only used by tests"))]
+    #[cfg_attr(
+        all(not(test), not(feature = "test-utils")),
+        expect(dead_code, reason = "only used by tests")
+    )]
     pub(crate) post_state: S,
     /// Accumulated DA data for the constructed block.
     pub(crate) accumulated_da: AccumulatedDaData,

--- a/crates/ol/block-assembly/src/command.rs
+++ b/crates/ol/block-assembly/src/command.rs
@@ -1,6 +1,6 @@
 //! Command types for OL block assembly service.
 
-use strata_identifiers::OLBlockId;
+use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::OLBlock;
 use strata_service::CommandCompletionSender;
 use tokio::sync::oneshot;
@@ -19,11 +19,10 @@ type GetBlockTemplateResult = Result<FullBlockTemplate, BlockAssemblyError>;
 /// Type alias for block template completion result.
 type CompleteBlockTemplateResult = Result<OLBlock, BlockAssemblyError>;
 
+/// Type alias for completed-template status release result.
+type ReleaseCompletedTemplateStatusResult = bool;
+
 #[derive(Debug)]
-#[expect(
-    clippy::enum_variant_names,
-    reason = "BlockTemplate suffix is intentionally descriptive"
-)]
 pub(crate) enum BlockasmCommand {
     GenerateBlockTemplate {
         config: BlockGenerationConfig,
@@ -38,6 +37,13 @@ pub(crate) enum BlockasmCommand {
         template_id: OLBlockId,
         data: BlockCompletionData,
         completion: CommandCompletionSender<CompleteBlockTemplateResult>,
+    },
+    ReleaseCompletedTemplateStatus {
+        /// Parent for the completed-template status.
+        parent_block_id: OLBlockId,
+        /// Block commitment stored in the completed-template status.
+        block: OLBlockCommitment,
+        completion: CommandCompletionSender<ReleaseCompletedTemplateStatusResult>,
     },
 }
 

--- a/crates/ol/block-assembly/src/command.rs
+++ b/crates/ol/block-assembly/src/command.rs
@@ -22,6 +22,9 @@ type CompleteBlockTemplateResult = Result<OLBlock, BlockAssemblyError>;
 /// Type alias for completed-template status release result.
 type ReleaseCompletedTemplateStatusResult = bool;
 
+/// Type alias for recording a persisted block result.
+type RecordPersistedBlockResult = Result<(), BlockAssemblyError>;
+
 #[derive(Debug)]
 pub(crate) enum BlockasmCommand {
     GenerateBlockTemplate {
@@ -33,7 +36,7 @@ pub(crate) enum BlockasmCommand {
         completion: CommandCompletionSender<GetBlockTemplateResult>,
     },
     CompleteBlockTemplate {
-        /// The ID of a previously generated template, used to look up the cached template.
+        /// The ID of the cached template to complete into a block.
         template_id: OLBlockId,
         data: BlockCompletionData,
         completion: CommandCompletionSender<CompleteBlockTemplateResult>,
@@ -44,6 +47,11 @@ pub(crate) enum BlockasmCommand {
         /// Block commitment stored in the completed-template status.
         block: OLBlockCommitment,
         completion: CommandCompletionSender<ReleaseCompletedTemplateStatusResult>,
+    },
+    RecordPersistedBlock {
+        /// The ID of the template that produced the persisted block.
+        template_id: OLBlockId,
+        completion: CommandCompletionSender<RecordPersistedBlockResult>,
     },
 }
 

--- a/crates/ol/block-assembly/src/error.rs
+++ b/crates/ol/block-assembly/src/error.rs
@@ -60,6 +60,13 @@ pub enum BlockAssemblyError {
     #[error("no pending template found for parent id: {0}")]
     NoPendingTemplateForParent(OLBlockId),
 
+    /// A template for this parent already produced a block.
+    #[error("template already completed for parent id {parent}: {block}")]
+    TemplateAlreadyCompletedForParent {
+        parent: OLBlockId,
+        block: OLBlockCommitment,
+    },
+
     /// Invalid signature for block template completion.
     #[error("invalid signature for template: {0}")]
     InvalidSignature(OLBlockId),

--- a/crates/ol/block-assembly/src/handle.rs
+++ b/crates/ol/block-assembly/src/handle.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use strata_identifiers::OLBlockId;
+use strata_identifiers::{OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::OLBlock;
 use strata_service::{CommandHandle, ServiceMonitor};
 use tokio::sync::oneshot;
@@ -88,5 +88,20 @@ impl BlockasmHandle {
             completion,
         };
         self.send_command(command, rx).await?
+    }
+
+    /// Release a completed-template status if it references `block`.
+    pub async fn release_completed_template_status(
+        &self,
+        parent_block_id: OLBlockId,
+        block: OLBlockCommitment,
+    ) -> BlockAssemblyResult<bool> {
+        let (completion, rx) = create_completion();
+        let command = BlockasmCommand::ReleaseCompletedTemplateStatus {
+            parent_block_id,
+            block,
+            completion,
+        };
+        self.send_command(command, rx).await
     }
 }

--- a/crates/ol/block-assembly/src/handle.rs
+++ b/crates/ol/block-assembly/src/handle.rs
@@ -75,7 +75,10 @@ impl BlockasmHandle {
         self.send_command(command, rx).await?
     }
 
-    /// Complete specified template with completion data and return the final block.
+    /// Completes a cached template with completion data and returns the block.
+    ///
+    /// This validates the completion data and does not remove the template from the cache. Call
+    /// [`Self::record_persisted_block`] after the block is durably persisted.
     pub async fn complete_block_template(
         &self,
         template_id: OLBlockId,
@@ -103,5 +106,15 @@ impl BlockasmHandle {
             completion,
         };
         self.send_command(command, rx).await
+    }
+
+    /// Records that the block produced from this template has been persisted.
+    pub async fn record_persisted_block(&self, template_id: OLBlockId) -> BlockAssemblyResult<()> {
+        let (completion, rx) = create_completion();
+        let command = BlockasmCommand::RecordPersistedBlock {
+            template_id,
+            completion,
+        };
+        self.send_command(command, rx).await?
     }
 }

--- a/crates/ol/block-assembly/src/lib.rs
+++ b/crates/ol/block-assembly/src/lib.rs
@@ -12,8 +12,8 @@ mod handle;
 mod mempool_provider;
 mod service;
 mod state;
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 #[cfg(test)]
 mod tests;
 mod types;

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -15,7 +15,7 @@ use crate::{
     block_assembly::generate_block_template_inner,
     command::BlockasmCommand,
     error::BlockAssemblyError,
-    state::BlockasmServiceState,
+    state::{BlockTemplateStatus, BlockasmServiceState},
     types::{BlockCompletionData, BlockGenerationConfig},
 };
 
@@ -87,6 +87,17 @@ where
                 let result = complete_block_template(state, template_id, data);
                 _ = completion.send(result).await;
             }
+
+            BlockasmCommand::ReleaseCompletedTemplateStatus {
+                parent_block_id,
+                block,
+                completion,
+            } => {
+                let released = state
+                    .state_mut()
+                    .release_completed_template_status(parent_block_id, block);
+                _ = completion.send(released).await;
+            }
         }
 
         Ok(Response::Continue)
@@ -110,15 +121,29 @@ where
     <<S::State as IStateAccessorMut>::AccountStateMut as IAccountStateMut>::SnarkAccountStateMut:
         Clone,
 {
+    let parent_blkid = config.parent_block_id();
+    state
+        .state_mut()
+        .prune_completed_template_statuses_for_parent(config.parent_block_commitment());
+
     // Check if we already have a pending template for this parent block ID
     if let Ok(template) = state
         .state_mut()
-        .get_pending_block_template_by_parent(config.parent_block_id())
+        .get_pending_block_template_by_parent(parent_blkid)
     {
         return Ok(template);
     }
 
-    let parent_blkid = config.parent_block_id();
+    if let Some(BlockTemplateStatus::Completed { block }) = state
+        .state_mut()
+        .get_template_status_by_parent(parent_blkid)
+    {
+        return Err(BlockAssemblyError::TemplateAlreadyCompletedForParent {
+            parent: parent_blkid,
+            block,
+        });
+    }
+
     let parent_da = state
         .fetch_epoch_da_until_parent(config.parent_block_commitment())
         .await?;
@@ -146,14 +171,15 @@ where
 
     let template_id = full_template.get_blockid();
 
+    let evicted_template_ids = state
+        .state_mut()
+        .insert_template(template_id, full_template.clone())?;
+
     // Store accumulated DA for the new block, removing parent entry.
     state
         .epoch_da_tracker_mut()
         .set_accumulated_da_and_remove_parent_entry(template_id, parent_blkid, accumulated_da);
 
-    let evicted_template_ids = state
-        .state_mut()
-        .insert_template(template_id, full_template.clone());
     for evicted_template_id in evicted_template_ids {
         state
             .epoch_da_tracker_mut()
@@ -179,7 +205,7 @@ fn get_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
 /// 1. Sequencer calls `GenerateBlockTemplate` to get a template with header hash
 /// 2. Sequencer signs the header hash externally (e.g., via signing service)
 /// 3. Sequencer calls `CompleteBlockTemplate` with the signature
-/// 4. This function validates the signature before completing the block
+/// 4. This function validates the signature before completing the cached template
 ///
 /// The completed block is returned to the caller, who is responsible for submitting it
 /// to the Fork Choice Manager (FCM) and storage.
@@ -188,10 +214,9 @@ fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
     template_id: OLBlockId,
     completion_data: BlockCompletionData,
 ) -> Result<OLBlock, BlockAssemblyError> {
-    // Get template to verify signature before removing it
     let template_ref = state.state_mut().get_pending_block_template(template_id)?;
 
-    // Verify signature first (before removing from cache)
+    // Verify the signature before removing the template from the cache.
     if !check_completion_data(
         state.sequencer_predicate(),
         template_ref.header(),
@@ -200,17 +225,17 @@ fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
         return Err(BlockAssemblyError::InvalidSignature(template_id));
     }
 
-    // Signature valid - now remove template from cache
-    let template = state.state_mut().remove_template(template_id)?;
+    // The signature is valid; mark the template as completed.
+    let template = state.state_mut().mark_template_completed(template_id)?;
     state
         .epoch_da_tracker_mut()
         .remove_accumulated_da(template_id);
 
-    // Complete the template
+    // Apply the signature and return the completed block.
     Ok(template.complete_block_template(completion_data))
 }
 
-/// Check if completion data (signature) is valid.
+/// Checks whether the sequencer signature matches the template header.
 fn check_completion_data(
     sequencer_predicate: &PredicateKey,
     header: &OLBlockHeader,
@@ -231,7 +256,7 @@ mod tests {
 
     use strata_config::BlockAssemblyConfig;
     use strata_crypto::sign_schnorr_sig;
-    use strata_identifiers::{Buf32, Buf64};
+    use strata_identifiers::{Buf32, Buf64, OLBlockCommitment};
     use strata_ol_chain_types_new::test_utils::schnorr_predicate;
     use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
     use strata_ol_params::OLParams;
@@ -326,7 +351,10 @@ mod tests {
         let template_id = template.get_blockid();
         let parent = *template.header().parent_blkid();
 
-        state.state_mut().insert_template(template_id, template);
+        state
+            .state_mut()
+            .insert_template(template_id, template)
+            .expect("test template insert should succeed");
         state
             .state_mut()
             .set_template_created_at_for_test(template_id, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
@@ -497,7 +525,8 @@ mod tests {
         let stale_template_id = stale_template.get_blockid();
         state
             .state_mut()
-            .insert_template(stale_template_id, stale_template);
+            .insert_template(stale_template_id, stale_template)
+            .expect("stale test template insert should succeed");
         state
             .epoch_da_tracker_mut()
             .set_accumulated_da(stale_template_id, AccumulatedDaData::new_empty());
@@ -688,6 +717,152 @@ mod tests {
         assert!(
             matches!(err, BlockAssemblyError::UnknownTemplateId(id) if id == template_id),
             "second completion should return UnknownTemplateId, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_generation_after_completion_returns_completed_parent_error() {
+        let (mut state, mempool, env, sk) = build_service_state(true).await;
+        let signing_key = sk.expect("schnorr signing key should be present");
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let parent = config.parent_block_id();
+        let template = generate_block_template(&mut state, config.clone())
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+
+        let completion_data = valid_completion_data(&template, signing_key);
+        let completed = complete_block_template(&mut state, template_id, completion_data)
+            .expect("valid signature should complete template");
+        let completed_commitment = OLBlockCommitment::new(
+            completed.header().slot(),
+            completed.header().compute_blkid(),
+        );
+
+        // If generation tries to rebuild, this fail mode makes the test fail.
+        mempool.set_fail_mode(MockMempoolFailMode::GetTransactions);
+        let err = generate_block_template(&mut state, config)
+            .await
+            .expect_err("completed parent should not generate a fresh template");
+
+        assert!(
+            matches!(
+                err,
+                BlockAssemblyError::TemplateAlreadyCompletedForParent {
+                    parent: err_parent,
+                    block: err_block,
+                } if err_parent == parent && err_block == completed_commitment
+            ),
+            "expected TemplateAlreadyCompletedForParent, got: {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_release_completed_template_status_command_releases_exact_match() {
+        let (mut state, _mempool, env, sk) = build_service_state(true).await;
+        let signing_key = sk.expect("schnorr signing key should be present");
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let parent = config.parent_block_id();
+        let template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+
+        let completion_data = valid_completion_data(&template, signing_key);
+        let completed = complete_block_template(&mut state, template_id, completion_data)
+            .expect("valid signature should complete template");
+        let completed_commitment = OLBlockCommitment::new(
+            completed.header().slot(),
+            completed.header().compute_blkid(),
+        );
+
+        let (completion, rx) = create_completion();
+        let cmd = BlockasmCommand::ReleaseCompletedTemplateStatus {
+            parent_block_id: parent,
+            block: completed_commitment,
+            completion,
+        };
+        BlockasmService::<_, _, _>::process_input(&mut state, cmd)
+            .await
+            .expect("process_input should succeed");
+
+        assert!(
+            rx.await.expect("release completion should be delivered"),
+            "completed status should be released when parent and block match"
+        );
+        assert!(
+            state
+                .state_mut()
+                .get_template_status_by_parent(parent)
+                .is_none(),
+            "released completed status should be removed"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_generation_after_completed_status_release_rebuilds_template() {
+        let sender = test_account_id(92);
+        let (mut state, mempool, env, sk) =
+            build_service_state_with_accounts(true, [TestAccount::new(sender, 10_000)]).await;
+        let signing_key = sk.expect("schnorr signing key should be present");
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let parent = config.parent_block_id();
+        let first = generate_block_template(&mut state, config.clone())
+            .await
+            .expect("first generation should succeed");
+        let first_template_id = first.get_blockid();
+
+        let completion_data = valid_completion_data(&first, signing_key);
+        let completed = complete_block_template(&mut state, first_template_id, completion_data)
+            .expect("valid signature should complete template");
+        let completed_commitment = OLBlockCommitment::new(
+            completed.header().slot(),
+            completed.header().compute_blkid(),
+        );
+        assert_eq!(
+            state.state_mut().get_template_status_by_parent(parent),
+            Some(BlockTemplateStatus::Completed {
+                block: completed_commitment
+            }),
+            "completed template should leave a completed parent status"
+        );
+
+        assert!(
+            state
+                .state_mut()
+                .release_completed_template_status(parent, completed_commitment),
+            "matching completed status should be released"
+        );
+        assert!(
+            state
+                .state_mut()
+                .get_template_status_by_parent(parent)
+                .is_none(),
+            "released parent should not retain a completed status"
+        );
+
+        let tx = MempoolSnarkTxBuilder::new(sender).with_seq_no(0).build();
+        mempool.add_transaction(tx.compute_txid(), tx);
+
+        let second = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should rebuild after completed status release");
+        assert_eq!(
+            second.header().slot(),
+            completed_commitment.slot(),
+            "replacement template should target the same child slot"
+        );
+        assert_ne!(
+            second.get_blockid(),
+            first_template_id,
+            "released parent should rebuild a distinct template"
+        );
+        assert_eq!(
+            state.state_mut().get_template_status_by_parent(parent),
+            Some(BlockTemplateStatus::Pending {
+                template_id: second.get_blockid()
+            }),
+            "released parent should track the replacement template as pending"
         );
     }
 

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -57,12 +57,15 @@ where
     }
 
     async fn process_input(state: &mut Self::State, input: Self::Msg) -> anyhow::Result<Response> {
-        // Lazily clean up expired templates on every command.
-        let expired_template_ids = state.state_mut().cleanup_expired_templates();
-        for template_id in expired_template_ids {
-            state
-                .epoch_da_tracker_mut()
-                .remove_accumulated_da(template_id);
+        if !matches!(&input, BlockasmCommand::RecordPersistedBlock { .. }) {
+            // Lazily clean up expired templates on every command except the post-persist
+            // state update, which must be able to observe an already-persisted block.
+            let expired_template_ids = state.state_mut().cleanup_expired_templates();
+            for template_id in expired_template_ids {
+                state
+                    .epoch_da_tracker_mut()
+                    .remove_accumulated_da(template_id);
+            }
         }
 
         match input {
@@ -97,6 +100,14 @@ where
                     .state_mut()
                     .release_completed_template_status(parent_block_id, block);
                 _ = completion.send(released).await;
+            }
+
+            BlockasmCommand::RecordPersistedBlock {
+                template_id,
+                completion,
+            } => {
+                let result = record_persisted_block(state, template_id);
+                _ = completion.send(result).await;
             }
         }
 
@@ -199,7 +210,7 @@ fn get_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
         .get_pending_block_template_by_parent(parent_block_id)
 }
 
-/// Complete a block template with signature.
+/// Completes a cached template with a signature.
 ///
 /// The signature is provided by the caller (sequencer) via `BlockCompletionData`. The flow is:
 /// 1. Sequencer calls `GenerateBlockTemplate` to get a template with header hash
@@ -207,8 +218,9 @@ fn get_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
 /// 3. Sequencer calls `CompleteBlockTemplate` with the signature
 /// 4. This function validates the signature before completing the cached template
 ///
-/// The completed block is returned to the caller, who is responsible for submitting it
-/// to the Fork Choice Manager (FCM) and storage.
+/// The completed block is returned to the caller, who is responsible for durably storing it,
+/// recording the persisted block for the template, and submitting it to the Fork Choice Manager
+/// (FCM).
 fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
     state: &mut BlockasmServiceState<M, E, S>,
     template_id: OLBlockId,
@@ -216,7 +228,8 @@ fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
 ) -> Result<OLBlock, BlockAssemblyError> {
     let template_ref = state.state_mut().get_pending_block_template(template_id)?;
 
-    // Verify the signature before removing the template from the cache.
+    // Verify the signature before returning a completed block. Failed signatures keep the
+    // cached template retryable.
     if !check_completion_data(
         state.sequencer_predicate(),
         template_ref.header(),
@@ -225,14 +238,19 @@ fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
         return Err(BlockAssemblyError::InvalidSignature(template_id));
     }
 
-    // The signature is valid; mark the template as completed.
-    let template = state.state_mut().mark_template_completed(template_id)?;
+    Ok(template_ref.complete_block_template(completion_data))
+}
+
+/// Records that a block has been stored for a template and removes its accumulated DA entry.
+fn record_persisted_block<M: MempoolProvider, E: EpochSealingPolicy, S>(
+    state: &mut BlockasmServiceState<M, E, S>,
+    template_id: OLBlockId,
+) -> Result<(), BlockAssemblyError> {
+    state.state_mut().record_persisted_block(template_id)?;
     state
         .epoch_da_tracker_mut()
         .remove_accumulated_da(template_id);
-
-    // Apply the signature and return the completed block.
-    Ok(template.complete_block_template(completion_data))
+    Ok(())
 }
 
 /// Checks whether the sequencer signature matches the template header.
@@ -643,12 +661,21 @@ mod tests {
             template_id,
             "completed block id should match template id"
         );
+
+        let cached_template = state
+            .state_mut()
+            .get_pending_block_template(template_id)
+            .expect("template should remain cached until storage succeeds");
+        assert_eq!(cached_template.get_blockid(), template_id);
+
+        record_persisted_block(&mut state, template_id)
+            .expect("persisted block should be recorded for template after storage succeeds");
         assert!(
             matches!(
                 state.state_mut().get_pending_block_template(template_id),
                 Err(BlockAssemblyError::UnknownTemplateId(id)) if id == template_id
             ),
-            "template should be removed after successful completion"
+            "template should be removed after persisted block is recorded"
         );
     }
 
@@ -697,6 +724,22 @@ mod tests {
             template_id,
             "completed block id should match template id"
         );
+
+        let cached_template = state
+            .state_mut()
+            .get_pending_block_template(template_id)
+            .expect("template should remain cached until storage succeeds");
+        assert_eq!(cached_template.get_blockid(), template_id);
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(template_id)
+                .is_some(),
+            "completion should not evict DA tracker entry before storage succeeds"
+        );
+
+        record_persisted_block(&mut state, template_id)
+            .expect("persisted block should be recorded for template after storage succeeds");
         assert!(
             matches!(
                 state.state_mut().get_pending_block_template(template_id),
@@ -721,6 +764,53 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_record_persisted_block_skips_ttl_cleanup() {
+        let (mut state, _mempool, env, sk) = build_service_state(true).await;
+        let signing_key = sk.expect("schnorr signing key should be present");
+        let config = BlockGenerationConfig::new(env.parent_commitment());
+        let template = generate_block_template(&mut state, config)
+            .await
+            .expect("generation should succeed");
+        let template_id = template.get_blockid();
+
+        let completion_data = valid_completion_data(&template, signing_key);
+        complete_block_template(&mut state, template_id, completion_data)
+            .expect("valid signature should complete template");
+
+        state
+            .state_mut()
+            .set_template_created_at_for_test(template_id, Instant::now() - TEST_BLOCK_TEMPLATE_TTL)
+            .expect("template should be present before backdating");
+
+        let (completion, rx) = create_completion();
+        let cmd = BlockasmCommand::RecordPersistedBlock {
+            template_id,
+            completion,
+        };
+        BlockasmService::<_, _, _>::process_input(&mut state, cmd)
+            .await
+            .unwrap();
+        rx.await
+            .expect("completion sender should respond")
+            .expect("recording persisted block should ignore template TTL after storage succeeds");
+
+        assert!(
+            matches!(
+                state.state_mut().get_pending_block_template(template_id),
+                Err(BlockAssemblyError::UnknownTemplateId(id)) if id == template_id
+            ),
+            "template should be removed after persisted block is recorded"
+        );
+        assert!(
+            state
+                .epoch_da_tracker()
+                .get_accumulated_da(template_id)
+                .is_none(),
+            "recording persisted block should evict DA tracker entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_generation_after_completion_returns_completed_parent_error() {
         let (mut state, mempool, env, sk) = build_service_state(true).await;
         let signing_key = sk.expect("schnorr signing key should be present");
@@ -738,6 +828,8 @@ mod tests {
             completed.header().slot(),
             completed.header().compute_blkid(),
         );
+        record_persisted_block(&mut state, template_id)
+            .expect("persisted block should be recorded for template after storage succeeds");
 
         // If generation tries to rebuild, this fail mode makes the test fail.
         mempool.set_fail_mode(MockMempoolFailMode::GetTransactions);
@@ -771,6 +863,8 @@ mod tests {
         let completion_data = valid_completion_data(&template, signing_key);
         let completed = complete_block_template(&mut state, template_id, completion_data)
             .expect("valid signature should complete template");
+        record_persisted_block(&mut state, template_id)
+            .expect("completed template should be recorded as persisted");
         let completed_commitment = OLBlockCommitment::new(
             completed.header().slot(),
             completed.header().compute_blkid(),
@@ -815,6 +909,8 @@ mod tests {
         let completion_data = valid_completion_data(&first, signing_key);
         let completed = complete_block_template(&mut state, first_template_id, completion_data)
             .expect("valid signature should complete template");
+        record_persisted_block(&mut state, first_template_id)
+            .expect("completed template should be recorded as persisted");
         let completed_commitment = OLBlockCommitment::new(
             completed.header().slot(),
             completed.header().compute_blkid(),

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -44,8 +44,8 @@ pub(crate) enum BlockTemplateStatus {
 /// Mutable state for block assembly service (owned by service task).
 ///
 /// Manages pending block templates that have been generated but not yet completed with a
-/// signature. Templates are created by `GenerateBlockTemplate` and marked completed when
-/// `CompleteBlockTemplate` is called with a valid signature.
+/// signature. Templates are created by `GenerateBlockTemplate` and recorded when
+/// `CompleteBlockTemplate` has produced a durably persisted block.
 ///
 /// Templates expire after a configurable TTL. Expired entries are cleaned up during insertion
 /// and are treated as absent during lookups.
@@ -54,7 +54,7 @@ pub(crate) enum BlockTemplateStatus {
 /// 1. Template created via `generate_block_template()` and stored here
 /// 2. Template retrieved via `get_pending_block_template()` for signing
 /// 3. Template copied for signature validation without cache mutation
-/// 4. Template marked `Completed` after signature validation
+/// 4. Template recorded after its block is persisted
 /// 5. Template expires and is cleaned up if never completed
 #[derive(Debug)]
 pub(crate) struct BlockAssemblyState {
@@ -192,15 +192,14 @@ impl BlockAssemblyState {
             ))
     }
 
-    /// Marks a pending template as completed.
-    pub(crate) fn mark_template_completed(
+    /// Records that the block produced from a pending template has been persisted.
+    pub(crate) fn record_persisted_block(
         &mut self,
         template_id: OLBlockId,
     ) -> Result<FullBlockTemplate, BlockAssemblyError> {
         let cached = self
             .pending_templates
             .get(&template_id)
-            .filter(|cached| cached.created_at.elapsed() < self.ttl)
             .ok_or(BlockAssemblyError::UnknownTemplateId(template_id))?;
 
         let template = cached.template.clone();
@@ -526,7 +525,7 @@ mod tests {
     }
 
     #[test]
-    fn mark_template_completed_sets_completed_status() {
+    fn record_persisted_block_sets_completed_status() {
         let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
         let template = create_test_template();
         let id = template.get_blockid();
@@ -534,10 +533,10 @@ mod tests {
         let block = template.header().compute_block_commitment();
 
         state.insert_template(id, template).unwrap();
-        let committed = state.mark_template_completed(id).unwrap();
+        let committed = state.record_persisted_block(id).unwrap();
         assert_eq!(committed.get_blockid(), id);
 
-        assert!(state.mark_template_completed(id).is_err());
+        assert!(state.record_persisted_block(id).is_err());
 
         // Verify parent lookup fails for signable templates, but the completed tombstone remains.
         assert!(state.get_pending_block_template_by_parent(parent).is_err());
@@ -557,7 +556,7 @@ mod tests {
         let block = template.header().compute_block_commitment();
 
         state.insert_template(id, template).unwrap();
-        state.mark_template_completed(id).unwrap();
+        state.record_persisted_block(id).unwrap();
 
         let replacement = create_test_template_with_parent(parent);
         let replacement_id = replacement.get_blockid();
@@ -592,7 +591,7 @@ mod tests {
         let block = template.header().compute_block_commitment();
 
         state.insert_template(id, template).unwrap();
-        state.mark_template_completed(id).unwrap();
+        state.record_persisted_block(id).unwrap();
 
         assert!(
             state.release_completed_template_status(parent, block),
@@ -628,7 +627,7 @@ mod tests {
             OLBlockCommitment::new(block.slot(), OLBlockId::from(Buf32::from([0x55; 32])));
 
         state.insert_template(id, template).unwrap();
-        state.mark_template_completed(id).unwrap();
+        state.record_persisted_block(id).unwrap();
 
         assert!(
             !state.release_completed_template_status(parent, other_block),
@@ -671,7 +670,7 @@ mod tests {
         let block = template.header().compute_block_commitment();
 
         state.insert_template(id, template).unwrap();
-        state.mark_template_completed(id).unwrap();
+        state.record_persisted_block(id).unwrap();
 
         state.prune_completed_template_statuses_for_parent(block);
 
@@ -690,7 +689,7 @@ mod tests {
         let block = template.header().compute_block_commitment();
 
         state.insert_template(id, template).unwrap();
-        state.mark_template_completed(id).unwrap();
+        state.record_persisted_block(id).unwrap();
 
         let parent_commitment = OLBlockCommitment::new(block.slot().saturating_sub(1), parent);
         state.prune_completed_template_statuses_for_parent(parent_commitment);
@@ -720,7 +719,7 @@ mod tests {
             let id = template.get_blockid();
             let block = template.header().compute_block_commitment();
             state.insert_template(id, template).unwrap();
-            state.mark_template_completed(id).unwrap();
+            state.record_persisted_block(id).unwrap();
             completed.push((parent, block));
         }
 

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -31,10 +31,20 @@ pub(crate) struct CachedTemplate {
     pub(crate) created_at: Instant,
 }
 
+/// Lifecycle state for a block template.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum BlockTemplateStatus {
+    /// The template is awaiting a sequencer signature.
+    Pending { template_id: OLBlockId },
+
+    /// The template header was signed, producing the referenced OL block.
+    Completed { block: OLBlockCommitment },
+}
+
 /// Mutable state for block assembly service (owned by service task).
 ///
 /// Manages pending block templates that have been generated but not yet completed with a
-/// signature. Templates are created by `GenerateBlockTemplate` command and removed when
+/// signature. Templates are created by `GenerateBlockTemplate` and marked completed when
 /// `CompleteBlockTemplate` is called with a valid signature.
 ///
 /// Templates expire after a configurable TTL. Expired entries are cleaned up during insertion
@@ -43,15 +53,16 @@ pub(crate) struct CachedTemplate {
 /// # Template Lifecycle
 /// 1. Template created via `generate_block_template()` and stored here
 /// 2. Template retrieved via `get_pending_block_template()` for signing
-/// 3. Template completed and removed via `remove_template()` after signature validation
-/// 4. Template expires and is cleaned up if never completed
+/// 3. Template copied for signature validation without cache mutation
+/// 4. Template marked `Completed` after signature validation
+/// 5. Template expires and is cleaned up if never completed
 #[derive(Debug)]
 pub(crate) struct BlockAssemblyState {
     /// Pending templates: template_id -> cached template.
     pub(crate) pending_templates: HashMap<OLBlockId, CachedTemplate>,
 
-    /// Parent block ID -> template ID mapping for cache lookups.
-    pub(crate) pending_by_parent: HashMap<OLBlockId, OLBlockId>,
+    /// Parent block ID -> template status.
+    pub(crate) template_status_by_parent: HashMap<OLBlockId, BlockTemplateStatus>,
 
     /// Time-to-live for cached templates.
     ttl: Duration,
@@ -61,7 +72,7 @@ impl BlockAssemblyState {
     pub(crate) fn new(ttl: Duration) -> Self {
         Self {
             pending_templates: HashMap::new(),
-            pending_by_parent: HashMap::new(),
+            template_status_by_parent: HashMap::new(),
             ttl,
         }
     }
@@ -75,12 +86,25 @@ impl BlockAssemblyState {
         &mut self,
         template_id: OLBlockId,
         template: FullBlockTemplate,
-    ) -> Vec<OLBlockId> {
+    ) -> Result<Vec<OLBlockId>, BlockAssemblyError> {
         let mut evicted_template_ids = Vec::new();
         let parent = *template.header().parent_blkid();
 
+        if let Some(BlockTemplateStatus::Completed { block }) =
+            self.template_status_by_parent.get(&parent)
+        {
+            return Err(BlockAssemblyError::TemplateAlreadyCompletedForParent {
+                parent,
+                block: *block,
+            });
+        }
+
         // If we already have a template cached for this parent, evict it to avoid orphans.
-        if let Some(old_id) = self.pending_by_parent.insert(parent, template_id)
+        if let Some(BlockTemplateStatus::Pending {
+            template_id: old_id,
+        }) = self
+            .template_status_by_parent
+            .insert(parent, BlockTemplateStatus::Pending { template_id })
             && old_id != template_id
         {
             self.pending_templates.remove(&old_id);
@@ -101,7 +125,33 @@ impl BlockAssemblyState {
         }
 
         evicted_template_ids.extend(self.cleanup_expired_templates());
-        evicted_template_ids
+        Ok(evicted_template_ids)
+    }
+
+    pub(crate) fn get_template_status_by_parent(
+        &self,
+        parent_block_id: OLBlockId,
+    ) -> Option<BlockTemplateStatus> {
+        self.template_status_by_parent
+            .get(&parent_block_id)
+            .copied()
+    }
+
+    /// Keeps completed tombstones above the current parent slot.
+    ///
+    /// If the current parent is still slot `N - 1`, a completed child at slot `N`
+    /// survives and blocks regeneration. Reorgs to lower slots may leave
+    /// higher-slot tombstones until the parent slot advances past them.
+    pub(crate) fn prune_completed_template_statuses_for_parent(
+        &mut self,
+        parent_block: OLBlockCommitment,
+    ) {
+        let parent_slot = parent_block.slot();
+        self.template_status_by_parent
+            .retain(|_, status| match status {
+                BlockTemplateStatus::Pending { .. } => true,
+                BlockTemplateStatus::Completed { block } => block.slot() > parent_slot,
+            });
     }
 
     /// Gets a pending template by template ID.
@@ -125,9 +175,13 @@ impl BlockAssemblyState {
         &self,
         parent_block_id: OLBlockId,
     ) -> Result<FullBlockTemplate, BlockAssemblyError> {
-        let template_id = self.pending_by_parent.get(&parent_block_id).ok_or(
-            BlockAssemblyError::NoPendingTemplateForParent(parent_block_id),
-        )?;
+        let Some(BlockTemplateStatus::Pending { template_id }) =
+            self.template_status_by_parent.get(&parent_block_id)
+        else {
+            return Err(BlockAssemblyError::NoPendingTemplateForParent(
+                parent_block_id,
+            ));
+        };
 
         self.pending_templates
             .get(template_id)
@@ -138,23 +192,49 @@ impl BlockAssemblyState {
             ))
     }
 
-    /// Remove a template and return it.
-    pub(crate) fn remove_template(
+    /// Marks a pending template as completed.
+    pub(crate) fn mark_template_completed(
         &mut self,
         template_id: OLBlockId,
     ) -> Result<FullBlockTemplate, BlockAssemblyError> {
         let cached = self
             .pending_templates
-            .remove(&template_id)
+            .get(&template_id)
+            .filter(|cached| cached.created_at.elapsed() < self.ttl)
             .ok_or(BlockAssemblyError::UnknownTemplateId(template_id))?;
 
-        let parent = *cached.template.header().parent_blkid();
-        // Only remove mapping if it still points to this template id.
-        if self.pending_by_parent.get(&parent) == Some(&template_id) {
-            self.pending_by_parent.remove(&parent);
+        let template = cached.template.clone();
+        let parent = *template.header().parent_blkid();
+        let expected_status = BlockTemplateStatus::Pending { template_id };
+        if self.template_status_by_parent.get(&parent) != Some(&expected_status) {
+            return Err(BlockAssemblyError::UnknownTemplateId(template_id));
         }
 
-        Ok(cached.template)
+        self.pending_templates.remove(&template_id);
+        self.template_status_by_parent.insert(
+            parent,
+            BlockTemplateStatus::Completed {
+                block: template.header().compute_block_commitment(),
+            },
+        );
+
+        Ok(template)
+    }
+
+    /// Removes a completed status when it references the provided block.
+    pub(crate) fn release_completed_template_status(
+        &mut self,
+        parent_block_id: OLBlockId,
+        block: OLBlockCommitment,
+    ) -> bool {
+        if self.template_status_by_parent.get(&parent_block_id)
+            == Some(&BlockTemplateStatus::Completed { block })
+        {
+            self.template_status_by_parent.remove(&parent_block_id);
+            return true;
+        }
+
+        false
     }
 
     /// Removes expired entries from both maps and returns removed template IDs.
@@ -171,8 +251,12 @@ impl BlockAssemblyState {
         for template_id in &expired_ids {
             if let Some(cached) = self.pending_templates.remove(template_id) {
                 let parent = *cached.template.header().parent_blkid();
-                if self.pending_by_parent.get(&parent) == Some(template_id) {
-                    self.pending_by_parent.remove(&parent);
+                if self.template_status_by_parent.get(&parent)
+                    == Some(&BlockTemplateStatus::Pending {
+                        template_id: *template_id,
+                    })
+                {
+                    self.template_status_by_parent.remove(&parent);
                 }
             }
         }
@@ -338,7 +422,7 @@ mod tests {
 
     use strata_config::BlockAssemblyConfig;
     use strata_identifiers::{AccountSerial, Buf32, Buf64};
-    use strata_ol_chain_types_new::{OLBlock, OLLog, SignedOLBlockHeader};
+    use strata_ol_chain_types_new::{OLBlock, OLBlockHeader, OLLog, SignedOLBlockHeader};
     use strata_ol_state_provider::OLStateManagerProviderImpl;
     use strata_ol_state_support_types::EpochDaAccumulator;
     use strata_predicate::PredicateKey;
@@ -368,6 +452,25 @@ mod tests {
         )
     }
 
+    fn create_test_template_with_parent_and_slot(
+        parent: OLBlockId,
+        slot: u64,
+    ) -> FullBlockTemplate {
+        let template = create_test_template_with_parent(parent);
+        let header = template.header();
+        let header = OLBlockHeader::new(
+            header.timestamp(),
+            header.flags(),
+            slot,
+            header.epoch(),
+            *header.parent_blkid(),
+            *header.body_root(),
+            *header.state_root(),
+            *header.logs_root(),
+        );
+        FullBlockTemplate::new(header, template.body().clone())
+    }
+
     async fn build_service_state_with_env(parent_slot: u64) -> (TestServiceState, TestEnv) {
         let (fixture, parent_commitment) = TestStorageFixtureBuilder::new()
             .with_parent_slot(parent_slot)
@@ -394,7 +497,7 @@ mod tests {
         let template = create_test_template();
         let id = template.get_blockid();
 
-        state.insert_template(id, template);
+        state.insert_template(id, template).unwrap();
 
         let got = state.get_pending_block_template(id).unwrap();
         assert_eq!(got.get_blockid(), id);
@@ -407,7 +510,7 @@ mod tests {
         let id = template.get_blockid();
         let parent = *template.header().parent_blkid();
 
-        state.insert_template(id, template);
+        state.insert_template(id, template).unwrap();
 
         let got = state.get_pending_block_template_by_parent(parent).unwrap();
         assert_eq!(got.get_blockid(), id);
@@ -423,25 +526,222 @@ mod tests {
     }
 
     #[test]
-    fn remove_template_succeeds() {
+    fn mark_template_completed_sets_completed_status() {
         let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
         let template = create_test_template();
         let id = template.get_blockid();
         let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
 
-        state.insert_template(id, template);
-        let removed = state.remove_template(id).unwrap();
-        assert_eq!(removed.get_blockid(), id);
+        state.insert_template(id, template).unwrap();
+        let committed = state.mark_template_completed(id).unwrap();
+        assert_eq!(committed.get_blockid(), id);
 
-        // Second removal should fail.
-        assert!(state.remove_template(id).is_err());
+        assert!(state.mark_template_completed(id).is_err());
 
-        // Verify parent lookup also fails (proves both maps cleaned up).
+        // Verify parent lookup fails for signable templates, but the completed tombstone remains.
         assert!(state.get_pending_block_template_by_parent(parent).is_err());
-        assert!(
-            !state.pending_by_parent.contains_key(&parent),
-            "parent index must be cleared when template is removed"
+        assert_eq!(
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Completed { block }),
+            "parent index must record the completed block"
         );
+    }
+
+    #[test]
+    fn insert_template_rejects_completed_parent() {
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let template = create_test_template();
+        let id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
+
+        state.insert_template(id, template).unwrap();
+        state.mark_template_completed(id).unwrap();
+
+        let replacement = create_test_template_with_parent(parent);
+        let replacement_id = replacement.get_blockid();
+        let err = state
+            .insert_template(replacement_id, replacement)
+            .expect_err("completed parent must reject replacement templates");
+
+        assert!(
+            matches!(
+                err,
+                BlockAssemblyError::TemplateAlreadyCompletedForParent {
+                    parent: err_parent,
+                    block: err_block,
+                } if err_parent == parent && err_block == block
+            ),
+            "expected TemplateAlreadyCompletedForParent, got: {err:?}"
+        );
+        assert!(state.get_pending_block_template(replacement_id).is_err());
+        assert_eq!(
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Completed { block }),
+            "completed status must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn release_completed_template_status_removes_exact_match() {
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let template = create_test_template();
+        let id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
+
+        state.insert_template(id, template).unwrap();
+        state.mark_template_completed(id).unwrap();
+
+        assert!(
+            state.release_completed_template_status(parent, block),
+            "completed status should be released when parent and block match"
+        );
+        assert!(
+            !state.template_status_by_parent.contains_key(&parent),
+            "released completed status should be removed from the parent index"
+        );
+
+        let replacement = create_test_template_with_parent(parent);
+        let replacement_id = replacement.get_blockid();
+        state
+            .insert_template(replacement_id, replacement)
+            .expect("released parent should accept a replacement template");
+        assert_eq!(
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Pending {
+                template_id: replacement_id
+            }),
+            "released parent should point to the replacement template"
+        );
+    }
+
+    #[test]
+    fn release_completed_template_status_keeps_mismatched_block() {
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let template = create_test_template();
+        let id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
+        let other_block =
+            OLBlockCommitment::new(block.slot(), OLBlockId::from(Buf32::from([0x55; 32])));
+
+        state.insert_template(id, template).unwrap();
+        state.mark_template_completed(id).unwrap();
+
+        assert!(
+            !state.release_completed_template_status(parent, other_block),
+            "completed status should not be released for a different block"
+        );
+        assert_eq!(
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Completed { block }),
+            "mismatched release must keep the completed status"
+        );
+    }
+
+    #[test]
+    fn release_completed_template_status_keeps_pending_status() {
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let template = create_test_template();
+        let id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
+
+        state.insert_template(id, template).unwrap();
+
+        assert!(
+            !state.release_completed_template_status(parent, block),
+            "pending status should not be released by the completed-status path"
+        );
+        assert_eq!(
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Pending { template_id: id }),
+            "pending status should remain unchanged"
+        );
+    }
+
+    #[test]
+    fn completed_status_releases_when_requested_parent_is_completed_block() {
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let template = create_test_template();
+        let id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
+
+        state.insert_template(id, template).unwrap();
+        state.mark_template_completed(id).unwrap();
+
+        state.prune_completed_template_statuses_for_parent(block);
+
+        assert!(
+            !state.template_status_by_parent.contains_key(&parent),
+            "completed status should be released once generation moves to the completed block"
+        );
+    }
+
+    #[test]
+    fn completed_status_does_not_release_for_same_parent_request() {
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let template = create_test_template();
+        let id = template.get_blockid();
+        let parent = *template.header().parent_blkid();
+        let block = template.header().compute_block_commitment();
+
+        state.insert_template(id, template).unwrap();
+        state.mark_template_completed(id).unwrap();
+
+        let parent_commitment = OLBlockCommitment::new(block.slot().saturating_sub(1), parent);
+        state.prune_completed_template_statuses_for_parent(parent_commitment);
+
+        assert_eq!(
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Completed { block }),
+            "same-parent generation must keep the completed status"
+        );
+    }
+
+    #[test]
+    fn completed_status_cleanup_removes_older_slots() {
+        fn parent_id(n: u64) -> OLBlockId {
+            let mut bytes = [0u8; 32];
+            bytes[..8].copy_from_slice(&n.to_le_bytes());
+            OLBlockId::from(Buf32::from(bytes))
+        }
+
+        let mut state = BlockAssemblyState::new(TEST_BLOCK_TEMPLATE_TTL);
+        let parents = [parent_id(1), parent_id(2), parent_id(3)];
+        let slots = [9, 10, 11];
+        let mut completed = Vec::new();
+
+        for (parent, slot) in parents.into_iter().zip(slots) {
+            let template = create_test_template_with_parent_and_slot(parent, slot);
+            let id = template.get_blockid();
+            let block = template.header().compute_block_commitment();
+            state.insert_template(id, template).unwrap();
+            state.mark_template_completed(id).unwrap();
+            completed.push((parent, block));
+        }
+
+        let cleanup_slot = 10;
+        let cleanup_parent = OLBlockCommitment::new(cleanup_slot, parent_id(99));
+
+        state.prune_completed_template_statuses_for_parent(cleanup_parent);
+
+        for (parent, block) in completed {
+            if block.slot() <= cleanup_slot {
+                assert!(
+                    !state.template_status_by_parent.contains_key(&parent),
+                    "completed status at or before the current parent slot should be removed"
+                );
+            } else {
+                assert!(
+                    state.template_status_by_parent.contains_key(&parent),
+                    "completed status above the current parent slot should remain"
+                );
+            }
+        }
     }
 
     #[test]
@@ -451,7 +751,7 @@ mod tests {
         let id = template.get_blockid();
         let parent = *template.header().parent_blkid();
 
-        state.insert_template(id, template);
+        state.insert_template(id, template).unwrap();
 
         // Backdate the entry so it appears expired.
         state
@@ -470,20 +770,20 @@ mod tests {
         let t1 = create_test_template();
         let parent = *t1.header().parent_blkid();
         let id1 = t1.get_blockid();
-        state.insert_template(id1, t1);
+        state.insert_template(id1, t1).unwrap();
 
         let t2 = create_test_template_with_parent(parent);
         let id2 = t2.get_blockid();
         assert_ne!(id1, id2, "templates must have distinct block IDs");
-        state.insert_template(id2, t2);
+        state.insert_template(id2, t2).unwrap();
 
         // Old template should be evicted.
         assert!(state.get_pending_block_template(id1).is_err());
         // New template should be present.
         assert!(state.get_pending_block_template(id2).is_ok());
         assert_eq!(
-            state.pending_by_parent.get(&parent),
-            Some(&id2),
+            state.template_status_by_parent.get(&parent),
+            Some(&BlockTemplateStatus::Pending { template_id: id2 }),
             "parent index must point to the newest template id"
         );
     }
@@ -496,13 +796,13 @@ mod tests {
         let t1 = create_test_template();
         let id1 = t1.get_blockid();
         let parent1 = *t1.header().parent_blkid();
-        state.insert_template(id1, t1);
+        state.insert_template(id1, t1).unwrap();
 
         let t2 = create_test_template();
         let id2 = t2.get_blockid();
         let parent2 = *t2.header().parent_blkid();
         assert_ne!(parent1, parent2, "templates must have different parents");
-        state.insert_template(id2, t2);
+        state.insert_template(id2, t2).unwrap();
 
         // Backdate the first template to make it expired.
         state
@@ -514,11 +814,11 @@ mod tests {
 
         // Expired template should be removed from both maps.
         assert!(!state.pending_templates.contains_key(&id1));
-        assert!(!state.pending_by_parent.contains_key(&parent1));
+        assert!(!state.template_status_by_parent.contains_key(&parent1));
 
         // Fresh template should still be present.
         assert!(state.pending_templates.contains_key(&id2));
-        assert!(state.pending_by_parent.contains_key(&parent2));
+        assert!(state.template_status_by_parent.contains_key(&parent2));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1,4 +1,11 @@
 //! Test utilities for block assembly tests.
+#![cfg_attr(
+    all(not(test), feature = "test-utils"),
+    expect(
+        dead_code,
+        reason = "shared test fixture module contains helpers used selectively by crate and downstream tests"
+    )
+)]
 
 use std::{
     future::Future,
@@ -160,7 +167,8 @@ pub(crate) fn create_test_context(storage: Arc<NodeStorage>) -> BlockAssemblyCon
 pub(crate) const TEST_L1_REORG_SAFE_DEPTH: u32 = 0;
 
 /// Mock mempool provider for tests that stores transactions in memory.
-pub(crate) struct MockMempoolProvider {
+#[derive(Debug)]
+pub struct MockMempoolProvider {
     transactions: Mutex<Vec<(OLTxId, OLTransaction)>>,
     report_call_count: AtomicUsize,
     last_reported_invalid_txs: Mutex<Vec<(OLTxId, MempoolTxInvalidReason)>>,
@@ -178,7 +186,7 @@ pub(crate) enum MockMempoolFailMode {
 
 impl MockMempoolProvider {
     /// Create a new empty mock mempool provider.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             transactions: Mutex::new(Vec::new()),
             report_call_count: AtomicUsize::new(0),
@@ -205,6 +213,12 @@ impl MockMempoolProvider {
     /// Returns the most recent invalid-tx payload passed to `report_invalid_transactions`.
     pub(crate) fn last_reported_invalid_txs(&self) -> Vec<(OLTxId, MempoolTxInvalidReason)> {
         self.last_reported_invalid_txs.lock().unwrap().clone()
+    }
+}
+
+impl Default for MockMempoolProvider {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -807,7 +821,11 @@ impl TestAccount {
 }
 
 /// Storage fixture layer for block assembly tests.
-pub(crate) struct TestStorageFixture {
+#[expect(
+    missing_debug_implementations,
+    reason = "NodeStorage does not implement Debug"
+)]
+pub struct TestStorageFixture {
     storage: Arc<NodeStorage>,
     /// Seeded L1 block ref claims. Each claim's `idx()` is the L1 height of the
     /// corresponding L1 block ref.
@@ -839,7 +857,7 @@ impl TestStorageFixture {
     }
 
     /// Returns storage handle for lower-level tests.
-    pub(crate) fn storage(&self) -> &Arc<NodeStorage> {
+    pub fn storage(&self) -> &Arc<NodeStorage> {
         &self.storage
     }
 
@@ -1103,7 +1121,11 @@ pub(crate) fn block_and_post_state_from_output(
 
 /// Builder for seeded storage fixtures used by block assembly tests.
 #[derive(Default)]
-pub(crate) struct TestStorageFixtureBuilder {
+#[expect(
+    missing_debug_implementations,
+    reason = "Test fixture input types do not all implement Debug"
+)]
+pub struct TestStorageFixtureBuilder {
     parent_slot: Option<u64>,
     l1_manifest_height_range: Option<RangeInclusive<L1Height>>,
     asm_manifest_heights: Vec<L1Height>,
@@ -1113,7 +1135,7 @@ pub(crate) struct TestStorageFixtureBuilder {
 
 impl TestStorageFixtureBuilder {
     /// Creates a new builder with default values.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self::default()
     }
 
@@ -1143,7 +1165,7 @@ impl TestStorageFixtureBuilder {
     }
 
     /// Uses the slot-0 genesis parent and seeds `count` L1 manifests after it.
-    pub(crate) fn with_genesis_parent_and_l1_manifest_count(mut self, count: L1Height) -> Self {
+    pub fn with_genesis_parent_and_l1_manifest_count(mut self, count: L1Height) -> Self {
         self.parent_slot = Some(0);
         self.l1_manifest_height_range =
             Some(GENESIS_L1_MANIFEST_HEIGHT..=GENESIS_L1_MANIFEST_HEIGHT + count);
@@ -1173,7 +1195,7 @@ impl TestStorageFixtureBuilder {
     /// Builds and seeds the storage fixture.
     ///
     /// Returns `(fixture, parent_commitment)` for advanced tests that need lower layers directly.
-    pub(crate) async fn build_fixture(self) -> (Arc<TestStorageFixture>, OLBlockCommitment) {
+    pub async fn build_fixture(self) -> (Arc<TestStorageFixture>, OLBlockCommitment) {
         let fixture = TestStorageFixture::new(create_test_storage());
 
         // Setup ASM state with L1 manifests if configured.

--- a/crates/ol/sequencer/src/extraction.rs
+++ b/crates/ol/sequencer/src/extraction.rs
@@ -14,12 +14,31 @@ pub async fn extract_duties(
     node_storage: &NodeStorage,
 ) -> Result<Vec<Duty>, Error> {
     let mut duties = vec![];
+    let block_high_watermark = node_storage
+        .ol_block()
+        .get_block_high_watermark_async()
+        .await?;
 
     // Block duties. Read-only lookup; generation is handled by GenerationTick.
     match blockasm.get_block_template(tip_blkid).await {
         Ok(template) => {
-            let blkduty = BlockSigningDuty::new(template);
-            duties.push(Duty::SignBlock(blkduty));
+            let template_slot = template.header().slot();
+            let should_offer = block_high_watermark
+                .as_ref()
+                .is_none_or(|high_watermark| template_slot > high_watermark.slot());
+            if should_offer {
+                let blkduty = BlockSigningDuty::new(template);
+                duties.push(Duty::SignBlock(blkduty));
+            } else if let Some(high_watermark) = block_high_watermark.as_ref() {
+                debug!(
+                    tip_blkid = ?tip_blkid,
+                    template_slot,
+                    high_watermark = %high_watermark,
+                    "cached block template is at or below block high-watermark; skipping block duty"
+                );
+            } else {
+                unreachable!("block duty should only be skipped when a high-watermark exists");
+            }
         }
         Err(BlockAssemblyError::NoPendingTemplateForParent(_)) => {
             debug!(

--- a/crates/ol/sequencer/src/service.rs
+++ b/crates/ol/sequencer/src/service.rs
@@ -118,16 +118,85 @@ async fn process_generation_tick<C: SequencerContext>(state: &mut SequencerServi
         }
     };
 
-    if generated_tip.is_none() {
-        debug!("generation tick skipped: no canonical tip");
-    }
+    let Some(generated_tip) = generated_tip else {
+        debug!("generation tick skipped");
+        return;
+    };
 
     let previous_tip = state.last_seen_tip;
-    state.last_seen_tip = generated_tip;
+    state.last_seen_tip = Some(generated_tip);
 
     if previous_tip != state.last_seen_tip {
         state.templates_generated += 1;
         counter!("strata_sequencer_templates_generated_total").increment(1);
         debug!(?previous_tip, current_tip = ?state.last_seen_tip, "sequencer tip changed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
+
+    use strata_primitives::{Buf32, OLBlockId};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MockSequencerContext {
+        results: Mutex<VecDeque<Result<Option<OLBlockId>, SequencerContextError>>>,
+    }
+
+    impl MockSequencerContext {
+        fn new(
+            results: impl IntoIterator<Item = Result<Option<OLBlockId>, SequencerContextError>>,
+        ) -> Self {
+            Self {
+                results: Mutex::new(results.into_iter().collect()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SequencerContext for MockSequencerContext {
+        async fn generate_template_for_tip(
+            &self,
+        ) -> Result<Option<OLBlockId>, SequencerContextError> {
+            self.results
+                .lock()
+                .expect("mock sequencer context mutex poisoned")
+                .pop_front()
+                .expect("test should provide a generation result")
+        }
+    }
+
+    fn block_id(byte: u8) -> OLBlockId {
+        OLBlockId::from(Buf32::from([byte; 32]))
+    }
+
+    #[tokio::test]
+    async fn generation_tick_does_not_count_skipped_second_tick() {
+        let tip = block_id(1);
+        let context = Arc::new(MockSequencerContext::new([Ok(Some(tip)), Ok(None)]));
+        let mut state = SequencerServiceState::new(context);
+
+        SequencerService::<MockSequencerContext>::process_input(
+            &mut state,
+            SequencerEvent::GenerationTick,
+        )
+        .await
+        .expect("first generation tick should process");
+        SequencerService::<MockSequencerContext>::process_input(
+            &mut state,
+            SequencerEvent::GenerationTick,
+        )
+        .await
+        .expect("second generation tick should process");
+
+        let status = SequencerService::<MockSequencerContext>::get_status(&state);
+        assert_eq!(status.templates_generated, 1);
+        assert_eq!(state.last_seen_tip, Some(tip));
     }
 }

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -111,6 +111,28 @@ impl OLBlockManager {
         self.ops.clear_block_high_watermark_blocking(expected)
     }
 
+    /// Rolls the block high-watermark back to an existing target block.
+    ///
+    /// This is not normal chain progression; it is used by explicit recovery
+    /// paths that revert OL state.
+    pub async fn rollback_block_high_watermark_async(
+        &self,
+        target: OLBlockCommitment,
+    ) -> DbResult<bool> {
+        self.ops.rollback_block_high_watermark_async(target).await
+    }
+
+    /// Rolls the block high-watermark back to an existing target block.
+    ///
+    /// This is not normal chain progression; it is used by explicit recovery
+    /// paths that revert OL state.
+    pub fn rollback_block_high_watermark_blocking(
+        &self,
+        target: OLBlockCommitment,
+    ) -> DbResult<bool> {
+        self.ops.rollback_block_high_watermark_blocking(target)
+    }
+
     /// Gets a block either in the cache or from the underlying database.
     pub async fn get_block_data_async(&self, id: OLBlockId) -> DbResult<Option<OLBlock>> {
         self.block_cache

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -46,6 +46,71 @@ impl OLBlockManager {
         Ok(())
     }
 
+    /// Gets the block high-watermark.
+    ///
+    /// This is not the OL tip. Plain block writes do not update it.
+    pub async fn get_block_high_watermark_async(&self) -> DbResult<Option<OLBlockCommitment>> {
+        self.ops.get_block_high_watermark_async().await
+    }
+
+    /// Gets the block high-watermark.
+    ///
+    /// This is not the OL tip. Plain block writes do not update it.
+    pub fn get_block_high_watermark_blocking(&self) -> DbResult<Option<OLBlockCommitment>> {
+        self.ops.get_block_high_watermark_blocking()
+    }
+
+    /// Puts a block and advances the block high-watermark atomically.
+    ///
+    /// This uses the guarded high-watermark path; plain block writes do not update it.
+    pub async fn put_block_data_with_high_watermark_async(
+        &self,
+        block: OLBlock,
+    ) -> DbResult<OLBlockCommitment> {
+        let block_id = block.header().compute_blkid();
+        let commitment = self
+            .ops
+            .put_block_data_with_high_watermark_async(block)
+            .await?;
+        self.block_cache.purge_async(&block_id).await;
+        Ok(commitment)
+    }
+
+    /// Puts a block and advances the block high-watermark atomically.
+    ///
+    /// This uses the guarded high-watermark path; plain block writes do not update it.
+    pub fn put_block_data_with_high_watermark_blocking(
+        &self,
+        block: OLBlock,
+    ) -> DbResult<OLBlockCommitment> {
+        let block_id = block.header().compute_blkid();
+        let commitment = self
+            .ops
+            .put_block_data_with_high_watermark_blocking(block)?;
+        self.block_cache.purge_blocking(&block_id);
+        Ok(commitment)
+    }
+
+    /// Clears the block high-watermark if it currently equals `expected`.
+    ///
+    /// This does not delete block data or purge cached blocks.
+    pub async fn clear_block_high_watermark_async(
+        &self,
+        expected: OLBlockCommitment,
+    ) -> DbResult<bool> {
+        self.ops.clear_block_high_watermark_async(expected).await
+    }
+
+    /// Clears the block high-watermark if it currently equals `expected`.
+    ///
+    /// This does not delete block data or purge cached blocks.
+    pub fn clear_block_high_watermark_blocking(
+        &self,
+        expected: OLBlockCommitment,
+    ) -> DbResult<bool> {
+        self.ops.clear_block_high_watermark_blocking(expected)
+    }
+
     /// Gets a block either in the cache or from the underlying database.
     pub async fn get_block_data_async(&self, id: OLBlockId) -> DbResult<Option<OLBlock>> {
         self.block_cache

--- a/crates/storage/src/ops/ol.rs
+++ b/crates/storage/src/ops/ol.rs
@@ -1,7 +1,7 @@
 //! OL block data operation interface.
 
 use strata_db_types::traits::*;
-use strata_identifiers::{OLBlockId, Slot};
+use strata_identifiers::{OLBlockCommitment, OLBlockId, Slot};
 use strata_ol_chain_types_new::OLBlock;
 
 use crate::{exec::*, instrumentation::components};
@@ -10,6 +10,9 @@ inst_ops_simple! {
     (<D: OLBlockDatabase> => OLBlockOps, component = components::STORAGE_OL) {
         get_block_data(id: OLBlockId) => Option<OLBlock>;
         put_block_data(block: OLBlock) => ();
+        get_block_high_watermark() => Option<OLBlockCommitment>;
+        put_block_data_with_high_watermark(block: OLBlock) => OLBlockCommitment;
+        clear_block_high_watermark(expected: OLBlockCommitment) => bool;
         del_block_data(id: OLBlockId) => bool;
         get_blocks_at_height(slot: u64) => Vec<OLBlockId>;
         get_tip_slot() => Slot;

--- a/crates/storage/src/ops/ol.rs
+++ b/crates/storage/src/ops/ol.rs
@@ -13,6 +13,7 @@ inst_ops_simple! {
         get_block_high_watermark() => Option<OLBlockCommitment>;
         put_block_data_with_high_watermark(block: OLBlock) => OLBlockCommitment;
         clear_block_high_watermark(expected: OLBlockCommitment) => bool;
+        rollback_block_high_watermark(target: OLBlockCommitment) => bool;
         del_block_data(id: OLBlockId) => bool;
         get_blocks_at_height(slot: u64) => Vec<OLBlockId>;
         get_tip_slot() => Slot;

--- a/functional-tests/common/crash_helpers.py
+++ b/functional-tests/common/crash_helpers.py
@@ -47,6 +47,7 @@ def crash_and_recover(
     *,
     expected_block_advance: int = 1,
     after_arm: Callable[[], None] | None = None,
+    after_crash: Callable[[Any], None] | None = None,
     crash_timeout: int = 30,
     restart_timeout: int = 20,
     recovery_timeout: int = 30,
@@ -65,6 +66,8 @@ def crash_and_recover(
         after_arm: Optional callable invoked between arming the bail and
             waiting for the crash. Used by tests where an external action
             (e.g. mining L1 blocks) is required to actually trip the bail.
+        after_crash: Optional callable invoked after the process exits and
+            before restart. The callable receives the pre-crash sync status.
         crash_timeout: Seconds to wait for the process to die after arming.
         restart_timeout: Seconds to wait for the new process's RPC to come up.
         recovery_timeout: Seconds to wait for the chain to advance.
@@ -98,6 +101,10 @@ def crash_and_recover(
     # which only happens via stop(). The process is already dead, so this is a
     # bookkeeping reset, not a real terminate.
     strata.stop()
+
+    if after_crash is not None:
+        after_crash(pre_status)
+
     strata.start()
     rpc = strata.wait_for_rpc_ready(timeout=restart_timeout)
 

--- a/functional-tests/tests/dbtool/helpers.py
+++ b/functional-tests/tests/dbtool/helpers.py
@@ -290,6 +290,11 @@ def parse_finalized_epoch_from_syncinfo(syncinfo: dict[str, Any]) -> tuple[str, 
     return last_blkid, parsed_last_slot
 
 
+def get_ol_blocks_at_slot(datadir: str, slot: int) -> dict[str, Any]:
+    """Return the dbtool output for OL blocks indexed at a slot."""
+    return run_dbtool_json(datadir, "get-ol-blocks-at-slot", str(slot))
+
+
 def parse_ol_block_parent_blkid(ol_block: dict[str, Any]) -> str:
     """Parse and validate parent block id from get-ol-block JSON."""
     parent_blkid = ol_block.get("header_prev_blkid")
@@ -343,6 +348,17 @@ def assert_epoch_summary_present(datadir: str, epoch: int) -> None:
     """Assert epoch summary entry is present for epoch."""
     epoch_summary = run_dbtool_json(datadir, "get-epoch-summary", str(epoch))
     assert epoch_summary.get("epoch_summary") is not None
+
+
+def assert_ol_block_status(datadir: str, block_id: str, expected_status: str) -> dict[str, Any]:
+    """Assert OL block status for a known block ID."""
+    block = run_dbtool_json(datadir, "get-ol-block", block_id)
+    status = block["status"]
+
+    assert status == expected_status, (
+        f"expected OL block {block_id} status {expected_status}, got {status}"
+    )
+    return block
 
 
 def assert_checkpoint_deleted(datadir: str, epoch: int) -> None:

--- a/functional-tests/tests/strata/test_crash_fcm_new_block.py
+++ b/functional-tests/tests/strata/test_crash_fcm_new_block.py
@@ -5,8 +5,27 @@ import logging
 import flexitest
 
 from common.crash_helpers import CrashTest, crash_and_recover
+from tests.dbtool.helpers import assert_ol_block_status, get_ol_blocks_at_slot
 
 logger = logging.getLogger(__name__)
+
+
+def get_single_block_at_slot(datadir: str, slot: int) -> str:
+    blocks_at_slot = get_ol_blocks_at_slot(datadir, slot)
+    count = int(blocks_at_slot["count"])
+    block_ids = blocks_at_slot["block_ids"]
+
+    assert int(blocks_at_slot["slot"]) == slot
+    assert count == 1, f"expected one OL block at slot {slot}, got {count}: {block_ids}"
+    return block_ids[0]
+
+
+def assert_single_block_at_slot(datadir: str, slot: int, expected_block_id: str) -> None:
+    block_id = get_single_block_at_slot(datadir, slot)
+
+    assert block_id == expected_block_id, (
+        f"expected slot {slot} to contain only {expected_block_id}, got {block_id}"
+    )
 
 
 @flexitest.register
@@ -16,12 +35,38 @@ class TestCrashFcmNewBlock(CrashTest):
     def main(self, ctx):
         strata = self.get_strata()
         rpc = strata.wait_for_rpc_ready(timeout=10)
+        datadir = strata.props["datadir"]
+        crashed_block: dict[str, int | str] = {}
 
         strata.wait_for_additional_blocks(2, rpc)
 
+        def inspect_crashed_block(pre_status: dict) -> None:
+            slot = int(pre_status["tip"]["slot"]) + 1
+            block_id = get_single_block_at_slot(datadir, slot)
+            block = assert_ol_block_status(datadir, block_id, "Unchecked")
+            assert int(block["header_slot"]) == slot
+
+            crashed_block["slot"] = slot
+            crashed_block["block_id"] = block_id
+            logger.info("Crashed block persisted unchecked: slot=%s block_id=%s", slot, block_id)
+
         # FCM crash happens during block processing — require 2 blocks of advance
         # to confirm the chain is genuinely producing again, not just one in flight.
-        result = crash_and_recover(strata, "fcm_new_block", expected_block_advance=2)
+        result = crash_and_recover(
+            strata,
+            "fcm_new_block",
+            expected_block_advance=2,
+            after_crash=inspect_crashed_block,
+        )
+
+        slot = int(crashed_block["slot"])
+        block_id = str(crashed_block["block_id"])
+        assert result.post_status["tip"]["slot"] > slot
 
         logger.info(f"Post-recovery height: {result.post_status['tip']['slot']}")
+        strata.stop()
+
+        assert_single_block_at_slot(datadir, slot, block_id)
+        assert_ol_block_status(datadir, block_id, "Valid")
+        logger.info("Recovered crashed block is valid and unique at slot=%s", slot)
         return True


### PR DESCRIPTION
## Description

Prevent accidental OL block proposer equivocation

### Problem
The sequencer could generate, sign, and accept two OL blocks for the same slot on the same parent. Storage indexes `slot → Vec<OLBlockId>`, FCM checks only the signature, the unfinalized tracker accepts siblings, and the STF enforces `slot = parent.slot + 1` only per chain, so nothing downstream rejected it. The trigger: completing a template released the parent before the signed block became the visible tip, so a generation tick on the stale tip rebuilt a second template; a restart reopened the window.

### Fix
- `fix(ol/block-assembly)`: per-parent `Pending`/`Completed` tombstone; generation no-ops on `Completed`; tip-progression pruning, no wall-clock release.
- `feat(db)`: durable monotonic per-slot high-watermark.
- `fix(ol/sequencer)`: generation and duty extraction skip slots `≤` the high-watermark; completion persists via the atomic write; completion is split so the in-memory release happens only after the durable commit; FCM clears the high-watermark when that block is marked `Invalid`.
- `fix(strata)`: on startup, resubmit the high-watermark block to FCM if it is still `Unchecked`; clear the high-watermark if that block is already `Invalid`.
- `feat(strata-dbtool)`: expose OL blocks by slot for raw DB inspection.
- `fix(strata-dbtool)`: rollback OL block high-watermark on `revert-ol-state`.

### DB API + naming
Adds `get_block_high_watermark()` and `put_block_data_with_high_watermark(block)` to `OLBlockDatabase`, backed by a dedicated sled tree in the same `with_retry` transaction as block/status/height. The write rejects `slot ≤ current.slot` (`BlockHighWatermarkConflict`), else advances the mark and persists the block atomically. `put_block_data` is unchanged, so ingestion/sync paths are unaffected.

Also adds `clear_block_high_watermark(expected)` and `rollback_block_high_watermark(target)`. Clearing removes the singleton mark only if it currently equals `expected`, used when FCM invalidates that block. Rollback rewinds the mark to an existing target block during `strata-dbtool revert-ol-state`.

Naming is use-neutral on purpose: the DB knows only a monotonic-by-slot high-watermark over committed blocks, not that the caller treats it as an anti-equivocation signing floor. The persisted block keeps its `Unchecked` status until FCM processes it; the high-watermark is a separate singleton record, not a block status, and is not the canonical tip.

### Invalid Blocks
If the high-watermark block is marked `Invalid`, the mark is cleared so the existing replacement behavior can continue. In that case the DB may retain the invalid block plus a replacement at the same slot. The safety invariant is that the node does not accidentally accept/persist two competing non-invalid proposals because of the original race.

### strata-dbtool
Adds `get-ol-blocks-at-slot <slot>`. The node RPC is canonical-chain-only, so a non-canonical sibling at a slot is invisible over RPC. The command reads the raw per-slot block IDs plus a count from the OL block DB as JSON, so the functional test can assert exactly one block at the crash slot. It runs against a stopped node, since dbtool reads sled directly.

### Why no signer-side guard
`strata-signer` is a stateless signing oracle: key plus RPC, no DB. It signs whatever duty the node hands it. The guards live on the node, which controls what gets offered for signing and what gets accepted. A durable signer guard would require adding persistence to the signer and would only close the pre-commit crash window, where the stray signature is non-durable and never reaches storage or FCM.

### Tests
- DB proptests: same-slot put rejected with no partial write; plain `put_block_data` does not advance the mark; mark is monotonic under mixed puts; clearing only removes the expected mark; rollback rewinds only to an existing lower block; `get_blocks_at_height` returns all siblings at a slot.
- Block assembly: no rebuild after completion; tombstone pruning boundary; completion split, so the template stays cached until the durable commit; releasing an invalid completed-template tombstone allows same-slot regeneration.
- Unit: resume/startup decision covers `Unchecked` resubmit, `Valid` skip, and `Invalid` clear; generation and duty-extraction high-watermark filters; `NodeSequencerContext` releases an invalid completed-template tombstone and retries generation.
- Functional (`test_crash_fcm_new_block`): crash after the block is durably committed leaves one `Unchecked` block at the crashed slot; restart resubmits it; chain advances past it; the same block becomes `Valid` and remains unique at that slot.

### Scope
Stops an honest sequencer from accidentally producing two blocks per slot, including across restart.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Please check the issue flagged by Codex below about `Invalid` high-watermark blocks.
The high-watermark is intentionally not cleared when FCM marks the recorded block `Invalid`. `BlockStatus::Invalid` is not currently a proof that the proposal can be safely forgotten: FCM also maps execution/processing failures into `Invalid` (see the STR-2141 TODO around distinguishing invalid blocks from exec failures).

Clearing the high-watermark on `Invalid` would allow the sequencer to sign and persist a different block at the same slot after a transient local failure, which reopens accidental proposer equivocation. The safe behavior in this PR is to retry the same high-watermark block on startup. If it was transiently rejected, retry can recover; if it is genuinely invalid, the sequencer remains stuck and needs operator/protocol-level intervention rather than automatic same-slot replacement.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
[STR-3422](https://alpenlabs.atlassian.net/browse/STR-3422)


[STR-3422]: https://alpenlabs.atlassian.net/browse/STR-3422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ