### PR TITLE
chore: tag existing TODO and FIXME comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -50,7 +50,7 @@ body:
   - type: textarea
     id: fullnode-version
     attributes:
-      # FIXME: use `--version` instead
+      # FIXME(STR-3693): use `--version` instead
       label: What is the sha256 checksum of the full node you are running?
     validations:
       required: false

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -19,7 +19,7 @@ jobs:
   mutants-test:
     name: Generate mutants on diff against default branch and test
     runs-on: ubuntu-latest
-    continue-on-error: true # FIXME: remove this if all mutants are covered
+    continue-on-error: true # FIXME(STR-3693): remove this if all mutants are covered
     strategy:
       fail-fast: false # Collect all mutants even if some are missed
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rust.unreachable_pub = "warn"
 rust.unused_crate_dependencies = "deny"
 rust.unused_must_use = "deny"
-# rust.missing_docs = "warn" # TODO: we need to enable this in the near future
+# rust.missing_docs = "warn" # TODO(STR-3693): we need to enable this in the near future
 clippy.allow_attributes = "warn"
 clippy.allow_attributes_without_reason = "warn"
 clippy.absolute_paths = "warn"

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -179,11 +179,11 @@ fn main() {
 
             let datadir = builder.config().datadir().data_dir().to_path_buf();
 
-            // TODO: read config, params from file
+            // TODO(STR-2982): read config, params from file
             let genesis_info = ee_genesis_block_info(&ext.custom_chain);
 
-            // TODO: this must also be read from the params file
-            // TODO: define how we want to deterministically generate the AccountId
+            // TODO(STR-3675): this must also be read from the params file
+            // TODO(STR-3675): define how we want to deterministically generate the AccountId
             const ALPEN_EE_ACCOUNT_ID: AccountId = AccountId::new([1u8; 32]);
 
             info!(blockhash=%genesis_info.blockhash(), "EE genesis info");
@@ -905,8 +905,6 @@ fn main() {
                     .spawn_critical("ee_batch_lifecycle", batch_lifecycle_task);
                 node.task_executor
                     .spawn_critical("ee_update_submitter", update_submitter_task);
-                // TODO: proof generation
-                // TODO: post update to OL
             }
 
             health_check_state.mark_ready();

--- a/bin/datatool/src/cmd/params.rs
+++ b/bin/datatool/src/cmd/params.rs
@@ -107,7 +107,7 @@ pub(super) fn exec(cmd: SubcParams, ctx: &mut CmdContext) -> anyhow::Result<()> 
         seqkey,
         opkeys,
         checkpoint_predicate: rollup_vk,
-        // TODO make a const
+        // TODO(STR-3635): make a const
         deposit_sats,
         proof_timeout: cmd.proof_timeout,
         evm_genesis_info,
@@ -172,7 +172,7 @@ struct ParamsConfig {
 }
 
 /// Constructs the parameters for a Strata network.
-// TODO convert this to also initialize the sync params
+// TODO(STR-3635): convert this to also initialize the sync params
 fn construct_params(config: ParamsConfig) -> anyhow::Result<RollupParams> {
     let cr = config
         .seqkey
@@ -189,24 +189,24 @@ fn construct_params(config: ParamsConfig) -> anyhow::Result<RollupParams> {
         magic_bytes: config.magic,
         block_time: config.block_time_sec * 1000,
         cred_rule: cr,
-        // TODO do we want to remove this?
+        // TODO(STR-2168): do we want to remove this?
         genesis_l1_view: config.genesis_l1_view,
         operators: opkeys,
         evm_genesis_block_hash: config.evm_genesis_info.blockhash.0.into(),
         evm_genesis_block_state_root: config.evm_genesis_info.stateroot.0.into(),
-        // TODO make configurable
+        // TODO(STR-3635): make configurable
         l1_reorg_safe_depth: 4,
         target_l2_batch_size: config.epoch_slots as u64,
         deposit_amount: Amount::from_sat(config.deposit_sats),
         checkpoint_predicate: config.checkpoint_predicate,
-        // TODO make configurable
+        // TODO(STR-3635): make configurable
         dispatch_assignment_dur: 64,
         recovery_delay: DEFAULT_RECOVERY_DELAY,
         proof_publish_mode: config
             .proof_timeout
             .map(|t| ProofPublishMode::Timeout(t as u64))
             .unwrap_or(ProofPublishMode::Strict),
-        // TODO make configurable
+        // TODO(STR-3635): make configurable
         max_deposits_in_block: 16,
         network: config.bitcoin_network,
     })

--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -384,7 +384,7 @@ fn create_bitcoin_rpc_client(config: &BitcoindConfig) -> Result<Arc<Client>, Ini
     )
     .map_err(|e| InitError::BitcoinClientCreation(e.to_string()))?;
 
-    // TODO remove this
+    // TODO(STR-3694): remove this
     if config.network != Network::Regtest {
         warn!("network not set to regtest, ignoring");
     }

--- a/bin/strata/src/helpers.rs
+++ b/bin/strata/src/helpers.rs
@@ -17,7 +17,7 @@ use tokio::time;
 use tracing::warn;
 
 // Borrowed from old binary (bin/strata-client/src/main.rs).
-// TODO: these might need to come from config.
+// TODO(STR-3050): these might need to come from config.
 #[cfg(feature = "sequencer")]
 const SEQ_ADDR_GENERATION_TIMEOUT: u64 = 10; // seconds
 #[cfg(feature = "sequencer")]

--- a/contrib/check_ticketless_todos.sh
+++ b/contrib/check_ticketless_todos.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Check that newly added TODO/FIXME comments include a ticket reference.
+# Check that newly added task-marker comments include a ticket reference.
 #
-# Valid:   TODO(STR-2105), FIXME(#123), TODO(PROJ-42)
-# Invalid: TODO, TODO:, FIXME without a ticket
+# Valid markers include a Jira key or GitHub issue number immediately after the marker word.
+# Invalid markers omit that parenthesized reference.
 #
 # Usage:
 #   ./contrib/check_ticketless_todos.sh [base_ref]
@@ -23,18 +23,22 @@ if [ -z "$added_lines" ]; then
     exit 0
 fi
 
-# Match TODO or FIXME that are NOT immediately followed by '(' (which would contain a ticket ref).
-# This catches: TODO, TODO:, TODO should, FIXME:, FIXME this, etc.
-# But allows: TODO(STR-123), FIXME(#456), TODO(PROJ-78)
+# Match the task markers that are not followed by an accepted parenthesized reference.
+todo_word='TO''DO'
+fixme_word='FIX''ME'
+marker_regex="\\b(${todo_word}|${fixme_word})\\b"
+jira_marker_regex="\\b(${todo_word}|${fixme_word})\\([A-Za-z]+-[0-9]+\\)"
+github_marker_regex="\\b(${todo_word}|${fixme_word})\\(#[0-9]+\\)"
+
 ticketless=$(echo "$added_lines" \
-    | grep -E '\b(TODO|FIXME)\b' \
-    | grep -vE '\b(TODO|FIXME)\([A-Za-z]+-[0-9]+\)' \
-    | grep -vE '\b(TODO|FIXME)\(#[0-9]+\)' \
+    | grep -E "$marker_regex" \
+    | grep -vE "$jira_marker_regex" \
+    | grep -vE "$github_marker_regex" \
     || true)
 
 if [ -n "$ticketless" ]; then
-    echo "ERROR: Found TODO/FIXME without a ticket reference."
-    echo "       Use the format TODO(PROJ-123) or FIXME(#456) instead."
+    echo "ERROR: Found a task marker without a ticket reference."
+    echo "       Put a Jira key or GitHub issue number in parentheses immediately after the marker."
     echo ""
     echo "$ticketless"
     exit 1

--- a/crates/acct-types/src/mmr.rs
+++ b/crates/acct-types/src/mmr.rs
@@ -1,12 +1,12 @@
 //! Concrete orchestration layer MMR types.
-// TODO move this to its own crate, why is it in acct-types?
+// TODO(STR-3608): move this to its own crate, why is it in acct-types?
 
 use strata_merkle::*;
 
 /// The basic hasher we use for all the MMR stuff.
 ///
 /// This is SHA-256 with the full 32 byte hash.
-// TODO should this be blake3 and be only 20 bytes or something?
+// TODO(STR-3608): should this be blake3 and be only 20 bytes or something?
 pub type StrataHasher = Sha256Hasher;
 
 /// Compact 64 bit merkle mountain range.

--- a/crates/acct-types/src/state.rs
+++ b/crates/acct-types/src/state.rs
@@ -104,7 +104,7 @@ pub trait AccountTypeState {
     /// Account type ID.
     const ID: AccountTypeId;
 
-    // TODO decoding
+    // TODO(STR-3685): decoding
 }
 
 #[cfg(test)]

--- a/crates/alpen-ee/block-assembly/src/package.rs
+++ b/crates/alpen-ee/block-assembly/src/package.rs
@@ -87,7 +87,7 @@ pub(crate) fn build_block_package<TPayload: EnginePayload>(
 ) -> ExecBlockPackage {
     // 1. build block commitment
     let exec_blkid = payload.blockhash();
-    // TODO: get using `EvmExecutionEnvironment`
+    // TODO(STR-3682): get using `EvmExecutionEnvironment`
     let raw_block_encoded_hash = Hash::new([0u8; 32]);
     let commitment = ExecBlockCommitment::new(exec_blkid, raw_block_encoded_hash);
 

--- a/crates/alpen-ee/common/src/types/prover.rs
+++ b/crates/alpen-ee/common/src/types/prover.rs
@@ -3,7 +3,7 @@ use strata_acct_types::Hash;
 /// Unique identifier to a proof.
 pub type ProofId = Hash;
 
-// TODO: proper proof type
+// TODO(STR-3682): proper proof type
 #[derive(Debug)]
 pub struct Proof(Vec<u8>);
 

--- a/crates/alpen-ee/engine/src/sync.rs
+++ b/crates/alpen-ee/engine/src/sync.rs
@@ -57,7 +57,7 @@ impl<'a, N: NodeTypesWithDB + ProviderNodeTypes> BlockExistenceChecker for RethB
 /// # Returns
 ///
 /// `Ok(())` if sync completed successfully, or an error if sync failed.
-// TODO: retry on network errors
+// TODO(STR-3680): retry on network errors
 pub async fn sync_chainstate_to_engine<N, E, S>(
     storage: &S,
     provider: &BlockchainProvider<N>,

--- a/crates/alpen-ee/exec-chain/src/task.rs
+++ b/crates/alpen-ee/exec-chain/src/task.rs
@@ -90,11 +90,11 @@ pub(crate) async fn handle_ol_update<TStorage: ExecBlockStorage>(
 
     if state.contains_orphan_block(&finalized) {
         // finalized block is a known but unconnected block
-        // TODO: store the finalized state and retry later
+        // TODO(STR-3682): store the finalized state and retry later
         return Ok(());
     }
 
-    // TODO: we have a deep reorg beyond what we consider finalized.
+    // TODO(STR-3682): we have a deep reorg beyond what we consider finalized.
     unimplemented!("deep reorg");
 }
 

--- a/crates/alpen-ee/ol-tracker/src/task.rs
+++ b/crates/alpen-ee/ol-tracker/src/task.rs
@@ -24,7 +24,7 @@ pub(crate) struct OLEpochOperations {
 #[derive(Debug)]
 pub(crate) enum TrackOLAction {
     /// Extend local view of the OL chain with new epochs.
-    /// TODO: stream
+    /// TODO(STR-3682): stream
     Extend(Vec<OLEpochOperations>, Box<OLChainStatus>),
     /// Refresh local finality state without extending the confirmed epoch.
     RefreshFinalized(Box<OLChainStatus>),

--- a/crates/alpen-ee/sequencer/src/batch_builder/reorg.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/reorg.rs
@@ -18,7 +18,7 @@ async fn find_last_canonical_unfinalized_batch(
         .await?
         .ok_or_else(|| eyre!("no batches in storage; genesis batch expected"))?;
 
-    // TODO: get this directly
+    // TODO(STR-3682): get this directly
     let finalized_blocknum = canonical_reader.finalized_blocknum().await?;
 
     let mut idx = batch.idx();

--- a/crates/alpen-ee/sequencer/src/batch_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/batch_builder/task.rs
@@ -255,7 +255,7 @@ where
             // Continue execution with new state.
         }
         ReorgReport::DeepReorg => {
-            // TODO: unrecoverable error
+            // TODO(STR-3682): unrecoverable error
             return Err(eyre!("deep reorg detected"));
         }
     }

--- a/crates/alpen-ee/sequencer/src/block_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/task.rs
@@ -236,7 +236,7 @@ async fn block_builder_task_inner<TEngine: PayloadBuilderEngine>(
         .await
         .context("block_builder: submit new exec block")?;
 
-    // TODO: should this wait for block
+    // TODO(STR-3682): should this wait for block
 
     Ok((blockhash, next_block_target))
 }

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/init.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/init.rs
@@ -17,7 +17,7 @@ pub async fn init_ol_chain_tracker_state<TStorage: ExecBlockStorage, TClient: Se
     let local_finalized_ol_block = *finalized_exec_block.ol_block();
 
     // chain status according to OL
-    // TODO: retry
+    // TODO(STR-3682): retry
     let ol_chain_status = ol_client.chain_status().await?;
     let remote_finalized_ol_block = ol_chain_status.finalized().to_block_commitment();
 
@@ -37,8 +37,8 @@ pub async fn init_ol_chain_tracker_state<TStorage: ExecBlockStorage, TClient: Se
         ));
     }
 
-    // TODO: retry
-    // TODO: chunk calls by slot range
+    // TODO(STR-3682): retry
+    // TODO(STR-3682): chunk calls by slot range
     let blocks = get_inbox_messages_checked(
         ol_client,
         local_finalized_ol_block.slot(),

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/task.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/task.rs
@@ -112,7 +112,7 @@ async fn handle_chain_update(
         Err(err) => {
             error!(?err, "failed to track ol state");
             // retry next cycle
-            // TODO: unrecoverable error
+            // TODO(STR-3682): unrecoverable error
         }
     };
 }

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -95,7 +95,7 @@ fn calculate_target_next_block(
     l1_manager: &L1BlockManager,
     horz_height: L1Height,
 ) -> anyhow::Result<L1Height> {
-    // TODO switch to checking the L1 tip in the consensus/client state
+    // TODO(STR-3691): switch to checking the L1 tip in the consensus/client state
     let target_next_block = l1_manager
         .get_canonical_chain_tip()?
         .map(|(height, _)| height + 1)
@@ -269,7 +269,7 @@ async fn poll_for_new_blocks<R: Reader>(
             return Ok(vec![revert_ev]);
         }
     } else {
-        // TODO make this case a bit more structured
+        // TODO(STR-3691): make this case a bit more structured
         error!("unable to find common block with client chain, something is seriously wrong here!");
         bail!("things are broken with l1 reader");
     }

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -47,7 +47,7 @@ pub struct EnvelopeConfig {
     ///
     /// NOTE: must be higher than the dust limit.
     //
-    // TODO: Make this and all other bitcoin related values to Amount
+    // TODO(STR-3690): Make this and all other bitcoin related values to Amount
     pub reveal_amount: u64,
     /// Bitcoin network
     pub network: Network,
@@ -83,7 +83,7 @@ impl EnvelopeConfig {
     }
 }
 
-// TODO: these might need to be in rollup params
+// TODO(STR-2982): these might need to be in rollup params
 #[derive(Debug, Error)]
 pub enum EnvelopeError {
     #[error("no payload provided")]
@@ -936,5 +936,5 @@ mod tests {
         assert_ne!(unsigned.sighash, Buf32::zero());
     }
 
-    // TODO: make the tests more comprehensive
+    // TODO(STR-3691): make the tests more comprehensive
 }

--- a/crates/btcio/src/writer/bundler/logic.rs
+++ b/crates/btcio/src/writer/bundler/logic.rs
@@ -24,7 +24,7 @@ pub(crate) async fn process_unbundled_entries(
         // intents and create payload entries accordingly
         let payload_entry = BundledPayloadEntry::new_unsigned(entry.payload().clone());
 
-        // TODO: the following block till "Atomic Ends" should be atomic.
+        // TODO(STR-3691): the following block till "Atomic Ends" should be atomic.
         let idx = ops.get_next_payload_idx_async().await?;
         ops.put_payload_entry_async(idx, payload_entry).await?;
         info!(

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -175,8 +175,8 @@ impl ChainWorkerServiceState {
         if block.header().is_terminal() {
             self.handle_complete_epoch(&block, &output, &new_state)?;
             // Send the epoch commitment to receiver
-            // TODO: it seems to be done for each block at the moment. Ideally we would do it just
-            // here.
+            // TODO(STR-3673): it seems to be done for each block at the moment. Ideally we would do
+            // it just here.
         }
 
         // Persist results (including the full state)

--- a/crates/checkpoint-types/src/checkpoint.rs
+++ b/crates/checkpoint-types/src/checkpoint.rs
@@ -79,7 +79,7 @@ impl Checkpoint {
     }
 
     // #[deprecated(note = "use `checkpoint_verification::construct_receipt`")]
-    // TODO: commented for now
+    // TODO(STR-3629): commented for now
     // understand the rationale for making it deprecated
     pub fn construct_receipt(&self) -> ProofReceipt {
         let proof = self.proof().clone();
@@ -90,7 +90,7 @@ impl Checkpoint {
     }
 
     pub fn hash(&self) -> Buf32 {
-        // FIXME make this more structured and use incremental hashing
+        // FIXME(STR-3629): make this more structured and use incremental hashing
 
         let mut buf = vec![];
         let batch_serialized = borsh::to_vec(&self.commitment.batch_info)
@@ -197,7 +197,7 @@ impl L1CommittedCheckpoint {
 
 /// Verifies that a signed checkpoint has a proper signature according to rollup
 /// params.
-// TODO this might want to take a chainstate in the future, but we don't have
+// TODO(STR-3629): this might want to take a chainstate in the future, but we don't have
 // the ability to get that where we call this yet
 pub fn verify_signed_checkpoint_sig(
     signed_checkpoint: &SignedCheckpoint,

--- a/crates/consensus-logic/src/fcm/input.rs
+++ b/crates/consensus-logic/src/fcm/input.rs
@@ -15,7 +15,7 @@ pub enum FcmEvent {
 #[derive(Debug)]
 pub struct FcmInput {
     fcm_rx: mpsc::Receiver<ForkChoiceMessage>,
-    // TODO: Rename CheckpointState to sth like ClientStateAtL1
+    // TODO(STR-3673): Rename CheckpointState to sth like ClientStateAtL1
     checkpoint_state_rx: watch::Receiver<CheckpointState>,
 }
 

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -193,7 +193,7 @@ async fn process_fc_message<C: FcmContext>(
                     prev_epoch,
                     confirmed_epoch,
                     finalized_epoch,
-                    // FIXME this is a bit convoluted, could this be simpler?
+                    // FIXME(STR-3673): this is a bit convoluted, could this be simpler?
                     safe_l1: last_l1_blk,
                 };
 
@@ -346,7 +346,7 @@ async fn handle_new_block<C: FcmContext>(
         .collect();
     let best_block = pick_best_block_async(&cur_tip, &tips, fcm_state.ctx()).await?;
 
-    // TODO make configurable
+    // TODO(STR-3050): make configurable
     let depth = 100;
 
     let tip_update = compute_tip_update(&cur_tip, &best_block, depth, fcm_state.chain_tracker())?;
@@ -405,7 +405,7 @@ async fn handle_epoch_finalization<C: FcmContext>(
 
     info!(?next_finalizable_epoch, "updated finalized tip");
     //trace!(?fin_report, "finalization report");
-    // TODO do something with the finalization report?
+    // TODO(STR-3580): do something with the finalization report?
 
     Ok(Some(next_finalizable_epoch))
 }
@@ -481,7 +481,7 @@ async fn apply_tip_update<C: FcmContext>(
     match update {
         // Easy case.
         TipUpdate::ExtendTip(_cur, _new) => {
-            // TODO: what's the relation between _new and bundle
+            // TODO(STR-3673): what's the relation between _new and bundle
             // Update the tip block in the FCM state.
             let blk_cmmt =
                 OLBlockCommitment::new(bundle.header().slot(), bundle.header().compute_blkid());
@@ -557,7 +557,7 @@ async fn apply_tip_update<C: FcmContext>(
                 return Err(Error::OLApplyTipMismatch(expected_tip, final_tip).into());
             }
 
-            // TODO any cleanup?
+            // TODO(STR-3673): any cleanup?
 
             counter!("strata_fcm_reorgs_total").increment(1);
             histogram!("strata_fcm_reorg_depth").record(reorg_depth as f64);

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -156,14 +156,15 @@ impl<C: FcmContext> FcmServiceState<C> {
     }
 
     pub(crate) async fn get_block_slot(&self, blkid: OLBlockId) -> anyhow::Result<u64> {
-        // FIXME this comes from old code that said "this is horrible but it makes our current use
-        // case much faster, see below"
+        // FIXME(STR-3673): this comes from old code that said "this is horrible but it makes our
+        // current use case much faster, see below"
         if blkid == *self.cur_best_block().blkid() {
             return Ok(self.cur_best_block().slot());
         }
 
-        // FIXME we should have some in-memory cache of blkid->height, although now that we use the
-        // manager this is less significant because we're cloning what's already in memory
+        // FIXME(STR-3673): we should have some in-memory cache of blkid->height, although now that
+        // we use the manager this is less significant because we're cloning what's already
+        // in memory
         let block = self
             .ctx()
             .get_ol_block(blkid)
@@ -196,7 +197,7 @@ impl<C: FcmContext> FcmServiceState<C> {
 }
 
 impl<C: FcmContext> ServiceState for FcmServiceState<C> {
-    // FIXME: these methods should really be within `Service` trait
+    // FIXME(STR-3673): these methods should really be within `Service` trait
     fn name(&self) -> &str {
         "fcm"
     }

--- a/crates/consensus-logic/src/tip_update.rs
+++ b/crates/consensus-logic/src/tip_update.rs
@@ -170,7 +170,7 @@ pub fn compute_tip_update(
         return Ok(None);
     }
 
-    // TODO figure out if this is actually just a revert
+    // TODO(STR-2140): figure out if this is actually just a revert
 
     // Now reverse so that common ancestor is at the beginning
     down_blocks.reverse();

--- a/crates/consensus-logic/src/unfinalized_tracker/mod.rs
+++ b/crates/consensus-logic/src/unfinalized_tracker/mod.rs
@@ -122,7 +122,7 @@ impl UnfinalizedBlockTracker {
     ///
     /// Returns if this new block forks off and creates a new unfinalized tip
     /// block.
-    // TODO do a `SealedL2BlockHeader` thing that includes the blkid
+    // TODO(STR-3370): do a `SealedL2BlockHeader` thing that includes the blkid
     pub fn attach_block(
         &mut self,
         slot: Slot,

--- a/crates/csm-types/src/client_state.rs
+++ b/crates/csm-types/src/client_state.rs
@@ -87,7 +87,7 @@ impl ClientState {
 
 /// A [`ClientState`] wrapper used in StatusChannel.
 /// Supplied with block to wait for genesis.
-/// TODO: to be reworked.
+/// TODO(STR-3583): to be reworked.
 #[derive(Debug, Clone, Default)]
 pub struct CheckpointState {
     pub client_state: ClientState,

--- a/crates/da-framework/src/compound.rs
+++ b/crates/da-framework/src/compound.rs
@@ -163,7 +163,7 @@ impl<T: Bitmap> Default for BitSeqWriter<T> {
 /// using the macro. This gives full control over how context is used during apply.
 ///
 /// See the `context` test module for an example of manual `DaWrite` implementation.
-// TODO turn this into a proc macro
+// TODO(STR-2148): turn this into a proc macro
 #[macro_export]
 macro_rules! make_compound_impl {
     // Entry point without context type - uses () context and default error

--- a/crates/da-framework/src/counter.rs
+++ b/crates/da-framework/src/counter.rs
@@ -23,7 +23,7 @@ pub trait CounterScheme {
     /// of an increment.
     ///
     /// Returns `None` if invalid or out of range.
-    // TODO should these be passed by ref?
+    // TODO(STR-2148): should these be passed by ref?
     fn compare(a: Self::Base, b: Self::Base) -> Option<Self::Incr>;
 }
 
@@ -241,7 +241,7 @@ macro_rules! inst_via_ctr_schemes {
                 }
 
                 fn update(base: &mut Self::Base, incr: &Self::Incr) {
-                    // TODO add more overflow checks here
+                    // TODO(STR-2148): add more overflow checks here
                     *base = ((*base as $viaty) + (*incr as $viaty)) as $basety;
                 }
 

--- a/crates/da-framework/src/queue.rs
+++ b/crates/da-framework/src/queue.rs
@@ -4,7 +4,7 @@ use crate::{
     BuilderError, Codec, CodecResult, CompoundMember, DaBuilder, DaWrite, Decoder, Encoder,
 };
 
-// TODO make this generic over the queue type
+// TODO(STR-2148): make this generic over the queue type
 
 /// The type that we use to refer to queue indexes.
 pub type IdxTy = usize;
@@ -30,11 +30,11 @@ pub trait DaQueueTarget {
     type Entry: Codec;
 
     /// Gets the global index of the next entry to be removed from the queue.
-    fn cur_front(&self) -> IncrTy; // TODO make a `IdxTy`
+    fn cur_front(&self) -> IncrTy; // TODO(STR-2148): make a `IdxTy`
 
     /// Gets what would be the global index of the next entry to be added to the
     /// queue.
-    fn cur_next(&self) -> IncrTy; // TODO make a `IdxTy`
+    fn cur_next(&self) -> IncrTy; // TODO(STR-2148): make a `IdxTy`
 
     /// Increments the index of the front of the queue.
     fn increment_front(&mut self, incr: IncrTy);
@@ -54,7 +54,7 @@ pub struct DaQueue<Q: DaQueueTarget> {
     tail: Vec<Q::Entry>,
 
     /// The new front of the queue.
-    // TODO should this be converted to a counter?
+    // TODO(STR-2148): should this be converted to a counter?
     incr_front: IncrTy,
 }
 
@@ -63,7 +63,7 @@ impl<Q: DaQueueTarget> DaQueue<Q> {
         <Self as Default>::default()
     }
 
-    // TODO add fn to safely add to the back, needs some context
+    // TODO(STR-2148): add fn to safely add to the back, needs some context
 }
 
 impl<Q: DaQueueTarget> Default for DaQueue<Q> {

--- a/crates/da-framework/src/varint64.rs
+++ b/crates/da-framework/src/varint64.rs
@@ -3,7 +3,7 @@
 //! Provides compact LEB128-style encoding for both signed and unsigned values
 //! where small values (the common case) use fewer bytes.
 //!
-//! TODO: Eventually move to strata-codec and reconcile with its VarInt type.
+//! TODO(STR-2148): Eventually move to strata-codec and reconcile with its VarInt type.
 
 use crate::{Codec, CodecError, Decoder, Encoder};
 

--- a/crates/db/store-sled/src/asm/db.rs
+++ b/crates/db/store-sled/src/asm/db.rs
@@ -9,7 +9,7 @@ use crate::define_sled_database;
 define_sled_database!(
     pub struct AsmDBSled {
         asm_state_tree: AsmStateSchema,
-        // TODO(refactor) - it should operate on manifests instead of logs.
+        // TODO(STR-2653): it should operate on manifests instead of logs.
         asm_log_tree: AsmLogSchema,
         asm_aux_data_tree: AsmAuxDataSchema,
     }

--- a/crates/db/tests/src/asm_tests.rs
+++ b/crates/db/tests/src/asm_tests.rs
@@ -54,7 +54,7 @@ pub fn test_put_get_aux_data(db: &impl AsmDatabase) {
     assert_eq!(retrieved, aux_data);
 }
 
-// TODO(QQ): add more tests.
+// TODO(STR-2653): add more tests.
 #[macro_export]
 macro_rules! asm_state_db_tests {
     ($setup_expr:expr) => {

--- a/crates/db/tests/src/client_state_tests.rs
+++ b/crates/db/tests/src/client_state_tests.rs
@@ -20,7 +20,7 @@ pub fn test_get_consensus_update(db: &impl ClientStateDatabase) {
     assert_eq!(update, output);
 }
 
-// TODO(QQ): add more tests.
+// TODO(STR-2653): add more tests.
 #[macro_export]
 macro_rules! client_state_db_tests {
     ($setup_expr:expr) => {

--- a/crates/db/tests/src/l1_tests.rs
+++ b/crates/db/tests/src/l1_tests.rs
@@ -7,7 +7,7 @@ pub fn test_insert_into_empty_db(db: &impl L1Database) {
     let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
     let idx = 1;
 
-    // TODO maybe tweak this to make it a bit more realistic?
+    // TODO(STR-2653): maybe tweak this to make it a bit more realistic?
     let mf = AsmManifest::new(idx, arb.generate(), arb.generate(), vec![])
         .expect("generated test manifest should be valid");
 

--- a/crates/db/tests/src/l1_writer_tests.rs
+++ b/crates/db/tests/src/l1_writer_tests.rs
@@ -173,7 +173,8 @@ pub fn test_put_intent_new_entry(db: &impl L1WriterDatabase) {
     assert_eq!(stored_intent, Some(intent));
 }
 
-// TODO: This and the above test are identical. Merge them or make them test different scenarios.
+// TODO(STR-2653): This and the above test are identical. Merge them or make them test different
+// scenarios.
 pub fn test_put_intent_entry(db: &impl L1WriterDatabase) {
     let intent: IntentEntry = ArbitraryGenerator::new().generate();
     let intent_id: Buf32 = [0; 32].into();

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -97,7 +97,7 @@ pub trait L1Database: Send + Sync + 'static {
     /// Prune earliest blocks till height
     fn prune_to_height(&self, height: L1Height) -> DbResult<()>;
 
-    // TODO DA scraping storage
+    // TODO(STR-2653): DA scraping storage
 
     // Gets current chain tip height, blockid
     fn get_canonical_chain_tip(&self) -> DbResult<Option<(L1Height, L1BlockId)>>;
@@ -108,7 +108,8 @@ pub trait L1Database: Send + Sync + 'static {
     /// Gets the blockid at height for the current chain.
     fn get_canonical_blockid_at_height(&self, height: L1Height) -> DbResult<Option<L1BlockId>>;
 
-    // TODO: This should not exist in database level and should be handled by downstream manager.
+    // TODO(STR-2653): This should not exist in database level and should be handled by downstream
+    // manager.
     /// Returns a half-open interval of block hashes, if we have all of them
     /// present.  Otherwise, returns error.
     fn get_canonical_blockid_range(
@@ -117,7 +118,7 @@ pub trait L1Database: Send + Sync + 'static {
         end_idx: L1Height,
     ) -> DbResult<Vec<L1BlockId>>;
 
-    // TODO DA queries
+    // TODO(STR-2653): DA queries
 }
 
 /// Db for client state updates and checkpoints.

--- a/crates/ee-acct-runtime/src/ee_program.rs
+++ b/crates/ee-acct-runtime/src/ee_program.rs
@@ -98,7 +98,7 @@ impl<E: ExecutionEnvironment> SnarkAccountProgramVerification for EeSnarkAccount
             vinput.ee(),
             vinput.chunk_predicate_key(),
             state,
-            ulinfo.outputs().clone(), // TODO ugh, avoid this clone
+            ulinfo.outputs().clone(), // TODO(STR-3685): ugh, avoid this clone
             vinput.input_chunks(),
             vinput.raw_partial_pre_state(),
         ))
@@ -188,12 +188,12 @@ pub(crate) fn apply_decoded_message(
         }
 
         DecodedEeMessageData::SubjTransfer(_data) => {
-            // TODO handle subject transfers
+            // TODO(STR-3685): handle subject transfers
         }
 
         DecodedEeMessageData::Commit(_data) => {
             // Just ignore this one for now because we're not handling it.
-            // TODO support this
+            // TODO(STR-3685): support this
         }
     }
 

--- a/crates/ee-acct-runtime/src/verification_state.rs
+++ b/crates/ee-acct-runtime/src/verification_state.rs
@@ -101,7 +101,7 @@ pub struct EeVerificationState<'a, E: ExecutionEnvironment> {
     input_chunks: &'a [ArchivedChunkInput],
 
     /// Partial pre-state corresponding to the last verified block.
-    // TODO use this to support DA
+    // TODO(STR-3685): use this to support DA
     raw_partial_pre_state: &'a [u8],
 }
 

--- a/crates/ee-acct-types/src/commit.rs
+++ b/crates/ee-acct-types/src/commit.rs
@@ -17,7 +17,7 @@ impl CommitChainSegment {
     }
 
     pub fn decode(_buf: &[u8]) -> Result<Self, EnvError> {
-        // TODO
+        // TODO(STR-3685): implement decoding.
         unimplemented!()
     }
 

--- a/crates/ee-acct-types/src/messages.rs
+++ b/crates/ee-acct-types/src/messages.rs
@@ -23,7 +23,7 @@ pub const COMMIT_MSG_TYPE: TypeId = 0x10;
 /// Decoded possible EE account messages we want to honor.
 ///
 /// This is not intended to capture all possible message types.
-// TODO make zero copy?
+// TODO(STR-2172): make zero copy?
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DecodedEeMessageData {
     /// Deposit from L1 to a subject in the EE.
@@ -103,7 +103,7 @@ impl_type_flat_struct! {
     /// Describes a chunk a sequencer wants to stage.
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct CommitMsgData {
-        // TODO rename to new_tip_exec_blkid
+        // TODO(STR-3685): rename to new_tip_exec_blkid
         new_tip_exec_blkid: [u8; 32],
     }
 }

--- a/crates/ee-acct-types/src/outputs.rs
+++ b/crates/ee-acct-types/src/outputs.rs
@@ -7,7 +7,7 @@ use crate::traits::ExecutionEnvironment;
 pub struct ExecBlockOutput<E: ExecutionEnvironment> {
     write_batch: E::WriteBatch,
     outputs: ExecOutputs,
-    // TODO
+    // TODO(STR-3685): add any remaining block output fields.
 }
 
 impl<E: ExecutionEnvironment> ExecBlockOutput<E> {

--- a/crates/ee-acct-types/src/traits.rs
+++ b/crates/ee-acct-types/src/traits.rs
@@ -1,4 +1,4 @@
-// TODO should some of these types be moved to a more generic "exec env types"
+// TODO(STR-3685): should some of these types be moved to a more generic "exec env types"
 // crate?  so that ee-chunk-runtime doesn't have to depend on this crate?  maybe
 // do this after repo restructure
 

--- a/crates/ee-chain-types/src/chunk.rs
+++ b/crates/ee-chain-types/src/chunk.rs
@@ -73,4 +73,4 @@ impl ChunkTransition {
     }
 }
 
-// TODO whatever proptest stuff?
+// TODO(STR-3685): whatever proptest stuff?

--- a/crates/ee-chain-types/src/io.rs
+++ b/crates/ee-chain-types/src/io.rs
@@ -49,7 +49,7 @@ impl SubjectDepositData {
 impl ExecOutputs {
     fn new(output_transfers: Vec<OutputTransfer>, output_messages: Vec<OutputMessage>) -> Self {
         Self {
-            // TODO propagate up the bounds checks here
+            // TODO(STR-2172): propagate up the bounds checks here
             output_transfers: output_transfers
                 .try_into()
                 .expect("output_transfers should not exceed capacity"),
@@ -70,7 +70,7 @@ impl ExecOutputs {
 
     /// Adds a transfer output.
     pub fn add_transfer(&mut self, t: OutputTransfer) {
-        // FIXME remove expect
+        // FIXME(STR-2172): remove expect
         self.output_transfers
             .push(t)
             .expect("chain/io: output_transfers list at capacity");
@@ -82,7 +82,7 @@ impl ExecOutputs {
 
     /// Adds a message output.
     pub fn add_message(&mut self, m: OutputMessage) {
-        // FIXME remove expect
+        // FIXME(STR-2172): remove expect
         self.output_messages
             .push(m)
             .expect("chain/io: output_messages list at capacity");

--- a/crates/ee-chunk-runtime/src/chunk_processing.rs
+++ b/crates/ee-chunk-runtime/src/chunk_processing.rs
@@ -144,7 +144,7 @@ pub fn verify_chunk_transition<E: ExecutionEnvironment>(
     // matches the chunk transition.
     let computed_prev_blkid = prev_header.compute_block_id();
     if computed_prev_blkid != tsn.parent_exec_blkid() {
-        // TODO better error type?
+        // TODO(STR-3685): better error type?
         return Err(EnvError::MismatchedChainSegment);
     }
 

--- a/crates/ee-chunk-runtime/src/runtime.rs
+++ b/crates/ee-chunk-runtime/src/runtime.rs
@@ -15,7 +15,7 @@ pub fn verify_input<E: ExecutionEnvironment>(
         .try_decode_chunk_transition()
         .map_err(|_| EnvError::MalformedChainSegment)?;
 
-    // FIXME do we actually need the header or just the blkid+state?
+    // FIXME(STR-3685): do we actually need the header or just the blkid+state?
     let prev_header = input
         .try_decode_prev_header::<E>()
         .map_err(|_| EnvError::MalformedChainSegment)?;
@@ -25,7 +25,7 @@ pub fn verify_input<E: ExecutionEnvironment>(
         .map_err(|_| EnvError::MalformedChainState)?;
 
     // 2. Parse the blocks into a chunk we can execute.
-    // TODO rework borrowings here because this is really ugly
+    // TODO(STR-3685): rework borrowings here because this is really ugly
     let mut block_inputs = Vec::new();
     let mut block_outputs = Vec::new();
     for b in input.raw_chunk().blocks() {

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -95,7 +95,7 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
         exec_payload: &ExecPayload<'_, Self::Block>,
         inputs: &ExecInputs,
     ) -> EnvResult<ExecBlockOutput<Self>> {
-        // TODO Split this function up into multiple stages, there's a lot going
+        // TODO(STR-3683): Split this function up into multiple stages, there's a lot going
         // on here.  There's also check happening here that should be done in
         // `check_outputs_against_header`.  We don't have to clone the state,
         // those checks are managed by the chunk runtime.
@@ -158,7 +158,7 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
         // Step 10: Get state root from header intrinsics (verification happens during merge)
         // This avoids an expensive state clone that would be needed to compute the root here.
         //
-        // FIXME This is not correct behavior, the state root is a "result" of
+        // FIXME(STR-3683): This is not correct behavior, the state root is a "result" of
         // processing the block, so it *can't* be an intrinsic, see the doc
         // comment for `Intrinsics`.  I think we may be doing unnecessary checks
         // here.
@@ -187,7 +187,7 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
         // an expensive state clone. The actual verification happens when the state
         // is mutated and we can compute the root directly without cloning.
         //
-        // FIXME this should be checked here
+        // FIXME(STR-3683): this should be checked here
         // Note: The following are verified during execution in execute_block_body():
         // - transactions_root, ommers_hash, withdrawals_root: by validate_body_against_header()
         // - receipts_root, logs_bloom, gas_used: by validate_block_post_execution()

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -122,11 +122,10 @@ pub const KECCAK_EMPTY: B256 =
 /// This function is a thin wrapper around the Keccak256 hashing algorithm
 /// and is optimized for performance.
 ///
-/// # TODO
-/// - Consider switching the return type to `B256` for consistency with other parts of the codebase.
+/// # TODO(STR-3687): /// - Consider switching the return type to `B256` for consistency with other parts of the codebase.
 #[inline]
 pub fn keccak(data: impl AsRef<[u8]>) -> [u8; 32] {
-    // TODO: Remove this benchmarking code once performance testing is complete.
+    // TODO(STR-3687): Remove this benchmarking code once performance testing is complete.
     // std::hint::black_box(sha2::Sha256::digest(&data));
     *keccak256(data)
 }
@@ -296,7 +295,7 @@ impl Encodable for MptNode {
 ///
 /// **Note**: This implementation is still using the older RLP library and needs to be
 /// migrated to `alloy_rlp` in the future.
-// TODO: migrate to alloy_rlp
+// TODO(STR-3687): migrate to alloy_rlp
 impl Decodable for MptNode {
     /// Decodes an RLP-encoded node from the provided `rlp` buffer.
     ///

--- a/crates/ol/chain-types/Cargo.toml
+++ b/crates/ol/chain-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-# TODO: replace the older ol-chain-types crate with this and remove "-new" suffix
+# TODO(STR-3677): replace the older ol-chain-types crate with this and remove "-new" suffix
 # "-new" is added to maintain compatibility with existing code without disruptive changes
 name = "strata-ol-chain-types-new"
 version = "0.1.0"

--- a/crates/ol/chain-types/src/block.rs
+++ b/crates/ol/chain-types/src/block.rs
@@ -157,7 +157,7 @@ impl OLBlockBody {
         Self::new(tx_segment, None)
     }
 
-    // TODO convert to builder?
+    // TODO(STR-3677): convert to builder?
     pub fn set_manifests(&mut self, manifests: OLAsmManifestContainer) {
         self.manifests = Some(manifests).into();
     }

--- a/crates/ol/msg-types/src/message.rs
+++ b/crates/ol/msg-types/src/message.rs
@@ -1,6 +1,6 @@
 //! Message parsing utilities for orchestration layer messages.
-// TODO this is some weird thing claude invented, I've seen it before but it seems tedious to keep
-// maintained, maybe we should get rid of it?
+// TODO(STR-3677): this is some weird thing claude invented, I've seen it before but it seems
+// tedious to keep maintained, maybe we should get rid of it?
 
 use strata_codec::decode_buf_exact;
 use strata_msg_fmt::{Msg, MsgRef};

--- a/crates/ol/msg-types/src/withdrawal.rs
+++ b/crates/ol/msg-types/src/withdrawal.rs
@@ -15,7 +15,7 @@ pub const WITHDRAWAL_REJECTION_MSG_TYPE_ID: u16 = 0x05;
 /// Maximum length for withdrawal destination descriptor.
 pub const MAX_WITHDRAWAL_DESC_LEN: u32 = 255;
 
-// TODO: allow users to specify operator fee
+// TODO(STR-580): allow users to specify operator fee
 pub const DEFAULT_OPERATOR_FEE: u32 = 0;
 
 /// Bounded [`VarVec`] holding destination descriptor.

--- a/crates/ol/state-support-types/src/index_types.rs
+++ b/crates/ol/state-support-types/src/index_types.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains types that capture operations performed on state
 //! for later use by indexers. These are produced by the `IndexerState` layer.
-// TODO make the field names here more consistent, which should also reflect in
+// TODO(STR-3677): make the field names here more consistent, which should also reflect in
 // the spec and state accessor fn/arg names
 
 use strata_acct_types::{AccountId, Hash, L1BlockRecord, MessageEntry};

--- a/crates/ol/stf/src/chain_processing.rs
+++ b/crates/ol/stf/src/chain_processing.rs
@@ -16,7 +16,7 @@ pub fn process_epoch_initial<S: IStateAccessor>(
     context: &EpochInitialContext,
 ) -> ExecResult<()> {
     // 1. Check that this is the first block of the epoch.
-    // TODO maybe we actually do this implicitly?
+    // TODO(STR-3677): maybe we actually do this implicitly?
 
     // 2. Make sure the state's epoch matches the block.
     let state_cur_epoch = state.cur_epoch();
@@ -32,7 +32,7 @@ pub fn process_epoch_initial<S: IStateAccessor>(
     // For genesis block (epoch 0), there is no previous terminal
     if state_cur_epoch > 0 {
         let _prev_ec = EpochCommitment::from_terminal(state_cur_epoch - 1, context.prev_terminal());
-        // TODO insert into MMR
+        // TODO(STR-3677): insert into MMR
     }
 
     Ok(())
@@ -48,7 +48,7 @@ pub fn process_block_start<S: IStateAccessorMut>(
 ) -> ExecResult<()> {
     // 1. Make sure that our epoch matches what we expect it to be based on the
     // previous header.
-    // FIXME we already basically do this in verify_header_continuity, should we
+    // FIXME(STR-3677): we already basically do this in verify_header_continuity, should we
     // also error out on this when constructing blocks?
     let header_epoch = context.epoch();
     if let Some(ph) = context.parent_header() {

--- a/crates/ol/stf/src/constants.rs
+++ b/crates/ol/stf/src/constants.rs
@@ -9,9 +9,9 @@ pub const BRIDGE_GATEWAY_ACCT_ID: AccountId = AccountId::special(BRIDGE_GATEWAY_
 pub const BRIDGE_GATEWAY_ACCT_SERIAL: AccountSerial = AccountSerial::reserved(BRIDGE_GATEWAY_REF);
 
 /// ID for sequencer-sent accounts.
-// TODO make this different, really, it should be the sequencer producing the block
+// TODO(STR-3677): make this different, really, it should be the sequencer producing the block
 pub const SEQUENCER_ACCT_ID: AccountId = BRIDGE_GATEWAY_ACCT_ID;
 
 /// Serial of the bridge gateway account.
-// TODO make this different, really, it should be the sequencer producing the block
+// TODO(STR-3677): make this different, really, it should be the sequencer producing the block
 pub const SEQUENCER_ACCT_SERIAL: AccountSerial = BRIDGE_GATEWAY_ACCT_SERIAL;

--- a/crates/ol/stf/src/context.rs
+++ b/crates/ol/stf/src/context.rs
@@ -159,7 +159,7 @@ impl<'b> BlockContext<'b> {
             return OLBlockCommitment::null();
         };
 
-        // FIXME uhhh this actually does the same destructuring as above but
+        // FIXME(STR-3677): uhhh this actually does the same destructuring as above but
         // LLVM should be able to figure it out after inlining
         let blkid = self.compute_parent_blkid();
         OLBlockCommitment::new(ph.slot(), blkid)

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -285,7 +285,7 @@ fn process_deposit_log<S: IStateAccessorMut>(
     );
 
     // Deliver the deposit message to the target account.
-    // TODO need to tweak this a bit to deal with the changes to epoch contexts
+    // TODO(STR-3677): need to tweak this a bit to deal with the changes to epoch contexts
     account_processing::process_message(
         state,
         BRIDGE_GATEWAY_ACCT_ID,

--- a/crates/ol/stf/src/output.rs
+++ b/crates/ol/stf/src/output.rs
@@ -11,7 +11,7 @@ use crate::errors::{ExecError, ExecResult};
 #[derive(Clone, Debug)]
 pub struct ExecOutputBuffer {
     // maybe we'll have stuff other than logs in the future
-    // TODO don't use refcell, this sucks
+    // TODO(STR-3677): don't use refcell, this sucks
     logs: RefCell<Vec<OLLog>>,
 }
 

--- a/crates/ol/stf/src/verification.rs
+++ b/crates/ol/stf/src/verification.rs
@@ -325,7 +325,7 @@ pub fn verify_block_structure(header: &OLBlockHeader, body: &OLBlockBody) -> Exe
 }
 
 /// Helper function to compute logs root.
-// TODO move this somewhere?
+// TODO(STR-3677): move this somewhere?
 fn compute_logs_root(logs: &[OLLog]) -> Buf32 {
     if logs.is_empty() {
         return Buf32::zero();

--- a/crates/params/src/lib.rs
+++ b/crates/params/src/lib.rs
@@ -33,7 +33,7 @@ pub struct RollupParams {
     pub operators: Vec<XOnlyPublicKey>,
 
     /// Hardcoded EL genesis info
-    /// TODO: move elsewhere
+    /// TODO(STR-3050): move elsewhere
     pub evm_genesis_block_hash: Buf32,
     pub evm_genesis_block_state_root: Buf32,
 
@@ -73,7 +73,7 @@ impl RollupParams {
             return Err(ParamsError::NoOperators);
         }
 
-        // TODO maybe make all these be a macro?
+        // TODO(STR-3050): maybe make all these be a macro?
         if self.block_time == 0 {
             return Err(ParamsError::ZeroProperty("block_time"));
         }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,7 +1,7 @@
 //! Collection of generic internal data types that are used widely.
 
-// TODO import address types
-// TODO import generic account types
+// TODO(STR-3689): import address types
+// TODO(STR-3689): import generic account types
 
 // Re-export identifier types from strata-identifiers
 pub use strata_identifiers::{

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::prelude::Buf32;
 
 /// Temporary schnorr keypair.
-// FIXME why temporary?
+// FIXME(STR-3689): why temporary?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct SchnorrKeypair {
     /// Secret key.
@@ -17,7 +17,7 @@ pub struct SchnorrKeypair {
 ///
 /// These are generated randomly and added here just for functional tests till we don't have proper
 /// genesis configuration plus operator  addition mechanism ready
-// FIXME remove
+// FIXME(STR-3689): remove
 pub fn get_test_schnorr_keys() -> [SchnorrKeypair; 2] {
     let sk1 = Buf32::from([
         155, 178, 84, 107, 54, 0, 197, 195, 174, 240, 129, 191, 24, 173, 144, 52, 153, 57, 41, 184,

--- a/crates/proof-impl/evm-ee-stf/src/utils.rs
+++ b/crates/proof-impl/evm-ee-stf/src/utils.rs
@@ -11,7 +11,7 @@ pub fn generate_exec_update(el_proof_pp: &EvmBlockStfOutput) -> ExecSegment {
         .withdrawal_intents
         .iter()
         .map(|intent| {
-            // TODO: proper error handling
+            // TODO(STR-3684): proper error handling
             WithdrawalIntent::new(
                 BitcoinAmount::from_sat(intent.amt),
                 intent.destination.clone(),

--- a/crates/reth/evm/src/apis/validation.rs
+++ b/crates/reth/evm/src/apis/validation.rs
@@ -131,7 +131,7 @@ pub fn validate_tx_env<CTX: ContextTr, Error>(
                 return Err(InvalidTransaction::EmptyAuthorizationList);
             }
         }
-        /* // TODO(EOF) EOF removed from spec.
+        /* // TODO(STR-3681): EOF removed from spec.
         TransactionType::Eip7873 => {
             // Check if EIP-7873 transaction is enabled.
             if !spec_id.is_enabled_in(SpecId::OSAKA) {

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -62,7 +62,7 @@ pub(crate) fn bridge_context_call(
             PrecompileError::Fatal("Failed to reset BRIDGEOUT_ADDRESS account balance".into())
         })?;
 
-    // TODO: Properly calculate and deduct gas for the bridge out operation
+    // TODO(STR-3676): Properly calculate and deduct gas for the bridge out operation
     let gas_cost = 0;
 
     Ok(PrecompileOutput::new(gas_cost, Bytes::new()))

--- a/crates/reth/exex/src/state_diff_exex.rs
+++ b/crates/reth/exex/src/state_diff_exex.rs
@@ -54,7 +54,7 @@ impl<
                 .ok_or_else(|| eyre::eyre!("block not found for hash {:?}", block_hash))?;
             let current_block_idx: u64 = current_block.number;
 
-            // TODO: maybe put db writes in another thread
+            // TODO(STR-3649): maybe put db writes in another thread
             if let Err(err) = self
                 .db
                 .put_state_diff(block_hash, current_block_idx, &state_diff)

--- a/crates/reth/node/src/pool.rs
+++ b/crates/reth/node/src/pool.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info};
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
 pub struct AlpenEthereumPoolBuilder {
-    // TODO add options for txpool args
+    // TODO(STR-3681): add options for txpool args
 }
 impl<Types, Node> PoolBuilder<Node> for AlpenEthereumPoolBuilder
 where

--- a/crates/reth/statediff/src/batch/builder.rs
+++ b/crates/reth/statediff/src/batch/builder.rs
@@ -65,7 +65,7 @@ impl<T> TrackedState<T> {
 /// in consecutive order. Callers must ensure blocks are applied sequentially (block N, then
 /// block N+1, etc.). Applying blocks out of order will produce incorrect diffs.
 ///
-/// **TODO**: Add block number tracking and validation to reject non-consecutive blocks.
+/// **TODO(STR-3649)**: Add block number tracking and validation to reject non-consecutive blocks.
 #[derive(Clone, Debug, Default)]
 pub struct BatchBuilder {
     /// Account states: address -> tracked state (original is None if account didn't exist).

--- a/crates/snark-acct-runtime/src/program_processing.rs
+++ b/crates/snark-acct-runtime/src/program_processing.rs
@@ -43,7 +43,7 @@ pub fn verify_and_process_update<'i, P: SnarkAccountProgramVerification>(
         });
     }
 
-    // TODO maybe we should remove the inbox indexes from the pub params?
+    // TODO(STR-3685): maybe we should remove the inbox indexes from the pub params?
     if update.cur_state().next_inbox_msg_idx() + msg_count as u64
         != update.new_state().next_inbox_msg_idx()
     {

--- a/crates/snark-acct-types/src/update.rs
+++ b/crates/snark-acct-types/src/update.rs
@@ -11,7 +11,7 @@ impl UpdateStateData {
     pub fn new(proof_state: ProofState, extra_data: Vec<u8>) -> Self {
         Self {
             proof_state,
-            // FIXME does this panic?
+            // FIXME(STR-3686): does this panic?
             extra_data: extra_data
                 .try_into()
                 .expect("snark account extra data must fit within SSZ max length"),
@@ -31,7 +31,7 @@ impl UpdateInputData {
     pub fn new(seq_no: u64, messages: Vec<MessageEntry>, update_state: UpdateStateData) -> Self {
         Self {
             seq_no,
-            // FIXME does this panic?
+            // FIXME(STR-3686): does this panic?
             messages: messages
                 .try_into()
                 .expect("snark account messages must fit within SSZ max length"),
@@ -65,7 +65,7 @@ impl UpdateOperationData {
         outputs: UpdateOutputs,
         extra_data: Vec<u8>,
     ) -> Self {
-        // TODO rework?
+        // TODO(STR-3685): rework?
         Self {
             input: UpdateInputData::new(
                 seq_no,
@@ -115,7 +115,7 @@ impl From<UpdateOperationData> for UpdateInputData {
 impl LedgerRefs {
     pub fn new(l1_block_refs: Vec<AccumulatorClaim>) -> Self {
         Self {
-            // FIXME does this panic?
+            // FIXME(STR-3686): does this panic?
             l1_block_refs: l1_block_refs
                 .try_into()
                 .expect("ledger refs must fit within SSZ max length"),
@@ -138,7 +138,7 @@ impl LedgerRefs {
 impl LedgerRefProofs {
     pub fn new(l1_block_ref_proofs: Vec<RawMerkleProof>) -> Self {
         Self {
-            // FIXME does this panic?
+            // FIXME(STR-3686): does this panic?
             l1_block_ref_proofs: l1_block_ref_proofs
                 .try_into()
                 .expect("ledger ref proofs must fit within SSZ max length"),
@@ -154,7 +154,7 @@ impl SnarkAccountUpdate {
     pub fn new(operation: UpdateOperationData, update_proof: Vec<u8>) -> Self {
         Self {
             operation,
-            // FIXME does this panic?
+            // FIXME(STR-3686): does this panic?
             update_proof: update_proof
                 .try_into()
                 .expect("update proof bytes must fit within SSZ max length"),
@@ -173,7 +173,7 @@ impl SnarkAccountUpdate {
 impl UpdateAccumulatorProofs {
     pub fn new(inbox_proofs: Vec<RawMerkleProof>, ledger_ref_proofs: LedgerRefProofs) -> Self {
         Self {
-            // FIXME does this panic?
+            // FIXME(STR-3686): does this panic?
             inbox_proofs: inbox_proofs
                 .try_into()
                 .expect("inbox proofs must fit within SSZ max length"),

--- a/crates/state/src/exec_env.rs
+++ b/crates/state/src/exec_env.rs
@@ -26,12 +26,12 @@ pub struct ExecEnvState {
     /// Deposits that have been queued by something but haven't been accepted in
     /// an update yet.  The sequencer should be processing these as soon as
     /// possible.
-    // TODO make this not pub
+    // TODO(STR-3688): make this not pub
     pub pending_deposits: StateQueue<DepositIntent>,
 
     /// Forced inclusions that have been accepted by the CL but not processed by
     /// a CL payload yet.
-    // TODO This is a stub, we don't support these yet and should assert it to
+    // TODO(STR-3688): This is a stub, we don't support these yet and should assert it to
     // be empty.
     pending_forced_incls: StateQueue<forced_inclusion::ForcedInclusion>,
 }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use strata_primitives::l1::L1BlockCommitment;
 
 /// Interface to submit blocks to CSM in blocking or async fashion.
-// TODO reverse the convention on these function names, since you can't
+// TODO(STR-3688): reverse the convention on these function names, since you can't
 // accidentally call an async fn in a blocking context
 #[async_trait]
 pub trait BlockSubmitter: Send + Sync {

--- a/crates/state/src/state_queue.rs
+++ b/crates/state/src/state_queue.rs
@@ -48,7 +48,7 @@ impl<T> StateQueue<T> {
 
     /// Returns a slice over the entries in the queue, without their positioning
     /// information.  Consider if `.iter_entries` is more well-suited.
-    // TODO is it bad to expose this?
+    // TODO(STR-3688): is it bad to expose this?
     pub fn entries(&self) -> &[T] {
         &self.entries
     }
@@ -284,7 +284,7 @@ impl<T> StateQueue<T> {
 mod tests {
     use super::StateQueue;
 
-    // TODO maybe add a queue that goes back and forth several times
+    // TODO(STR-3688): maybe add a queue that goes back and forth several times
     #[test]
     fn test_push_pop_arr() {
         let mut q = StateQueue::<u64>::new_empty();
@@ -365,6 +365,6 @@ mod tests {
         assert_eq!(q.back_idx(), Some(10));
         assert_eq!(q.back(), Some(&5));
 
-        // TODO
+        // TODO(STR-3688): add more coverage here.
     }
 }

--- a/crates/storage-common/src/cache.rs
+++ b/crates/storage-common/src/cache.rs
@@ -63,7 +63,7 @@ impl<K: Clone + Eq + Hash, V: Clone, E: From<OpsError> + error::Error + Clone> C
     }
 
     /// Gets the number of elements in the cache.
-    // TODO replace this with an atomic we update after every op
+    // TODO(STR-3679): replace this with an atomic we update after every op
     #[allow(dead_code, clippy::allow_attributes, reason = "used for debugging")]
     pub async fn get_len_async(&self) -> usize {
         let cache = self.cache.lock().await;
@@ -71,7 +71,7 @@ impl<K: Clone + Eq + Hash, V: Clone, E: From<OpsError> + error::Error + Clone> C
     }
 
     /// Gets the number of elements in the cache.
-    // TODO replace this with an atomic we update after every op
+    // TODO(STR-3679): replace this with an atomic we update after every op
     #[allow(dead_code, clippy::allow_attributes, reason = "used for debugging")]
     pub fn get_len_blocking(&self) -> usize {
         let cache = self.cache.blocking_lock();

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -29,7 +29,7 @@ use strata_db_types::traits::DatabaseBackend;
 pub use strata_db_types::MmrId;
 
 /// A consolidation of database managers.
-// TODO move this to its own module
+// TODO(STR-3679): move this to its own module
 #[expect(
     missing_debug_implementations,
     reason = "Some inner types don't have Debug implementation"

--- a/crates/storage/src/managers/client_state.rs
+++ b/crates/storage/src/managers/client_state.rs
@@ -1,5 +1,5 @@
 //! Client state manager.
-// TODO should this also include sync events?
+// TODO(STR-3679): should this also include sync events?
 
 use std::sync::Arc;
 
@@ -21,7 +21,7 @@ use crate::{
 pub struct ClientStateManager {
     ops: ClientStateOps,
 
-    // TODO actually use caches
+    // TODO(STR-3679): actually use caches
     update_cache: cache::CacheTable<L1Height, Option<ClientUpdateOutput>>,
     state_cache: cache::CacheTable<L1Height, Arc<ClientState>>,
 
@@ -50,7 +50,7 @@ impl ClientStateManager {
         })
     }
 
-    // TODO convert to managing these with Arcs
+    // TODO(STR-3679): convert to managing these with Arcs
     pub async fn get_state_async(&self, block: L1BlockCommitment) -> DbResult<Option<ClientState>> {
         Ok(self
             .ops
@@ -78,7 +78,7 @@ impl ClientStateManager {
         block: &L1BlockCommitment,
         update: ClientUpdateOutput,
     ) -> DbResult<Arc<ClientState>> {
-        // FIXME this is a lot of cloning, good thing the type isn't gigantic,
+        // FIXME(STR-3679): this is a lot of cloning, good thing the type isn't gigantic,
         // still feels bad though
         let state = Arc::new(update.state().clone());
         let height = block.height();

--- a/crates/test-utils/l2/src/legacy.rs
+++ b/crates/test-utils/l2/src/legacy.rs
@@ -22,7 +22,8 @@ use strata_test_utils_btc::BtcMainnetSegment;
 ///
 /// N.B. Currently, uses the same seed under the hood.
 pub fn gen_params() -> Params {
-    // TODO: create a random seed if we really need random op_pubkeys every time this is called
+    // TODO(STR-3692): create a random seed if we really need random op_pubkeys every time this is
+    // called
     gen_params_with_seed(0)
 }
 

--- a/crates/test-utils/l2/src/lib.rs
+++ b/crates/test-utils/l2/src/lib.rs
@@ -1,5 +1,6 @@
 //! Test utilities for L2 (Orchestration Layer) components.
 
+// TODO(STR-3692): (@PG) remove the legacy code
 mod legacy;
 pub use legacy::{gen_params, get_test_operator_secret_key};
 

--- a/docker/test_ee_proof.sh
+++ b/docker/test_ee_proof.sh
@@ -85,7 +85,7 @@ PROOF_ID=$(echo "$RESPONSE" | jq -r '.result[0]')
 
 echo "Got proof handle: $PROOF_ID"
 
-# TODO change to 60
+# TODO(STR-3692): change to 60
 MAX_RETRIES=6000
 # 5 minutes should be more than enough to proof a range of blocks in native mode.
 #MAX_RETRIES=60

--- a/functional-tests/common/config/params.py
+++ b/functional-tests/common/config/params.py
@@ -30,7 +30,8 @@ def hex_bytes_repeated(n: int, repeat: int = 32) -> str:
 @dataclass
 class L1BlockCommitment:
     height: int = field(default=100)
-    blkid: str = field(default_factory=lambda: hex_bytes_repeated(0))  # TODO: more type safe
+    # TODO(STR-3692): more type safe
+    blkid: str = field(default_factory=lambda: hex_bytes_repeated(0))
 
 
 @dataclass
@@ -38,7 +39,8 @@ class GenesisL1View:
     blk: L1BlockCommitment = field(default_factory=L1BlockCommitment)
     next_target: int = field(default=1000)
     epoch_start_timestamp: int = field(default=1000)
-    last_11_timestamps: list[int] = field(default_factory=lambda: [0] * 11)  # TODO: more type safe
+    # TODO(STR-3692): more type safe
+    last_11_timestamps: list[int] = field(default_factory=lambda: [0] * 11)
 
     @staticmethod
     def at_latest_block(btc_rpc) -> "GenesisL1View":
@@ -87,7 +89,7 @@ class GenesisL1View:
         )
 
 
-# TODO: move this to some place common as this should be useful for other purposes as well
+# TODO(STR-3692): move this to some place common as this should be useful for other purposes as well
 def gen_random_keypair() -> tuple[str, Key]:
     """Generates a keypair and returns a tuple of xonly pubkey and privkey."""
     key = Key()
@@ -105,7 +107,7 @@ ProofPublishMode = Literal["strict"] | ProofPublishModeTimeout
 
 @dataclass
 class SchnorrVerify:
-    schnorr_key: str  # TODO: more sophisticated, using pydantic?
+    schnorr_key: str  # TODO(STR-3692): more sophisticated, using pydantic?
 
 
 CredRule = SchnorrVerify | Literal["unchecked"]

--- a/functional-tests/common/rpc_types/strata.py
+++ b/functional-tests/common/rpc_types/strata.py
@@ -4,7 +4,7 @@ Strata RPC types
 
 from typing import TypedDict
 
-HexBytes32 = str  # TODO: stricter
+HexBytes32 = str  # TODO(STR-3692): stricter
 HexBytes = str
 
 

--- a/functional-tests/run_tests.sh
+++ b/functional-tests/run_tests.sh
@@ -17,8 +17,8 @@ setup_path() {
 
 # Builds the binary.
 build() {
-    # TODO: add conditional builds as we go
-    # TODO: different binaries for sequencer and full nodes
+    # TODO(STR-3692): add conditional builds as we go
+    # TODO(STR-3692): different binaries for sequencer and full nodes
     cargo build  -F sequencer -F debug-utils -F test-mode -F debug-asm -F prover --bin strata --bin strata-signer --bin alpen-client --bin strata-datatool --bin strata-test-cli --bin strata-dbtool
 }
 

--- a/functional-tests/tests/alpen_client/test_interaction_with_strata.py
+++ b/functional-tests/tests/alpen_client/test_interaction_with_strata.py
@@ -16,7 +16,7 @@ from common.wait import wait_until_with_value
 logger = logging.getLogger(__name__)
 
 # This is empirical and is used to allow alpen to create and submit DA and get it confirmed.
-# TODO: might need to more intelligently calculate this
+# TODO(STR-3692): might need to more intelligently calculate this
 EXPECT_UPDATE_WITHIN_EPOCH = 10
 CHECK_N_UPDATES = 3  # How many updates from alpen to check in strata
 NUM_INIT_BLOCKS = 5


### PR DESCRIPTION
## Description

Tags the existing ticketless `TODO` / `FIXME` comments covered by `contrib/check_ticketless_todos.sh`, so future PRs do not keep tripping over the pre-existing backlog.

This PR:

- Adds Jira keys to existing TODO/FIXME comments across the checker-scanned file types.
- Replaces pseudo-tags like `TODO(QQ)` / `TODO(refactor)` / `TODO(EOF)` with valid Jira tags.
- Deletes two stale comments in `bin/alpen-client/src/main.rs`.
- Rewrites `contrib/check_ticketless_todos.sh` comments/regex setup so the checker no longer matches its own explanatory text.

Created follow-up Jira tickets `STR-3673` through `STR-3694` for groups that did not have an existing suitable live ticket.

Tally after rebasing over PR #1887's legacy TN1 removal:

| Item | Count |
|---|---:|
| Initial checker-equivalent ticketless hits | 160 |
| Deleted stale comments | 2 |
| Rewritten checker-script self-matches | 8 |
| Tagged to existing Jira tickets | 45 |
| Tagged to newly created Jira tickets | 105 |
| New Jira tickets created | 22 |

So the accounting is:

`160 = 2 deleted + 8 checker-script rewrites + 45 existing-ticket tags + 105 new-ticket tags`

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is intentionally mechanical. It does not attempt to resolve the underlying TODO/FIXME work, except for deleting two stale comments that were already covered by completed EE update/proof plumbing.

Validation run:

```sh
just fmt-ws
./contrib/check_ticketless_todos.sh main
git diff --check
cargo check -p strata-db-types -p strata-consensus-logic -p strata-storage -p strata-test-utils-l2 --all-targets
```

All returned clean.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance was used to inventory, classify, and mechanically tag the existing `TODO`/`FIXME` comments.

## Related Issues

STR-3404
