### PR TITLE
[CRUTCH -- REVIEW CAREFULLY] Prover simulation logs (stderr capture)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16514,6 +16514,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "borsh",
+ "libc",
  "parking_lot 0.12.5",
  "serde",
  "thiserror 2.0.18",

--- a/crates/prover-core/Cargo.toml
+++ b/crates/prover-core/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 borsh.workspace = true
+libc = "0.2"
 parking_lot.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/prover-core/src/lib.rs
+++ b/crates/prover-core/src/lib.rs
@@ -12,6 +12,7 @@ mod config;
 mod error;
 mod in_memory;
 mod prover;
+mod stderr_capture;
 mod strategy;
 mod task;
 mod traits;

--- a/crates/prover-core/src/prover.rs
+++ b/crates/prover-core/src/prover.rs
@@ -13,7 +13,7 @@ use std::{
 
 use parking_lot::Mutex;
 use tokio::{sync::oneshot, task::spawn_blocking};
-use tracing::{error, info, info_span, warn, Instrument};
+use tracing::{error, info, info_span, warn, Instrument, Span};
 use zkaleido::ZkVmHost;
 #[cfg(feature = "remote")]
 use zkaleido::ZkVmRemoteHost;
@@ -356,7 +356,19 @@ impl<H: ProofSpec> Prover<H> {
             });
 
             let strategy = self.strategy.clone();
-            let prove_result = spawn_blocking(move || strategy.prove(&input, ctx)).await;
+            // Capture the active `prove{task=...}` span (set up at the top
+            // of run_task and active here via `.instrument(span)`) and
+            // re-enter it inside the blocking closure. spawn_blocking runs
+            // on a different thread than the async task; tracing's span
+            // dispatch is thread-local, so without this re-entry every
+            // event emitted by the strategy (zkaleido logs, SP1 SDK logs,
+            // any future guest-stderr tee) would lose the task tag.
+            let parent_span = Span::current();
+            let prove_result = spawn_blocking(move || {
+                let _guard = parent_span.enter();
+                strategy.prove(&input, ctx)
+            })
+            .await;
 
             let receipt = match prove_result {
                 Ok(Ok(receipt)) => receipt,

--- a/crates/prover-core/src/prover.rs
+++ b/crates/prover-core/src/prover.rs
@@ -22,6 +22,7 @@ use crate::{
     config::{ProverConfig, RetryConfig},
     error::{ProverError, ProverResult},
     in_memory::InMemoryTaskStore,
+    stderr_capture,
     strategy::NativeStrategy,
     task::{now_secs, TaskRecord, TaskResult, TaskStatus},
     traits::{ProofSpec, ProveContext, ProveStrategy, ReceiptHook, ReceiptStore, TaskStore},
@@ -366,7 +367,12 @@ impl<H: ProofSpec> Prover<H> {
             let parent_span = Span::current();
             let prove_result = spawn_blocking(move || {
                 let _guard = parent_span.enter();
-                strategy.prove(&input, ctx)
+                // Capture the guest output SP1 writes to host stderr during
+                // simulation/proving and re-emit it under the prove span. See
+                // `stderr_capture` for why fd-level capture is the only seam.
+                let (result, captured) = stderr_capture::capture(|| strategy.prove(&input, ctx));
+                stderr_capture::tee_to_tracing(&captured);
+                result
             })
             .await;
 

--- a/crates/prover-core/src/stderr_capture.rs
+++ b/crates/prover-core/src/stderr_capture.rs
@@ -1,0 +1,247 @@
+//! Capture of SP1 guest output emitted during simulation/proving.
+//!
+//! A hacky solution with a single purpose be able to see simulation
+//! panic logs during the time we stabilize our proof statements.
+//! Must be reconsidered and reassessed after TN3 deployment is complete.
+//!
+//! Some broader technical context:
+//!
+//! SP1's executor writes the guest's file descriptors 1 and 2 directly to the
+//! host process's standard error via `eprintln!`, line-prefixed `stdout: ` and
+//! `stderr: ` respectively (`sp1-core-executor` `syscalls/write.rs`). There is
+//! no SDK, [`SP1Context`], or hook seam to intercept them: the writer fields on
+//! the context are dead code, the SDK's `stdout()`/`stderr()` builders are
+//! commented out, and fd 1/2 are short-circuited before the hook table. The
+//! only place the bytes exist is the host's fd 2.
+//!
+//! [`capture`] brackets a closure by redirecting OS fd 2 into a pipe, draining
+//! it on a helper thread, then restoring fd 2 and returning the captured bytes.
+//! [`tee_to_tracing`] re-emits each captured line as a `tracing` event under
+//! the `sp1.guest` target, so guest output inherits the active `prove{task=…}`
+//! span instead of vanishing into raw container logs.
+//!
+//! This is the alpen-side ("broad window") home for the capture: it wraps the
+//! whole `strategy.prove` call in [`crate::prover`], so it sees output from
+//! both the simulation pre-flight and the local prover without touching
+//! zkaleido. The narrower alternative captures inside zkaleido's executor.
+//!
+//! # Cross-talk: what else can land in the pipe
+//!
+//! There is exactly **one** fd-2 slot per process, and [`CAPTURE_LOCK`] only
+//! serializes *our own* capture windows against each other — it does **not**
+//! stop other threads from writing to fd 2. So anything any thread writes to
+//! stderr while the window is open is diverted into our pipe: it is captured
+//! and re-emitted (see [`tee_to_tracing`]) rather than lost, but it does not
+//! reach the real stderr in real time, surfaces *after* the window, and — since
+//! it lacks SP1's `stdout: `/`stderr: ` prefix — is relabeled as `sp1.guest`.
+//!
+//! In practice this is a small risk **in this deployment**, because the things
+//! that would otherwise collide do not go to fd 2:
+//!
+//! - `strata-logging`'s structured logs go to **stdout (fd 1)** (the `tracing_subscriber::fmt`
+//!   layer's default writer) and/or a **file**, never to stderr. So routine `tracing` output from
+//!   concurrent tasks is *not* captured by this window. (This holds only while that layer keeps its
+//!   stdout/file writer — if it is ever switched to `with_writer(io::stderr)`, the cross-talk
+//!   returns.)
+//! - The realistic residue is therefore a **concurrent thread's panic banner** (Rust's default
+//!   panic hook prints `thread '…' panicked at …` to stderr) or an explicit `eprintln!`/direct
+//!   `io::stderr()` write — both rare during a prove, and the former already signals an abnormal
+//!   event.
+//!
+//! # Other caveats
+//!
+//! - guests are typically `panic = "abort"`, so a panic yields the message and location, not a full
+//!   backtrace.
+//! - capture is best-effort: any failure to set up the redirection runs the closure with stderr
+//!   untouched (capturing empty buffer) and would result in not capturing the simulation's stderr.
+
+use std::{
+    fs::File,
+    io::{stderr, Read, Write},
+    os::fd::FromRawFd,
+    sync::Mutex,
+    thread,
+};
+
+use tracing::{info, warn};
+
+/// Serializes fd-2 redirection across threads (the redirect is process-global).
+static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
+/// `tracing` target for re-emitted guest output.
+const GUEST_TARGET: &str = "sp1.guest";
+
+/// Runs `f` with the host's standard error (fd 2) redirected into a pipe and
+/// returns `f`'s result alongside the bytes written to fd 2 during the call.
+///
+/// Best-effort: if the redirection cannot be set up, `f` runs with stderr
+/// untouched and the captured buffer is empty.
+pub(crate) fn capture<R>(f: impl FnOnce() -> R) -> (R, Vec<u8>) {
+    let _guard = CAPTURE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Flush so previously buffered host stderr is not pulled into the pipe.
+    let _ = stderr().flush();
+
+    let Some(mut redirect) = Redirect::install() else {
+        return (f(), Vec::new());
+    };
+
+    let result = f();
+    let captured = redirect.finish();
+    (result, captured)
+}
+
+/// Re-emits captured guest output as `tracing` events under [`GUEST_TARGET`].
+///
+/// Lines tagged `stderr: ` (guest panics and stderr) are emitted at WARN;
+/// `stdout: ` lines (guest `println!`) at INFO. The prefixes are added by SP1's
+/// executor. Call this only after fd 2 is restored, so events flow to the real
+/// subscriber rather than back into the capture pipe.
+pub(crate) fn tee_to_tracing(captured: &[u8]) {
+    if captured.is_empty() {
+        return;
+    }
+    for line in String::from_utf8_lossy(captured).lines() {
+        if let Some(rest) = line.strip_prefix("stderr: ") {
+            warn!(target: GUEST_TARGET, stream = "stderr", line = %rest);
+        } else if let Some(rest) = line.strip_prefix("stdout: ") {
+            info!(target: GUEST_TARGET, stream = "stdout", line = %rest);
+        } else {
+            // Unprefixed output: another host stderr writer captured in the
+            // window, or a future SP1 format. Surface it verbatim.
+            warn!(target: GUEST_TARGET, line = %line);
+        }
+    }
+}
+
+/// RAII fd-2 redirection.
+///
+/// [`Redirect::install`] points fd 2 at a fresh pipe and spawns a reader thread
+/// draining it; [`Redirect::finish`] restores fd 2 and returns the drained
+/// bytes. [`Drop`] restores fd 2 best-effort if `finish` was not called (e.g. a
+/// panic unwound through the captured closure), so stderr is never left
+/// dangling on the pipe.
+struct Redirect {
+    /// `dup` of the original fd 2, restored over fd 2 on finish/drop. `-1` once
+    /// consumed.
+    saved_fd: i32,
+    /// Reader thread draining the pipe; joined to recover the captured bytes.
+    reader: Option<thread::JoinHandle<Vec<u8>>>,
+}
+
+impl Redirect {
+    fn install() -> Option<Self> {
+        // SAFETY: raw fd syscalls. Return values are checked; each fd is closed
+        // exactly once (read end by the reader thread's `File`, write end here,
+        // saved end on restore).
+        unsafe {
+            let saved_fd = libc::dup(libc::STDERR_FILENO);
+            if saved_fd < 0 {
+                return None;
+            }
+            let mut fds = [0i32; 2];
+            if libc::pipe(fds.as_mut_ptr()) != 0 {
+                libc::close(saved_fd);
+                return None;
+            }
+            let [read_fd, write_fd] = fds;
+
+            // Drain on a helper thread so a guest that out-writes the pipe
+            // buffer cannot block on a full pipe.
+            let reader = thread::spawn(move || {
+                let mut pipe = File::from_raw_fd(read_fd);
+                let mut buf = Vec::new();
+                let _ = pipe.read_to_end(&mut buf);
+                buf
+            });
+
+            if libc::dup2(write_fd, libc::STDERR_FILENO) < 0 {
+                // Closing write_fd leaves the pipe with no writer, so the reader
+                // sees EOF and exits on its own.
+                libc::close(write_fd);
+                libc::close(saved_fd);
+                return None;
+            }
+            // fd 2 now dups the write end; drop our own handle so the pipe's
+            // only writer is fd 2 itself (closed on restore → reader EOF).
+            libc::close(write_fd);
+
+            Some(Self {
+                saved_fd,
+                reader: Some(reader),
+            })
+        }
+    }
+
+    /// Restores fd 2 and returns the captured bytes.
+    fn finish(&mut self) -> Vec<u8> {
+        self.restore();
+        match self.reader.take() {
+            Some(handle) => handle.join().unwrap_or_default(),
+            None => Vec::new(),
+        }
+    }
+
+    fn restore(&mut self) {
+        let _ = stderr().flush();
+        if self.saved_fd >= 0 {
+            // SAFETY: `saved_fd` is a valid dup of the original stderr.
+            // Restoring it reassigns fd 2 and closes the pipe's last write end,
+            // signalling EOF to the reader.
+            unsafe {
+                libc::dup2(self.saved_fd, libc::STDERR_FILENO);
+                libc::close(self.saved_fd);
+            }
+            self.saved_fd = -1;
+        }
+    }
+}
+
+impl Drop for Redirect {
+    fn drop(&mut self) {
+        self.restore();
+        if let Some(handle) = self.reader.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Writes a line to fd 2 the way SP1's executor effectively does at
+    /// runtime — directly through the [`std::io::Stderr`] handle, *not* via the
+    /// `eprintln!` macro. The macro path is intercepted by libtest's
+    /// thread-local output capture and would never reach fd 2 under test.
+    fn write_fd2(line: &str) {
+        let mut err = stderr();
+        let _ = writeln!(err, "{line}");
+    }
+
+    #[test]
+    fn captures_stderr_writes() {
+        let (ret, captured) = capture(|| {
+            write_fd2("stderr: boom at lib.rs:1");
+            write_fd2("stdout: hello");
+            42
+        });
+        assert_eq!(ret, 42);
+        let text = String::from_utf8_lossy(&captured);
+        assert!(text.contains("stderr: boom at lib.rs:1"), "got: {text}");
+        assert!(text.contains("stdout: hello"), "got: {text}");
+    }
+
+    #[test]
+    fn restores_stderr_after_capture() {
+        // After a capture window, fd 2 must be a normal stderr again: a second
+        // capture still works, proving the first restored cleanly.
+        let _ = capture(|| write_fd2("stderr: first"));
+        let (_, captured) = capture(|| write_fd2("stderr: second"));
+        let text = String::from_utf8_lossy(&captured);
+        assert!(text.contains("second"), "got: {text}");
+        assert!(!text.contains("first"), "leaked across windows: {text}");
+    }
+}


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Currently, if (built-in) simulation fails, we:
(1) do not send the proof request (which is correct IMO -- the request anyway would be unfulfillable)
(2) do not have any idea whatsoever why simulation fails (and, _transitively_, **why precisely we haven't sent the proof request**): for example, _a panic on the assert of some proof statement_ within guest simply does not appear in our logs

The current PR is an attempt to alleviate (2) in some form.
It's intended to be very hacky temporary solution to ease debugging and investigation (and I'd advocate to remove it once we stabilize stuff).
 
### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
PLEASE ASSESS CRITICALLY THE LOGIC INSIDE THE PR AND PROS/CONS AS DESCRIBED IN THE DOCSTRINGS OF `STDERR_CAPTURE` 
I am absolutely fine if reviewers decide its not worth it in such a form and we don't merge.


Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
