### PR TITLE
fix(alpen-cli): reserve gas for alpen drain

### DIFF
--- a/bin/alpen-cli/src/cmd/drain.rs
+++ b/bin/alpen-cli/src/cmd/drain.rs
@@ -153,52 +153,51 @@ pub async fn drain(
             .internal_error("Failed to fetch Alpen balance")?;
         if balance == U256::ZERO {
             println!("No Alpen bitcoin to send");
+        } else {
+            let estimate_tx = l2w
+                .transaction_request()
+                .from(l2w.default_signer_address())
+                .to(address)
+                .value(U256::from(1));
+
+            let gas_price = l2w
+                .get_gas_price()
+                .await
+                .internal_error("Failed to fetch Alpen gas price.")?;
+            let gas_estimate = l2w
+                .estimate_gas(estimate_tx)
+                .await
+                .internal_error("Failed to estimate Alpen gas")?;
+
+            if let Some(max_send_amount) = max_alpen_drain_value(balance, gas_estimate, gas_price) {
+                let tx = l2w
+                    .transaction_request()
+                    .to(address)
+                    .value(max_send_amount)
+                    .gas_limit(gas_estimate)
+                    .gas_price(gas_price);
+
+                let res = l2w
+                    .send_transaction(tx)
+                    .await
+                    .internal_error("Failed to broadcast strata transaction")?;
+
+                println!(
+                    "{}",
+                    OnchainObject::from(res.tx_hash())
+                        .with_maybe_explorer(settings.blockscout_endpoint.as_deref())
+                        .pretty()
+                );
+
+                println!(
+                    "Drained {} from Alpen wallet to {}",
+                    Amount::from_sat((max_send_amount / U256::from(SATS_TO_WEI)).wrapping_to()),
+                    address,
+                );
+            } else {
+                println!("No Alpen bitcoin to send after reserving gas");
+            }
         }
-
-        let estimate_tx = l2w
-            .transaction_request()
-            .from(l2w.default_signer_address())
-            .to(address)
-            .value(U256::from(1));
-
-        let gas_price = l2w
-            .get_gas_price()
-            .await
-            .internal_error("Failed to fetch Alpen gas price.")?;
-        let gas_estimate = l2w
-            .estimate_gas(estimate_tx)
-            .await
-            .internal_error("Failed to estimate Alpen gas")?;
-
-        let Some(max_send_amount) = max_alpen_drain_value(balance, gas_estimate, gas_price) else {
-            println!("No Alpen bitcoin to send after reserving gas");
-            return Ok(());
-        };
-
-        let tx = l2w
-            .transaction_request()
-            .to(address)
-            .value(max_send_amount)
-            .gas_limit(gas_estimate)
-            .gas_price(gas_price);
-
-        let res = l2w
-            .send_transaction(tx)
-            .await
-            .internal_error("Failed to broadcast strata transaction")?;
-
-        println!(
-            "{}",
-            OnchainObject::from(res.tx_hash())
-                .with_maybe_explorer(settings.blockscout_endpoint.as_deref())
-                .pretty()
-        );
-
-        println!(
-            "Drained {} from Alpen wallet to {}",
-            Amount::from_sat((max_send_amount / U256::from(SATS_TO_WEI)).wrapping_to()),
-            address,
-        );
     }
 
     Ok(())

--- a/bin/alpen-cli/src/cmd/drain.rs
+++ b/bin/alpen-cli/src/cmd/drain.rs
@@ -43,6 +43,18 @@ pub struct DrainArgs {
 #[derive(Debug, Clone, Copy)]
 pub struct MissingTargetAddress;
 
+fn alpen_drain_fee(gas_limit: u64, gas_price: u128) -> U256 {
+    U256::from(gas_limit) * U256::from(gas_price)
+}
+
+fn max_alpen_drain_value(balance: U256, gas_limit: u64, gas_price: u128) -> Option<U256> {
+    let max_send_amount = balance.checked_sub(alpen_drain_fee(gas_limit, gas_price))?;
+    if max_send_amount == U256::ZERO {
+        return None;
+    }
+    Some(max_send_amount)
+}
+
 pub async fn drain(
     DrainArgs {
         signet_address,
@@ -152,16 +164,23 @@ pub async fn drain(
         let gas_price = l2w
             .get_gas_price()
             .await
-            .internal_error("Failed to fetch Alpen gas price.")? as u64;
+            .internal_error("Failed to fetch Alpen gas price.")?;
         let gas_estimate = l2w
             .estimate_gas(estimate_tx)
             .await
             .internal_error("Failed to estimate Alpen gas")?;
 
-        let total_fee = gas_estimate * gas_price;
-        let max_send_amount = balance.saturating_sub(U256::from(total_fee));
+        let Some(max_send_amount) = max_alpen_drain_value(balance, gas_estimate, gas_price) else {
+            println!("No Alpen bitcoin to send after reserving gas");
+            return Ok(());
+        };
 
-        let tx = l2w.transaction_request().to(address).value(max_send_amount);
+        let tx = l2w
+            .transaction_request()
+            .to(address)
+            .value(max_send_amount)
+            .gas_limit(gas_estimate)
+            .gas_price(gas_price);
 
         let res = l2w
             .send_transaction(tx)
@@ -183,4 +202,50 @@ pub async fn drain(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alpen_drain_value_reserves_exact_fee() {
+        let balance = U256::from(1_000_000_000_000_000_000u128);
+        let gas_limit = 21_000;
+        let gas_price = 1_000_000_000;
+
+        let amount = max_alpen_drain_value(balance, gas_limit, gas_price).unwrap();
+
+        assert_eq!(amount, U256::from(999_979_000_000_000_000u128));
+        assert_eq!(amount + alpen_drain_fee(gas_limit, gas_price), balance);
+    }
+
+    #[test]
+    fn alpen_drain_value_rejects_balance_equal_to_fee() {
+        let gas_limit = 21_000;
+        let gas_price = 1_000_000_000;
+        let balance = alpen_drain_fee(gas_limit, gas_price);
+
+        assert_eq!(max_alpen_drain_value(balance, gas_limit, gas_price), None);
+    }
+
+    #[test]
+    fn alpen_drain_value_rejects_balance_below_fee() {
+        let gas_limit = 21_000;
+        let gas_price = 1_000_000_000;
+        let balance = alpen_drain_fee(gas_limit, gas_price) - U256::from(1);
+
+        assert_eq!(max_alpen_drain_value(balance, gas_limit, gas_price), None);
+    }
+
+    #[test]
+    fn alpen_drain_fee_uses_wide_arithmetic() {
+        let gas_limit = u64::MAX;
+        let gas_price = u128::MAX;
+
+        assert_eq!(
+            alpen_drain_fee(gas_limit, gas_price),
+            U256::from(gas_limit) * U256::from(gas_price)
+        );
+    }
 }

--- a/bin/alpen-cli/src/cmd/drain.rs
+++ b/bin/alpen-cli/src/cmd/drain.rs
@@ -153,51 +153,53 @@ pub async fn drain(
             .internal_error("Failed to fetch Alpen balance")?;
         if balance == U256::ZERO {
             println!("No Alpen bitcoin to send");
-        } else {
-            let estimate_tx = l2w
-                .transaction_request()
-                .from(l2w.default_signer_address())
-                .to(address)
-                .value(U256::from(1));
-
-            let gas_price = l2w
-                .get_gas_price()
-                .await
-                .internal_error("Failed to fetch Alpen gas price.")?;
-            let gas_estimate = l2w
-                .estimate_gas(estimate_tx)
-                .await
-                .internal_error("Failed to estimate Alpen gas")?;
-
-            if let Some(max_send_amount) = max_alpen_drain_value(balance, gas_estimate, gas_price) {
-                let tx = l2w
-                    .transaction_request()
-                    .to(address)
-                    .value(max_send_amount)
-                    .gas_limit(gas_estimate)
-                    .gas_price(gas_price);
-
-                let res = l2w
-                    .send_transaction(tx)
-                    .await
-                    .internal_error("Failed to broadcast strata transaction")?;
-
-                println!(
-                    "{}",
-                    OnchainObject::from(res.tx_hash())
-                        .with_maybe_explorer(settings.blockscout_endpoint.as_deref())
-                        .pretty()
-                );
-
-                println!(
-                    "Drained {} from Alpen wallet to {}",
-                    Amount::from_sat((max_send_amount / U256::from(SATS_TO_WEI)).wrapping_to()),
-                    address,
-                );
-            } else {
-                println!("No Alpen bitcoin to send after reserving gas");
-            }
+            return Ok(());
         }
+
+        let estimate_tx = l2w
+            .transaction_request()
+            .from(l2w.default_signer_address())
+            .to(address)
+            .value(U256::from(1));
+
+        let gas_price = l2w
+            .get_gas_price()
+            .await
+            .internal_error("Failed to fetch Alpen gas price.")?;
+        let gas_estimate = l2w
+            .estimate_gas(estimate_tx)
+            .await
+            .internal_error("Failed to estimate Alpen gas")?;
+
+        let Some(max_send_amount) = max_alpen_drain_value(balance, gas_estimate, gas_price) else {
+            println!("No Alpen bitcoin to send after reserving gas");
+            return Ok(());
+        };
+
+        let tx = l2w
+            .transaction_request()
+            .to(address)
+            .value(max_send_amount)
+            .gas_limit(gas_estimate)
+            .gas_price(gas_price);
+
+        let res = l2w
+            .send_transaction(tx)
+            .await
+            .internal_error("Failed to broadcast strata transaction")?;
+
+        println!(
+            "{}",
+            OnchainObject::from(res.tx_hash())
+                .with_maybe_explorer(settings.blockscout_endpoint.as_deref())
+                .pretty()
+        );
+
+        println!(
+            "Drained {} from Alpen wallet to {}",
+            Amount::from_sat((max_send_amount / U256::from(SATS_TO_WEI)).wrapping_to()),
+            address,
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- reserve Alpen drain gas using wide `U256` arithmetic
- submit the drain transaction with the same explicit `gas_limit` and `gas_price` used for the balance calculation
- add focused tests for exact-fee, below-fee, and wide-arithmetic cases

## Bug Encountered
During the local k2 `alpen-cli` smoke run, `alpen drain --alpen-address 0x000000000000000000000000000000000000c0Fe` failed after the CLI wallet had been funded and had already sent an Alpen transfer. The RPC rejected the drain transaction with:

```text
insufficient funds for gas * price + value: have 998966468221608000 want 998979000000000000
```

The old code estimated gas for a 1-wei transaction, computed `balance - gas_estimate * gas_price`, then submitted a different max-value transaction while leaving the provider to fill gas fields again. That allowed the submitted transaction's upfront gas requirement to exceed the amount reserved by the drain calculation.

This PR fixes that by calculating the reserved fee with `U256`, returning early when there is no spendable balance after gas, and setting `gas_limit` and `gas_price` explicitly on the submitted drain transaction.

