### PR TITLE
fix(alpen-ee): avoid invalid finalized forkchoice updates

### DIFF
--- a/crates/alpen-ee/engine/Cargo.toml
+++ b/crates/alpen-ee/engine/Cargo.toml
@@ -12,6 +12,7 @@ alpen-reth-node.workspace = true
 strata-acct-types.workspace = true
 strata-common = { workspace = true, features = ["async"] }
 
+alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 async-trait.workspace = true

--- a/crates/alpen-ee/engine/src/control.rs
+++ b/crates/alpen-ee/engine/src/control.rs
@@ -1,12 +1,13 @@
 use std::future::Future;
 
+use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ForkchoiceState;
 use alpen_ee_common::{BlockNumHash, ConsensusHeads, ExecutionEngine};
 use reth_node_builder::NodeTypesWithDB;
 use reth_provider::{
     providers::{BlockchainProvider, ProviderNodeTypes},
-    BlockHashReader, BlockNumReader, ProviderResult,
+    BlockHashReader, BlockNumReader, HeaderProvider, ProviderResult,
 };
 use tokio::{select, sync::watch};
 use tracing::{error, warn};
@@ -14,6 +15,8 @@ use tracing::{error, warn};
 #[cfg_attr(test, mockall::automock)]
 trait CanonicalChainReader {
     fn is_in_canonical_chain(&self, blockhash: B256) -> ProviderResult<bool>;
+    fn block_number(&self, blockhash: B256) -> ProviderResult<Option<u64>>;
+    fn parent_hash(&self, blockhash: B256) -> ProviderResult<Option<B256>>;
 }
 
 struct RethCanonicalChainReader<'a, N: NodeTypesWithDB + ProviderNodeTypes> {
@@ -30,7 +33,7 @@ impl<'a, N: NodeTypesWithDB + ProviderNodeTypes> CanonicalChainReader
     for RethCanonicalChainReader<'a, N>
 {
     fn is_in_canonical_chain(&self, blockhash: B256) -> ProviderResult<bool> {
-        let Some(block_number) = self.provider.block_number(blockhash)? else {
+        let Some(block_number) = self.block_number(blockhash)? else {
             return Ok(false);
         };
         let Some(canonical_blockhash) = self.provider.block_hash(block_number)? else {
@@ -38,6 +41,45 @@ impl<'a, N: NodeTypesWithDB + ProviderNodeTypes> CanonicalChainReader
         };
         Ok(blockhash == canonical_blockhash)
     }
+
+    fn block_number(&self, blockhash: B256) -> ProviderResult<Option<u64>> {
+        self.provider.block_number(blockhash)
+    }
+
+    fn parent_hash(&self, blockhash: B256) -> ProviderResult<Option<B256>> {
+        Ok(self
+            .provider
+            .header(blockhash)?
+            .map(|header| header.parent_num_hash().hash))
+    }
+}
+
+fn is_ancestor_of(
+    descendant: B256,
+    ancestor: B256,
+    reader: &impl CanonicalChainReader,
+) -> ProviderResult<bool> {
+    let Some(mut current_number) = reader.block_number(descendant)? else {
+        return Ok(false);
+    };
+    let Some(ancestor_number) = reader.block_number(ancestor)? else {
+        return Ok(false);
+    };
+
+    if ancestor_number > current_number {
+        return Ok(false);
+    }
+
+    let mut current_hash = descendant;
+    while current_number > ancestor_number {
+        let Some(parent_hash) = reader.parent_hash(current_hash)? else {
+            return Ok(false);
+        };
+        current_hash = parent_hash;
+        current_number -= 1;
+    }
+
+    Ok(current_hash == ancestor)
 }
 
 fn forkchoice_state_from_consensus_with_reader(
@@ -48,7 +90,8 @@ fn forkchoice_state_from_consensus_with_reader(
     let safe_block_hash = B256::from_slice(consensus_state.confirmed().as_slice());
     let finalized_block_hash = B256::from_slice(consensus_state.finalized().as_slice());
 
-    let head_block_hash = if reader.is_in_canonical_chain(safe_block_hash)? {
+    let switching_to_ol_fork = !reader.is_in_canonical_chain(safe_block_hash)?;
+    let head_block_hash = if !switching_to_ol_fork {
         head_block_hash
     } else {
         // Safe block is not in canonical chain on reth.
@@ -59,15 +102,25 @@ fn forkchoice_state_from_consensus_with_reader(
         safe_block_hash
     };
 
-    let finalized_block_hash =
-        if finalized_block_hash.is_zero() || reader.is_in_canonical_chain(finalized_block_hash)? {
+    let finalized_block_hash = if finalized_block_hash.is_zero() {
+        B256::ZERO
+    } else if switching_to_ol_fork {
+        if is_ancestor_of(head_block_hash, finalized_block_hash, reader)? {
             finalized_block_hash
         } else {
-            // Reth rejects forkchoice updates with a non-canonical finalized hash as
-            // `invalid forkchoice state`. Drop the finalized pointer until this node has
-            // canonicalized the same block locally.
+            // If this update is switching to OL's fork, preserve finalized only when it is
+            // on that chosen fork. A finalized hash from any other branch is inconsistent with
+            // the requested head and still needs to be cleared.
             B256::ZERO
-        };
+        }
+    } else if reader.is_in_canonical_chain(finalized_block_hash)? {
+        finalized_block_hash
+    } else {
+        // Reth rejects forkchoice updates with a non-canonical finalized hash as
+        // `invalid forkchoice state`. Drop the finalized pointer until this node has
+        // canonicalized the same block locally.
+        B256::ZERO
+    };
 
     Ok(ForkchoiceState {
         head_block_hash,
@@ -223,10 +276,20 @@ mod tests {
             .with(eq(b256_from_u8(3)))
             .return_once(|_| Ok(false));
         reader
-            .expect_is_in_canonical_chain()
+            .expect_block_number()
             .once()
             .with(eq(b256_from_u8(4)))
-            .return_once(|_| Ok(true));
+            .return_once(|_| Ok(Some(4)));
+        reader
+            .expect_block_number()
+            .once()
+            .with(eq(b256_from_u8(3)))
+            .return_once(|_| Ok(Some(5)));
+        reader
+            .expect_parent_hash()
+            .once()
+            .with(eq(b256_from_u8(3)))
+            .return_once(|_| Ok(Some(b256_from_u8(4))));
 
         let state =
             forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
@@ -278,6 +341,86 @@ mod tests {
 
         assert_eq!(state.head_block_hash, current_head);
         assert_eq!(state.safe_block_hash, b256_from_u8(7));
+        assert_eq!(state.finalized_block_hash, B256::ZERO);
+    }
+
+    #[test]
+    fn forkchoice_keeps_noncanonical_finalized_when_switching_to_same_ol_fork() {
+        let mut reader = MockCanonicalChainReader::new();
+        let heads = consensus_heads(8, 6);
+        let current_head = b256_from_u8(9);
+
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(8)))
+            .return_once(|_| Ok(false));
+        reader
+            .expect_block_number()
+            .once()
+            .with(eq(b256_from_u8(8)))
+            .return_once(|_| Ok(Some(8)));
+        reader
+            .expect_block_number()
+            .once()
+            .with(eq(b256_from_u8(6)))
+            .return_once(|_| Ok(Some(6)));
+        reader
+            .expect_parent_hash()
+            .once()
+            .with(eq(b256_from_u8(8)))
+            .return_once(|_| Ok(Some(b256_from_u8(7))));
+        reader
+            .expect_parent_hash()
+            .once()
+            .with(eq(b256_from_u8(7)))
+            .return_once(|_| Ok(Some(b256_from_u8(6))));
+
+        let state =
+            forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
+
+        assert_eq!(state.head_block_hash, b256_from_u8(8));
+        assert_eq!(state.safe_block_hash, b256_from_u8(8));
+        assert_eq!(state.finalized_block_hash, b256_from_u8(6));
+    }
+
+    #[test]
+    fn forkchoice_drops_finalized_from_different_noncanonical_fork() {
+        let mut reader = MockCanonicalChainReader::new();
+        let heads = consensus_heads(8, 5);
+        let current_head = b256_from_u8(9);
+
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(8)))
+            .return_once(|_| Ok(false));
+        reader
+            .expect_block_number()
+            .once()
+            .with(eq(b256_from_u8(8)))
+            .return_once(|_| Ok(Some(8)));
+        reader
+            .expect_block_number()
+            .once()
+            .with(eq(b256_from_u8(5)))
+            .return_once(|_| Ok(Some(6)));
+        reader
+            .expect_parent_hash()
+            .once()
+            .with(eq(b256_from_u8(8)))
+            .return_once(|_| Ok(Some(b256_from_u8(7))));
+        reader
+            .expect_parent_hash()
+            .once()
+            .with(eq(b256_from_u8(7)))
+            .return_once(|_| Ok(Some(b256_from_u8(6))));
+
+        let state =
+            forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
+
+        assert_eq!(state.head_block_hash, b256_from_u8(8));
+        assert_eq!(state.safe_block_hash, b256_from_u8(8));
         assert_eq!(state.finalized_block_hash, B256::ZERO);
     }
 }

--- a/crates/alpen-ee/engine/src/control.rs
+++ b/crates/alpen-ee/engine/src/control.rs
@@ -11,29 +11,44 @@ use reth_provider::{
 use tokio::{select, sync::watch};
 use tracing::{error, warn};
 
-/// Check if `blockhash` is in canonical chain provided by [`BlockchainProvider`].
-fn is_in_canonical_chain<N: NodeTypesWithDB + ProviderNodeTypes>(
-    blockhash: B256,
-    provider: &BlockchainProvider<N>,
-) -> ProviderResult<bool> {
-    let Some(block_number) = provider.block_number(blockhash)? else {
-        return Ok(false);
-    };
-    let Some(canonical_blockhash) = provider.block_hash(block_number)? else {
-        return Ok(false);
-    };
-    Ok(blockhash == canonical_blockhash)
+#[cfg_attr(test, mockall::automock)]
+trait CanonicalChainReader {
+    fn is_in_canonical_chain(&self, blockhash: B256) -> ProviderResult<bool>;
 }
 
-fn forkchoice_state_from_consensus<N: NodeTypesWithDB + ProviderNodeTypes>(
+struct RethCanonicalChainReader<'a, N: NodeTypesWithDB + ProviderNodeTypes> {
+    provider: &'a BlockchainProvider<N>,
+}
+
+impl<'a, N: NodeTypesWithDB + ProviderNodeTypes> RethCanonicalChainReader<'a, N> {
+    fn new(provider: &'a BlockchainProvider<N>) -> Self {
+        Self { provider }
+    }
+}
+
+impl<'a, N: NodeTypesWithDB + ProviderNodeTypes> CanonicalChainReader
+    for RethCanonicalChainReader<'a, N>
+{
+    fn is_in_canonical_chain(&self, blockhash: B256) -> ProviderResult<bool> {
+        let Some(block_number) = self.provider.block_number(blockhash)? else {
+            return Ok(false);
+        };
+        let Some(canonical_blockhash) = self.provider.block_hash(block_number)? else {
+            return Ok(false);
+        };
+        Ok(blockhash == canonical_blockhash)
+    }
+}
+
+fn forkchoice_state_from_consensus_with_reader(
     consensus_state: &ConsensusHeads,
     head_block_hash: B256,
-    provider: &BlockchainProvider<N>,
+    reader: &impl CanonicalChainReader,
 ) -> ProviderResult<ForkchoiceState> {
     let safe_block_hash = B256::from_slice(consensus_state.confirmed().as_slice());
     let finalized_block_hash = B256::from_slice(consensus_state.finalized().as_slice());
 
-    let head_block_hash = if is_in_canonical_chain(safe_block_hash, provider)? {
+    let head_block_hash = if reader.is_in_canonical_chain(safe_block_hash)? {
         head_block_hash
     } else {
         // Safe block is not in canonical chain on reth.
@@ -44,11 +59,33 @@ fn forkchoice_state_from_consensus<N: NodeTypesWithDB + ProviderNodeTypes>(
         safe_block_hash
     };
 
+    let finalized_block_hash =
+        if finalized_block_hash.is_zero() || reader.is_in_canonical_chain(finalized_block_hash)? {
+            finalized_block_hash
+        } else {
+            // Reth rejects forkchoice updates with a non-canonical finalized hash as
+            // `invalid forkchoice state`. Drop the finalized pointer until this node has
+            // canonicalized the same block locally.
+            B256::ZERO
+        };
+
     Ok(ForkchoiceState {
         head_block_hash,
         safe_block_hash,
         finalized_block_hash,
     })
+}
+
+fn forkchoice_state_from_consensus<N: NodeTypesWithDB + ProviderNodeTypes>(
+    consensus_state: &ConsensusHeads,
+    head_block_hash: B256,
+    provider: &BlockchainProvider<N>,
+) -> ProviderResult<ForkchoiceState> {
+    forkchoice_state_from_consensus_with_reader(
+        consensus_state,
+        head_block_hash,
+        &RethCanonicalChainReader::new(provider),
+    )
 }
 
 /// Takes chain updates from OL and sequencer/p2p and updates the chain in engine (reth).
@@ -119,4 +156,128 @@ pub fn create_engine_control_task<N: NodeTypesWithDB + ProviderNodeTypes, E: Exe
     engine_control: E,
 ) -> impl Future<Output = ()> {
     engine_control_task_inner(preconf_rx, consensus_rx, provider, engine_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use mockall::predicate::eq;
+    use strata_acct_types::Hash;
+    use strata_identifiers::Epoch;
+
+    use super::*;
+
+    fn hash_from_u8(value: u8) -> Hash {
+        let mut bytes = [0u8; 32];
+        bytes[0] = value;
+        Hash::from(bytes)
+    }
+
+    fn b256_from_u8(value: u8) -> B256 {
+        B256::from_slice(hash_from_u8(value).as_ref())
+    }
+
+    fn consensus_heads(confirmed: u8, finalized: u8) -> ConsensusHeads {
+        ConsensusHeads {
+            confirmed: hash_from_u8(confirmed),
+            confirmed_epoch: Epoch::from(10u32),
+            finalized: hash_from_u8(finalized),
+            finalized_epoch: Epoch::from(9u32),
+        }
+    }
+
+    #[test]
+    fn forkchoice_keeps_head_when_confirmed_is_canonical() {
+        let mut reader = MockCanonicalChainReader::new();
+        let heads = consensus_heads(1, 2);
+        let current_head = b256_from_u8(9);
+
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(1)))
+            .return_once(|_| Ok(true));
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(2)))
+            .return_once(|_| Ok(true));
+
+        let state =
+            forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
+
+        assert_eq!(state.head_block_hash, current_head);
+        assert_eq!(state.safe_block_hash, b256_from_u8(1));
+        assert_eq!(state.finalized_block_hash, b256_from_u8(2));
+    }
+
+    #[test]
+    fn forkchoice_rewrites_head_when_confirmed_is_noncanonical() {
+        let mut reader = MockCanonicalChainReader::new();
+        let heads = consensus_heads(3, 4);
+        let current_head = b256_from_u8(9);
+
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(3)))
+            .return_once(|_| Ok(false));
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(4)))
+            .return_once(|_| Ok(true));
+
+        let state =
+            forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
+
+        assert_eq!(state.head_block_hash, b256_from_u8(3));
+        assert_eq!(state.safe_block_hash, b256_from_u8(3));
+        assert_eq!(state.finalized_block_hash, b256_from_u8(4));
+    }
+
+    #[test]
+    fn forkchoice_drops_noncanonical_finalized_hash() {
+        let mut reader = MockCanonicalChainReader::new();
+        let heads = consensus_heads(5, 6);
+        let current_head = b256_from_u8(9);
+
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(5)))
+            .return_once(|_| Ok(true));
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(6)))
+            .return_once(|_| Ok(false));
+
+        let state =
+            forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
+
+        assert_eq!(state.head_block_hash, current_head);
+        assert_eq!(state.safe_block_hash, b256_from_u8(5));
+        assert_eq!(state.finalized_block_hash, B256::ZERO);
+    }
+
+    #[test]
+    fn forkchoice_skips_finalized_lookup_when_finalized_is_zero() {
+        let mut reader = MockCanonicalChainReader::new();
+        let heads = consensus_heads(7, 0);
+        let current_head = b256_from_u8(9);
+
+        reader
+            .expect_is_in_canonical_chain()
+            .once()
+            .with(eq(b256_from_u8(7)))
+            .return_once(|_| Ok(true));
+
+        let state =
+            forkchoice_state_from_consensus_with_reader(&heads, current_head, &reader).unwrap();
+
+        assert_eq!(state.head_block_hash, current_head);
+        assert_eq!(state.safe_block_hash, b256_from_u8(7));
+        assert_eq!(state.finalized_block_hash, B256::ZERO);
+    }
 }

--- a/crates/alpen-ee/engine/src/engine.rs
+++ b/crates/alpen-ee/engine/src/engine.rs
@@ -32,7 +32,9 @@ fn map_forkchoice_error(err: BeaconForkChoiceUpdateError) -> ExecutionEngineErro
         BeaconForkChoiceUpdateError::EngineUnavailable => {
             ExecutionEngineError::communication(err.to_string())
         }
-        BeaconForkChoiceUpdateError::Internal(_) => ExecutionEngineError::communication(err.to_string()),
+        BeaconForkChoiceUpdateError::Internal(_) => {
+            ExecutionEngineError::communication(err.to_string())
+        }
         BeaconForkChoiceUpdateError::ForkchoiceUpdateError(_) => {
             ExecutionEngineError::fork_choice_update(err.to_string())
         }
@@ -107,9 +109,10 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+    use std::time::Duration;
 
     use alloy_primitives::B256;
-    use alloy_rpc_types_engine::ForkchoiceState;
+    use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatus, PayloadStatusEnum};
     use alpen_ee_common::ExecutionEngineError;
     use reth_node_builder::{BeaconEngineMessage, OnForkChoiceUpdated};
     use tokio::sync::mpsc::unbounded_channel;
@@ -131,7 +134,7 @@ mod tests {
                 attempts_clone.fetch_add(1, Ordering::SeqCst);
                 tx.send(Ok(OnForkChoiceUpdated::invalid_state()))
                     .expect("receiver should still be alive");
-            };
+            }
         });
 
         let err = engine
@@ -168,19 +171,24 @@ mod tests {
         let attempts_clone = attempts.clone();
 
         let responder = tokio::spawn(async move {
-            let mut seen_retry = false;
+            let mut should_fail = true;
             while let Some(message) = rx.recv().await {
                 let BeaconEngineMessage::ForkchoiceUpdated { tx, .. } = message else {
                     panic!("expected forkchoice update message");
                 };
-                let current_attempt = attempts_clone.fetch_add(1, Ordering::SeqCst) + 1;
-                drop(tx);
-                if current_attempt >= 2 {
-                    seen_retry = true;
+                attempts_clone.fetch_add(1, Ordering::SeqCst);
+
+                if should_fail {
+                    should_fail = false;
+                    drop(tx);
+                } else {
+                    tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::from_status(
+                        PayloadStatusEnum::Valid,
+                    ))))
+                    .expect("receiver should still be alive");
                     break;
                 }
             }
-            seen_retry
         });
 
         let update_task = tokio::spawn({
@@ -196,15 +204,15 @@ mod tests {
             }
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(1700)).await;
-
-        update_task.abort();
-        let _ = update_task.await;
-
-        assert!(responder.await.expect("responder task should complete"));
+        tokio::time::timeout(Duration::from_secs(5), update_task)
+            .await
+            .expect("update task should finish within the timeout")
+            .expect("update task should complete")
+            .expect("retryable engine-unavailable errors should succeed after a retry");
+        responder.await.expect("responder task should complete");
         assert!(
-            attempts.load(Ordering::SeqCst) >= 2,
-            "retryable engine-unavailable errors should trigger at least one retry"
+            attempts.load(Ordering::SeqCst) == 2,
+            "retryable engine-unavailable errors should perform exactly one retry in this test"
         );
     }
 }

--- a/crates/alpen-ee/engine/src/engine.rs
+++ b/crates/alpen-ee/engine/src/engine.rs
@@ -3,12 +3,14 @@ use alpen_ee_common::{ExecutionEngine, ExecutionEngineError};
 use alpen_reth_node::{AlpenBuiltPayload, AlpenEngineTypes};
 use async_trait::async_trait;
 use reth_node_builder::{
-    BuiltPayload, ConsensusEngineHandle, EngineApiMessageVersion, PayloadTypes,
+    BeaconForkChoiceUpdateError, BuiltPayload, ConsensusEngineHandle, EngineApiMessageVersion,
+    PayloadTypes,
 };
 use strata_common::retry::{
-    policies::ExponentialBackoff, retry_with_backoff_async, DEFAULT_ENGINE_CALL_MAX_RETRIES,
+    policies::ExponentialBackoff, retry_with_backoff_async, Backoff,
+    DEFAULT_ENGINE_CALL_MAX_RETRIES,
 };
-use tracing::debug;
+use tracing::{debug, error, warn};
 
 /// Execution engine implementation using Reth for Alpen EE.
 #[derive(Debug, Clone)]
@@ -21,6 +23,18 @@ impl AlpenRethExecEngine {
     pub fn new(beacon_engine_handle: ConsensusEngineHandle<AlpenEngineTypes>) -> Self {
         Self {
             beacon_engine_handle,
+        }
+    }
+}
+
+fn map_forkchoice_error(err: BeaconForkChoiceUpdateError) -> ExecutionEngineError {
+    match err {
+        BeaconForkChoiceUpdateError::EngineUnavailable => {
+            ExecutionEngineError::communication(err.to_string())
+        }
+        BeaconForkChoiceUpdateError::Internal(_) => ExecutionEngineError::communication(err.to_string()),
+        BeaconForkChoiceUpdateError::ForkchoiceUpdateError(_) => {
+            ExecutionEngineError::fork_choice_update(err.to_string())
         }
     }
 }
@@ -51,19 +65,146 @@ impl ExecutionEngine for AlpenRethExecEngine {
         &self,
         state: ForkchoiceState,
     ) -> Result<(), ExecutionEngineError> {
-        retry_with_backoff_async(
-            "exec_engine_update_consensus_state",
-            DEFAULT_ENGINE_CALL_MAX_RETRIES,
-            &ExponentialBackoff::default(),
-            || async {
+        let backoff = ExponentialBackoff::default();
+        let mut delay = backoff.base_delay_ms();
+
+        for attempt in 0..=DEFAULT_ENGINE_CALL_MAX_RETRIES {
+            let result = {
                 debug!(?state, "Sending fork choice state to beacon");
                 self.beacon_engine_handle
                     .fork_choice_updated(state, None, EngineApiMessageVersion::V4)
                     .await
                     .map(|_| ())
-                    .map_err(|e| ExecutionEngineError::fork_choice_update(e.to_string()))
-            },
-        )
-        .await
+                    .map_err(map_forkchoice_error)
+            };
+
+            match result {
+                Ok(value) => return Ok(value),
+                Err(err) if attempt < DEFAULT_ENGINE_CALL_MAX_RETRIES && err.is_retryable() => {
+                    warn!(
+                        "Attempt {} failed with {err:?} while running exec_engine_update_consensus_state. Retrying in {delay:?}ms",
+                        attempt + 1,
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                    delay = backoff.next_delay_ms(delay);
+                }
+                Err(err) => {
+                    if attempt >= DEFAULT_ENGINE_CALL_MAX_RETRIES {
+                        error!("Max retries exceeded while running exec_engine_update_consensus_state, returning with the last error");
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use alloy_primitives::B256;
+    use alloy_rpc_types_engine::ForkchoiceState;
+    use alpen_ee_common::ExecutionEngineError;
+    use reth_node_builder::{BeaconEngineMessage, OnForkChoiceUpdated};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn update_consensus_state_maps_invalid_state_to_forkchoice_error_without_retry() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+
+        let responder = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                let BeaconEngineMessage::ForkchoiceUpdated { tx, .. } = message else {
+                    panic!("expected forkchoice update message");
+                };
+                attempts_clone.fetch_add(1, Ordering::SeqCst);
+                tx.send(Ok(OnForkChoiceUpdated::invalid_state()))
+                    .expect("receiver should still be alive");
+            };
+        });
+
+        let err = engine
+            .update_consensus_state(ForkchoiceState {
+                head_block_hash: B256::from([9u8; 32]),
+                safe_block_hash: B256::from([5u8; 32]),
+                finalized_block_hash: B256::from([6u8; 32]),
+            })
+            .await
+            .expect_err("invalid forkchoice state should surface as an error");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        drop(engine);
+        responder.await.expect("responder task should complete");
+
+        match err {
+            ExecutionEngineError::ForkChoiceUpdate(msg) => {
+                assert!(
+                    !msg.is_empty(),
+                    "fork choice update error message should not be empty"
+                );
+                assert_eq!(msg, "forkchoice update error: invalid forkchoice state");
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_consensus_state_retries_engine_unavailable_errors() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+
+        let responder = tokio::spawn(async move {
+            let mut seen_retry = false;
+            while let Some(message) = rx.recv().await {
+                let BeaconEngineMessage::ForkchoiceUpdated { tx, .. } = message else {
+                    panic!("expected forkchoice update message");
+                };
+                let current_attempt = attempts_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                drop(tx);
+                if current_attempt >= 2 {
+                    seen_retry = true;
+                    break;
+                }
+            }
+            seen_retry
+        });
+
+        let update_task = tokio::spawn({
+            let engine = engine.clone();
+            async move {
+                engine
+                    .update_consensus_state(ForkchoiceState {
+                        head_block_hash: B256::from([9u8; 32]),
+                        safe_block_hash: B256::from([5u8; 32]),
+                        finalized_block_hash: B256::from([6u8; 32]),
+                    })
+                    .await
+            }
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(1700)).await;
+
+        update_task.abort();
+        let _ = update_task.await;
+
+        assert!(responder.await.expect("responder task should complete"));
+        assert!(
+            attempts.load(Ordering::SeqCst) >= 2,
+            "retryable engine-unavailable errors should trigger at least one retry"
+        );
     }
 }


### PR DESCRIPTION
## Description

Fixes `forkchoiceUpdated` handling when OL reports a finalized EE hash that this Reth node still sees as non-canonical.

Before this change, `crates/alpen-ee/engine/src/control.rs` canonical-checked `confirmed` / safe but forwarded `finalized` unchanged. During sync or fork-switch windows, that could send a non-canonical finalized hash into `forkchoiceUpdated`, which Reth rejects as `invalid forkchoice state`.

This patch canonical-checks `finalized_block_hash`, clears it to `B256::ZERO` when it is inconsistent with the chosen fork, and keeps finalized when the update is switching to OL's fork and the finalized block is an ancestor of the new target head. On the engine side it also stops retrying deterministic forkchoice validation failures while still retrying communication-style failures.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The serialized interface is unchanged.

The key behavioral boundaries are:
- finalized now drops to zero only when it is inconsistent with the chosen fork
- a finalized block on the OL target fork stays preserved across the fork switch
- `ExecutionEngineError::ForkChoiceUpdate(...)` no longer goes through the retry loop

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues
