### PR TITLE
fix(ci): set SAFE_HARBOUR_ADDRESS in SP1 E2E test runner

### DIFF
--- a/.github/sp1-e2e/run-test.sh
+++ b/.github/sp1-e2e/run-test.sh
@@ -34,6 +34,10 @@ export CHECKPOINT_PREDICATE=sp1-groth16
 export ALPEN_PREDICATE=sp1-groth16
 export ALPEN_CHAIN_CONFIG="${REPO_ROOT}/crates/reth/chainspec/src/res/testnet-chain.json"
 export CHAIN_SPEC=testnet
+# P2TR BOSD for the bridge safe harbour address (required by init-network.sh).
+# CI-only throwaway value — 04 (P2TR type tag) + 32-byte x-only pubkey derived
+# from the "abandon" mnemonic. Not used for real funds.
+export SAFE_HARBOUR_ADDRESS="0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
 
 # --- Low-level helpers ---
 


### PR DESCRIPTION
## Description

`init-network.sh` now requires `SAFE_HARBOUR_ADDRESS` (PR #1925). The SP1 E2E workflow was not setting it, causing all scheduled runs since `6b286bd` to fail with `Required options not provided: --safe-harbour-address`.

Sets a CI-only throwaway P2TR BOSD (secp256k1 generator point G) in `run-test.sh`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes to Reviewers

Affected runs (3 out of 6 recent failures were caused by this):
- https://github.com/alpenlabs/alpen/actions/runs/26806063938
- https://github.com/alpenlabs/alpen/actions/runs/26791897226
- https://github.com/alpenlabs/alpen/actions/runs/26777748311

The remaining 3 failures are SP1 network transport errors (`rpc.production.succinct.xyz`), tracked in STR-3702.

- [ ] Yes
- [x] No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] My changes do not introduce new warnings.
- [x] New and existing tests pass with my changes.

## Related Issues

Fixes the `--safe-harbour-address` regression from #1925.