### PR TITLE
fix(evmexec): classify syncing payload preparation correctly

### DIFF
--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -161,7 +161,7 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
                 // without a payload id while the engine is still backfilling.
                 return Err(EngineError::Other(
                     "engine syncing while preparing payload".into(),
-                ))
+                ));
             }
             PayloadStatusEnum::Invalid { validation_error } => {
                 return Err(EngineError::Other(format!(
@@ -521,6 +521,26 @@ mod tests {
         }
     }
 
+    fn random_payload_build_inputs() -> (PayloadEnv, EVML2Block) {
+        let el_payload = random_el_payload();
+
+        let mut arb = strata_test_utils::ArbitraryGenerator::new();
+        let l2block: L2Block = arb.generate();
+        let accessory = L2BlockAccessory::new(borsh::to_vec(&el_payload).unwrap(), 0);
+        let l2block_bundle = L2BlockBundle::new(l2block, accessory);
+
+        let evm_l2_block = EVML2Block::try_extract(&l2block_bundle).unwrap();
+
+        let timestamp = 0;
+        let el_ops = vec![];
+        let safe_l1_block = Buf32(FixedBytes::<32>::random().into());
+        let prev_l2_block = Buf32(FixedBytes::<32>::random().into()).into();
+
+        let payload_env = PayloadEnv::new(timestamp, prev_l2_block, safe_l1_block, el_ops, None);
+
+        (payload_env, evm_l2_block)
+    }
+
     #[tokio::test]
     async fn test_update_block_state_success() {
         let mut mock_client = MockEngineRpc::new();
@@ -601,23 +621,9 @@ mod tests {
                     .with_payload_id(PayloadId::new([1u8; 8])))
             });
 
-        let el_payload = random_el_payload();
-
-        let mut arb = strata_test_utils::ArbitraryGenerator::new();
-        let l2block: L2Block = arb.generate();
-        let accessory = L2BlockAccessory::new(borsh::to_vec(&el_payload).unwrap(), 0);
-        let l2block_bundle = L2BlockBundle::new(l2block, accessory);
-
-        let evm_l2_block = EVML2Block::try_extract(&l2block_bundle).unwrap();
+        let (payload_env, evm_l2_block) = random_payload_build_inputs();
 
         let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
-
-        let timestamp = 0;
-        let el_ops = vec![];
-        let safe_l1_block = Buf32(FixedBytes::<32>::random().into());
-        let prev_l2_block = Buf32(FixedBytes::<32>::random().into()).into();
-
-        let payload_env = PayloadEnv::new(timestamp, prev_l2_block, safe_l1_block, el_ops, None);
 
         let result = rpc_exec_engine_inner
             .build_block_from_mempool(payload_env, evm_l2_block)
@@ -644,23 +650,9 @@ mod tests {
             .expect_fork_choice_updated_v3()
             .returning(move |_, _| Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing)));
 
-        let el_payload = random_el_payload();
-
-        let mut arb = strata_test_utils::ArbitraryGenerator::new();
-        let l2block: L2Block = arb.generate();
-        let accessory = L2BlockAccessory::new(borsh::to_vec(&el_payload).unwrap(), 0);
-        let l2block_bundle = L2BlockBundle::new(l2block, accessory);
-
-        let evm_l2_block = EVML2Block::try_extract(&l2block_bundle).unwrap();
+        let (payload_env, evm_l2_block) = random_payload_build_inputs();
 
         let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
-
-        let timestamp = 0;
-        let el_ops = vec![];
-        let safe_l1_block = Buf32(FixedBytes::<32>::random().into());
-        let prev_l2_block = Buf32(FixedBytes::<32>::random().into()).into();
-
-        let payload_env = PayloadEnv::new(timestamp, prev_l2_block, safe_l1_block, el_ops, None);
 
         let result = rpc_exec_engine_inner
             .build_block_from_mempool(payload_env, evm_l2_block)
@@ -669,6 +661,79 @@ mod tests {
         assert!(matches!(
             result,
             Err(EngineError::Other(msg)) if msg == "engine syncing while preparing payload"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_build_block_from_mempool_returns_invalid_status_error() {
+        let mut mock_client = MockEngineRpc::new();
+        let head_block_hash = B256::random();
+
+        mock_client
+            .expect_fork_choice_updated_v3()
+            .returning(move |_, _| {
+                Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Invalid {
+                    validation_error: "bad attributes".into(),
+                }))
+            });
+
+        let (payload_env, evm_l2_block) = random_payload_build_inputs();
+
+        let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
+
+        let result = rpc_exec_engine_inner
+            .build_block_from_mempool(payload_env, evm_l2_block)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(EngineError::Other(msg)) if msg == "payload build request rejected: bad attributes"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_build_block_from_mempool_returns_accepted_status_error() {
+        let mut mock_client = MockEngineRpc::new();
+        let head_block_hash = B256::random();
+
+        mock_client
+            .expect_fork_choice_updated_v3()
+            .returning(move |_, _| Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Accepted)));
+
+        let (payload_env, evm_l2_block) = random_payload_build_inputs();
+
+        let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
+
+        let result = rpc_exec_engine_inner
+            .build_block_from_mempool(payload_env, evm_l2_block)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(EngineError::Other(msg)) if msg == "unexpected ACCEPTED status while preparing payload"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_build_block_from_mempool_rejects_missing_payload_id_for_valid_status() {
+        let mut mock_client = MockEngineRpc::new();
+        let head_block_hash = B256::random();
+
+        mock_client
+            .expect_fork_choice_updated_v3()
+            .returning(move |_, _| Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)));
+
+        let (payload_env, evm_l2_block) = random_payload_build_inputs();
+
+        let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
+
+        let result = rpc_exec_engine_inner
+            .build_block_from_mempool(payload_env, evm_l2_block)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(EngineError::Other(msg)) if msg == "payload_id missing"
         ));
     }
 

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -152,9 +152,28 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         // TODO: correct error type
         let update_status = forkchoice_result.map_err(|err| EngineError::Other(err.to_string()))?;
 
-        let payload_id: PayloadId = update_status
-            .payload_id
-            .ok_or(EngineError::Other("payload_id missing".into()))?; // should never happen
+        let payload_id: PayloadId = match update_status.payload_status.status {
+            PayloadStatusEnum::Valid => update_status
+                .payload_id
+                .ok_or(EngineError::Other("payload_id missing".into()))?,
+            PayloadStatusEnum::Syncing => {
+                // `forkchoiceUpdated` with payload attributes can report `SYNCING`
+                // without a payload id while the engine is still backfilling.
+                return Err(EngineError::Other(
+                    "engine syncing while preparing payload".into(),
+                ))
+            }
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(EngineError::Other(format!(
+                    "payload build request rejected: {validation_error}"
+                )))
+            }
+            PayloadStatusEnum::Accepted => {
+                return Err(EngineError::Other(
+                    "unexpected ACCEPTED status while preparing payload".into(),
+                ))
+            }
+        };
 
         let raw_id: [u8; 8] = payload_id.0.into();
 
@@ -614,6 +633,43 @@ mod tests {
                 == head_block_hash,
             "cached head block remains unchanged"
         );
+    }
+
+    #[tokio::test]
+    async fn test_build_block_from_mempool_returns_syncing_error() {
+        let mut mock_client = MockEngineRpc::new();
+        let head_block_hash = B256::random();
+
+        mock_client
+            .expect_fork_choice_updated_v3()
+            .returning(move |_, _| Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing)));
+
+        let el_payload = random_el_payload();
+
+        let mut arb = strata_test_utils::ArbitraryGenerator::new();
+        let l2block: L2Block = arb.generate();
+        let accessory = L2BlockAccessory::new(borsh::to_vec(&el_payload).unwrap(), 0);
+        let l2block_bundle = L2BlockBundle::new(l2block, accessory);
+
+        let evm_l2_block = EVML2Block::try_extract(&l2block_bundle).unwrap();
+
+        let rpc_exec_engine_inner = RpcExecEngineInner::new(mock_client, head_block_hash);
+
+        let timestamp = 0;
+        let el_ops = vec![];
+        let safe_l1_block = Buf32(FixedBytes::<32>::random().into());
+        let prev_l2_block = Buf32(FixedBytes::<32>::random().into()).into();
+
+        let payload_env = PayloadEnv::new(timestamp, prev_l2_block, safe_l1_block, el_ops, None);
+
+        let result = rpc_exec_engine_inner
+            .build_block_from_mempool(payload_env, evm_l2_block)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(EngineError::Other(msg)) if msg == "engine syncing while preparing payload"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Fixes payload preparation error classification in `build_block_from_mempool`.

Before this change, the function called `forkchoiceUpdated` with payload attributes and then immediately required `payload_id`. That treated a legal `SYNCING` response as `payload_id missing`, even though payload building has not started yet in that state.

This patch checks `payload_status.status` before reading `payload_id`, keeps the existing `VALID + payload_id` path, and returns explicit errors for `SYNCING`, `INVALID`, and unexpected `ACCEPTED`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The happy path is unchanged.

The important change is that the function now classifies the full response surface explicitly instead of assuming every success response must carry a payload id. The current branch tests `VALID`, `SYNCING`, `INVALID`, unexpected `ACCEPTED`, and `VALID` without a payload id.

AI was used to assist in this PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have disclosed my use of AI in the body of this PR.

## Related Issues
