### PR TITLE
STR-3562: make --sequencer flag configurable via SEQUENCER_MODE env

### DIFF
--- a/.github/sp1-e2e/compose-override.yml
+++ b/.github/sp1-e2e/compose-override.yml
@@ -30,6 +30,7 @@ services:
     shm_size: '8gb'
     command: []
     environment:
+      - SEQUENCER_MODE=true
       - NETWORK_PRIVATE_KEY=${NETWORK_PRIVATE_KEY}
       - OL_SUBMIT_URL=ws://strata:8435
       - STRATA_SUBMIT_RPC_TOKEN=dev-only-submit-token

--- a/docker/alpen-client/entrypoint.sh
+++ b/docker/alpen-client/entrypoint.sh
@@ -11,7 +11,9 @@ if [ "${1-}" = "help" ] || [ "${1-}" = "--help" ] || [ "${1-}" = "-h" ]; then
 fi
 
 # Build command from environment variables.
+# Set SEQUENCER_MODE=true to run as sequencer (default: fullnode).
 
+SEQUENCER_MODE="${SEQUENCER_MODE:-false}"
 SEQUENCER_PUBKEY="${SEQUENCER_PUBKEY:?SEQUENCER_PUBKEY must be set}"
 CHAIN_SPEC="${CHAIN_SPEC:-dev}"
 EE_DA_MAGIC_BYTES="${EE_DA_MAGIC_BYTES:-ALPN}"
@@ -29,8 +31,13 @@ else
         "$@"
 fi
 
+SEQUENCER_FLAG=""
+if [ "${SEQUENCER_MODE}" = "true" ]; then
+    SEQUENCER_FLAG="--sequencer"
+fi
+
 exec alpen-client \
-    --sequencer \
+    ${SEQUENCER_FLAG} \
     --sequencer-pubkey "${SEQUENCER_PUBKEY}" \
     --custom-chain "${CHAIN_SPEC}" \
     --datadir "${DATADIR:-/app/data}" \

--- a/docker/alpen-client/entrypoint.sh
+++ b/docker/alpen-client/entrypoint.sh
@@ -16,28 +16,34 @@ fi
 SEQUENCER_MODE="${SEQUENCER_MODE:-false}"
 SEQUENCER_PUBKEY="${SEQUENCER_PUBKEY:?SEQUENCER_PUBKEY must be set}"
 CHAIN_SPEC="${CHAIN_SPEC:-dev}"
-EE_DA_MAGIC_BYTES="${EE_DA_MAGIC_BYTES:-ALPN}"
-BITCOIND_RPC_URL="${BITCOIND_RPC_URL:?BITCOIND_RPC_URL must be set}"
-BITCOIND_RPC_USER="${BITCOIND_RPC_USER:?BITCOIND_RPC_USER must be set}"
-BITCOIND_RPC_PASSWORD="${BITCOIND_RPC_PASSWORD:?BITCOIND_RPC_PASSWORD must be set}"
 
 if [ "${DUMMY_OL_CLIENT:-0}" = "1" ]; then
     set -- --dummy-ol-client "$@"
 else
-    STRATA_SUBMIT_RPC_TOKEN="${STRATA_SUBMIT_RPC_TOKEN:?STRATA_SUBMIT_RPC_TOKEN must be set}"
     set -- \
         --ol-client-url "${OL_CLIENT_URL:-ws://strata:8432}" \
         --ol-submit-url "${OL_SUBMIT_URL:-ws://strata:8435}" \
         "$@"
 fi
 
-SEQUENCER_FLAG=""
+# Sequencer-only: DA flags and BTC credentials
 if [ "${SEQUENCER_MODE}" = "true" ]; then
-    SEQUENCER_FLAG="--sequencer"
+    BITCOIND_RPC_URL="${BITCOIND_RPC_URL:?BITCOIND_RPC_URL must be set}"
+    BITCOIND_RPC_USER="${BITCOIND_RPC_USER:?BITCOIND_RPC_USER must be set}"
+    BITCOIND_RPC_PASSWORD="${BITCOIND_RPC_PASSWORD:?BITCOIND_RPC_PASSWORD must be set}"
+    STRATA_SUBMIT_RPC_TOKEN="${STRATA_SUBMIT_RPC_TOKEN:?STRATA_SUBMIT_RPC_TOKEN must be set}"
+    EE_DA_MAGIC_BYTES="${EE_DA_MAGIC_BYTES:-ALPN}"
+
+    set -- \
+        --sequencer \
+        --ee-da-magic-bytes "${EE_DA_MAGIC_BYTES}" \
+        --btc-rpc-url "${BITCOIND_RPC_URL}" \
+        --btc-rpc-user "${BITCOIND_RPC_USER}" \
+        --btc-rpc-password "${BITCOIND_RPC_PASSWORD}" \
+        "$@"
 fi
 
 exec alpen-client \
-    ${SEQUENCER_FLAG} \
     --sequencer-pubkey "${SEQUENCER_PUBKEY}" \
     --custom-chain "${CHAIN_SPEC}" \
     --datadir "${DATADIR:-/app/data}" \
@@ -53,10 +59,6 @@ exec alpen-client \
     --authrpc.addr 0.0.0.0 \
     --authrpc.port "${AUTHRPC_PORT:-8551}" \
     --authrpc.jwtsecret "${JWT_SECRET:-/app/keys/jwt.hex}" \
-    --ee-da-magic-bytes "${EE_DA_MAGIC_BYTES}" \
-    --btc-rpc-url "${BITCOIND_RPC_URL}" \
-    --btc-rpc-user "${BITCOIND_RPC_USER}" \
-    --btc-rpc-password "${BITCOIND_RPC_PASSWORD}" \
     --l1-reorg-safe-depth "${L1_REORG_SAFE_DEPTH:-4}" \
     --batch-sealing-block-count "${BATCH_SEALING_BLOCK_COUNT:-120}" \
     --bridge-denomination "${BRIDGE_DENOMINATION:-100000000}" \

--- a/docker/alpen-client/entrypoint.sh
+++ b/docker/alpen-client/entrypoint.sh
@@ -22,11 +22,10 @@ if [ "${DUMMY_OL_CLIENT:-0}" = "1" ]; then
 else
     set -- \
         --ol-client-url "${OL_CLIENT_URL:-ws://strata:8432}" \
-        --ol-submit-url "${OL_SUBMIT_URL:-ws://strata:8435}" \
         "$@"
 fi
 
-# Sequencer-only: DA flags and BTC credentials
+# Sequencer-only: submit URL, DA flags, and BTC credentials
 if [ "${SEQUENCER_MODE}" = "true" ]; then
     BITCOIND_RPC_URL="${BITCOIND_RPC_URL:?BITCOIND_RPC_URL must be set}"
     BITCOIND_RPC_USER="${BITCOIND_RPC_USER:?BITCOIND_RPC_USER must be set}"
@@ -36,6 +35,7 @@ if [ "${SEQUENCER_MODE}" = "true" ]; then
 
     set -- \
         --sequencer \
+        --ol-submit-url "${OL_SUBMIT_URL:-ws://strata:8435}" \
         --ee-da-magic-bytes "${EE_DA_MAGIC_BYTES}" \
         --btc-rpc-url "${BITCOIND_RPC_URL}" \
         --btc-rpc-user "${BITCOIND_RPC_USER}" \

--- a/docker/compose-ol-el-seq.yml
+++ b/docker/compose-ol-el-seq.yml
@@ -80,6 +80,7 @@ services:
       - .env
       - ./configs/generated/.env.alpen
     environment:
+      SEQUENCER_MODE: "true"
       OL_SUBMIT_URL: ws://strata:8435
       STRATA_SUBMIT_RPC_TOKEN: ${STRATA_SUBMIT_RPC_TOKEN:-dev-only-submit-token}
     volumes:


### PR DESCRIPTION
## Description

The Docker entrypoint (`docker/alpen-client/entrypoint.sh`) hardcoded `--sequencer`, forcing fullnode deployments to bypass the entrypoint entirely with `command: ["alpen-client"]` and duplicate all args manually.

Add `SEQUENCER_MODE` env var (default `false`) that conditionally includes `--sequencer`. Sequencer compose sets `SEQUENCER_MODE=true`; fullnodes can now use the same entrypoint without overriding it.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- Default is `false` (fullnode mode). Existing sequencer deployments must add `SEQUENCER_MODE=true` to their env.
- The local docker compose (`compose-ol-el-seq.yml`) is updated to set `SEQUENCER_MODE=true`.
- K8s deployment values will need a corresponding update (add `SEQUENCER_MODE: "true"` to sequencer env, remove `command: ["alpen-client"]` override from fullnodes).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-3562