### PR TITLE
fix(alpen-ee): preserve newPayload status semantics

### DIFF
--- a/crates/alpen-ee/engine/Cargo.toml
+++ b/crates/alpen-ee/engine/Cargo.toml
@@ -28,4 +28,7 @@ strata-ee-acct-types.workspace = true
 strata-ee-chain-types.workspace = true
 strata-identifiers.workspace = true
 
+alloy-consensus.workspace = true
 mockall.workspace = true
+reth-ethereum-engine-primitives.workspace = true
+reth-primitives.workspace = true

--- a/crates/alpen-ee/engine/src/engine.rs
+++ b/crates/alpen-ee/engine/src/engine.rs
@@ -52,11 +52,7 @@ impl ExecutionEngine for AlpenRethExecEngine {
                             alloy_rpc_types_engine::PayloadStatusEnum::Syncing.as_str(),
                         ))
                     }
-                    alloy_rpc_types_engine::PayloadStatusEnum::Accepted => {
-                        Err(ExecutionEngineError::engine_syncing(
-                            alloy_rpc_types_engine::PayloadStatusEnum::Accepted.as_str(),
-                        ))
-                    }
+                    alloy_rpc_types_engine::PayloadStatusEnum::Accepted => Ok(()),
                 });
 
             match result {
@@ -257,30 +253,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_payload_retries_accepted_status_until_valid() {
+    async fn submit_payload_treats_accepted_status_as_success() {
         let (tx, mut rx) = unbounded_channel();
         let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
         let attempts = Arc::new(AtomicUsize::new(0));
         let attempts_clone = attempts.clone();
 
         let responder = tokio::spawn(async move {
-            let mut should_accept = true;
-            while let Some(message) = rx.recv().await {
-                let BeaconEngineMessage::NewPayload { tx, .. } = message else {
-                    panic!("expected new payload message");
-                };
-                attempts_clone.fetch_add(1, Ordering::SeqCst);
-
-                if should_accept {
-                    should_accept = false;
-                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Accepted)))
-                        .expect("receiver should still be alive");
-                } else {
-                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Valid)))
-                        .expect("receiver should still be alive");
-                    break;
-                }
-            }
+            let Some(BeaconEngineMessage::NewPayload { tx, .. }) = rx.recv().await else {
+                panic!("expected new payload message");
+            };
+            attempts_clone.fetch_add(1, Ordering::SeqCst);
+            tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Accepted)))
+                .expect("receiver should still be alive");
         });
 
         tokio::time::timeout(
@@ -289,10 +274,10 @@ mod tests {
         )
         .await
         .expect("submit payload should finish within the timeout")
-        .expect("accepted status should retry and then succeed");
+        .expect("accepted status should be treated as a non-fatal success");
 
         responder.await.expect("responder task should complete");
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/alpen-ee/engine/src/engine.rs
+++ b/crates/alpen-ee/engine/src/engine.rs
@@ -6,9 +6,10 @@ use reth_node_builder::{
     BuiltPayload, ConsensusEngineHandle, EngineApiMessageVersion, PayloadTypes,
 };
 use strata_common::retry::{
-    policies::ExponentialBackoff, retry_with_backoff_async, DEFAULT_ENGINE_CALL_MAX_RETRIES,
+    policies::ExponentialBackoff, retry_with_backoff_async, Backoff,
+    DEFAULT_ENGINE_CALL_MAX_RETRIES,
 };
-use tracing::debug;
+use tracing::{debug, error, warn};
 
 /// Execution engine implementation using Reth for Alpen EE.
 #[derive(Debug, Clone)]
@@ -30,21 +31,54 @@ impl ExecutionEngine for AlpenRethExecEngine {
     type TEnginePayload = AlpenBuiltPayload;
 
     async fn submit_payload(&self, payload: AlpenBuiltPayload) -> Result<(), ExecutionEngineError> {
-        retry_with_backoff_async(
-            "exec_engine_submit_payload",
-            DEFAULT_ENGINE_CALL_MAX_RETRIES,
-            &ExponentialBackoff::default(),
-            || async {
-                self.beacon_engine_handle
-                    .new_payload(AlpenEngineTypes::block_to_payload(
-                        payload.block().to_owned(),
-                    ))
-                    .await
-                    .map(|_| ())
-                    .map_err(|e| ExecutionEngineError::payload_submission(e.to_string()))
-            },
-        )
-        .await
+        let backoff = ExponentialBackoff::default();
+        let mut delay = backoff.base_delay_ms();
+
+        for attempt in 0..=DEFAULT_ENGINE_CALL_MAX_RETRIES {
+            let result = self
+                .beacon_engine_handle
+                .new_payload(AlpenEngineTypes::block_to_payload(
+                    payload.block().to_owned(),
+                ))
+                .await
+                .map_err(|e| ExecutionEngineError::communication(e.to_string()))
+                .and_then(|status| match status.status {
+                    alloy_rpc_types_engine::PayloadStatusEnum::Valid => Ok(()),
+                    alloy_rpc_types_engine::PayloadStatusEnum::Invalid { validation_error } => {
+                        Err(ExecutionEngineError::invalid_payload(validation_error))
+                    }
+                    alloy_rpc_types_engine::PayloadStatusEnum::Syncing => {
+                        Err(ExecutionEngineError::engine_syncing(
+                            alloy_rpc_types_engine::PayloadStatusEnum::Syncing.as_str(),
+                        ))
+                    }
+                    alloy_rpc_types_engine::PayloadStatusEnum::Accepted => {
+                        Err(ExecutionEngineError::engine_syncing(
+                            alloy_rpc_types_engine::PayloadStatusEnum::Accepted.as_str(),
+                        ))
+                    }
+                });
+
+            match result {
+                Ok(value) => return Ok(value),
+                Err(err) if attempt < DEFAULT_ENGINE_CALL_MAX_RETRIES && err.is_retryable() => {
+                    warn!(
+                        "Attempt {} failed with {err:?} while running exec_engine_submit_payload. Retrying in {delay:?}ms",
+                        attempt + 1,
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                    delay = backoff.next_delay_ms(delay);
+                }
+                Err(err) => {
+                    if attempt >= DEFAULT_ENGINE_CALL_MAX_RETRIES {
+                        error!("Max retries exceeded while running exec_engine_submit_payload, returning with the last error");
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        unreachable!()
     }
 
     async fn update_consensus_state(
@@ -65,5 +99,156 @@ impl ExecutionEngine for AlpenRethExecEngine {
             },
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use alloy_consensus::Header;
+    use alloy_rpc_types_engine::{PayloadStatus, PayloadStatusEnum};
+    use alpen_ee_common::ExecutionEngineError;
+    use alpen_reth_node::WithdrawalIntent;
+    use reth_ethereum_engine_primitives::EthBuiltPayload;
+    use reth_node_builder::BeaconEngineMessage;
+    use reth_primitives::{BlockBody, SealedBlock};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::*;
+
+    fn dummy_payload() -> AlpenBuiltPayload {
+        let header = Header {
+            gas_limit: 30_000_000,
+            gas_used: 0,
+            timestamp: 1,
+            base_fee_per_gas: Some(0),
+            withdrawals_root: Some(Default::default()),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            parent_beacon_block_root: Some(Default::default()),
+            requests_hash: Some(Default::default()),
+            ..Default::default()
+        };
+        let block = alloy_consensus::Block {
+            header,
+            body: BlockBody {
+                transactions: Vec::new(),
+                ommers: Vec::new(),
+                withdrawals: Some(vec![].into()),
+            },
+        };
+        let sealed_block: Arc<SealedBlock<_>> = Arc::new(SealedBlock::seal_slow(block));
+        let eth_payload =
+            EthBuiltPayload::new(Default::default(), sealed_block, Default::default(), None);
+        AlpenBuiltPayload::new(eth_payload, Vec::<WithdrawalIntent>::new())
+    }
+
+    #[tokio::test]
+    async fn submit_payload_maps_invalid_payload_status_to_invalid_payload_error() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+
+        let responder = tokio::spawn(async move {
+            let Some(BeaconEngineMessage::NewPayload { tx, .. }) = rx.recv().await else {
+                panic!("expected new payload message");
+            };
+            tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {
+                validation_error: "invalid block".into(),
+            })))
+            .expect("receiver should still be alive");
+        });
+
+        let result = engine.submit_payload(dummy_payload()).await;
+
+        responder.await.expect("responder task should complete");
+
+        match result {
+            Err(ExecutionEngineError::InvalidPayload(msg)) => {
+                assert_eq!(msg, "invalid block");
+            }
+            other => panic!("unexpected submit payload result: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_payload_maps_syncing_status_to_engine_syncing_error() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+        let max_retries = usize::from(DEFAULT_ENGINE_CALL_MAX_RETRIES);
+
+        let responder = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                let BeaconEngineMessage::NewPayload { tx, .. } = message else {
+                    panic!("expected new payload message");
+                };
+                attempts_clone.fetch_add(1, Ordering::SeqCst);
+                tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing)))
+                    .expect("receiver should still be alive");
+
+                if attempts_clone.load(Ordering::SeqCst) > max_retries {
+                    break;
+                }
+            }
+        });
+
+        let result = engine.submit_payload(dummy_payload()).await;
+
+        responder.await.expect("responder task should complete");
+        assert_eq!(attempts.load(Ordering::SeqCst), max_retries + 1);
+
+        match result {
+            Err(ExecutionEngineError::EngineSyncing(msg)) => {
+                assert_eq!(msg, "SYNCING");
+            }
+            other => panic!("unexpected submit payload result: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_payload_retries_syncing_status_until_valid() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+
+        let responder = tokio::spawn(async move {
+            let mut should_sync = true;
+            while let Some(message) = rx.recv().await {
+                let BeaconEngineMessage::NewPayload { tx, .. } = message else {
+                    panic!("expected new payload message");
+                };
+                attempts_clone.fetch_add(1, Ordering::SeqCst);
+
+                if should_sync {
+                    should_sync = false;
+                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing)))
+                        .expect("receiver should still be alive");
+                } else {
+                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Valid)))
+                        .expect("receiver should still be alive");
+                    break;
+                }
+            }
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            engine.submit_payload(dummy_payload()),
+        )
+        .await
+        .expect("submit payload should finish within the timeout")
+        .expect("syncing status should retry and then succeed");
+
+        responder.await.expect("responder task should complete");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }

--- a/crates/alpen-ee/engine/src/engine.rs
+++ b/crates/alpen-ee/engine/src/engine.rs
@@ -154,11 +154,14 @@ mod tests {
     async fn submit_payload_maps_invalid_payload_status_to_invalid_payload_error() {
         let (tx, mut rx) = unbounded_channel();
         let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
 
         let responder = tokio::spawn(async move {
             let Some(BeaconEngineMessage::NewPayload { tx, .. }) = rx.recv().await else {
                 panic!("expected new payload message");
             };
+            attempts_clone.fetch_add(1, Ordering::SeqCst);
             tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {
                 validation_error: "invalid block".into(),
             })))
@@ -168,6 +171,7 @@ mod tests {
         let result = engine.submit_payload(dummy_payload()).await;
 
         responder.await.expect("responder task should complete");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
 
         match result {
             Err(ExecutionEngineError::InvalidPayload(msg)) => {
@@ -247,6 +251,83 @@ mod tests {
         .await
         .expect("submit payload should finish within the timeout")
         .expect("syncing status should retry and then succeed");
+
+        responder.await.expect("responder task should complete");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn submit_payload_retries_accepted_status_until_valid() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+
+        let responder = tokio::spawn(async move {
+            let mut should_accept = true;
+            while let Some(message) = rx.recv().await {
+                let BeaconEngineMessage::NewPayload { tx, .. } = message else {
+                    panic!("expected new payload message");
+                };
+                attempts_clone.fetch_add(1, Ordering::SeqCst);
+
+                if should_accept {
+                    should_accept = false;
+                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Accepted)))
+                        .expect("receiver should still be alive");
+                } else {
+                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Valid)))
+                        .expect("receiver should still be alive");
+                    break;
+                }
+            }
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            engine.submit_payload(dummy_payload()),
+        )
+        .await
+        .expect("submit payload should finish within the timeout")
+        .expect("accepted status should retry and then succeed");
+
+        responder.await.expect("responder task should complete");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn submit_payload_retries_communication_error_until_valid() {
+        let (tx, mut rx) = unbounded_channel();
+        let engine = AlpenRethExecEngine::new(ConsensusEngineHandle::new(tx));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+
+        let responder = tokio::spawn(async move {
+            let mut should_drop_response = true;
+            while let Some(message) = rx.recv().await {
+                let BeaconEngineMessage::NewPayload { tx, .. } = message else {
+                    panic!("expected new payload message");
+                };
+                attempts_clone.fetch_add(1, Ordering::SeqCst);
+
+                if should_drop_response {
+                    should_drop_response = false;
+                    drop(tx);
+                } else {
+                    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Valid)))
+                        .expect("receiver should still be alive");
+                    break;
+                }
+            }
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            engine.submit_payload(dummy_payload()),
+        )
+        .await
+        .expect("submit payload should finish within the timeout")
+        .expect("communication error should retry and then succeed");
 
         responder.await.expect("responder task should complete");
         assert_eq!(attempts.load(Ordering::SeqCst), 2);


### PR DESCRIPTION
## Description

Stops `submit_payload()` from flattening every successful `new_payload(...)` transport round-trip into `Ok(())`.

Before this change, Alpen EE discarded the returned `PayloadStatus`, so `Invalid` and `Syncing` never surfaced as engine-level outcomes. This patch keeps the retry loop but maps the status explicitly: `Valid` succeeds, `Invalid` returns `ExecutionEngineError::InvalidPayload`, `Syncing` returns `ExecutionEngineError::EngineSyncing`, and `Accepted` returns success.

That keeps `Accepted` as a non-fatal outcome in this `Result<(), ExecutionEngineError>` path instead of retrying the same payload until the retry budget expires.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The production change is the payload-status mapping in `crates/alpen-ee/engine/src/engine.rs`.

The current branch also locks the retry boundary in tests:
- invalid payload returns immediately
- syncing stays retryable
- accepted is non-fatal
- transport failure still retries and can recover

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues
