### PR TITLE
STR 3078 Update the OL node RPC surface based on the node type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16094,7 +16094,6 @@ name = "strata-ol-rpc-types"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "hex",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/bin/alpen-client/src/rpc_client.rs
+++ b/bin/alpen-client/src/rpc_client.rs
@@ -16,9 +16,9 @@ use strata_common::{
 use strata_identifiers::{
     AccountId, Epoch, EpochCommitment, Hash, L1Height, OLBlockCommitment, OLTxId,
 };
-use strata_ol_rpc_api::{OLClientRpcClient, OLFullNodeRpcClient, OLSubmitRpcClient};
+use strata_ol_rpc_api::{OLClientRpcClient, OLSubmitRpcClient};
 use strata_ol_rpc_types::{
-    OLBlockOrTag, RpcOLTransaction, RpcSnarkAccountUpdate, RpcTransactionPayload, RpcTxConstraints,
+    OLBlockTag, RpcOLTransaction, RpcSnarkAccountUpdate, RpcTransactionPayload, RpcTxConstraints,
 };
 use strata_snark_acct_types::{ProofState, SnarkAccountUpdate};
 use tracing::info;
@@ -271,7 +271,7 @@ impl SequencerOLClient for RpcOLClient {
     async fn get_latest_account_state(&self) -> Result<OLAccountStateView, OLClientError> {
         let snark_account_state = call_read_rpc!(
             self,
-            get_snark_account_state(self.account_id, OLBlockOrTag::Latest)
+            get_snark_account_state_by_tag(self.account_id, OLBlockTag::Latest)
         )?
         .ok_or_else(|| OLClientError::Rpc("missing latest account state".into()))?;
 

--- a/bin/alpen-client/src/rpc_client.rs
+++ b/bin/alpen-client/src/rpc_client.rs
@@ -16,7 +16,7 @@ use strata_common::{
 use strata_identifiers::{
     AccountId, Epoch, EpochCommitment, Hash, L1Height, OLBlockCommitment, OLTxId,
 };
-use strata_ol_rpc_api::{OLClientRpcClient, OLSubmitRpcClient};
+use strata_ol_rpc_api::{OLClientRpcClient, OLFullNodeRpcClient, OLSubmitRpcClient};
 use strata_ol_rpc_types::{
     OLBlockOrTag, RpcOLTransaction, RpcSnarkAccountUpdate, RpcTransactionPayload, RpcTxConstraints,
 };

--- a/bin/strata/src/rpc/mod.rs
+++ b/bin/strata/src/rpc/mod.rs
@@ -37,7 +37,7 @@ use tracing::info;
 
 #[cfg(feature = "sequencer")]
 use crate::helpers::sequencer_schnorr_key;
-use crate::run_context::RunContext;
+use crate::run_context::{NodeRole, RunContext};
 #[cfg(feature = "sequencer")]
 use crate::sequencer::OLSeqRpcServer;
 
@@ -57,6 +57,7 @@ struct RpcDeps {
     submit_rpc_bearer_token: Option<SecretString>,
     genesis_l1_height: L1Height,
     max_headers_range: usize,
+    node_role: NodeRole,
     storage: Arc<NodeStorage>,
     status_channel: Arc<StatusChannel>,
     /// [`None`] on checkpoint-sync nodes; `submit_transaction` returns an
@@ -172,6 +173,7 @@ pub(crate) fn start_rpc(runctx: &RunContext) -> Result<()> {
         submit_rpc_bearer_token: runctx.config().client.submit_rpc_bearer_token.clone(),
         genesis_l1_height: runctx.asm_params().anchor.block.height(),
         max_headers_range: runctx.config().client.max_headers_range,
+        node_role: runctx.node_role(),
         storage: runctx.storage().clone(),
         status_channel: runctx.status_channel().clone(),
         mempool_handle: runctx.mempool_handle().cloned(),
@@ -182,7 +184,7 @@ pub(crate) fn start_rpc(runctx: &RunContext) -> Result<()> {
     runctx
         .executor()
         .spawn_critical_async("main-rpc", spawn_public_rpc(deps.clone()));
-    if runctx.config().client.is_sequencer {
+    if deps.node_role.serves_sequencer_rpc() {
         runctx
             .executor()
             .spawn_critical_async("admin-rpc", spawn_admin_rpc(deps.clone()));
@@ -196,7 +198,15 @@ pub(crate) fn start_rpc(runctx: &RunContext) -> Result<()> {
 fn build_public_rpc_module(deps: &RpcDeps) -> Result<RpcModule<()>> {
     let mut module = build_public_static_rpc_module();
 
-    // Create and register OL client RPC server
+    register_client_rpc(&mut module, deps)?;
+    if deps.node_role.serves_fullnode_rpc() {
+        register_fullnode_rpc(&mut module, deps)?;
+    }
+
+    Ok(module)
+}
+
+fn register_client_rpc(module: &mut RpcModule<()>, deps: &RpcDeps) -> Result<()> {
     let client_provider = NodeRpcProvider::new(
         deps.storage.clone(),
         deps.status_channel.clone(),
@@ -210,9 +220,10 @@ fn build_public_rpc_module(deps: &RpcDeps) -> Result<RpcModule<()>> {
     let ol_module = OLClientRpcServer::into_rpc(ol_rpc_server);
     module
         .merge(ol_module)
-        .map_err(|e| anyhow!("Failed to merge OL RPC module: {}", e))?;
+        .map_err(|e| anyhow!("Failed to merge OL RPC module: {}", e))
+}
 
-    // Create and register OL fullnode RPC listener
+fn register_fullnode_rpc(module: &mut RpcModule<()>, deps: &RpcDeps) -> Result<()> {
     let fullnode_provider = NodeRpcProvider::new(
         deps.storage.clone(),
         deps.status_channel.clone(),
@@ -226,9 +237,7 @@ fn build_public_rpc_module(deps: &RpcDeps) -> Result<RpcModule<()>> {
     let ol_fullnode_module = OLFullNodeRpcServer::into_rpc(ol_fullnode_listener);
     module
         .merge(ol_fullnode_module)
-        .map_err(|e| anyhow!("Failed to merge OL fullnode RPC module: {}", e))?;
-
-    Ok(module)
+        .map_err(|e| anyhow!("Failed to merge OL fullnode RPC module: {}", e))
 }
 
 fn build_public_static_rpc_module() -> RpcModule<()> {

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -19,7 +19,7 @@ use strata_ledger_types::{IAccountState, ISnarkAccountState};
 use strata_ol_chain_types_new::{OLBlock, OLTransaction, TransactionPayload};
 use strata_ol_rpc_api::{OLClientRpcServer, OLFullNodeRpcServer, OLSubmitRpcServer};
 use strata_ol_rpc_types::{
-    OLBlockOrTag, OLRpcProvider, RpcAccountBlockSummary, RpcAccountChange, RpcAccountChangeType,
+    OLBlockTag, OLRpcProvider, RpcAccountBlockSummary, RpcAccountChange, RpcAccountChangeType,
     RpcAccountEpochSummary, RpcAccountState, RpcBlockAccountChanges, RpcBlockEntry,
     RpcBlockHeaderEntry, RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref,
     RpcIndexedEntry, RpcMessageEntry, RpcOLBlockDetail, RpcOLBlockInfo, RpcOLBlockSummary,
@@ -204,45 +204,60 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
             })
     }
 
-    /// Resolves an [`OLBlockOrTag`] to a concrete [`OLBlockCommitment`].
-    ///
-    /// `Latest`, `Confirmed`, and `Finalized` come from the OL sync status.
-    /// `OLBlockId` requires fetching the block to read its slot. `Slot` looks
-    /// up the canonical block at that slot.
-    async fn resolve_block_or_tag(
-        &self,
-        block_or_tag: OLBlockOrTag,
-    ) -> RpcResult<OLBlockCommitment> {
-        Ok(match block_or_tag {
-            OLBlockOrTag::Latest => {
-                self.provider
-                    .get_ol_sync_status()
-                    .ok_or_else(|| internal_error("OL sync status not available"))?
-                    .tip
-            }
-            OLBlockOrTag::Confirmed => self
-                .provider
-                .get_ol_sync_status()
-                .ok_or_else(|| internal_error("OL sync status not available"))?
-                .confirmed_epoch
-                .to_block_commitment(),
-            OLBlockOrTag::Finalized => self
-                .provider
-                .get_ol_sync_status()
-                .ok_or_else(|| internal_error("OL sync status not available"))?
-                .finalized_epoch
-                .to_block_commitment(),
-            OLBlockOrTag::OLBlockId(block_id) => {
-                let block = self.get_block(block_id).await?;
-                OLBlockCommitment::new(block.header().slot(), block_id)
-            }
-            OLBlockOrTag::Slot(slot) => self
-                .provider
-                .get_canonical_block_at(slot)
-                .await
-                .map_err(db_error)?
-                .ok_or_else(|| not_found_error(format!("No block found at slot {slot}")))?,
+    /// Resolves an [`OLBlockTag`] to a concrete [`OLBlockCommitment`].
+    async fn resolve_block_tag(&self, tag: OLBlockTag) -> RpcResult<OLBlockCommitment> {
+        let sync_status = self
+            .provider
+            .get_ol_sync_status()
+            .ok_or_else(|| internal_error("OL sync status not available"))?;
+
+        Ok(match tag {
+            OLBlockTag::Latest => sync_status.tip,
+            OLBlockTag::Confirmed => sync_status.confirmed_epoch.to_block_commitment(),
+            OLBlockTag::Finalized => sync_status.finalized_epoch.to_block_commitment(),
         })
+    }
+
+    async fn get_snark_account_state_at_block(
+        &self,
+        account_id: AccountId,
+        block_commitment: OLBlockCommitment,
+    ) -> RpcResult<Option<RpcSnarkAccountState>> {
+        // Get OL state at the resolved block
+        let ol_state = self
+            .provider
+            .get_toplevel_ol_state(block_commitment)
+            .await
+            .map_err(|e| {
+                error!(?e, %block_commitment, "Failed to get OL state");
+                db_error(e)
+            })?
+            .ok_or_else(|| {
+                not_found_error(format!("No OL state found for block {block_commitment}"))
+            })?;
+
+        // Get account state
+        let Some(account_state) = ol_state.get_account_state(&account_id) else {
+            return Ok(None); // Account doesn't exist
+        };
+
+        // Try to get snark account state; return None if not a snark account
+        match account_state.as_snark_account() {
+            Ok(snark_state) => {
+                let seq_no: u64 = *snark_state.seqno().inner();
+                let inner_state = snark_state.inner_state_root().0.into();
+                let next_inbox_msg_idx = snark_state.next_inbox_msg_idx();
+                let update_vk = snark_state.update_vk().clone();
+
+                Ok(Some(RpcSnarkAccountState::new(
+                    seq_no,
+                    inner_state,
+                    next_inbox_msg_idx,
+                    update_vk,
+                )))
+            }
+            Err(_) => Ok(None), // Not a snark account
+        }
     }
 
     /// Walks the canonical chain backwards from `end_slot` to `start_slot`,
@@ -945,6 +960,16 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .map(|(offset, message)| RpcIndexedEntry::new(start + offset as u64, message.into()))
             .collect())
     }
+
+    async fn get_snark_account_state_by_tag(
+        &self,
+        account_id: AccountId,
+        tag: OLBlockTag,
+    ) -> RpcResult<Option<RpcSnarkAccountState>> {
+        let block_commitment = self.resolve_block_tag(tag).await?;
+        self.get_snark_account_state_at_block(account_id, block_commitment)
+            .await
+    }
 }
 
 const MAX_RAW_BLOCKS_RANGE: usize = 5000;
@@ -1119,48 +1144,12 @@ impl<P: OLRpcProvider> OLFullNodeRpcServer for OLRpcServer<P> {
         Ok(summaries)
     }
 
-    async fn get_snark_account_state(
+    async fn get_snark_account_state_at_block(
         &self,
         account_id: AccountId,
-        block_or_tag: OLBlockOrTag,
+        block: OLBlockCommitment,
     ) -> RpcResult<Option<RpcSnarkAccountState>> {
-        let block_commitment = self.resolve_block_or_tag(block_or_tag).await?;
-
-        // Get OL state at the resolved block
-        let ol_state = self
-            .provider
-            .get_toplevel_ol_state(block_commitment)
-            .await
-            .map_err(|e| {
-                error!(?e, %block_commitment, "Failed to get OL state");
-                db_error(e)
-            })?
-            .ok_or_else(|| {
-                not_found_error(format!("No OL state found for block {block_commitment}"))
-            })?;
-
-        // Get account state
-        let Some(account_state) = ol_state.get_account_state(&account_id) else {
-            return Ok(None); // Account doesn't exist
-        };
-
-        // Try to get snark account state; return None if not a snark account
-        match account_state.as_snark_account() {
-            Ok(snark_state) => {
-                let seq_no: u64 = *snark_state.seqno().inner();
-                let inner_state = snark_state.inner_state_root().0.into();
-                let next_inbox_msg_idx = snark_state.next_inbox_msg_idx();
-                let update_vk = snark_state.update_vk().clone();
-
-                Ok(Some(RpcSnarkAccountState::new(
-                    seq_no,
-                    inner_state,
-                    next_inbox_msg_idx,
-                    update_vk,
-                )))
-            }
-            Err(_) => Ok(None), // Not a snark account
-        }
+        OLRpcServer::get_snark_account_state_at_block(self, account_id, block).await
     }
 
     async fn get_block_transactions(&self, slot: u64) -> RpcResult<Vec<RpcOLTxDetail>> {

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -802,6 +802,39 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         }))
     }
 
+    async fn get_account_genesis_epoch_commitment(
+        &self,
+        account_id: AccountId,
+    ) -> RpcResult<EpochCommitment> {
+        let epoch = self
+            .provider
+            .get_account_creation_epoch(account_id)
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                not_found_error(format!("No creation epoch found for account {account_id}"))
+            })?;
+
+        self.provider
+            .get_canonical_epoch_commitment_at(epoch)
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| not_found_error(format!("No epoch commitment found for epoch {epoch}")))
+    }
+
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> RpcResult<Option<HexBytes32>> {
+        let manifest = self
+            .provider
+            .get_block_manifest_at_height(l1_height)
+            .await
+            .map_err(db_error)?;
+
+        Ok(manifest.map(|m| HexBytes32::from(*m.compute_hash().as_ref())))
+    }
+
     async fn get_blocks_summaries(
         &self,
         account_id: AccountId,
@@ -875,7 +908,6 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
 
         Ok(summaries)
     }
-
     async fn get_snark_acct_inbox_msg_range(
         &self,
         account_id: AccountId,
@@ -912,83 +944,6 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .enumerate()
             .map(|(offset, message)| RpcIndexedEntry::new(start + offset as u64, message.into()))
             .collect())
-    }
-
-    async fn get_account_genesis_epoch_commitment(
-        &self,
-        account_id: AccountId,
-    ) -> RpcResult<EpochCommitment> {
-        let epoch = self
-            .provider
-            .get_account_creation_epoch(account_id)
-            .await
-            .map_err(db_error)?
-            .ok_or_else(|| {
-                not_found_error(format!("No creation epoch found for account {account_id}"))
-            })?;
-
-        self.provider
-            .get_canonical_epoch_commitment_at(epoch)
-            .await
-            .map_err(db_error)?
-            .ok_or_else(|| not_found_error(format!("No epoch commitment found for epoch {epoch}")))
-    }
-
-    async fn get_asm_manifest_commitment(
-        &self,
-        l1_height: L1Height,
-    ) -> RpcResult<Option<HexBytes32>> {
-        let manifest = self
-            .provider
-            .get_block_manifest_at_height(l1_height)
-            .await
-            .map_err(db_error)?;
-
-        Ok(manifest.map(|m| HexBytes32::from(*m.compute_hash().as_ref())))
-    }
-
-    async fn get_snark_account_state(
-        &self,
-        account_id: AccountId,
-        block_or_tag: OLBlockOrTag,
-    ) -> RpcResult<Option<RpcSnarkAccountState>> {
-        let block_commitment = self.resolve_block_or_tag(block_or_tag).await?;
-
-        // Get OL state at the resolved block
-        let ol_state = self
-            .provider
-            .get_toplevel_ol_state(block_commitment)
-            .await
-            .map_err(|e| {
-                error!(?e, %block_commitment, "Failed to get OL state");
-                db_error(e)
-            })?
-            .ok_or_else(|| {
-                not_found_error(format!("No OL state found for block {block_commitment}"))
-            })?;
-
-        // Get account state
-        let Some(account_state) = ol_state.get_account_state(&account_id) else {
-            return Ok(None); // Account doesn't exist
-        };
-
-        // Try to get snark account state; return None if not a snark account
-        match account_state.as_snark_account() {
-            Ok(snark_state) => {
-                let seq_no: u64 = *snark_state.seqno().inner();
-                let inner_state = snark_state.inner_state_root().0.into();
-                let next_inbox_msg_idx = snark_state.next_inbox_msg_idx();
-                let update_vk = snark_state.update_vk().clone();
-
-                Ok(Some(RpcSnarkAccountState::new(
-                    seq_no,
-                    inner_state,
-                    next_inbox_msg_idx,
-                    update_vk,
-                )))
-            }
-            Err(_) => Ok(None), // Not a snark account
-        }
     }
 }
 
@@ -1162,6 +1117,50 @@ impl<P: OLRpcProvider> OLFullNodeRpcServer for OLRpcServer<P> {
         }
         summaries.reverse();
         Ok(summaries)
+    }
+
+    async fn get_snark_account_state(
+        &self,
+        account_id: AccountId,
+        block_or_tag: OLBlockOrTag,
+    ) -> RpcResult<Option<RpcSnarkAccountState>> {
+        let block_commitment = self.resolve_block_or_tag(block_or_tag).await?;
+
+        // Get OL state at the resolved block
+        let ol_state = self
+            .provider
+            .get_toplevel_ol_state(block_commitment)
+            .await
+            .map_err(|e| {
+                error!(?e, %block_commitment, "Failed to get OL state");
+                db_error(e)
+            })?
+            .ok_or_else(|| {
+                not_found_error(format!("No OL state found for block {block_commitment}"))
+            })?;
+
+        // Get account state
+        let Some(account_state) = ol_state.get_account_state(&account_id) else {
+            return Ok(None); // Account doesn't exist
+        };
+
+        // Try to get snark account state; return None if not a snark account
+        match account_state.as_snark_account() {
+            Ok(snark_state) => {
+                let seq_no: u64 = *snark_state.seqno().inner();
+                let inner_state = snark_state.inner_state_root().0.into();
+                let next_inbox_msg_idx = snark_state.next_inbox_msg_idx();
+                let update_vk = snark_state.update_vk().clone();
+
+                Ok(Some(RpcSnarkAccountState::new(
+                    seq_no,
+                    inner_state,
+                    next_inbox_msg_idx,
+                    update_vk,
+                )))
+            }
+            Err(_) => Ok(None), // Not a snark account
+        }
     }
 
     async fn get_block_transactions(&self, slot: u64) -> RpcResult<Vec<RpcOLTxDetail>> {

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -2757,10 +2757,10 @@ async fn submit_transaction_nonexistent_account_returns_error() {
     assert_eq!(result.unwrap_err().code(), INVALID_PARAMS_CODE);
 }
 
-// ── get_snark_account_state ──
+// ── get_snark_account_state_by_tag / get_snark_account_state_at_block ──
 
 #[tokio::test]
-async fn snark_account_state_latest_returns_state() {
+async fn snark_account_state_by_tag_latest_returns_state() {
     let account_id = test_account_id(1);
 
     let block = make_block(5, 0, null_blkid());
@@ -2783,7 +2783,7 @@ async fn snark_account_state_latest_returns_state() {
     let rpc = make_rpc(provider);
 
     let state = rpc
-        .get_snark_account_state(account_id, OLBlockOrTag::Latest)
+        .get_snark_account_state_by_tag(account_id, OLBlockTag::Latest)
         .await
         .expect("snark state")
         .expect("should be Some");
@@ -2793,16 +2793,16 @@ async fn snark_account_state_latest_returns_state() {
 }
 
 #[tokio::test]
-async fn snark_account_state_by_slot() {
+async fn snark_account_state_at_block_returns_state() {
     let account_id = test_account_id(1);
 
     let block = make_block(10, 0, null_blkid());
     let blkid = block.header().compute_blkid();
-    let tip = OLBlockCommitment::new(10, blkid);
+    let block_commitment = OLBlockCommitment::new(10, blkid);
 
     let provider = MockProvider::new()
         .with_sync_status(make_sync_status(
-            tip,
+            block_commitment,
             0,
             false,
             EpochCommitment::null(),
@@ -2816,7 +2816,7 @@ async fn snark_account_state_by_slot() {
     let rpc = make_rpc(provider);
 
     let state = rpc
-        .get_snark_account_state(account_id, OLBlockOrTag::Slot(10))
+        .get_snark_account_state_at_block(account_id, block_commitment)
         .await
         .expect("snark state")
         .expect("should be Some");
@@ -2845,7 +2845,7 @@ async fn snark_account_state_non_snark_returns_none() {
     let rpc = make_rpc(provider);
 
     let result = rpc
-        .get_snark_account_state(account_id, OLBlockOrTag::Latest)
+        .get_snark_account_state_by_tag(account_id, OLBlockTag::Latest)
         .await
         .expect("should succeed");
 
@@ -2868,7 +2868,7 @@ async fn snark_account_state_missing_account_returns_none() {
     let rpc = make_rpc(provider);
 
     let result = rpc
-        .get_snark_account_state(test_account_id(99), OLBlockOrTag::Latest)
+        .get_snark_account_state_by_tag(test_account_id(99), OLBlockTag::Latest)
         .await
         .expect("should succeed");
 
@@ -2881,42 +2881,10 @@ async fn snark_account_state_no_ol_sync_returns_error() {
     let rpc = make_rpc(provider);
 
     let result = rpc
-        .get_snark_account_state(test_account_id(1), OLBlockOrTag::Latest)
+        .get_snark_account_state_by_tag(test_account_id(1), OLBlockTag::Latest)
         .await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), INTERNAL_ERROR_CODE);
-}
-
-#[tokio::test]
-async fn snark_account_state_by_block_id() {
-    let account_id = test_account_id(1);
-
-    let block = make_block(8, 0, null_blkid());
-    let blkid = block.header().compute_blkid();
-    let tip = OLBlockCommitment::new(8, blkid);
-
-    let provider = MockProvider::new()
-        .with_sync_status(make_sync_status(
-            tip,
-            0,
-            false,
-            EpochCommitment::null(),
-            EpochCommitment::null(),
-            EpochCommitment::null(),
-        ))
-        .with_block_and_state(
-            &block,
-            ol_state_with_snark_account(account_id, 8, 11, DEFAULT_NEXT_INBOX_MSG_IDX),
-        );
-    let rpc = make_rpc(provider);
-
-    let state = rpc
-        .get_snark_account_state(account_id, OLBlockOrTag::OLBlockId(blkid))
-        .await
-        .expect("snark state")
-        .expect("should be Some");
-
-    assert_eq!(state.seq_no(), 11);
 }
 
 #[tokio::test]
@@ -2948,7 +2916,7 @@ async fn snark_account_state_confirmed_uses_confirmed_epoch() {
     let rpc = make_rpc(provider);
 
     let state = rpc
-        .get_snark_account_state(account_id, OLBlockOrTag::Confirmed)
+        .get_snark_account_state_by_tag(account_id, OLBlockTag::Confirmed)
         .await
         .expect("snark state")
         .expect("confirmed snark account");

--- a/bin/strata/src/run_context.rs
+++ b/bin/strata/src/run_context.rs
@@ -22,6 +22,33 @@ use strata_status::StatusChannel;
 use strata_storage::NodeStorage;
 use strata_tasks::{TaskExecutor, TaskManager};
 
+/// Runtime node role derived from the composed service set.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum NodeRole {
+    /// Checkpoint-sync node without complete OL block history.
+    CheckpointSync,
+    /// Full OL node with complete OL block data, but no sequencer-only endpoints.
+    #[expect(
+        dead_code,
+        reason = "reserved for the future OL full-node service profile"
+    )]
+    FullNode,
+    /// Sequencer node with block execution and sequencer-only endpoints.
+    Sequencer,
+}
+
+impl NodeRole {
+    /// Returns true when the node can serve OL full-node RPC methods.
+    pub(crate) fn serves_fullnode_rpc(self) -> bool {
+        matches!(self, Self::FullNode | Self::Sequencer)
+    }
+
+    /// Returns true when the node can serve sequencer submit/admin RPC methods.
+    pub(crate) fn serves_sequencer_rpc(self) -> bool {
+        matches!(self, Self::Sequencer)
+    }
+}
+
 /// Holds handles and monitors for all running services.
 pub(crate) struct RunContext {
     pub task_manager: TaskManager,
@@ -43,6 +70,15 @@ impl RunContext {
     /// Returns the config.
     pub(crate) fn config(&self) -> &Config {
         self.common.config()
+    }
+
+    /// Returns the runtime node role.
+    pub(crate) fn node_role(&self) -> NodeRole {
+        if self.config().client.is_sequencer {
+            NodeRole::Sequencer
+        } else {
+            NodeRole::CheckpointSync
+        }
     }
 
     pub(crate) fn asm_params(&self) -> &Arc<AsmParams> {

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -29,6 +29,24 @@ pub trait OLClientRpc {
     #[method(name = "getCheckpointInfo")]
     async fn get_checkpoint_info(&self, epoch: Epoch) -> RpcResult<Option<RpcCheckpointInfo>>;
 
+    /// Get the epoch commitment for the epoch in which an account was first created.
+    ///
+    /// Resolves the creation epoch and returns the corresponding
+    /// [`EpochCommitment`] in a single call.
+    #[method(name = "getAccountGenesisEpochCommitment")]
+    async fn get_account_genesis_epoch_commitment(
+        &self,
+        account_id: AccountId,
+    ) -> RpcResult<EpochCommitment>;
+
+    /// Get the canonical ASM-manifest commitment (the manifest's tree-hash root)
+    /// for the given L1 block height.
+    #[method(name = "getAsmManifestCommitment")]
+    async fn get_asm_manifest_commitment(
+        &self,
+        l1_height: L1Height,
+    ) -> RpcResult<Option<HexBytes32>>;
+
     /// Get account-specific summaries for blocks in a slot range.
     ///
     /// Returns the account's state (balance, sequence number, inbox position) at each block
@@ -57,32 +75,6 @@ pub trait OLClientRpc {
         start: u64,
         end: u64,
     ) -> RpcResult<Vec<RpcIndexedEntry<RpcMessageEntry>>>;
-
-    /// Get snark account state of an account at a specified block.
-    #[method(name = "getSnarkAccountState")]
-    async fn get_snark_account_state(
-        &self,
-        account_id: AccountId,
-        block_or_tag: OLBlockOrTag,
-    ) -> RpcResult<Option<RpcSnarkAccountState>>;
-
-    /// Get the epoch commitment for the epoch in which an account was first created.
-    ///
-    /// Resolves the creation epoch and returns the corresponding
-    /// [`EpochCommitment`] in a single call.
-    #[method(name = "getAccountGenesisEpochCommitment")]
-    async fn get_account_genesis_epoch_commitment(
-        &self,
-        account_id: AccountId,
-    ) -> RpcResult<EpochCommitment>;
-
-    /// Get the canonical ASM-manifest commitment (the manifest's tree-hash root)
-    /// for the given L1 block height.
-    #[method(name = "getAsmManifestCommitment")]
-    async fn get_asm_manifest_commitment(
-        &self,
-        l1_height: L1Height,
-    ) -> RpcResult<Option<HexBytes32>>;
 }
 
 /// OL RPC methods served by sequencer nodes for transaction submission.
@@ -134,6 +126,14 @@ pub trait OLFullNodeRpc {
     /// blocks in ascending slot order.
     #[method(name = "getRecentBlocks")]
     async fn get_recent_blocks(&self, count: u64) -> RpcResult<Vec<RpcOLBlockSummary>>;
+
+    /// Get snark account state of an account at a specified block.
+    #[method(name = "getSnarkAccountState")]
+    async fn get_snark_account_state(
+        &self,
+        account_id: AccountId,
+        block_or_tag: OLBlockOrTag,
+    ) -> RpcResult<Option<RpcSnarkAccountState>>;
 
     /// Get all transactions in the canonical OL block at the given slot.
     #[method(name = "getBlockTransactions")]

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -6,7 +6,7 @@ use serde_json as _;
 use strata_identifiers::{AccountId, Epoch, EpochCommitment, L1Height, OLBlockId, OLTxId};
 use strata_ol_rpc_types::*;
 use strata_ol_sequencer::BlockCompletionData;
-use strata_primitives::{HexBytes, HexBytes32, HexBytes64};
+use strata_primitives::{HexBytes, HexBytes32, HexBytes64, OLBlockCommitment};
 
 /// Common OL RPC methods that are served by all kinds of nodes(DA, block executing).
 #[strata_open_rpc_macros::open_rpc(namespace = "strata", tag = "Client Node")]
@@ -75,6 +75,14 @@ pub trait OLClientRpc {
         start: u64,
         end: u64,
     ) -> RpcResult<Vec<RpcIndexedEntry<RpcMessageEntry>>>;
+
+    /// Get Snark account state at a CSS-safe chain tag.
+    #[method(name = "getSnarkAccountStateByTag")]
+    async fn get_snark_account_state_by_tag(
+        &self,
+        account_id: AccountId,
+        tag: OLBlockTag,
+    ) -> RpcResult<Option<RpcSnarkAccountState>>;
 }
 
 /// OL RPC methods served by sequencer nodes for transaction submission.
@@ -127,12 +135,12 @@ pub trait OLFullNodeRpc {
     #[method(name = "getRecentBlocks")]
     async fn get_recent_blocks(&self, count: u64) -> RpcResult<Vec<RpcOLBlockSummary>>;
 
-    /// Get snark account state of an account at a specified block.
-    #[method(name = "getSnarkAccountState")]
-    async fn get_snark_account_state(
+    /// Get Snark account state at an exact OL block commitment.
+    #[method(name = "getSnarkAccountStateAtBlock")]
+    async fn get_snark_account_state_at_block(
         &self,
         account_id: AccountId,
-        block_or_tag: OLBlockOrTag,
+        block: OLBlockCommitment,
     ) -> RpcResult<Option<RpcSnarkAccountState>>;
 
     /// Get all transactions in the canonical OL block at the given slot.

--- a/crates/ol/rpc/types/Cargo.toml
+++ b/crates/ol/rpc/types/Cargo.toml
@@ -26,7 +26,6 @@ strata-snark-acct-types.workspace = true
 strata-status.workspace = true
 
 async-trait.workspace = true
-hex.workspace = true
 schemars = { workspace = true, optional = true }
 serde.workspace = true
 ssz.workspace = true

--- a/crates/ol/rpc/types/src/blocktag.rs
+++ b/crates/ol/rpc/types/src/blocktag.rs
@@ -4,49 +4,26 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use strata_identifiers::Slot;
-use strata_primitives::{Buf32, OLBlockId};
-
-/// Identifies a block by tag, hash, or slot number.
-#[derive(Clone)]
-pub enum OLBlockOrTag {
+/// Identifies a CSS-safe OL state point by tag.
+#[derive(Clone, Copy)]
+pub enum OLBlockTag {
     /// The most recent block produced.
     Latest,
     /// The most recent block confirmed on L1.
     Confirmed,
     /// The most recent block finalized on L1.
     Finalized,
-    /// A specific block by its hash.
-    OLBlockId(OLBlockId),
-    /// A specific block by its slot number.
-    Slot(Slot),
 }
 
-impl From<OLBlockId> for OLBlockOrTag {
-    fn from(value: OLBlockId) -> Self {
-        Self::OLBlockId(value)
-    }
-}
-
-impl From<Slot> for OLBlockOrTag {
-    fn from(value: Slot) -> Self {
-        Self::Slot(value)
-    }
-}
-
-impl Serialize for OLBlockOrTag {
+impl Serialize for OLBlockTag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         match self {
-            OLBlockOrTag::Latest => serializer.serialize_str("latest"),
-            OLBlockOrTag::Confirmed => serializer.serialize_str("confirmed"),
-            OLBlockOrTag::Finalized => serializer.serialize_str("finalized"),
-            OLBlockOrTag::OLBlockId(olblock_id) => {
-                serializer.serialize_str(&format!("0x{}", hex::encode(olblock_id.as_ref())))
-            }
-            OLBlockOrTag::Slot(slot) => serializer.serialize_str(&slot.to_string()),
+            OLBlockTag::Latest => serializer.serialize_str("latest"),
+            OLBlockTag::Confirmed => serializer.serialize_str("confirmed"),
+            OLBlockTag::Finalized => serializer.serialize_str("finalized"),
         }
     }
 }
@@ -56,7 +33,7 @@ impl Serialize for OLBlockOrTag {
     clippy::allow_attributes,
     reason = "distinguish serde Error"
 )]
-impl<'de> Deserialize<'de> for OLBlockOrTag {
+impl<'de> Deserialize<'de> for OLBlockTag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -66,7 +43,7 @@ impl<'de> Deserialize<'de> for OLBlockOrTag {
     }
 }
 
-impl FromStr for OLBlockOrTag {
+impl FromStr for OLBlockTag {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -74,29 +51,14 @@ impl FromStr for OLBlockOrTag {
             "latest" => Self::Latest,
             "confirmed" => Self::Confirmed,
             "finalized" => Self::Finalized,
-            s => {
-                // check if it a blockhash
-                if s.starts_with("0x") && s.len() == 66 {
-                    let mut bytes = [0u8; 32];
-                    hex::decode_to_slice(&s[2..], &mut bytes)
-                        .map_err(|_| "invalid blockhash hex")?;
-
-                    Self::OLBlockId(OLBlockId::from(Buf32::from(bytes)))
-                } else {
-                    // try to parse slot
-                    let slot: u64 = s.parse().map_err(|_| "invalid slot")?;
-                    Self::Slot(slot)
-                }
-            }
+            _ => return Err("invalid OL block tag"),
         })
     }
 }
 
-impl Display for OLBlockOrTag {
+impl Display for OLBlockTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Slot(x) => write!(f, "{x}"),
-            Self::OLBlockId(olblock_id) => write!(f, "0x{}", hex::encode(olblock_id.as_ref())),
             Self::Latest => f.pad("latest"),
             Self::Confirmed => f.pad("confirmed"),
             Self::Finalized => f.pad("finalized"),
@@ -104,7 +66,7 @@ impl Display for OLBlockOrTag {
     }
 }
 
-impl Debug for OLBlockOrTag {
+impl Debug for OLBlockTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
@@ -114,73 +76,36 @@ impl Debug for OLBlockOrTag {
 mod tests {
     use super::*;
 
-    fn roundtrip(block: &OLBlockOrTag) -> OLBlockOrTag {
+    fn roundtrip(block: &OLBlockTag) -> OLBlockTag {
         let serialized = serde_json::to_string(block).unwrap();
         serde_json::from_str(&serialized).unwrap()
     }
 
     #[test]
     fn test_latest_roundtrip() {
-        let block = OLBlockOrTag::Latest;
+        let block = OLBlockTag::Latest;
         let result = roundtrip(&block);
-        assert!(matches!(result, OLBlockOrTag::Latest));
+        assert!(matches!(result, OLBlockTag::Latest));
     }
 
     #[test]
     fn test_confirmed_roundtrip() {
-        let block = OLBlockOrTag::Confirmed;
+        let block = OLBlockTag::Confirmed;
         let result = roundtrip(&block);
-        assert!(matches!(result, OLBlockOrTag::Confirmed));
+        assert!(matches!(result, OLBlockTag::Confirmed));
     }
 
     #[test]
     fn test_finalized_roundtrip() {
-        let block = OLBlockOrTag::Finalized;
+        let block = OLBlockTag::Finalized;
         let result = roundtrip(&block);
-        assert!(matches!(result, OLBlockOrTag::Finalized));
+        assert!(matches!(result, OLBlockTag::Finalized));
     }
 
     #[test]
-    fn test_hash_roundtrip() {
-        let bytes = [0xab; 32];
-        let block = OLBlockOrTag::OLBlockId(OLBlockId::from(Buf32::from(bytes)));
-        let result = roundtrip(&block);
-        match result {
-            OLBlockOrTag::OLBlockId(id) => assert_eq!(id.as_ref(), &bytes),
-            _ => panic!("expected Hash variant"),
-        }
-    }
-
-    #[test]
-    fn test_slot_roundtrip() {
-        let block = OLBlockOrTag::Slot(12345);
-        let result = roundtrip(&block);
-        match result {
-            OLBlockOrTag::Slot(slot) => assert_eq!(slot, 12345),
-            _ => panic!("expected Slot variant"),
-        }
-    }
-
-    #[test]
-    fn test_deserialize_invalid_hex() {
-        let json = r#""0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ""#;
-        let result: Result<OLBlockOrTag, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_deserialize_wrong_length_hex() {
-        // 0x + 64 chars is valid (32 bytes), test with wrong length
-        let json = r#""0xabcd""#;
-        let result: Result<OLBlockOrTag, _> = serde_json::from_str(json);
-        // This should fail to parse as hash (wrong length) and fail as slot (not numeric)
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_deserialize_invalid_slot() {
+    fn test_deserialize_invalid_tag() {
         let json = r#""not_a_number""#;
-        let result: Result<OLBlockOrTag, _> = serde_json::from_str(json);
+        let result: Result<OLBlockTag, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
 
@@ -196,7 +121,7 @@ mod tests {
         ];
         for case in cases {
             let json = format!(r#""{case}""#);
-            let result: Result<OLBlockOrTag, _> = serde_json::from_str(&json);
+            let result: Result<OLBlockTag, _> = serde_json::from_str(&json);
             assert!(result.is_ok(), "failed to parse: {case}");
         }
     }

--- a/crates/ol/rpc/types/src/jsonschema.rs
+++ b/crates/ol/rpc/types/src/jsonschema.rs
@@ -2,17 +2,17 @@
 
 use std::borrow::Cow;
 
-use crate::{OLBlockOrTag, RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref};
+use crate::{OLBlockTag, RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref};
 
-impl schemars::JsonSchema for OLBlockOrTag {
+impl schemars::JsonSchema for OLBlockTag {
     fn schema_name() -> Cow<'static, str> {
-        "OLBlockOrTag".into()
+        "OLBlockTag".into()
     }
 
     fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
             "type": "string",
-            "description": "Block identifier: 'latest', 'confirmed', 'finalized', a slot number, or a 0x-prefixed block hash"
+            "description": "Block tag: 'latest', 'confirmed', or 'finalized'"
         })
     }
 }

--- a/crates/ol/rpc/types/src/lib.rs
+++ b/crates/ol/rpc/types/src/lib.rs
@@ -25,7 +25,7 @@ pub use account_summary::{
 pub use block::{
     RpcBlockEntry, RpcBlockHeaderEntry, RpcOLBlockDetail, RpcOLBlockSummary, RpcOLManifestsSummary,
 };
-pub use blocktag::OLBlockOrTag;
+pub use blocktag::OLBlockTag;
 pub use chain_status::{RpcOLBlockInfo, RpcOLChainStatus};
 pub use checkpoint::{RpcCheckpointConfStatus, RpcCheckpointInfo, RpcCheckpointL1Ref};
 pub use duty::*;

--- a/functional-tests/tests/alpen_client/test_ee_predicate_transition.py
+++ b/functional-tests/tests/alpen_client/test_ee_predicate_transition.py
@@ -76,9 +76,13 @@ class TestEePredicateTransition(BaseTest):
 
         def fetch_update_vk_and_mine() -> str:
             btc_rpc.proxy.generatetoaddress(1, mine_addr)
-            return strata_rpc.strata_getSnarkAccountState(ALPEN_ACCOUNT_ID, "latest")["update_vk"]
+            return strata_rpc.strata_getSnarkAccountStateByTag(ALPEN_ACCOUNT_ID, "latest")[
+                "update_vk"
+            ]
 
-        initial_vk = strata_rpc.strata_getSnarkAccountState(ALPEN_ACCOUNT_ID, "latest")["update_vk"]
+        initial_vk = strata_rpc.strata_getSnarkAccountStateByTag(ALPEN_ACCOUNT_ID, "latest")[
+            "update_vk"
+        ]
         if initial_vk != INITIAL_ACCT_PREDICATE:
             raise AssertionError(
                 f"expected initial update_vk to be {INITIAL_ACCT_PREDICATE!r}, got {initial_vk!r}"

--- a/functional-tests/tests/ol_isolated/test_mock_withdrawal.py
+++ b/functional-tests/tests/ol_isolated/test_mock_withdrawal.py
@@ -40,7 +40,7 @@ def get_account_balance(rpc, account_id_hex: str) -> int:
     """Query the account balance at the latest slot.
 
     Uses getChainStatus to find the latest slot, then getBlocksSummaries
-    to get the balance, since getSnarkAccountState does not include balance.
+    to get the balance, since getSnarkAccountStateByTag does not include balance.
     """
     status = rpc.strata_getChainStatus()
     tip_slot = status["tip"]["slot"]
@@ -129,7 +129,7 @@ class TestMockWithdrawal(StrataNodeTest):
 
         # Step 5: Build withdrawal transaction
         # Get snark account state for withdrawal params
-        account_state = rpc.strata_getSnarkAccountState(account_id_hex, "latest")
+        account_state = rpc.strata_getSnarkAccountStateByTag(account_id_hex, "latest")
         if account_state is None:
             raise AssertionError("Account state not found")
 

--- a/functional-tests/tests/strata/test_public_rpc_surface.py
+++ b/functional-tests/tests/strata/test_public_rpc_surface.py
@@ -1,0 +1,73 @@
+"""Node public RPC surfaces match node capabilities."""
+
+import flexitest
+
+from common.base_test import BaseTest
+from common.config.constants import ALPEN_ACCOUNT_ID, ServiceType
+from common.rpc import JsonRpcClient, RpcError
+from common.services.strata import StrataService
+
+DUMMY_TRANSACTION = {}
+
+
+@flexitest.register
+class TestPublicRpcSurface(BaseTest):
+    """Checks role-specific public RPC method exposure."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env("el_ol_checkpoint_sync")
+
+    def main(self, ctx):
+        sequencer: StrataService = self.get_service(ServiceType.Strata)
+        checkpoint_node: StrataService = self.get_service(ServiceType.StrataCheckpointNode)
+
+        sequencer_rpc = sequencer.wait_for_rpc_ready(timeout=20)
+        checkpoint_rpc = checkpoint_node.wait_for_rpc_ready(timeout=20)
+
+        # Use an inverted range to avoid depending on available block data; any
+        # error other than method-not-found proves the method is registered.
+        assert_method_registered(sequencer_rpc, "strata_getRawBlocksRange", 1, 0)
+        assert_method_not_found(sequencer_rpc, "strata_submitTransaction", DUMMY_TRANSACTION)
+        assert_method_not_found(sequencer_rpc, "strata_strataadmin_getSequencerDuties")
+
+        assert_method_not_found(checkpoint_rpc, "strata_getRawBlocksRange", 1, 0)
+        assert_method_registered(
+            checkpoint_rpc,
+            "strata_getBlocksSummaries",
+            ALPEN_ACCOUNT_ID,
+            1,
+            0,
+        )
+        assert_method_not_found(
+            checkpoint_rpc,
+            "strata_getSnarkAcctUpdateManifest",
+            ALPEN_ACCOUNT_ID,
+            0,
+        )
+        assert_method_not_found(checkpoint_rpc, "strata_submitTransaction", DUMMY_TRANSACTION)
+        assert_method_not_found(
+            checkpoint_rpc,
+            "strata_getSnarkAccountState",
+            ALPEN_ACCOUNT_ID,
+            "latest",
+        )
+        assert_method_registered(checkpoint_rpc, "strata_getChainStatus")
+
+
+def assert_method_registered(rpc: JsonRpcClient, method: str, *params) -> None:
+    """Asserts that an RPC method is registered on this endpoint."""
+    try:
+        rpc.call(method, *params)
+    except RpcError as err:
+        assert err.code != -32601, f"{method} should be registered, got {err}"
+
+
+def assert_method_not_found(rpc: JsonRpcClient, method: str, *params) -> None:
+    """Asserts that an RPC method is not registered on this endpoint."""
+    try:
+        rpc.call(method, *params)
+    except RpcError as err:
+        assert err.code == -32601, f"expected method-not-found for {method}, got {err}"
+        return
+
+    raise AssertionError(f"{method} unexpectedly exists")


### PR DESCRIPTION
## Description

Segregates OL RPC method exposure by node role so each node only advertises endpoints it can actually serve.

Before this PR, non-sequencer nodes exposed public RPC methods that require complete OL block history. A checkpoint-sync node could accept calls like `getRawBlocksRange` and return misleading empty results.

After this PR:
- **CheckpointSync** serves `OLClientRpc` only.
- **FullNode** serves `OLClientRpc + OLFullNodeRpc` when the full-node service profile is implemented.
- **Sequencer** serves `OLClientRpc + OLFullNodeRpc` on the public endpoint.
- `OLSubmitRpc` and `OLSequencerRpc` stay on dedicated submit/admin endpoints and are only started for sequencer nodes.

The role is derived once from `config.client.is_sequencer` at composition time. The internal `NodeRole` type is the seam future work can use when node role becomes an explicit config field.

## Why split `getSnarkAccountState`

The old `getSnarkAccountState(account_id, OLBlockOrTag)` mixed two operations with different node requirements:

- `Latest` / `Confirmed` / `Finalized` are CSS-safe because checkpoint-sync nodes track those states.
- `OLBlockId` / `Slot` require historical OL block/state access and belong on the full-node surface.

One method could not cleanly satisfy both contracts. The split makes the node-surface classification type-driven:

- `strata_getSnarkAccountStateByTag(account_id, OLBlockTag)` is on `OLClientRpc`.
- `strata_getSnarkAccountStateAtBlock(account_id, OLBlockCommitment)` is on `OLFullNodeRpc`.

Both implementations share one private core helper.

`getBlocksSummaries` remains on `OLClientRpc` because the EE client uses it through checkpoint-sync nodes to read inbox summaries for tracked slot ranges.

## Breaking changes
- `strata_getSnarkAccountState` is removed.
- Use `strata_getSnarkAccountStateByTag` for `latest` / `confirmed` / `finalized`.
- Use `strata_getSnarkAccountStateAtBlock` for exact block-commitment queries.
- `OLBlockOrTag::OLBlockId(_)` and `OLBlockOrTag::Slot(_)` are removed. No in-tree caller used those variants.
- Checkpoint-sync public RPC no longer exposes full-node-only methods such as `getRawBlocksRange`, `getRawBlockById`, `getHeadersInRange`, `getBlockBySlot`, `getRecentBlocks`, `getBlockTransactions`, `getBlockAccountChanges`, `getSnarkAccountStateAtBlock`, or `getSnarkAcctUpdateManifest`.
- Calls to unsupported methods on checkpoint-sync nodes now return `-32601 method not found` instead of misleading empty results.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3078](https://alpenlabs.atlassian.net/browse/STR-3078)

[STR-3078]: https://alpenlabs.atlassian.net/browse/STR-3078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ