### PR TITLE
STR 3718 add snark acct update manifest rpc

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -23,7 +23,8 @@ use strata_ol_rpc_types::{
     RpcAccountEpochSummary, RpcAccountState, RpcBlockAccountChanges, RpcBlockEntry,
     RpcBlockHeaderEntry, RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref,
     RpcIndexedEntry, RpcMessageEntry, RpcOLBlockDetail, RpcOLBlockInfo, RpcOLBlockSummary,
-    RpcOLChainStatus, RpcOLTransaction, RpcOLTxDetail, RpcSnarkAccountState, RpcUpdateInputData,
+    RpcOLChainStatus, RpcOLTransaction, RpcOLTxDetail, RpcSnarkAccountState,
+    RpcSnarkAcctUpdateManifest, RpcUpdateInputData,
 };
 use strata_ol_state_types::OLState;
 use strata_primitives::{HexBytes, HexBytes32};
@@ -323,9 +324,8 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
     }
 
     /// Fetches per-(account, epoch) update and inbox records over
-    /// `[first_epoch, last_epoch]`. Updates are grouped by block commitment,
-    /// filtered to `block_commitments`. Out-of-chain and checkpoint-sync
-    /// records still advance the inbox cursor so in-chain slices stay accurate.
+    /// `[first_epoch, last_epoch]`. Updates are grouped by block commitment
+    /// and filtered to `block_commitments`.
     async fn fetch_records_in_epoch_range(
         &self,
         account_id: AccountId,
@@ -333,28 +333,8 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
         last_epoch: Epoch,
         block_commitments: &HashSet<OLBlockCommitment>,
     ) -> RpcResult<AccountRecords> {
-        // Seed the cursor once. If the account isn't found in the prior epoch's
-        // terminal state — either because `first_epoch == 0` (no prior epoch
-        // to query) or because it didn't exist as a snark account at that
-        // point — start at 0. Both cases mean "no prior record of the account
-        // in queryable state, so its inbox starts at 0."
-        let mut cursor: u64 = if first_epoch == 0 {
-            0
-        } else {
-            let (_, prev_ol_state) = self
-                .get_toplevel_ol_state_for_epoch(first_epoch - 1)
-                .await?;
-            prev_ol_state
-                .get_account_state(&account_id)
-                .and_then(|s| s.as_snark_account().ok())
-                .map_or(0, |s| s.next_inbox_msg_idx())
-        };
-
-        // Walk records across all epochs in one pass. Out-of-chain and
-        // checkpoint-sync rows advance the cursor without emitting; in-chain
-        // records emit a `Pending` triple capturing the inbox slice they
-        // consumed. Inbox indexing is monotonic per account across epoch
-        // boundaries, so the cursor flows through without re-seeding.
+        // Walk records across all epochs in one pass. In-chain records emit a
+        // `Pending` triple capturing the inbox slice they consumed.
         struct Pending {
             block_commitment: OLBlockCommitment,
             seq_no: u64,
@@ -374,10 +354,6 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                 .map_err(db_error)?
             {
                 for r in records {
-                    let prev_cursor = cursor;
-                    let next_cursor = r.next_inbox_idx();
-                    cursor = next_cursor;
-
                     // Skip rows with no block attribution: checkpoint-sync,
                     // or CSS-terminal-stamped rows (root present but block
                     // absent). This endpoint is the block-scoped view.
@@ -412,8 +388,8 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                         seq_no: r.seq_no(),
                         new_state_root: meta.new_state_root(),
                         extra_data,
-                        cursor_start: prev_cursor,
-                        cursor_end: next_cursor,
+                        cursor_start: r.prev_next_inbox_idx(),
+                        cursor_end: r.next_inbox_idx(),
                     });
                 }
             }
@@ -579,6 +555,19 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
 
         Ok((epoch_commitment, ol_state))
     }
+
+    /// Returns the account's current Snark update seqno at the tip epoch.
+    async fn current_snark_account_seq_no(
+        &self,
+        account_id: AccountId,
+        tip_epoch: Epoch,
+    ) -> RpcResult<Option<u64>> {
+        let (_, tip_ol_state) = self.get_toplevel_ol_state_for_epoch(tip_epoch).await?;
+        Ok(tip_ol_state
+            .get_account_state(&account_id)
+            .and_then(|state| state.as_snark_account().ok())
+            .map(|state| *state.seqno().inner()))
+    }
 }
 
 #[async_trait]
@@ -612,20 +601,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                 )));
             }
 
-            // Inbox-message ranges are contiguous per record:
-            // [prev_record.next_inbox_idx, this.next_inbox_idx). The first
-            // record's lower bound is the prior epoch's terminal next_inbox_idx.
-            // Epoch 0 is genesis: no prior terminal state, no collectable messages.
             let skip_fetch = epoch == 0;
-            let mut cursor = if skip_fetch {
-                0
-            } else {
-                let (_, prev_ol_state) = self.get_toplevel_ol_state_for_epoch(epoch - 1).await?;
-                prev_ol_state
-                    .get_account_state(&account_id)
-                    .and_then(|s| s.as_snark_account().ok())
-                    .map_or(0, |s| s.next_inbox_msg_idx())
-            };
 
             struct Pending {
                 seq_no: u64,
@@ -637,10 +613,6 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
 
             let mut pending = Vec::with_capacity(records.len());
             for r in &records {
-                let cursor_start = cursor;
-                let cursor_end = r.next_inbox_idx();
-                cursor = cursor_end;
-
                 let new_state_root = r.update_meta().map(|m| m.new_state_root());
                 let extra_data = r
                     .extra_data()
@@ -656,8 +628,8 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                     seq_no: r.seq_no(),
                     new_state_root,
                     extra_data,
-                    cursor_start,
-                    cursor_end,
+                    cursor_start: r.prev_next_inbox_idx(),
+                    cursor_end: r.next_inbox_idx(),
                 });
             }
 
@@ -959,6 +931,70 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .enumerate()
             .map(|(offset, message)| RpcIndexedEntry::new(start + offset as u64, message.into()))
             .collect())
+    }
+
+    async fn get_snark_acct_update_manifest(
+        &self,
+        account_id: AccountId,
+        seq_no: u64,
+    ) -> RpcResult<RpcSnarkAcctUpdateManifest> {
+        let creation_epoch = self
+            .provider
+            .get_account_creation_epoch(account_id)
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                not_found_error(format!("No creation epoch found for account {account_id}"))
+            })?;
+        let tip_epoch = self
+            .provider
+            .get_ol_sync_status()
+            .ok_or_else(|| internal_error("OL sync status not available"))?
+            .tip_epoch;
+        if let Some(current_seq_no) = self
+            .current_snark_account_seq_no(account_id, tip_epoch)
+            .await?
+        {
+            // Account state stores the next operation seqno. Published manifests
+            // can only exist for operation seqnos below that upper bound.
+            if seq_no >= current_seq_no {
+                return Err(not_found_error(format!(
+                    "No Snark account update manifest found for account {account_id} seq_no {seq_no}"
+                )));
+            }
+        }
+        for epoch in creation_epoch..=tip_epoch {
+            let Some(records) = self
+                .provider
+                .get_account_update_records(epoch, account_id)
+                .await
+                .map_err(db_error)?
+            else {
+                continue;
+            };
+
+            for record in records {
+                let operation_seq_no = record.orig_acct_seq_no().ok_or_else(|| {
+                    internal_error(format!(
+                        "update record for account {account_id} epoch {epoch} has invalid \
+                         post-state seq_no 0",
+                    ))
+                })?;
+
+                if operation_seq_no != seq_no {
+                    continue;
+                }
+
+                return Ok(RpcSnarkAcctUpdateManifest::from_account_update_record(
+                    &record,
+                    operation_seq_no,
+                ));
+            }
+        }
+
+        Err(not_found_error(format!(
+            "No Snark account update manifest found for account {account_id} seq_no {seq_no}"
+        )))
     }
 
     async fn get_snark_account_state_by_tag(

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -1,4 +1,12 @@
-use std::{collections::HashMap, slice, sync::Arc};
+use std::{
+    collections::HashMap,
+    ops::Range,
+    slice,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use async_trait::async_trait;
 use proptest::prelude::*;
@@ -37,6 +45,33 @@ use crate::rpc::errors::{
 
 type SubmitFn = Box<dyn Fn(OLTransaction) -> OLMempoolResult<OLTxId> + Send + Sync>;
 type InboxFetchFn = Box<dyn Fn(AccountId, u64, u64) -> DbResult<Vec<MessageEntry>> + Send + Sync>;
+type UpdateRecordsFetchFn =
+    Box<dyn Fn(Epoch, AccountId) -> DbResult<Option<Vec<AccountUpdateRecord>>> + Send + Sync>;
+
+fn update_record(
+    update_meta: Option<AccountUpdateMeta>,
+    seq_no: u64,
+    next_inbox_idx: u64,
+    extra_data: Option<Vec<u8>>,
+) -> AccountUpdateRecord {
+    update_record_with_prev(update_meta, seq_no, 0, next_inbox_idx, extra_data)
+}
+
+fn update_record_with_prev(
+    update_meta: Option<AccountUpdateMeta>,
+    seq_no: u64,
+    prev_next_inbox_idx: u64,
+    next_inbox_idx: u64,
+    extra_data: Option<Vec<u8>>,
+) -> AccountUpdateRecord {
+    AccountUpdateRecord::new(
+        update_meta,
+        seq_no,
+        prev_next_inbox_idx,
+        next_inbox_idx,
+        extra_data,
+    )
+}
 
 struct MockProvider {
     blocks: HashMap<OLBlockId, OLBlock>,
@@ -54,6 +89,7 @@ struct MockProvider {
     sync_status: Option<OLSyncStatus>,
     submit_fn: SubmitFn,
     inbox_fetch_fn: Option<InboxFetchFn>,
+    update_records_fetch_fn: Option<UpdateRecordsFetchFn>,
 }
 
 impl MockProvider {
@@ -74,6 +110,7 @@ impl MockProvider {
             sync_status: None,
             submit_fn: Box::new(|_| Ok(OLTxId::from(Buf32::from([0xAB; 32])))),
             inbox_fetch_fn: None,
+            update_records_fetch_fn: None,
         }
     }
 
@@ -154,12 +191,23 @@ impl MockProvider {
         )
     }
 
+    fn with_snark_tip_state(
+        self,
+        commitment: EpochCommitment,
+        account_id: AccountId,
+        seq_no: u64,
+        next_inbox_msg_idx: u64,
+    ) -> Self {
+        self.with_epoch_commitment(commitment.epoch(), commitment)
+            .with_snark_state_at_terminal(commitment, account_id, seq_no, next_inbox_msg_idx)
+    }
+
     fn with_genesis_state_at_terminal(self, commitment: EpochCommitment) -> Self {
         self.with_state_at(commitment.to_block_commitment(), genesis_ol_state())
     }
 
     fn with_account_extra_data(
-        mut self,
+        self,
         account_id: AccountId,
         epoch: Epoch,
         seq_no: u64,
@@ -167,8 +215,33 @@ impl MockProvider {
         extra_data: Vec<u8>,
         block: OLBlockCommitment,
     ) -> Self {
+        self.with_account_extra_data_range(
+            account_id,
+            epoch,
+            seq_no,
+            0..next_inbox_idx,
+            extra_data,
+            block,
+        )
+    }
+
+    fn with_account_extra_data_range(
+        mut self,
+        account_id: AccountId,
+        epoch: Epoch,
+        seq_no: u64,
+        inbox_range: Range<u64>,
+        extra_data: Vec<u8>,
+        block: OLBlockCommitment,
+    ) -> Self {
         let meta = AccountUpdateMeta::new(Some(block), [0u8; 32].into());
-        let record = AccountUpdateRecord::new(Some(meta), seq_no, next_inbox_idx, Some(extra_data));
+        let record = update_record_with_prev(
+            Some(meta),
+            seq_no,
+            inbox_range.start,
+            inbox_range.end,
+            Some(extra_data),
+        );
         self.account_update_entries
             .entry((epoch, account_id))
             .or_default()
@@ -195,6 +268,25 @@ impl MockProvider {
         )
     }
 
+    fn with_account_extra_data_range_at_terminal(
+        self,
+        account_id: AccountId,
+        epoch: Epoch,
+        seq_no: u64,
+        inbox_range: Range<u64>,
+        extra_data: Vec<u8>,
+        commitment: EpochCommitment,
+    ) -> Self {
+        self.with_account_extra_data_range(
+            account_id,
+            epoch,
+            seq_no,
+            inbox_range,
+            extra_data,
+            commitment.to_block_commitment(),
+        )
+    }
+
     fn with_account_update_records(
         mut self,
         account_id: AccountId,
@@ -203,6 +295,11 @@ impl MockProvider {
     ) -> Self {
         self.account_update_entries
             .insert((epoch, account_id), records);
+        self
+    }
+
+    fn with_account_creation_epoch(mut self, account_id: AccountId, epoch: Epoch) -> Self {
+        self.account_creation_epochs.insert(account_id, epoch);
         self
     }
 
@@ -230,6 +327,17 @@ impl MockProvider {
         f: impl Fn(AccountId, u64, u64) -> DbResult<Vec<MessageEntry>> + Send + Sync + 'static,
     ) -> Self {
         self.inbox_fetch_fn = Some(Box::new(f));
+        self
+    }
+
+    fn with_update_records_fetch_fn(
+        mut self,
+        f: impl Fn(Epoch, AccountId) -> DbResult<Option<Vec<AccountUpdateRecord>>>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        self.update_records_fetch_fn = Some(Box::new(f));
         self
     }
 }
@@ -284,6 +392,10 @@ impl OLRpcProvider for MockProvider {
         epoch: Epoch,
         account: AccountId,
     ) -> DbResult<Option<Vec<AccountUpdateRecord>>> {
+        if let Some(fetch_fn) = &self.update_records_fetch_fn {
+            return fetch_fn(epoch, account);
+        }
+
         Ok(self.account_update_entries.get(&(epoch, account)).cloned())
     }
 
@@ -1512,7 +1624,7 @@ async fn blocks_summaries_populates_updates_and_new_inbox_messages_from_index() 
     let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
     let final_state_root = fixed_buf32(0x66);
     let extra_data = vec![0xF0, 0x0D];
-    let update_record = AccountUpdateRecord::new(
+    let update_record = update_record(
         Some(AccountUpdateMeta::new(Some(commitment), final_state_root)),
         6,
         2,
@@ -1576,15 +1688,17 @@ async fn blocks_summaries_slices_processed_messages_from_index_ranges() {
     let block = make_block(10, epoch, null_blkid());
     let commitment = OLBlockCommitment::new(10, block.header().compute_blkid());
     let records = vec![
-        AccountUpdateRecord::new(
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(commitment), [0x11; 32].into())),
             21,
+            2,
             4,
             Some(vec![0xA0]),
         ),
-        AccountUpdateRecord::new(
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(commitment), [0x22; 32].into())),
             22,
+            4,
             6,
             Some(vec![0xA1]),
         ),
@@ -1638,7 +1752,7 @@ async fn blocks_summaries_slices_processed_messages_from_index_ranges() {
 }
 
 #[tokio::test]
-async fn blocks_summaries_walks_cursor_across_epochs() {
+async fn blocks_summaries_reads_indexed_ranges_across_epochs() {
     let account_id = test_account_id(1);
 
     // Genesis (epoch 0, slot 0) → block_e1 (epoch 1's terminal, slot 5)
@@ -1655,7 +1769,7 @@ async fn blocks_summaries_walks_cursor_across_epochs() {
     let block_e2 = make_block(10, 2, blkid_e1);
     let commitment_e2 = OLBlockCommitment::new(10, block_e2.header().compute_blkid());
 
-    let record_e1 = AccountUpdateRecord::new(
+    let record_e1 = update_record(
         Some(AccountUpdateMeta::new(
             Some(commitment_e1),
             [0x11; 32].into(),
@@ -1664,12 +1778,13 @@ async fn blocks_summaries_walks_cursor_across_epochs() {
         2,
         Some(vec![0xA0]),
     );
-    let record_e2 = AccountUpdateRecord::new(
+    let record_e2 = update_record_with_prev(
         Some(AccountUpdateMeta::new(
             Some(commitment_e2),
             [0x22; 32].into(),
         )),
         11,
+        2,
         4,
         Some(vec![0xA1]),
     );
@@ -1726,7 +1841,7 @@ async fn blocks_summaries_walks_cursor_across_epochs() {
 }
 
 #[tokio::test]
-async fn blocks_summaries_seeds_cursor_to_zero_for_new_account() {
+async fn blocks_summaries_reads_zero_prev_range_for_new_account() {
     let account_id = test_account_id(1);
     let epoch: Epoch = 1;
 
@@ -1736,7 +1851,7 @@ async fn blocks_summaries_seeds_cursor_to_zero_for_new_account() {
 
     let block = make_block(5, epoch, genesis_blkid);
     let commitment = OLBlockCommitment::new(5, block.header().compute_blkid());
-    let record = AccountUpdateRecord::new(
+    let record = update_record(
         Some(AccountUpdateMeta::new(Some(commitment), [0x33; 32].into())),
         1,
         2,
@@ -1757,7 +1872,7 @@ async fn blocks_summaries_seeds_cursor_to_zero_for_new_account() {
             EpochCommitment::null(),
         ))
         .with_epoch_commitment(0, prev_epoch_commitment)
-        // Genesis state has no snark account — exercises the cursor=0 fallback.
+        // First indexed update for a new account consumes messages from index 0.
         .with_block_and_state(&genesis_block, genesis_ol_state())
         .with_block_and_state(&block, ol_state_with_snark_account(account_id, 5, 1, 2))
         .with_account_update_records(account_id, epoch, vec![record])
@@ -1794,12 +1909,9 @@ async fn blocks_summaries_account_appears_midway_through_range() {
     let genesis_blkid = genesis_block.header().compute_blkid();
     let epoch0_commitment = EpochCommitment::new(0, 0, genesis_blkid);
 
-    // Range covers epochs 1..=5. Account doesn't exist at epoch 0 (cursor
-    // seeds to 0), has no records in epochs 1 and 2 (cursor stays at 0),
-    // first appears at epoch 3, then no records again in epochs 4 and 5.
-    // The cursor walk must hold the seed through empty leading epochs,
-    // apply [0, next_inbox_idx) to the first record, and emit nothing for
-    // the trailing empty epochs.
+    // Range covers epochs 1..=5. Account doesn't exist at epoch 0, has no
+    // records in epochs 1 and 2, first appears at epoch 3, then has no records
+    // again in epochs 4 and 5. Only the indexed update in epoch 3 should emit.
     let blocks: Vec<OLBlock> = {
         let mut acc = Vec::with_capacity(NUM_EPOCHS as usize);
         let mut parent = genesis_blkid;
@@ -1823,7 +1935,7 @@ async fn blocks_summaries_account_appears_midway_through_range() {
         tip_block.header().compute_blkid(),
     );
 
-    let record = AccountUpdateRecord::new(
+    let record = update_record(
         Some(AccountUpdateMeta::new(
             Some(appears_commitment),
             [0x33; 32].into(),
@@ -1902,7 +2014,7 @@ async fn blocks_summaries_ignores_records_for_other_blocks() {
     let block = make_block(0, 0, null_blkid());
     let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
     let other_commitment = OLBlockCommitment::new(99, fixed_ol_block_id(0x99));
-    let update_record = AccountUpdateRecord::new(
+    let update_record = update_record(
         Some(AccountUpdateMeta::new(
             Some(other_commitment),
             [0x44; 32].into(),
@@ -1947,7 +2059,7 @@ async fn blocks_summaries_out_of_chain_directset_does_not_fail_rpc() {
     // Out-of-chain DirectSet record (extra_data = None). If filtering happened
     // after hydration, this would trip the "no extra_data (DirectSet)" error
     // and fail the entire RPC. The chain filter must drop it before hydration.
-    let out_of_chain_directset = AccountUpdateRecord::new(
+    let out_of_chain_directset = update_record(
         Some(AccountUpdateMeta::new(
             Some(other_commitment),
             [0x99; 32].into(),
@@ -1956,11 +2068,12 @@ async fn blocks_summaries_out_of_chain_directset_does_not_fail_rpc() {
         2,
         None,
     );
-    let in_chain_update = AccountUpdateRecord::new(
+    let in_chain_update = update_record_with_prev(
         Some(AccountUpdateMeta::new(
             Some(queried_commitment),
             [0x11; 32].into(),
         )),
+        2,
         2,
         4,
         Some(vec![0xA0]),
@@ -1992,7 +2105,7 @@ async fn blocks_summaries_out_of_chain_directset_does_not_fail_rpc() {
 }
 
 #[tokio::test]
-async fn blocks_summaries_cursor_passes_checkpoint_sync_row() {
+async fn blocks_summaries_reads_ranges_past_checkpoint_sync_row() {
     let account_id = test_account_id(1);
     let epoch: Epoch = 2;
     let prev_epoch_commitment = test_epoch_commitment(epoch - 1, 5, 0x10);
@@ -2003,21 +2116,21 @@ async fn blocks_summaries_cursor_passes_checkpoint_sync_row() {
 
     // Three records in this epoch:
     //   A: in-chain Update consuming inbox [2, 4)
-    //   B: checkpoint-sync row (meta=None) consuming inbox [4, 6) — must
-    //      advance the cursor without being emitted
-    //   C: in-chain Update consuming inbox [6, 8) — its slice depends on the
-    //      cursor having moved past B
+    //   B: checkpoint-sync row (meta=None) consuming inbox [4, 6), not emitted
+    //   C: in-chain Update consuming inbox [6, 8)
     let records = vec![
-        AccountUpdateRecord::new(
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(commitment), [0x11; 32].into())),
             21,
+            2,
             4,
             Some(vec![0xA0]),
         ),
-        AccountUpdateRecord::new(None, 22, 6, Some(vec![0xA1])),
-        AccountUpdateRecord::new(
+        update_record_with_prev(None, 22, 4, 6, Some(vec![0xA1])),
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(commitment), [0x33; 32].into())),
             23,
+            6,
             8,
             Some(vec![0xA2]),
         ),
@@ -2109,10 +2222,9 @@ proptest! {
         let block1 = make_block(2, epoch, block0.header().compute_blkid());
         let block1_commitment = OLBlockCommitment::new(2, block1.header().compute_blkid());
 
-        // Property under test is grouping by block_commitment, not cursor walking.
-        // Force `next_inbox_idx = 0` for every record so the cursor never advances
-        // and the inbox fetch is skipped — keeps `processed_messages` empty
-        // regardless of record ordering.
+        // Property under test is grouping by block_commitment, not inbox slicing.
+        // Force empty ranges for every record so the inbox fetch is skipped and
+        // `processed_messages` stays empty regardless of record ordering.
         let records: Vec<AccountUpdateRecord> = generated_updates
             .iter()
             .map(|(use_second_block, seq_no, root, extra_data)| {
@@ -2121,7 +2233,7 @@ proptest! {
                 } else {
                     block0_commitment
                 };
-                AccountUpdateRecord::new(
+                update_record(
                     Some(AccountUpdateMeta::new(Some(commitment), (*root).into())),
                     u64::from(*seq_no),
                     0,
@@ -2363,11 +2475,11 @@ async fn epoch_summary_returns_messages_from_mmr_range() {
             prev_seq_no,
             prev_next_inbox_msg_idx,
         )
-        .with_account_extra_data_at_terminal(
+        .with_account_extra_data_range_at_terminal(
             account_id,
             epoch,
             cur_seq_no,
-            cur_next_inbox_msg_idx,
+            prev_next_inbox_msg_idx..cur_next_inbox_msg_idx,
             vec![2, 2, 5],
             epoch_commitment,
         )
@@ -2423,21 +2535,24 @@ async fn epoch_summary_multi_record_slices_messages_per_update() {
     ];
 
     let records = vec![
-        AccountUpdateRecord::new(
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(block1), [0x11; 32].into())),
             10,
+            2,
             4,
             Some(vec![1, 2]),
         ),
-        AccountUpdateRecord::new(
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(block2), [0x22; 32].into())),
             11,
             4,
+            4,
             Some(vec![3, 4]),
         ),
-        AccountUpdateRecord::new(
+        update_record_with_prev(
             Some(AccountUpdateMeta::new(Some(block3), [0x33; 32].into())),
             12,
+            4,
             7,
             Some(vec![5, 6]),
         ),
@@ -2544,11 +2659,11 @@ async fn epoch_summary_no_idx_delta_returns_empty_messages() {
             prev_seq_no,
             unchanged_next_inbox_msg_idx,
         )
-        .with_account_extra_data_at_terminal(
+        .with_account_extra_data_range_at_terminal(
             account_id,
             epoch,
             cur_seq_no,
-            unchanged_next_inbox_msg_idx,
+            unchanged_next_inbox_msg_idx..unchanged_next_inbox_msg_idx,
             vec![4, 7],
             epoch_commitment,
         )
@@ -2684,6 +2799,336 @@ async fn epoch_summary_mmr_fetch_error_propagates() {
     let result = rpc.get_acct_epoch_summary(account_id, epoch).await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), INTERNAL_ERROR_CODE);
+}
+
+// ── get_snark_acct_update_manifest ──
+
+#[tokio::test]
+async fn snark_acct_update_manifest_returns_record_with_indexed_range() {
+    let account_id = test_account_id(1);
+    let prev_epoch_commitment = test_epoch_commitment(0, 0, 0x10);
+    let tip_epoch_commitment = test_epoch_commitment(2, 10, 0x20);
+    let final_state_root = fixed_buf32(0x22);
+    let extra_data = vec![0xBB, 0xCC];
+
+    let records_epoch_1 = vec![update_record(
+        Some(AccountUpdateMeta::new(None, [0x11; 32].into())),
+        8,
+        2,
+        Some(vec![0xAA]),
+    )];
+    let records_epoch_2 = vec![update_record_with_prev(
+        Some(AccountUpdateMeta::new(None, final_state_root)),
+        9,
+        2,
+        5,
+        Some(extra_data.clone()),
+    )];
+
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            2,
+            false,
+            prev_epoch_commitment,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 1)
+        .with_epoch_commitment(0, prev_epoch_commitment)
+        .with_genesis_state_at_terminal(prev_epoch_commitment)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 10, 5)
+        .with_account_update_records(account_id, 1, records_epoch_1)
+        .with_account_update_records(account_id, 2, records_epoch_2);
+    let rpc = make_rpc(provider);
+
+    let manifest = rpc
+        .get_snark_acct_update_manifest(account_id, 8)
+        .await
+        .expect("manifest");
+
+    assert_eq!(manifest.seq_no(), 8);
+    assert_eq!(manifest.prev_next_msg_idx(), 2);
+    assert_eq!(manifest.new_next_msg_idx(), 5);
+    assert_eq!(
+        manifest.new_inner_state_root().expect("state root").0,
+        final_state_root.0
+    );
+    assert_eq!(manifest.extra_data().expect("extra data").0, extra_data);
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_unknown_account_errors() {
+    let rpc = make_rpc(MockProvider::new());
+
+    let err = rpc
+        .get_snark_acct_update_manifest(test_account_id(99), 0)
+        .await
+        .expect_err("unknown account should error");
+
+    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_missing_seqno_errors() {
+    let account_id = test_account_id(2);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x20);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 100, 0)
+        .with_account_update_records(
+            account_id,
+            0,
+            vec![update_record(
+                Some(AccountUpdateMeta::new(None, [0x11; 32].into())),
+                1,
+                0,
+                Some(vec![0xAA]),
+            )],
+        );
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 99)
+        .await
+        .expect_err("missing seqno should error");
+
+    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_out_of_range_seqno_skips_record_walk() {
+    let account_id = test_account_id(7);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x70);
+    let fetch_count = Arc::new(AtomicUsize::new(0));
+    let fetch_count_for_closure = fetch_count.clone();
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 2, 0)
+        .with_update_records_fetch_fn(move |_epoch, _account| {
+            fetch_count_for_closure.fetch_add(1, Ordering::Relaxed);
+            Ok(None)
+        });
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 2)
+        .await
+        .expect_err("out-of-range seqno should error");
+
+    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    assert_eq!(fetch_count.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_errors_when_ol_sync_unavailable() {
+    let account_id = test_account_id(2);
+    let provider = MockProvider::new().with_account_creation_epoch(account_id, 0);
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 1)
+        .await
+        .expect_err("missing OL sync status should error");
+
+    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
+    assert_eq!(err.message(), "OL sync status not available");
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_maps_update_record_db_error() {
+    let account_id = test_account_id(2);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x21);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 2, 0)
+        .with_update_records_fetch_fn(move |epoch, account| {
+            assert_eq!(epoch, 0);
+            assert_eq!(account, account_id);
+            Err(DbError::Other("forced update-record fetch failure".into()))
+        });
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 1)
+        .await
+        .expect_err("update record DB error should propagate");
+
+    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
+    assert!(err.message().contains("Database error"));
+    assert!(err.message().contains("forced update-record fetch failure"));
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_no_message_update_returns_empty_extra_data() {
+    let account_id = test_account_id(3);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x30);
+    let final_state_root = fixed_buf32(0x33);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 1, 0)
+        .with_account_update_records(
+            account_id,
+            0,
+            vec![update_record(
+                Some(AccountUpdateMeta::new(None, final_state_root)),
+                1,
+                0,
+                Some(Vec::new()),
+            )],
+        );
+    let rpc = make_rpc(provider);
+
+    let manifest = rpc
+        .get_snark_acct_update_manifest(account_id, 0)
+        .await
+        .expect("manifest");
+
+    assert_eq!(manifest.seq_no(), 0);
+    assert_eq!(manifest.prev_next_msg_idx(), 0);
+    assert_eq!(manifest.new_next_msg_idx(), 0);
+    assert!(manifest.extra_data().expect("extra data").0.is_empty());
+    assert_eq!(
+        manifest.new_inner_state_root().expect("state root").0,
+        final_state_root.0
+    );
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_rejects_invalid_stored_seqno_zero() {
+    let account_id = test_account_id(6);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x60);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 1, 0)
+        .with_account_update_records(
+            account_id,
+            0,
+            vec![update_record(
+                Some(AccountUpdateMeta::new(None, [0x11; 32].into())),
+                0,
+                0,
+                Some(Vec::new()),
+            )],
+        );
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 0)
+        .await
+        .expect_err("stored post-state seqno 0 should be invalid");
+
+    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
+    assert!(err.message().contains("invalid post-state seq_no 0"));
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_missing_update_meta_returns_null_state_root() {
+    let account_id = test_account_id(4);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x40);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 1, 0)
+        .with_account_update_records(
+            account_id,
+            0,
+            vec![update_record(None, 1, 0, Some(vec![0xAA]))],
+        );
+    let rpc = make_rpc(provider);
+
+    let manifest = rpc
+        .get_snark_acct_update_manifest(account_id, 0)
+        .await
+        .expect("missing update metadata should still return manifest");
+
+    assert_eq!(manifest.seq_no(), 0);
+    assert!(manifest.new_inner_state_root().is_none());
+    assert_eq!(manifest.extra_data().expect("extra data").0, vec![0xAA]);
+}
+
+#[tokio::test]
+async fn snark_acct_update_manifest_missing_extra_data_returns_null_extra_data() {
+    let account_id = test_account_id(5);
+    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x50);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 0)
+        .with_snark_tip_state(tip_epoch_commitment, account_id, 1, 0)
+        .with_account_update_records(
+            account_id,
+            0,
+            vec![update_record(
+                Some(AccountUpdateMeta::new(None, [0x11; 32].into())),
+                1,
+                0,
+                None,
+            )],
+        );
+    let rpc = make_rpc(provider);
+
+    let manifest = rpc
+        .get_snark_acct_update_manifest(account_id, 0)
+        .await
+        .expect("missing extra data should still return manifest");
+
+    assert_eq!(manifest.seq_no(), 0);
+    assert!(manifest.extra_data().is_none());
+    assert!(manifest.new_inner_state_root().is_some());
 }
 
 // ── submit_transaction ──

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -421,6 +421,7 @@ fn build_indexing_writes(
         let record = AccountUpdateRecord::new(
             Some(meta),
             *update.seqno().inner(),
+            update.prev_next_read_idx(),
             update.next_read_idx(),
             Some(log.extra_data().to_vec()),
         );
@@ -429,6 +430,8 @@ fn build_indexing_writes(
             .or_default()
             .push(record);
     }
+
+    debug_assert_contiguous_update_ranges(&account_updates);
 
     let mut account_inbox_writes: BTreeMap<AccountId, Vec<InboxMessageRecord>> = BTreeMap::new();
     for write in indexer_writes.inbox_messages() {
@@ -460,6 +463,20 @@ fn collect_snark_update_logs<'a>(
         }
     }
     Ok(out)
+}
+
+fn debug_assert_contiguous_update_ranges(
+    account_updates: &BTreeMap<AccountId, Vec<AccountUpdateRecord>>,
+) {
+    for (account_id, records) in account_updates {
+        for pair in records.windows(2) {
+            debug_assert_eq!(
+                pair[1].prev_next_inbox_idx(),
+                pair[0].next_inbox_idx(),
+                "non-contiguous snark update inbox range for account {account_id}",
+            );
+        }
+    }
 }
 
 /// Builds an [`IndexingWrites`] payload for a DA-reconstructed epoch.
@@ -498,6 +515,7 @@ pub(crate) fn build_checkpoint_indexing_writes(
         let record = AccountUpdateRecord::new(
             None,
             *update.seqno().inner(),
+            update.prev_next_read_idx(),
             update.next_read_idx(),
             Some(log.extra_data().to_vec()),
         );
@@ -506,6 +524,8 @@ pub(crate) fn build_checkpoint_indexing_writes(
             .or_default()
             .push(record);
     }
+
+    debug_assert_contiguous_update_ranges(&account_updates);
 
     let mut account_inbox_writes: BTreeMap<AccountId, Vec<InboxMessageRecord>> = BTreeMap::new();
     for write in indexer_writes.inbox_messages() {
@@ -656,6 +676,7 @@ mod tests {
         indexer_writes.push_snark_acct_update(SnarkAcctStateUpdate::new(
             account_id,
             Some(state),
+            0,
             next_read_idx,
             seqno,
         ));
@@ -679,6 +700,7 @@ mod tests {
             .expect("account update should be present");
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].extra_data(), Some(extra.as_slice()));
+        assert_eq!(records[0].prev_next_inbox_idx(), 0);
         assert_eq!(records[0].next_inbox_idx(), next_read_idx);
     }
 
@@ -689,6 +711,7 @@ mod tests {
         indexer_writes.push_snark_acct_update(SnarkAcctStateUpdate::new(
             AccountId::from([1u8; 32]),
             Some(Hash::from([0u8; 32])),
+            0,
             0,
             Seqno::from(1),
         ));

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -41,6 +41,14 @@ use crate::{
     traits::ChainWorkerContext,
 };
 
+#[derive(Clone, Copy)]
+struct SnarkAccountCursor {
+    seqno: Seqno,
+    next_inbox_msg_idx: u64,
+}
+
+type SnarkAccountCursors = HashMap<AccountSerial, SnarkAccountCursor>;
+
 /// Mutable state for the chain worker.
 ///
 /// This contains the actual "state" - data that changes during the worker's
@@ -468,10 +476,10 @@ pub(crate) fn apply_checkpoint_epoch(
         .map(|log| OLLog::new(log.account_serial(), log.payload().to_vec()))
         .collect();
 
-    // Read each snark account's seqno as of the previous epoch's terminal state.
-    // The set of affected accounts is inferred from `ol_logs`, which records the
-    // changes made during the epoch (we don't directly have the per-account input set).
-    let pre_seqnos = collect_pre_seqnos(&base_state, &ol_logs)?;
+    // Read each snark account's seqno and inbox cursor as of the previous
+    // epoch's terminal state. The set of affected accounts is inferred from
+    // `ol_logs`, which records the changes made during the epoch.
+    let pre_cursors = collect_pre_snark_account_cursors(&base_state, &ol_logs)?;
 
     // Reconstruct: wrap the base state in the write-tracking + indexer stack,
     // run apply_da_epoch, then extract the batch and indexer writes.
@@ -494,8 +502,12 @@ pub(crate) fn apply_checkpoint_epoch(
 
     // Replace the DA-collapsed snark records (one per account) with per-update
     // records derived from the epoch's `ol_logs`.
-    let (rebuilt_snark_updates, derived_seqnos) =
-        rebuild_snark_records_from_logs(&indexer_state, &ol_logs, &pre_seqnos)?;
+    let (rebuilt_snark_updates, derived_cursors) =
+        rebuild_snark_records_from_logs(&indexer_state, &ol_logs, &pre_cursors)?;
+    let derived_seqnos: HashMap<AccountSerial, Seqno> = derived_cursors
+        .iter()
+        .map(|(&serial, cursor)| (serial, cursor.seqno))
+        .collect();
 
     let (tracking_state, mut indexer_writes) = indexer_state.into_parts();
     let write_batch: WriteBatch<OLAccountState> = tracking_state.into_batch();
@@ -713,23 +725,24 @@ fn verify_snark_seqno_invariant<S: IStateAccessor>(
     Ok(())
 }
 
-/// Reads each affected snark account's seqno from the prior epoch's terminal
-/// state. The account set is inferred from `ol_logs` (a record of changes made
-/// during the epoch).
-fn collect_pre_seqnos<S: IStateAccessor>(
+/// Reads each affected snark account's pre-epoch cursor state.
+///
+/// The account set is inferred from `ol_logs` (a record of changes made during
+/// the epoch).
+fn collect_pre_snark_account_cursors<S: IStateAccessor>(
     base_state: &S,
     ol_logs: &[OLLog],
-) -> WorkerResult<HashMap<AccountSerial, Seqno>> {
-    let mut pre_seqnos = HashMap::new();
+) -> WorkerResult<SnarkAccountCursors> {
+    let mut pre_cursors = HashMap::new();
     for log in ol_logs {
         let serial = log.account_serial();
         if MsgRef::try_from(log.payload())?.ty() != SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID {
             continue;
         }
-        if pre_seqnos.contains_key(&serial) {
+        if pre_cursors.contains_key(&serial) {
             continue;
         }
-        let seqno = match base_state
+        let cursor = match base_state
             .find_account_id_by_serial(serial)
             .map_err(|source| WorkerError::AccountStateRead {
                 stage: "pre-state serial lookup",
@@ -743,27 +756,36 @@ fn collect_pre_seqnos<S: IStateAccessor>(
             })? {
                 Some(state) => state
                     .as_snark_account()
-                    .map(|s| s.seqno())
+                    .map(|s| SnarkAccountCursor {
+                        seqno: s.seqno(),
+                        next_inbox_msg_idx: s.next_inbox_msg_idx(),
+                    })
                     .map_err(|source| WorkerError::AccountStateRead {
                         stage: "pre-state as_snark_account",
                         source,
                     })?,
-                None => Seqno::zero(),
+                None => SnarkAccountCursor {
+                    seqno: Seqno::zero(),
+                    next_inbox_msg_idx: 0,
+                },
             },
-            None => Seqno::zero(),
+            None => SnarkAccountCursor {
+                seqno: Seqno::zero(),
+                next_inbox_msg_idx: 0,
+            },
         };
-        pre_seqnos.insert(serial, seqno);
+        pre_cursors.insert(serial, cursor);
     }
-    Ok(pre_seqnos)
+    Ok(pre_cursors)
 }
 
 /// Rebuilds per-update snark index records from the epoch's OL logs.
 fn rebuild_snark_records_from_logs<S: IStateAccessor>(
     state: &S,
     ol_logs: &[OLLog],
-    pre_seqnos: &HashMap<AccountSerial, Seqno>,
-) -> WorkerResult<(Vec<SnarkAcctStateUpdate>, HashMap<AccountSerial, Seqno>)> {
-    let mut next_seqno: HashMap<AccountSerial, Seqno> = HashMap::new();
+    pre_cursors: &SnarkAccountCursors,
+) -> WorkerResult<(Vec<SnarkAcctStateUpdate>, SnarkAccountCursors)> {
+    let mut next_cursor: SnarkAccountCursors = HashMap::new();
     let mut records = Vec::with_capacity(ol_logs.len());
 
     for log in ol_logs {
@@ -786,22 +808,31 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
             })?
             .ok_or(WorkerError::UnknownAccountSerial(serial))?;
 
-        let cur = next_seqno
-            .entry(serial)
-            .or_insert_with(|| pre_seqnos.get(&serial).copied().unwrap_or_else(Seqno::zero));
-        *cur = cur.incr();
-        let seqno = *cur;
+        let cur = next_cursor.entry(serial).or_insert_with(|| {
+            pre_cursors
+                .get(&serial)
+                .copied()
+                .unwrap_or(SnarkAccountCursor {
+                    seqno: Seqno::zero(),
+                    next_inbox_msg_idx: 0,
+                })
+        });
+        let prev_next_read_idx = cur.next_inbox_msg_idx;
+        cur.seqno = cur.seqno.incr();
+        cur.next_inbox_msg_idx = log_data.new_msg_idx;
+        let seqno = cur.seqno;
 
         // No per-update inner state root is available from checkpoint logs.
         records.push(SnarkAcctStateUpdate::new(
             account_id,
             None,
+            prev_next_read_idx,
             log_data.new_msg_idx,
             seqno,
         ));
     }
 
-    Ok((records, next_seqno))
+    Ok((records, next_cursor))
 }
 
 /// The values produced by reconstructing one epoch from its checkpoint,

--- a/crates/db/tests/src/ol_state_indexing_tests.rs
+++ b/crates/db/tests/src/ol_state_indexing_tests.rs
@@ -35,7 +35,7 @@ fn record(
     idx: u64,
     extra: Option<Vec<u8>>,
 ) -> AccountUpdateRecord {
-    AccountUpdateRecord::new(meta, seq, idx, extra)
+    AccountUpdateRecord::new(meta, seq, 0, idx, extra)
 }
 
 #[track_caller]
@@ -178,6 +178,9 @@ pub fn test_apply_block_indexing_appends(db: &impl OLStateIndexingDatabase) {
     assert_eq!(got[0].seq_no(), 1);
     assert_eq!(got[1].seq_no(), 2);
     assert_eq!(got[2].seq_no(), 3);
+    assert_eq!(got[0].prev_next_inbox_idx(), 0);
+    assert_eq!(got[1].prev_next_inbox_idx(), 0);
+    assert_eq!(got[2].prev_next_inbox_idx(), 0);
 
     let inb = db
         .get_account_inbox_records(epoch, acct_a)

--- a/crates/db/types/src/ol_state_index.rs
+++ b/crates/db/types/src/ol_state_index.rs
@@ -166,14 +166,13 @@ impl AccountUpdateMeta {
 /// Single snark account state update.
 ///
 /// Messages consumed by this update are the inbox entries in the range
-/// `[prev_record.next_inbox_idx, self.next_inbox_idx)`. The first record
-/// in an epoch uses the prior epoch's terminal `next_inbox_idx` as the
-/// lower bound. Callers fetch the actual entries from the inbox MMR
-/// when needed.
+/// `[self.prev_next_inbox_idx, self.next_inbox_idx)`. Callers fetch the
+/// actual entries from the inbox MMR when needed.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AccountUpdateRecord {
     update_meta: Option<AccountUpdateMeta>,
     seq_no: u64,
+    prev_next_inbox_idx: u64,
     next_inbox_idx: u64,
     extra_data: Option<Vec<u8>>,
 }
@@ -182,12 +181,14 @@ impl AccountUpdateRecord {
     pub fn new(
         update_meta: Option<AccountUpdateMeta>,
         seq_no: u64,
+        prev_next_inbox_idx: u64,
         next_inbox_idx: u64,
         extra_data: Option<Vec<u8>>,
     ) -> Self {
         Self {
             update_meta,
             seq_no,
+            prev_next_inbox_idx,
             next_inbox_idx,
             extra_data,
         }
@@ -199,6 +200,18 @@ impl AccountUpdateRecord {
 
     pub fn seq_no(&self) -> u64 {
         self.seq_no
+    }
+
+    /// Returns the operation seqno that produced this record.
+    ///
+    /// The record stores the post-update account seqno. Snark account updates
+    /// publish the pre-update operation seqno, so this is `seq_no - 1`.
+    pub fn orig_acct_seq_no(&self) -> Option<u64> {
+        self.seq_no.checked_sub(1)
+    }
+
+    pub fn prev_next_inbox_idx(&self) -> u64 {
+        self.prev_next_inbox_idx
     }
 
     pub fn next_inbox_idx(&self) -> u64 {

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -83,6 +83,19 @@ pub trait OLClientRpc {
         account_id: AccountId,
         tag: OLBlockTag,
     ) -> RpcResult<Option<RpcSnarkAccountState>>;
+
+    /// Get published manifest metadata for a Snark account update.
+    ///
+    /// The consumed inbox range inside the resulting [`RpcSnarkAcctUpdateManifest`] is half-open:
+    /// `[prev_next_msg_idx, new_next_msg_idx)`.
+    /// `prev_next_msg_idx` is the first message consumed by this update, and
+    /// `new_next_msg_idx` is the first message not consumed.
+    #[method(name = "getSnarkAcctUpdateManifest")]
+    async fn get_snark_acct_update_manifest(
+        &self,
+        account_id: AccountId,
+        seq_no: u64,
+    ) -> RpcResult<RpcSnarkAcctUpdateManifest>;
 }
 
 /// OL RPC methods served by sequencer nodes for transaction submission.

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use strata_acct_types::{AccountId, BitcoinAmount, MessageEntry, MsgPayload, MsgPayloadError};
+use strata_db_types::ol_state_index::AccountUpdateRecord;
 use strata_identifiers::OLBlockCommitment;
 use strata_primitives::{EpochCommitment, HexBytes, HexBytes32};
 use strata_snark_acct_types::{ProofState, UpdateInputData};
@@ -164,6 +165,81 @@ pub struct RpcUpdateInputData {
     pub messages: Vec<RpcMessageEntry>,
 }
 
+/// Published manifest metadata for a Snark account update.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct RpcSnarkAcctUpdateManifest {
+    /// Sequence number of the update.
+    seq_no: u64,
+    /// Inner state root after this update, if stored by the serving node.
+    new_inner_state_root: Option<HexBytes32>,
+    /// Inbox cursor before this update.
+    prev_next_msg_idx: u64,
+    /// Inbox cursor after this update.
+    new_next_msg_idx: u64,
+    /// Extra data posted with this update, if stored by the serving node.
+    extra_data: Option<HexBytes>,
+}
+
+impl RpcSnarkAcctUpdateManifest {
+    /// Creates a new [`RpcSnarkAcctUpdateManifest`].
+    pub fn new(
+        seq_no: u64,
+        new_inner_state_root: Option<HexBytes32>,
+        prev_next_msg_idx: u64,
+        new_next_msg_idx: u64,
+        extra_data: Option<HexBytes>,
+    ) -> Self {
+        Self {
+            seq_no,
+            new_inner_state_root,
+            prev_next_msg_idx,
+            new_next_msg_idx,
+            extra_data,
+        }
+    }
+
+    /// Creates a manifest response from an account update record.
+    pub fn from_account_update_record(record: &AccountUpdateRecord, operation_seq_no: u64) -> Self {
+        Self {
+            seq_no: operation_seq_no,
+            new_inner_state_root: record
+                .update_meta()
+                .map(|meta| HexBytes32::from(*meta.new_state_root().as_ref())),
+            prev_next_msg_idx: record.prev_next_inbox_idx(),
+            new_next_msg_idx: record.next_inbox_idx(),
+            extra_data: record
+                .extra_data()
+                .map(|data| HexBytes::from(data.to_vec())),
+        }
+    }
+
+    /// Returns the update sequence number.
+    pub fn seq_no(&self) -> u64 {
+        self.seq_no
+    }
+
+    /// Returns the inner state root after this update, if available.
+    pub fn new_inner_state_root(&self) -> Option<&HexBytes32> {
+        self.new_inner_state_root.as_ref()
+    }
+
+    /// Returns the inbox cursor before this update.
+    pub fn prev_next_msg_idx(&self) -> u64 {
+        self.prev_next_msg_idx
+    }
+
+    /// Returns the inbox cursor after this update.
+    pub fn new_next_msg_idx(&self) -> u64 {
+        self.new_next_msg_idx
+    }
+
+    /// Returns the update extra data, if available.
+    pub fn extra_data(&self) -> Option<&HexBytes> {
+        self.extra_data.as_ref()
+    }
+}
+
 impl From<UpdateInputData> for RpcUpdateInputData {
     fn from(value: UpdateInputData) -> Self {
         let proof_state = value.update_state.proof_state;
@@ -281,6 +357,18 @@ impl From<ProofState> for RpcProofState {
             inner_state: state.inner_state().0.into(),
             next_inbox_msg_idx: state.next_inbox_msg_idx(),
         }
+    }
+}
+
+impl RpcProofState {
+    /// Returns the state root.
+    pub fn inner_state(&self) -> &HexBytes32 {
+        &self.inner_state
+    }
+
+    /// Returns the next inbox message index.
+    pub fn next_inbox_msg_idx(&self) -> u64 {
+        self.next_inbox_msg_idx
     }
 }
 

--- a/crates/ol/rpc/types/src/lib.rs
+++ b/crates/ol/rpc/types/src/lib.rs
@@ -20,7 +20,7 @@ pub use account_state::{
 };
 pub use account_summary::{
     RpcAccountBlockSummary, RpcAccountEpochSummary, RpcIndexedEntry, RpcMessageEntry,
-    RpcUpdateInputData,
+    RpcProofState, RpcSnarkAcctUpdateManifest, RpcUpdateInputData,
 };
 pub use block::{
     RpcBlockEntry, RpcBlockHeaderEntry, RpcOLBlockDetail, RpcOLBlockSummary, RpcOLManifestsSummary,

--- a/crates/ol/state-support-types/src/index_types.rs
+++ b/crates/ol/state-support-types/src/index_types.rs
@@ -68,7 +68,10 @@ pub struct SnarkAcctStateUpdate {
     /// rebuilt from logs, which carry no per-update intermediate root.
     state: Option<Hash>,
 
-    /// The next read index.
+    /// The inbox cursor before this update.
+    prev_next_read_idx: u64,
+
+    /// The inbox cursor after this update.
     next_read_idx: u64,
 
     /// The seqno after the update.
@@ -79,12 +82,14 @@ impl SnarkAcctStateUpdate {
     pub fn new(
         account_id: AccountId,
         state: Option<Hash>,
+        prev_next_read_idx: u64,
         next_read_idx: u64,
         seqno: Seqno,
     ) -> Self {
         Self {
             account_id,
             state,
+            prev_next_read_idx,
             next_read_idx,
             seqno,
         }
@@ -100,7 +105,12 @@ impl SnarkAcctStateUpdate {
         self.state
     }
 
-    /// Returns the next read index for this update.
+    /// Returns the inbox cursor before this update.
+    pub fn prev_next_read_idx(&self) -> u64 {
+        self.prev_next_read_idx
+    }
+
+    /// Returns the inbox cursor after this update.
     pub fn next_read_idx(&self) -> u64 {
         self.next_read_idx
     }

--- a/crates/ol/state-support-types/src/indexer_layer.rs
+++ b/crates/ol/state-support-types/src/indexer_layer.rs
@@ -104,7 +104,14 @@ impl<S: ISnarkAccountStateMut> ISnarkAccountState for IndexerSnarkAccountStateMu
 
 impl<S: ISnarkAccountStateMut> ISnarkAccountStateMut for IndexerSnarkAccountStateMut<S> {
     fn set_proof_state(&mut self, state: Hash, next_read_idx: u64, seqno: Seqno) {
-        let update = SnarkAcctStateUpdate::new(self.account_id, Some(state), next_read_idx, seqno);
+        let prev_next_read_idx = self.inner.next_inbox_msg_idx();
+        let update = SnarkAcctStateUpdate::new(
+            self.account_id,
+            Some(state),
+            prev_next_read_idx,
+            next_read_idx,
+            seqno,
+        );
 
         // Pass through to inner.
         self.inner.set_proof_state(state, next_read_idx, seqno);
@@ -1105,6 +1112,7 @@ mod tests {
         let update = &writes.snark_state_updates()[0];
         assert_eq!(update.account_id(), account_id);
         assert_eq!(update.state(), Some(new_hash));
+        assert_eq!(update.prev_next_read_idx(), 0);
         assert_eq!(update.next_read_idx(), next_read_idx);
         assert_eq!(update.seqno(), seqno);
     }
@@ -1136,6 +1144,7 @@ mod tests {
 
         for (i, update) in writes.snark_state_updates().iter().enumerate() {
             assert_eq!(update.account_id(), account_id);
+            assert_eq!(update.prev_next_read_idx(), i.saturating_sub(1) as u64);
             assert_eq!(update.next_read_idx(), i as u64);
             assert_eq!(update.seqno(), Seqno::from(i as u64));
         }

--- a/functional-tests/tests/strata/test_public_rpc_surface.py
+++ b/functional-tests/tests/strata/test_public_rpc_surface.py
@@ -38,7 +38,7 @@ class TestPublicRpcSurface(BaseTest):
             1,
             0,
         )
-        assert_method_not_found(
+        assert_method_registered(
             checkpoint_rpc,
             "strata_getSnarkAcctUpdateManifest",
             ALPEN_ACCOUNT_ID,


### PR DESCRIPTION
## Description

Adds `strata_getSnarkAcctUpdateManifest(account_id, seq_no)` to `OLClientRpc`. The response includes operation seqno, optional post-update inner state root, consumed inbox range `[prev_next_msg_idx, new_next_msg_idx)`, and optional extra data. Message payloads remain available through `strata_getSnarkAcctInboxMsgRange`.

The lookup scans existing account update records, with an early not-found return when the requested seqno is at or above the account's current tip seqno. Consumed range starts are persisted as `prev_next_inbox_idx`, so RPCs read `[prev_next_inbox_idx, next_inbox_idx)` directly instead of re-threading cursors.

Also updates block-sync/checkpoint-sync indexing to populate the new field and updates account-summary paths to use it.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3718](https://alpenlabs.atlassian.net/browse/STR-3718)


[STR-3718]: https://alpenlabs.atlassian.net/browse/STR-3718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ