### PR TITLE
fix(evmexec): treat accepted payloads as non-fatal

### DIFF
--- a/crates/eectl/src/worker.rs
+++ b/crates/eectl/src/worker.rs
@@ -414,7 +414,12 @@ mod tests {
         let engine = Arc::new(TestExecEngine {
             submit_status: BlockStatus::Syncing,
         });
-        let mut state = ExecWorkerState::new(engine, (), dummy_block_commitment(1), dummy_block_commitment(0));
+        let mut state = ExecWorkerState::new(
+            engine,
+            (),
+            dummy_block_commitment(1),
+            dummy_block_commitment(0),
+        );
         let block = dummy_block_commitment(1);
         let payload = ExecPayloadData::new(
             ExecUpdate::new(
@@ -428,5 +433,33 @@ mod tests {
         let result = state.try_exec_el_payload(&block, &payload);
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_exec_el_payload_treats_invalid_as_fatal() {
+        let engine = Arc::new(TestExecEngine {
+            submit_status: BlockStatus::Invalid,
+        });
+        let mut state = ExecWorkerState::new(
+            engine,
+            (),
+            dummy_block_commitment(1),
+            dummy_block_commitment(0),
+        );
+        let block = dummy_block_commitment(1);
+        let payload = ExecPayloadData::new(
+            ExecUpdate::new(
+                UpdateInput::new(0, vec![], Buf32::zero(), vec![]),
+                UpdateOutput::new_from_state(Buf32::zero()),
+            ),
+            vec![],
+            vec![],
+        );
+
+        let result = state.try_exec_el_payload(&block, &payload);
+
+        assert!(
+            matches!(result, Err(EngineError::InvalidPayload(err_block)) if err_block == block)
+        );
     }
 }

--- a/crates/eectl/src/worker.rs
+++ b/crates/eectl/src/worker.rs
@@ -341,7 +341,56 @@ pub trait ExecWorkerContext {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use strata_ol_chain_types::L2BlockId;
+    use strata_primitives::buf::Buf32;
+    use strata_state::exec_update::{ExecUpdate, UpdateInput, UpdateOutput};
+
     use super::*;
+    use crate::{
+        engine::{BlockStatus, ExecEngineCtl, L2BlockRef, PayloadStatus},
+        messages::{ExecPayloadData, PayloadEnv},
+    };
+
+    #[derive(Debug)]
+    struct TestExecEngine {
+        submit_status: BlockStatus,
+    }
+
+    impl ExecEngineCtl for TestExecEngine {
+        fn submit_payload(&self, _payload: ExecPayloadData) -> EngineResult<BlockStatus> {
+            Ok(self.submit_status)
+        }
+
+        fn prepare_payload(&self, _env: PayloadEnv) -> EngineResult<u64> {
+            unimplemented!("not needed in this test")
+        }
+
+        fn get_payload_status(&self, _id: u64) -> EngineResult<PayloadStatus> {
+            unimplemented!("not needed in this test")
+        }
+
+        fn update_head_block(&self, _id: L2BlockId) -> EngineResult<()> {
+            unimplemented!("not needed in this test")
+        }
+
+        fn update_safe_block(&self, _id: L2BlockId) -> EngineResult<()> {
+            unimplemented!("not needed in this test")
+        }
+
+        fn update_finalized_block(&self, _id: L2BlockId) -> EngineResult<()> {
+            unimplemented!("not needed in this test")
+        }
+
+        fn check_block_exists<'a>(&self, _id_ref: L2BlockRef<'a>) -> EngineResult<bool> {
+            unimplemented!("not needed in this test")
+        }
+    }
+
+    fn dummy_block_commitment(slot: u64) -> L2BlockCommitment {
+        L2BlockCommitment::new(slot, L2BlockId::from(Buf32::from([slot as u8; 32])))
+    }
 
     #[test]
     fn test_find_last_match() {
@@ -358,5 +407,26 @@ mod tests {
             find_last_match((0, 5), |_| Err(EngineError::Other(error_message.into()))),
             Err(err) if err.to_string().contains(error_message)
         ));
+    }
+
+    #[test]
+    fn try_exec_el_payload_treats_syncing_as_non_fatal() {
+        let engine = Arc::new(TestExecEngine {
+            submit_status: BlockStatus::Syncing,
+        });
+        let mut state = ExecWorkerState::new(engine, (), dummy_block_commitment(1), dummy_block_commitment(0));
+        let block = dummy_block_commitment(1);
+        let payload = ExecPayloadData::new(
+            ExecUpdate::new(
+                UpdateInput::new(0, vec![], Buf32::zero(), vec![]),
+                UpdateOutput::new_from_state(Buf32::zero()),
+            ),
+            vec![],
+            vec![],
+        );
+
+        let result = state.try_exec_el_payload(&block, &payload);
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -714,12 +714,14 @@ mod tests {
             vec![],
         );
 
-        mock_client.expect_new_payload_v4().returning(move |_, _, _, _| {
-            Ok(PayloadStatus {
-                status: PayloadStatusEnum::Accepted,
-                latest_valid_hash: None,
-            })
-        });
+        mock_client
+            .expect_new_payload_v4()
+            .returning(move |_, _, _, _| {
+                Ok(PayloadStatus {
+                    status: PayloadStatusEnum::Accepted,
+                    latest_valid_hash: None,
+                })
+            });
 
         let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
 

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -259,7 +259,9 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
             PayloadStatusEnum::Valid => EngineResult::Ok(BlockStatus::Valid),
             PayloadStatusEnum::Syncing => EngineResult::Ok(BlockStatus::Syncing),
             PayloadStatusEnum::Invalid { .. } => EngineResult::Ok(BlockStatus::Invalid),
-            PayloadStatusEnum::Accepted => EngineResult::Err(EngineError::Unimplemented), // TODO
+            // Engine API uses ACCEPTED for payloads that passed basic checks but were not fully
+            // validated yet. In the eectl contract this is a non-fatal, non-invalid outcome.
+            PayloadStatusEnum::Accepted => EngineResult::Ok(BlockStatus::Syncing),
         }
     }
 
@@ -678,6 +680,52 @@ mod tests {
         let result = rpc_exec_engine_inner.submit_new_payload(payload_data).await;
 
         assert!(matches!(result, EngineResult::Ok(BlockStatus::Valid)));
+    }
+
+    #[tokio::test]
+    async fn test_submit_new_payload_maps_accepted_to_syncing() {
+        let mut mock_client = MockEngineRpc::new();
+        let head_block_hash = B256::random();
+
+        let el_payload = ElPayload {
+            base_fee_per_gas: Buf32(FixedBytes::<32>::from(U256::from(10)).into()),
+            parent_hash: Default::default(),
+            fee_recipient: Default::default(),
+            state_root: Default::default(),
+            receipts_root: Default::default(),
+            logs_bloom: [0u8; 256],
+            prev_randao: Default::default(),
+            block_number: Default::default(),
+            gas_limit: Default::default(),
+            gas_used: Default::default(),
+            timestamp: Default::default(),
+            extra_data: Default::default(),
+            block_hash: Default::default(),
+            transactions: Default::default(),
+        };
+        let accessory_data = borsh::to_vec(&el_payload).unwrap();
+
+        let update_input = make_update_input_from_payload_and_ops(el_payload, &[]).unwrap();
+        let update_output = UpdateOutput::new_from_state(Buf32::zero());
+
+        let payload_data = ExecPayloadData::new(
+            ExecUpdate::new(update_input, update_output),
+            accessory_data,
+            vec![],
+        );
+
+        mock_client.expect_new_payload_v4().returning(move |_, _, _, _| {
+            Ok(PayloadStatus {
+                status: PayloadStatusEnum::Accepted,
+                latest_valid_hash: None,
+            })
+        });
+
+        let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
+
+        let result = rpc_exec_engine_inner.submit_new_payload(payload_data).await;
+
+        assert!(matches!(result, EngineResult::Ok(BlockStatus::Syncing)));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Treats `PayloadStatusEnum::Accepted` from `engine_newPayload` as a non-fatal outcome in `crates/evmexec/src/engine.rs`.

Before this change, `evmexec` mapped `Accepted` to `Err(EngineError::Unimplemented)`. That was stronger than the `strata-eectl` contract expects, since the worker only treats `BlockStatus::Invalid` as fatal and lets other non-invalid outcomes continue through block execution and missing-block sync.

This patch changes only that mapping. `Accepted` now returns `Ok(BlockStatus::Syncing)`, which keeps the result on the existing non-fatal path without claiming stronger validity than the engine has actually reported.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The production change is the single `Accepted -> Ok(BlockStatus::Syncing)` mapping in `evmexec`.

The caller-side contract is pinned in `eectl` tests as well:
- `Invalid` stays fatal
- `Syncing` stays non-fatal

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues
