### PR TITLE
STR 3717 add snark acct inbox range rpc

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -22,8 +22,8 @@ use strata_ol_rpc_types::{
     OLBlockOrTag, OLRpcProvider, RpcAccountBlockSummary, RpcAccountChange, RpcAccountChangeType,
     RpcAccountEpochSummary, RpcAccountState, RpcBlockAccountChanges, RpcBlockEntry,
     RpcBlockHeaderEntry, RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref,
-    RpcOLBlockDetail, RpcOLBlockInfo, RpcOLBlockSummary, RpcOLChainStatus, RpcOLTransaction,
-    RpcOLTxDetail, RpcSnarkAccountState, RpcUpdateInputData,
+    RpcIndexedEntry, RpcMessageEntry, RpcOLBlockDetail, RpcOLBlockInfo, RpcOLBlockSummary,
+    RpcOLChainStatus, RpcOLTransaction, RpcOLTxDetail, RpcSnarkAccountState, RpcUpdateInputData,
 };
 use strata_ol_state_types::OLState;
 use strata_primitives::{HexBytes, HexBytes32};
@@ -54,6 +54,12 @@ struct AccountRecords {
     updates_by_block: HashMap<OLBlockCommitment, Vec<UpdateInputData>>,
     inbox: Vec<InboxMessageRecord>,
 }
+
+/// Maximum number of Snark account inbox messages returned by one RPC call.
+///
+/// This is a server-side page-size and DoS guard, not a protocol limit. Callers
+/// that need a larger inbox span should split it into multiple requests.
+const MAX_SNARK_ACCT_INBOX_MSG_RANGE: u64 = 1_000;
 
 fn local_inbox_message_range(
     account_id: AccountId,
@@ -868,6 +874,44 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         }
 
         Ok(summaries)
+    }
+
+    async fn get_snark_acct_inbox_msg_range(
+        &self,
+        account_id: AccountId,
+        start: u64,
+        end: u64,
+    ) -> RpcResult<Vec<RpcIndexedEntry<RpcMessageEntry>>> {
+        if start > end {
+            return Err(invalid_params_error("start must be <= end"));
+        }
+        let requested_message_count = end - start;
+        if requested_message_count > MAX_SNARK_ACCT_INBOX_MSG_RANGE {
+            return Err(invalid_params_error(format!(
+                "Inbox message range too big \
+                 (count {requested_message_count}, max {MAX_SNARK_ACCT_INBOX_MSG_RANGE})",
+            )));
+        }
+
+        // NOTE: This intentionally does not pre-validate account existence or
+        // account type. The provider/MMR path owns that behavior: empty ranges
+        // return empty, while non-empty missing inbox data surfaces as a
+        // storage error.
+        let messages = self
+            .provider
+            .get_account_inbox_messages(account_id, start, end)
+            .await
+            .map_err(db_error)?;
+        debug_assert!(
+            u64::try_from(messages.len()).expect("message count must fit in u64") <= end - start,
+            "provider returned more inbox messages than requested range"
+        );
+
+        Ok(messages
+            .into_iter()
+            .enumerate()
+            .map(|(offset, message)| RpcIndexedEntry::new(start + offset as u64, message.into()))
+            .collect())
     }
 
     async fn get_account_genesis_epoch_commitment(

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -528,6 +528,22 @@ fn rpc_messages_to_entries(messages: &[RpcMessageEntry]) -> Vec<MessageEntry> {
         .collect()
 }
 
+fn indexed_rpc_messages_to_entries(
+    messages: &[RpcIndexedEntry<RpcMessageEntry>],
+) -> Vec<(u64, MessageEntry)> {
+    messages
+        .iter()
+        .map(|msg| {
+            let entry = msg
+                .value()
+                .clone()
+                .try_into()
+                .expect("message payload bytes must fit within SSZ max length");
+            (msg.index(), entry)
+        })
+        .collect()
+}
+
 fn rpc_update_to_input(update: RpcUpdateInputData) -> UpdateInputData {
     let messages: Vec<MessageEntry> = update
         .messages
@@ -1170,6 +1186,115 @@ async fn checkpoint_info_errors_when_l1_tip_is_below_observed_height() {
     let result = rpc.get_checkpoint_info(2).await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), INTERNAL_ERROR_CODE);
+}
+
+// ── get_snark_acct_inbox_msg_range ──
+
+#[tokio::test]
+async fn snark_acct_inbox_msg_range_returns_indexed_messages() {
+    let account_id = test_account_id(1);
+    let messages = vec![
+        make_message_entry(test_account_id(10), 2, 30, vec![0x01]),
+        make_message_entry(test_account_id(11), 2, 40, vec![0x02]),
+    ];
+    let provider = MockProvider::new().with_inbox_fetch_fn(inbox_fetch_expect_success(
+        account_id,
+        7,
+        9,
+        messages.clone(),
+    ));
+    let rpc = make_rpc(provider);
+
+    let response = rpc
+        .get_snark_acct_inbox_msg_range(account_id, 7, 9)
+        .await
+        .expect("inbox range should succeed");
+
+    assert_eq!(
+        indexed_rpc_messages_to_entries(&response),
+        vec![(7, messages[0].clone()), (8, messages[1].clone())]
+    );
+}
+
+#[tokio::test]
+async fn snark_acct_inbox_msg_range_empty_range_returns_empty() {
+    let account_id = test_account_id(1);
+    let provider = MockProvider::new().with_inbox_fetch_fn(inbox_fetch_expect_success(
+        account_id,
+        5,
+        5,
+        vec![],
+    ));
+    let rpc = make_rpc(provider);
+
+    let response = rpc
+        .get_snark_acct_inbox_msg_range(account_id, 5, 5)
+        .await
+        .expect("empty range should succeed");
+
+    assert!(response.is_empty());
+}
+
+#[tokio::test]
+async fn snark_acct_inbox_msg_range_rejects_reversed_range() {
+    let provider =
+        MockProvider::new().with_inbox_fetch_fn(inbox_fetch_panic("invalid range must not fetch"));
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_inbox_msg_range(test_account_id(1), 9, 7)
+        .await
+        .expect_err("reversed range must fail");
+
+    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+}
+
+#[tokio::test]
+async fn snark_acct_inbox_msg_range_rejects_oversized_range() {
+    let provider = MockProvider::new()
+        .with_inbox_fetch_fn(inbox_fetch_panic("oversized range must not fetch"));
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_inbox_msg_range(test_account_id(1), 0, 1_001)
+        .await
+        .expect_err("oversized range must fail");
+
+    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+}
+
+#[tokio::test]
+async fn snark_acct_inbox_msg_range_allows_range_at_limit() {
+    let account_id = test_account_id(1);
+    let provider = MockProvider::new().with_inbox_fetch_fn(inbox_fetch_expect_success(
+        account_id,
+        0,
+        1_000,
+        vec![],
+    ));
+    let rpc = make_rpc(provider);
+
+    let response = rpc
+        .get_snark_acct_inbox_msg_range(account_id, 0, 1_000)
+        .await
+        .expect("range at limit should succeed");
+
+    assert!(response.is_empty());
+}
+
+#[tokio::test]
+async fn snark_acct_inbox_msg_range_maps_provider_error() {
+    let account_id = test_account_id(1);
+    let provider =
+        MockProvider::new().with_inbox_fetch_fn(inbox_fetch_error("inbox preimage missing"));
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_inbox_msg_range(account_id, 1, 2)
+        .await
+        .expect_err("provider error must fail");
+
+    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
 }
 
 // ── get_blocks_summaries ──

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -46,6 +46,18 @@ pub trait OLClientRpc {
         end_slot: u64,
     ) -> RpcResult<Vec<RpcAccountBlockSummary>>;
 
+    /// Get indexed inbox messages for a Snark account.
+    ///
+    /// The range is half-open: `[start, end)`. Returned entries are ordered by
+    /// increasing inbox index. An empty range returns an empty list.
+    #[method(name = "getSnarkAcctInboxMsgRange")]
+    async fn get_snark_acct_inbox_msg_range(
+        &self,
+        account_id: AccountId,
+        start: u64,
+        end: u64,
+    ) -> RpcResult<Vec<RpcIndexedEntry<RpcMessageEntry>>>;
+
     /// Get snark account state of an account at a specified block.
     #[method(name = "getSnarkAccountState")]
     async fn get_snark_account_state(

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -177,6 +177,33 @@ impl From<UpdateInputData> for RpcUpdateInputData {
     }
 }
 
+/// RPC serializable value with its absolute index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct RpcIndexedEntry<T> {
+    /// Absolute index of the value.
+    index: u64,
+    /// Value at `index`.
+    value: T,
+}
+
+impl<T> RpcIndexedEntry<T> {
+    /// Creates a new [`RpcIndexedEntry`].
+    pub fn new(index: u64, value: T) -> Self {
+        Self { index, value }
+    }
+
+    /// Returns the absolute index.
+    pub fn index(&self) -> u64 {
+        self.index
+    }
+
+    /// Returns the indexed value.
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+}
+
 /// RPC serializable version of [`MessageEntry`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]

--- a/crates/ol/rpc/types/src/lib.rs
+++ b/crates/ol/rpc/types/src/lib.rs
@@ -19,7 +19,8 @@ pub use account_state::{
     RpcAccountTypeData, RpcBlockAccountChanges, RpcSnarkAccountState,
 };
 pub use account_summary::{
-    RpcAccountBlockSummary, RpcAccountEpochSummary, RpcMessageEntry, RpcUpdateInputData,
+    RpcAccountBlockSummary, RpcAccountEpochSummary, RpcIndexedEntry, RpcMessageEntry,
+    RpcUpdateInputData,
 };
 pub use block::{
     RpcBlockEntry, RpcBlockHeaderEntry, RpcOLBlockDetail, RpcOLBlockSummary, RpcOLManifestsSummary,


### PR DESCRIPTION
## Description

Adds `strata_getSnarkAcctInboxMsgRange(account_id, start, end)` to `OLClientRpc`.
The range is half-open `[start, end)`. The RPC returns
`Vec<RpcIndexedEntry<RpcMessageEntry>>`, pairing each Snark account inbox message
with its absolute inbox index.

The implementation reuses the existing
`OLRpcProvider::get_account_inbox_messages` storage/MMR path.

Changes:
- `crates/ol/rpc/types/src/account_summary.rs`: add generic `RpcIndexedEntry<T>` (`Serialize` / `Deserialize` / `JsonSchema`).
- `crates/ol/rpc/types/src/lib.rs`: re-export `RpcIndexedEntry`.
- `crates/ol/rpc/api/src/lib.rs`: add `getSnarkAcctInboxMsgRange` to `OLClientRpc` with `[start, end)` semantics.
- `bin/strata/src/rpc/node.rs`: validate `start <= end`, call the provider, and enumerate results from `start`. Includes a debug_assert! against storage range regressions and delegates unknown-account behavior to the existing storage/MMR lookup.
- `bin/strata/src/rpc/node_tests.rs`: add tests for valid range, empty range, reversed range, and provider error mapping.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3717](https://alpenlabs.atlassian.net/browse/STR-3717)

[STR-3717]: https://alpenlabs.atlassian.net/browse/STR-3717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ