### PR TITLE
feat(prover-perf): add checkpoint prove mode

### DIFF
--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -61,6 +61,7 @@ strata-predicate.workspace = true
 default = ["sp1"]
 sp1 = [
   "zkaleido-sp1-host/perf",
+  "zkaleido-sp1-host/cuda",
   "strata-zkvm-hosts/sp1-builder",
   "dep:zkaleido-sp1-host",
   "dep:strata-sp1-guest-builder",

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -61,7 +61,6 @@ strata-predicate.workspace = true
 default = ["sp1"]
 sp1 = [
   "zkaleido-sp1-host/perf",
-  "zkaleido-sp1-host/cuda",
   "strata-zkvm-hosts/sp1-builder",
   "dep:zkaleido-sp1-host",
   "dep:strata-sp1-guest-builder",

--- a/bin/prover-perf/src/args.rs
+++ b/bin/prover-perf/src/args.rs
@@ -2,6 +2,24 @@ use argh::FromArgs;
 
 use crate::programs::GuestProgram;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerfMode {
+    Execute,
+    Prove,
+}
+
+impl std::str::FromStr for PerfMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "execute" => Ok(Self::Execute),
+            "prove" => Ok(Self::Prove),
+            _ => Err(format!("unknown mode: {s}")),
+        }
+    }
+}
+
 /// Evaluate the performance of SP1 on programs.
 #[derive(Debug, Clone, FromArgs)]
 pub struct EvalArgs {
@@ -20,6 +38,10 @@ pub struct EvalArgs {
     /// the commit hash
     #[argh(option, default = "String::from(\"local_commit\")")]
     pub commit_hash: String,
+
+    /// benchmark mode: `execute` for execution summary, `prove` for real proof generation
+    #[argh(option, default = "String::from(\"execute\")")]
+    pub mode: String,
 
     /// programs to run (comma-delimited and/or repeated),
     /// e.g. `--programs alpen-chunk,checkpoint` or `--programs alpen-chunk
@@ -40,4 +62,23 @@ pub fn parse_programs(raw: &[String]) -> Result<Vec<GuestProgram>, String> {
         .filter(|s| !s.is_empty())
         .map(|s| s.parse::<GuestProgram>())
         .collect()
+}
+
+pub fn parse_mode(raw: &str) -> Result<PerfMode, String> {
+    raw.parse()
+}
+
+pub fn validate_mode_programs(mode: PerfMode, programs: &[GuestProgram]) -> Result<(), String> {
+    if mode == PerfMode::Prove
+        && programs
+            .iter()
+            .any(|program| !matches!(program, GuestProgram::Checkpoint))
+    {
+        return Err(
+            "prove mode currently supports only `checkpoint`; use `--programs checkpoint`"
+                .to_string(),
+        );
+    }
+
+    Ok(())
 }

--- a/bin/prover-perf/src/args.rs
+++ b/bin/prover-perf/src/args.rs
@@ -82,3 +82,33 @@ pub fn validate_mode_programs(mode: PerfMode, programs: &[GuestProgram]) -> Resu
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mode_accepts_known_values_case_insensitively() {
+        assert_eq!(parse_mode("execute").unwrap(), PerfMode::Execute);
+        assert_eq!(parse_mode("PrOvE").unwrap(), PerfMode::Prove);
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown_values() {
+        assert_eq!(parse_mode("gpu").unwrap_err(), "unknown mode: gpu");
+    }
+
+    #[test]
+    fn validate_mode_programs_rejects_non_checkpoint_prove_targets() {
+        let err = validate_mode_programs(PerfMode::Prove, &[GuestProgram::AlpenChunk]).unwrap_err();
+        assert_eq!(
+            err,
+            "prove mode currently supports only `checkpoint`; use `--programs checkpoint`"
+        );
+    }
+
+    #[test]
+    fn validate_mode_programs_accepts_execute_mode_for_any_program() {
+        validate_mode_programs(PerfMode::Execute, &[GuestProgram::AlpenAcct]).unwrap();
+    }
+}

--- a/bin/prover-perf/src/format.rs
+++ b/bin/prover-perf/src/format.rs
@@ -1,7 +1,16 @@
+use std::time::Duration;
+
 use num_format::{Locale, ToFormattedString};
 use zkaleido::ExecutionSummary;
 
-use crate::args::EvalArgs;
+use crate::args::{EvalArgs, PerfMode};
+
+#[derive(Debug, Clone)]
+pub struct ProofSummary {
+    pub duration: Duration,
+    pub proof_bytes: usize,
+    pub proof_type: String,
+}
 
 /// Returns a formatted header for the performance report with basic PR data.
 pub fn format_header(args: &EvalArgs) -> String {
@@ -13,11 +22,13 @@ pub fn format_header(args: &EvalArgs) -> String {
         detail_text.push_str("*Local execution*\n");
     }
 
+    detail_text.push_str(&format!("*Mode*: {}\n", args.mode));
+
     detail_text
 }
 
 /// Returns formatted results for the [`ExecutionSummary`]s shaped in a table.
-pub fn format_results(results: &[(String, ExecutionSummary)], host_name: String) -> String {
+pub fn format_execute_results(results: &[(String, ExecutionSummary)], host_name: String) -> String {
     let mut table_text = String::new();
     table_text.push('\n');
     table_text.push_str("| program                | cycles      | gas      |\n");
@@ -34,4 +45,36 @@ pub fn format_results(results: &[(String, ExecutionSummary)], host_name: String)
     table_text.push('\n');
 
     format!("*{host_name} Execution Results*\n {table_text}")
+}
+
+pub fn format_prove_results(results: &[(String, ProofSummary)], host_name: String) -> String {
+    let mut table_text = String::new();
+    table_text.push('\n');
+    table_text.push_str("| program                | proof type | proof bytes | duration ms |\n");
+    table_text.push_str("|------------------------|------------|-------------|-------------|");
+
+    for (name, summary) in results.iter() {
+        table_text.push_str(&format!(
+            "\n| {:<22} | {:<10} | {:>11} | {:>11} |",
+            name,
+            summary.proof_type,
+            summary.proof_bytes.to_formatted_string(&Locale::en),
+            summary.duration.as_millis().to_formatted_string(&Locale::en)
+        ));
+    }
+    table_text.push('\n');
+
+    format!("*{host_name} Proving Results*\n {table_text}")
+}
+
+pub fn format_results_for_mode(
+    mode: PerfMode,
+    execute_results: &[(String, ExecutionSummary)],
+    prove_results: &[(String, ProofSummary)],
+    host_name: String,
+) -> String {
+    match mode {
+        PerfMode::Execute => format_execute_results(execute_results, host_name),
+        PerfMode::Prove => format_prove_results(prove_results, host_name),
+    }
 }

--- a/bin/prover-perf/src/format.rs
+++ b/bin/prover-perf/src/format.rs
@@ -95,3 +95,34 @@ pub fn format_results_for_mode(
         PerfMode::Prove => format_prove_results(prove_results, host_name),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn format_prove_results_includes_timing_breakdown_columns() {
+        let text = format_prove_results(
+            &[(
+                "Checkpoint".to_string(),
+                ProofSummary {
+                    prepare_duration: Duration::from_millis(12),
+                    prove_duration: Duration::from_millis(34),
+                    total_duration: Duration::from_millis(46),
+                    proof_bytes: 356,
+                    proof_type: "Groth16".to_string(),
+                },
+            )],
+            "SP1".to_string(),
+        );
+
+        assert!(text.contains("prepare ms"));
+        assert!(text.contains("prove ms"));
+        assert!(text.contains("total ms"));
+        assert!(text.contains("Checkpoint"));
+        assert!(text.contains("Groth16"));
+        assert!(text.contains("356"));
+    }
+}

--- a/bin/prover-perf/src/format.rs
+++ b/bin/prover-perf/src/format.rs
@@ -7,7 +7,9 @@ use crate::args::{EvalArgs, PerfMode};
 
 #[derive(Debug, Clone)]
 pub struct ProofSummary {
-    pub duration: Duration,
+    pub prepare_duration: Duration,
+    pub prove_duration: Duration,
+    pub total_duration: Duration,
     pub proof_bytes: usize,
     pub proof_type: String,
 }
@@ -50,16 +52,31 @@ pub fn format_execute_results(results: &[(String, ExecutionSummary)], host_name:
 pub fn format_prove_results(results: &[(String, ProofSummary)], host_name: String) -> String {
     let mut table_text = String::new();
     table_text.push('\n');
-    table_text.push_str("| program                | proof type | proof bytes | duration ms |\n");
-    table_text.push_str("|------------------------|------------|-------------|-------------|");
+    table_text.push_str(
+        "| program                | proof type | proof bytes | prepare ms | prove ms | total ms |\n",
+    );
+    table_text.push_str(
+        "|------------------------|------------|-------------|------------|----------|----------|",
+    );
 
     for (name, summary) in results.iter() {
         table_text.push_str(&format!(
-            "\n| {:<22} | {:<10} | {:>11} | {:>11} |",
+            "\n| {:<22} | {:<10} | {:>11} | {:>10} | {:>8} | {:>8} |",
             name,
             summary.proof_type,
             summary.proof_bytes.to_formatted_string(&Locale::en),
-            summary.duration.as_millis().to_formatted_string(&Locale::en)
+            summary
+                .prepare_duration
+                .as_millis()
+                .to_formatted_string(&Locale::en),
+            summary
+                .prove_duration
+                .as_millis()
+                .to_formatted_string(&Locale::en),
+            summary
+                .total_duration
+                .as_millis()
+                .to_formatted_string(&Locale::en)
         ));
     }
     table_text.push('\n');

--- a/bin/prover-perf/src/github.rs
+++ b/bin/prover-perf/src/github.rs
@@ -5,6 +5,8 @@ use serde_json::json;
 
 use crate::args::EvalArgs;
 
+const BASE_URL: &str = "https://api.github.com/repos/alpenlabs/alpen";
+
 /// Posts the message to the PR on the github.
 ///
 /// Updates an existing previous comment (if there is one) or posts a new comment.
@@ -14,8 +16,7 @@ pub async fn post_to_github_pr(
 ) -> Result<(), Box<dyn error::Error>> {
     let client = Client::new();
 
-    const BASE_URL: &str = "https://api.github.com/repos/alpenlabs/strata";
-    let comments_url = format!("{}/issues/{}/comments", BASE_URL, args.pr_number);
+    let comments_url = format!("{}/issues/{}/comments", BASE_URL, &args.pr_number);
 
     // Get all comments on the PR
     let comments_response = set_github_headers(client.get(&comments_url), &args.github_token)
@@ -76,4 +77,14 @@ pub fn format_github_message(results_text: &[String]) -> String {
     }
 
     formatted_message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BASE_URL;
+
+    #[test]
+    fn github_base_url_targets_alpen_repo() {
+        assert_eq!(BASE_URL, "https://api.github.com/repos/alpenlabs/alpen");
+    }
 }

--- a/bin/prover-perf/src/main.rs
+++ b/bin/prover-perf/src/main.rs
@@ -14,8 +14,8 @@ pub mod github;
 pub mod programs;
 
 use anyhow::Result;
-use args::{EvalArgs, PerfMode, parse_mode, parse_programs, validate_mode_programs};
-use format::{ProofSummary, format_header, format_results_for_mode};
+use args::{parse_mode, parse_programs, validate_mode_programs, EvalArgs, PerfMode};
+use format::{format_header, format_results_for_mode, ProofSummary};
 use github::{format_github_message, post_to_github_pr};
 #[cfg(feature = "sp1")]
 use zkaleido::ExecutionSummary;

--- a/bin/prover-perf/src/main.rs
+++ b/bin/prover-perf/src/main.rs
@@ -14,8 +14,8 @@ pub mod github;
 pub mod programs;
 
 use anyhow::Result;
-use args::{parse_programs, EvalArgs};
-use format::{format_header, format_results};
+use args::{EvalArgs, PerfMode, parse_mode, parse_programs, validate_mode_programs};
+use format::{ProofSummary, format_header, format_results_for_mode};
 use github::{format_github_message, post_to_github_pr};
 #[cfg(feature = "sp1")]
 use zkaleido::ExecutionSummary;
@@ -30,14 +30,37 @@ async fn main() -> Result<(), Box<dyn Error>> {
         eprintln!("Error: {e}");
         process::exit(1);
     });
+    let mode = parse_mode(&args.mode).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
+    validate_mode_programs(mode, &programs).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
 
     let mut results_text = vec![format_header(&args)];
 
     #[cfg(feature = "sp1")]
     {
-        let sp1_reports: Vec<(String, ExecutionSummary)> =
-            programs::run_sp1_programs(&programs).await;
-        results_text.push(format_results(&sp1_reports, "SP1".to_owned()));
+        let mut execute_reports: Vec<(String, ExecutionSummary)> = Vec::new();
+        let mut prove_reports: Vec<(String, ProofSummary)> = Vec::new();
+
+        match mode {
+            PerfMode::Execute => {
+                execute_reports = programs::run_sp1_execute_programs(&programs).await;
+            }
+            PerfMode::Prove => {
+                prove_reports = programs::run_sp1_prove_programs(&programs).await;
+            }
+        }
+
+        results_text.push(format_results_for_mode(
+            mode,
+            &execute_reports,
+            &prove_reports,
+            "SP1".to_owned(),
+        ));
     }
 
     // Print results

--- a/bin/prover-perf/src/programs/checkpoint.rs
+++ b/bin/prover-perf/src/programs/checkpoint.rs
@@ -26,7 +26,7 @@ use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram
 const SLOTS_PER_EPOCH: u64 = 9;
 const NUM_BLOCKS: usize = 10;
 
-fn prepare_input() -> CheckpointProverInput {
+pub(super) fn prepare_input() -> CheckpointProverInput {
     let mut state = make_genesis_state();
     let mut blocks = build_empty_chain(&mut state, NUM_BLOCKS, SLOTS_PER_EPOCH)
         .expect("build_empty_chain should succeed");
@@ -81,11 +81,13 @@ pub(crate) fn gen_perf_report(host: &impl ZkVmHost) -> (String, ExecutionSummary
     (CheckpointProgram::name(), summary)
 }
 
-pub(crate) fn gen_proof(host: &impl ZkVmHost) -> (String, ProofReceiptWithMetadata) {
+pub(crate) fn prove_with_input(
+    input: &CheckpointProverInput,
+    host: &impl ZkVmHost,
+) -> (String, ProofReceiptWithMetadata) {
     info!("Generating proof for Checkpoint");
-    let input = prepare_input();
     let receipt =
-        <CheckpointProgram as ZkVmProgram>::prove(&input, host).expect("checkpoint proving");
+        <CheckpointProgram as ZkVmProgram>::prove(input, host).expect("checkpoint proving");
     (CheckpointProgram::name(), receipt)
 }
 

--- a/bin/prover-perf/src/programs/checkpoint.rs
+++ b/bin/prover-perf/src/programs/checkpoint.rs
@@ -21,12 +21,12 @@ use strata_ol_da::{GlobalStateDiff, LedgerDiff, OLDaPayloadV1, StateDiff};
 use strata_ol_stf::test_utils::{build_empty_chain, make_genesis_state};
 use strata_proofimpl_checkpoint::program::{CheckpointProgram, CheckpointProverInput};
 use tracing::info;
-use zkaleido::{ExecutionSummary, ZkVmHost, ZkVmProgram};
+use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram};
 
 const SLOTS_PER_EPOCH: u64 = 9;
 const NUM_BLOCKS: usize = 10;
 
-fn prepare_checkpoint_input() -> CheckpointProverInput {
+fn prepare_input() -> CheckpointProverInput {
     let mut state = make_genesis_state();
     let mut blocks = build_empty_chain(&mut state, NUM_BLOCKS, SLOTS_PER_EPOCH)
         .expect("build_empty_chain should succeed");
@@ -75,10 +75,18 @@ fn prepare_checkpoint_input() -> CheckpointProverInput {
 
 pub(crate) fn gen_perf_report(host: &impl ZkVmHost) -> (String, ExecutionSummary) {
     info!("Generating execution summary for Checkpoint");
-    let input = prepare_checkpoint_input();
+    let input = prepare_input();
     let summary =
         <CheckpointProgram as ZkVmProgram>::execute(&input, host).expect("checkpoint execution");
     (CheckpointProgram::name(), summary)
+}
+
+pub(crate) fn gen_proof(host: &impl ZkVmHost) -> (String, ProofReceiptWithMetadata) {
+    info!("Generating proof for Checkpoint");
+    let input = prepare_input();
+    let receipt =
+        <CheckpointProgram as ZkVmProgram>::prove(&input, host).expect("checkpoint proving");
+    (CheckpointProgram::name(), receipt)
 }
 
 #[cfg(test)]
@@ -87,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_native_execution() {
-        let input = prepare_checkpoint_input();
+        let input = prepare_input();
         let output = CheckpointProgram::execute(&input).unwrap();
         dbg!(output);
     }

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -60,18 +60,36 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
 
     let mut reports = Vec::with_capacity(programs.len());
     for program in programs {
-        let cfg = SP1HostConfig::default();
-        let started_at = Instant::now();
-        let (name, receipt): (String, ProofReceiptWithMetadata) = match program {
+        let total_started_at = Instant::now();
+        let (name, receipt, prepare_duration, prove_duration): (
+            String,
+            ProofReceiptWithMetadata,
+            _,
+            _,
+        ) = match program {
             GuestProgram::AlpenAcct | GuestProgram::AlpenChunk => {
-                unreachable!("prove mode is validated to checkpoint-only before execution")
+                unreachable!("prove mode rejects unsupported programs before execution")
             }
-            GuestProgram::Checkpoint => checkpoint::gen_proof(&**checkpoint_host(cfg).await),
+            GuestProgram::Checkpoint => {
+                let prepare_started_at = Instant::now();
+                let input = checkpoint::prepare_input();
+                let prepare_duration = prepare_started_at.elapsed();
+
+                let cfg = SP1HostConfig::default();
+                let host = checkpoint_host(cfg).await;
+                let prove_started_at = Instant::now();
+                let (name, receipt) = checkpoint::prove_with_input(&input, &**host);
+                let prove_duration = prove_started_at.elapsed();
+
+                (name, receipt, prepare_duration, prove_duration)
+            }
         };
         reports.push((
             name,
             ProofSummary {
-                duration: started_at.elapsed(),
+                prepare_duration,
+                prove_duration,
+                total_duration: total_started_at.elapsed(),
                 proof_bytes: receipt.receipt().proof().as_bytes().len(),
                 proof_type: format!("{:?}", receipt.metadata().proof_type()),
             },

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -1,11 +1,15 @@
 use std::str::FromStr;
+use std::time::Instant;
 
 mod alpen_acct;
 mod alpen_chunk;
 mod checkpoint;
 
 #[cfg(feature = "sp1")]
-use zkaleido::ExecutionSummary;
+use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata};
+
+#[cfg(feature = "sp1")]
+use crate::format::ProofSummary;
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -31,7 +35,7 @@ impl FromStr for GuestProgram {
 /// Runs SP1 programs and pairs each program's name with its
 /// [`ExecutionSummary`] (cycles, gas, public values).
 #[cfg(feature = "sp1")]
-pub async fn run_sp1_programs(programs: &[GuestProgram]) -> Vec<(String, ExecutionSummary)> {
+pub async fn run_sp1_execute_programs(programs: &[GuestProgram]) -> Vec<(String, ExecutionSummary)> {
     use strata_zkvm_hosts::sp1::{alpen_acct_host, alpen_chunk_host, checkpoint_host};
     use zkaleido_sp1_host::SP1HostConfig;
     let mut reports = Vec::with_capacity(programs.len());
@@ -45,6 +49,33 @@ pub async fn run_sp1_programs(programs: &[GuestProgram]) -> Vec<(String, Executi
             GuestProgram::Checkpoint => checkpoint::gen_perf_report(&**checkpoint_host(cfg).await),
         };
         reports.push(report);
+    }
+    reports
+}
+
+#[cfg(feature = "sp1")]
+pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, ProofSummary)> {
+    use strata_zkvm_hosts::sp1::checkpoint_host;
+    use zkaleido_sp1_host::SP1HostConfig;
+
+    let mut reports = Vec::with_capacity(programs.len());
+    for program in programs {
+        let cfg = SP1HostConfig::default();
+        let started_at = Instant::now();
+        let (name, receipt): (String, ProofReceiptWithMetadata) = match program {
+            GuestProgram::AlpenAcct | GuestProgram::AlpenChunk => {
+                unreachable!("prove mode is validated to checkpoint-only before execution")
+            }
+            GuestProgram::Checkpoint => checkpoint::gen_proof(&**checkpoint_host(cfg).await),
+        };
+        reports.push((
+            name,
+            ProofSummary {
+                duration: started_at.elapsed(),
+                proof_bytes: receipt.receipt().proof().as_bytes().len(),
+                proof_type: format!("{:?}", receipt.metadata().proof_type()),
+            },
+        ));
     }
     reports
 }

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -1,5 +1,4 @@
-use std::str::FromStr;
-use std::time::Instant;
+use std::{str::FromStr, time::Instant};
 
 mod alpen_acct;
 mod alpen_chunk;
@@ -35,7 +34,9 @@ impl FromStr for GuestProgram {
 /// Runs SP1 programs and pairs each program's name with its
 /// [`ExecutionSummary`] (cycles, gas, public values).
 #[cfg(feature = "sp1")]
-pub async fn run_sp1_execute_programs(programs: &[GuestProgram]) -> Vec<(String, ExecutionSummary)> {
+pub async fn run_sp1_execute_programs(
+    programs: &[GuestProgram],
+) -> Vec<(String, ExecutionSummary)> {
     use strata_zkvm_hosts::sp1::{alpen_acct_host, alpen_chunk_host, checkpoint_host};
     use zkaleido_sp1_host::SP1HostConfig;
     let mut reports = Vec::with_capacity(programs.len());
@@ -73,10 +74,10 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
             GuestProgram::Checkpoint => {
                 let prepare_started_at = Instant::now();
                 let input = checkpoint::prepare_input();
-                let prepare_duration = prepare_started_at.elapsed();
 
                 let cfg = SP1HostConfig::default();
                 let host = checkpoint_host(cfg).await;
+                let prepare_duration = prepare_started_at.elapsed();
                 let prove_started_at = Instant::now();
                 let (name, receipt) = checkpoint::prove_with_input(&input, &**host);
                 let prove_duration = prove_started_at.elapsed();

--- a/provers/sp1/build.rs
+++ b/provers/sp1/build.rs
@@ -213,7 +213,10 @@ fn ensure_cache_validity(program: &str) -> Result<SP1VerifyingKey, String> {
 
     if !is_cache_valid(&elf_hash, &paths) {
         // Cache is invalid, need to generate the verifying key.
-        let client = ProverClient::from_env();
+        // Build-time VK generation should stay on the local CPU path. It runs inside a Cargo
+        // build script, not inside the runtime proving environment, so inheriting SP1_PROVER=cuda
+        // can panic while the CUDA client tries to spawn async work without a Tokio runtime.
+        let client = ProverClient::builder().cpu().build();
         let pk = client
             .setup(elf.clone().into())
             .map_err(|e| format!("Failed to set up proving key: {e}"))?;


### PR DESCRIPTION
## Description

Closes #1870.

Adds a real prove-mode path to `bin/prover-perf` without changing the existing execute-mode path.

Before this change, `prover-perf` only measured `ZkVmProgram::execute(...)`, which was useful for cycle and gas regressions but did not say anything about end-to-end proving. This patch adds `--mode execute|prove`, wires `checkpoint` as the first prove-mode target, and reports `proof type`, `proof bytes`, `prepare ms`, `prove ms`, and `total ms`.

It also keeps build-time VK generation on `ProverClient::builder().cpu().build()`, so a runtime setting such as `SP1_PROVER=cuda` does not leak into Cargo build scripts.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This PR is the prove-mode infrastructure PR only.

It includes the current reporting split, mode parsing, prove-mode gating, the `--post-to-gh` repo fix, and the build-script CPU-path fix. Separate workload coverage lives in `#1875`.

The public branch validates on the pinned public dependency graph. Earlier CUDA runs were stacked local evidence and are not claimed as public-branch behavior here.

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues

#1870
