### PR TITLE
feat(sp1-e2e): pin checkout to selected image commit

### DIFF
--- a/.github/workflows/ci-sp1-e2e.yml
+++ b/.github/workflows/ci-sp1-e2e.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       short_tag: ${{ steps.check.outputs.short_tag }}
+      commit_sha: ${{ steps.check.outputs.commit_sha }}
     steps:
       - name: Check for new commits since last success
         id: check
@@ -40,38 +41,42 @@ jobs:
           INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          REPO="${{ github.repository }}"
+
           if [ -n "${INPUT_IMAGE_TAG}" ]; then
-            # Manual dispatch with explicit tag
+            # Manual tag: resolve the full commit SHA that produced the image.
             SHORT_TAG="${INPUT_IMAGE_TAG}"
             SHORT_TAG="${SHORT_TAG:0:7}"
-            echo "short_tag=${SHORT_TAG}" >> "$GITHUB_OUTPUT"
-            echo "Manual trigger with tag ${SHORT_TAG} — running"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            BUILD_SHA=$(gh run list -R "${REPO}" \
+              --workflow ci-build.yml \
+              --status success \
+              --limit 100 \
+              --json headSha \
+              --jq ".[] | select(.headSha | startswith(\"${SHORT_TAG}\")) | .headSha" | head -n1)
+          else
+            # Scheduled/default run: use the latest successful main image build.
+            BUILD_SHA=$(gh run list -R "${REPO}" \
+              --workflow ci-build.yml \
+              --branch main \
+              --status success \
+              --limit 1 \
+              --json headSha \
+              --jq '.[0].headSha // ""')
+            SHORT_TAG="${BUILD_SHA:0:7}"
           fi
 
-          # Find the latest successful image build on main
-          REPO="${{ github.repository }}"
-          BUILD_SHA=$(gh run list -R "${REPO}" \
-            --workflow ci-build.yml \
-            --branch main \
-            --status success \
-            --limit 1 \
-            --json headSha \
-            --jq '.[0].headSha // ""')
-
           if [ -z "${BUILD_SHA}" ]; then
-            echo "::error::No successful image build found on main"
+            echo "::error::No successful ci-build found for ${SHORT_TAG:-main}"
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          SHORT_TAG="${BUILD_SHA:0:7}"
           echo "short_tag=${SHORT_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Latest image build: ${SHORT_TAG}"
+          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Selected image build: ${SHORT_TAG} (${BUILD_SHA})"
 
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "Manual trigger — running with latest build ${SHORT_TAG}"
+            echo "Manual trigger — running"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -107,6 +112,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
+          ref: ${{ needs.check-new-commits.outputs.commit_sha }}
           persist-credentials: false
 
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/ci-sp1-e2e.yml
+++ b/.github/workflows/ci-sp1-e2e.yml
@@ -15,6 +15,10 @@ on:
         description: "Image tag to test (default: current SHA short)"
         required: false
         type: string
+      checkout_ref:
+        description: "Repo ref to checkout (default: image commit SHA)"
+        required: false
+        type: string
 
 env:
   AWS_REGION: us-east-1
@@ -33,14 +37,20 @@ jobs:
       should_run: ${{ steps.check.outputs.should_run }}
       short_tag: ${{ steps.check.outputs.short_tag }}
       commit_sha: ${{ steps.check.outputs.commit_sha }}
+      checkout_ref: ${{ steps.check.outputs.checkout_ref }}
     steps:
       - name: Check for new commits since last success
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          set_output() {
+            echo "$1=$2" >> "$GITHUB_OUTPUT"
+          }
+
           REPO="${{ github.repository }}"
 
           if [ -n "${INPUT_IMAGE_TAG}" ]; then
@@ -67,17 +77,18 @@ jobs:
 
           if [ -z "${BUILD_SHA}" ]; then
             echo "::error::No successful ci-build found for ${SHORT_TAG:-main}"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            set_output should_run false
             exit 0
           fi
 
-          echo "short_tag=${SHORT_TAG}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
+          set_output short_tag "${SHORT_TAG}"
+          set_output commit_sha "${BUILD_SHA}"
+          set_output checkout_ref "${INPUT_CHECKOUT_REF:-${BUILD_SHA}}"
           echo "Selected image build: ${SHORT_TAG} (${BUILD_SHA})"
 
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "Manual trigger — running"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            set_output should_run true
             exit 0
           fi
 
@@ -92,10 +103,10 @@ jobs:
 
           if [ "${LAST_SUCCESS}" = "${BUILD_SHA}" ]; then
             echo "Already tested build ${SHORT_TAG} — skipping"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            set_output should_run false
           else
             echo "New build ${SHORT_TAG} not yet tested — running"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            set_output should_run true
           fi
 
   sp1-e2e:
@@ -112,7 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
-          ref: ${{ needs.check-new-commits.outputs.commit_sha }}
+          ref: ${{ needs.check-new-commits.outputs.checkout_ref }}
           persist-credentials: false
 
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## Description

Pins the SP1 E2E workflow checkout to the commit that produced the selected Docker images by default. This keeps workflow scripts, Docker compose files, and datatool assumptions aligned with the image tag under test.

Manual runs can still pass `checkout_ref` to test workflow changes from a branch against an existing image tag.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The default path preserves STR-3529's anti-drift behavior: when `checkout_ref` is omitted, `actions/checkout` uses the resolved image commit SHA. The override is only for manual workflow debugging.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

Validation:

- `git diff --check`
- `actionlint .github/workflows/ci-sp1-e2e.yml`

AI assistance notice: This PR was prepared with AI assistance.

## Related Issues

STR-3529
