### PR TITLE
fix(rpc): source L1 tip height from ASM state instead of status channel

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -757,7 +757,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         let confirmation_status = if let Some(obs) = l1_ref {
             let l1_reference = RpcCheckpointL1Ref::new(obs.l1_commitment, obs.txid, obs.wtxid);
             let observed_height = obs.l1_commitment.height();
-            let Some(tip) = self.provider.get_l1_tip_height() else {
+            let Some(tip) = self.provider.get_l1_tip_height().await.map_err(db_error)? else {
                 return Err(internal_error(
                     "L1 tip height unavailable while constructing checkpoint info",
                 ));

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -327,8 +327,8 @@ impl OLRpcProvider for MockProvider {
         self.sync_status
     }
 
-    fn get_l1_tip_height(&self) -> Option<L1Height> {
-        self.l1_tip_height
+    async fn get_l1_tip_height(&self) -> DbResult<Option<L1Height>> {
+        Ok(self.l1_tip_height)
     }
 
     async fn submit_transaction(&self, tx: OLTransaction) -> OLMempoolResult<OLTxId> {

--- a/bin/strata/src/rpc/provider.rs
+++ b/bin/strata/src/rpc/provider.rs
@@ -188,8 +188,13 @@ impl OLRpcProvider for NodeRpcProvider {
         self.status_channel.get_ol_sync_status()
     }
 
-    fn get_l1_tip_height(&self) -> Option<L1Height> {
-        Some(self.status_channel.get_l1_status().cur_height)
+    async fn get_l1_tip_height(&self) -> DbResult<Option<L1Height>> {
+        Ok(self
+            .storage
+            .asm()
+            .fetch_most_recent_state_async()
+            .await?
+            .map(|(commit, _)| commit.height()))
     }
 
     async fn submit_transaction(&self, tx: OLTransaction) -> OLMempoolResult<OLTxId> {

--- a/crates/consensus-logic/src/asm_worker_context.rs
+++ b/crates/consensus-logic/src/asm_worker_context.rs
@@ -80,7 +80,7 @@ impl WorkerContext for AsmWorkerCtx {
 
     fn get_anchor_state(&self, blockid: &L1BlockCommitment) -> WorkerResult<WorkerAsmState> {
         self.asmman
-            .get_state(*blockid)
+            .get_state_blocking(*blockid)
             .map_err(conv_db_err)?
             .map(storage_to_worker_state)
             .ok_or(WorkerError::MissingAsmState(*blockid.blkid()))
@@ -92,7 +92,7 @@ impl WorkerContext for AsmWorkerCtx {
         state: &WorkerAsmState,
     ) -> WorkerResult<()> {
         self.asmman
-            .put_state(*blockid, worker_to_storage_state(state))
+            .put_state_blocking(*blockid, worker_to_storage_state(state))
             .map_err(conv_db_err)
     }
 
@@ -160,7 +160,7 @@ impl WorkerContext for AsmWorkerCtx {
         data: &strata_asm_common::AuxData,
     ) -> WorkerResult<()> {
         self.asmman
-            .put_aux_data(*blockid, data.clone())
+            .put_aux_data_blocking(*blockid, data.clone())
             .map_err(conv_db_err)
     }
 
@@ -168,7 +168,9 @@ impl WorkerContext for AsmWorkerCtx {
         &self,
         blockid: &L1BlockCommitment,
     ) -> WorkerResult<Option<strata_asm_common::AuxData>> {
-        self.asmman.get_aux_data(*blockid).map_err(conv_db_err)
+        self.asmman
+            .get_aux_data_blocking(*blockid)
+            .map_err(conv_db_err)
     }
 
     fn has_l1_manifest(&self, blockid: &L1BlockId) -> WorkerResult<bool> {

--- a/crates/consensus-logic/src/asm_worker_context.rs
+++ b/crates/consensus-logic/src/asm_worker_context.rs
@@ -73,7 +73,7 @@ impl WorkerContext for AsmWorkerCtx {
 
     fn get_latest_asm_state(&self) -> WorkerResult<Option<(L1BlockCommitment, WorkerAsmState)>> {
         self.asmman
-            .fetch_most_recent_state()
+            .fetch_most_recent_state_blocking()
             .map_err(conv_db_err)
             .map(|state| state.map(|(block, state)| (block, storage_to_worker_state(state))))
     }

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -105,14 +105,14 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
     fn get_asm_state(&self, block: &L1BlockCommitment) -> anyhow::Result<AsmState> {
         self.storage
             .asm()
-            .get_state(*block)?
+            .get_state_blocking(*block)?
             .ok_or_else(|| anyhow::anyhow!("missing ASM state for {block}"))
     }
 
     fn get_aux_data(&self, block: &L1BlockCommitment) -> anyhow::Result<AuxData> {
         self.storage
             .asm()
-            .get_aux_data(*block)?
+            .get_aux_data_blocking(*block)?
             .ok_or_else(|| anyhow::anyhow!("missing ASM aux data for {block}"))
     }
 

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -197,7 +197,7 @@ fn spawn_csm_listener(
         // Get the latest ASM state as fallback
         let (latest_block, _) = storage
             .asm()
-            .fetch_most_recent_state()?
+            .fetch_most_recent_state_blocking()?
             .expect("No ASM state available");
         latest_block
     };

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -205,7 +205,7 @@ fn spawn_csm_listener(
     // Fetch historical ASM states starting from the next height.
     let max_historical_blocks = 1000;
     let nh = from_block.height() + 1;
-    let historical_states = storage.asm().get_states_from(
+    let historical_states = storage.asm().get_states_from_blocking(
         L1BlockCommitment::new(nh, Default::default()),
         max_historical_blocks,
     )?;

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -180,7 +180,7 @@ where
         let asm_tip_height = match self
             .storage
             .asm()
-            .fetch_most_recent_state()
+            .fetch_most_recent_state_blocking()
             .map_err(BlockAssemblyError::Db)?
         {
             Some((commitment, _)) => commitment.height(),

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -762,7 +762,7 @@ pub(crate) async fn setup_asm_state_with_l1_manifests(
 
     storage
         .asm()
-        .put_state(l1_commitment, asm_state)
+        .put_state_blocking(l1_commitment, asm_state)
         .expect("Failed to store ASM state");
 
     l1_commitment

--- a/crates/ol/rpc/types/src/provider.rs
+++ b/crates/ol/rpc/types/src/provider.rs
@@ -94,7 +94,7 @@ pub trait OLRpcProvider: Send + Sync + 'static {
     fn get_ol_sync_status(&self) -> Option<OLSyncStatus>;
 
     /// Get current L1 tip height.
-    fn get_l1_tip_height(&self) -> Option<L1Height>;
+    async fn get_l1_tip_height(&self) -> DbResult<Option<L1Height>>;
 
     /// Submit a transaction to the mempool.
     async fn submit_transaction(&self, tx: OLTransaction) -> OLMempoolResult<OLTxId>;

--- a/crates/storage/src/managers/asm.rs
+++ b/crates/storage/src/managers/asm.rs
@@ -39,12 +39,16 @@ impl AsmStateManager {
     }
 
     /// Returns [`AsmState`] that corresponds to passed block.
-    pub fn get_state(&self, block: L1BlockCommitment) -> DbResult<Option<AsmState>> {
+    pub fn get_state_blocking(&self, block: L1BlockCommitment) -> DbResult<Option<AsmState>> {
         self.ops.get_asm_state_blocking(block)
     }
 
     /// Puts [`AsmState`] for the given block.
-    pub fn put_state(&self, block: L1BlockCommitment, asm_state: AsmState) -> DbResult<()> {
+    pub fn put_state_blocking(
+        &self,
+        block: L1BlockCommitment,
+        asm_state: AsmState,
+    ) -> DbResult<()> {
         self.ops.put_asm_state_blocking(block, asm_state)
     }
 
@@ -52,7 +56,7 @@ impl AsmStateManager {
     ///
     /// Returns entries in ascending order (oldest first). If `from_block` doesn't exist,
     /// starts from the next available block after it.
-    pub fn get_states_from(
+    pub fn get_states_from_blocking(
         &self,
         from_block: L1BlockCommitment,
         max_count: usize,
@@ -61,12 +65,12 @@ impl AsmStateManager {
     }
 
     /// Puts [`AuxData`] for the given block.
-    pub fn put_aux_data(&self, block: L1BlockCommitment, data: AuxData) -> DbResult<()> {
+    pub fn put_aux_data_blocking(&self, block: L1BlockCommitment, data: AuxData) -> DbResult<()> {
         self.ops.put_aux_data_blocking(block, data)
     }
 
     /// Returns [`AuxData`] that corresponds to passed block.
-    pub fn get_aux_data(&self, block: L1BlockCommitment) -> DbResult<Option<AuxData>> {
+    pub fn get_aux_data_blocking(&self, block: L1BlockCommitment) -> DbResult<Option<AuxData>> {
         self.ops.get_aux_data_blocking(block)
     }
 }

--- a/crates/storage/src/managers/asm.rs
+++ b/crates/storage/src/managers/asm.rs
@@ -25,8 +25,17 @@ impl AsmStateManager {
     }
 
     /// Returns [`AsmState`] that corresponds to the "highest" block.
-    pub fn fetch_most_recent_state(&self) -> DbResult<Option<(L1BlockCommitment, AsmState)>> {
+    pub fn fetch_most_recent_state_blocking(
+        &self,
+    ) -> DbResult<Option<(L1BlockCommitment, AsmState)>> {
         self.ops.get_latest_asm_state_blocking()
+    }
+
+    /// Returns [`AsmState`] that corresponds to the "highest" block.
+    pub async fn fetch_most_recent_state_async(
+        &self,
+    ) -> DbResult<Option<(L1BlockCommitment, AsmState)>> {
+        self.ops.get_latest_asm_state_async().await
     }
 
     /// Returns [`AsmState`] that corresponds to passed block.


### PR DESCRIPTION
## Description

`get_checkpoint_info` compared the persisted checkpoint observation height against `L1Status.cur_height`, which starts at 0 on restart and lags reader progress. Spurious "L1 tip below observed height" errors followed.

Switch the source to the latest persisted ASM state. It survives restarts and advances in lockstep with the checkpoint observation, so `tip >= observed_height` holds by construction.

This PR was created with help from Claude Code and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3672](https://alpenlabs.atlassian.net/browse/STR-3672)

[STR-3672]: https://alpenlabs.atlassian.net/browse/STR-3672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ