### PR TITLE
STR-3701: Reconcile stale checkpoint artifacts on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14624,6 +14624,7 @@ dependencies = [
  "strata-acct-types",
  "strata-asm-common",
  "strata-asm-params",
+ "strata-asm-proto-checkpoint",
  "strata-asm-proto-checkpoint-txs",
  "strata-asm-worker",
  "strata-btc-types",

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -43,6 +43,7 @@ ssz.workspace = true
 strata-acct-types.workspace = true
 strata-asm-common.workspace = true
 strata-asm-params.workspace = true
+strata-asm-proto-checkpoint.workspace = true
 strata-asm-proto-checkpoint-txs = { workspace = true, optional = true }
 strata-asm-worker.workspace = true
 strata-btc-types.workspace = true

--- a/bin/strata/src/checkpoint_reconcile.rs
+++ b/bin/strata/src/checkpoint_reconcile.rs
@@ -28,8 +28,8 @@ pub(crate) fn reconcile_unaccepted_checkpoint_artifacts(nodectx: &NodeContext) -
 
     let deleted_payloads = storage
         .ol_checkpoint()
-        .del_checkpoint_payload_entries_from_epoch_blocking(first_unaccepted_epoch)
-        .context("delete unaccepted checkpoint payloads")?;
+        .del_local_checkpoint_payload_entries_from_epoch_blocking(first_unaccepted_epoch)
+        .context("delete unaccepted local checkpoint payloads")?;
     extend_missing(&mut cleanup_commitments, deleted_payloads.iter().copied());
 
     let mut deleted_proofs = 0usize;

--- a/bin/strata/src/checkpoint_reconcile.rs
+++ b/bin/strata/src/checkpoint_reconcile.rs
@@ -1,0 +1,146 @@
+//! Reconciles local checkpoint artifacts against ASM-accepted state.
+
+use anyhow::{Context, Result};
+use strata_asm_common::Subprotocol;
+use strata_asm_proto_checkpoint::CheckpointSubprotocol;
+use strata_checkpoint_types::CheckpointProofTask;
+use strata_identifiers::{Epoch, EpochCommitment};
+use strata_node_context::NodeContext;
+use tracing::{debug, info};
+
+/// Deletes local checkpoint artifacts after ASM's accepted checkpoint tip.
+///
+/// Checkpoint payloads, proofs, and prover tasks past the ASM verified tip are
+/// local candidate state. Rebuilding them on startup prevents a rotated OL
+/// image from reusing stale pre-rotation proof artifacts.
+pub(crate) fn reconcile_unaccepted_checkpoint_artifacts(nodectx: &NodeContext) -> Result<()> {
+    if nodectx.config().prover.is_none() {
+        return Ok(());
+    }
+
+    let Some(first_unaccepted_epoch) = first_unaccepted_checkpoint_epoch(nodectx)? else {
+        return Ok(());
+    };
+
+    let storage = nodectx.storage();
+    let mut cleanup_commitments =
+        checkpoint_commitments_from_epoch(nodectx, first_unaccepted_epoch)?;
+
+    let deleted_payloads = storage
+        .ol_checkpoint()
+        .del_checkpoint_payload_entries_from_epoch_blocking(first_unaccepted_epoch)
+        .context("delete unaccepted checkpoint payloads")?;
+    extend_missing(&mut cleanup_commitments, deleted_payloads.iter().copied());
+
+    let mut deleted_proofs = 0usize;
+    let mut deleted_tasks = 0usize;
+
+    for commitment in cleanup_commitments {
+        if storage
+            .checkpoint_proof()
+            .del_proof(commitment)
+            .with_context(|| format!("delete checkpoint proof for commitment {commitment}"))?
+        {
+            deleted_proofs += 1;
+        }
+
+        let task_key = CheckpointProofTask(commitment).to_key_bytes();
+        if storage
+            .prover_tasks()
+            .delete_task(&task_key)
+            .with_context(|| format!("delete checkpoint prover task for commitment {commitment}"))?
+        {
+            deleted_tasks += 1;
+        }
+    }
+
+    if !deleted_payloads.is_empty() || deleted_proofs > 0 || deleted_tasks > 0 {
+        info!(
+            first_unaccepted_epoch,
+            deleted_payloads = deleted_payloads.len(),
+            deleted_proofs,
+            deleted_tasks,
+            "reconciled unaccepted checkpoint artifacts against ASM verified tip"
+        );
+    }
+
+    Ok(())
+}
+
+fn checkpoint_commitments_from_epoch(
+    nodectx: &NodeContext,
+    first_unaccepted_epoch: Epoch,
+) -> Result<Vec<EpochCommitment>> {
+    let storage = nodectx.storage();
+    let Some(last_summarized_epoch) = storage
+        .ol_checkpoint()
+        .get_last_summarized_epoch_blocking()
+        .context("read last summarized checkpoint epoch")?
+    else {
+        return Ok(Vec::new());
+    };
+
+    if first_unaccepted_epoch > last_summarized_epoch {
+        return Ok(Vec::new());
+    }
+
+    let mut commitments = Vec::new();
+    for epoch in first_unaccepted_epoch..=last_summarized_epoch {
+        let epoch_commitments = storage
+            .ol_checkpoint()
+            .get_epoch_commitments_at_blocking(epoch)
+            .with_context(|| format!("read checkpoint commitments for epoch {epoch}"))?;
+        extend_missing(&mut commitments, epoch_commitments);
+    }
+
+    Ok(commitments)
+}
+
+fn extend_missing<T>(items: &mut Vec<T>, candidates: impl IntoIterator<Item = T>)
+where
+    T: Copy + Eq,
+{
+    for candidate in candidates {
+        if !items.contains(&candidate) {
+            items.push(candidate);
+        }
+    }
+}
+
+fn first_unaccepted_checkpoint_epoch(nodectx: &NodeContext) -> Result<Option<Epoch>> {
+    let Some((asm_l1, asm_state)) = nodectx
+        .storage()
+        .asm()
+        .fetch_most_recent_state()
+        .context("fetch latest ASM state")?
+    else {
+        debug!("latest ASM state is not available; skipping checkpoint artifact reconciliation");
+        return Ok(None);
+    };
+
+    let checkpoint_state = asm_state
+        .state()
+        .find_section(<CheckpointSubprotocol as Subprotocol>::ID)
+        .context("latest ASM state is missing checkpoint subprotocol state")?
+        .try_to_state::<CheckpointSubprotocol>()
+        .context("decode checkpoint subprotocol state")?;
+
+    let verified_epoch = checkpoint_state.verified_tip().epoch;
+    let Some(first_unaccepted_epoch) = verified_epoch.checked_add(1) else {
+        debug!(
+            %asm_l1,
+            verified_epoch,
+            "ASM checkpoint verified tip is at maximum epoch; no checkpoint artifacts to reconcile"
+        );
+        return Ok(None);
+    };
+
+    debug!(
+        %asm_l1,
+        verified_epoch,
+        first_unaccepted_epoch,
+        "resolved first unaccepted checkpoint epoch from ASM verified tip"
+    );
+
+    Ok(Some(first_unaccepted_epoch))
+}

--- a/bin/strata/src/checkpoint_reconcile.rs
+++ b/bin/strata/src/checkpoint_reconcile.rs
@@ -111,7 +111,7 @@ fn first_unaccepted_checkpoint_epoch(nodectx: &NodeContext) -> Result<Option<Epo
     let Some((asm_l1, asm_state)) = nodectx
         .storage()
         .asm()
-        .fetch_most_recent_state()
+        .fetch_most_recent_state_blocking()
         .context("fetch latest ASM state")?
     else {
         debug!("latest ASM state is not available; skipping checkpoint artifact reconciliation");

--- a/bin/strata/src/main.rs
+++ b/bin/strata/src/main.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 
 mod args;
+mod checkpoint_reconcile;
 mod config;
 mod context;
 mod css;

--- a/bin/strata/src/prover/mod.rs
+++ b/bin/strata/src/prover/mod.rs
@@ -197,7 +197,21 @@ fn spawn_checkpoint_runner(
     executor.spawn_critical_async("checkpoint-proof-runner", async move {
         // Resume after the last checkpointed epoch, or start from epoch 1.
         let mut next_epoch_to_prove: Epoch = last_payload_epoch.map_or(1, |e| e + 1);
-        let mut latest_epoch = epoch_rx.borrow().map_or(0, |commitment| commitment.epoch());
+        // The epoch-summary watch channel resets to `None` on restart, so fall
+        // back to the last summarized epoch from storage. Otherwise the catch-up
+        // loop below would idle at 0 and never re-prove epochs whose proofs were
+        // cleared by startup reconciliation until a new terminal epoch arrives.
+        let mut latest_epoch = epoch_rx
+            .borrow()
+            .map(|commitment| commitment.epoch())
+            .or_else(|| {
+                storage
+                    .ol_checkpoint()
+                    .get_last_summarized_epoch_blocking()
+                    .ok()
+                    .flatten()
+            })
+            .unwrap_or(0);
         let mut retry_tick = time::interval(PROVER_RETRY_INTERVAL);
         retry_tick.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -16,6 +16,7 @@ use strata_ol_mempool::{MempoolBuilder, MempoolHandle, OLMempoolConfig};
 use strata_service::ServiceMonitor;
 
 use crate::{
+    checkpoint_reconcile::reconcile_unaccepted_checkpoint_artifacts,
     context::ensure_genesis,
     css, fcm,
     helpers::rollup_to_btcio_params,
@@ -267,6 +268,7 @@ pub(crate) fn start_strata_services(
         nodectx.ol_params(),
         nodectx.status_channel().as_ref(),
     )?;
+    reconcile_unaccepted_checkpoint_artifacts(&nodectx)?;
 
     let is_sequencer = nodectx.config().client.is_sequencer;
 

--- a/crates/db/store-sled/src/ol_checkpoint/db.rs
+++ b/crates/db/store-sled/src/ol_checkpoint/db.rs
@@ -248,6 +248,43 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
         Ok(deleted_epochs)
     }
 
+    fn del_local_checkpoint_payload_entries_from_epoch(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>> {
+        let mut keys = Vec::new();
+        for item in self.payload_tree.iter() {
+            let (epoch_comm, _entry) = item?;
+            if epoch_comm.epoch() >= start_epoch {
+                keys.push(epoch_comm);
+            }
+        }
+
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let deleted_epochs = self.config.with_retry(
+            (&self.payload_tree, &self.signing_tree, &self.unsigned_tree),
+            |(pt, st, ut)| {
+                let mut deleted_epochs = Vec::new();
+                for epoch_comm in &keys {
+                    if pt.contains_key(epoch_comm)? {
+                        let had_signing = st.contains_key(epoch_comm)?;
+                        pt.remove(epoch_comm)?;
+                        st.remove(epoch_comm)?;
+                        if !had_signing {
+                            ut.remove(&epoch_comm.epoch())?;
+                        }
+                        deleted_epochs.push(*epoch_comm);
+                    }
+                }
+                Ok(deleted_epochs)
+            },
+        )?;
+        Ok(deleted_epochs)
+    }
+
     fn put_checkpoint_signing_entry(
         &self,
         epoch: EpochCommitment,

--- a/crates/db/tests/src/ol_checkpoint_tests.rs
+++ b/crates/db/tests/src/ol_checkpoint_tests.rs
@@ -736,6 +736,64 @@ pub fn test_l1_observed_payload_separate_from_sequencer_payload(db: &impl OLChec
     assert_eq!(from_l1, sequencer_payload);
 }
 
+pub fn test_del_local_checkpoint_payload_entries_preserves_l1_observations(
+    db: &impl OLCheckpointDatabase,
+) {
+    let observed_payload = payload_for_epoch(10);
+    let observed_key = checkpoint_epoch_commitment(&observed_payload);
+    let observed_ref = l1_ref_entry(110);
+    db.put_checkpoint_payload_entry(observed_key, observed_payload.clone())
+        .expect("put local observed payload");
+    db.put_checkpoint_l1_observation(observed_key, observed_payload.clone(), observed_ref.clone())
+        .expect("put l1 observation");
+    db.put_checkpoint_signing_entry(observed_key, 10)
+        .expect("put signing entry");
+
+    let unsigned_payload = payload_for_epoch(11);
+    let unsigned_key = checkpoint_epoch_commitment(&unsigned_payload);
+    db.put_checkpoint_payload_entry(unsigned_key, unsigned_payload)
+        .expect("put unsigned payload");
+    assert_eq!(
+        db.get_next_unsigned_checkpoint_epoch()
+            .expect("get unsigned before local cleanup"),
+        Some(Epoch::from(11u32))
+    );
+
+    let mut deleted = db
+        .del_local_checkpoint_payload_entries_from_epoch(Epoch::from(10u32))
+        .expect("delete local payloads");
+    deleted.sort();
+    let mut expected = vec![observed_key, unsigned_key];
+    expected.sort();
+    assert_eq!(deleted, expected);
+
+    assert!(db
+        .get_checkpoint_payload_entry(observed_key)
+        .expect("get deleted local payload")
+        .is_none());
+    assert!(db
+        .get_checkpoint_signing_entry(observed_key)
+        .expect("get deleted signing")
+        .is_none());
+    assert_eq!(
+        db.get_next_unsigned_checkpoint_epoch()
+            .expect("get unsigned after local cleanup"),
+        None
+    );
+
+    let stored_ref = db
+        .get_checkpoint_l1_ref(observed_key)
+        .expect("get preserved l1 ref")
+        .expect("l1 ref should remain");
+    assert_eq!(stored_ref, observed_ref);
+
+    let stored_observed_payload = db
+        .get_checkpoint_l1_observed_payload(observed_key)
+        .expect("get preserved l1-observed payload")
+        .expect("l1-observed payload should remain");
+    assert_eq!(stored_observed_payload, observed_payload);
+}
+
 pub fn test_get_last_checkpoint_l1_ref_epoch_empty(db: &impl OLCheckpointDatabase) {
     assert!(db
         .get_last_checkpoint_l1_ref_epoch()
@@ -914,6 +972,12 @@ macro_rules! ol_checkpoint_db_tests {
         fn test_l1_observed_payload_separate_from_sequencer_payload() {
             let db = $setup_expr;
             $crate::ol_checkpoint_tests::test_l1_observed_payload_separate_from_sequencer_payload(&db);
+        }
+
+        #[test]
+        fn test_del_local_checkpoint_payload_entries_preserves_l1_observations() {
+            let db = $setup_expr;
+            $crate::ol_checkpoint_tests::test_del_local_checkpoint_payload_entries_preserves_l1_observations(&db);
         }
 
         #[test]

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -224,6 +224,16 @@ pub trait OLCheckpointDatabase: Send + Sync + 'static {
         start_epoch: Epoch,
     ) -> DbResult<Vec<EpochCommitment>>;
 
+    /// Delete locally-built checkpoint payload entries from the specified epoch onwards.
+    ///
+    /// Returns a vector of deleted epoch commitments. Signing entries for deleted
+    /// payload commitments are also deleted. L1-observed checkpoint payloads and
+    /// L1 refs are preserved.
+    fn del_local_checkpoint_payload_entries_from_epoch(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>>;
+
     /// Store an OL checkpoint signing entry by epoch.
     fn put_checkpoint_signing_entry(
         &self,

--- a/crates/ol/checkpoint/src/service.rs
+++ b/crates/ol/checkpoint/src/service.rs
@@ -40,6 +40,14 @@ impl<C: CheckpointWorkerContext> Service for OLCheckpointService<C> {
 impl<C: CheckpointWorkerContext> SyncService for OLCheckpointService<C> {
     fn on_launch(state: &mut Self::State) -> anyhow::Result<()> {
         state.initialize();
+        // The epoch-summary watch channel resets to `None` on restart and is
+        // never replayed, so drive a one-shot catch-up to rebuild checkpoint
+        // payloads for epochs already summarized before launch (e.g. those
+        // cleared by startup checkpoint reconciliation). Later epochs arrive
+        // through the watch channel as usual.
+        if let Some(commitment) = state.last_summarized_commitment()? {
+            Self::process_input(state, Some(commitment))?;
+        }
         Ok(())
     }
 

--- a/crates/ol/checkpoint/src/state.rs
+++ b/crates/ol/checkpoint/src/state.rs
@@ -44,6 +44,15 @@ impl<C: CheckpointWorkerContext> OLCheckpointServiceState<C> {
         self.initialized = true;
     }
 
+    /// Returns the canonical commitment of the most recently summarized epoch,
+    /// or `None` if no epoch has been summarized yet.
+    pub(crate) fn last_summarized_commitment(&self) -> anyhow::Result<Option<EpochCommitment>> {
+        let Some(epoch_index) = self.ctx.get_last_summarized_epoch()? else {
+            return Ok(None);
+        };
+        self.ctx.get_canonical_epoch_commitment_at(epoch_index)
+    }
+
     /// Handles a completed epoch, catching up from last checkpoint to latest summary.
     ///
     /// The `target` commitment identifies the epoch that was completed. We process

--- a/crates/storage/src/managers/ol_checkpoint.rs
+++ b/crates/storage/src/managers/ol_checkpoint.rs
@@ -212,6 +212,25 @@ impl OLCheckpointManager {
             .del_checkpoint_payload_entries_from_epoch_blocking(start_epoch)
     }
 
+    /// Deletes locally-built OL checkpoint payload entries from the specified epoch onwards.
+    pub async fn del_local_checkpoint_payload_entries_from_epoch_async(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>> {
+        self.ops
+            .del_local_checkpoint_payload_entries_from_epoch_async(start_epoch)
+            .await
+    }
+
+    /// Deletes locally-built OL checkpoint payload entries from the specified epoch onwards.
+    pub fn del_local_checkpoint_payload_entries_from_epoch_blocking(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>> {
+        self.ops
+            .del_local_checkpoint_payload_entries_from_epoch_blocking(start_epoch)
+    }
+
     /// Stores an OL checkpoint signing entry by epoch commitment.
     pub async fn put_checkpoint_signing_entry_async(
         &self,

--- a/crates/storage/src/managers/prover_task.rs
+++ b/crates/storage/src/managers/prover_task.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use strata_db_types::{errors::DbError, traits::ProverTaskDatabase};
+use strata_db_types::{errors::DbError, traits::ProverTaskDatabase, DbResult};
 use strata_paas::{ProverError, ProverResult, TaskRecord, TaskRecordData, TaskStatus, TaskStore};
 use threadpool::ThreadPool;
 
@@ -27,6 +27,11 @@ impl ProverTaskDbManager {
     pub fn new(pool: ThreadPool, db: Arc<impl ProverTaskDatabase + 'static>) -> Self {
         let ops = Context::new(db).into_ops(pool);
         Self { ops }
+    }
+
+    /// Deletes a task record by key.
+    pub fn delete_task(&self, key: &[u8]) -> DbResult<bool> {
+        self.ops.delete_task_blocking(key.to_vec())
     }
 }
 

--- a/crates/storage/src/ops/ol_checkpoint.rs
+++ b/crates/storage/src/ops/ol_checkpoint.rs
@@ -20,6 +20,7 @@ inst_ops_simple! {
         get_last_checkpoint_payload_epoch() => Option<EpochCommitment>;
         del_checkpoint_payload_entry(epoch: EpochCommitment) => bool;
         del_checkpoint_payload_entries_from_epoch(start_epoch: Epoch) => Vec<EpochCommitment>;
+        del_local_checkpoint_payload_entries_from_epoch(start_epoch: Epoch) => Vec<EpochCommitment>;
         put_checkpoint_signing_entry(epoch: EpochCommitment, payload_intent_idx: L1PayloadIntentIndex) => ();
         get_checkpoint_signing_entry(epoch: EpochCommitment) => Option<L1PayloadIntentIndex>;
         del_checkpoint_signing_entry(epoch: EpochCommitment) => bool;

--- a/crates/storage/src/ops/prover_task.rs
+++ b/crates/storage/src/ops/prover_task.rs
@@ -10,6 +10,7 @@ inst_ops_simple! {
         get_task(key: Vec<u8>) => Option<TaskRecordData>;
         insert_task(key: Vec<u8>, record: TaskRecordData) => ();
         put_task(key: Vec<u8>, record: TaskRecordData) => ();
+        delete_task(key: Vec<u8>) => bool;
         list_retriable(now_secs: u64) => Vec<(Vec<u8>, TaskRecordData)>;
         list_unfinished() => Vec<(Vec<u8>, TaskRecordData)>;
         count_tasks() => usize;


### PR DESCRIPTION
## Summary
- Reconcile local checkpoint artifacts against ASM verified checkpoint tip during strata startup
- Delete unaccepted checkpoint payloads, checkpoint proofs, and checkpoint prover tasks before checkpoint/prover services start
- Expose prover task deletion through the storage manager

Jira: STR-3701
