### PR TITLE
fix(alpen-client): publish finalized-only OL tracker updates

### DIFF
--- a/crates/alpen-ee/ol-tracker/src/service.rs
+++ b/crates/alpen-ee/ol-tracker/src/service.rs
@@ -16,7 +16,7 @@ use crate::{
     error::OLTrackerError,
     reorg::handle_reorg,
     state::OLTrackerState,
-    task::{handle_extend_ee_state, track_ol_state, TrackOLAction},
+    task::{handle_extend_ee_state, handle_refresh_finalized, track_ol_state, TrackOLAction},
 };
 
 /// OL tracker service marker type.
@@ -120,6 +120,19 @@ where
                 debug!(?epoch_operations, ?chain_status, "received track action");
                 if let Err(error) = handle_extend_ee_state(
                     &epoch_operations,
+                    &chain_status,
+                    &mut state.tracker_state,
+                    state.storage.as_ref(),
+                )
+                .await
+                {
+                    return handle_tracker_error(error);
+                }
+                state.notify_watchers();
+            }
+            Ok(TrackOLAction::RefreshFinalized(chain_status)) => {
+                debug!(?chain_status, "received finalized refresh action");
+                if let Err(error) = handle_refresh_finalized(
                     &chain_status,
                     &mut state.tracker_state,
                     state.storage.as_ref(),

--- a/crates/alpen-ee/ol-tracker/src/state.rs
+++ b/crates/alpen-ee/ol-tracker/src/state.rs
@@ -25,6 +25,11 @@ impl OLTrackerState {
 }
 
 impl OLTrackerState {
+    /// Returns the confirmed EE account state.
+    pub(crate) fn best_account_state(&self) -> &EeAccountStateAtEpoch {
+        &self.confirmed
+    }
+
     /// Returns the best EE account state.
     pub fn best_ee_state(&self) -> &EeAccountState {
         self.confirmed.ee_state()
@@ -33,6 +38,11 @@ impl OLTrackerState {
     /// Returns the best OL block commitment.
     pub fn best_ol_epoch(&self) -> &EpochCommitment {
         self.confirmed.epoch_commitment()
+    }
+
+    /// Returns the finalized OL epoch commitment.
+    pub(crate) fn finalized_ol_epoch(&self) -> &EpochCommitment {
+        self.finalized.epoch_commitment()
     }
 
     /// Returns the consensus heads derived from confirmed and finalized states.

--- a/crates/alpen-ee/ol-tracker/src/task.rs
+++ b/crates/alpen-ee/ol-tracker/src/task.rs
@@ -26,6 +26,8 @@ pub(crate) enum TrackOLAction {
     /// Extend local view of the OL chain with new epochs.
     /// TODO: stream
     Extend(Vec<OLEpochOperations>, Box<OLChainStatus>),
+    /// Refresh local finality state without extending the confirmed epoch.
+    RefreshFinalized(Box<OLChainStatus>),
     /// Local tip not present in OL chain, need to resolve local view.
     Reorg,
     /// Local tip is synced with OL chain, nothing to do.
@@ -87,6 +89,10 @@ pub(crate) async fn track_ol_state(
                 "detect chain mismatch; trigger reorg"
             );
             return Ok(TrackOLAction::Reorg);
+        } else if effective_ol_status.finalized().epoch() > state.finalized_ol_epoch().epoch() {
+            return Ok(TrackOLAction::RefreshFinalized(Box::new(
+                effective_ol_status,
+            )));
         } else {
             // local view is in sync with OL, nothing to do
             return Ok(TrackOLAction::Noop);
@@ -170,6 +176,17 @@ pub(crate) fn apply_epoch_operations(
         .map_err(|e| OLTrackerError::Other(e.to_string()))?;
     }
 
+    Ok(())
+}
+
+pub(crate) async fn handle_refresh_finalized<TStorage: Storage>(
+    chain_status: &OLChainStatus,
+    state: &mut OLTrackerState,
+    storage: &TStorage,
+) -> Result<()> {
+    let next_state =
+        build_tracker_state(state.best_account_state().clone(), chain_status, storage).await?;
+    *state = next_state;
     Ok(())
 }
 
@@ -310,6 +327,43 @@ mod tests {
                 .unwrap();
 
             assert!(matches!(result, TrackOLAction::Noop));
+        }
+
+        #[tokio::test]
+        async fn test_refresh_finalized_when_confirmed_is_synced() {
+            // Scenario: Local chain already tracks the confirmed epoch, but
+            // the OL finalized epoch advances after L1 depth catches up.
+            // Expected:       RefreshFinalized so watchers learn the new
+            // finalized OL block without waiting for the next checkpoint.
+
+            let chain = create_epochs(&[100, 101, 102, 103]);
+            let state = OLTrackerState::new(chain[3].clone(), chain[0].clone());
+
+            let mut mock_client = MockOLClient::new();
+
+            mock_client.expect_chain_status().times(1).returning(|| {
+                Ok(OLChainStatus {
+                    tip: make_block_commitment(31, 104),
+                    confirmed: make_epoch_commitment(3, 30, 103),
+                    finalized: make_epoch_commitment(3, 30, 103),
+                    latest: make_epoch_commitment(3, 30, 103),
+                })
+            });
+
+            let result = track_ol_state(&state, &mock_client, 10, EpochTrackingMode::Confirmed)
+                .await
+                .unwrap();
+
+            match result {
+                TrackOLAction::RefreshFinalized(status) => {
+                    assert_eq!(status.finalized.epoch(), 3);
+                    assert_eq!(
+                        status.finalized.last_blkid(),
+                        chain[3].epoch_commitment().last_blkid()
+                    );
+                }
+                _ => panic!("Expected RefreshFinalized action"),
+            }
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Description

Fixes STR-3634 by making the Alpen EE OL tracker notify watchers when only the finalized OL epoch advances while the confirmed epoch is already synced.

Previously, `track_ol_state` treated this as a no-op. That meant the Alpen block builder did not observe the finalized checkpoint transition that should make a deposit mintable, so funds were only minted after a later confirmed checkpoint woke the tracker again.

This PR:

- adds a finalized-only tracker refresh path
- publishes watcher updates after finalized-only refreshes

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

AI was used to debug staging and help address the fix.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3634
