### PR TITLE
feat(ee/sequencer): add composable batch sealing with gas-limit policy

### DIFF
--- a/bin/alpen-client/src/gas_data_provider.rs
+++ b/bin/alpen-client/src/gas_data_provider.rs
@@ -1,0 +1,36 @@
+//! [`RethGasDataProvider`] — Reth-backed [`BlockDataProvider`] for gas-limit
+//! batch sealing.
+
+use alloy_consensus::BlockHeader;
+use alpen_ee_sequencer::{BlockDataProvider, GasBlockData, GasLimitPolicy};
+use async_trait::async_trait;
+use reth_provider::HeaderProvider;
+use strata_acct_types::Hash;
+
+/// Data provider that reads `gas_used` from reth block headers.
+#[derive(Debug)]
+pub(crate) struct RethGasDataProvider<P> {
+    provider: P,
+}
+
+impl<P> RethGasDataProvider<P> {
+    pub(crate) fn new(provider: P) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl<P> BlockDataProvider<GasLimitPolicy> for RethGasDataProvider<P>
+where
+    P: HeaderProvider + Send + Sync,
+{
+    async fn get_block_data(&self, hash: Hash) -> eyre::Result<Option<GasBlockData>> {
+        let block_hash = hash.0.into();
+        let Some(header) = self.provider.header(block_hash)? else {
+            return Ok(None);
+        };
+        Ok(Some(GasBlockData {
+            gas_used: header.gas_used(),
+        }))
+    }
+}

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -1,6 +1,8 @@
 //! Reth node for the Alpen codebase.
 
 mod dummy_ol_client;
+#[cfg(feature = "sequencer")]
+mod gas_data_provider;
 mod genesis;
 mod gossip;
 #[cfg(feature = "sequencer")]
@@ -481,8 +483,12 @@ fn main() {
                 use alpen_ee_sequencer::{
                     backfill_missing_chunk_witnesses, chunk_witness_channel, chunk_witness_task,
                     create_batch_builder, create_batch_lifecycle_task,
-                    create_update_submitter_task, BlockCountDataProvider, FixedBlockCountSealing,
+                    create_update_submitter_task, BlockCountDataProvider, ComposedDataProvider,
+                    FixedBlockCountSealing, MaxGasSealing, OrSealing,
                 };
+
+                use crate::gas_data_provider::RethGasDataProvider;
+
                 let payload_engine = Arc::new(AlpenRethPayloadEngine::new(
                     node.payload_builder_handle.clone(),
                     node.beacon_engine_handle.clone(),
@@ -507,9 +513,17 @@ fn main() {
 
                 let (latest_batch, _) = require_latest_batch(storage.as_ref()).await?;
 
-                let batch_sealing_policy =
-                    FixedBlockCountSealing::new(ext.batch_sealing_block_count);
-                let block_data_provider = Arc::new(BlockCountDataProvider);
+                // u64::MAX effectively disables the gas policy while keeping a
+                // single monomorphic code path (no dyn / enum branching).
+                let batch_gas_limit = ext.batch_sealing_gas_limit.unwrap_or(u64::MAX);
+                let batch_sealing_policy = OrSealing::new(
+                    FixedBlockCountSealing::new(ext.batch_sealing_block_count),
+                    MaxGasSealing::new(batch_gas_limit),
+                );
+                let block_data_provider = Arc::new(ComposedDataProvider::new(
+                    BlockCountDataProvider,
+                    RethGasDataProvider::new(node.provider.clone()),
+                ));
 
                 // Chunk-spanning witness extractor. Single producer of
                 // `ChunkWitnessRecord`: the background `chunk_witness_task`
@@ -1022,6 +1036,13 @@ pub struct AdditionalConfig {
     /// Lower values seal batches more frequently (useful for testing).
     #[arg(long, default_value = "100")]
     pub batch_sealing_block_count: u64,
+
+    /// Cumulative gas limit per batch before sealing.
+    /// When set, a batch is sealed when either the block count or the gas
+    /// limit is reached (whichever comes first). When omitted, only the
+    /// block count policy is used.
+    #[arg(long, required = false)]
+    pub batch_sealing_gas_limit: Option<u64>,
 
     /// Bridge denomination in satoshis (1 BTC default).
     #[arg(long, default_value_t = DEFAULT_DENOMINATION_SATS)]

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -513,6 +513,25 @@ fn main() {
 
                 let (latest_batch, _) = require_latest_batch(storage.as_ref()).await?;
 
+                // Validate --batch-sealing-gas-limit if configured.
+                //
+                // EIP-1559 lets the per-block gas limit drift from genesis by
+                // ±1/1024 per block, so the actual block gas limit at runtime
+                // may be slightly higher than genesis. We use 2× the genesis
+                // gas limit as a conservative floor to accommodate this drift
+                // while still catching obvious misconfigurations.
+                if let Some(configured) = ext.batch_sealing_gas_limit {
+                    let min_batch_gas = ext.custom_chain.genesis().gas_limit.saturating_mul(2);
+                    eyre::ensure!(
+                        configured >= min_batch_gas,
+                        "--batch-sealing-gas-limit ({configured}) is below the minimum \
+                         ({min_batch_gas}, 2× genesis block gas limit {}). A single block \
+                         can use up to the per-block gas limit, so the batch budget must \
+                         be large enough to always fit at least one block.",
+                        ext.custom_chain.genesis().gas_limit,
+                    );
+                }
+
                 // u64::MAX effectively disables the gas policy while keeping a
                 // single monomorphic code path (no dyn / enum branching).
                 let batch_gas_limit = ext.batch_sealing_gas_limit.unwrap_or(u64::MAX);

--- a/crates/alpen-ee/sequencer/src/batch_builder/accumulator.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/accumulator.rs
@@ -2,7 +2,7 @@
 
 use alpen_ee_common::BlockNumHash;
 
-use super::BatchPolicy;
+use super::{BatchPolicy, BatchSealingPolicy};
 
 /// Accumulates blocks and policy-specific value for the pending batch.
 #[derive(Debug)]
@@ -60,6 +60,15 @@ impl<P: BatchPolicy> Accumulator<P> {
     /// Access the accumulated value.
     pub fn value(&self) -> &P::AccumulatedValue {
         &self.value
+    }
+
+    /// Check if adding a block would exceed the sealing policy threshold.
+    pub fn would_exceed(
+        &self,
+        policy: &impl BatchSealingPolicy<P>,
+        block_data: &P::BlockData,
+    ) -> bool {
+        policy.would_exceed(self.value(), block_data)
     }
 
     /// Reset accumulator for a new batch.

--- a/crates/alpen-ee/sequencer/src/batch_builder/block_count.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/block_count.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use strata_acct_types::Hash;
 
-use super::{Accumulator, BatchPolicy, BatchSealingPolicy, BlockDataProvider};
+use super::{BatchPolicy, BatchSealingPolicy, BlockDataProvider};
 
 /// Block-count based batching policy.
 #[derive(Debug)]
@@ -11,24 +11,23 @@ pub struct BlockCountPolicy;
 
 /// Block data for block-count policy.
 ///
-/// No additional data is needed since the count is tracked by the
-/// accumulator's block list.
+/// No additional data is needed; each block increments the count by one.
 #[derive(Debug, Clone, Default)]
 pub struct BlockCountData;
 
-/// Accumulated value for block-count policy.
-///
-/// This is a unit type since the block count is tracked by
-/// `Accumulator::block_count()` directly.
+/// Accumulated block count.
 #[derive(Debug, Default)]
-pub struct BlockCountValue;
+pub struct BlockCountValue {
+    /// Number of blocks accumulated so far.
+    pub count: u64,
+}
 
 impl BatchPolicy for BlockCountPolicy {
     type BlockData = BlockCountData;
     type AccumulatedValue = BlockCountValue;
 
-    fn accumulate(_value: &mut Self::AccumulatedValue, _data: &Self::BlockData) {
-        // No-op: block count is tracked by Accumulator::blocks.len()
+    fn accumulate(value: &mut Self::AccumulatedValue, _data: &Self::BlockData) {
+        value.count += 1;
     }
 }
 
@@ -57,13 +56,9 @@ impl FixedBlockCountSealing {
 }
 
 impl BatchSealingPolicy<BlockCountPolicy> for FixedBlockCountSealing {
-    fn would_exceed(
-        &self,
-        accumulator: &Accumulator<BlockCountPolicy>,
-        _block_data: &BlockCountData,
-    ) -> bool {
-        // Seal if we've already reached max_blocks
-        accumulator.block_count() >= self.max_blocks
+    fn would_exceed(&self, value: &BlockCountValue, _block_data: &BlockCountData) -> bool {
+        // Each block contributes exactly 1 to the count.
+        value.count + 1 > self.max_blocks
     }
 }
 
@@ -84,14 +79,14 @@ impl BlockDataProvider<BlockCountPolicy> for BlockCountDataProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::*;
+    use crate::{batch_builder::Accumulator, test_utils::*};
 
     #[test]
     fn test_would_not_exceed_when_empty() {
         let sealing = FixedBlockCountSealing::new(3);
         let accumulator: Accumulator<BlockCountPolicy> = Accumulator::new();
 
-        assert!(!sealing.would_exceed(&accumulator, &BlockCountData));
+        assert!(!accumulator.would_exceed(&sealing, &BlockCountData));
     }
 
     #[test]
@@ -99,15 +94,29 @@ mod tests {
         let sealing = FixedBlockCountSealing::new(3);
         let mut accumulator: Accumulator<BlockCountPolicy> = Accumulator::new();
 
+        // 0 + 1 = 1 <= 3
         accumulator.add_block(test_blocknumhash(1), &BlockCountData);
-        assert!(!sealing.would_exceed(&accumulator, &BlockCountData));
+        assert!(!accumulator.would_exceed(&sealing, &BlockCountData));
 
+        // 1 + 1 = 2 <= 3
         accumulator.add_block(test_blocknumhash(2), &BlockCountData);
-        assert!(!sealing.would_exceed(&accumulator, &BlockCountData));
+        assert!(!accumulator.would_exceed(&sealing, &BlockCountData));
     }
 
     #[test]
-    fn test_would_exceed_at_max() {
+    fn test_would_not_exceed_at_exact_max() {
+        let sealing = FixedBlockCountSealing::new(3);
+        let mut accumulator: Accumulator<BlockCountPolicy> = Accumulator::new();
+
+        accumulator.add_block(test_blocknumhash(1), &BlockCountData);
+        accumulator.add_block(test_blocknumhash(2), &BlockCountData);
+
+        // 2 + 1 = 3 <= 3, batch of exactly max_blocks is allowed
+        assert!(!accumulator.would_exceed(&sealing, &BlockCountData));
+    }
+
+    #[test]
+    fn test_would_exceed_past_max() {
         let sealing = FixedBlockCountSealing::new(3);
         let mut accumulator: Accumulator<BlockCountPolicy> = Accumulator::new();
 
@@ -115,8 +124,8 @@ mod tests {
         accumulator.add_block(test_blocknumhash(2), &BlockCountData);
         accumulator.add_block(test_blocknumhash(3), &BlockCountData);
 
-        // Now at 3 blocks, adding another would exceed
-        assert!(sealing.would_exceed(&accumulator, &BlockCountData));
+        // 3 + 1 = 4 > 3, seal before adding the 4th
+        assert!(accumulator.would_exceed(&sealing, &BlockCountData));
     }
 
     #[test]

--- a/crates/alpen-ee/sequencer/src/batch_builder/gas_limit.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/gas_limit.rs
@@ -1,0 +1,125 @@
+//! Gas-limit based batching policy implementation.
+//!
+//! Seals a batch when the cumulative gas used across blocks reaches a
+//! configured maximum.
+
+use super::{BatchPolicy, BatchSealingPolicy};
+
+/// Gas-limit based batching policy.
+#[derive(Debug)]
+pub struct GasLimitPolicy;
+
+/// Per-block gas data.
+#[derive(Debug, Clone)]
+pub struct GasBlockData {
+    /// Gas used by this block.
+    pub gas_used: u64,
+}
+
+/// Accumulated gas across blocks in the pending batch.
+#[derive(Debug, Default)]
+pub struct GasValue {
+    /// Total gas used so far.
+    pub total_gas: u64,
+}
+
+impl BatchPolicy for GasLimitPolicy {
+    type BlockData = GasBlockData;
+    type AccumulatedValue = GasValue;
+
+    fn accumulate(value: &mut GasValue, data: &GasBlockData) {
+        value.total_gas += data.gas_used;
+    }
+}
+
+/// Seals a batch when cumulative gas reaches the configured limit.
+#[derive(Debug)]
+pub struct MaxGasSealing {
+    max_gas: u64,
+}
+
+impl MaxGasSealing {
+    /// Create a new max-gas sealing policy.
+    pub fn new(max_gas: u64) -> Self {
+        Self { max_gas }
+    }
+
+    /// Get the gas limit.
+    pub fn max_gas(&self) -> u64 {
+        self.max_gas
+    }
+}
+
+impl BatchSealingPolicy<GasLimitPolicy> for MaxGasSealing {
+    fn would_exceed(&self, value: &GasValue, data: &GasBlockData) -> bool {
+        value.total_gas + data.gas_used > self.max_gas
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{batch_builder::Accumulator, test_utils::*};
+
+    #[test]
+    fn test_accumulates_gas() {
+        let mut acc: Accumulator<GasLimitPolicy> = Accumulator::new();
+
+        acc.add_block(test_blocknumhash(1), &GasBlockData { gas_used: 100 });
+        acc.add_block(test_blocknumhash(2), &GasBlockData { gas_used: 200 });
+
+        assert_eq!(acc.value().total_gas, 300);
+    }
+
+    #[test]
+    fn test_would_not_exceed_below_limit() {
+        let sealing = MaxGasSealing::new(1000);
+        let mut acc: Accumulator<GasLimitPolicy> = Accumulator::new();
+
+        // 500 + 400 = 900 <= 1000
+        acc.add_block(test_blocknumhash(1), &GasBlockData { gas_used: 500 });
+        assert!(!acc.would_exceed(&sealing, &GasBlockData { gas_used: 400 }));
+    }
+
+    #[test]
+    fn test_would_not_exceed_at_exact_limit() {
+        let sealing = MaxGasSealing::new(1000);
+        let mut acc: Accumulator<GasLimitPolicy> = Accumulator::new();
+
+        // 500 + 500 = 1000 <= 1000, batch of exactly max_gas is allowed
+        acc.add_block(test_blocknumhash(1), &GasBlockData { gas_used: 500 });
+        assert!(!acc.would_exceed(&sealing, &GasBlockData { gas_used: 500 }));
+    }
+
+    #[test]
+    fn test_would_exceed_past_limit() {
+        let sealing = MaxGasSealing::new(1000);
+        let mut acc: Accumulator<GasLimitPolicy> = Accumulator::new();
+
+        // 500 + 501 = 1001 > 1000, seal before adding this block
+        acc.add_block(test_blocknumhash(1), &GasBlockData { gas_used: 500 });
+        assert!(acc.would_exceed(&sealing, &GasBlockData { gas_used: 501 }));
+    }
+
+    #[test]
+    fn test_single_block_exceeding_limit_seals_empty_batch() {
+        let sealing = MaxGasSealing::new(1000);
+        let acc: Accumulator<GasLimitPolicy> = Accumulator::new();
+
+        // 0 + 1500 = 1500 > 1000, but accumulator is empty so the
+        // caller's `!is_empty()` guard prevents sealing an empty batch.
+        // The block still gets added. This test documents that the
+        // sealing check itself returns true.
+        assert!(acc.would_exceed(&sealing, &GasBlockData { gas_used: 1500 }));
+    }
+
+    #[test]
+    fn test_resets_after_drain() {
+        let mut acc: Accumulator<GasLimitPolicy> = Accumulator::new();
+
+        acc.add_block(test_blocknumhash(1), &GasBlockData { gas_used: 999 });
+        acc.drain_for_batch();
+
+        assert_eq!(acc.value().total_gas, 0);
+    }
+}

--- a/crates/alpen-ee/sequencer/src/batch_builder/mod.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/mod.rs
@@ -70,7 +70,9 @@ mod accumulator;
 mod block_count;
 mod canonical;
 mod ctx;
+mod gas_limit;
 mod handle;
+mod or_policy;
 mod reorg;
 mod state;
 mod task;
@@ -81,6 +83,8 @@ pub use block_count::{
     BlockCountData, BlockCountDataProvider, BlockCountPolicy, BlockCountValue,
     FixedBlockCountSealing,
 };
+pub use gas_limit::{GasBlockData, GasLimitPolicy, GasValue, MaxGasSealing};
 pub use handle::{create_batch_builder, BatchBuilderHandle};
+pub use or_policy::{ComposedDataProvider, ComposedPolicy, OrSealing};
 pub use state::{init_batch_builder_state, BatchBuilderState};
 pub use traits::{BatchPolicy, BatchSealingPolicy, BlockDataProvider};

--- a/crates/alpen-ee/sequencer/src/batch_builder/or_policy.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/or_policy.rs
@@ -1,0 +1,218 @@
+//! Combinators for composing batch policies and sealing strategies.
+//!
+//! [`ComposedPolicy`] pairs two [`BatchPolicy`] types into one whose block data
+//! and accumulated value are tuples of the inner types. Sealing combinators
+//! like [`OrSealing`] define how the two halves are checked.
+//! [`ComposedDataProvider`] fetches block data from both inner providers.
+
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use strata_acct_types::Hash;
+
+use super::{BatchPolicy, BatchSealingPolicy, BlockDataProvider};
+
+/// Composed batch policy that pairs two inner policies.
+///
+/// `BlockData` is `(A::BlockData, B::BlockData)` and `AccumulatedValue` is
+/// `(A::AccumulatedValue, B::AccumulatedValue)`. Each half is accumulated
+/// independently.
+#[derive(Debug)]
+pub struct ComposedPolicy<A: BatchPolicy, B: BatchPolicy>(PhantomData<(A, B)>);
+
+impl<A: BatchPolicy, B: BatchPolicy> BatchPolicy for ComposedPolicy<A, B> {
+    type BlockData = (A::BlockData, B::BlockData);
+    type AccumulatedValue = (A::AccumulatedValue, B::AccumulatedValue);
+
+    fn accumulate(value: &mut Self::AccumulatedValue, data: &Self::BlockData) {
+        A::accumulate(&mut value.0, &data.0);
+        B::accumulate(&mut value.1, &data.1);
+    }
+}
+
+/// Seals a batch when **either** of two sealing policies triggers.
+///
+/// Both `SA` and `SB` operate on their respective projected half of the
+/// composed accumulated value.
+#[derive(Debug)]
+pub struct OrSealing<A: BatchPolicy, B: BatchPolicy, SA, SB> {
+    a: SA,
+    b: SB,
+    _marker: PhantomData<(A, B)>,
+}
+
+impl<A, B, SA, SB> OrSealing<A, B, SA, SB>
+where
+    A: BatchPolicy,
+    B: BatchPolicy,
+    SA: BatchSealingPolicy<A>,
+    SB: BatchSealingPolicy<B>,
+{
+    /// Create a new OR-combined sealing policy.
+    pub fn new(a: SA, b: SB) -> Self {
+        Self {
+            a,
+            b,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<A, B, SA, SB> BatchSealingPolicy<ComposedPolicy<A, B>> for OrSealing<A, B, SA, SB>
+where
+    A: BatchPolicy,
+    B: BatchPolicy,
+    SA: BatchSealingPolicy<A>,
+    SB: BatchSealingPolicy<B>,
+{
+    fn would_exceed(
+        &self,
+        value: &(A::AccumulatedValue, B::AccumulatedValue),
+        block_data: &(A::BlockData, B::BlockData),
+    ) -> bool {
+        self.a.would_exceed(&value.0, &block_data.0) || self.b.would_exceed(&value.1, &block_data.1)
+    }
+}
+
+/// Composed data provider that fetches block data from two inner providers.
+#[derive(Debug)]
+pub struct ComposedDataProvider<A: BatchPolicy, B: BatchPolicy, DA, DB> {
+    a: DA,
+    b: DB,
+    _marker: PhantomData<(A, B)>,
+}
+
+impl<A, B, DA, DB> ComposedDataProvider<A, B, DA, DB>
+where
+    A: BatchPolicy,
+    B: BatchPolicy,
+    DA: BlockDataProvider<A>,
+    DB: BlockDataProvider<B>,
+{
+    /// Create a new composed data provider.
+    pub fn new(a: DA, b: DB) -> Self {
+        Self {
+            a,
+            b,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<A, B, DA, DB> BlockDataProvider<ComposedPolicy<A, B>> for ComposedDataProvider<A, B, DA, DB>
+where
+    A: BatchPolicy,
+    B: BatchPolicy,
+    DA: BlockDataProvider<A>,
+    DB: BlockDataProvider<B>,
+{
+    async fn get_block_data(
+        &self,
+        hash: Hash,
+    ) -> eyre::Result<Option<(A::BlockData, B::BlockData)>> {
+        let (a, b) = tokio::try_join!(self.a.get_block_data(hash), self.b.get_block_data(hash))?;
+        Ok(a.zip(b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        batch_builder::{
+            block_count::{BlockCountData, BlockCountPolicy, FixedBlockCountSealing},
+            gas_limit::{GasBlockData, GasLimitPolicy, MaxGasSealing},
+            Accumulator,
+        },
+        test_utils::*,
+    };
+
+    type Combined = ComposedPolicy<BlockCountPolicy, GasLimitPolicy>;
+
+    fn block_data(gas: u64) -> (BlockCountData, GasBlockData) {
+        (BlockCountData, GasBlockData { gas_used: gas })
+    }
+
+    #[test]
+    fn test_seals_on_block_count() {
+        // max 2 blocks, high gas limit
+        let sealing = OrSealing::new(FixedBlockCountSealing::new(2), MaxGasSealing::new(10_000));
+        let mut acc: Accumulator<Combined> = Accumulator::new();
+
+        // 1 accumulated + 1 incoming = 2 <= 2, no seal
+        acc.add_block(test_blocknumhash(1), &block_data(10));
+        assert!(!acc.would_exceed(&sealing, &block_data(10)));
+
+        // 2 accumulated + 1 incoming = 3 > 2, seal on count
+        acc.add_block(test_blocknumhash(2), &block_data(10));
+        assert!(acc.would_exceed(&sealing, &block_data(10)));
+    }
+
+    #[test]
+    fn test_seals_on_gas() {
+        // high block count, max 50 gas
+        let sealing = OrSealing::new(FixedBlockCountSealing::new(100), MaxGasSealing::new(50));
+        let mut acc: Accumulator<Combined> = Accumulator::new();
+
+        // 0 + 40 = 40 <= 50, no seal
+        assert!(!acc.would_exceed(&sealing, &block_data(40)));
+
+        // 40 accumulated + 20 incoming = 60 > 50, seal on gas
+        acc.add_block(test_blocknumhash(1), &block_data(40));
+        assert!(acc.would_exceed(&sealing, &block_data(20)));
+    }
+
+    #[test]
+    fn test_neither_seals() {
+        let sealing = OrSealing::new(FixedBlockCountSealing::new(100), MaxGasSealing::new(1000));
+        let mut acc: Accumulator<Combined> = Accumulator::new();
+
+        // 0 + 1 = 1 block (<< 100), 0 + 10 = 10 gas (<< 1000)
+        acc.add_block(test_blocknumhash(1), &block_data(10));
+        assert!(!acc.would_exceed(&sealing, &block_data(10)));
+    }
+
+    /// When gas limit is `u64::MAX` the gas policy never fires, so only
+    /// block count matters. This mirrors the production path when
+    /// `--batch-sealing-gas-limit` is omitted.
+    #[test]
+    fn test_gas_disabled_via_max() {
+        let sealing = OrSealing::new(FixedBlockCountSealing::new(3), MaxGasSealing::new(u64::MAX));
+        let mut acc: Accumulator<Combined> = Accumulator::new();
+
+        // Accumulate huge gas — still shouldn't seal until block count exceeds 3
+        acc.add_block(test_blocknumhash(1), &block_data(u64::MAX / 4));
+        acc.add_block(test_blocknumhash(2), &block_data(u64::MAX / 4));
+        // 2 + 1 = 3 <= 3, no seal
+        assert!(!acc.would_exceed(&sealing, &block_data(0)));
+
+        // 3 + 1 = 4 > 3, seal on count
+        acc.add_block(test_blocknumhash(3), &block_data(0));
+        assert!(acc.would_exceed(&sealing, &block_data(0)));
+    }
+
+    /// After draining the accumulator (sealing a batch), both halves of the
+    /// composed value reset so the next batch starts fresh.
+    #[test]
+    fn test_drain_resets_both_values() {
+        let sealing = OrSealing::new(FixedBlockCountSealing::new(2), MaxGasSealing::new(100));
+        let mut acc: Accumulator<Combined> = Accumulator::new();
+
+        acc.add_block(test_blocknumhash(1), &block_data(80));
+        acc.add_block(test_blocknumhash(2), &block_data(80));
+
+        // count: 2 + 1 = 3 > 2, gas: 160 + 10 = 170 > 100 — both would seal
+        assert!(acc.would_exceed(&sealing, &block_data(10)));
+
+        // Drain (seal the batch)
+        let (inner, last) = acc.drain_for_batch();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(last, test_blocknumhash(2));
+
+        // After drain, both counters are zero — neither policy seals
+        assert!(!acc.would_exceed(&sealing, &block_data(0)));
+        assert_eq!(acc.value().0.count, 0);
+        assert_eq!(acc.value().1.total_gas, 0);
+    }
+}

--- a/crates/alpen-ee/sequencer/src/batch_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/task.rs
@@ -323,9 +323,9 @@ where
 
         // Check if adding this block would exceed threshold
         if !state.accumulator().is_empty()
-            && ctx
-                .sealing_policy
-                .would_exceed(state.accumulator(), &block_data)
+            && state
+                .accumulator()
+                .would_exceed(&ctx.sealing_policy, &block_data)
         {
             if let Some(batch_id) = seal_batch(
                 state,

--- a/crates/alpen-ee/sequencer/src/batch_builder/traits.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/traits.rs
@@ -5,8 +5,6 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use strata_acct_types::Hash;
 
-use super::Accumulator;
-
 /// Core trait that defines the types for a batching strategy.
 ///
 /// The `BatchPolicy` trait allows different batching strategies to be implemented
@@ -38,9 +36,11 @@ pub trait BatchSealingPolicy<P: BatchPolicy>: Send + Sync {
     /// adding this block. The block will then become the first block of
     /// the next batch.
     ///
-    /// This is called with the current accumulator state and the data for
-    /// the block about to be added.
-    fn would_exceed(&self, accumulator: &Accumulator<P>, block_data: &P::BlockData) -> bool;
+    /// # Arguments
+    ///
+    /// * `value` - The accumulated policy-specific value
+    /// * `block_data` - Data for the block about to be added
+    fn would_exceed(&self, value: &P::AccumulatedValue, block_data: &P::BlockData) -> bool;
 }
 
 /// Trait to fetch processed block data for batch sealing.

--- a/crates/alpen-ee/sequencer/src/lib.rs
+++ b/crates/alpen-ee/sequencer/src/lib.rs
@@ -12,7 +12,8 @@ mod update_submitter;
 pub use batch_builder::{
     create_batch_builder, init_batch_builder_state, Accumulator, BatchBuilderHandle,
     BatchBuilderState, BatchPolicy, BatchSealingPolicy, BlockCountData, BlockCountDataProvider,
-    BlockCountPolicy, BlockCountValue, BlockDataProvider, FixedBlockCountSealing,
+    BlockCountPolicy, BlockCountValue, BlockDataProvider, ComposedDataProvider, ComposedPolicy,
+    FixedBlockCountSealing, GasBlockData, GasLimitPolicy, GasValue, MaxGasSealing, OrSealing,
 };
 pub use batch_lifecycle::{
     create_batch_lifecycle_task, init_lifecycle_state, BatchLifecycleHandle, BatchLifecycleState,

--- a/crates/reth/node/src/payload.rs
+++ b/crates/reth/node/src/payload.rs
@@ -22,30 +22,12 @@ pub struct AlpenPayloadAttributes {
     /// Original Ethereum payload attributes
     #[serde(flatten)]
     pub inner: EthPayloadAttributes,
-    // additional custom fields for strata
-    /// Optional cumulative gas limit for blocks
-    pub batch_gas_limit: Option<u64>,
-}
-
-impl AlpenPayloadBuilderAttributes {
-    pub(crate) fn batch_gas_limit(&self) -> Option<u64> {
-        self.batch_gas_limit
-    }
 }
 
 impl AlpenPayloadAttributes {
     pub fn new_from_eth(payload_attributes: EthPayloadAttributes) -> Self {
         Self {
             inner: payload_attributes,
-            // more fields here
-            batch_gas_limit: None,
-        }
-    }
-
-    pub fn new(payload_attributes: EthPayloadAttributes, batch_gas_limit: Option<u64>) -> Self {
-        Self {
-            inner: payload_attributes,
-            batch_gas_limit,
         }
     }
 }
@@ -68,7 +50,6 @@ impl PayloadAttributes for AlpenPayloadAttributes {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AlpenPayloadBuilderAttributes {
     pub(crate) inner: EthPayloadBuilderAttributes,
-    pub(crate) batch_gas_limit: Option<u64>,
 }
 
 impl PayloadBuilderAttributes for AlpenPayloadBuilderAttributes {
@@ -82,7 +63,6 @@ impl PayloadBuilderAttributes for AlpenPayloadBuilderAttributes {
     ) -> Result<Self, Infallible> {
         Ok(Self {
             inner: EthPayloadBuilderAttributes::new(parent, attributes.inner),
-            batch_gas_limit: attributes.batch_gas_limit,
         })
     }
 

--- a/crates/reth/node/src/payload_builder.rs
+++ b/crates/reth/node/src/payload_builder.rs
@@ -180,7 +180,6 @@ where
         attributes,
     } = config;
 
-    let batch_gas_limit = attributes.batch_gas_limit();
     let attributes = attributes.inner;
 
     let state_provider = client.state_by_block_hash(parent_header.hash())?;
@@ -209,10 +208,7 @@ where
 
     debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
     let mut cumulative_gas_used = 0;
-    let env_block_gas_limit: u64 = builder.evm_mut().block().gas_limit;
-    let block_gas_limit = batch_gas_limit
-        .map(|batch_gas_limit| batch_gas_limit.min(env_block_gas_limit))
-        .unwrap_or(env_block_gas_limit);
+    let block_gas_limit: u64 = builder.evm_mut().block().gas_limit;
 
     let base_fee = builder.evm_mut().block().basefee;
 


### PR DESCRIPTION
## Description
Add option to limit total gas consumed in a batch.

- Refactor BatchSealingPolicy to enable generic policy composition.
- Add ComposedPolicy to pair two BatchPolicy types with tuple block data and accumulated values, OrSealing to seal when either policy triggers, and ComposedDataProvider to fetch data from both providers.
- Add GasLimitPolicy that accumulates per-block gas_used and seals when the cumulative gas would exceed a configured limit.
- Add --batch-sealing-gas-limit optional CLI arg. When omitted, gas limit defaults to u64::MAX (effectively block-count only).
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers
1. The previous iteration of batch gas limit worked at the reth block builder level, keeping remaining blocks in the batch empty if the limit was crossed. This one works by sealing batches early, and ensuring no batch exceeds specified limits.
2. If a single oversized block exceeds batch limit by itself (highly improbable and likely a misconfiguration), an oversized batch with the single block will be created.  
3. After #1851 adds chunk sealing policy, this gas limit should be moved to chunk instead of batches, as that will define the prover job size.
4. ~`crates/eectl`, `crates/evmexec` and `crates/sequencer` are no longer being used and should be removed. This PR touches some files there to ensure it builds correctly, but these are not functional.~

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
