### PR TITLE
ci: add mechanical formatting autofix workflow

### DIFF
--- a/.github/workflows/autofix-formatting.yml
+++ b/.github/workflows/autofix-formatting.yml
@@ -1,0 +1,72 @@
+name: Autofix mechanical formatting
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: autofix-mechanical-formatting-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mechanical-formatters:
+    name: Apply mechanical formatter fixes
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 30
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Extract Rust toolchain version
+        id: extract-rust-version
+        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+
+      - name: Set up Rust
+        env:
+          RUST_NIGHTLY: ${{ steps.extract-rust-version.outputs.rust-version }}
+        run: |
+          rustup toolchain install "$RUST_NIGHTLY" --profile minimal --component rustfmt
+          rustup default "$RUST_NIGHTLY"
+
+      - name: Install taplo
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \
+            | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          working-directory: functional-tests
+          activate-environment: true
+          enable-cache: true
+          cache-suffix: "functional-tests"
+
+      - name: Run mechanical formatters
+        run: |
+          # Add only deterministic, non-semantic formatting fixes here.
+          cargo fmt --all
+          taplo fmt
+          cd functional-tests
+          uv run ruff format
+
+      - name: Commit mechanical formatter fixes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet; then
+            echo "No mechanical formatter changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "style: apply mechanical formatter fixes"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_HEAD_REF}"


### PR DESCRIPTION
## Description

Adds a pull request workflow that applies deterministic mechanical formatting fixes and pushes them back to same-repository PR branches. The workflow currently runs Rust, TOML, and functional-test Python formatters:

- `cargo fmt --all`
- `taplo fmt`
- `uv run ruff format` in `functional-tests`

The existing lint workflows remain responsible for checking the resulting commit.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The workflow is limited to PR branches from this repository, so it does not try to push to fork PRs. It requests `contents: write` because the built-in `GITHUB_TOKEN` needs that permission to push formatter commits.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

Validation: `actionlint .github/workflows/autofix-formatting.yml`

AI assistance notice: This PR was prepared with AI assistance.

## Related Issues

