### PR TITLE
fix(strata-test-cli): stale `SignedAmount`

### DIFF
--- a/bin/strata-test-cli/src/cmd/post_ee_da_envelope.rs
+++ b/bin/strata-test-cli/src/cmd/post_ee_da_envelope.rs
@@ -9,7 +9,6 @@ use bitcoin::{
     consensus::encode::serialize_hex,
     key::Keypair,
     secp256k1::{SecretKey, SECP256K1},
-    SignedAmount,
 };
 use bitcoind_async_client::corepc_types::model::ListUnspentItem;
 use serde_json::json;
@@ -247,7 +246,7 @@ fn to_corepc_list_unspent_item(entry: ListUnspentResultEntry) -> anyhow::Result<
         address,
         label: entry.label.unwrap_or_default(),
         script_pubkey: entry.script_pub_key,
-        amount: SignedAmount::from_sat(entry.amount.to_sat() as i64),
+        amount: entry.amount,
         confirmations: entry.confirmations,
         redeem_script: entry.redeem_script,
         spendable: entry.spendable,


### PR DESCRIPTION
## Description

#1824 was merged without the merge queue and it was rebased a long time ago so all CI was green despite having a compilation issue for `strata-test-cli` binary.

This PR fixes this.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues


