### PR TITLE
feat(ee): assign unique indices to withdrawal structs

### DIFF
--- a/bin/alpen-client/src/payload_builder.rs
+++ b/bin/alpen-client/src/payload_builder.rs
@@ -91,10 +91,9 @@ impl AlpenRethPayloadEngine {
             .iter()
             .map(|deposit| {
                 Ok::<Withdrawal, eyre::Error>(Withdrawal {
-                    // Index fields are set to 0 because Alpen uses the Withdrawal type
-                    // to transfer deposits into the EVM state, not for validator withdrawals.
-                    // These indices are unused in our execution context.
-                    index: 0,
+                    // Alpen uses the Withdrawal type to transfer deposits into the EVM state, not
+                    // for validator withdrawals.
+                    index: deposit.idx(),
                     validator_index: 0,
                     address: deposit.address(),
                     amount: sats_to_gwei(deposit.amount().to_sat())

--- a/crates/alpen-ee/block-assembly/src/block.rs
+++ b/crates/alpen-ee/block-assembly/src/block.rs
@@ -25,6 +25,8 @@ pub struct BlockAssemblyInputs<'a> {
     pub max_deposits_per_block: NonZero<u8>,
     /// Account id for bridge gateway on ol.
     pub bridge_gateway_account_id: AccountId,
+    /// Monotonically incrementing index for next deposit to use.
+    pub next_deposit_idx: u64,
 }
 
 /// Outputs from block assembly
@@ -36,6 +38,8 @@ pub struct BlockAssemblyOutputs {
     pub payload: ExecBlockPayload,
     /// EeAccountState after applying the new block.
     pub account_state: EeAccountState,
+    /// Monotonically incrementing index for next deposit to use.
+    pub next_deposit_idx: u64,
 }
 
 /// Builds the next block using `inputs` and `payload_builder`.
@@ -50,6 +54,7 @@ pub async fn build_next_exec_block<E: PayloadBuilderEngine>(
         timestamp_ms,
         max_deposits_per_block,
         bridge_gateway_account_id,
+        next_deposit_idx,
     } = inputs;
 
     // 1. apply new inbox messages to account state
@@ -57,11 +62,12 @@ pub async fn build_next_exec_block<E: PayloadBuilderEngine>(
         .context("build_next_exec_block: failed to apply input messages")?;
 
     // 2. build exec block payload
-    let (payload, update_extra_data) = build_exec_payload(
+    let (payload, update_extra_data, next_deposit_idx) = build_exec_payload(
         &mut account_state,
         parent_exec_blkid,
         timestamp_ms,
         max_deposits_per_block,
+        next_deposit_idx,
         payload_builder,
     )
     .await?;
@@ -83,5 +89,6 @@ pub async fn build_next_exec_block<E: PayloadBuilderEngine>(
                 .context("build_next_exec_block: failed to serialized payload")?,
         ),
         account_state,
+        next_deposit_idx,
     })
 }

--- a/crates/alpen-ee/block-assembly/src/payload.rs
+++ b/crates/alpen-ee/block-assembly/src/payload.rs
@@ -13,13 +13,17 @@ use tracing::{debug, info};
 pub(crate) fn extract_deposits(
     pending_inputs: &[PendingInputEntry],
     max_deposits: NonZero<u8>,
+    next_deposit_idx: u64,
 ) -> Vec<DepositInfo> {
     pending_inputs
         .iter()
-        .map(|entry| match entry {
-            PendingInputEntry::Deposit(data) => {
-                DepositInfo::new(subject_to_address_unchecked(&data.dest()), data.value())
-            }
+        .enumerate()
+        .map(|(idx, entry)| match entry {
+            PendingInputEntry::Deposit(data) => DepositInfo::new(
+                next_deposit_idx + idx as u64,
+                subject_to_address_unchecked(&data.dest()),
+                data.value(),
+            ),
         })
         .take(max_deposits.get() as usize)
         .collect()
@@ -33,12 +37,18 @@ pub(crate) async fn build_exec_payload<E: PayloadBuilderEngine>(
     parent_exec_blkid: Hash,
     timestamp_ms: u64,
     max_deposits_per_block: NonZero<u8>,
+    deposit_counter: u64,
     payload_builder: &E,
-) -> eyre::Result<(E::TEnginePayload, UpdateExtraData)> {
+) -> eyre::Result<(E::TEnginePayload, UpdateExtraData, u64)> {
     let parent = B256::from_slice(parent_exec_blkid.as_slice());
     let timestamp_sec = timestamp_ms / 1_000;
 
-    let deposits = extract_deposits(account_state.pending_inputs(), max_deposits_per_block);
+    let deposits = extract_deposits(
+        account_state.pending_inputs(),
+        max_deposits_per_block,
+        deposit_counter,
+    );
+    let deposits_processed = deposits.len() as u64;
     let processed_inputs = deposits.len() as u32;
     // dont handle forced inclusions currently
     let processed_fincls = 0;
@@ -73,7 +83,11 @@ pub(crate) async fn build_exec_payload<E: PayloadBuilderEngine>(
         processed_fincls,
     );
 
-    Ok((payload, update_extra_data))
+    Ok((
+        payload,
+        update_extra_data,
+        deposit_counter + deposits_processed,
+    ))
 }
 
 #[cfg(test)]
@@ -96,12 +110,14 @@ mod tests {
         // SubjectId with valid EVM address: [0x00..0x00 (12 bytes), 0xaa..0xaa (20 bytes)]
         let mut subject_bytes = [0u8; 32];
         subject_bytes[12..32].copy_from_slice(&[0xaa; 20]);
+        let next_deposit_idx = 5;
 
         let inputs = vec![make_deposit(subject_bytes, 1000)];
-        let deposits = extract_deposits(&inputs, NonZero::new(10).unwrap());
+        let deposits = extract_deposits(&inputs, NonZero::new(10).unwrap(), next_deposit_idx);
 
         assert_eq!(deposits.len(), 1);
         assert_eq!(deposits[0].address(), Address::from([0xaa; 20]));
+        assert_eq!(deposits[0].idx(), 5);
     }
 
     #[test]
@@ -126,13 +142,17 @@ mod tests {
             make_deposit(subject5, 5000),
         ];
         let max = NonZero::new(3).unwrap();
+        let next_deposit_idx = 9;
 
-        let deposits = extract_deposits(&inputs, max);
+        let deposits = extract_deposits(&inputs, max, next_deposit_idx);
 
         assert_eq!(deposits.len(), 3);
         // Verify order is preserved (first 3)
         assert_eq!(deposits[0].amount(), BitcoinAmount::from_sat(1000));
+        assert_eq!(deposits[0].idx(), 9);
         assert_eq!(deposits[1].amount(), BitcoinAmount::from_sat(2000));
+        assert_eq!(deposits[1].idx(), 10);
         assert_eq!(deposits[2].amount(), BitcoinAmount::from_sat(3000));
+        assert_eq!(deposits[2].idx(), 11);
     }
 }

--- a/crates/alpen-ee/common/src/traits/storage/exec_block.rs
+++ b/crates/alpen-ee/common/src/traits/storage/exec_block.rs
@@ -397,6 +397,7 @@ pub mod exec_block_storage_test_fns {
             timestamp_ms,
             parent_hash,
             0,
+            0,
             messages,
         )
     }

--- a/crates/alpen-ee/common/src/types/exec_record.rs
+++ b/crates/alpen-ee/common/src/types/exec_record.rs
@@ -25,6 +25,8 @@ struct ExecPackageMetadata {
     ol_block: OLBlockCommitment,
     /// Next inbox message index at this ol_block.
     next_inbox_msg_idx: u64,
+    /// Monotonically incrementing index for next deposit to use.
+    next_deposit_idx: u64,
 }
 
 /// `ExecBlockPackage` with additional block metadata
@@ -50,6 +52,7 @@ impl ExecBlockRecord {
         timestamp_ms: u64,
         parent_blockhash: Hash,
         next_inbox_msg_idx: u64,
+        next_deposit_idx: u64,
         messages: Vec<MessageEntry>,
     ) -> Self {
         Self {
@@ -62,6 +65,7 @@ impl ExecBlockRecord {
                 timestamp_ms,
                 parent_blockhash,
                 next_inbox_msg_idx,
+                next_deposit_idx,
             },
         }
     }
@@ -100,6 +104,10 @@ impl ExecBlockRecord {
 
     pub fn next_inbox_msg_idx(&self) -> u64 {
         self.metadata.next_inbox_msg_idx
+    }
+
+    pub fn next_deposit_idx(&self) -> u64 {
+        self.metadata.next_deposit_idx
     }
 
     pub fn messages(&self) -> &[MessageEntry] {

--- a/crates/alpen-ee/common/src/types/payload_builder.rs
+++ b/crates/alpen-ee/common/src/types/payload_builder.rs
@@ -37,6 +37,8 @@ impl PayloadBuildAttributes {
 /// Describes an incoming deposit that should be minted.
 #[derive(Debug, Clone)]
 pub struct DepositInfo {
+    /// Unique index for this deposit.
+    idx: u64,
     /// Address inside evm chain where the deposit should be minted to.
     address: Address,
     /// Amount that has been deposited.
@@ -44,8 +46,16 @@ pub struct DepositInfo {
 }
 
 impl DepositInfo {
-    pub fn new(address: Address, amount: BitcoinAmount) -> Self {
-        Self { address, amount }
+    pub fn new(idx: u64, address: Address, amount: BitcoinAmount) -> Self {
+        Self {
+            idx,
+            address,
+            amount,
+        }
+    }
+
+    pub fn idx(&self) -> u64 {
+        self.idx
     }
 
     pub fn address(&self) -> Address {

--- a/crates/alpen-ee/database/src/serialization_types/exec_block.rs
+++ b/crates/alpen-ee/database/src/serialization_types/exec_block.rs
@@ -18,6 +18,7 @@ pub(crate) struct DBExecBlockRecord {
     package_ssz: Vec<u8>,
     account_state: DBEeAccountState,
     next_inbox_msg_idx: u64,
+    next_deposit_idx: u64,
     messages: Vec<DBMessageEntry>,
 }
 
@@ -28,6 +29,7 @@ impl From<ExecBlockRecord> for DBExecBlockRecord {
         let timestamp_ms = value.timestamp_ms();
         let ol_block = *value.ol_block();
         let next_inbox_msg_idx = value.next_inbox_msg_idx();
+        let next_deposit_idx = value.next_deposit_idx();
         let (package, account_state, messages) = value.into_parts();
         let package_ssz = package.as_ssz_bytes();
         let account_state = account_state.into();
@@ -41,6 +43,7 @@ impl From<ExecBlockRecord> for DBExecBlockRecord {
             package_ssz,
             account_state,
             next_inbox_msg_idx,
+            next_deposit_idx,
             messages,
         }
     }
@@ -61,6 +64,7 @@ impl TryFrom<DBExecBlockRecord> for ExecBlockRecord {
             value.timestamp_ms,
             value.parent_blockhash,
             value.next_inbox_msg_idx,
+            value.next_deposit_idx,
             value.messages.into_iter().map(Into::into).collect(),
         ))
     }

--- a/crates/alpen-ee/engine/src/sync.rs
+++ b/crates/alpen-ee/engine/src/sync.rs
@@ -488,6 +488,7 @@ mod tests {
             timestamp_ms,
             parent_hash,
             0,
+            0,
             vec![],
         )
     }

--- a/crates/alpen-ee/exec-chain/src/state.rs
+++ b/crates/alpen-ee/exec-chain/src/state.rs
@@ -235,6 +235,7 @@ mod tests {
             0,
             parent_blockhash,
             0,
+            0,
             vec![],
         )
     }

--- a/crates/alpen-ee/genesis/src/utils.rs
+++ b/crates/alpen-ee/genesis/src/utils.rs
@@ -44,6 +44,7 @@ pub fn build_genesis_exec_block(
     let genesis_block_timestamp_ms = 0;
     let genesis_parent_blockhash = Buf32([0; 32]); // 0x0
     let genesis_next_inbox_msg_idx = 0;
+    let genesis_next_deposit_idx = 0;
     let genesis_messages = vec![];
 
     let block = ExecBlockRecord::new(
@@ -54,6 +55,7 @@ pub fn build_genesis_exec_block(
         genesis_block_timestamp_ms,
         genesis_parent_blockhash,
         genesis_next_inbox_msg_idx,
+        genesis_next_deposit_idx,
         genesis_messages,
     );
     let payload = ExecBlockPayload::from_bytes(Vec::new());

--- a/crates/alpen-ee/sequencer/src/block_builder/task.rs
+++ b/crates/alpen-ee/sequencer/src/block_builder/task.rs
@@ -114,6 +114,7 @@ fn create_block_assembly_inputs<'a>(
         timestamp_ms,
         max_deposits_per_block: config.max_deposits_per_block(),
         bridge_gateway_account_id: config.bridge_gateway_account_id(),
+        next_deposit_idx: last_local_block.next_deposit_idx(),
     }
 }
 
@@ -127,6 +128,7 @@ fn create_next_exec_block_record(
     timestamp_ms: u64,
     parent_blockhash: Hash,
     next_inbox_msg_idx: u64,
+    next_deposit_idx: u64,
     messages: Vec<MessageEntry>,
 ) -> ExecBlockRecord {
     ExecBlockRecord::new(
@@ -137,6 +139,7 @@ fn create_next_exec_block_record(
         timestamp_ms,
         parent_blockhash,
         next_inbox_msg_idx,
+        next_deposit_idx,
         messages,
     )
 }
@@ -309,6 +312,7 @@ async fn build_next_block(
         package,
         payload,
         account_state,
+        next_deposit_idx,
     } = build_next_exec_block(block_assembly_inputs, payload_builder)
         .await
         .context("build_next_block: failed to build exec block")?;
@@ -323,6 +327,7 @@ async fn build_next_block(
         timestamp_ms,
         parent_blockhash,
         next_inbox_msg_idx,
+        next_deposit_idx,
         inbox_messages,
     );
 
@@ -366,6 +371,7 @@ mod tests {
             ol_block,
             timestamp_ms,
             Hash::default(),
+            0,
             0,
             vec![],
         )

--- a/crates/alpen-ee/sequencer/src/ol_chain_tracker/test_utils.rs
+++ b/crates/alpen-ee/sequencer/src/ol_chain_tracker/test_utils.rs
@@ -111,6 +111,7 @@ pub(crate) fn create_mock_exec_record(ol_block: OLBlockCommitment) -> ExecBlockR
         1_000_000,
         Hash::default(),
         0,
+        0,
         vec![],
     )
 }


### PR DESCRIPTION
## Description
Track a monotonically incrementing counter in the sequencer's ExecBlockRecord and propagate it through block assembly into the Withdrawal.index field. 
Existing implementation since #1229 sets this always at 0, which is causing issues during indexing by blockscout.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
