### PR TITLE
feat(prover-perf): add evm-ee-stf compressed prove target

### DIFF
--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -59,7 +59,6 @@ strata-predicate.workspace = true
 default = ["sp1"]
 sp1 = [
   "zkaleido-sp1-host/perf",
-  "zkaleido-sp1-host/cuda",
   "strata-zkvm-hosts/sp1-builder",
   "dep:zkaleido-sp1-host",
   "dep:strata-sp1-guest-builder",

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -14,6 +14,7 @@ zkaleido.workspace = true
 strata-proofimpl-alpen-acct.workspace = true
 strata-proofimpl-alpen-chunk.workspace = true
 strata-proofimpl-checkpoint.workspace = true
+strata-proofimpl-evm-ee-stf.workspace = true
 
 strata-acct-types.workspace = true
 strata-codec.workspace = true
@@ -30,6 +31,7 @@ strata-ol-da.workspace = true
 strata-ol-stf = { workspace = true, features = ["test-utils"] }
 strata-snark-acct-runtime.workspace = true
 strata-snark-acct-types.workspace = true
+strata-test-utils-evm-ee.workspace = true
 strata-zkvm-hosts.workspace = true
 
 reth-chainspec.workspace = true

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -57,6 +57,7 @@ strata-predicate.workspace = true
 default = ["sp1"]
 sp1 = [
   "zkaleido-sp1-host/perf",
+  "zkaleido-sp1-host/cuda",
   "strata-zkvm-hosts/sp1-builder",
   "dep:zkaleido-sp1-host",
   "dep:strata-sp1-guest-builder",

--- a/bin/prover-perf/src/args.rs
+++ b/bin/prover-perf/src/args.rs
@@ -72,12 +72,9 @@ pub fn validate_mode_programs(mode: PerfMode, programs: &[GuestProgram]) -> Resu
     if mode == PerfMode::Prove
         && programs
             .iter()
-            .any(|program| !matches!(program, GuestProgram::Checkpoint))
+            .any(|program| !matches!(program, GuestProgram::Checkpoint | GuestProgram::EvmEeStf))
     {
-        return Err(
-            "prove mode currently supports only `checkpoint`; use `--programs checkpoint`"
-                .to_string(),
-        );
+        return Err("prove mode currently supports only `checkpoint` and `evm-ee-stf`".to_string());
     }
 
     Ok(())

--- a/bin/prover-perf/src/args.rs
+++ b/bin/prover-perf/src/args.rs
@@ -79,3 +79,37 @@ pub fn validate_mode_programs(mode: PerfMode, programs: &[GuestProgram]) -> Resu
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mode_accepts_known_values_case_insensitively() {
+        assert_eq!(parse_mode("execute").unwrap(), PerfMode::Execute);
+        assert_eq!(parse_mode("PrOvE").unwrap(), PerfMode::Prove);
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown_values() {
+        assert_eq!(parse_mode("gpu").unwrap_err(), "unknown mode: gpu");
+    }
+
+    #[test]
+    fn validate_mode_programs_rejects_non_prove_targets() {
+        let err = validate_mode_programs(PerfMode::Prove, &[GuestProgram::AlpenChunk]).unwrap_err();
+        assert_eq!(
+            err,
+            "prove mode currently supports only `checkpoint` and `evm-ee-stf`"
+        );
+    }
+
+    #[test]
+    fn validate_mode_programs_accepts_supported_prove_targets() {
+        validate_mode_programs(
+            PerfMode::Prove,
+            &[GuestProgram::Checkpoint, GuestProgram::EvmEeStf],
+        )
+        .unwrap();
+    }
+}

--- a/bin/prover-perf/src/args.rs
+++ b/bin/prover-perf/src/args.rs
@@ -2,6 +2,24 @@ use argh::FromArgs;
 
 use crate::programs::GuestProgram;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerfMode {
+    Execute,
+    Prove,
+}
+
+impl std::str::FromStr for PerfMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "execute" => Ok(Self::Execute),
+            "prove" => Ok(Self::Prove),
+            _ => Err(format!("unknown mode: {s}")),
+        }
+    }
+}
+
 /// Evaluate the performance of SP1 on programs.
 #[derive(Debug, Clone, FromArgs)]
 pub struct EvalArgs {
@@ -20,6 +38,10 @@ pub struct EvalArgs {
     /// the commit hash
     #[argh(option, default = "String::from(\"local_commit\")")]
     pub commit_hash: String,
+
+    /// benchmark mode: `execute` for execution summary, `prove` for real proof generation
+    #[argh(option, default = "String::from(\"execute\")")]
+    pub mode: String,
 
     /// programs to run (comma-delimited and/or repeated),
     /// e.g. `--programs alpen-chunk,checkpoint` or `--programs alpen-chunk
@@ -40,4 +62,23 @@ pub fn parse_programs(raw: &[String]) -> Result<Vec<GuestProgram>, String> {
         .filter(|s| !s.is_empty())
         .map(|s| s.parse::<GuestProgram>())
         .collect()
+}
+
+pub fn parse_mode(raw: &str) -> Result<PerfMode, String> {
+    raw.parse()
+}
+
+pub fn validate_mode_programs(mode: PerfMode, programs: &[GuestProgram]) -> Result<(), String> {
+    if mode == PerfMode::Prove
+        && programs
+            .iter()
+            .any(|program| !matches!(program, GuestProgram::Checkpoint))
+    {
+        return Err(
+            "prove mode currently supports only `checkpoint`; use `--programs checkpoint`"
+                .to_string(),
+        );
+    }
+
+    Ok(())
 }

--- a/bin/prover-perf/src/format.rs
+++ b/bin/prover-perf/src/format.rs
@@ -95,3 +95,34 @@ pub fn format_results_for_mode(
         PerfMode::Prove => format_prove_results(prove_results, host_name),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn format_prove_results_includes_timing_breakdown_columns() {
+        let text = format_prove_results(
+            &[(
+                "EVM EE STF".to_string(),
+                ProofSummary {
+                    prepare_duration: Duration::from_millis(8),
+                    prove_duration: Duration::from_millis(3220),
+                    total_duration: Duration::from_millis(13677),
+                    proof_bytes: 1_272_546,
+                    proof_type: "Compressed".to_string(),
+                },
+            )],
+            "SP1".to_string(),
+        );
+
+        assert!(text.contains("prepare ms"));
+        assert!(text.contains("prove ms"));
+        assert!(text.contains("total ms"));
+        assert!(text.contains("EVM EE STF"));
+        assert!(text.contains("Compressed"));
+        assert!(text.contains("1,272,546"));
+    }
+}

--- a/bin/prover-perf/src/format.rs
+++ b/bin/prover-perf/src/format.rs
@@ -1,7 +1,16 @@
+use std::time::Duration;
+
 use num_format::{Locale, ToFormattedString};
 use zkaleido::ExecutionSummary;
 
-use crate::args::EvalArgs;
+use crate::args::{EvalArgs, PerfMode};
+
+#[derive(Debug, Clone)]
+pub struct ProofSummary {
+    pub duration: Duration,
+    pub proof_bytes: usize,
+    pub proof_type: String,
+}
 
 /// Returns a formatted header for the performance report with basic PR data.
 pub fn format_header(args: &EvalArgs) -> String {
@@ -13,11 +22,13 @@ pub fn format_header(args: &EvalArgs) -> String {
         detail_text.push_str("*Local execution*\n");
     }
 
+    detail_text.push_str(&format!("*Mode*: {}\n", args.mode));
+
     detail_text
 }
 
 /// Returns formatted results for the [`ExecutionSummary`]s shaped in a table.
-pub fn format_results(results: &[(String, ExecutionSummary)], host_name: String) -> String {
+pub fn format_execute_results(results: &[(String, ExecutionSummary)], host_name: String) -> String {
     let mut table_text = String::new();
     table_text.push('\n');
     table_text.push_str("| program                | cycles      | gas      |\n");
@@ -34,4 +45,36 @@ pub fn format_results(results: &[(String, ExecutionSummary)], host_name: String)
     table_text.push('\n');
 
     format!("*{host_name} Execution Results*\n {table_text}")
+}
+
+pub fn format_prove_results(results: &[(String, ProofSummary)], host_name: String) -> String {
+    let mut table_text = String::new();
+    table_text.push('\n');
+    table_text.push_str("| program                | proof type | proof bytes | duration ms |\n");
+    table_text.push_str("|------------------------|------------|-------------|-------------|");
+
+    for (name, summary) in results.iter() {
+        table_text.push_str(&format!(
+            "\n| {:<22} | {:<10} | {:>11} | {:>11} |",
+            name,
+            summary.proof_type,
+            summary.proof_bytes.to_formatted_string(&Locale::en),
+            summary.duration.as_millis().to_formatted_string(&Locale::en)
+        ));
+    }
+    table_text.push('\n');
+
+    format!("*{host_name} Proving Results*\n {table_text}")
+}
+
+pub fn format_results_for_mode(
+    mode: PerfMode,
+    execute_results: &[(String, ExecutionSummary)],
+    prove_results: &[(String, ProofSummary)],
+    host_name: String,
+) -> String {
+    match mode {
+        PerfMode::Execute => format_execute_results(execute_results, host_name),
+        PerfMode::Prove => format_prove_results(prove_results, host_name),
+    }
 }

--- a/bin/prover-perf/src/format.rs
+++ b/bin/prover-perf/src/format.rs
@@ -7,7 +7,9 @@ use crate::args::{EvalArgs, PerfMode};
 
 #[derive(Debug, Clone)]
 pub struct ProofSummary {
-    pub duration: Duration,
+    pub prepare_duration: Duration,
+    pub prove_duration: Duration,
+    pub total_duration: Duration,
     pub proof_bytes: usize,
     pub proof_type: String,
 }
@@ -50,16 +52,31 @@ pub fn format_execute_results(results: &[(String, ExecutionSummary)], host_name:
 pub fn format_prove_results(results: &[(String, ProofSummary)], host_name: String) -> String {
     let mut table_text = String::new();
     table_text.push('\n');
-    table_text.push_str("| program                | proof type | proof bytes | duration ms |\n");
-    table_text.push_str("|------------------------|------------|-------------|-------------|");
+    table_text.push_str(
+        "| program                | proof type | proof bytes | prepare ms | prove ms | total ms |\n",
+    );
+    table_text.push_str(
+        "|------------------------|------------|-------------|------------|----------|----------|",
+    );
 
     for (name, summary) in results.iter() {
         table_text.push_str(&format!(
-            "\n| {:<22} | {:<10} | {:>11} | {:>11} |",
+            "\n| {:<22} | {:<10} | {:>11} | {:>10} | {:>8} | {:>8} |",
             name,
             summary.proof_type,
             summary.proof_bytes.to_formatted_string(&Locale::en),
-            summary.duration.as_millis().to_formatted_string(&Locale::en)
+            summary
+                .prepare_duration
+                .as_millis()
+                .to_formatted_string(&Locale::en),
+            summary
+                .prove_duration
+                .as_millis()
+                .to_formatted_string(&Locale::en),
+            summary
+                .total_duration
+                .as_millis()
+                .to_formatted_string(&Locale::en)
         ));
     }
     table_text.push('\n');

--- a/bin/prover-perf/src/github.rs
+++ b/bin/prover-perf/src/github.rs
@@ -5,6 +5,8 @@ use serde_json::json;
 
 use crate::args::EvalArgs;
 
+const BASE_URL: &str = "https://api.github.com/repos/alpenlabs/alpen";
+
 /// Posts the message to the PR on the github.
 ///
 /// Updates an existing previous comment (if there is one) or posts a new comment.
@@ -14,7 +16,6 @@ pub async fn post_to_github_pr(
 ) -> Result<(), Box<dyn error::Error>> {
     let client = Client::new();
 
-    const BASE_URL: &str = "https://api.github.com/repos/alpenlabs/strata";
     let comments_url = format!("{}/issues/{}/comments", BASE_URL, &args.pr_number);
 
     // Get all comments on the PR
@@ -76,4 +77,14 @@ pub fn format_github_message(results_text: &[String]) -> String {
     }
 
     formatted_message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BASE_URL;
+
+    #[test]
+    fn github_base_url_targets_alpen_repo() {
+        assert_eq!(BASE_URL, "https://api.github.com/repos/alpenlabs/alpen");
+    }
 }

--- a/bin/prover-perf/src/main.rs
+++ b/bin/prover-perf/src/main.rs
@@ -14,8 +14,8 @@ pub mod github;
 pub mod programs;
 
 use anyhow::Result;
-use args::{parse_programs, EvalArgs};
-use format::{format_header, format_results};
+use args::{EvalArgs, PerfMode, parse_mode, parse_programs, validate_mode_programs};
+use format::{ProofSummary, format_header, format_results_for_mode};
 use github::{format_github_message, post_to_github_pr};
 #[cfg(feature = "sp1")]
 use zkaleido::ExecutionSummary;
@@ -30,14 +30,37 @@ async fn main() -> Result<(), Box<dyn Error>> {
         eprintln!("Error: {e}");
         process::exit(1);
     });
+    let mode = parse_mode(&args.mode).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
+    validate_mode_programs(mode, &programs).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
 
     let mut results_text = vec![format_header(&args)];
 
     #[cfg(feature = "sp1")]
     {
-        let sp1_reports: Vec<(String, ExecutionSummary)> =
-            programs::run_sp1_programs(&programs).await;
-        results_text.push(format_results(&sp1_reports, "SP1".to_owned()));
+        let mut execute_reports: Vec<(String, ExecutionSummary)> = Vec::new();
+        let mut prove_reports: Vec<(String, ProofSummary)> = Vec::new();
+
+        match mode {
+            PerfMode::Execute => {
+                execute_reports = programs::run_sp1_execute_programs(&programs).await;
+            }
+            PerfMode::Prove => {
+                prove_reports = programs::run_sp1_prove_programs(&programs).await;
+            }
+        }
+
+        results_text.push(format_results_for_mode(
+            mode,
+            &execute_reports,
+            &prove_reports,
+            "SP1".to_owned(),
+        ));
     }
 
     // Print results

--- a/bin/prover-perf/src/programs/checkpoint.rs
+++ b/bin/prover-perf/src/programs/checkpoint.rs
@@ -20,12 +20,12 @@ use strata_ol_da::{GlobalStateDiff, LedgerDiff, OLDaPayloadV1, StateDiff};
 use strata_ol_stf::test_utils::{build_empty_chain, make_genesis_state};
 use strata_proofimpl_checkpoint::program::{CheckpointProgram, CheckpointProverInput};
 use tracing::info;
-use zkaleido::{ExecutionSummary, ZkVmHost, ZkVmProgram};
+use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram};
 
 const SLOTS_PER_EPOCH: u64 = 9;
 const NUM_BLOCKS: usize = 10;
 
-fn prepare_checkpoint_input() -> CheckpointProverInput {
+fn prepare_input() -> CheckpointProverInput {
     let mut state = make_genesis_state();
     let mut blocks = build_empty_chain(&mut state, NUM_BLOCKS, SLOTS_PER_EPOCH)
         .expect("build_empty_chain should succeed");
@@ -73,10 +73,18 @@ fn prepare_checkpoint_input() -> CheckpointProverInput {
 
 pub(crate) fn gen_perf_report(host: &impl ZkVmHost) -> (String, ExecutionSummary) {
     info!("Generating execution summary for Checkpoint");
-    let input = prepare_checkpoint_input();
+    let input = prepare_input();
     let summary =
         <CheckpointProgram as ZkVmProgram>::execute(&input, host).expect("checkpoint execution");
     (CheckpointProgram::name(), summary)
+}
+
+pub(crate) fn gen_proof(host: &impl ZkVmHost) -> (String, ProofReceiptWithMetadata) {
+    info!("Generating proof for Checkpoint");
+    let input = prepare_input();
+    let receipt =
+        <CheckpointProgram as ZkVmProgram>::prove(&input, host).expect("checkpoint proving");
+    (CheckpointProgram::name(), receipt)
 }
 
 #[cfg(test)]
@@ -85,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_native_execution() {
-        let input = prepare_checkpoint_input();
+        let input = prepare_input();
         let output = CheckpointProgram::execute(&input).unwrap();
         dbg!(output);
     }

--- a/bin/prover-perf/src/programs/checkpoint.rs
+++ b/bin/prover-perf/src/programs/checkpoint.rs
@@ -25,7 +25,7 @@ use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram
 const SLOTS_PER_EPOCH: u64 = 9;
 const NUM_BLOCKS: usize = 10;
 
-fn prepare_input() -> CheckpointProverInput {
+pub(super) fn prepare_input() -> CheckpointProverInput {
     let mut state = make_genesis_state();
     let mut blocks = build_empty_chain(&mut state, NUM_BLOCKS, SLOTS_PER_EPOCH)
         .expect("build_empty_chain should succeed");
@@ -79,11 +79,13 @@ pub(crate) fn gen_perf_report(host: &impl ZkVmHost) -> (String, ExecutionSummary
     (CheckpointProgram::name(), summary)
 }
 
-pub(crate) fn gen_proof(host: &impl ZkVmHost) -> (String, ProofReceiptWithMetadata) {
+pub(crate) fn prove_with_input(
+    input: &CheckpointProverInput,
+    host: &impl ZkVmHost,
+) -> (String, ProofReceiptWithMetadata) {
     info!("Generating proof for Checkpoint");
-    let input = prepare_input();
     let receipt =
-        <CheckpointProgram as ZkVmProgram>::prove(&input, host).expect("checkpoint proving");
+        <CheckpointProgram as ZkVmProgram>::prove(input, host).expect("checkpoint proving");
     (CheckpointProgram::name(), receipt)
 }
 

--- a/bin/prover-perf/src/programs/evm_ee_stf.rs
+++ b/bin/prover-perf/src/programs/evm_ee_stf.rs
@@ -12,7 +12,7 @@ use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram
 const START_BLOCK: u64 = 1;
 const END_BLOCK: u64 = 4;
 
-fn prepare_input() -> EvmEeProofInput {
+pub(super) fn prepare_input() -> EvmEeProofInput {
     info!(
         "Preparing input for EVM EE STF from saved fixture range {}..={}",
         START_BLOCK, END_BLOCK
@@ -30,9 +30,11 @@ pub(crate) fn gen_perf_report(host: &impl ZkVmHost) -> (String, ExecutionSummary
     (EvmEeProgram::name(), summary)
 }
 
-pub(crate) fn gen_proof(host: &impl ZkVmHost) -> (String, ProofReceiptWithMetadata) {
+pub(crate) fn prove_with_input(
+    input: &EvmEeProofInput,
+    host: &impl ZkVmHost,
+) -> (String, ProofReceiptWithMetadata) {
     info!("Generating proof for EVM EE STF");
-    let input = prepare_input();
     let receipt = <EvmEeProgram as ZkVmProgram>::prove(&input, host).expect("evm-ee-stf proving");
     (EvmEeProgram::name(), receipt)
 }

--- a/bin/prover-perf/src/programs/evm_ee_stf.rs
+++ b/bin/prover-perf/src/programs/evm_ee_stf.rs
@@ -1,0 +1,50 @@
+//! Perf input for the standalone EVM EE STF SP1 guest.
+//!
+//! Uses the saved multi-block EVM witness fixtures so `prove` mode can exercise
+//! Alpen's existing `ProofType::Compressed` path without depending on Groth16 /
+//! Icicle acceleration.
+
+use strata_proofimpl_evm_ee_stf::{primitives::EvmEeProofInput, program::EvmEeProgram};
+use strata_test_utils_evm_ee::EvmSegment;
+use tracing::info;
+use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram};
+
+const START_BLOCK: u64 = 1;
+const END_BLOCK: u64 = 4;
+
+fn prepare_input() -> EvmEeProofInput {
+    info!(
+        "Preparing input for EVM EE STF from saved fixture range {}..={}",
+        START_BLOCK, END_BLOCK
+    );
+    EvmSegment::initialize_from_saved_ee_data(START_BLOCK, END_BLOCK)
+        .get_inputs()
+        .clone()
+}
+
+pub(crate) fn gen_perf_report(host: &impl ZkVmHost) -> (String, ExecutionSummary) {
+    info!("Generating execution summary for EVM EE STF");
+    let input = prepare_input();
+    let summary =
+        <EvmEeProgram as ZkVmProgram>::execute(&input, host).expect("evm-ee-stf execution");
+    (EvmEeProgram::name(), summary)
+}
+
+pub(crate) fn gen_proof(host: &impl ZkVmHost) -> (String, ProofReceiptWithMetadata) {
+    info!("Generating proof for EVM EE STF");
+    let input = prepare_input();
+    let receipt = <EvmEeProgram as ZkVmProgram>::prove(&input, host).expect("evm-ee-stf proving");
+    (EvmEeProgram::name(), receipt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_evm_ee_stf_native_execution() {
+        let input = prepare_input();
+        let output = EvmEeProgram::execute(&input).expect("native execution");
+        assert_eq!(output.len(), input.len());
+    }
+}

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -66,19 +66,49 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
 
     let mut reports = Vec::with_capacity(programs.len());
     for program in programs {
-        let cfg = SP1HostConfig::default();
-        let started_at = Instant::now();
-        let (name, receipt): (String, ProofReceiptWithMetadata) = match program {
+        let total_started_at = Instant::now();
+        let (name, receipt, prepare_duration, prove_duration): (
+            String,
+            ProofReceiptWithMetadata,
+            _,
+            _,
+        ) = match program {
             GuestProgram::AlpenAcct | GuestProgram::AlpenChunk => {
                 unreachable!("prove mode rejects unsupported programs before execution")
             }
-            GuestProgram::Checkpoint => checkpoint::gen_proof(&**checkpoint_host(cfg).await),
-            GuestProgram::EvmEeStf => evm_ee_stf::gen_proof(&**evm_ee_stf_host(cfg).await),
+            GuestProgram::Checkpoint => {
+                let prepare_started_at = Instant::now();
+                let input = checkpoint::prepare_input();
+                let prepare_duration = prepare_started_at.elapsed();
+
+                let cfg = SP1HostConfig::default();
+                let host = checkpoint_host(cfg).await;
+                let prove_started_at = Instant::now();
+                let (name, receipt) = checkpoint::prove_with_input(&input, &**host);
+                let prove_duration = prove_started_at.elapsed();
+
+                (name, receipt, prepare_duration, prove_duration)
+            }
+            GuestProgram::EvmEeStf => {
+                let prepare_started_at = Instant::now();
+                let input = evm_ee_stf::prepare_input();
+                let prepare_duration = prepare_started_at.elapsed();
+
+                let cfg = SP1HostConfig::default();
+                let host = evm_ee_stf_host(cfg).await;
+                let prove_started_at = Instant::now();
+                let (name, receipt) = evm_ee_stf::prove_with_input(&input, &**host);
+                let prove_duration = prove_started_at.elapsed();
+
+                (name, receipt, prepare_duration, prove_duration)
+            }
         };
         reports.push((
             name,
             ProofSummary {
-                duration: started_at.elapsed(),
+                prepare_duration,
+                prove_duration,
+                total_duration: total_started_at.elapsed(),
                 proof_bytes: receipt.receipt().proof().as_bytes().len(),
                 proof_type: format!("{:?}", receipt.metadata().proof_type()),
             },

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -1,11 +1,15 @@
 use std::str::FromStr;
+use std::time::Instant;
 
 mod alpen_acct;
 mod alpen_chunk;
 mod checkpoint;
 
 #[cfg(feature = "sp1")]
-use zkaleido::ExecutionSummary;
+use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata};
+
+#[cfg(feature = "sp1")]
+use crate::format::ProofSummary;
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -31,7 +35,7 @@ impl FromStr for GuestProgram {
 /// Runs SP1 programs and pairs each program's name with its
 /// [`ExecutionSummary`] (cycles, gas, public values).
 #[cfg(feature = "sp1")]
-pub async fn run_sp1_programs(programs: &[GuestProgram]) -> Vec<(String, ExecutionSummary)> {
+pub async fn run_sp1_execute_programs(programs: &[GuestProgram]) -> Vec<(String, ExecutionSummary)> {
     use strata_zkvm_hosts::sp1::{alpen_acct_host, alpen_chunk_host, checkpoint_host};
     use zkaleido_sp1_host::SP1HostConfig;
     let mut reports = Vec::with_capacity(programs.len());
@@ -45,6 +49,33 @@ pub async fn run_sp1_programs(programs: &[GuestProgram]) -> Vec<(String, Executi
             GuestProgram::Checkpoint => checkpoint::gen_perf_report(&**checkpoint_host(cfg).await),
         };
         reports.push(report);
+    }
+    reports
+}
+
+#[cfg(feature = "sp1")]
+pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, ProofSummary)> {
+    use strata_zkvm_hosts::sp1::checkpoint_host;
+    use zkaleido_sp1_host::SP1HostConfig;
+
+    let mut reports = Vec::with_capacity(programs.len());
+    for program in programs {
+        let cfg = SP1HostConfig::default();
+        let started_at = Instant::now();
+        let (name, receipt): (String, ProofReceiptWithMetadata) = match program {
+            GuestProgram::AlpenAcct | GuestProgram::AlpenChunk => {
+                unreachable!("prove mode is validated to checkpoint-only before execution")
+            }
+            GuestProgram::Checkpoint => checkpoint::gen_proof(&**checkpoint_host(cfg).await),
+        };
+        reports.push((
+            name,
+            ProofSummary {
+                duration: started_at.elapsed(),
+                proof_bytes: receipt.receipt().proof().as_bytes().len(),
+                proof_type: format!("{:?}", receipt.metadata().proof_type()),
+            },
+        ));
     }
     reports
 }

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -79,10 +79,10 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
             GuestProgram::Checkpoint => {
                 let prepare_started_at = Instant::now();
                 let input = checkpoint::prepare_input();
-                let prepare_duration = prepare_started_at.elapsed();
 
                 let cfg = SP1HostConfig::default();
                 let host = checkpoint_host(cfg).await;
+                let prepare_duration = prepare_started_at.elapsed();
                 let prove_started_at = Instant::now();
                 let (name, receipt) = checkpoint::prove_with_input(&input, &**host);
                 let prove_duration = prove_started_at.elapsed();
@@ -92,10 +92,10 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
             GuestProgram::EvmEeStf => {
                 let prepare_started_at = Instant::now();
                 let input = evm_ee_stf::prepare_input();
-                let prepare_duration = prepare_started_at.elapsed();
 
                 let cfg = SP1HostConfig::default();
                 let host = evm_ee_stf_host(cfg).await;
+                let prepare_duration = prepare_started_at.elapsed();
                 let prove_started_at = Instant::now();
                 let (name, receipt) = evm_ee_stf::prove_with_input(&input, &**host);
                 let prove_duration = prove_started_at.elapsed();

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 mod alpen_acct;
 mod alpen_chunk;
 mod checkpoint;
+mod evm_ee_stf;
 
 #[cfg(feature = "sp1")]
 use zkaleido::{ExecutionSummary, ProofReceiptWithMetadata};
@@ -17,6 +18,7 @@ pub enum GuestProgram {
     AlpenAcct,
     AlpenChunk,
     Checkpoint,
+    EvmEeStf,
 }
 
 impl FromStr for GuestProgram {
@@ -27,6 +29,7 @@ impl FromStr for GuestProgram {
             "alpen-acct" => Ok(GuestProgram::AlpenAcct),
             "alpen-chunk" => Ok(GuestProgram::AlpenChunk),
             "checkpoint" => Ok(GuestProgram::Checkpoint),
+            "evm-ee-stf" => Ok(GuestProgram::EvmEeStf),
             _ => Err(format!("unknown program: {s}")),
         }
     }
@@ -36,7 +39,9 @@ impl FromStr for GuestProgram {
 /// [`ExecutionSummary`] (cycles, gas, public values).
 #[cfg(feature = "sp1")]
 pub async fn run_sp1_execute_programs(programs: &[GuestProgram]) -> Vec<(String, ExecutionSummary)> {
-    use strata_zkvm_hosts::sp1::{alpen_acct_host, alpen_chunk_host, checkpoint_host};
+    use strata_zkvm_hosts::sp1::{
+        alpen_acct_host, alpen_chunk_host, checkpoint_host, evm_ee_stf_host,
+    };
     use zkaleido_sp1_host::SP1HostConfig;
     let mut reports = Vec::with_capacity(programs.len());
     for program in programs {
@@ -47,6 +52,7 @@ pub async fn run_sp1_execute_programs(programs: &[GuestProgram]) -> Vec<(String,
                 alpen_chunk::gen_perf_report(&**alpen_chunk_host(cfg).await)
             }
             GuestProgram::Checkpoint => checkpoint::gen_perf_report(&**checkpoint_host(cfg).await),
+            GuestProgram::EvmEeStf => evm_ee_stf::gen_perf_report(&**evm_ee_stf_host(cfg).await),
         };
         reports.push(report);
     }
@@ -55,7 +61,7 @@ pub async fn run_sp1_execute_programs(programs: &[GuestProgram]) -> Vec<(String,
 
 #[cfg(feature = "sp1")]
 pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, ProofSummary)> {
-    use strata_zkvm_hosts::sp1::checkpoint_host;
+    use strata_zkvm_hosts::sp1::{checkpoint_host, evm_ee_stf_host};
     use zkaleido_sp1_host::SP1HostConfig;
 
     let mut reports = Vec::with_capacity(programs.len());
@@ -67,6 +73,7 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
                 unreachable!("prove mode is validated to checkpoint-only before execution")
             }
             GuestProgram::Checkpoint => checkpoint::gen_proof(&**checkpoint_host(cfg).await),
+            GuestProgram::EvmEeStf => evm_ee_stf::gen_proof(&**evm_ee_stf_host(cfg).await),
         };
         reports.push((
             name,

--- a/bin/prover-perf/src/programs/mod.rs
+++ b/bin/prover-perf/src/programs/mod.rs
@@ -70,7 +70,7 @@ pub async fn run_sp1_prove_programs(programs: &[GuestProgram]) -> Vec<(String, P
         let started_at = Instant::now();
         let (name, receipt): (String, ProofReceiptWithMetadata) = match program {
             GuestProgram::AlpenAcct | GuestProgram::AlpenChunk => {
-                unreachable!("prove mode is validated to checkpoint-only before execution")
+                unreachable!("prove mode rejects unsupported programs before execution")
             }
             GuestProgram::Checkpoint => checkpoint::gen_proof(&**checkpoint_host(cfg).await),
             GuestProgram::EvmEeStf => evm_ee_stf::gen_proof(&**evm_ee_stf_host(cfg).await),

--- a/crates/zkvm/hosts/src/sp1.rs
+++ b/crates/zkvm/hosts/src/sp1.rs
@@ -58,3 +58,9 @@ define_host!(
     GUEST_ALPEN_ACCT_ELF,
     "guest-alpen-acct.elf"
 );
+define_host!(
+    evm_ee_stf_host,
+    EVM_EE_STF_HOST,
+    GUEST_EVM_EE_STF_ELF,
+    "guest-evm-ee-stf.elf"
+);

--- a/provers/sp1/build.rs
+++ b/provers/sp1/build.rs
@@ -213,7 +213,10 @@ fn ensure_cache_validity(program: &str) -> Result<SP1VerifyingKey, String> {
 
     if !is_cache_valid(&elf_hash, &paths) {
         // Cache is invalid, need to generate the verifying key.
-        let client = ProverClient::from_env();
+        // Build-time VK generation should stay on the local CPU path. It runs inside a Cargo
+        // build script, not inside the runtime proving environment, so inheriting SP1_PROVER=cuda
+        // can panic while the CUDA client tries to spawn async work without a Tokio runtime.
+        let client = ProverClient::builder().cpu().build();
         let pk = client
             .setup(elf.clone().into())
             .map_err(|e| format!("Failed to set up proving key: {e}"))?;

--- a/provers/sp1/build.rs
+++ b/provers/sp1/build.rs
@@ -32,6 +32,7 @@ struct VkHashes {
 const CHECKPOINT: &str = "guest-checkpoint";
 const ALPEN_CHUNK: &str = "guest-alpen-chunk";
 const ALPEN_ACCT: &str = "guest-alpen-acct";
+const EVM_EE_STF: &str = "guest-evm-ee-stf";
 
 /// Returns a map of program dependencies.
 ///
@@ -45,7 +46,7 @@ fn get_program_dependencies() -> HashMap<&'static str, Vec<&'static str>> {
 
 fn main() {
     // List of guest programs to build
-    let guest_programs = [CHECKPOINT, ALPEN_CHUNK, ALPEN_ACCT];
+    let guest_programs = [CHECKPOINT, ALPEN_CHUNK, ALPEN_ACCT, EVM_EE_STF];
 
     // HashSet to keep track of programs that have been built
     let mut built_programs = HashSet::new();

--- a/provers/sp1/guest-evm-ee-stf/Cargo.toml
+++ b/provers/sp1/guest-evm-ee-stf/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2021"
+name = "guest-sp1-evm-ee-stf"
+version = "0.1.0"
+
+[workspace]
+
+[dependencies]
+strata-proofimpl-evm-ee-stf = { path = "../../../crates/proof-impl/evm-ee-stf" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.1" }
+
+[patch.crates-io]
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0" }
+secp256k1-sys = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0" }
+sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.0.0" }
+substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.0.0-substrate-bn" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.0.0" }
+k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.0.0" }
+
+[features]
+mock-verify = ["zkaleido-sp1-guest-env/mock-verify"]
+zkvm-verify = ["zkaleido-sp1-guest-env/zkvm-verify"]

--- a/provers/sp1/guest-evm-ee-stf/src/main.rs
+++ b/provers/sp1/guest-evm-ee-stf/src/main.rs
@@ -1,0 +1,9 @@
+#![no_main]
+zkaleido_sp1_guest_env::entrypoint!(main);
+
+use strata_proofimpl_evm_ee_stf::process_block_transaction_outer;
+use zkaleido_sp1_guest_env::Sp1ZkVmEnv;
+
+fn main() {
+    process_block_transaction_outer(&Sp1ZkVmEnv)
+}


### PR DESCRIPTION
## Description

Follow-up to `#1871`.

Adds `evm-ee-stf` as the first additional prove-mode workload in `bin/prover-perf`, including the standalone SP1 guest and host wiring needed to exercise Alpen's existing `ProofType::Compressed` path.

This also extends the same coarse timing split from `#1871` to this workload. `prepare ms` now covers prover input construction plus SP1 host initialization, and `prove ms` covers the proving call itself.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is the follow-up workload PR, not the prove-mode infrastructure PR.

GitHub shows it against `main`, so the public commit list still includes the shared `#1871` groundwork. The intended review unit is the `evm-ee-stf` target on top of that base.

The public branch validates on the pinned public dependency graph. The successful CUDA rerun for `evm-ee-stf` was stacked local evidence and depended on follow-up work in `alpenlabs/zkaleido#140` and `#141`.

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues
