### PR TITLE
chore(reth): route EVM fees to Safe collector

### DIFF
--- a/crates/reth/evm/src/constants.rs
+++ b/crates/reth/evm/src/constants.rs
@@ -15,7 +15,7 @@ pub const SCHNORR_PRECOMPILE_ADDRESS: Address =
 pub const SCHNORR_PRECOMPILE_PRECOMPILE_ID: &str = "alpen-schnorr-precompile";
 
 /// The address to send transaction basefee to instead of burning.
-pub const BASEFEE_ADDRESS: Address = address!("5400000000000000000000000000000000000010");
+pub const BASEFEE_ADDRESS: Address = address!("0xdECAf4F0106935C225ab91Ec33EC8F77da42659d");
 
 /// The address to send transaction priority fees to.
-pub const COINBASE_ADDRESS: Address = address!("5400000000000000000000000000000000000011");
+pub const COINBASE_ADDRESS: Address = address!("0xdECAf4F0106935C225ab91Ec33EC8F77da42659d");

--- a/functional-tests/common/config/constants.py
+++ b/functional-tests/common/config/constants.py
@@ -24,10 +24,10 @@ DEV_CHAIN_ID = 2892
 # =============================================================================
 # Protocol Addresses
 # =============================================================================
-# System addresses for fee distribution in Alpen EVM.
-# These are hardcoded in the chain spec.
-BASEFEE_ADDRESS = "0x5400000000000000000000000000000000000010"
-BENEFICIARY_ADDRESS = "0x5400000000000000000000000000000000000011"
+# Collector address for fee distribution in Alpen EVM.
+FEE_COLLECTOR_ADDRESS = "0xdECAf4F0106935C225ab91Ec33EC8F77da42659d"
+BASEFEE_ADDRESS = FEE_COLLECTOR_ADDRESS
+BENEFICIARY_ADDRESS = FEE_COLLECTOR_ADDRESS
 
 # =============================================================================
 # Unit Conversions


### PR DESCRIPTION
## Description

Routes Alpen EVM fee collection to the Safe account requested in STR-3671:

- sends base fees to `0xdECAf4F0106935C225ab91Ec33EC8F77da42659d`
- sends priority fees / block beneficiary rewards to the same address
- updates functional-test fee constants to match the runtime collector address

This intentionally does not update the chainspec `coinbase` fields. Those only affect the genesis block beneficiary, and the existing genesis blocks have `gasUsed: 0x0`; changing them would alter genesis data without being needed for fee collection in produced blocks.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Please double-check that the intended fee-routing path is covered by `BASEFEE_ADDRESS` and `COINBASE_ADDRESS`, and that leaving the chainspec genesis `coinbase` values unchanged is acceptable.

Is this PR addressing any specification, design doc or external reference document?

- []  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3671