### PR TITLE
fix(cli): clamp signet fee rate to broadcast minimum

### DIFF
--- a/bin/alpen-cli/src/signet.rs
+++ b/bin/alpen-cli/src/signet.rs
@@ -34,13 +34,100 @@ pub async fn get_fee_rate(
     user_provided_sats_per_vb: Option<u64>,
     signet_backend: &dyn SignetBackend,
 ) -> FeeRate {
-    match user_provided_sats_per_vb {
+    let fee_rate = match user_provided_sats_per_vb {
         Some(fr) => FeeRate::from_sat_per_vb(fr).expect("valid fee rate"),
         None => signet_backend
             .get_fee_rate(1)
             .await
             .expect("valid fee rate")
             .unwrap_or(FeeRate::BROADCAST_MIN),
+    };
+
+    fee_rate.max(FeeRate::BROADCAST_MIN)
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use bdk_wallet::{
+        bitcoin::{FeeRate, Transaction},
+        chain::{
+            spk_client::{FullScanRequestBuilder, SyncRequestBuilder},
+            CheckPoint,
+        },
+        KeychainKind,
+    };
+    use terrors::OneOf;
+
+    use super::{
+        backend::{BroadcastTxError, GetFeeRateError, InvalidFee, ScanError, UpdateSender},
+        get_fee_rate, SignetBackend, SyncError,
+    };
+
+    #[derive(Debug)]
+    struct TestSignetBackend {
+        fee_rate: Option<FeeRate>,
+    }
+
+    #[async_trait]
+    impl SignetBackend for TestSignetBackend {
+        async fn sync_wallet(
+            &self,
+            _req: SyncRequestBuilder<(KeychainKind, u32)>,
+            _last_cp: CheckPoint,
+            _send_update: UpdateSender,
+        ) -> Result<(), SyncError> {
+            unimplemented!("not needed for fee rate tests")
+        }
+
+        async fn scan_wallet(
+            &self,
+            _req: FullScanRequestBuilder<KeychainKind>,
+            _last_cp: CheckPoint,
+            _send_update: UpdateSender,
+        ) -> Result<(), ScanError> {
+            unimplemented!("not needed for fee rate tests")
+        }
+
+        async fn broadcast_tx(&self, _tx: &Transaction) -> Result<(), BroadcastTxError> {
+            unimplemented!("not needed for fee rate tests")
+        }
+
+        async fn get_fee_rate(
+            &self,
+            _target: u16,
+        ) -> Result<Option<FeeRate>, OneOf<(InvalidFee, GetFeeRateError)>> {
+            Ok(self.fee_rate)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_fee_rate_clamps_backend_zero_to_broadcast_minimum() {
+        let backend = TestSignetBackend {
+            fee_rate: Some(FeeRate::ZERO),
+        };
+
+        let fee_rate = get_fee_rate(None, &backend).await;
+
+        assert_eq!(fee_rate, FeeRate::BROADCAST_MIN);
+    }
+
+    #[tokio::test]
+    async fn test_get_fee_rate_uses_broadcast_minimum_when_backend_has_no_estimate() {
+        let backend = TestSignetBackend { fee_rate: None };
+
+        let fee_rate = get_fee_rate(None, &backend).await;
+
+        assert_eq!(fee_rate, FeeRate::BROADCAST_MIN);
+    }
+
+    #[tokio::test]
+    async fn test_get_fee_rate_clamps_user_zero_to_broadcast_minimum() {
+        let backend = TestSignetBackend { fee_rate: None };
+
+        let fee_rate = get_fee_rate(Some(0), &backend).await;
+
+        assert_eq!(fee_rate, FeeRate::BROADCAST_MIN);
     }
 }
 


### PR DESCRIPTION
## Description

Fixes `alpen-cli` signet commands using `0 sat/vB` when the fee backend returns a zero or sub-1 sat/vB estimate. The CLI now clamps the resolved fee rate to `FeeRate::BROADCAST_MIN`, preventing `min relay fee not met` broadcast failures for `send` and `deposit`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The fix is intentionally applied at the shared CLI fee-rate boundary rather than inside the Esplora backend adapter, so all signet fee sources are protected from returning a zero effective fee rate.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This PR was prepared with assistance from Codex.

## Related Issues

STR-3654