### PR TITLE
[DO NOT MERGE] STR 2404 EE DA verification tool

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Build Cargo project
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
-        run: cargo build --locked -F sequencer -F debug-utils -F test-mode -F debug-asm -F prover --bin strata --bin strata-signer --bin alpen-client --bin strata-datatool --bin strata-test-cli --bin strata-dbtool
+        run: cargo build --locked -F sequencer -F debug-utils -F test-mode -F debug-asm -F prover --bin strata --bin strata-signer --bin alpen-client --bin strata-datatool --bin strata-test-cli --bin strata-dbtool --bin alpen-ee-da-tool
 
       - name: Run functional tests
         id: funcTestsRun

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,20 +1304,35 @@ dependencies = [
 name = "alpen-ee-da-tool"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "alpen-chainspec",
+ "alpen-ee-config",
  "alpen-ee-da-l1-extraction",
+ "alpen-ee-da-state-replay",
  "alpen-ee-da-types",
+ "alpen-ee-genesis",
+ "alpen-reth-statediff",
  "argh",
  "bitcoin",
  "bitcoind-async-client",
  "futures",
+ "jsonrpsee",
  "serde",
  "serde_json",
+ "ssz",
+ "strata-acct-types",
  "strata-cli-common",
+ "strata-codec",
+ "strata-ee-acct-runtime",
+ "strata-ee-acct-types",
  "strata-identifiers",
  "strata-l1-txfmt",
+ "strata-ol-rpc-api",
+ "strata-ol-rpc-types",
  "terrors",
+ "thiserror 2.0.18",
  "tokio",
  "toml 0.5.11",
+ "tree_hash 0.16.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpen-ee-da-state-replay"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "alloy-primitives",
+ "alpen-ee-da-types",
+ "alpen-reth-statediff",
+ "proptest",
+ "serde",
+ "serde_json",
+ "strata-identifiers",
+ "strata-mpt",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alpen-ee-da-tool"
 version = "0.3.0-alpha.1"
 dependencies = [
@@ -1652,6 +1667,7 @@ dependencies = [
  "serde_json",
  "strata-codec",
  "strata-da-framework",
+ "strata-identifiers",
  "strata-mpt",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpen-ee-da-l1-extraction"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "alpen-ee-da-types",
+ "bitcoin",
+ "bitcoind-async-client",
+ "futures",
+ "proptest",
+ "strata-btcio",
+ "strata-codec",
+ "strata-common",
+ "strata-identifiers",
+ "strata-l1-envelope-fmt",
+ "strata-l1-txfmt",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "alpen-ee-da-provider"
 version = "0.3.0-alpha.1"
 dependencies = [
@@ -1270,13 +1289,19 @@ dependencies = [
 name = "alpen-ee-da-tool"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "alpen-ee-da-l1-extraction",
+ "alpen-ee-da-types",
  "argh",
  "bitcoin",
+ "bitcoind-async-client",
+ "futures",
  "serde",
  "serde_json",
  "strata-cli-common",
  "strata-identifiers",
+ "strata-l1-txfmt",
  "terrors",
+ "tokio",
  "toml 0.5.11",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpen-ee-da-tool"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "argh",
+ "bitcoin",
+ "serde",
+ "serde_json",
+ "strata-cli-common",
+ "strata-identifiers",
+ "terrors",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "alpen-ee-da-types"
 version = "0.3.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ members = [
   # binaries listed separately
   "bin/datatool",
   "bin/alpen-cli",
+  "bin/alpen-ee-da-tool",
   "bin/strata-dbtool",
   "bin/alpen-client",
   "bin/strata",
@@ -112,6 +113,7 @@ default-members = [
   "bin/strata-dbtool",
   "bin/strata-signer",
   "bin/alpen-cli",
+  "bin/alpen-ee-da-tool",
   "bin/strata-test-cli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/alpen-ee/da/l1-extraction",
   "crates/alpen-ee/da/provider",
   "crates/alpen-ee/da/runtime",
+  "crates/alpen-ee/da/state-replay",
   "crates/alpen-ee/da/types",
   "crates/alpen-ee/database",
   "crates/alpen-ee/engine",
@@ -138,6 +139,7 @@ alpen-ee-config = { path = "crates/alpen-ee/config" }
 alpen-ee-da-l1-extraction = { path = "crates/alpen-ee/da/l1-extraction" }
 alpen-ee-da-provider = { path = "crates/alpen-ee/da/provider" }
 alpen-ee-da-runtime = { path = "crates/alpen-ee/da/runtime" }
+alpen-ee-da-state-replay = { path = "crates/alpen-ee/da/state-replay" }
 alpen-ee-da-types = { path = "crates/alpen-ee/da/types" }
 alpen-ee-database = { path = "crates/alpen-ee/database", default-features = false }
 alpen-ee-engine = { path = "crates/alpen-ee/engine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/alpen-ee/exec-chain",
   "crates/alpen-ee/common",
   "crates/alpen-ee/config",
+  "crates/alpen-ee/da/l1-extraction",
   "crates/alpen-ee/da/provider",
   "crates/alpen-ee/da/runtime",
   "crates/alpen-ee/da/types",
@@ -134,6 +135,7 @@ alpen-chainspec = { path = "crates/reth/chainspec" }
 alpen-ee-block-assembly = { path = "crates/alpen-ee/block-assembly" }
 alpen-ee-common = { path = "crates/alpen-ee/common" }
 alpen-ee-config = { path = "crates/alpen-ee/config" }
+alpen-ee-da-l1-extraction = { path = "crates/alpen-ee/da/l1-extraction" }
 alpen-ee-da-provider = { path = "crates/alpen-ee/da/provider" }
 alpen-ee-da-runtime = { path = "crates/alpen-ee/da/runtime" }
 alpen-ee-da-types = { path = "crates/alpen-ee/da/types" }

--- a/bin/alpen-ee-da-tool/Cargo.toml
+++ b/bin/alpen-ee-da-tool/Cargo.toml
@@ -11,18 +11,33 @@ name = "alpen-ee-da-tool"
 path = "src/main.rs"
 
 [dependencies]
+alpen-chainspec.workspace = true
+alpen-ee-config.workspace = true
 alpen-ee-da-l1-extraction.workspace = true
+alpen-ee-da-state-replay.workspace = true
 alpen-ee-da-types.workspace = true
+alpen-ee-genesis.workspace = true
+alpen-reth-statediff = { workspace = true, features = ["chainspec"] }
+strata-acct-types.workspace = true
 strata-cli-common.workspace = true
+strata-codec.workspace = true
+strata-ee-acct-runtime.workspace = true
+strata-ee-acct-types.workspace = true
 strata-identifiers.workspace = true
 strata-l1-txfmt.workspace = true
+strata-ol-rpc-api = { workspace = true, features = ["client"] }
+strata-ol-rpc-types.workspace = true
 
 argh.workspace = true
 bitcoin.workspace = true
 bitcoind-async-client.workspace = true
 futures.workspace = true
+jsonrpsee = { workspace = true, features = ["http-client"] }
 serde.workspace = true
 serde_json.workspace = true
+ssz.workspace = true
 terrors.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tree_hash.workspace = true

--- a/bin/alpen-ee-da-tool/Cargo.toml
+++ b/bin/alpen-ee-da-tool/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2021"
+name = "alpen-ee-da-tool"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "alpen-ee-da-tool"
+path = "src/main.rs"
+
+[dependencies]
+strata-cli-common.workspace = true
+strata-identifiers.workspace = true
+
+argh.workspace = true
+bitcoin.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+terrors.workspace = true
+toml.workspace = true

--- a/bin/alpen-ee-da-tool/config.example.toml
+++ b/bin/alpen-ee-da-tool/config.example.toml
@@ -3,3 +3,7 @@ bitcoind_rpc_user = "rpc_user"
 bitcoind_rpc_password = "rpc_password"
 sequencer_pubkey = "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
 ee_params = "/path/to/ee-params.json"
+
+# Optional: enable expected-root comparison through OL's Snark account update
+# manifest RPC. The tool uses Alpen EE's canonical account id.
+# ol_rpc_url = "http://127.0.0.1:8432"

--- a/bin/alpen-ee-da-tool/config.example.toml
+++ b/bin/alpen-ee-da-tool/config.example.toml
@@ -1,0 +1,5 @@
+bitcoind_url = "http://127.0.0.1:18443"
+bitcoind_rpc_user = "rpc_user"
+bitcoind_rpc_password = "rpc_password"
+sequencer_pubkey = "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+ee_params = "/path/to/ee-params.json"

--- a/bin/alpen-ee-da-tool/src/cli.rs
+++ b/bin/alpen-ee-da-tool/src/cli.rs
@@ -55,6 +55,18 @@ pub(crate) struct Cli {
     #[argh(option)]
     pub(crate) expected_root: Option<Buf32>,
 
+    /// EVM chain spec selector or path.
+    #[argh(option, default = "\"dev\".to_string()")]
+    pub(crate) custom_chain: String,
+
+    /// optional replay pre-state snapshot JSON path.
+    #[argh(option, long = "snapshot", arg_name = "path")]
+    pub(crate) snapshot_path: Option<PathBuf>,
+
+    /// optional post-run replay snapshot JSON output path.
+    #[argh(option, long = "export-snapshot", arg_name = "path")]
+    pub(crate) export_snapshot_path: Option<PathBuf>,
+
     /// report output format (`porcelain` or `json`).
     #[argh(option)]
     pub(crate) output_format: Option<OutputFormat>,
@@ -62,7 +74,7 @@ pub(crate) struct Cli {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use argh::FromArgs;
     use strata_identifiers::Buf32;
@@ -89,6 +101,9 @@ mod tests {
         assert_eq!(cli.start_height, 100);
         assert_eq!(cli.end_height, 200);
         assert_eq!(cli.expected_root, None);
+        assert_eq!(cli.custom_chain, "dev");
+        assert_eq!(cli.snapshot_path, None);
+        assert_eq!(cli.export_snapshot_path, None);
         assert_eq!(cli.output_format, None);
     }
 
@@ -103,12 +118,27 @@ mod tests {
             "200",
             "--expected-root",
             "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "--custom-chain",
+            "testnet",
+            "--snapshot",
+            "/tmp/pre-state.json",
+            "--export-snapshot",
+            "/tmp/post-state.json",
             "--output-format",
             "json",
         ])
         .expect("optional args must parse");
 
         assert_eq!(cli.expected_root, Some(Buf32::from([0x01u8; 32])));
+        assert_eq!(cli.custom_chain, "testnet");
+        assert_eq!(
+            cli.snapshot_path,
+            Some(PathBuf::from("/tmp/pre-state.json"))
+        );
+        assert_eq!(
+            cli.export_snapshot_path,
+            Some(PathBuf::from("/tmp/post-state.json"))
+        );
         assert_eq!(cli.output_format, Some(OutputFormat::Json));
     }
 

--- a/bin/alpen-ee-da-tool/src/cli.rs
+++ b/bin/alpen-ee-da-tool/src/cli.rs
@@ -1,0 +1,138 @@
+use std::{
+    fmt::{self, Display},
+    path::PathBuf,
+    str::FromStr,
+};
+
+use argh::FromArgs;
+use strata_identifiers::{Buf32, L1Height};
+
+/// Report output format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OutputFormat {
+    Porcelain,
+    Json,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct OutputFormatParseError;
+
+impl Display for OutputFormatParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("must be 'porcelain' or 'json'")
+    }
+}
+
+impl FromStr for OutputFormat {
+    type Err = OutputFormatParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "porcelain" => Ok(Self::Porcelain),
+            "json" => Ok(Self::Json),
+            _ => Err(OutputFormatParseError),
+        }
+    }
+}
+
+/// Parses command-line flags for EE DA verification.
+#[derive(Debug, FromArgs, PartialEq, Eq)]
+#[argh(description = "verify EE DA state roots from Bitcoin data")]
+pub(crate) struct Cli {
+    /// verifier config path (TOML).
+    #[argh(option)]
+    pub(crate) config: PathBuf,
+
+    /// inclusive Bitcoin start height.
+    #[argh(option)]
+    pub(crate) start_height: L1Height,
+
+    /// inclusive Bitcoin end height.
+    #[argh(option)]
+    pub(crate) end_height: L1Height,
+
+    /// optional expected EE state root for comparison.
+    #[argh(option)]
+    pub(crate) expected_root: Option<Buf32>,
+
+    /// report output format (`porcelain` or `json`).
+    #[argh(option)]
+    pub(crate) output_format: Option<OutputFormat>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use argh::FromArgs;
+    use strata_identifiers::Buf32;
+
+    use super::{Cli, OutputFormat};
+
+    fn parse_cli(args: &[&str]) -> Result<Cli, argh::EarlyExit> {
+        Cli::from_args(&["alpen-ee-da-tool"], args)
+    }
+
+    #[test]
+    fn cli_parses_required_args() {
+        let cli = parse_cli(&[
+            "--config",
+            "/tmp/alpen-ee-da-tool.toml",
+            "--start-height",
+            "100",
+            "--end-height",
+            "200",
+        ])
+        .expect("required args must parse");
+
+        assert_eq!(cli.config, Path::new("/tmp/alpen-ee-da-tool.toml"));
+        assert_eq!(cli.start_height, 100);
+        assert_eq!(cli.end_height, 200);
+        assert_eq!(cli.expected_root, None);
+        assert_eq!(cli.output_format, None);
+    }
+
+    #[test]
+    fn cli_parses_optional_args() {
+        let cli = parse_cli(&[
+            "--config",
+            "/tmp/alpen-ee-da-tool.toml",
+            "--start-height",
+            "100",
+            "--end-height",
+            "200",
+            "--expected-root",
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "--output-format",
+            "json",
+        ])
+        .expect("optional args must parse");
+
+        assert_eq!(cli.expected_root, Some(Buf32::from([0x01u8; 32])));
+        assert_eq!(cli.output_format, Some(OutputFormat::Json));
+    }
+
+    #[test]
+    fn cli_rejects_unknown_output_format() {
+        let err = parse_cli(&[
+            "--config",
+            "/tmp/alpen-ee-da-tool.toml",
+            "--start-height",
+            "100",
+            "--end-height",
+            "200",
+            "--output-format",
+            "default",
+        ])
+        .expect_err("unknown format must fail");
+
+        assert!(err.output.contains("must be 'porcelain' or 'json'"));
+    }
+
+    #[test]
+    fn cli_requires_config_path() {
+        let err = parse_cli(&["--start-height", "1", "--end-height", "2"])
+            .expect_err("missing --config must fail");
+        assert!(err.output.contains("--config"));
+    }
+}

--- a/bin/alpen-ee-da-tool/src/config.rs
+++ b/bin/alpen-ee-da-tool/src/config.rs
@@ -34,6 +34,8 @@ pub(crate) struct VerifierConfig {
     pub(crate) sequencer_pubkey: XOnlyPublicKey,
 
     pub(crate) ee_params: PathBuf,
+
+    pub(crate) ol_rpc_url: Option<String>,
 }
 
 /// Invalid verifier config TOML or invalid typed field value.
@@ -102,6 +104,24 @@ ee_params = "/tmp/ee-params.json"
             XOnlyPublicKey::from_str(TEST_SEQUENCER_PUBKEY).expect("valid test key")
         );
         assert_eq!(config.ee_params, Path::new("/tmp/ee-params.json"));
+        assert_eq!(config.ol_rpc_url, None);
+    }
+
+    #[test]
+    fn parse_toml_succeeds_for_expected_root_source_config() {
+        let config = VerifierConfig::parse_toml(
+            r#"
+bitcoind_url = "http://127.0.0.1:18443"
+bitcoind_rpc_user = "rpc_user"
+bitcoind_rpc_password = "rpc_password"
+sequencer_pubkey = "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+ee_params = "/tmp/ee-params.json"
+ol_rpc_url = "http://127.0.0.1:8432"
+"#,
+        )
+        .expect("config must parse");
+
+        assert_eq!(config.ol_rpc_url, Some("http://127.0.0.1:8432".to_string()));
     }
 
     #[test]

--- a/bin/alpen-ee-da-tool/src/config.rs
+++ b/bin/alpen-ee-da-tool/src/config.rs
@@ -1,0 +1,142 @@
+//! Verifier configuration.
+
+use std::{
+    error::Error,
+    fmt, fs, io,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use bitcoin::secp256k1::XOnlyPublicKey;
+use serde::{de::Error as DeError, Deserialize, Deserializer};
+use terrors::OneOf;
+use toml::de::Error as TomlError;
+
+/// Deserializes a 32-byte x-only public key from hex.
+fn deserialize_xonly_public_key<'de, D>(deserializer: D) -> Result<XOnlyPublicKey, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    XOnlyPublicKey::from_str(&value).map_err(DeError::custom)
+}
+
+/// Effective verifier configuration loaded from the config file.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct VerifierConfig {
+    pub(crate) bitcoind_url: String,
+
+    pub(crate) bitcoind_rpc_user: String,
+
+    pub(crate) bitcoind_rpc_password: String,
+
+    #[serde(deserialize_with = "deserialize_xonly_public_key")]
+    pub(crate) sequencer_pubkey: XOnlyPublicKey,
+
+    pub(crate) ee_params: PathBuf,
+}
+
+/// Invalid verifier config TOML or invalid typed field value.
+pub(crate) struct ConfigError(TomlError);
+
+impl fmt::Debug for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for ConfigError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl VerifierConfig {
+    /// Loads and parses verifier configuration from a TOML file.
+    pub(crate) fn load(path: &Path) -> Result<Self, OneOf<(io::Error, ConfigError)>> {
+        let contents = fs::read_to_string(path).map_err(OneOf::new)?;
+        Self::parse_toml(&contents).map_err(OneOf::new)
+    }
+
+    /// Parses verifier configuration from TOML contents.
+    fn parse_toml(contents: &str) -> Result<Self, ConfigError> {
+        toml::from_str::<Self>(contents).map_err(ConfigError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, str::FromStr};
+
+    use bitcoin::secp256k1::XOnlyPublicKey;
+
+    use super::VerifierConfig;
+
+    const TEST_SEQUENCER_PUBKEY: &str =
+        "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f";
+
+    fn valid_config_toml() -> &'static str {
+        r#"
+bitcoind_url = "http://127.0.0.1:18443"
+bitcoind_rpc_user = "rpc_user"
+bitcoind_rpc_password = "rpc_password"
+sequencer_pubkey = "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+ee_params = "/tmp/ee-params.json"
+"#
+    }
+
+    #[test]
+    fn parse_toml_succeeds_for_valid_config() {
+        let config = VerifierConfig::parse_toml(valid_config_toml()).expect("config must parse");
+        assert_eq!(config.bitcoind_url, "http://127.0.0.1:18443");
+        assert_eq!(config.bitcoind_rpc_user, "rpc_user");
+        assert_eq!(config.bitcoind_rpc_password, "rpc_password");
+        assert_eq!(
+            config.sequencer_pubkey,
+            XOnlyPublicKey::from_str(TEST_SEQUENCER_PUBKEY).expect("valid test key")
+        );
+        assert_eq!(config.ee_params, Path::new("/tmp/ee-params.json"));
+    }
+
+    #[test]
+    fn parse_toml_fails_when_required_field_missing() {
+        let err = VerifierConfig::parse_toml(
+            r#"
+bitcoind_url = "http://127.0.0.1:18443"
+bitcoind_rpc_user = "rpc_user"
+bitcoind_rpc_password = "rpc_password"
+sequencer_pubkey = "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+"#,
+        )
+        .expect_err("missing field must fail");
+        let details = format!("{err:?}");
+        assert!(details.contains("missing field"));
+        assert!(details.contains("ee_params"));
+    }
+
+    #[test]
+    fn load_fails_for_nonexistent_file() {
+        VerifierConfig::load(Path::new("/nonexistent/config.toml"))
+            .expect_err("missing file must fail");
+    }
+
+    #[test]
+    fn parse_toml_fails_when_sequencer_pubkey_invalid() {
+        VerifierConfig::parse_toml(
+            r#"
+bitcoind_url = "http://127.0.0.1:18443"
+bitcoind_rpc_user = "rpc_user"
+bitcoind_rpc_password = "rpc_password"
+sequencer_pubkey = "not-a-pubkey"
+ee_params = "/tmp/ee-params.json"
+"#,
+        )
+        .expect_err("invalid sequencer pubkey must fail");
+    }
+}

--- a/bin/alpen-ee-da-tool/src/l1.rs
+++ b/bin/alpen-ee-da-tool/src/l1.rs
@@ -1,0 +1,76 @@
+//! L1 client setup, block scanning, and CLI error mapping.
+
+use alpen_ee_da_l1_extraction::{
+    fetch_range, FetchError, FetchReader, L1RangeScanner, ParsedEnvelope,
+};
+use alpen_ee_da_types::EE_DA_MAGIC_BYTES;
+use bitcoind_async_client::{traits::Reader, Auth, Client};
+use futures::StreamExt;
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
+use strata_identifiers::L1Height;
+use strata_l1_txfmt::MagicBytes;
+
+use crate::config::VerifierConfig;
+
+const DISABLE_CLIENT_RETRIES: u16 = 0;
+
+/// Builds a bitcoind client and verifies readiness before fetch starts.
+pub(crate) async fn create_ready_client(config: &VerifierConfig) -> Result<Client, DisplayedError> {
+    let client = Client::new(
+        config.bitcoind_url.clone(),
+        Auth::UserPass(
+            config.bitcoind_rpc_user.clone(),
+            config.bitcoind_rpc_password.clone(),
+        ),
+        Some(DISABLE_CLIENT_RETRIES),
+        None,
+        None,
+    )
+    .user_error("failed to initialize bitcoind client")?;
+
+    Reader::get_blockchain_info(&client)
+        .await
+        .internal_error("bitcoind not ready for fetch")?;
+
+    Ok(client)
+}
+
+/// Fetches blocks in the range and scans each for complete EE DA envelopes.
+pub(crate) async fn collect_envelopes(
+    reader: &impl FetchReader,
+    config: &VerifierConfig,
+    start_height: L1Height,
+    end_height: L1Height,
+) -> Result<Vec<ParsedEnvelope>, DisplayedError> {
+    let mut scanner =
+        L1RangeScanner::new(MagicBytes::new(EE_DA_MAGIC_BYTES), config.sequencer_pubkey);
+    let mut stream =
+        fetch_range(reader, start_height, end_height).user_error("invalid block range")?;
+
+    while let Some(item) = stream.next().await {
+        let block_data = item.map_err(map_fetch_error_to_displayed)?;
+        scanner
+            .ingest_block(block_data.block())
+            .internal_error("failed to scan L1 block for EE DA envelopes")?;
+    }
+
+    scanner
+        .finish()
+        .internal_error("failed to scan L1 range for EE DA envelopes")
+}
+
+fn map_fetch_error_to_displayed(error: FetchError) -> DisplayedError {
+    match error {
+        FetchError::HeightOutOfRange { .. } => {
+            DisplayedError::UserError("requested height out of range".to_string(), Box::new(error))
+        }
+        FetchError::RetriesExhausted { .. } => DisplayedError::InternalError(
+            "retries exhausted while fetching L1 blocks".to_string(),
+            Box::new(error),
+        ),
+        FetchError::Client { .. } => DisplayedError::InternalError(
+            "bitcoind client error while fetching L1 blocks".to_string(),
+            Box::new(error),
+        ),
+    }
+}

--- a/bin/alpen-ee-da-tool/src/l1.rs
+++ b/bin/alpen-ee-da-tool/src/l1.rs
@@ -6,6 +6,7 @@ use alpen_ee_da_l1_extraction::{
 use alpen_ee_da_types::EE_DA_MAGIC_BYTES;
 use bitcoind_async_client::{traits::Reader, Auth, Client};
 use futures::StreamExt;
+use serde::Serialize;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_identifiers::L1Height;
 use strata_l1_txfmt::MagicBytes;
@@ -35,28 +36,49 @@ pub(crate) async fn create_ready_client(config: &VerifierConfig) -> Result<Clien
     Ok(client)
 }
 
+/// Aggregate stats from the bounded L1 scan stage.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct L1ScanStats {
+    pub(crate) fetched_block_count: u64,
+}
+
+/// Output of the bounded L1 scan stage.
+pub(crate) struct L1ScanOutput {
+    pub(crate) stats: L1ScanStats,
+    pub(crate) envelopes: Vec<ParsedEnvelope>,
+}
+
 /// Fetches blocks in the range and scans each for complete EE DA envelopes.
 pub(crate) async fn collect_envelopes(
     reader: &impl FetchReader,
     config: &VerifierConfig,
     start_height: L1Height,
     end_height: L1Height,
-) -> Result<Vec<ParsedEnvelope>, DisplayedError> {
+) -> Result<L1ScanOutput, DisplayedError> {
     let mut scanner =
         L1RangeScanner::new(MagicBytes::new(EE_DA_MAGIC_BYTES), config.sequencer_pubkey);
+    let mut fetched_block_count = 0u64;
     let mut stream =
         fetch_range(reader, start_height, end_height).user_error("invalid block range")?;
 
     while let Some(item) = stream.next().await {
         let block_data = item.map_err(map_fetch_error_to_displayed)?;
+        fetched_block_count += 1;
         scanner
             .ingest_block(block_data.block())
             .internal_error("failed to scan L1 block for EE DA envelopes")?;
     }
 
-    scanner
+    let envelopes = scanner
         .finish()
-        .internal_error("failed to scan L1 range for EE DA envelopes")
+        .internal_error("failed to scan L1 range for EE DA envelopes")?;
+
+    Ok(L1ScanOutput {
+        stats: L1ScanStats {
+            fetched_block_count,
+        },
+        envelopes,
+    })
 }
 
 fn map_fetch_error_to_displayed(error: FetchError) -> DisplayedError {

--- a/bin/alpen-ee-da-tool/src/main.rs
+++ b/bin/alpen-ee-da-tool/src/main.rs
@@ -1,0 +1,33 @@
+//! Command-line entry point for EE DA reconstruction and verification.
+
+mod cli;
+mod config;
+mod output;
+
+use std::process::ExitCode;
+
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
+
+use crate::{
+    cli::{Cli, OutputFormat},
+    config::VerifierConfig,
+    output::{output, Report},
+};
+
+fn main() -> ExitCode {
+    let cli: Cli = argh::from_env();
+    let format = cli.output_format.unwrap_or(OutputFormat::Porcelain);
+    match run(&cli).and_then(|report| output(&report, format)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: &Cli) -> Result<Report, DisplayedError> {
+    let _config = VerifierConfig::load(&cli.config)
+        .user_error(format!("failed to load {}", cli.config.display()))?;
+    Ok(Report {})
+}

--- a/bin/alpen-ee-da-tool/src/main.rs
+++ b/bin/alpen-ee-da-tool/src/main.rs
@@ -3,18 +3,34 @@
 mod cli;
 mod config;
 mod l1;
+mod ol;
 mod output;
+mod replay;
+mod snapshot;
 
-use std::process::ExitCode;
+use std::{fs, process::ExitCode};
 
+use alpen_chainspec::{chain_value_parser, ee_genesis_block_info};
+use alpen_ee_config::AlpenEeParams;
 use alpen_ee_da_l1_extraction::reassemble_da_blobs;
+use alpen_ee_da_state_replay::{
+    replay_blobs_from_genesis, replay_blobs_from_snapshot, ReplayError, ReplaySummary,
+};
+use alpen_ee_genesis::build_genesis_ee_account_state;
+use alpen_reth_statediff::StateReconstructor;
+use ssz::{Decode, DecodeError};
+use strata_acct_types::AccountId;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
+use strata_ee_acct_types::EeAccountState;
 
 use crate::{
     cli::{Cli, OutputFormat},
     config::VerifierConfig,
     l1::{collect_envelopes, create_ready_client},
-    output::{output, Report},
+    ol::{apply_published_update_and_get_inner_root, compute_account_inner_root},
+    output::{output, InnerRootComparison, Report, ReportInput},
+    replay::ReplayStart,
+    snapshot::{build_export_snapshot, load_snapshot, write_snapshot},
 };
 
 #[tokio::main]
@@ -33,8 +49,305 @@ async fn main() -> ExitCode {
 async fn run(cli: &Cli) -> Result<Report, DisplayedError> {
     let config = VerifierConfig::load(&cli.config)
         .user_error(format!("failed to load {}", cli.config.display()))?;
+    let ee_params = load_ee_params(&config)?;
+    validate_ee_params_genesis(&ee_params, &cli.custom_chain)?;
     let client = create_ready_client(&config).await?;
-    let envelopes = collect_envelopes(&client, &config, cli.start_height, cli.end_height).await?;
-    reassemble_da_blobs(envelopes).internal_error("failed to reassemble DA blobs")?;
-    Ok(Report {})
+    let scan_output = collect_envelopes(&client, &config, cli.start_height, cli.end_height).await?;
+    let envelope_count = scan_output.envelopes.len() as u64;
+    let blobs = reassemble_da_blobs(scan_output.envelopes)
+        .internal_error("failed to reassemble DA blobs")?;
+    let input_snapshot = cli
+        .snapshot_path
+        .as_deref()
+        .map(load_snapshot)
+        .transpose()?;
+    let replay_start = if input_snapshot.is_some() {
+        ReplayStart::Snapshot
+    } else {
+        ReplayStart::Genesis
+    };
+    let replay_summary = match &input_snapshot {
+        Some(snapshot) => replay_blobs_from_snapshot(snapshot, &blobs),
+        None => {
+            let reconstructor = create_genesis_reconstructor(&cli.custom_chain)?;
+            replay_blobs_from_genesis(reconstructor, &blobs)
+        }
+    }
+    .map_err(map_replay_error_to_displayed)?;
+    let expected_state_root = cli.expected_root;
+    let mut account_state = load_initial_account_state(&ee_params, input_snapshot.as_ref())?;
+    let inner_root_comparison = resolve_inner_root_comparison(
+        &config,
+        ee_params.account_id(),
+        account_state.as_mut(),
+        &blobs,
+        &replay_summary,
+    )
+    .await?;
+
+    if let Some(path) = cli.export_snapshot_path.as_deref() {
+        let exported_snapshot = build_export_snapshot(
+            input_snapshot.as_ref(),
+            &blobs,
+            &replay_summary,
+            account_state.as_ref(),
+        )?;
+        write_snapshot(path, &exported_snapshot)?;
+    }
+
+    Ok(Report::new(ReportInput {
+        scan_stats: scan_output.stats,
+        envelope_count,
+        blobs_reassembled: blobs.len() as u64,
+        replay_summary,
+        replay_start,
+        expected_state_root,
+        inner_root_comparison,
+    }))
+}
+
+async fn resolve_inner_root_comparison(
+    config: &VerifierConfig,
+    account_id: AccountId,
+    account_state: Option<&mut EeAccountState>,
+    blobs: &[alpen_ee_da_types::DaBlob],
+    replay_summary: &ReplaySummary,
+) -> Result<Option<InnerRootComparison>, DisplayedError> {
+    let Some(ol_rpc_url) = config.ol_rpc_url.as_deref() else {
+        return Ok(None);
+    };
+
+    let Some(applied) = replay_summary.applied() else {
+        return Ok(None);
+    };
+
+    let Some(account_state) = account_state else {
+        return Err(DisplayedError::UserError(
+            "published inner-root comparison requires a genesis replay".to_string(),
+            Box::new(PublishedComparisonError::SnapshotAccountStateUnavailable),
+        ));
+    };
+
+    let per_blob_state_roots = replay_summary.per_blob_state_roots();
+    if per_blob_state_roots.len() != blobs.len() {
+        return Err(DisplayedError::InternalError(
+            "replay summary state-root count does not match input blob count".to_string(),
+            Box::new(PublishedComparisonError::PerBlobStateRootCountMismatch {
+                state_root_count: per_blob_state_roots.len(),
+                blob_count: blobs.len(),
+            }),
+        ));
+    }
+
+    let mut final_inner_roots = None;
+    let mut first_inner_root_mismatch = None;
+    for (blob, reconstructed_state_root) in blobs.iter().zip(per_blob_state_roots.iter().copied()) {
+        let published_inner_root = apply_published_update_and_get_inner_root(
+            ol_rpc_url,
+            account_id,
+            account_state,
+            blob.update_seq_no,
+            reconstructed_state_root,
+        )
+        .await?;
+        let computed_inner_root = compute_account_inner_root(account_state);
+        final_inner_roots = Some((computed_inner_root, published_inner_root));
+        if computed_inner_root != published_inner_root && first_inner_root_mismatch.is_none() {
+            first_inner_root_mismatch = Some((
+                blob.update_seq_no,
+                computed_inner_root,
+                published_inner_root,
+            ));
+        }
+    }
+
+    let Some((final_reconstructed_inner_root, final_expected_inner_root)) = final_inner_roots
+    else {
+        return Ok(None);
+    };
+
+    if applied.count() != blobs.len() {
+        return Err(DisplayedError::InternalError(
+            "applied DA blob count does not match input blob count".to_string(),
+            Box::new(PublishedComparisonError::AppliedBlobCountMismatch {
+                applied_count: applied.count(),
+                blob_count: blobs.len(),
+            }),
+        ));
+    }
+
+    let (
+        reconstructed_inner_state_root,
+        expected_inner_state_root,
+        inner_state_root_matches_expected,
+        mismatch_update_seq_no,
+    ) = match first_inner_root_mismatch {
+        Some((update_seq_no, reconstructed_root, expected_root)) => (
+            reconstructed_root,
+            expected_root,
+            false,
+            Some(update_seq_no),
+        ),
+        None => (
+            final_reconstructed_inner_root,
+            final_expected_inner_root,
+            true,
+            None,
+        ),
+    };
+
+    Ok(Some(InnerRootComparison {
+        reconstructed_inner_state_root,
+        expected_inner_state_root,
+        inner_state_root_matches_expected,
+        mismatch_update_seq_no,
+    }))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum PublishedComparisonError {
+    #[error("snapshot replay does not carry EE account state")]
+    SnapshotAccountStateUnavailable,
+
+    #[error("invalid snapshot EE account state: {source}")]
+    InvalidSnapshotAccountState {
+        #[source]
+        source: DecodeError,
+    },
+
+    #[error("applied blob count {applied_count} does not match blob count {blob_count}")]
+    AppliedBlobCountMismatch {
+        applied_count: usize,
+        blob_count: usize,
+    },
+
+    #[error("per-blob state-root count {state_root_count} does not match blob count {blob_count}")]
+    PerBlobStateRootCountMismatch {
+        state_root_count: usize,
+        blob_count: usize,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+enum EeParamsGenesisMismatch {
+    #[error("EE params genesis blockhash {params_blockhash} does not match chain genesis blockhash {chain_blockhash}")]
+    Blockhash {
+        params_blockhash: String,
+        chain_blockhash: String,
+    },
+
+    #[error("EE params genesis state root {params_stateroot} does not match chain genesis state root {chain_stateroot}")]
+    StateRoot {
+        params_stateroot: String,
+        chain_stateroot: String,
+    },
+
+    #[error("EE params genesis block number {params_blocknum} does not match chain genesis block number {chain_blocknum}")]
+    BlockNumber {
+        params_blocknum: u64,
+        chain_blocknum: u64,
+    },
+}
+
+fn create_genesis_reconstructor(custom_chain: &str) -> Result<StateReconstructor, DisplayedError> {
+    StateReconstructor::from_chain_spec(custom_chain).user_error(format!(
+        "failed to initialize EE genesis from {custom_chain}"
+    ))
+}
+
+fn load_ee_params(config: &VerifierConfig) -> Result<AlpenEeParams, DisplayedError> {
+    let json = fs::read_to_string(&config.ee_params).user_error(format!(
+        "failed to read EE params {}",
+        config.ee_params.display()
+    ))?;
+    AlpenEeParams::from_json_str(&json).user_error(format!(
+        "failed to parse EE params {}",
+        config.ee_params.display()
+    ))
+}
+
+fn validate_ee_params_genesis(
+    ee_params: &AlpenEeParams,
+    custom_chain: &str,
+) -> Result<(), DisplayedError> {
+    let chain_spec = chain_value_parser(custom_chain)
+        .user_error(format!("failed to load EE chain spec {custom_chain}"))?;
+    let genesis_info = ee_genesis_block_info(&chain_spec);
+
+    if ee_params.genesis_blockhash() != genesis_info.blockhash() {
+        return Err(DisplayedError::UserError(
+            "EE params do not match selected chain spec".to_string(),
+            Box::new(EeParamsGenesisMismatch::Blockhash {
+                params_blockhash: ee_params.genesis_blockhash().to_string(),
+                chain_blockhash: genesis_info.blockhash().to_string(),
+            }),
+        ));
+    }
+
+    if ee_params.genesis_stateroot() != genesis_info.stateroot() {
+        return Err(DisplayedError::UserError(
+            "EE params do not match selected chain spec".to_string(),
+            Box::new(EeParamsGenesisMismatch::StateRoot {
+                params_stateroot: ee_params.genesis_stateroot().to_string(),
+                chain_stateroot: genesis_info.stateroot().to_string(),
+            }),
+        ));
+    }
+
+    if ee_params.genesis_blocknum() != genesis_info.blocknum() {
+        return Err(DisplayedError::UserError(
+            "EE params do not match selected chain spec".to_string(),
+            Box::new(EeParamsGenesisMismatch::BlockNumber {
+                params_blocknum: ee_params.genesis_blocknum(),
+                chain_blocknum: genesis_info.blocknum(),
+            }),
+        ));
+    }
+
+    Ok(())
+}
+
+fn load_initial_account_state(
+    ee_params: &AlpenEeParams,
+    input_snapshot: Option<&alpen_ee_da_state_replay::ReplayPreStateSnapshot>,
+) -> Result<Option<EeAccountState>, DisplayedError> {
+    let Some(snapshot) = input_snapshot else {
+        return Ok(Some(build_genesis_ee_account_state(ee_params)));
+    };
+
+    snapshot
+        .ee_account_state_ssz()
+        .map(EeAccountState::from_ssz_bytes)
+        .transpose()
+        .map_err(|source| {
+            DisplayedError::UserError(
+                "invalid replay snapshot EE account state".to_string(),
+                Box::new(PublishedComparisonError::InvalidSnapshotAccountState { source }),
+            )
+        })
+}
+
+fn map_replay_error_to_displayed(error: ReplayError) -> DisplayedError {
+    match error {
+        ReplayError::NonGenesisStart { .. } => DisplayedError::UserError(
+            "requested DA range does not start at genesis".to_string(),
+            Box::new(error),
+        ),
+        ReplayError::SnapshotRootMismatch { .. }
+        | ReplayError::SnapshotUpdateSeqNoMismatch { .. }
+        | ReplayError::SnapshotBlockAnchorMismatch { .. }
+        | ReplayError::InvalidSnapshotState { .. } => {
+            DisplayedError::UserError("invalid replay snapshot".to_string(), Box::new(error))
+        }
+        ReplayError::UpdateSeqNoGap { .. }
+        | ReplayError::DuplicateUpdateSeqNo { .. }
+        | ReplayError::NonIncreasingBlockNumber { .. } => DisplayedError::UserError(
+            "DA blob sequence is inconsistent".to_string(),
+            Box::new(error),
+        ),
+        ReplayError::ApplyDiff { .. } => DisplayedError::InternalError(
+            "state reconstruction failed while replaying DA blobs".to_string(),
+            Box::new(error),
+        ),
+    }
 }

--- a/bin/alpen-ee-da-tool/src/main.rs
+++ b/bin/alpen-ee-da-tool/src/main.rs
@@ -2,22 +2,26 @@
 
 mod cli;
 mod config;
+mod l1;
 mod output;
 
 use std::process::ExitCode;
 
+use alpen_ee_da_l1_extraction::reassemble_da_blobs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 
 use crate::{
     cli::{Cli, OutputFormat},
     config::VerifierConfig,
+    l1::{collect_envelopes, create_ready_client},
     output::{output, Report},
 };
 
-fn main() -> ExitCode {
+#[tokio::main]
+async fn main() -> ExitCode {
     let cli: Cli = argh::from_env();
     let format = cli.output_format.unwrap_or(OutputFormat::Porcelain);
-    match run(&cli).and_then(|report| output(&report, format)) {
+    match run(&cli).await.and_then(|report| output(&report, format)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("{error}");
@@ -26,8 +30,11 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(cli: &Cli) -> Result<Report, DisplayedError> {
-    let _config = VerifierConfig::load(&cli.config)
+async fn run(cli: &Cli) -> Result<Report, DisplayedError> {
+    let config = VerifierConfig::load(&cli.config)
         .user_error(format!("failed to load {}", cli.config.display()))?;
+    let client = create_ready_client(&config).await?;
+    let envelopes = collect_envelopes(&client, &config, cli.start_height, cli.end_height).await?;
+    reassemble_da_blobs(envelopes).internal_error("failed to reassemble DA blobs")?;
     Ok(Report {})
 }

--- a/bin/alpen-ee-da-tool/src/ol.rs
+++ b/bin/alpen-ee-da-tool/src/ol.rs
@@ -1,0 +1,199 @@
+//! OL-backed published-root lookup.
+
+use jsonrpsee::{core::client::Error as RpcClientError, http_client::HttpClientBuilder};
+use strata_acct_types::{AccountId, MessageEntry};
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
+use strata_codec::{decode_buf_exact, CodecError};
+use strata_ee_acct_runtime::apply_input_messages;
+use strata_ee_acct_types::{EeAccountState, EnvError, UpdateExtraData};
+use strata_identifiers::Buf32;
+use strata_ol_rpc_api::OLClientRpcClient;
+use strata_ol_rpc_types::{RpcIndexedEntry, RpcMessageEntry};
+use tree_hash::{Sha256Hasher, TreeHash};
+
+/// Errors raised while deriving the published root from OL.
+#[derive(Debug, thiserror::Error)]
+enum PublishedRootLookupError {
+    /// The returned manifest does not match the requested update sequence.
+    #[error(
+        "manifest seq_no mismatch: expected {expected_update_seq_no}, got {actual_update_seq_no}"
+    )]
+    SeqNoMismatch {
+        expected_update_seq_no: u64,
+        actual_update_seq_no: u64,
+    },
+
+    /// The manifest does not contain a stored Snark account inner root.
+    #[error("manifest for account {account_id} update_seq_no {update_seq_no} has no inner root")]
+    MissingInnerRoot {
+        account_id: AccountId,
+        update_seq_no: u64,
+    },
+
+    /// The manifest does not contain EE-specific update extra data.
+    #[error("manifest for account {account_id} update_seq_no {update_seq_no} has no extra_data")]
+    MissingExtraData {
+        account_id: AccountId,
+        update_seq_no: u64,
+    },
+
+    /// The manifest extra data is not an EE [`UpdateExtraData`] payload.
+    #[error("failed to decode manifest extra_data for update_seq_no {update_seq_no}: {source}")]
+    InvalidExtraData {
+        update_seq_no: u64,
+        #[source]
+        source: CodecError,
+    },
+
+    /// An inbox message returned by OL cannot be converted to an account message.
+    #[error("failed to decode inbox message {message_index} for update_seq_no {update_seq_no}: {source}")]
+    InvalidInboxMessage {
+        update_seq_no: u64,
+        message_index: u64,
+        #[source]
+        source: strata_acct_types::MsgPayloadError,
+    },
+
+    /// Applying update inputs to the local EE account state failed.
+    #[error("failed to apply inbox messages for update_seq_no {update_seq_no}: {source}")]
+    ApplyInboxMessages {
+        update_seq_no: u64,
+        #[source]
+        source: EnvError,
+    },
+}
+
+/// Applies the published update metadata to `account_state` and returns the OL-published inner
+/// root.
+pub(crate) async fn apply_published_update_and_get_inner_root(
+    ol_rpc_url: &str,
+    account_id: AccountId,
+    account_state: &mut EeAccountState,
+    update_seq_no: u64,
+    reconstructed_state_root: Buf32,
+) -> Result<Buf32, DisplayedError> {
+    let client = HttpClientBuilder::default()
+        .build(ol_rpc_url)
+        .user_error("failed to initialize OL RPC client")?;
+    let manifest = client
+        .get_snark_acct_update_manifest(account_id, update_seq_no)
+        .await
+        .map_err(map_manifest_rpc_error)?;
+
+    if manifest.seq_no() != update_seq_no {
+        return Err(DisplayedError::InternalError(
+            "Published update manifest response has unexpected sequence number".to_string(),
+            Box::new(PublishedRootLookupError::SeqNoMismatch {
+                expected_update_seq_no: update_seq_no,
+                actual_update_seq_no: manifest.seq_no(),
+            }),
+        ));
+    }
+
+    let published_inner_root = manifest.new_inner_state_root().ok_or_else(|| {
+        DisplayedError::UserError(
+            "Published update manifest lacks inner state root".to_string(),
+            Box::new(PublishedRootLookupError::MissingInnerRoot {
+                account_id,
+                update_seq_no,
+            }),
+        )
+    })?;
+    let extra_data = manifest.extra_data().ok_or_else(|| {
+        DisplayedError::UserError(
+            "Published update manifest lacks EE update extra_data".to_string(),
+            Box::new(PublishedRootLookupError::MissingExtraData {
+                account_id,
+                update_seq_no,
+            }),
+        )
+    })?;
+    let extra_data = decode_buf_exact::<UpdateExtraData>(&extra_data.0).map_err(|source| {
+        DisplayedError::UserError(
+            "Published update manifest extra_data is not an EE update payload".to_string(),
+            Box::new(PublishedRootLookupError::InvalidExtraData {
+                update_seq_no,
+                source,
+            }),
+        )
+    })?;
+
+    let inbox_messages = client
+        .get_snark_acct_inbox_msg_range(
+            account_id,
+            manifest.prev_next_msg_idx(),
+            manifest.new_next_msg_idx(),
+        )
+        .await
+        .map_err(map_inbox_rpc_error)?;
+    let messages = rpc_messages_to_entries(update_seq_no, inbox_messages)?;
+
+    apply_input_messages(account_state, &messages).map_err(|source| {
+        DisplayedError::InternalError(
+            "failed to apply published inbox messages".to_string(),
+            Box::new(PublishedRootLookupError::ApplyInboxMessages {
+                update_seq_no,
+                source,
+            }),
+        )
+    })?;
+    account_state.set_last_exec_blkid(Buf32(*extra_data.new_tip_blkid().as_ref()));
+    account_state.set_last_exec_state_root(reconstructed_state_root);
+    account_state.remove_pending_inputs(*extra_data.processed_inputs() as usize);
+    account_state.remove_pending_fincls(*extra_data.processed_fincls() as usize);
+
+    Ok(Buf32(published_inner_root.0))
+}
+
+/// Computes the SSZ inner root for the reconstructed EE account state.
+pub(crate) fn compute_account_inner_root(account_state: &EeAccountState) -> Buf32 {
+    <EeAccountState as TreeHash>::tree_hash_root::<Sha256Hasher>(account_state).into()
+}
+
+fn rpc_messages_to_entries(
+    update_seq_no: u64,
+    messages: Vec<RpcIndexedEntry<RpcMessageEntry>>,
+) -> Result<Vec<MessageEntry>, DisplayedError> {
+    messages
+        .into_iter()
+        .map(|message| {
+            let message_index = message.index();
+            message.value().clone().try_into().map_err(|source| {
+                DisplayedError::UserError(
+                    "Published update inbox message is invalid".to_string(),
+                    Box::new(PublishedRootLookupError::InvalidInboxMessage {
+                        update_seq_no,
+                        message_index,
+                        source,
+                    }),
+                )
+            })
+        })
+        .collect()
+}
+
+fn map_manifest_rpc_error(error: RpcClientError) -> DisplayedError {
+    match error {
+        RpcClientError::Call(_) => DisplayedError::UserError(
+            "failed to fetch published update manifest for applied update".to_string(),
+            Box::new(error),
+        ),
+        _ => DisplayedError::InternalError(
+            "OL RPC request failed while fetching update manifest".to_string(),
+            Box::new(error),
+        ),
+    }
+}
+
+fn map_inbox_rpc_error(error: RpcClientError) -> DisplayedError {
+    match error {
+        RpcClientError::Call(_) => DisplayedError::UserError(
+            "failed to fetch published inbox messages for applied update".to_string(),
+            Box::new(error),
+        ),
+        _ => DisplayedError::InternalError(
+            "OL RPC request failed while fetching inbox messages".to_string(),
+            Box::new(error),
+        ),
+    }
+}

--- a/bin/alpen-ee-da-tool/src/output/helpers.rs
+++ b/bin/alpen-ee-da-tool/src/output/helpers.rs
@@ -1,0 +1,37 @@
+//! Writes a report in porcelain or JSON.
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
+
+use super::Formattable;
+use crate::cli::OutputFormat;
+
+/// Renders `data` to stdout in the requested format.
+pub(crate) fn output<T: Serialize + Formattable>(
+    data: &T,
+    format: OutputFormat,
+) -> Result<(), DisplayedError> {
+    output_to(data, format, &mut io::stdout())
+}
+
+/// Renders `data` to the given writer in the requested format.
+pub(crate) fn output_to<T: Serialize + Formattable, W: Write>(
+    data: &T,
+    format: OutputFormat,
+    writer: &mut W,
+) -> Result<(), DisplayedError> {
+    match format {
+        OutputFormat::Porcelain => {
+            writeln!(writer, "{}", data.format_porcelain())
+                .internal_error("failed to write porcelain output")?;
+        }
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(data)
+                .internal_error("failed to serialize JSON output")?;
+            writeln!(writer, "{json}").internal_error("failed to write JSON output")?;
+        }
+    }
+    Ok(())
+}

--- a/bin/alpen-ee-da-tool/src/output/helpers.rs
+++ b/bin/alpen-ee-da-tool/src/output/helpers.rs
@@ -1,12 +1,20 @@
 //! Writes a report in porcelain or JSON.
 
-use std::io::{self, Write};
+use std::{
+    fmt::Display,
+    io::{self, Write},
+};
 
 use serde::Serialize;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 
 use super::Formattable;
 use crate::cli::OutputFormat;
+
+/// Formats a single porcelain field as `key: value`.
+pub(crate) fn porcelain_field<T: Display>(key: &str, value: T) -> String {
+    format!("{key}: {value}")
+}
 
 /// Renders `data` to stdout in the requested format.
 pub(crate) fn output<T: Serialize + Formattable>(

--- a/bin/alpen-ee-da-tool/src/output/mod.rs
+++ b/bin/alpen-ee-da-tool/src/output/mod.rs
@@ -1,0 +1,10 @@
+mod helpers;
+mod report;
+
+pub(crate) use helpers::output;
+pub(crate) use report::Report;
+
+/// Types that can render themselves as porcelain output.
+pub(crate) trait Formattable {
+    fn format_porcelain(&self) -> String;
+}

--- a/bin/alpen-ee-da-tool/src/output/mod.rs
+++ b/bin/alpen-ee-da-tool/src/output/mod.rs
@@ -2,7 +2,7 @@ mod helpers;
 mod report;
 
 pub(crate) use helpers::output;
-pub(crate) use report::Report;
+pub(crate) use report::{InnerRootComparison, Report, ReportInput};
 
 /// Types that can render themselves as porcelain output.
 pub(crate) trait Formattable {

--- a/bin/alpen-ee-da-tool/src/output/report.rs
+++ b/bin/alpen-ee-da-tool/src/output/report.rs
@@ -1,0 +1,15 @@
+//! Output produced by the verifier.
+
+use serde::Serialize;
+
+use super::Formattable;
+
+/// Verifier run report. Stage commits extend this with stage-specific fields.
+#[derive(Debug, Serialize)]
+pub(crate) struct Report {}
+
+impl Formattable for Report {
+    fn format_porcelain(&self) -> String {
+        "no stages executed".to_string()
+    }
+}

--- a/bin/alpen-ee-da-tool/src/output/report.rs
+++ b/bin/alpen-ee-da-tool/src/output/report.rs
@@ -1,15 +1,190 @@
 //! Output produced by the verifier.
 
+use alpen_ee_da_state_replay::{AppliedExecBlockRange, ReplaySummary};
 use serde::Serialize;
+use strata_identifiers::Buf32;
 
-use super::Formattable;
+use super::{helpers::porcelain_field, Formattable};
+use crate::{l1::L1ScanStats, replay::ReplayStart};
+
+const BYTECODE_DEDUP_SOUNDNESS_NOTE: &str =
+    "bytecode preimage availability for omitted deduplicated bytecodes is not independently verified";
+const EE_HEADER_SOUNDNESS_NOTE: &str =
+    "EE header summaries are replayed from DA and are not cross-checked against an EE RPC endpoint";
 
 /// Verifier run report. Stage commits extend this with stage-specific fields.
 #[derive(Debug, Serialize)]
-pub(crate) struct Report {}
+pub(crate) struct Report {
+    pub(crate) replay_start: ReplayStart,
+    pub(crate) fetched_block_count: u64,
+    pub(crate) envelope_count: u64,
+    pub(crate) blobs_reassembled: u64,
+    pub(crate) reconstructed_state_root: Buf32,
+    pub(crate) applied_range: Option<AppliedExecBlockRange>,
+    pub(crate) expected_state_root: Option<Buf32>,
+    pub(crate) state_root_matches_expected: Option<bool>,
+    pub(crate) reconstructed_inner_state_root: Option<Buf32>,
+    pub(crate) expected_inner_state_root: Option<Buf32>,
+    pub(crate) inner_state_root_matches_expected: Option<bool>,
+    pub(crate) inner_state_root_mismatch_update_seq_no: Option<u64>,
+    pub(crate) soundness_notes: Vec<&'static str>,
+}
+
+/// Published inner-root comparison result.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InnerRootComparison {
+    pub(crate) reconstructed_inner_state_root: Buf32,
+    pub(crate) expected_inner_state_root: Buf32,
+    pub(crate) inner_state_root_matches_expected: bool,
+    pub(crate) mismatch_update_seq_no: Option<u64>,
+}
+
+/// Inputs used to assemble a [`Report`].
+pub(crate) struct ReportInput {
+    pub(crate) scan_stats: L1ScanStats,
+    pub(crate) envelope_count: u64,
+    pub(crate) blobs_reassembled: u64,
+    pub(crate) replay_summary: ReplaySummary,
+    pub(crate) replay_start: ReplayStart,
+    pub(crate) expected_state_root: Option<Buf32>,
+    pub(crate) inner_root_comparison: Option<InnerRootComparison>,
+}
+
+impl Report {
+    /// Assembles a [`Report`] from the pipeline stage outputs.
+    pub(crate) fn new(input: ReportInput) -> Self {
+        let ReportInput {
+            scan_stats,
+            envelope_count,
+            blobs_reassembled,
+            replay_summary,
+            replay_start,
+            expected_state_root,
+            inner_root_comparison,
+        } = input;
+        let reconstructed_state_root = replay_summary.final_state_root();
+        let state_root_matches_expected =
+            expected_state_root.map(|expected| expected == reconstructed_state_root);
+        let reconstructed_inner_state_root =
+            inner_root_comparison.map(|comparison| comparison.reconstructed_inner_state_root);
+        let expected_inner_state_root =
+            inner_root_comparison.map(|comparison| comparison.expected_inner_state_root);
+        let inner_state_root_matches_expected =
+            inner_root_comparison.map(|comparison| comparison.inner_state_root_matches_expected);
+        let inner_state_root_mismatch_update_seq_no =
+            inner_root_comparison.and_then(|comparison| comparison.mismatch_update_seq_no);
+        let soundness_notes = if blobs_reassembled > 0 {
+            vec![BYTECODE_DEDUP_SOUNDNESS_NOTE, EE_HEADER_SOUNDNESS_NOTE]
+        } else {
+            Vec::new()
+        };
+        Self {
+            replay_start,
+            fetched_block_count: scan_stats.fetched_block_count,
+            envelope_count,
+            blobs_reassembled,
+            reconstructed_state_root,
+            applied_range: replay_summary.applied().cloned(),
+            expected_state_root,
+            state_root_matches_expected,
+            reconstructed_inner_state_root,
+            expected_inner_state_root,
+            inner_state_root_matches_expected,
+            inner_state_root_mismatch_update_seq_no,
+            soundness_notes,
+        }
+    }
+}
 
 impl Formattable for Report {
     fn format_porcelain(&self) -> String {
-        "no stages executed".to_string()
+        let mut output = vec![
+            porcelain_field("replay_start", self.replay_start),
+            porcelain_field("fetched_block_count", self.fetched_block_count),
+            porcelain_field("envelope_count", self.envelope_count),
+            porcelain_field("blobs_reassembled", self.blobs_reassembled),
+            porcelain_field("reconstructed_state_root", self.reconstructed_state_root),
+        ];
+
+        if let Some(range) = &self.applied_range {
+            output.push(porcelain_field(
+                "applied_range.first_block_num",
+                range.first_block_num(),
+            ));
+            output.push(porcelain_field(
+                "applied_range.first_update_seq_no",
+                range.first_update_seq_no(),
+            ));
+            output.push(porcelain_field(
+                "applied_range.last_block_num",
+                range.last_block_num(),
+            ));
+            output.push(porcelain_field(
+                "applied_range.last_update_seq_no",
+                range.last_update_seq_no(),
+            ));
+            output.push(porcelain_field("applied_range.count", range.count()));
+        }
+
+        if let Some(expected) = self.expected_state_root {
+            output.push(porcelain_field("expected_state_root", expected));
+        }
+        if let Some(matches) = self.state_root_matches_expected {
+            output.push(porcelain_field("state_root_matches_expected", matches));
+        }
+        if let Some(root) = self.reconstructed_inner_state_root {
+            output.push(porcelain_field("reconstructed_inner_state_root", root));
+        }
+        if let Some(root) = self.expected_inner_state_root {
+            output.push(porcelain_field("expected_inner_state_root", root));
+        }
+        if let Some(matches) = self.inner_state_root_matches_expected {
+            output.push(porcelain_field(
+                "inner_state_root_matches_expected",
+                matches,
+            ));
+        }
+        if let Some(update_seq_no) = self.inner_state_root_mismatch_update_seq_no {
+            output.push(porcelain_field(
+                "inner_state_root_mismatch_update_seq_no",
+                update_seq_no,
+            ));
+        }
+        for (index, note) in self.soundness_notes.iter().enumerate() {
+            output.push(porcelain_field(&format!("soundness_notes.{index}"), note));
+        }
+
+        output.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_ee_da_state_replay::replay_blobs_from_genesis;
+    use alpen_reth_statediff::StateReconstructor;
+
+    use super::*;
+    use crate::replay::ReplayStart;
+
+    #[test]
+    fn report_compares_reconstructed_root_against_expected_root() {
+        let replay_summary = replay_blobs_from_genesis(StateReconstructor::new(), &[])
+            .expect("empty genesis replay must succeed");
+        let reconstructed_state_root = replay_summary.final_state_root();
+        let report = Report::new(ReportInput {
+            scan_stats: L1ScanStats {
+                fetched_block_count: 1,
+            },
+            envelope_count: 0,
+            blobs_reassembled: 0,
+            replay_summary,
+            replay_start: ReplayStart::Genesis,
+            expected_state_root: Some(Buf32::from([0x11; 32])),
+            inner_root_comparison: None,
+        });
+
+        assert_eq!(report.reconstructed_state_root, reconstructed_state_root);
+        assert_eq!(report.expected_state_root, Some(Buf32::from([0x11; 32])));
+        assert_eq!(report.state_root_matches_expected, Some(false));
     }
 }

--- a/bin/alpen-ee-da-tool/src/replay.rs
+++ b/bin/alpen-ee-da-tool/src/replay.rs
@@ -1,0 +1,22 @@
+//! Replay pipeline types.
+
+use std::fmt::{self, Display};
+
+use serde::Serialize;
+
+/// Starting state used for replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplayStart {
+    Genesis,
+    Snapshot,
+}
+
+impl Display for ReplayStart {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Genesis => f.write_str("genesis"),
+            Self::Snapshot => f.write_str("snapshot"),
+        }
+    }
+}

--- a/bin/alpen-ee-da-tool/src/snapshot.rs
+++ b/bin/alpen-ee-da-tool/src/snapshot.rs
@@ -1,0 +1,171 @@
+//! Replay snapshot loading, writing, and export assembly.
+
+use std::{fs, path::Path};
+
+use alpen_ee_da_state_replay::{
+    ReplayPreStateSnapshot, ReplaySummary, REPLAY_PRE_STATE_SNAPSHOT_VERSION,
+};
+use alpen_ee_da_types::DaBlob;
+use ssz::Encode;
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
+use strata_ee_acct_types::EeAccountState;
+
+/// Loads a replay pre-state snapshot JSON file.
+pub(crate) fn load_snapshot(path: &Path) -> Result<ReplayPreStateSnapshot, DisplayedError> {
+    let contents = fs::read_to_string(path)
+        .user_error(format!("failed to read snapshot {}", path.display()))?;
+    let snapshot: ReplayPreStateSnapshot = serde_json::from_str(&contents)
+        .user_error(format!("failed to parse snapshot {}", path.display()))?;
+    if snapshot.version() != REPLAY_PRE_STATE_SNAPSHOT_VERSION {
+        return Err(DisplayedError::UserError(
+            "unsupported replay snapshot version".to_string(),
+            Box::new(SnapshotLoadError::UnsupportedVersion {
+                version: snapshot.version(),
+                supported_version: REPLAY_PRE_STATE_SNAPSHOT_VERSION,
+            }),
+        ));
+    }
+    Ok(snapshot)
+}
+
+/// Writes a replay pre-state snapshot JSON file.
+pub(crate) fn write_snapshot(
+    path: &Path,
+    snapshot: &ReplayPreStateSnapshot,
+) -> Result<(), DisplayedError> {
+    let contents = serde_json::to_string_pretty(snapshot)
+        .internal_error("failed to serialize replay snapshot")?;
+    fs::write(path, contents).user_error(format!("failed to write snapshot {}", path.display()))
+}
+
+/// Builds the post-run snapshot for `--export-snapshot`.
+pub(crate) fn build_export_snapshot(
+    input_snapshot: Option<&ReplayPreStateSnapshot>,
+    blobs: &[DaBlob],
+    replay_summary: &ReplaySummary,
+    account_state: Option<&EeAccountState>,
+) -> Result<ReplayPreStateSnapshot, DisplayedError> {
+    if replay_summary.applied().is_none() && input_snapshot.is_none() {
+        return Err(DisplayedError::UserError(
+            "cannot export replay snapshot".to_string(),
+            Box::new(SnapshotExportError::NoReplayInput),
+        ));
+    }
+
+    let next_update_seq_no = match replay_summary.applied() {
+        Some(applied) => applied.last_update_seq_no().checked_add(1).ok_or_else(|| {
+            DisplayedError::InternalError(
+                "cannot export snapshot after update_seq_no overflow".to_string(),
+                Box::new(SnapshotExportError::UpdateSeqNoOverflow),
+            )
+        })?,
+        None => input_snapshot
+            .map(ReplayPreStateSnapshot::next_update_seq_no)
+            .unwrap_or(0),
+    };
+    let last_applied_block_num = replay_summary
+        .applied()
+        .map(|applied| applied.last_block_num())
+        .or_else(|| input_snapshot.and_then(ReplayPreStateSnapshot::last_applied_block_num));
+    let mut bytecodes = input_snapshot
+        .map(|snapshot| snapshot.bytecodes().clone())
+        .unwrap_or_default();
+    for blob in blobs {
+        bytecodes.extend(
+            blob.state_diff
+                .deployed_bytecodes
+                .iter()
+                .map(|(code_hash, bytecode)| (*code_hash, bytecode.clone())),
+        );
+    }
+
+    let mut snapshot = ReplayPreStateSnapshot::new(
+        replay_summary.final_state_root(),
+        next_update_seq_no,
+        last_applied_block_num,
+        replay_summary.final_reconstructor_prestate().clone(),
+        bytecodes,
+    );
+    if let Some(account_state) = account_state {
+        snapshot = snapshot.with_ee_account_state_ssz(account_state.as_ssz_bytes());
+    } else if replay_summary.applied().is_none() {
+        if let Some(ee_account_state_ssz) =
+            input_snapshot.and_then(ReplayPreStateSnapshot::ee_account_state_ssz)
+        {
+            snapshot = snapshot.with_ee_account_state_ssz(ee_account_state_ssz.to_vec());
+        }
+    }
+
+    Ok(snapshot)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotExportError {
+    NoReplayInput,
+    UpdateSeqNoOverflow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+enum SnapshotLoadError {
+    #[error(
+        "unsupported replay snapshot version {version}; supported version is {supported_version}"
+    )]
+    UnsupportedVersion {
+        version: u32,
+        supported_version: u32,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_ee_da_state_replay::replay_blobs_from_genesis;
+    use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+    use alpen_reth_statediff::StateReconstructor;
+    use strata_cli_common::errors::DisplayedError;
+
+    use super::build_export_snapshot;
+
+    #[test]
+    fn build_export_snapshot_advances_applied_anchor() {
+        let blobs = vec![test_blob(0, 100), test_blob(1, 101)];
+        let replay_summary = replay_blobs_from_genesis(StateReconstructor::new(), &blobs)
+            .expect("genesis replay must succeed");
+
+        let snapshot = build_export_snapshot(None, &blobs, &replay_summary, None)
+            .expect("snapshot export must succeed");
+
+        assert_eq!(
+            snapshot.expected_state_root(),
+            replay_summary.final_state_root()
+        );
+        assert_eq!(snapshot.next_update_seq_no(), 2);
+        assert_eq!(snapshot.last_applied_block_num(), Some(101));
+    }
+
+    #[test]
+    fn build_export_snapshot_rejects_empty_genesis_replay() {
+        let replay_summary = replay_blobs_from_genesis(StateReconstructor::new(), &[])
+            .expect("empty genesis replay must succeed");
+
+        let error = build_export_snapshot(None, &[], &replay_summary, None)
+            .expect_err("empty genesis replay must not export a snapshot");
+
+        assert!(matches!(error, DisplayedError::UserError(_, _)));
+        assert!(error.to_string().contains("cannot export replay snapshot"));
+    }
+
+    fn test_blob(update_seq_no: u64, block_num: u64) -> DaBlob {
+        let gas_used = block_num % 1_000;
+        DaBlob {
+            update_seq_no,
+            evm_header: EvmHeaderSummary {
+                block_num,
+                timestamp: block_num,
+                base_fee: block_num,
+                gas_used,
+                gas_limit: gas_used.saturating_add(1),
+            },
+            state_diff: Default::default(),
+        }
+    }
+}

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -29,7 +29,7 @@ use strata_ol_rpc_types::{
 use strata_ol_state_types::OLState;
 use strata_primitives::{HexBytes, HexBytes32};
 use strata_snark_acct_types::{ProofState, UpdateInputData, UpdateStateData};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::rpc::errors::{
     db_error, internal_error, invalid_params_error, map_mempool_error_to_rpc,
@@ -60,6 +60,17 @@ struct ChainBlock {
     slot: u64,
     blkid: OLBlockId,
     epoch: Epoch,
+}
+
+enum ToplevelOlStateLookup {
+    Found {
+        epoch_commitment: EpochCommitment,
+        ol_state: Arc<OLState>,
+    },
+    MissingEpochCommitment,
+    MissingTerminalState {
+        terminal_commitment: OLBlockCommitment,
+    },
 }
 
 /// OL RPC server implementation, generic over a provider.
@@ -548,13 +559,11 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
         )))
     }
 
-    /// Resolves an epoch to its terminal-block OL state. Errors if either the
-    /// canonical commitment or the terminal-block state is missing.
-    async fn get_toplevel_ol_state_for_epoch(
+    async fn lookup_toplevel_ol_state_for_epoch(
         &self,
         epoch: Epoch,
-    ) -> RpcResult<(EpochCommitment, Arc<OLState>)> {
-        let epoch_commitment = self
+    ) -> RpcResult<ToplevelOlStateLookup> {
+        let Some(epoch_commitment) = self
             .provider
             .get_canonical_epoch_commitment_at(epoch)
             .await
@@ -562,12 +571,12 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                 error!(?e, ?epoch, "Failed to get canonical epoch commitment");
                 db_error(e)
             })?
-            .ok_or_else(|| {
-                not_found_error(format!("No canonical commitment found for epoch {epoch}"))
-            })?;
+        else {
+            return Ok(ToplevelOlStateLookup::MissingEpochCommitment);
+        };
 
         let terminal_commitment = epoch_commitment.to_block_commitment();
-        let ol_state = self
+        let Some(ol_state) = self
             .provider
             .get_toplevel_ol_state(terminal_commitment)
             .await
@@ -575,22 +584,78 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                 error!(?e, %terminal_commitment, "Failed to get OL state");
                 db_error(e)
             })?
-            .ok_or_else(|| {
-                not_found_error(format!(
-                    "No OL state found for terminal block {terminal_commitment}"
-                ))
-            })?;
+        else {
+            return Ok(ToplevelOlStateLookup::MissingTerminalState {
+                terminal_commitment,
+            });
+        };
 
-        Ok((epoch_commitment, ol_state))
+        Ok(ToplevelOlStateLookup::Found {
+            epoch_commitment,
+            ol_state,
+        })
     }
 
-    /// Returns the account's current Snark update seqno at the tip epoch.
+    /// Resolves an epoch to its terminal-block OL state. Errors if either the
+    /// canonical commitment or the terminal-block state is missing.
+    async fn get_toplevel_ol_state_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> RpcResult<(EpochCommitment, Arc<OLState>)> {
+        match self.lookup_toplevel_ol_state_for_epoch(epoch).await? {
+            ToplevelOlStateLookup::Found {
+                epoch_commitment,
+                ol_state,
+            } => Ok((epoch_commitment, ol_state)),
+            ToplevelOlStateLookup::MissingEpochCommitment => Err(not_found_error(format!(
+                "No canonical commitment found for epoch {epoch}"
+            ))),
+            ToplevelOlStateLookup::MissingTerminalState {
+                terminal_commitment,
+            } => Err(not_found_error(format!(
+                "No OL state found for terminal block {terminal_commitment}"
+            ))),
+        }
+    }
+
+    async fn try_get_toplevel_ol_state_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> RpcResult<Option<(EpochCommitment, Arc<OLState>)>> {
+        match self.lookup_toplevel_ol_state_for_epoch(epoch).await? {
+            ToplevelOlStateLookup::Found {
+                epoch_commitment,
+                ol_state,
+            } => Ok(Some((epoch_commitment, ol_state))),
+            ToplevelOlStateLookup::MissingEpochCommitment => Ok(None),
+            ToplevelOlStateLookup::MissingTerminalState {
+                terminal_commitment,
+            } => {
+                warn!(
+                    ?epoch,
+                    %terminal_commitment,
+                    "Canonical commitment present but toplevel state missing"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Returns the account's current Snark update seqno when canonical tip state is available.
+    ///
+    /// This is an optimization for out-of-range manifest queries. Missing canonical
+    /// tip state means the current epoch is still in flight, so callers must fall
+    /// back to indexed records instead of treating that as a request error.
     async fn current_snark_account_seq_no(
         &self,
         account_id: AccountId,
         tip_epoch: Epoch,
     ) -> RpcResult<Option<u64>> {
-        let (_, tip_ol_state) = self.get_toplevel_ol_state_for_epoch(tip_epoch).await?;
+        let Some((_, tip_ol_state)) = self.try_get_toplevel_ol_state_for_epoch(tip_epoch).await?
+        else {
+            return Ok(None);
+        };
+
         Ok(tip_ol_state
             .get_account_state(&account_id)
             .and_then(|state| state.as_snark_account().ok())

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -3171,6 +3171,48 @@ async fn snark_acct_update_manifest_returns_record_with_indexed_range() {
 }
 
 #[tokio::test]
+async fn snark_acct_update_manifest_walks_records_when_tip_epoch_is_not_canonical() {
+    let account_id = test_account_id(8);
+    let tip_epoch_commitment = test_epoch_commitment(2, 10, 0x28);
+    let final_state_root = fixed_buf32(0x82);
+    let extra_data = vec![0xD0, 0xD1];
+    let records_epoch_2 = vec![update_record_with_prev(
+        Some(AccountUpdateMeta::new(None, final_state_root)),
+        9,
+        2,
+        5,
+        Some(extra_data.clone()),
+    )];
+
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            2,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 1)
+        .with_account_update_records(account_id, 2, records_epoch_2);
+    let rpc = make_rpc(provider);
+
+    let manifest = rpc
+        .get_snark_acct_update_manifest(account_id, 8)
+        .await
+        .expect("manifest");
+
+    assert_eq!(manifest.seq_no(), 8);
+    assert_eq!(manifest.prev_next_msg_idx(), 2);
+    assert_eq!(manifest.new_next_msg_idx(), 5);
+    assert_eq!(
+        manifest.new_inner_state_root().expect("state root").0,
+        final_state_root.0
+    );
+    assert_eq!(manifest.extra_data().expect("extra data").0, extra_data);
+}
+
+#[tokio::test]
 async fn snark_acct_update_manifest_unknown_account_errors() {
     let rpc = make_rpc(MockProvider::new());
 

--- a/crates/alpen-ee/da/l1-extraction/Cargo.toml
+++ b/crates/alpen-ee/da/l1-extraction/Cargo.toml
@@ -1,28 +1,25 @@
 [package]
 edition = "2021"
-name = "alpen-ee-da-tool"
+name = "alpen-ee-da-l1-extraction"
 version = "0.3.0-alpha.1"
 
 [lints]
 workspace = true
 
-[[bin]]
-name = "alpen-ee-da-tool"
-path = "src/main.rs"
-
 [dependencies]
-alpen-ee-da-l1-extraction.workspace = true
 alpen-ee-da-types.workspace = true
-strata-cli-common.workspace = true
+strata-codec.workspace = true
+strata-common = { workspace = true, features = ["async"] }
 strata-identifiers.workspace = true
 strata-l1-txfmt.workspace = true
 
-argh.workspace = true
 bitcoin.workspace = true
 bitcoind-async-client.workspace = true
 futures.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-terrors.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+strata-btcio.workspace = true
+strata-l1-envelope-fmt.workspace = true
 tokio.workspace = true
-toml.workspace = true

--- a/crates/alpen-ee/da/l1-extraction/src/fetch.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/fetch.rs
@@ -1,0 +1,696 @@
+//! Streams Bitcoin blocks from bitcoind with retry.
+
+use std::fmt::Debug;
+
+use bitcoin::{Block, BlockHash};
+use bitcoind_async_client::{error::ClientError, traits::Reader, ClientResult};
+use futures::{
+    future::BoxFuture,
+    stream::{self, BoxStream, StreamExt},
+};
+use strata_common::retry::{policies::ExponentialBackoff, retry_with_backoff_async};
+use strata_identifiers::L1Height;
+use thiserror::Error;
+
+/// Default retry count for each bitcoind RPC call in the fetch stage.
+const DEFAULT_FETCH_MAX_RETRIES: u16 = 5;
+
+/// Default initial retry delay (milliseconds) for fetch-stage RPC calls.
+const DEFAULT_FETCH_BACKOFF_BASE_DELAY_MS: u64 = 500;
+
+/// Default retry delay multiplier numerator.
+const DEFAULT_FETCH_BACKOFF_MULTIPLIER: u64 = 150;
+
+/// Default retry delay multiplier denominator.
+const DEFAULT_FETCH_BACKOFF_MULTIPLIER_BASE: u64 = 100;
+
+/// Maximum inclusive Bitcoin block count accepted by the default extractor.
+pub const MAX_EXTRACTION_BLOCK_RANGE: u64 = 5_000;
+
+/// bitcoind RPC error code for "Block height out of range".
+const BITCOIND_BLOCK_HEIGHT_OUT_OF_RANGE: i32 = -8;
+
+/// bitcoind RPC error code for "Loading block index" (node warming up).
+const BITCOIND_WARMING_UP: i32 = -28;
+
+/// Raw Bitcoin block data paired with its fetch metadata.
+#[derive(Debug, Clone)]
+pub struct L1BlockData {
+    height: L1Height,
+    hash: BlockHash,
+    block: Block,
+}
+
+impl L1BlockData {
+    /// Returns the L1 height where the block was fetched.
+    pub fn height(&self) -> L1Height {
+        self.height
+    }
+
+    /// Returns the Bitcoin block hash for the fetched block.
+    pub fn hash(&self) -> BlockHash {
+        self.hash
+    }
+
+    /// Returns the fetched Bitcoin block.
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+pub enum InvalidBlockRange {
+    #[error("--start-height ({start_height}) must be <= --end-height ({end_height})")]
+    Inverted {
+        start_height: L1Height,
+        end_height: L1Height,
+    },
+
+    #[error(
+        "requested L1 extraction range too large (requested {requested_block_count}, max {max_block_count})"
+    )]
+    TooLarge {
+        start_height: L1Height,
+        end_height: L1Height,
+        requested_block_count: u64,
+        max_block_count: u64,
+    },
+}
+
+impl InvalidBlockRange {
+    /// Returns the invalid range start height.
+    pub fn start_height(&self) -> L1Height {
+        match self {
+            Self::Inverted { start_height, .. } | Self::TooLarge { start_height, .. } => {
+                *start_height
+            }
+        }
+    }
+
+    /// Returns the invalid range end height.
+    pub fn end_height(&self) -> L1Height {
+        match self {
+            Self::Inverted { end_height, .. } | Self::TooLarge { end_height, .. } => *end_height,
+        }
+    }
+
+    /// Returns the requested block count when the range was too large.
+    pub fn requested_block_count(&self) -> Option<u64> {
+        match self {
+            Self::Inverted { .. } => None,
+            Self::TooLarge {
+                requested_block_count,
+                ..
+            } => Some(*requested_block_count),
+        }
+    }
+
+    /// Returns the maximum accepted block count when the range was too large.
+    pub fn max_block_count(&self) -> Option<u64> {
+        match self {
+            Self::Inverted { .. } => None,
+            Self::TooLarge {
+                max_block_count, ..
+            } => Some(*max_block_count),
+        }
+    }
+}
+
+impl L1BlockData {
+    /// Creates fetched L1 block data.
+    pub fn new(height: L1Height, hash: BlockHash, block: Block) -> Self {
+        Self {
+            height,
+            hash,
+            block,
+        }
+    }
+}
+
+/// Retry policy for bounded L1 block fetches.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FetchPolicy {
+    max_retries: u16,
+    backoff_base_delay_ms: u64,
+    backoff_multiplier: u64,
+    backoff_multiplier_base: u64,
+}
+
+impl FetchPolicy {
+    /// Creates a bounded fetch retry policy.
+    pub fn new(
+        max_retries: u16,
+        backoff_base_delay_ms: u64,
+        backoff_multiplier: u64,
+        backoff_multiplier_base: u64,
+    ) -> Self {
+        assert!(backoff_multiplier_base != 0);
+        Self {
+            max_retries,
+            backoff_base_delay_ms,
+            backoff_multiplier,
+            backoff_multiplier_base,
+        }
+    }
+
+    /// Returns the maximum number of retries per RPC call.
+    pub fn max_retries(&self) -> u16 {
+        self.max_retries
+    }
+
+    fn backoff(&self) -> ExponentialBackoff {
+        ExponentialBackoff::new(
+            self.backoff_base_delay_ms,
+            self.backoff_multiplier,
+            self.backoff_multiplier_base,
+        )
+    }
+}
+
+impl Default for FetchPolicy {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_FETCH_MAX_RETRIES,
+            DEFAULT_FETCH_BACKOFF_BASE_DELAY_MS,
+            DEFAULT_FETCH_BACKOFF_MULTIPLIER,
+            DEFAULT_FETCH_BACKOFF_MULTIPLIER_BASE,
+        )
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum FetchError {
+    #[error("height out of range at {height}: {source}")]
+    HeightOutOfRange {
+        height: L1Height,
+        #[source]
+        source: ClientError,
+    },
+
+    #[error("retries exhausted at height {height}: {source}")]
+    RetriesExhausted {
+        height: L1Height,
+        #[source]
+        source: ClientError,
+    },
+
+    #[error("client error at height {height}: {source}")]
+    Client {
+        height: L1Height,
+        #[source]
+        source: ClientError,
+    },
+}
+
+#[derive(Debug)]
+enum RpcFetchOutcome<T> {
+    Value(T),
+    HeightOutOfRange(ClientError),
+    RetriesExhausted(ClientError),
+    Terminal(ClientError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryClass {
+    Retryable,
+    Terminal,
+}
+
+pub trait FetchReader: Send + Sync {
+    fn get_block_hash(&self, height: L1Height) -> BoxFuture<'_, ClientResult<BlockHash>>;
+
+    fn get_block<'a>(&'a self, hash: &'a BlockHash) -> BoxFuture<'a, ClientResult<Block>>;
+}
+
+impl<T> FetchReader for T
+where
+    T: Reader + Send + Sync,
+{
+    fn get_block_hash(&self, height: L1Height) -> BoxFuture<'_, ClientResult<BlockHash>> {
+        Box::pin(Reader::get_block_hash(self, u64::from(height)))
+    }
+
+    fn get_block<'a>(&'a self, hash: &'a BlockHash) -> BoxFuture<'a, ClientResult<Block>> {
+        Box::pin(Reader::get_block(self, hash))
+    }
+}
+
+/// Returns an ordered stream of Bitcoin blocks for the inclusive height range.
+pub fn fetch_range<'a, R>(
+    reader: &'a R,
+    start_height: L1Height,
+    end_height: L1Height,
+) -> Result<BoxStream<'a, Result<L1BlockData, FetchError>>, InvalidBlockRange>
+where
+    R: FetchReader + ?Sized,
+{
+    fetch_range_with_policy(reader, start_height, end_height, FetchPolicy::default())
+}
+
+/// Returns an ordered stream of Bitcoin blocks using the supplied retry policy.
+pub fn fetch_range_with_policy<'a, R>(
+    reader: &'a R,
+    start_height: L1Height,
+    end_height: L1Height,
+    policy: FetchPolicy,
+) -> Result<BoxStream<'a, Result<L1BlockData, FetchError>>, InvalidBlockRange>
+where
+    R: FetchReader + ?Sized,
+{
+    if start_height > end_height {
+        return Err(InvalidBlockRange::Inverted {
+            start_height,
+            end_height,
+        });
+    }
+
+    let requested_block_count = u64::from(end_height - start_height) + 1;
+    if requested_block_count > MAX_EXTRACTION_BLOCK_RANGE {
+        return Err(InvalidBlockRange::TooLarge {
+            start_height,
+            end_height,
+            requested_block_count,
+            max_block_count: MAX_EXTRACTION_BLOCK_RANGE,
+        });
+    }
+
+    Ok(stream::iter(start_height..=end_height)
+        .then(move |height| fetch_block_at(reader, height, policy))
+        .boxed())
+}
+
+fn classify_retry(err: &ClientError) -> RetryClass {
+    match err {
+        ClientError::Connection(_) | ClientError::Timeout | ClientError::Request(_) => {
+            RetryClass::Retryable
+        }
+        ClientError::Server(BITCOIND_WARMING_UP, _) => RetryClass::Retryable,
+        _ => RetryClass::Terminal,
+    }
+}
+
+fn is_height_out_of_range(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Server(BITCOIND_BLOCK_HEIGHT_OUT_OF_RANGE, _)
+    )
+}
+
+async fn fetch_block_at<R>(
+    reader: &R,
+    height: L1Height,
+    policy: FetchPolicy,
+) -> Result<L1BlockData, FetchError>
+where
+    R: FetchReader + ?Sized,
+{
+    let hash = fetch_block_hash_with_retry(reader, height, policy).await?;
+    let block = fetch_block_with_retry(reader, height, hash, policy).await?;
+
+    Ok(L1BlockData {
+        height,
+        hash,
+        block,
+    })
+}
+
+async fn fetch_block_hash_with_retry<R>(
+    reader: &R,
+    height: L1Height,
+    policy: FetchPolicy,
+) -> Result<BlockHash, FetchError>
+where
+    R: FetchReader + ?Sized,
+{
+    let backoff = policy.backoff();
+    let outcome = retry_with_backoff_async(
+        "alpen_ee_da_l1_fetch_block_hash",
+        policy.max_retries(),
+        &backoff,
+        || async {
+            match reader.get_block_hash(height).await {
+                Ok(hash) => Ok(RpcFetchOutcome::Value(hash)),
+                Err(err) if is_height_out_of_range(&err) => {
+                    Ok(RpcFetchOutcome::HeightOutOfRange(err))
+                }
+                Err(err) if matches!(err, ClientError::MaxRetriesExceeded(_)) => {
+                    Ok(RpcFetchOutcome::RetriesExhausted(err))
+                }
+                Err(err) => match classify_retry(&err) {
+                    RetryClass::Retryable => Err(err),
+                    RetryClass::Terminal => Ok(RpcFetchOutcome::Terminal(err)),
+                },
+            }
+        },
+    )
+    .await
+    .map_err(|source| FetchError::RetriesExhausted { height, source })?;
+
+    match outcome {
+        RpcFetchOutcome::Value(hash) => Ok(hash),
+        RpcFetchOutcome::HeightOutOfRange(source) => {
+            Err(FetchError::HeightOutOfRange { height, source })
+        }
+        RpcFetchOutcome::RetriesExhausted(source) => {
+            Err(FetchError::RetriesExhausted { height, source })
+        }
+        RpcFetchOutcome::Terminal(source) => Err(FetchError::Client { height, source }),
+    }
+}
+
+async fn fetch_block_with_retry<R>(
+    reader: &R,
+    height: L1Height,
+    hash: BlockHash,
+    policy: FetchPolicy,
+) -> Result<Block, FetchError>
+where
+    R: FetchReader + ?Sized,
+{
+    let backoff = policy.backoff();
+    let outcome = retry_with_backoff_async(
+        "alpen_ee_da_l1_fetch_block",
+        policy.max_retries(),
+        &backoff,
+        || async {
+            match reader.get_block(&hash).await {
+                Ok(block) => Ok(RpcFetchOutcome::Value(block)),
+                Err(err) if matches!(err, ClientError::MaxRetriesExceeded(_)) => {
+                    Ok(RpcFetchOutcome::RetriesExhausted(err))
+                }
+                Err(err) => match classify_retry(&err) {
+                    RetryClass::Retryable => Err(err),
+                    RetryClass::Terminal => Ok(RpcFetchOutcome::Terminal(err)),
+                },
+            }
+        },
+    )
+    .await
+    .map_err(|source| FetchError::RetriesExhausted { height, source })?;
+
+    match outcome {
+        RpcFetchOutcome::Value(block) => Ok(block),
+        RpcFetchOutcome::HeightOutOfRange(_) => {
+            unreachable!("get_block uses a hash, not a height")
+        }
+        RpcFetchOutcome::RetriesExhausted(source) => {
+            Err(FetchError::RetriesExhausted { height, source })
+        }
+        RpcFetchOutcome::Terminal(source) => Err(FetchError::Client { height, source }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::Mutex,
+    };
+
+    use bitcoin::{
+        block::{Header, Version},
+        hashes::Hash,
+        pow::CompactTarget,
+        Block, BlockHash, TxMerkleNode,
+    };
+    use bitcoind_async_client::error::ClientError;
+    use futures::TryStreamExt;
+
+    use super::*;
+
+    #[derive(Default, Debug)]
+    struct MockReader {
+        hash_responses: Mutex<HashMap<L1Height, VecDeque<ClientResult<BlockHash>>>>,
+        block_responses: Mutex<HashMap<BlockHash, VecDeque<ClientResult<Block>>>>,
+        hash_calls: Mutex<Vec<L1Height>>,
+    }
+
+    impl MockReader {
+        fn with_hash_responses(
+            mut self,
+            height: L1Height,
+            responses: Vec<ClientResult<BlockHash>>,
+        ) -> Self {
+            self.hash_responses
+                .get_mut()
+                .expect("poisoned")
+                .insert(height, responses.into_iter().collect());
+            self
+        }
+
+        fn with_block_responses(
+            mut self,
+            hash: BlockHash,
+            responses: Vec<ClientResult<Block>>,
+        ) -> Self {
+            self.block_responses
+                .get_mut()
+                .expect("poisoned")
+                .insert(hash, responses.into_iter().collect());
+            self
+        }
+
+        fn hash_call_count(&self, height: L1Height) -> usize {
+            self.hash_calls
+                .lock()
+                .expect("poisoned")
+                .iter()
+                .filter(|h| **h == height)
+                .count()
+        }
+    }
+
+    impl FetchReader for MockReader {
+        fn get_block_hash(&self, height: L1Height) -> BoxFuture<'_, ClientResult<BlockHash>> {
+            self.hash_calls.lock().expect("poisoned").push(height);
+
+            let response = self
+                .hash_responses
+                .lock()
+                .expect("poisoned")
+                .get_mut(&height)
+                .and_then(|queue| queue.pop_front())
+                .expect("missing hash response for height");
+
+            Box::pin(async move { response })
+        }
+
+        fn get_block<'a>(&'a self, hash: &'a BlockHash) -> BoxFuture<'a, ClientResult<Block>> {
+            let response = self
+                .block_responses
+                .lock()
+                .expect("poisoned")
+                .get_mut(hash)
+                .and_then(|queue| queue.pop_front())
+                .expect("missing block response for hash");
+
+            Box::pin(async move { response })
+        }
+    }
+
+    fn test_hash(byte: u8) -> BlockHash {
+        BlockHash::from_byte_array([byte; 32])
+    }
+
+    fn test_block(nonce: u32) -> Block {
+        Block {
+            header: Header {
+                version: Version::from_consensus(1),
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: CompactTarget::from_consensus(0),
+                nonce,
+            },
+            txdata: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn fetch_range_rejects_invalid_height_range() {
+        let reader = MockReader::default();
+
+        let Err(error) = fetch_range(&reader, 12, 10) else {
+            panic!("invalid range must fail");
+        };
+
+        assert_eq!(
+            error,
+            InvalidBlockRange::Inverted {
+                start_height: 12,
+                end_height: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn fetch_range_accepts_maximum_block_count() {
+        let reader = MockReader::default();
+
+        let _stream = fetch_range(&reader, 0, (MAX_EXTRACTION_BLOCK_RANGE - 1) as L1Height)
+            .expect("range at maximum size must be accepted");
+    }
+
+    #[test]
+    fn fetch_range_rejects_range_above_maximum_block_count() {
+        let reader = MockReader::default();
+
+        let Err(error) = fetch_range(&reader, 0, MAX_EXTRACTION_BLOCK_RANGE as L1Height) else {
+            panic!("range above maximum size must fail");
+        };
+
+        assert_eq!(
+            error,
+            InvalidBlockRange::TooLarge {
+                start_height: 0,
+                end_height: MAX_EXTRACTION_BLOCK_RANGE as L1Height,
+                requested_block_count: MAX_EXTRACTION_BLOCK_RANGE + 1,
+                max_block_count: MAX_EXTRACTION_BLOCK_RANGE,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_range_preserves_height_ordering() {
+        let heights: [L1Height; 3] = [10, 11, 12];
+        let expected = heights
+            .iter()
+            .map(|height| (*height, test_hash(*height as u8)))
+            .collect::<Vec<_>>();
+
+        let mut reader = MockReader::default();
+        for (height, hash) in &expected {
+            reader = reader
+                .with_hash_responses(*height, vec![Ok(*hash)])
+                .with_block_responses(*hash, vec![Ok(test_block(*height))]);
+        }
+
+        let blocks = fetch_range(&reader, 10, 12)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect("fetch must succeed");
+
+        assert_eq!(blocks.len(), expected.len());
+        for (block, (height, hash)) in blocks.iter().zip(expected.iter()) {
+            assert_eq!(block.height(), *height);
+            assert_eq!(block.hash(), *hash);
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_range_retries_then_succeeds_on_transient_error() {
+        let hash = test_hash(7);
+
+        let reader = MockReader::default()
+            .with_hash_responses(
+                7,
+                vec![
+                    Err(ClientError::Connection("temporary".to_string())),
+                    Ok(hash),
+                ],
+            )
+            .with_block_responses(hash, vec![Ok(test_block(7))]);
+
+        let blocks = fetch_range(&reader, 7, 7)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect("fetch must succeed after retry");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].height(), 7);
+        assert_eq!(reader.hash_call_count(7), 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_range_does_not_retry_terminal_auth_error() {
+        let reader = MockReader::default().with_hash_responses(
+            1,
+            vec![Err(ClientError::Status(401, "Unauthorized".to_string()))],
+        );
+
+        let error = fetch_range(&reader, 1, 1)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("auth error must fail without retries");
+
+        assert!(matches!(
+            error,
+            FetchError::Client {
+                source: ClientError::Status(401, _),
+                ..
+            }
+        ));
+        assert_eq!(reader.hash_call_count(1), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_range_maps_missing_height_to_height_out_of_range() {
+        let reader = MockReader::default().with_hash_responses(
+            42,
+            vec![Err(ClientError::Server(
+                -8,
+                "Block height out of range".to_string(),
+            ))],
+        );
+
+        let error = fetch_range(&reader, 42, 42)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("missing height must fail");
+
+        assert!(matches!(
+            error,
+            FetchError::HeightOutOfRange {
+                source: ClientError::Server(-8, _),
+                ..
+            }
+        ));
+        assert_eq!(reader.hash_call_count(42), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_range_maps_retry_exhaustion_distinctly() {
+        let responses = (0..16)
+            .map(|_| Err(ClientError::Connection("temporary".to_string())))
+            .collect::<Vec<_>>();
+        let reader = MockReader::default().with_hash_responses(9, responses);
+
+        let error = fetch_range(&reader, 9, 9)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("persistent retryable errors must exhaust retries");
+
+        assert!(matches!(
+            error,
+            FetchError::RetriesExhausted {
+                source: ClientError::Connection(_),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_range_maps_client_max_retries_exceeded_to_retries_exhausted() {
+        let reader = MockReader::default()
+            .with_hash_responses(100, vec![Err(ClientError::MaxRetriesExceeded(3))]);
+
+        let error = fetch_range(&reader, 100, 100)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("client max-retries error must map to retries exhausted");
+
+        assert!(matches!(
+            error,
+            FetchError::RetriesExhausted {
+                source: ClientError::MaxRetriesExceeded(3),
+                ..
+            }
+        ));
+    }
+}

--- a/crates/alpen-ee/da/l1-extraction/src/lib.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/lib.rs
@@ -1,0 +1,22 @@
+//! EE DA extraction helpers for bounded L1 ranges.
+//!
+//! This crate is a stateless extractor for verifier-sized ranges. The current
+//! MVP rejects multiple DA blobs with the same `update_seq_no` instead of
+//! resolving candidates against OL-published Snark account inner roots.
+
+mod fetch;
+mod reassemble;
+mod scan;
+
+#[cfg(test)]
+mod test_utils;
+
+pub use fetch::{
+    fetch_range, fetch_range_with_policy, FetchError, FetchPolicy, FetchReader, InvalidBlockRange,
+    L1BlockData, MAX_EXTRACTION_BLOCK_RANGE,
+};
+pub use reassemble::{reassemble_da_blobs, ReassembleError};
+pub use scan::{
+    parse_chunked_envelope, peek_commit_marker, scan_blocks, CommitMarker, L1RangeScanner,
+    ParsedEnvelope, ScanError,
+};

--- a/crates/alpen-ee/da/l1-extraction/src/reassemble.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/reassemble.rs
@@ -1,0 +1,203 @@
+//! Reassembles parsed EE DA envelopes into decoded DA blobs.
+
+use alpen_ee_da_types::{reassemble_da_blob, DaBlob};
+use strata_codec::CodecError;
+use thiserror::Error;
+
+use crate::ParsedEnvelope;
+
+/// Errors raised while reassembling parsed EE DA envelopes.
+#[derive(Debug, Error)]
+pub enum ReassembleError {
+    #[error("blob reassembly failed at envelope {index}: {source}")]
+    Envelope {
+        index: usize,
+        #[source]
+        source: CodecError,
+    },
+
+    #[error("multiple DA blob candidates for update_seq_no {update_seq_no} are unsupported")]
+    MultipleCandidatesUnsupported { update_seq_no: u64 },
+
+    #[error(
+        "expected DA blob update_seq_no {expected} not found in supplied range; next blob has {actual}"
+    )]
+    MissingUpdateSeqNo { expected: u64, actual: u64 },
+}
+
+/// Reassembles parsed envelope chunks into decoded DA blobs.
+///
+/// The returned blobs are sorted by `update_seq_no`.
+///
+/// Gaps inside the returned range are rejected. Multiple candidates for the
+/// same sequence number are also rejected by this MVP; full spec compliance
+/// requires resolving them against the OL-published Snark account inner root.
+pub fn reassemble_da_blobs(
+    envelopes: impl IntoIterator<Item = ParsedEnvelope>,
+) -> Result<Vec<DaBlob>, ReassembleError> {
+    let mut blobs = Vec::new();
+
+    for (index, envelope) in envelopes.into_iter().enumerate() {
+        let blob = reassemble_da_blob(envelope.chunks())
+            .map_err(|source| ReassembleError::Envelope { index, source })?;
+        blobs.push(blob);
+    }
+
+    blobs.sort_by_key(|blob| blob.update_seq_no);
+    reject_update_seq_no_gaps(&blobs)?;
+
+    Ok(blobs)
+}
+
+fn reject_update_seq_no_gaps(blobs: &[DaBlob]) -> Result<(), ReassembleError> {
+    for pair in blobs.windows(2) {
+        let current = pair[0].update_seq_no;
+        let next = pair[1].update_seq_no;
+        if current == next {
+            return Err(ReassembleError::MultipleCandidatesUnsupported {
+                update_seq_no: current,
+            });
+        }
+
+        let expected = current + 1;
+        if next != expected {
+            return Err(ReassembleError::MissingUpdateSeqNo {
+                expected,
+                actual: next,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use strata_codec::{encode_to_vec, CodecError};
+
+    use super::{reassemble_da_blobs, ReassembleError};
+    use crate::test_utils::{
+        build_parsed_envelope_from_chunk_bytes, make_multi_chunk_test_blob, make_test_blob,
+        multi_chunk_bytecode_len_strategy,
+    };
+
+    const MAX_TEST_CHUNK_BYTES: usize = 395_000;
+
+    fn prepare_test_chunks(blob: &alpen_ee_da_types::DaBlob) -> Vec<Vec<u8>> {
+        encode_to_vec(blob)
+            .expect("test blob encodes")
+            .chunks(MAX_TEST_CHUNK_BYTES)
+            .map(|chunk| chunk.to_vec())
+            .collect()
+    }
+
+    #[test]
+    fn reassemble_da_blobs_returns_empty_for_empty_input() {
+        let blobs = reassemble_da_blobs(Vec::new()).expect("empty input is valid");
+        assert!(blobs.is_empty());
+    }
+
+    #[test]
+    fn reassemble_da_blobs_sorts_by_update_seq_no() {
+        let blob0 = make_test_blob(10);
+        let blob1 = make_test_blob(11);
+        let envelopes = vec![
+            build_parsed_envelope_from_chunk_bytes(prepare_test_chunks(&blob1)),
+            build_parsed_envelope_from_chunk_bytes(prepare_test_chunks(&blob0)),
+        ];
+
+        let blobs = reassemble_da_blobs(envelopes).expect("reassembly succeeds");
+
+        assert_eq!(
+            blobs
+                .iter()
+                .map(|blob| blob.update_seq_no)
+                .collect::<Vec<_>>(),
+            vec![10, 11]
+        );
+    }
+
+    #[test]
+    fn reassemble_da_blobs_rejects_multiple_candidates_for_same_seq_no() {
+        let blob0 = make_test_blob(10);
+        let blob1 = make_test_blob(10);
+        let envelopes = vec![
+            build_parsed_envelope_from_chunk_bytes(prepare_test_chunks(&blob0)),
+            build_parsed_envelope_from_chunk_bytes(prepare_test_chunks(&blob1)),
+        ];
+
+        let err = reassemble_da_blobs(envelopes).expect_err("duplicate seqno must fail");
+
+        assert!(matches!(
+            err,
+            ReassembleError::MultipleCandidatesUnsupported { update_seq_no: 10 }
+        ));
+    }
+
+    #[test]
+    fn reassemble_da_blobs_rejects_update_seq_no_gap() {
+        let blob0 = make_test_blob(10);
+        let blob1 = make_test_blob(12);
+        let envelopes = vec![
+            build_parsed_envelope_from_chunk_bytes(prepare_test_chunks(&blob0)),
+            build_parsed_envelope_from_chunk_bytes(prepare_test_chunks(&blob1)),
+        ];
+
+        let err = reassemble_da_blobs(envelopes).expect_err("seqno gap must fail");
+
+        assert!(matches!(
+            err,
+            ReassembleError::MissingUpdateSeqNo {
+                expected: 11,
+                actual: 12
+            }
+        ));
+    }
+
+    proptest! {
+        #[test]
+        fn reassemble_da_blobs_reports_failing_envelope_index(
+            valid_prefix_len in 0usize..=4,
+        ) {
+            let mut envelopes = (0..valid_prefix_len)
+                .map(|idx| make_test_blob(idx as u64))
+                .map(|blob| {
+                    build_parsed_envelope_from_chunk_bytes(
+                        prepare_test_chunks(&blob),
+                    )
+                })
+                .collect::<Vec<_>>();
+            envelopes.push(build_parsed_envelope_from_chunk_bytes(Vec::new()));
+
+            let err = reassemble_da_blobs(envelopes).expect_err("empty envelope must fail");
+            match err {
+                ReassembleError::Envelope { index, source: CodecError::MalformedField(_) } => {
+                    prop_assert_eq!(index, valid_prefix_len);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn reassemble_da_blobs_reassembles_multi_chunk_blob(
+            block_num in any::<u64>(),
+            bytecode_len in multi_chunk_bytecode_len_strategy(),
+            fill_byte in any::<u8>(),
+        ) {
+            let expected = make_multi_chunk_test_blob(block_num, bytecode_len, fill_byte);
+            let chunks = prepare_test_chunks(&expected);
+            prop_assert!(chunks.len() > 1, "fixture must produce multiple chunks");
+
+            let envelopes = vec![build_parsed_envelope_from_chunk_bytes(chunks)];
+            let blobs = reassemble_da_blobs(envelopes).expect("reassembly succeeds");
+            prop_assert_eq!(blobs.len(), 1);
+
+            let actual_encoded =
+                strata_codec::encode_to_vec(&blobs[0]).expect("encode reassembled blob");
+            let expected_encoded =
+                strata_codec::encode_to_vec(&expected).expect("encode expected blob");
+            prop_assert_eq!(actual_encoded, expected_encoded);
+        }
+    }
+}

--- a/crates/alpen-ee/da/l1-extraction/src/scan.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/scan.rs
@@ -1,0 +1,1003 @@
+//! Extracts EE DA chunked envelopes from bounded L1 block data.
+
+use std::{collections::BTreeMap, iter};
+
+use alpen_ee_da_types::{
+    extract_da_chunks, is_reveal_slot, last_commit_reveal_vout, read_commit_marker_payload,
+    DaParseError, DA_BLOB_VERSION,
+};
+use bitcoin::{
+    opcodes::all::{OP_CHECKSIG, OP_RETURN},
+    script::Instruction,
+    secp256k1::XOnlyPublicKey,
+    Script, Transaction, Txid,
+};
+use strata_l1_txfmt::MagicBytes;
+use thiserror::Error;
+
+use crate::fetch::L1BlockData;
+
+/// Lightweight commit marker recognized during discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommitMarker {
+    version: u32,
+}
+
+impl CommitMarker {
+    /// Returns the commit marker version.
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+/// Parsed chunks for one commit/reveal envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedEnvelope {
+    commit_txid: Txid,
+    chunks: Vec<Vec<u8>>,
+}
+
+impl ParsedEnvelope {
+    pub(crate) fn new(commit_txid: Txid, chunks: Vec<Vec<u8>>) -> Self {
+        Self {
+            commit_txid,
+            chunks,
+        }
+    }
+
+    /// Returns the transaction id of the commit transaction.
+    pub fn commit_txid(&self) -> Txid {
+        self.commit_txid
+    }
+
+    /// Returns raw encoded DA chunks ordered by commit output vout.
+    pub fn chunks(&self) -> &[Vec<u8>] {
+        &self.chunks
+    }
+
+    /// Consumes the envelope and returns its ordered raw encoded DA chunks.
+    pub fn into_chunks(self) -> Vec<Vec<u8>> {
+        self.chunks
+    }
+}
+
+/// Errors raised while discovering or parsing EE DA chunked envelopes.
+#[derive(Debug, Error)]
+pub enum ScanError {
+    #[error("malformed commit marker in transaction {txid}: {source}")]
+    MalformedCommitMarker {
+        txid: Txid,
+        #[source]
+        source: DaParseError,
+    },
+
+    #[error("missing commit marker in transaction {txid}")]
+    MissingCommitMarker { txid: Txid },
+
+    #[error("unsupported commit marker version {version} for commit {commit_txid}")]
+    UnsupportedCommitMarkerVersion { commit_txid: Txid, version: u32 },
+
+    #[error("duplicate commit transaction id {commit_txid}")]
+    DuplicateCommitTxid { commit_txid: Txid },
+
+    #[error("reveal {reveal_txid} spends slots from multiple commits")]
+    MultipleRevealCommitSpends { reveal_txid: Txid },
+
+    #[error("missing taproot leaf script in reveal {reveal_txid}")]
+    MissingLeafScript { reveal_txid: Txid },
+
+    #[error("invalid sequencer public key in reveal {reveal_txid}")]
+    InvalidSequencerPubkey { reveal_txid: Txid },
+
+    #[error("DA envelope parse failed for commit {commit_txid}: {source}")]
+    EnvelopeParse {
+        commit_txid: Txid,
+        #[source]
+        source: DaParseError,
+    },
+}
+
+#[derive(Debug)]
+struct CommitCandidate {
+    tx: Transaction,
+    txid: Txid,
+    last_reveal_vout: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+struct RevealCandidate {
+    tx: Transaction,
+    txid: Txid,
+}
+
+/// Incrementally scans a bounded L1 range for EE DA commit/reveal envelopes.
+///
+/// The scanner keeps only discovered commit and reveal candidate transactions;
+/// it does not retain every fetched Bitcoin block.
+#[derive(Debug)]
+pub struct L1RangeScanner {
+    magic_bytes: MagicBytes,
+    sequencer_pubkey: XOnlyPublicKey,
+    commits_by_txid: BTreeMap<Txid, CommitCandidate>,
+    reveals_by_commit: BTreeMap<Txid, BTreeMap<Txid, RevealCandidate>>,
+}
+
+impl L1RangeScanner {
+    /// Creates an empty scanner for one confirmed L1 range.
+    pub fn new(magic_bytes: MagicBytes, sequencer_pubkey: XOnlyPublicKey) -> Self {
+        Self {
+            magic_bytes,
+            sequencer_pubkey,
+            commits_by_txid: BTreeMap::new(),
+            reveals_by_commit: BTreeMap::new(),
+        }
+    }
+
+    /// Ingests one fetched L1 block.
+    pub fn ingest_block(&mut self, block: &bitcoin::Block) -> Result<(), ScanError> {
+        for tx in &block.txdata {
+            self.ingest_transaction(tx)?;
+        }
+        Ok(())
+    }
+
+    /// Finalizes all discovered commits into parsed envelopes.
+    pub fn finish(self) -> Result<Vec<ParsedEnvelope>, ScanError> {
+        self.commits_by_txid
+            .values()
+            .map(|commit| self.finalize_commit(commit))
+            .collect()
+    }
+
+    fn ingest_transaction(&mut self, tx: &Transaction) -> Result<(), ScanError> {
+        let txid = tx.compute_txid();
+
+        if parse_commit_marker(tx, txid, self.magic_bytes)?.is_some() {
+            let last_reveal_vout =
+                last_commit_reveal_vout(tx).map_err(|source| ScanError::EnvelopeParse {
+                    commit_txid: txid,
+                    source,
+                })?;
+            let candidate = CommitCandidate {
+                tx: tx.clone(),
+                txid,
+                last_reveal_vout,
+            };
+            if self.commits_by_txid.insert(txid, candidate).is_some() {
+                return Err(ScanError::DuplicateCommitTxid { commit_txid: txid });
+            }
+        }
+
+        // Bitcoin blocks order parents before children, so same-block reveals
+        // cannot appear before the commit output they spend.
+        let mut spent_commit_txid = None;
+        for input in &tx.input {
+            let candidate_commit_txid = input.previous_output.txid;
+            let Some(commit) = self.commits_by_txid.get(&candidate_commit_txid) else {
+                continue;
+            };
+            if !is_reveal_slot(input.previous_output.vout, commit.last_reveal_vout) {
+                continue;
+            }
+
+            match spent_commit_txid {
+                None => spent_commit_txid = Some(candidate_commit_txid),
+                Some(existing) if existing != candidate_commit_txid => {
+                    return Err(ScanError::MultipleRevealCommitSpends { reveal_txid: txid });
+                }
+                Some(_) => {}
+            }
+        }
+
+        if let Some(commit_txid) = spent_commit_txid {
+            self.reveals_by_commit
+                .entry(commit_txid)
+                .or_default()
+                .entry(txid)
+                .or_insert_with(|| RevealCandidate {
+                    tx: tx.clone(),
+                    txid,
+                });
+        }
+
+        Ok(())
+    }
+
+    fn finalize_commit(&self, commit: &CommitCandidate) -> Result<ParsedEnvelope, ScanError> {
+        let reveals = self
+            .reveals_by_commit
+            .get(&commit.txid)
+            .map(|reveals| reveals.values().cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        parse_one_envelope(&commit.tx, commit.txid, &reveals, self.sequencer_pubkey)
+    }
+}
+
+/// Returns the commit marker for a transaction if it is a valid EE DA commit.
+pub fn peek_commit_marker(
+    tx: &Transaction,
+    magic_bytes: MagicBytes,
+) -> Result<Option<CommitMarker>, ScanError> {
+    parse_commit_marker(tx, tx.compute_txid(), magic_bytes)
+}
+
+/// Scans a confirmed L1 range for complete EE DA chunked envelopes.
+///
+/// Prefer [`L1RangeScanner`] for production fetch paths so fetched blocks can be
+/// dropped after ingestion. This helper is intended for tests and callers that
+/// already hold the full range in memory.
+///
+/// Commit and reveal transactions may be finalized in different blocks inside
+/// the supplied range. Missing reveals are reported only after the whole range
+/// is scanned.
+pub fn scan_blocks(
+    blocks: &[L1BlockData],
+    magic_bytes: MagicBytes,
+    sequencer_pubkey: XOnlyPublicKey,
+) -> Result<Vec<ParsedEnvelope>, ScanError> {
+    let mut scanner = L1RangeScanner::new(magic_bytes, sequencer_pubkey);
+    for block in blocks {
+        scanner.ingest_block(block.block())?;
+    }
+    scanner.finish()
+}
+
+/// Parses one explicit commit transaction using candidate reveal transactions.
+///
+/// This is a single-envelope helper. Production L1 range extraction should use
+/// [`L1RangeScanner`] so commits and reveals can be discovered across fetched
+/// blocks without retaining the full block range.
+pub fn parse_chunked_envelope(
+    commit: &Transaction,
+    candidate_reveals: &[Transaction],
+    magic_bytes: MagicBytes,
+    sequencer_pubkey: XOnlyPublicKey,
+) -> Result<ParsedEnvelope, ScanError> {
+    let commit_txid = commit.compute_txid();
+    parse_commit_marker_strict(commit, commit_txid, magic_bytes)?
+        .ok_or(ScanError::MissingCommitMarker { txid: commit_txid })?;
+
+    let reveals = candidate_reveals
+        .iter()
+        .map(|tx| RevealCandidate {
+            tx: tx.clone(),
+            txid: tx.compute_txid(),
+        })
+        .collect::<Vec<_>>();
+
+    parse_one_envelope(commit, commit_txid, &reveals, sequencer_pubkey)
+}
+
+fn parse_commit_marker(
+    tx: &Transaction,
+    txid: Txid,
+    magic_bytes: MagicBytes,
+) -> Result<Option<CommitMarker>, ScanError> {
+    let Some(payload) = read_exact_commit_marker_payload_for_magic(tx, magic_bytes) else {
+        return Ok(None);
+    };
+
+    parse_commit_marker_payload(txid, payload).map(Some)
+}
+
+fn parse_commit_marker_strict(
+    tx: &Transaction,
+    txid: Txid,
+    magic_bytes: MagicBytes,
+) -> Result<Option<CommitMarker>, ScanError> {
+    let Some(payload) = read_commit_marker_payload_for_magic_strict(tx, magic_bytes)
+        .map_err(|source| ScanError::MalformedCommitMarker { txid, source })?
+    else {
+        return Ok(None);
+    };
+
+    parse_commit_marker_payload(txid, payload).map(Some)
+}
+
+fn parse_commit_marker_payload(txid: Txid, payload: [u8; 8]) -> Result<CommitMarker, ScanError> {
+    let mut version = [0u8; 4];
+    version.copy_from_slice(&payload[4..]);
+    let version = u32::from_be_bytes(version);
+    if version != DA_BLOB_VERSION {
+        return Err(ScanError::UnsupportedCommitMarkerVersion {
+            commit_txid: txid,
+            version,
+        });
+    }
+
+    Ok(CommitMarker { version })
+}
+
+fn read_exact_commit_marker_payload_for_magic(
+    tx: &Transaction,
+    magic_bytes: MagicBytes,
+) -> Option<[u8; 8]> {
+    let first_output = tx.output.first()?;
+    let mut instructions = first_output.script_pubkey.instructions();
+    let Some(Ok(Instruction::Op(OP_RETURN))) = instructions.next() else {
+        return None;
+    };
+    let Some(Ok(Instruction::PushBytes(push))) = instructions.next() else {
+        return None;
+    };
+    if instructions.next().is_some() || push.as_bytes().len() != 8 {
+        return None;
+    }
+    if !push.as_bytes().starts_with(magic_bytes.as_bytes()) {
+        return None;
+    }
+
+    let mut payload = [0u8; 8];
+    payload.copy_from_slice(push.as_bytes());
+    Some(payload)
+}
+
+fn read_commit_marker_payload_for_magic_strict(
+    tx: &Transaction,
+    magic_bytes: MagicBytes,
+) -> Result<Option<[u8; 8]>, DaParseError> {
+    if !first_op_return_push_starts_with_magic(tx, magic_bytes) {
+        return Ok(None);
+    }
+
+    read_commit_marker_payload(tx)
+}
+
+fn first_op_return_push_starts_with_magic(tx: &Transaction, magic_bytes: MagicBytes) -> bool {
+    let Some(first_output) = tx.output.first() else {
+        return false;
+    };
+    let mut instructions = first_output.script_pubkey.instructions();
+    let Some(Ok(Instruction::Op(OP_RETURN))) = instructions.next() else {
+        return false;
+    };
+    let Some(Ok(Instruction::PushBytes(push))) = instructions.next() else {
+        return false;
+    };
+
+    push.as_bytes().starts_with(magic_bytes.as_bytes())
+}
+
+fn parse_one_envelope(
+    commit: &Transaction,
+    commit_txid: Txid,
+    reveals: &[RevealCandidate],
+    sequencer_pubkey: XOnlyPublicKey,
+) -> Result<ParsedEnvelope, ScanError> {
+    let last_reveal_vout =
+        last_commit_reveal_vout(commit).map_err(|source| ScanError::EnvelopeParse {
+            commit_txid,
+            source,
+        })?;
+
+    for reveal in reveals {
+        authenticate_reveal(
+            &reveal.tx,
+            reveal.txid,
+            commit_txid,
+            last_reveal_vout,
+            sequencer_pubkey,
+        )?;
+    }
+
+    let chunks = extract_da_chunks(iter::once(commit).chain(reveals.iter().map(|r| &r.tx)))
+        .map_err(|source| ScanError::EnvelopeParse {
+            commit_txid,
+            source,
+        })?;
+
+    Ok(ParsedEnvelope::new(commit_txid, chunks))
+}
+
+fn authenticate_reveal(
+    reveal: &Transaction,
+    reveal_txid: Txid,
+    commit_txid: Txid,
+    last_reveal_vout: Option<u32>,
+    sequencer_pubkey: XOnlyPublicKey,
+) -> Result<(), ScanError> {
+    for input in &reveal.input {
+        if input.previous_output.txid != commit_txid {
+            continue;
+        }
+        if !is_reveal_slot(input.previous_output.vout, last_reveal_vout) {
+            continue;
+        }
+
+        let leaf_script = input
+            .witness
+            .taproot_leaf_script()
+            .ok_or(ScanError::MissingLeafScript { reveal_txid })?
+            .script
+            .to_owned();
+
+        if !script_uses_sequencer_pubkey(&leaf_script, sequencer_pubkey) {
+            return Err(ScanError::InvalidSequencerPubkey { reveal_txid });
+        }
+    }
+
+    Ok(())
+}
+
+fn script_uses_sequencer_pubkey(script: &Script, sequencer_pubkey: XOnlyPublicKey) -> bool {
+    let mut instructions = script.instructions_minimal();
+
+    match instructions.next() {
+        Some(Ok(Instruction::PushBytes(bytes)))
+            if bytes.as_bytes() == sequencer_pubkey.serialize() => {}
+        _ => return false,
+    }
+
+    matches!(instructions.next(), Some(Ok(Instruction::Op(OP_CHECKSIG))))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime,
+        block::{Header, Version},
+        hashes::Hash,
+        pow::CompactTarget,
+        script::Builder,
+        secp256k1::{Keypair, Secp256k1, SecretKey},
+        transaction::Version as TxVersion,
+        Address, Amount, FeeRate, Network, OutPoint, ScriptBuf, Sequence, TxIn, TxMerkleNode,
+        TxOut, Txid, Witness,
+    };
+    use bitcoind_async_client::corepc_types::model::ListUnspentItem;
+    use proptest::prelude::*;
+    use strata_btcio::writer::{
+        builder::EnvelopeConfig, chunked_envelope::build_chunked_envelope_txs,
+    };
+    use strata_l1_txfmt::{ParseConfig, TagDataRef};
+
+    use super::*;
+    use crate::test_utils::{
+        build_block_with_txs, build_commit_tx, build_reveal_tx, chunk_body_strategy,
+        magic_bytes_strategy,
+    };
+
+    fn test_magic() -> MagicBytes {
+        "ALPN".parse().expect("valid ASCII magic")
+    }
+
+    fn test_key(seed: u8) -> XOnlyPublicKey {
+        XOnlyPublicKey::from_keypair(&test_keypair(seed)).0
+    }
+
+    fn test_keypair(seed: u8) -> Keypair {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[seed; 32]).expect("valid secret key");
+        Keypair::from_secret_key(&secp, &secret_key)
+    }
+
+    fn test_change_address() -> Address {
+        let script = ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::all_zeros());
+        Address::from_script(&script, Network::Regtest).expect("valid P2WPKH address")
+    }
+
+    fn test_utxo(address: &Address) -> ListUnspentItem {
+        ListUnspentItem {
+            txid: "4cfbec13cf1510545f285cceceb6229bd7b6a918a8f6eba1dbee64d26226a3b7"
+                .parse::<Txid>()
+                .expect("valid txid"),
+            vout: 0,
+            address: address.as_unchecked().clone(),
+            script_pubkey: ScriptBuf::new(),
+            amount: Amount::from_btc(100.0).expect("valid amount"),
+            confirmations: 100,
+            spendable: true,
+            solvable: true,
+            label: String::new(),
+            safe: true,
+            redeem_script: None,
+            descriptor: None,
+            parent_descriptors: None,
+        }
+    }
+
+    fn block_data(height: u32, txs: Vec<Transaction>) -> L1BlockData {
+        L1BlockData::new(
+            height,
+            bitcoin::BlockHash::from_byte_array([height as u8; 32]),
+            build_block_with_txs(txs),
+        )
+    }
+
+    fn malformed_protocol_marker_script() -> ScriptBuf {
+        let mut payload = [0u8; 8];
+        payload[..4].copy_from_slice(test_magic().as_bytes());
+
+        Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice(payload)
+            .push_opcode(OP_RETURN)
+            .into_script()
+    }
+
+    fn unrelated_malformed_op_return_tx() -> Transaction {
+        Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: Builder::new()
+                    .push_opcode(OP_RETURN)
+                    .push_slice(*b"NOTE")
+                    .push_opcode(OP_RETURN)
+                    .into_script(),
+            }],
+        }
+    }
+
+    fn malformed_same_magic_op_return_tx() -> Transaction {
+        Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: Builder::new()
+                    .push_opcode(OP_RETURN)
+                    .push_slice(*b"ALPNnot-da")
+                    .into_script(),
+            }],
+        }
+    }
+
+    fn sps50_checkpoint_like_tx() -> Transaction {
+        let tag = TagDataRef::new(1, 1, &[]).expect("valid checkpoint-like tag");
+        let script_pubkey = ParseConfig::new(test_magic())
+            .encode_script_buf(&tag)
+            .expect("tag script encodes");
+
+        Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey,
+            }],
+        }
+    }
+
+    #[test]
+    fn peek_commit_marker_accepts_exact_marker_at_output_zero() {
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let marker = peek_commit_marker(&commit, test_magic())
+            .expect("marker parse succeeds")
+            .expect("marker");
+        assert_eq!(marker.version(), 0);
+    }
+
+    proptest! {
+        #[test]
+        fn peek_commit_marker_rejects_wrong_magic(wrong_magic in magic_bytes_strategy()) {
+            prop_assume!(wrong_magic != *b"ALPN");
+            let commit = build_commit_tx(MagicBytes::new(wrong_magic), 0, 1, false);
+            prop_assert_eq!(peek_commit_marker(&commit, test_magic()).expect("marker parse succeeds"), None);
+        }
+
+        #[test]
+        fn parse_chunked_envelope_orders_chunks_by_commit_vout(
+            chunk0 in chunk_body_strategy(32),
+            chunk1 in chunk_body_strategy(32),
+        ) {
+            let sequencer_pubkey = test_key(7);
+            let commit = build_commit_tx(test_magic(), 0, 2, false);
+            let commit_txid = commit.compute_txid();
+            let reveal1 = build_reveal_tx(commit_txid, 2, sequencer_pubkey, &chunk1);
+            let reveal0 = build_reveal_tx(commit_txid, 1, sequencer_pubkey, &chunk0);
+
+            let parsed = parse_chunked_envelope(
+                &commit,
+                &[reveal1, reveal0],
+                test_magic(),
+                sequencer_pubkey,
+            )
+            .expect("envelope parses");
+
+            prop_assert_eq!(parsed.commit_txid(), commit_txid);
+            prop_assert_eq!(parsed.chunks(), vec![chunk0, chunk1]);
+        }
+
+        #[test]
+        fn parse_chunked_envelope_rejects_missing_reveal(chunk in chunk_body_strategy(32)) {
+            let sequencer_pubkey = test_key(7);
+            let commit = build_commit_tx(test_magic(), 0, 2, false);
+            let reveal0 = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, &chunk);
+
+            let err = parse_chunked_envelope(&commit, &[reveal0], test_magic(), sequencer_pubkey)
+                .expect_err("missing reveal must fail");
+
+            prop_assert!(
+                matches!(err, ScanError::EnvelopeParse { source: DaParseError::MissingReveal(2), .. }),
+                "expected missing reveal error, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn parse_chunked_envelope_rejects_duplicate_reveal(
+            chunk0 in chunk_body_strategy(32),
+            chunk1 in chunk_body_strategy(32),
+        ) {
+            let sequencer_pubkey = test_key(7);
+            let commit = build_commit_tx(test_magic(), 0, 1, false);
+            let commit_txid = commit.compute_txid();
+            let reveal0 = build_reveal_tx(commit_txid, 1, sequencer_pubkey, &chunk0);
+            let reveal1 = build_reveal_tx(commit_txid, 1, sequencer_pubkey, &chunk1);
+
+            let err = parse_chunked_envelope(
+                &commit,
+                &[reveal0, reveal1],
+                test_magic(),
+                sequencer_pubkey,
+            )
+            .expect_err("duplicate reveal must fail");
+
+            prop_assert!(
+                matches!(err, ScanError::EnvelopeParse { source: DaParseError::DuplicateReveal(1), .. }),
+                "expected duplicate reveal error, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_wrong_sequencer_pubkey() {
+        let sequencer_pubkey = test_key(7);
+        let other_pubkey = test_key(8);
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, other_pubkey, b"chunk");
+
+        let err = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect_err("wrong sequencer pubkey must fail");
+
+        assert!(matches!(err, ScanError::InvalidSequencerPubkey { .. }));
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_unsupported_commit_version() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 1, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+
+        let err = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect_err("unsupported version must fail");
+
+        assert!(matches!(
+            err,
+            ScanError::UnsupportedCommitMarkerVersion { version: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_malformed_commit_marker() {
+        let sequencer_pubkey = test_key(7);
+        let mut commit = build_commit_tx(test_magic(), 0, 1, false);
+        commit.output[0].script_pubkey = malformed_protocol_marker_script();
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+
+        let err = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect_err("malformed commit marker must fail");
+
+        assert!(matches!(err, ScanError::MalformedCommitMarker { .. }));
+    }
+
+    #[test]
+    fn scan_blocks_ignores_unrelated_malformed_op_return() {
+        let sequencer_pubkey = test_key(7);
+        let blocks = vec![block_data(10, vec![unrelated_malformed_op_return_tx()])];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert!(envelopes.is_empty());
+    }
+
+    #[test]
+    fn scan_blocks_ignores_same_magic_non_ee_da_op_return() {
+        let sequencer_pubkey = test_key(7);
+        let blocks = vec![block_data(10, vec![malformed_same_magic_op_return_tx()])];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert!(envelopes.is_empty());
+    }
+
+    #[test]
+    fn scan_blocks_ignores_sps50_checkpoint_like_tx() {
+        let sequencer_pubkey = test_key(7);
+        let blocks = vec![block_data(10, vec![sps50_checkpoint_like_tx()])];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert!(envelopes.is_empty());
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_missing_commit_marker() {
+        let sequencer_pubkey = test_key(7);
+        let mut commit = build_commit_tx(test_magic(), 0, 1, false);
+        commit.output.swap(0, 1);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+
+        let err = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect_err("missing commit marker must fail");
+
+        assert!(matches!(err, ScanError::MissingCommitMarker { .. }));
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_missing_reveal_slots() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 0, false);
+
+        let err = parse_chunked_envelope(&commit, &[], test_magic(), sequencer_pubkey)
+            .expect_err("missing reveal slots must fail");
+
+        assert!(matches!(
+            err,
+            ScanError::EnvelopeParse {
+                source: DaParseError::MissingRevealSlots,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_reveal_spending_multiple_slots() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 2, false);
+        let mut reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let witness = reveal.input[0].witness.clone();
+        reveal.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: commit.compute_txid(),
+                vout: 2,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        });
+
+        let err = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect_err("one reveal spending multiple slots must fail");
+
+        assert!(matches!(
+            err,
+            ScanError::EnvelopeParse {
+                source: DaParseError::RevealMultipleCommitSpends,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_chunked_envelope_rejects_p2tr_change_ambiguity() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 1, true);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+
+        let err = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect_err("ambiguous P2TR change must fail");
+
+        assert!(matches!(
+            err,
+            ScanError::EnvelopeParse {
+                source: DaParseError::AmbiguousTaprootChangeOutput(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn scan_blocks_extracts_commit_and_reveal_from_different_blocks() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let blocks = vec![
+            block_data(10, vec![commit.clone()]),
+            block_data(11, vec![reveal]),
+        ];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), commit.compute_txid());
+        assert_eq!(envelopes[0].chunks(), vec![b"chunk".to_vec()]);
+    }
+
+    #[test]
+    fn scan_blocks_rejects_missing_reveal_after_full_range() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let blocks = vec![block_data(10, vec![commit])];
+
+        let err = scan_blocks(&blocks, test_magic(), sequencer_pubkey)
+            .expect_err("missing reveal must fail after range finalization");
+
+        assert!(matches!(
+            err,
+            ScanError::EnvelopeParse {
+                source: DaParseError::MissingReveal(1),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn scan_blocks_rejects_reveal_spending_slots_from_multiple_commits() {
+        let sequencer_pubkey = test_key(7);
+        let commit0 = build_commit_tx(test_magic(), 0, 1, false);
+        let mut commit1 = build_commit_tx(test_magic(), 0, 1, false);
+        commit1.input[0].sequence = Sequence::MAX;
+        let mut reveal = build_reveal_tx(commit0.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let witness = reveal.input[0].witness.clone();
+        reveal.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: commit1.compute_txid(),
+                vout: 1,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        });
+        let blocks = vec![
+            block_data(10, vec![commit0, commit1]),
+            block_data(11, vec![reveal]),
+        ];
+
+        let err = scan_blocks(&blocks, test_magic(), sequencer_pubkey)
+            .expect_err("multi-commit reveal must fail");
+
+        assert!(matches!(err, ScanError::MultipleRevealCommitSpends { .. }));
+    }
+
+    #[test]
+    fn scan_blocks_scans_reveal_only_blocks() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let reveal_block = bitcoin::Block {
+            header: Header {
+                version: Version::from_consensus(1),
+                prev_blockhash: bitcoin::BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: CompactTarget::from_consensus(0),
+                nonce: 0,
+            },
+            txdata: vec![reveal],
+        };
+        let blocks = vec![
+            block_data(10, vec![commit.clone()]),
+            L1BlockData::new(
+                11,
+                bitcoin::BlockHash::from_byte_array([11; 32]),
+                reveal_block,
+            ),
+        ];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), commit.compute_txid());
+    }
+
+    #[test]
+    fn scan_blocks_ignores_commit_non_reveal_output_spends() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let commit_txid = commit.compute_txid();
+        let reveal = build_reveal_tx(commit_txid, 1, sequencer_pubkey, b"chunk");
+        let change_spend = Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: commit_txid,
+                    vout: 2,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(500),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::all_zeros()),
+            }],
+        };
+        let blocks = vec![
+            block_data(10, vec![commit.clone()]),
+            block_data(11, vec![change_spend, reveal]),
+        ];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), commit_txid);
+        assert_eq!(envelopes[0].chunks(), vec![b"chunk".to_vec()]);
+    }
+
+    #[test]
+    fn parse_chunked_envelope_ignores_non_slot_input_during_authentication() {
+        let sequencer_pubkey = test_key(7);
+        let commit = build_commit_tx(test_magic(), 0, 1, false);
+        let commit_txid = commit.compute_txid();
+        let mut reveal = build_reveal_tx(commit_txid, 1, sequencer_pubkey, b"chunk");
+        reveal.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout: 2,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        });
+
+        let parsed = parse_chunked_envelope(&commit, &[reveal], test_magic(), sequencer_pubkey)
+            .expect("non-slot input does not require DA reveal authentication");
+
+        assert_eq!(parsed.commit_txid(), commit_txid);
+        assert_eq!(parsed.chunks(), vec![b"chunk".to_vec()]);
+    }
+
+    #[test]
+    fn scan_blocks_extracts_btcio_writer_envelope_across_blocks() {
+        let keypair = test_keypair(7);
+        let sequencer_pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
+        let change_address = test_change_address();
+        let config = EnvelopeConfig::new(
+            test_magic(),
+            change_address.clone(),
+            Network::Regtest,
+            FeeRate::from_sat_per_vb_u32(1_000),
+            546,
+            None,
+        );
+        let chunks = vec![b"chunk-0".to_vec(), b"chunk-1".to_vec()];
+        let txs = build_chunked_envelope_txs(
+            &config,
+            &chunks,
+            &test_magic(),
+            DA_BLOB_VERSION,
+            &keypair,
+            vec![test_utxo(&change_address)],
+        )
+        .expect("btcio writer builds envelope");
+        let blocks = vec![
+            block_data(10, vec![txs.commit_tx.clone()]),
+            block_data(11, txs.reveal_txs),
+        ];
+
+        let envelopes =
+            scan_blocks(&blocks, test_magic(), sequencer_pubkey).expect("scan succeeds");
+
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), txs.commit_tx.compute_txid());
+        assert_eq!(envelopes[0].chunks(), chunks);
+    }
+}

--- a/crates/alpen-ee/da/l1-extraction/src/test_utils.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/test_utils.rs
@@ -1,0 +1,210 @@
+use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+use bitcoin::{
+    absolute::LockTime,
+    block::{Header, Version},
+    hashes::{sha256, Hash},
+    opcodes::all::OP_RETURN,
+    pow::CompactTarget,
+    script::Builder,
+    secp256k1::{Parity, XOnlyPublicKey, SECP256K1},
+    taproot::{ControlBlock, LeafVersion, TaprootMerkleBranch},
+    transaction::Version as TxVersion,
+    Amount, Block, BlockHash, OutPoint, ScriptBuf, Sequence, TapNodeHash, Transaction, TxIn,
+    TxMerkleNode, TxOut, Txid, Witness,
+};
+use proptest::{collection, prelude::*};
+use strata_l1_envelope_fmt::builder::EnvelopeScriptBuilder;
+use strata_l1_txfmt::MagicBytes;
+
+use crate::ParsedEnvelope;
+
+const BASE_TIMESTAMP: u64 = 1_700_000_000;
+const BASE_GAS_LIMIT: u64 = 30_000_000;
+const MIN_MULTI_CHUNK_BYTECODE_LEN: usize = 400_000;
+const MAX_MULTI_CHUNK_BYTECODE_LEN: usize = 450_000;
+
+pub(crate) fn build_commit_marker_script(magic: MagicBytes, version: u32) -> ScriptBuf {
+    let mut payload = [0u8; 8];
+    payload[..4].copy_from_slice(magic.as_bytes());
+    payload[4..].copy_from_slice(&version.to_be_bytes());
+
+    Builder::new()
+        .push_opcode(OP_RETURN)
+        .push_slice(payload)
+        .into_script()
+}
+
+pub(crate) fn build_commit_tx(
+    magic: MagicBytes,
+    version: u32,
+    reveal_slots: usize,
+    add_ambiguous_p2tr_change: bool,
+) -> Transaction {
+    let mut output = vec![TxOut {
+        value: Amount::from_sat(0),
+        script_pubkey: build_commit_marker_script(magic, version),
+    }];
+
+    let reveal_key = test_xonly_public_key(3);
+    for _ in 0..reveal_slots {
+        output.push(TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new_p2tr(SECP256K1, reveal_key, None),
+        });
+    }
+
+    output.push(TxOut {
+        value: Amount::from_sat(1_000),
+        script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::all_zeros()),
+    });
+
+    if add_ambiguous_p2tr_change {
+        output.push(TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new_p2tr(SECP256K1, reveal_key, None),
+        });
+    }
+
+    Transaction {
+        version: TxVersion(2),
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output,
+    }
+}
+
+pub(crate) fn build_reveal_tx(
+    commit_txid: Txid,
+    commit_vout: u32,
+    sequencer_pubkey: XOnlyPublicKey,
+    chunk: &[u8],
+) -> Transaction {
+    let control_block = test_control_block(sequencer_pubkey);
+    let reveal_script = EnvelopeScriptBuilder::with_pubkey(&sequencer_pubkey.serialize())
+        .expect("pubkey accepted")
+        .add_envelope(chunk)
+        .expect("envelope payload accepted")
+        .build_without_min_check()
+        .expect("reveal script build succeeds");
+
+    let mut tx = Transaction {
+        version: TxVersion(2),
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout: commit_vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::all_zeros()),
+        }],
+    };
+
+    tx.input[0].witness.push([1u8; 64]);
+    tx.input[0].witness.push(reveal_script);
+    tx.input[0].witness.push(control_block.serialize());
+    tx
+}
+
+pub(crate) fn build_block_with_txs(txs: Vec<Transaction>) -> Block {
+    Block {
+        header: Header {
+            version: Version::from_consensus(1),
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 0,
+        },
+        txdata: txs,
+    }
+}
+
+pub(crate) fn magic_bytes_strategy() -> impl Strategy<Value = [u8; 4]> {
+    any::<[u8; 4]>()
+}
+
+pub(crate) fn chunk_body_strategy(max_len: usize) -> impl Strategy<Value = Vec<u8>> {
+    collection::vec(any::<u8>(), 0..=max_len)
+}
+
+pub(crate) fn make_test_blob(block_num: u64) -> DaBlob {
+    DaBlob {
+        update_seq_no: block_num,
+        evm_header: test_evm_header(block_num),
+        state_diff: Default::default(),
+    }
+}
+
+pub(crate) fn make_multi_chunk_test_blob(
+    block_num: u64,
+    bytecode_len: usize,
+    fill_byte: u8,
+) -> DaBlob {
+    let mut blob = make_test_blob(block_num);
+    blob.state_diff
+        .deployed_bytecodes
+        .insert(Default::default(), vec![fill_byte; bytecode_len].into());
+    blob
+}
+
+pub(crate) fn multi_chunk_bytecode_len_strategy() -> impl Strategy<Value = usize> {
+    MIN_MULTI_CHUNK_BYTECODE_LEN..=MAX_MULTI_CHUNK_BYTECODE_LEN
+}
+
+pub(crate) fn build_parsed_envelope_from_chunk_bytes(chunks: Vec<Vec<u8>>) -> ParsedEnvelope {
+    let txid = Txid::from_byte_array(synthetic_txid_bytes(&chunks));
+    ParsedEnvelope::new(txid, chunks)
+}
+
+fn test_evm_header(block_num: u64) -> EvmHeaderSummary {
+    let block_delta = block_num % 1_000_000;
+    let gas_used = BASE_GAS_LIMIT / 2 + (block_delta % 1_000);
+
+    EvmHeaderSummary {
+        block_num,
+        timestamp: BASE_TIMESTAMP + block_delta,
+        base_fee: 1_000_000_000 + block_delta,
+        gas_used,
+        gas_limit: BASE_GAS_LIMIT + (block_delta % 1_000),
+    }
+}
+
+fn test_xonly_public_key(seed: u8) -> XOnlyPublicKey {
+    use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[seed; 32]).expect("valid secret key");
+    let keypair = Keypair::from_secret_key(&secp, &secret_key);
+    XOnlyPublicKey::from_keypair(&keypair).0
+}
+
+fn test_control_block(internal_key: XOnlyPublicKey) -> ControlBlock {
+    let branch: [TapNodeHash; 0] = [];
+
+    ControlBlock {
+        leaf_version: LeafVersion::TapScript,
+        output_key_parity: Parity::Even,
+        internal_key,
+        merkle_branch: TaprootMerkleBranch::from(branch),
+    }
+}
+
+fn synthetic_txid_bytes(chunks: &[Vec<u8>]) -> [u8; 32] {
+    let mut seed = Vec::new();
+    for chunk in chunks {
+        seed.extend_from_slice(&chunk.len().to_le_bytes());
+        seed.extend_from_slice(chunk);
+    }
+    sha256::Hash::hash(&seed).to_byte_array()
+}

--- a/crates/alpen-ee/da/state-replay/Cargo.toml
+++ b/crates/alpen-ee/da/state-replay/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+edition = "2021"
+name = "alpen-ee-da-state-replay"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[dependencies]
+alpen-ee-da-types.workspace = true
+alpen-reth-statediff.workspace = true
+strata-identifiers.workspace = true
+
+alloy-primitives.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+serde_json.workspace = true
+strata-mpt.workspace = true

--- a/crates/alpen-ee/da/state-replay/src/error.rs
+++ b/crates/alpen-ee/da/state-replay/src/error.rs
@@ -1,0 +1,77 @@
+//! Replay error types.
+
+use alpen_reth_statediff::ReconstructError;
+use strata_identifiers::Buf32;
+
+/// Errors raised while replaying decoded DA blobs.
+#[derive(Debug, thiserror::Error)]
+pub enum ReplayError {
+    /// Genesis replay starts after the first EE DA update.
+    #[error(
+        "genesis replay requires first update_seq_no 0; first blob has update_seq_no {first_update_seq_no}"
+    )]
+    NonGenesisStart { first_update_seq_no: u64 },
+
+    /// The supplied snapshot prestate does not produce its claimed state root.
+    #[error("snapshot root mismatch: expected {expected_state_root}, got {actual_state_root}")]
+    SnapshotRootMismatch {
+        expected_state_root: Buf32,
+        actual_state_root: Buf32,
+    },
+
+    /// The first replayed blob does not match the snapshot update anchor.
+    #[error("snapshot update_seq_no mismatch: expected {expected_update_seq_no}, got {actual_update_seq_no}")]
+    SnapshotUpdateSeqNoMismatch {
+        expected_update_seq_no: u64,
+        actual_update_seq_no: u64,
+    },
+
+    /// The first replayed blob does not follow the snapshot block anchor.
+    #[error("snapshot block anchor mismatch: expected first block > {last_applied_block_num}, got {first_blob_block_num}")]
+    SnapshotBlockAnchorMismatch {
+        last_applied_block_num: u64,
+        first_blob_block_num: u64,
+    },
+
+    /// The reconstructor fails to initialize from the snapshot prestate.
+    #[error("invalid snapshot state: {source}")]
+    InvalidSnapshotState {
+        #[source]
+        source: ReconstructError,
+    },
+
+    /// The DA blob sequence skips an update sequence number.
+    #[error(
+        "blob {blob_index} has update_seq_no gap: expected {expected_update_seq_no}, got {actual_update_seq_no}"
+    )]
+    UpdateSeqNoGap {
+        blob_index: usize,
+        expected_update_seq_no: u64,
+        actual_update_seq_no: u64,
+    },
+
+    /// The DA blob sequence repeats an update sequence number.
+    #[error("blob {blob_index} has duplicate update_seq_no {update_seq_no}")]
+    DuplicateUpdateSeqNo {
+        blob_index: usize,
+        update_seq_no: u64,
+    },
+
+    /// The DA blob sequence does not strictly increase EVM block numbers.
+    #[error(
+        "blob {blob_index} has non-increasing block number: previous={previous_block_num}, current={current_block_num}"
+    )]
+    NonIncreasingBlockNumber {
+        blob_index: usize,
+        previous_block_num: u64,
+        current_block_num: u64,
+    },
+
+    /// The state reconstructor rejects a blob state diff.
+    #[error("failed to apply state diff for blob {blob_index}: {source}")]
+    ApplyDiff {
+        blob_index: usize,
+        #[source]
+        source: ReconstructError,
+    },
+}

--- a/crates/alpen-ee/da/state-replay/src/lib.rs
+++ b/crates/alpen-ee/da/state-replay/src/lib.rs
@@ -1,0 +1,16 @@
+//! Replays decoded EE DA blobs into reconstructed execution state.
+//!
+//! This crate applies the bytecodes present in each replayed DA blob. It does
+//! not prove that an omitted bytecode preimage was previously published on L1;
+//! consumers that need trustless bytecode availability must track preimages
+//! across replay windows.
+
+mod error;
+mod replay;
+mod snapshot;
+mod summary;
+
+pub use error::ReplayError;
+pub use replay::{replay_blobs_from_genesis, replay_blobs_from_snapshot};
+pub use snapshot::ReplayPreStateSnapshot;
+pub use summary::{AppliedExecBlockRange, ReplaySummary};

--- a/crates/alpen-ee/da/state-replay/src/lib.rs
+++ b/crates/alpen-ee/da/state-replay/src/lib.rs
@@ -12,5 +12,5 @@ mod summary;
 
 pub use error::ReplayError;
 pub use replay::{replay_blobs_from_genesis, replay_blobs_from_snapshot};
-pub use snapshot::ReplayPreStateSnapshot;
+pub use snapshot::{ReplayPreStateSnapshot, REPLAY_PRE_STATE_SNAPSHOT_VERSION};
 pub use summary::{AppliedExecBlockRange, ReplaySummary};

--- a/crates/alpen-ee/da/state-replay/src/replay.rs
+++ b/crates/alpen-ee/da/state-replay/src/replay.rs
@@ -63,11 +63,13 @@ pub fn replay_blobs_from_snapshot(
         }
 
         let first_blob_block_num = first.evm_header.block_num;
-        if first_blob_block_num <= snapshot.last_applied_block_num() {
-            return Err(ReplayError::SnapshotBlockAnchorMismatch {
-                last_applied_block_num: snapshot.last_applied_block_num(),
-                first_blob_block_num,
-            });
+        if let Some(last_applied_block_num) = snapshot.last_applied_block_num() {
+            if first_blob_block_num <= last_applied_block_num {
+                return Err(ReplayError::SnapshotBlockAnchorMismatch {
+                    last_applied_block_num,
+                    first_blob_block_num,
+                });
+            }
         }
     }
 
@@ -80,6 +82,7 @@ fn replay_blobs_with_reconstructor(
 ) -> Result<ReplaySummary, ReplayError> {
     let mut previous_update_seq_no: Option<u64> = None;
     let mut previous_block_num: Option<u64> = None;
+    let mut per_blob_state_roots = Vec::with_capacity(blobs.len());
 
     for (blob_index, blob) in blobs.iter().enumerate() {
         if let Some(previous_update_seq_no) = previous_update_seq_no {
@@ -114,12 +117,17 @@ fn replay_blobs_with_reconstructor(
         reconstructor
             .apply_diff(&blob.state_diff)
             .map_err(|source| ReplayError::ApplyDiff { blob_index, source })?;
+        let state_root = reconstructor.compute_state_root_buf32();
+        per_blob_state_roots.push(state_root);
 
         previous_update_seq_no = Some(blob.update_seq_no);
         previous_block_num = Some(current_block_num);
     }
 
-    let final_state_root = reconstructor.compute_state_root_buf32();
+    let final_state_root = per_blob_state_roots
+        .last()
+        .copied()
+        .unwrap_or_else(|| reconstructor.compute_state_root_buf32());
     let final_reconstructor_prestate = reconstructor.to_prestate();
     let applied_evm_headers = blobs.iter().map(|blob| blob.evm_header).collect();
     let applied = match (blobs.first(), blobs.last()) {
@@ -130,6 +138,7 @@ fn replay_blobs_with_reconstructor(
     Ok(ReplaySummary::new(
         applied,
         applied_evm_headers,
+        per_blob_state_roots,
         final_state_root,
         final_reconstructor_prestate,
     ))
@@ -189,6 +198,11 @@ mod tests {
             summary.applied_evm_headers(),
             blobs.iter().map(|blob| blob.evm_header).collect::<Vec<_>>()
         );
+        assert_eq!(summary.per_blob_state_roots().len(), blobs.len());
+        assert_eq!(
+            summary.per_blob_state_roots().last().copied(),
+            Some(summary.final_state_root())
+        );
     }
 
     #[test]
@@ -196,7 +210,7 @@ mod tests {
         let snapshot = ReplayPreStateSnapshot::new(
             Buf32::from([0x42; 32]),
             5,
-            99,
+            Some(99),
             StateReconstructorPreState::default(),
             BTreeMap::new(),
         );
@@ -397,7 +411,7 @@ mod tests {
         ReplayPreStateSnapshot::new(
             prestate_state_root(&reconstructor_prestate),
             next_update_seq_no,
-            last_applied_block_num,
+            Some(last_applied_block_num),
             reconstructor_prestate,
             BTreeMap::new(),
         )

--- a/crates/alpen-ee/da/state-replay/src/replay.rs
+++ b/crates/alpen-ee/da/state-replay/src/replay.rs
@@ -1,0 +1,415 @@
+//! Replay entry points.
+
+use alpen_ee_da_types::DaBlob;
+use alpen_reth_statediff::StateReconstructor;
+
+use crate::{
+    error::ReplayError,
+    snapshot::ReplayPreStateSnapshot,
+    summary::{AppliedExecBlockRange, ReplaySummary},
+};
+
+/// Replays genesis-start ordered DA blobs into an in-memory state reconstructor.
+///
+/// The input must be sorted by [`DaBlob::update_seq_no`] and must start at
+/// update sequence number 0 when non-empty. The caller must pass a reconstructor
+/// initialized from chain-spec genesis; final-root reconstruction is meaningful
+/// only for a complete replay from the first posted EE DA update. Partial-range
+/// replay needs an explicit starting state snapshot, not just a starting root.
+///
+/// Empty input returns the supplied genesis reconstructor's root as the final
+/// state root and no applied range.
+pub fn replay_blobs_from_genesis(
+    reconstructor: StateReconstructor,
+    blobs: &[DaBlob],
+) -> Result<ReplaySummary, ReplayError> {
+    if let Some(first) = blobs.first() {
+        if first.update_seq_no != 0 {
+            return Err(ReplayError::NonGenesisStart {
+                first_update_seq_no: first.update_seq_no,
+            });
+        }
+    }
+
+    replay_blobs_with_reconstructor(reconstructor, blobs)
+}
+
+/// Replays ordered DA blobs from an explicit starting state snapshot.
+///
+/// The snapshot must represent the EE state immediately before the first
+/// supplied blob. The pre-state root is checked before any blob is applied.
+/// Empty input returns the snapshot root as the final state root and no applied
+/// range.
+pub fn replay_blobs_from_snapshot(
+    snapshot: &ReplayPreStateSnapshot,
+    blobs: &[DaBlob],
+) -> Result<ReplaySummary, ReplayError> {
+    let reconstructor = StateReconstructor::from_prestate(snapshot.reconstructor_prestate())
+        .map_err(|source| ReplayError::InvalidSnapshotState { source })?;
+    let actual_state_root = reconstructor.compute_state_root_buf32();
+    if actual_state_root != snapshot.expected_state_root() {
+        return Err(ReplayError::SnapshotRootMismatch {
+            expected_state_root: snapshot.expected_state_root(),
+            actual_state_root,
+        });
+    }
+
+    if let Some(first) = blobs.first() {
+        if first.update_seq_no != snapshot.next_update_seq_no() {
+            return Err(ReplayError::SnapshotUpdateSeqNoMismatch {
+                expected_update_seq_no: snapshot.next_update_seq_no(),
+                actual_update_seq_no: first.update_seq_no,
+            });
+        }
+
+        let first_blob_block_num = first.evm_header.block_num;
+        if first_blob_block_num <= snapshot.last_applied_block_num() {
+            return Err(ReplayError::SnapshotBlockAnchorMismatch {
+                last_applied_block_num: snapshot.last_applied_block_num(),
+                first_blob_block_num,
+            });
+        }
+    }
+
+    replay_blobs_with_reconstructor(reconstructor, blobs)
+}
+
+fn replay_blobs_with_reconstructor(
+    mut reconstructor: StateReconstructor,
+    blobs: &[DaBlob],
+) -> Result<ReplaySummary, ReplayError> {
+    let mut previous_update_seq_no: Option<u64> = None;
+    let mut previous_block_num: Option<u64> = None;
+
+    for (blob_index, blob) in blobs.iter().enumerate() {
+        if let Some(previous_update_seq_no) = previous_update_seq_no {
+            if blob.update_seq_no == previous_update_seq_no {
+                return Err(ReplayError::DuplicateUpdateSeqNo {
+                    blob_index,
+                    update_seq_no: blob.update_seq_no,
+                });
+            }
+
+            let expected_update_seq_no = previous_update_seq_no.saturating_add(1);
+            if blob.update_seq_no != expected_update_seq_no {
+                return Err(ReplayError::UpdateSeqNoGap {
+                    blob_index,
+                    expected_update_seq_no,
+                    actual_update_seq_no: blob.update_seq_no,
+                });
+            }
+        }
+
+        let current_block_num = blob.evm_header.block_num;
+        if let Some(previous_block_num) = previous_block_num {
+            if current_block_num <= previous_block_num {
+                return Err(ReplayError::NonIncreasingBlockNumber {
+                    blob_index,
+                    previous_block_num,
+                    current_block_num,
+                });
+            }
+        }
+
+        reconstructor
+            .apply_diff(&blob.state_diff)
+            .map_err(|source| ReplayError::ApplyDiff { blob_index, source })?;
+
+        previous_update_seq_no = Some(blob.update_seq_no);
+        previous_block_num = Some(current_block_num);
+    }
+
+    let final_state_root = reconstructor.compute_state_root_buf32();
+    let final_reconstructor_prestate = reconstructor.to_prestate();
+    let applied_evm_headers = blobs.iter().map(|blob| blob.evm_header).collect();
+    let applied = match (blobs.first(), blobs.last()) {
+        (Some(first), Some(last)) => Some(AppliedExecBlockRange::new(first, last, blobs.len())),
+        _ => None,
+    };
+
+    Ok(ReplaySummary::new(
+        applied,
+        applied_evm_headers,
+        final_state_root,
+        final_reconstructor_prestate,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+    use alpen_reth_statediff::{StateReconstructor, StateReconstructorPreState};
+    use proptest::prelude::*;
+    use strata_identifiers::Buf32;
+
+    use crate::{
+        replay_blobs_from_genesis, replay_blobs_from_snapshot, ReplayError, ReplayPreStateSnapshot,
+    };
+
+    const MAX_SEQUENCE_INCREMENT_SUM: u64 = 16;
+    const MAX_SEQUENCE_LEN: usize = 8;
+
+    #[test]
+    fn replay_blobs_from_genesis_returns_empty_summary_for_empty_input() {
+        let summary =
+            replay_blobs_from_genesis(genesis_reconstructor(), &[]).expect("replay must succeed");
+        assert_eq!(summary.applied(), None);
+    }
+
+    #[test]
+    fn replay_blobs_from_snapshot_returns_snapshot_root_for_empty_input() {
+        let snapshot = test_snapshot(10, 100);
+
+        let summary = replay_blobs_from_snapshot(&snapshot, &[]).expect("replay must succeed");
+
+        assert_eq!(summary.applied(), None);
+        assert_eq!(summary.final_state_root(), snapshot.expected_state_root());
+        assert_eq!(
+            summary.final_reconstructor_prestate(),
+            snapshot.reconstructor_prestate()
+        );
+    }
+
+    #[test]
+    fn replay_blobs_from_snapshot_applies_valid_partial_sequence() {
+        let snapshot = test_snapshot(5, 99);
+        let blobs = vec![test_blob(5, 100), test_blob(6, 101)];
+
+        let summary = replay_blobs_from_snapshot(&snapshot, &blobs).expect("replay must succeed");
+        let applied = summary.applied().expect("applied range must be populated");
+
+        assert_eq!(applied.count(), 2);
+        assert_eq!(applied.first_update_seq_no(), 5);
+        assert_eq!(applied.last_update_seq_no(), 6);
+        assert_eq!(applied.first_block_num(), 100);
+        assert_eq!(applied.last_block_num(), 101);
+        assert_eq!(
+            summary.applied_evm_headers(),
+            blobs.iter().map(|blob| blob.evm_header).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn replay_blobs_from_snapshot_rejects_root_mismatch() {
+        let snapshot = ReplayPreStateSnapshot::new(
+            Buf32::from([0x42; 32]),
+            5,
+            99,
+            StateReconstructorPreState::default(),
+            BTreeMap::new(),
+        );
+
+        let err =
+            replay_blobs_from_snapshot(&snapshot, &[]).expect_err("replay must reject snapshot");
+
+        match err {
+            ReplayError::SnapshotRootMismatch {
+                expected_state_root,
+                ..
+            } => assert_eq!(expected_state_root, snapshot.expected_state_root()),
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn replay_blobs_from_snapshot_rejects_update_seq_no_mismatch() {
+        let snapshot = test_snapshot(5, 99);
+        let blobs = vec![test_blob(6, 100)];
+
+        let err =
+            replay_blobs_from_snapshot(&snapshot, &blobs).expect_err("replay must reject anchor");
+
+        match err {
+            ReplayError::SnapshotUpdateSeqNoMismatch {
+                expected_update_seq_no,
+                actual_update_seq_no,
+            } => {
+                assert_eq!(expected_update_seq_no, 5);
+                assert_eq!(actual_update_seq_no, 6);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn replay_blobs_from_snapshot_rejects_block_anchor_mismatch() {
+        let snapshot = test_snapshot(5, 100);
+        let blobs = vec![test_blob(5, 100)];
+
+        let err =
+            replay_blobs_from_snapshot(&snapshot, &blobs).expect_err("replay must reject anchor");
+
+        match err {
+            ReplayError::SnapshotBlockAnchorMismatch {
+                last_applied_block_num,
+                first_blob_block_num,
+            } => {
+                assert_eq!(last_applied_block_num, 100);
+                assert_eq!(first_blob_block_num, 100);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn replay_blobs_from_snapshot_rejects_update_seq_no_gap_after_anchor() {
+        let snapshot = test_snapshot(5, 99);
+        let blobs = vec![test_blob(5, 100), test_blob(7, 101)];
+
+        let err =
+            replay_blobs_from_snapshot(&snapshot, &blobs).expect_err("replay must reject gap");
+
+        match err {
+            ReplayError::UpdateSeqNoGap {
+                blob_index,
+                expected_update_seq_no,
+                actual_update_seq_no,
+            } => {
+                assert_eq!(blob_index, 1);
+                assert_eq!(expected_update_seq_no, 6);
+                assert_eq!(actual_update_seq_no, 7);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn replay_blobs_from_genesis_applies_valid_contiguous_sequence(
+            first_block_num in 0u64..=(u64::MAX - MAX_SEQUENCE_INCREMENT_SUM),
+            count in 1usize..=MAX_SEQUENCE_LEN,
+        ) {
+            let blobs = make_contiguous_blobs(first_block_num, count);
+
+            let summary = replay_blobs_from_genesis(genesis_reconstructor(), &blobs).expect("replay must succeed");
+            let applied = summary.applied().expect("applied range must be populated");
+            prop_assert_eq!(applied.count(), count);
+            prop_assert_eq!(applied.first_update_seq_no(), 0);
+            prop_assert_eq!(applied.last_update_seq_no(), count as u64 - 1);
+            prop_assert_eq!(applied.first_block_num(), first_block_num);
+            prop_assert_eq!(applied.last_block_num(), first_block_num + count as u64 - 1);
+        }
+
+        #[test]
+        fn replay_blobs_from_genesis_rejects_non_genesis_start(
+            first_update_seq_no in 1u64..=u64::MAX,
+            first_block_num in any::<u64>(),
+        ) {
+            let blobs = vec![test_blob(first_update_seq_no, first_block_num)];
+
+            let err = replay_blobs_from_genesis(genesis_reconstructor(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::NonGenesisStart { first_update_seq_no: got } => {
+                    prop_assert_eq!(got, first_update_seq_no);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn replay_blobs_from_genesis_rejects_update_seq_no_gap(
+            first_block_num in 0u64..=(u64::MAX - 2),
+        ) {
+            let blobs = vec![
+                test_blob(0, first_block_num),
+                test_blob(2, first_block_num + 1),
+            ];
+
+            let err = replay_blobs_from_genesis(genesis_reconstructor(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::UpdateSeqNoGap { blob_index, expected_update_seq_no, actual_update_seq_no } => {
+                    prop_assert_eq!(blob_index, 1);
+                    prop_assert_eq!(expected_update_seq_no, 1);
+                    prop_assert_eq!(actual_update_seq_no, 2);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn replay_blobs_from_genesis_rejects_duplicate_update_seq_no(
+            first_block_num in 0u64..=(u64::MAX - 2),
+        ) {
+            let blobs = vec![
+                test_blob(0, first_block_num),
+                test_blob(0, first_block_num + 1),
+            ];
+
+            let err = replay_blobs_from_genesis(genesis_reconstructor(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::DuplicateUpdateSeqNo { blob_index, update_seq_no: got } => {
+                    prop_assert_eq!(blob_index, 1);
+                    prop_assert_eq!(got, 0);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn replay_blobs_from_genesis_rejects_non_increasing_block_number(
+            first_block_num in any::<u64>(),
+            non_increase in 0u64..=3,
+        ) {
+            let second_block_num = first_block_num.saturating_sub(non_increase);
+            let blobs = vec![
+                test_blob(0, first_block_num),
+                test_blob(1, second_block_num),
+            ];
+
+            let err = replay_blobs_from_genesis(genesis_reconstructor(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::NonIncreasingBlockNumber { blob_index, .. } => {
+                    prop_assert_eq!(blob_index, 1);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+    }
+
+    fn test_blob(update_seq_no: u64, block_num: u64) -> DaBlob {
+        let gas_used = block_num % 1_000;
+        DaBlob {
+            update_seq_no,
+            evm_header: EvmHeaderSummary {
+                block_num,
+                timestamp: block_num,
+                base_fee: block_num,
+                gas_used,
+                gas_limit: gas_used.saturating_add(1),
+            },
+            state_diff: Default::default(),
+        }
+    }
+
+    fn make_contiguous_blobs(first_block_num: u64, count: usize) -> Vec<DaBlob> {
+        (0..count)
+            .map(|idx| test_blob(idx as u64, first_block_num + idx as u64))
+            .collect()
+    }
+
+    fn test_snapshot(
+        next_update_seq_no: u64,
+        last_applied_block_num: u64,
+    ) -> ReplayPreStateSnapshot {
+        let reconstructor_prestate = StateReconstructorPreState::default();
+        ReplayPreStateSnapshot::new(
+            prestate_state_root(&reconstructor_prestate),
+            next_update_seq_no,
+            last_applied_block_num,
+            reconstructor_prestate,
+            BTreeMap::new(),
+        )
+    }
+
+    fn genesis_reconstructor() -> StateReconstructor {
+        StateReconstructor::new()
+    }
+
+    fn prestate_state_root(reconstructor_prestate: &StateReconstructorPreState) -> Buf32 {
+        StateReconstructor::from_prestate(reconstructor_prestate)
+            .expect("prestate must be valid")
+            .compute_state_root_buf32()
+    }
+}

--- a/crates/alpen-ee/da/state-replay/src/snapshot.rs
+++ b/crates/alpen-ee/da/state-replay/src/snapshot.rs
@@ -7,6 +7,9 @@ use alpen_reth_statediff::StateReconstructorPreState;
 use serde::{Deserialize, Serialize};
 use strata_identifiers::Buf32;
 
+/// Current JSON snapshot format version.
+pub const REPLAY_PRE_STATE_SNAPSHOT_VERSION: u32 = 1;
+
 /// Explicit starting state for partial-range replay.
 ///
 /// The snapshot represents the EE state immediately before
@@ -15,11 +18,14 @@ use strata_identifiers::Buf32;
 /// before the replayed DA range.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplayPreStateSnapshot {
+    version: u32,
     expected_state_root: Buf32,
     next_update_seq_no: u64,
-    last_applied_block_num: u64,
+    last_applied_block_num: Option<u64>,
     reconstructor_prestate: StateReconstructorPreState,
     bytecodes: BTreeMap<B256, Bytes>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ee_account_state_ssz: Option<Vec<u8>>,
 }
 
 impl ReplayPreStateSnapshot {
@@ -27,17 +33,30 @@ impl ReplayPreStateSnapshot {
     pub fn new(
         expected_state_root: Buf32,
         next_update_seq_no: u64,
-        last_applied_block_num: u64,
+        last_applied_block_num: Option<u64>,
         reconstructor_prestate: StateReconstructorPreState,
         bytecodes: BTreeMap<B256, Bytes>,
     ) -> Self {
         Self {
+            version: REPLAY_PRE_STATE_SNAPSHOT_VERSION,
             expected_state_root,
             next_update_seq_no,
             last_applied_block_num,
             reconstructor_prestate,
             bytecodes,
+            ee_account_state_ssz: None,
         }
+    }
+
+    /// Attaches the SSZ-encoded EE account state for published-inner-root comparison.
+    pub fn with_ee_account_state_ssz(mut self, ee_account_state_ssz: Vec<u8>) -> Self {
+        self.ee_account_state_ssz = Some(ee_account_state_ssz);
+        self
+    }
+
+    /// Returns the JSON snapshot format version.
+    pub fn version(&self) -> u32 {
+        self.version
     }
 
     /// Returns the expected root of the pre-state.
@@ -51,7 +70,7 @@ impl ReplayPreStateSnapshot {
     }
 
     /// Returns the last EVM block number applied before this snapshot.
-    pub fn last_applied_block_num(&self) -> u64 {
+    pub fn last_applied_block_num(&self) -> Option<u64> {
         self.last_applied_block_num
     }
 
@@ -63,6 +82,11 @@ impl ReplayPreStateSnapshot {
     /// Returns bytecode preimages for accounts that existed before replay.
     pub fn bytecodes(&self) -> &BTreeMap<B256, Bytes> {
         &self.bytecodes
+    }
+
+    /// Returns the SSZ-encoded EE account state, if the snapshot carries it.
+    pub fn ee_account_state_ssz(&self) -> Option<&[u8]> {
+        self.ee_account_state_ssz.as_deref()
     }
 }
 
@@ -91,10 +115,11 @@ mod tests {
         let snapshot = ReplayPreStateSnapshot::new(
             Buf32::from([0x33; 32]),
             9,
-            123,
+            Some(123),
             reconstructor_prestate,
             BTreeMap::from([(B256::from([0x44; 32]), Bytes::from_static(b"bytecode"))]),
-        );
+        )
+        .with_ee_account_state_ssz(vec![0xaa, 0xbb]);
 
         let encoded = serde_json::to_string(&snapshot).expect("snapshot must serialize");
         let decoded: ReplayPreStateSnapshot =

--- a/crates/alpen-ee/da/state-replay/src/snapshot.rs
+++ b/crates/alpen-ee/da/state-replay/src/snapshot.rs
@@ -1,0 +1,105 @@
+//! Replay pre-state snapshot types.
+
+use std::collections::BTreeMap;
+
+use alloy_primitives::{Bytes, B256};
+use alpen_reth_statediff::StateReconstructorPreState;
+use serde::{Deserialize, Serialize};
+use strata_identifiers::Buf32;
+
+/// Explicit starting state for partial-range replay.
+///
+/// The snapshot represents the EE state immediately before
+/// [`ReplayPreStateSnapshot::next_update_seq_no`]. It carries the canonical
+/// reconstructor prestate plus bytecode preimages for accounts that existed
+/// before the replayed DA range.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayPreStateSnapshot {
+    expected_state_root: Buf32,
+    next_update_seq_no: u64,
+    last_applied_block_num: u64,
+    reconstructor_prestate: StateReconstructorPreState,
+    bytecodes: BTreeMap<B256, Bytes>,
+}
+
+impl ReplayPreStateSnapshot {
+    /// Creates an explicit starting state snapshot for partial replay.
+    pub fn new(
+        expected_state_root: Buf32,
+        next_update_seq_no: u64,
+        last_applied_block_num: u64,
+        reconstructor_prestate: StateReconstructorPreState,
+        bytecodes: BTreeMap<B256, Bytes>,
+    ) -> Self {
+        Self {
+            expected_state_root,
+            next_update_seq_no,
+            last_applied_block_num,
+            reconstructor_prestate,
+            bytecodes,
+        }
+    }
+
+    /// Returns the expected root of the pre-state.
+    pub fn expected_state_root(&self) -> Buf32 {
+        self.expected_state_root
+    }
+
+    /// Returns the first update sequence number accepted by this snapshot.
+    pub fn next_update_seq_no(&self) -> u64 {
+        self.next_update_seq_no
+    }
+
+    /// Returns the last EVM block number applied before this snapshot.
+    pub fn last_applied_block_num(&self) -> u64 {
+        self.last_applied_block_num
+    }
+
+    /// Returns the reconstructor prestate used to initialize replay.
+    pub fn reconstructor_prestate(&self) -> &StateReconstructorPreState {
+        &self.reconstructor_prestate
+    }
+
+    /// Returns bytecode preimages for accounts that existed before replay.
+    pub fn bytecodes(&self) -> &BTreeMap<B256, Bytes> {
+        &self.bytecodes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use strata_mpt::{StateAccount, EMPTY_ROOT};
+
+    use super::*;
+
+    #[test]
+    fn replay_pre_state_snapshot_json_roundtrips() {
+        let address = Address::from([0x11; 20]);
+        let slot_key = U256::from(1);
+        let slot_value = U256::from(2);
+        let account = StateAccount {
+            nonce: 7,
+            balance: U256::from(100),
+            storage_root: EMPTY_ROOT,
+            code_hash: B256::from([0x22; 32]),
+        };
+        let reconstructor_prestate = StateReconstructorPreState::new(
+            BTreeMap::from([(address, account)]),
+            BTreeMap::from([(address, BTreeMap::from([(slot_key, slot_value)]))]),
+        );
+        let snapshot = ReplayPreStateSnapshot::new(
+            Buf32::from([0x33; 32]),
+            9,
+            123,
+            reconstructor_prestate,
+            BTreeMap::from([(B256::from([0x44; 32]), Bytes::from_static(b"bytecode"))]),
+        );
+
+        let encoded = serde_json::to_string(&snapshot).expect("snapshot must serialize");
+        let decoded: ReplayPreStateSnapshot =
+            serde_json::from_str(&encoded).expect("snapshot must deserialize");
+
+        assert_eq!(decoded, snapshot);
+    }
+}

--- a/crates/alpen-ee/da/state-replay/src/summary.rs
+++ b/crates/alpen-ee/da/state-replay/src/summary.rs
@@ -58,6 +58,8 @@ pub struct ReplaySummary {
     applied: Option<AppliedExecBlockRange>,
     #[serde(skip)]
     applied_evm_headers: Vec<EvmHeaderSummary>,
+    #[serde(skip)]
+    per_blob_state_roots: Vec<Buf32>,
     final_state_root: Buf32,
     #[serde(skip)]
     final_reconstructor_prestate: StateReconstructorPreState,
@@ -67,12 +69,14 @@ impl ReplaySummary {
     pub(crate) fn new(
         applied: Option<AppliedExecBlockRange>,
         applied_evm_headers: Vec<EvmHeaderSummary>,
+        per_blob_state_roots: Vec<Buf32>,
         final_state_root: Buf32,
         final_reconstructor_prestate: StateReconstructorPreState,
     ) -> Self {
         Self {
             applied,
             applied_evm_headers,
+            per_blob_state_roots,
             final_state_root,
             final_reconstructor_prestate,
         }
@@ -86,6 +90,11 @@ impl ReplaySummary {
     /// Returns the EVM header summaries for each applied DA blob.
     pub fn applied_evm_headers(&self) -> &[EvmHeaderSummary] {
         &self.applied_evm_headers
+    }
+
+    /// Returns the reconstructed execution state root after each applied blob.
+    pub fn per_blob_state_roots(&self) -> &[Buf32] {
+        &self.per_blob_state_roots
     }
 
     /// Returns the reconstructed final state root.

--- a/crates/alpen-ee/da/state-replay/src/summary.rs
+++ b/crates/alpen-ee/da/state-replay/src/summary.rs
@@ -1,0 +1,100 @@
+//! Replay output summary types.
+
+use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+use alpen_reth_statediff::StateReconstructorPreState;
+use serde::Serialize;
+use strata_identifiers::Buf32;
+
+/// Range of EVM execution blocks applied during replay.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AppliedExecBlockRange {
+    first_update_seq_no: u64,
+    last_update_seq_no: u64,
+    first_block_num: u64,
+    last_block_num: u64,
+    count: usize,
+}
+
+impl AppliedExecBlockRange {
+    pub(crate) fn new(first: &DaBlob, last: &DaBlob, count: usize) -> Self {
+        Self {
+            first_update_seq_no: first.update_seq_no,
+            last_update_seq_no: last.update_seq_no,
+            first_block_num: first.evm_header.block_num,
+            last_block_num: last.evm_header.block_num,
+            count,
+        }
+    }
+
+    /// Returns the first applied EE DA update sequence number.
+    pub fn first_update_seq_no(&self) -> u64 {
+        self.first_update_seq_no
+    }
+
+    /// Returns the last applied EE DA update sequence number.
+    pub fn last_update_seq_no(&self) -> u64 {
+        self.last_update_seq_no
+    }
+
+    /// Returns the first applied EVM block number.
+    pub fn first_block_num(&self) -> u64 {
+        self.first_block_num
+    }
+
+    /// Returns the last applied EVM block number.
+    pub fn last_block_num(&self) -> u64 {
+        self.last_block_num
+    }
+
+    /// Returns the number of DA blobs applied.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+/// Replay-stage output summary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReplaySummary {
+    applied: Option<AppliedExecBlockRange>,
+    #[serde(skip)]
+    applied_evm_headers: Vec<EvmHeaderSummary>,
+    final_state_root: Buf32,
+    #[serde(skip)]
+    final_reconstructor_prestate: StateReconstructorPreState,
+}
+
+impl ReplaySummary {
+    pub(crate) fn new(
+        applied: Option<AppliedExecBlockRange>,
+        applied_evm_headers: Vec<EvmHeaderSummary>,
+        final_state_root: Buf32,
+        final_reconstructor_prestate: StateReconstructorPreState,
+    ) -> Self {
+        Self {
+            applied,
+            applied_evm_headers,
+            final_state_root,
+            final_reconstructor_prestate,
+        }
+    }
+
+    /// Returns the applied EVM block range, if any DA blobs were replayed.
+    pub fn applied(&self) -> Option<&AppliedExecBlockRange> {
+        self.applied.as_ref()
+    }
+
+    /// Returns the EVM header summaries for each applied DA blob.
+    pub fn applied_evm_headers(&self) -> &[EvmHeaderSummary] {
+        &self.applied_evm_headers
+    }
+
+    /// Returns the reconstructed final state root.
+    pub fn final_state_root(&self) -> Buf32 {
+        self.final_state_root
+    }
+
+    /// Returns the final canonical reconstructor prestate after replay.
+    pub fn final_reconstructor_prestate(&self) -> &StateReconstructorPreState {
+        &self.final_reconstructor_prestate
+    }
+}

--- a/crates/alpen-ee/da/types/src/commit_reveal.rs
+++ b/crates/alpen-ee/da/types/src/commit_reveal.rs
@@ -27,12 +27,18 @@ pub enum DaParseError {
     RevealWrongCommit,
     #[error("DA reveal spends commit output 0, which is the OP_RETURN marker")]
     RevealSpendsMarker,
+    #[error("DA reveal spends multiple outputs of the DA commit tx")]
+    RevealMultipleCommitSpends,
+    #[error("DA commit has no reveal slots")]
+    MissingRevealSlots,
     #[error("duplicate DA reveal for commit output {0}")]
     DuplicateReveal(u32),
     #[error("unexpected DA reveal for commit output {0}")]
     UnexpectedReveal(u32),
     #[error("missing DA reveal for commit output {0}")]
     MissingReveal(u32),
+    #[error("ambiguous P2TR change output at commit output {0}")]
+    AmbiguousTaprootChangeOutput(u32),
     #[error("DA reveal envelope parse failed: {0}")]
     RevealEnvelope(#[from] EnvelopeParseError),
 }
@@ -67,26 +73,20 @@ pub fn extract_da_chunks<'a>(
 
     let commit = commit.ok_or(DaParseError::MissingCommit)?;
     let commit_txid = commit.compute_txid();
-    let last_reveal_vout = last_commit_reveal_vout(commit);
+    let last_reveal_vout =
+        last_commit_reveal_vout(commit)?.ok_or(DaParseError::MissingRevealSlots)?;
 
     let mut chunks_by_vout = BTreeMap::new();
     for tx in non_commit_txs {
-        let (vout, chunk) = extract_reveal_chunk(tx, commit_txid)?;
-        // A reveal beyond the contiguous P2TR run or any reveal at all when
-        // the commit has no reveal outputs, is unexpected.
-        if !matches!(last_reveal_vout, Some(last) if vout <= last) {
-            return Err(DaParseError::UnexpectedReveal(vout));
-        }
+        let (vout, chunk) = extract_reveal_chunk(tx, commit_txid, last_reveal_vout)?;
         if chunks_by_vout.insert(vout, chunk).is_some() {
             return Err(DaParseError::DuplicateReveal(vout));
         }
     }
 
-    if let Some(last_reveal_vout) = last_reveal_vout {
-        for expected_vout in 1..=last_reveal_vout {
-            if !chunks_by_vout.contains_key(&expected_vout) {
-                return Err(DaParseError::MissingReveal(expected_vout));
-            }
+    for expected_vout in 1..=last_reveal_vout {
+        if !chunks_by_vout.contains_key(&expected_vout) {
+            return Err(DaParseError::MissingReveal(expected_vout));
         }
     }
 
@@ -98,19 +98,37 @@ pub fn extract_da_chunks<'a>(
 ///
 /// Scans outputs starting at vout 1 (vout 0 is the OP_RETURN marker) and
 /// returns the last vout of the contiguous P2TR run.
-fn last_commit_reveal_vout(commit: &Transaction) -> Option<u32> {
-    commit
-        .output
-        .iter()
-        .enumerate()
-        .skip(1)
-        .take_while(|(_, output)| output.script_pubkey.is_p2tr())
-        .map(|(idx, _)| idx as u32)
-        .last()
+pub fn last_commit_reveal_vout(commit: &Transaction) -> Result<Option<u32>, DaParseError> {
+    let mut last_reveal_vout = None;
+    let mut reveal_run_closed = false;
+
+    for (idx, output) in commit.output.iter().enumerate().skip(1) {
+        if output.script_pubkey.is_p2tr() {
+            if reveal_run_closed {
+                return Err(DaParseError::AmbiguousTaprootChangeOutput(idx as u32));
+            }
+            last_reveal_vout = Some(idx as u32);
+        } else {
+            reveal_run_closed = true;
+        }
+    }
+
+    Ok(last_reveal_vout)
+}
+
+/// Returns whether `vout` is inside a commit transaction's reveal-slot range.
+///
+/// Returns `false` when the commit has no reveal slots.
+pub fn is_reveal_slot(vout: u32, last_reveal_vout: Option<u32>) -> bool {
+    matches!(last_reveal_vout, Some(last) if (1..=last).contains(&vout))
 }
 
 /// Reads the 8-byte OP_RETURN marker payload (`magic || version`) from a
 /// commit transaction's vout-0 output, if present.
+///
+/// Callers scanning arbitrary L1 traffic should pre-filter by magic to avoid
+/// spurious [`DaParseError::MalformedCommitMarker`] errors on unrelated
+/// OP_RETURN protocols.
 ///
 /// Returns:
 /// - `Ok(Some([u8; 8]))` if the first output is a well-formed OP_RETURN with exactly 8 pushed bytes
@@ -146,18 +164,38 @@ pub fn read_commit_marker_payload(tx: &Transaction) -> Result<Option<[u8; 8]>, D
 fn extract_reveal_chunk(
     reveal: &Transaction,
     commit_txid: Txid,
+    last_reveal_vout: u32,
 ) -> Result<(u32, Vec<u8>), DaParseError> {
-    let input = reveal
-        .input
-        .first()
-        .ok_or(DaParseError::RevealMissingInputs)?;
-    if input.previous_output.txid != commit_txid {
-        return Err(DaParseError::RevealWrongCommit);
+    if reveal.input.is_empty() {
+        return Err(DaParseError::RevealMissingInputs);
     }
+
+    let mut matching_input = None;
+    let mut unexpected_vout = None;
+    for input in &reveal.input {
+        if input.previous_output.txid != commit_txid {
+            continue;
+        }
+        let vout = input.previous_output.vout;
+        if vout == 0 {
+            return Err(DaParseError::RevealSpendsMarker);
+        }
+        if !is_reveal_slot(vout, Some(last_reveal_vout)) {
+            unexpected_vout.get_or_insert(vout);
+            continue;
+        }
+        if matching_input.replace(input).is_some() {
+            return Err(DaParseError::RevealMultipleCommitSpends);
+        }
+    }
+
+    let input = matching_input.ok_or_else(|| {
+        unexpected_vout.map_or(
+            DaParseError::RevealWrongCommit,
+            DaParseError::UnexpectedReveal,
+        )
+    })?;
     let vout = input.previous_output.vout;
-    if vout == 0 {
-        return Err(DaParseError::RevealSpendsMarker);
-    }
 
     let leaf = input
         .witness
@@ -167,4 +205,141 @@ fn extract_reveal_chunk(
     let chunk = parse_envelope_payload(&script)?;
 
     Ok((vout, chunk))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime,
+        hashes::Hash,
+        opcodes::all::OP_RETURN,
+        script::Builder,
+        secp256k1::{Keypair, Parity, Secp256k1, SecretKey, XOnlyPublicKey},
+        taproot::{ControlBlock, LeafVersion, TapNodeHash, TaprootMerkleBranch},
+        transaction::Version,
+        Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    };
+    use strata_l1_envelope_fmt::builder::EnvelopeScriptBuilder;
+
+    use super::*;
+
+    fn txid(seed: u8) -> Txid {
+        Txid::from_byte_array([seed; 32])
+    }
+
+    fn test_key(seed: u8) -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[seed; 32]).expect("valid secret key");
+        let keypair = Keypair::from_secret_key(&secp, &secret_key);
+        XOnlyPublicKey::from_keypair(&keypair).0
+    }
+
+    fn test_control_block(internal_key: XOnlyPublicKey) -> ControlBlock {
+        let branch: [TapNodeHash; 0] = [];
+
+        ControlBlock {
+            leaf_version: LeafVersion::TapScript,
+            output_key_parity: Parity::Even,
+            internal_key,
+            merkle_branch: TaprootMerkleBranch::from(branch),
+        }
+    }
+
+    fn reveal_script(chunk: &[u8]) -> ScriptBuf {
+        let sequencer_pubkey = test_key(7);
+        EnvelopeScriptBuilder::with_pubkey(&sequencer_pubkey.serialize())
+            .expect("pubkey accepted")
+            .add_envelope(chunk)
+            .expect("envelope payload accepted")
+            .build_without_min_check()
+            .expect("reveal script build succeeds")
+    }
+
+    fn reveal_input(commit_txid: Txid, vout: u32, chunk: Option<&[u8]>) -> TxIn {
+        let mut witness = Witness::new();
+        if let Some(chunk) = chunk {
+            let sequencer_pubkey = test_key(7);
+            witness.push([1u8; 64]);
+            witness.push(reveal_script(chunk));
+            witness.push(test_control_block(sequencer_pubkey).serialize());
+        }
+
+        TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        }
+    }
+
+    fn reveal_tx(inputs: Vec<TxIn>) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: inputs,
+            output: vec![TxOut {
+                value: Amount::from_sat(1000),
+                script_pubkey: Builder::new().push_opcode(OP_RETURN).into_script(),
+            }],
+        }
+    }
+
+    #[test]
+    fn extract_reveal_chunk_ignores_out_of_range_commit_input() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![
+            reveal_input(commit_txid, 1, Some(b"chunk")),
+            reveal_input(commit_txid, 2, None),
+        ]);
+
+        let (vout, chunk) = extract_reveal_chunk(&tx, commit_txid, 1).expect("valid reveal");
+
+        assert_eq!(vout, 1);
+        assert_eq!(chunk, b"chunk");
+    }
+
+    #[test]
+    fn extract_reveal_chunk_rejects_only_out_of_range_commit_input() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![reveal_input(commit_txid, 2, None)]);
+
+        let error = extract_reveal_chunk(&tx, commit_txid, 1).expect_err("unexpected reveal");
+
+        assert!(matches!(error, DaParseError::UnexpectedReveal(2)));
+    }
+
+    #[test]
+    fn extract_reveal_chunk_rejects_multiple_slot_inputs() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![
+            reveal_input(commit_txid, 1, None),
+            reveal_input(commit_txid, 2, None),
+        ]);
+
+        let error = extract_reveal_chunk(&tx, commit_txid, 2).expect_err("multiple slot inputs");
+
+        assert!(matches!(error, DaParseError::RevealMultipleCommitSpends));
+    }
+
+    #[test]
+    fn extract_reveal_chunk_rejects_marker_spend() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![reveal_input(commit_txid, 0, None)]);
+
+        let error = extract_reveal_chunk(&tx, commit_txid, 1).expect_err("marker spend");
+
+        assert!(matches!(error, DaParseError::RevealSpendsMarker));
+    }
+
+    #[test]
+    fn extract_reveal_chunk_rejects_wrong_commit() {
+        let tx = reveal_tx(vec![reveal_input(txid(2), 1, None)]);
+
+        let error = extract_reveal_chunk(&tx, txid(1), 1).expect_err("wrong commit");
+
+        assert!(matches!(error, DaParseError::RevealWrongCommit));
+    }
 }

--- a/crates/alpen-ee/da/types/src/lib.rs
+++ b/crates/alpen-ee/da/types/src/lib.rs
@@ -17,7 +17,10 @@ pub use bitcoin_merkle::{
     compute_bitcoin_merkle_root_from_proof, hash_pair_sha256d, wtxid_leaves, wtxids_root_from_txs,
 };
 pub use blob::{reassemble_da_blob, DaBlob, EvmHeaderSummary, DA_BLOB_VERSION, EE_DA_MAGIC_BYTES};
-pub use commit_reveal::{extract_da_chunks, read_commit_marker_payload, DaParseError};
+pub use commit_reveal::{
+    extract_da_chunks, is_reveal_slot, last_commit_reveal_vout, read_commit_marker_payload,
+    DaParseError,
+};
 pub use dedup_witness::{
     ArchivedBytecodePreimage, ArchivedDedupWitness, BytecodePreimage, DedupWitness,
 };

--- a/crates/reth/statediff/Cargo.toml
+++ b/crates/reth/statediff/Cargo.toml
@@ -16,6 +16,7 @@ rsp-mpt.workspace = true
 serde.workspace = true
 strata-codec.workspace = true
 strata-da-framework.workspace = true
+strata-identifiers.workspace = true
 strata-mpt.workspace = true
 thiserror.workspace = true
 

--- a/crates/reth/statediff/src/lib.rs
+++ b/crates/reth/statediff/src/lib.rs
@@ -64,6 +64,7 @@ pub use batch::{AccountChange, AccountDiff, BatchBuilder, BatchStateDiff, Storag
 pub use block::{AccountSnapshot, BlockAccountChange, BlockStateChanges, BlockStorageDiff};
 pub use reconstruct::{
     apply_batch_state_diff_to_ethereum_state, ReconstructError, StateReconstructor,
+    StateReconstructorPreState,
 };
 #[cfg(feature = "serde")]
 pub use serde_impl::{AccountChangeSerde, AccountDiffSerde, BatchStateDiffSerde};

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -8,6 +8,7 @@ use revm_primitives::{alloy_primitives::Address, B256, U256};
 use rsp_mpt::EthereumState;
 use serde::{Deserialize, Serialize};
 use strata_da_framework::ContextlessDaWrite;
+use strata_identifiers::Buf32;
 #[cfg(feature = "chainspec")]
 use strata_mpt::KECCAK_EMPTY;
 use strata_mpt::{keccak, MptNode, StateAccount, EMPTY_ROOT};
@@ -323,6 +324,12 @@ impl StateReconstructor {
     /// Computes the current state root.
     pub fn compute_state_root(&self) -> B256 {
         self.state_trie.hash()
+    }
+
+    /// Computes the current state root as a [`Buf32`].
+    pub fn compute_state_root_buf32(&self) -> Buf32 {
+        let state_root: [u8; 32] = self.compute_state_root().into();
+        Buf32::from(state_root)
     }
 
     /// Computes the current storage root for an account.

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -1,26 +1,24 @@
 //! State reconstruction from batch diffs.
 
-#[cfg(test)]
-use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[cfg(feature = "chainspec")]
 use alpen_chainspec::chain_value_parser;
 use revm_primitives::{alloy_primitives::Address, B256, U256};
 use rsp_mpt::EthereumState;
+use serde::{Deserialize, Serialize};
 use strata_da_framework::ContextlessDaWrite;
 #[cfg(feature = "chainspec")]
 use strata_mpt::KECCAK_EMPTY;
 use strata_mpt::{keccak, MptNode, StateAccount, EMPTY_ROOT};
-use thiserror::Error as ThisError;
 
 use crate::{
-    batch::{AccountChange, BatchStateDiff},
+    batch::{AccountChange, BatchStateDiff, StorageDiff},
     block::AccountSnapshot,
 };
 
 /// Error that may occur during state reconstruction.
-#[derive(Debug, ThisError)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReconstructError {
     #[error("MPT: {0}")]
     Mpt(#[from] strata_mpt::Error),
@@ -30,14 +28,61 @@ pub enum ReconstructError {
     Da(#[from] strata_da_framework::DaError),
 }
 
+/// Canonical account and storage state used to initialize a [`StateReconstructor`].
+///
+/// The prestate stores account records separately from per-account storage. During
+/// initialization, the reconstructor recomputes each account's storage root from the
+/// supplied storage map before inserting the account into the global state trie.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateReconstructorPreState {
+    accounts: BTreeMap<Address, StateAccount>,
+    storage: BTreeMap<Address, BTreeMap<U256, U256>>,
+}
+
+impl StateReconstructorPreState {
+    /// Creates a prestate from canonical account and storage state.
+    pub fn new(
+        accounts: BTreeMap<Address, StateAccount>,
+        storage: BTreeMap<Address, BTreeMap<U256, U256>>,
+    ) -> Self {
+        Self { accounts, storage }
+    }
+
+    /// Returns the canonical account records keyed by address.
+    pub fn accounts(&self) -> &BTreeMap<Address, StateAccount> {
+        &self.accounts
+    }
+
+    /// Returns the canonical storage slots keyed by address and slot.
+    pub fn storage(&self) -> &BTreeMap<Address, BTreeMap<U256, U256>> {
+        &self.storage
+    }
+
+    /// Consumes the prestate and returns its canonical account and storage parts.
+    pub fn into_parts(
+        self,
+    ) -> (
+        BTreeMap<Address, StateAccount>,
+        BTreeMap<Address, BTreeMap<U256, U256>>,
+    ) {
+        (self.accounts, self.storage)
+    }
+}
+
 /// Reconstructs EVM state by applying [`BatchStateDiff`]s sequentially.
 ///
 /// Used primarily for testing to verify that state roots reconstructed
 /// from diffs match the actual state roots from EE blocks.
+///
+/// Maintains canonical account and storage maps alongside the MPTs to support
+/// cheap export through [`StateReconstructor::to_prestate`]. This roughly doubles
+/// state memory, and every mutation must keep the maps and MPTs in lock-step.
 #[derive(Clone, Default, Debug)]
 pub struct StateReconstructor {
     state_trie: MptNode,
     storage_trie: HashMap<Address, MptNode>,
+    accounts: BTreeMap<Address, StateAccount>,
+    storage: BTreeMap<Address, BTreeMap<U256, U256>>,
 }
 
 impl StateReconstructor {
@@ -66,22 +111,100 @@ impl StateReconstructor {
 
             if let Some(slots) = &account.storage {
                 if !slots.is_empty() {
-                    let acc_storage_trie = reconstructor.storage_trie.entry(*address).or_default();
-                    for (slot_key, slot_value) in slots.iter() {
-                        if slot_value != &B256::ZERO {
-                            acc_storage_trie.insert_rlp(&keccak(slot_key), *slot_value)?;
+                    let (storage_root, storage_trie_is_empty, acc_storage_is_empty) = {
+                        let acc_storage_trie =
+                            reconstructor.storage_trie.entry(*address).or_default();
+                        let acc_storage = reconstructor.storage.entry(*address).or_default();
+                        for (slot_key, slot_value) in slots.iter() {
+                            if slot_value != &B256::ZERO {
+                                // Chain specs key storage as raw 32-byte words; prestates use
+                                // U256 to match state-diff storage keys.
+                                let slot_key = U256::from_be_bytes(slot_key.0);
+                                let slot_value = U256::from_be_bytes(slot_value.0);
+                                acc_storage_trie.insert_rlp(
+                                    &keccak(slot_key.to_be_bytes::<32>()),
+                                    slot_value,
+                                )?;
+                                acc_storage.insert(slot_key, slot_value);
+                            }
                         }
+                        (
+                            acc_storage_trie.hash(),
+                            acc_storage_trie.is_empty(),
+                            acc_storage.is_empty(),
+                        )
+                    };
+
+                    state_account.storage_root = storage_root;
+                    if acc_storage_is_empty {
+                        reconstructor.storage.remove(address);
                     }
-                    state_account.storage_root = acc_storage_trie.hash();
+                    if storage_trie_is_empty {
+                        reconstructor.storage_trie.remove(address);
+                    }
                 }
             }
 
             reconstructor
                 .state_trie
-                .insert_rlp(&keccak(address), state_account)?;
+                .insert_rlp(&keccak(address), state_account.clone())?;
+            reconstructor.accounts.insert(*address, state_account);
         }
 
         Ok(reconstructor)
+    }
+
+    /// Creates a reconstructor initialized with explicit canonical state.
+    ///
+    /// Empty accounts are skipped during initialization. Each account's storage root
+    /// is recomputed from the prestate's storage map before the account is inserted
+    /// into the state trie.
+    pub fn from_prestate(prestate: &StateReconstructorPreState) -> Result<Self, ReconstructError> {
+        let mut reconstructor = Self::new();
+
+        for (address, account) in prestate.accounts() {
+            let mut state_account = account.clone();
+            if state_account.is_account_empty() {
+                continue;
+            }
+
+            let mut storage_trie = MptNode::default();
+            let mut account_storage = BTreeMap::new();
+
+            if let Some(prestate_storage) = prestate.storage().get(address) {
+                for (slot_key, slot_value) in prestate_storage {
+                    if slot_value.is_zero() {
+                        continue;
+                    }
+
+                    storage_trie.insert_rlp(&keccak(slot_key.to_be_bytes::<32>()), *slot_value)?;
+                    account_storage.insert(*slot_key, *slot_value);
+                }
+            }
+
+            state_account.storage_root = storage_trie.hash();
+            if !storage_trie.is_empty() {
+                reconstructor.storage_trie.insert(*address, storage_trie);
+            }
+            if !account_storage.is_empty() {
+                reconstructor.storage.insert(*address, account_storage);
+            }
+
+            reconstructor
+                .state_trie
+                .insert_rlp(&keccak(address), state_account.clone())?;
+            reconstructor.accounts.insert(*address, state_account);
+        }
+
+        Ok(reconstructor)
+    }
+
+    /// Exports the current canonical state as a reconstructor prestate.
+    ///
+    /// Empty accounts and zero-valued storage slots are not represented in the
+    /// returned prestate.
+    pub fn to_prestate(&self) -> StateReconstructorPreState {
+        StateReconstructorPreState::new(self.accounts.clone(), self.storage.clone())
     }
 
     /// Applies a [`BatchStateDiff`] to the current state.
@@ -92,10 +215,7 @@ impl StateReconstructor {
             match change {
                 AccountChange::Created(account_diff) | AccountChange::Updated(account_diff) => {
                     // Get current account state (if exists)
-                    let current: Option<StateAccount> = self
-                        .state_trie
-                        .get_rlp(&acc_info_trie_path)
-                        .unwrap_or_default();
+                    let current = self.accounts.get(address).cloned();
 
                     // Build snapshot from current state and apply diff
                     let mut snapshot = current
@@ -118,35 +238,24 @@ impl StateReconstructor {
                     }
 
                     // Calculate storage root
-                    state_account.storage_root = {
-                        let acc_storage_trie = self.storage_trie.entry(*address).or_default();
-                        if let Some(storage_diff) = diff.storage.get(address) {
-                            for (slot_key, slot_value) in storage_diff.iter() {
-                                let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
-                                match slot_value {
-                                    Some(v) if !v.is_zero() => {
-                                        acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
-                                    }
-                                    _ => {
-                                        acc_storage_trie.delete(&slot_trie_path)?;
-                                    }
-                                }
-                            }
-                        }
-                        acc_storage_trie.hash()
+                    state_account.storage_root = match diff.storage.get(address) {
+                        Some(storage_diff) => self.apply_storage_diff(*address, storage_diff)?,
+                        None => self.compute_storage_root(*address),
                     };
 
                     self.state_trie
-                        .insert_rlp(&acc_info_trie_path, state_account)?;
+                        .insert_rlp(&acc_info_trie_path, state_account.clone())?;
+                    self.accounts.insert(*address, state_account);
                 }
                 AccountChange::Deleted => {
                     self.state_trie.delete(&acc_info_trie_path)?;
                     self.storage_trie.remove(address);
+                    self.accounts.remove(address);
+                    self.storage.remove(address);
                 }
             }
         }
 
-        // Handle storage changes for accounts not in accounts map
         // (e.g., storage-only changes)
         for (address, storage_diff) in &diff.storage {
             if diff.accounts.contains_key(address) {
@@ -154,40 +263,70 @@ impl StateReconstructor {
             }
 
             let acc_info_trie_path = keccak(address);
-            let current: Option<StateAccount> = self
-                .state_trie
-                .get_rlp(&acc_info_trie_path)
-                .unwrap_or_default();
+            let current = self.accounts.get(address).cloned();
 
             if let Some(mut state_account) = current {
-                let acc_storage_trie = self.storage_trie.entry(*address).or_default();
-                for (slot_key, slot_value) in storage_diff.iter() {
-                    let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
-                    match slot_value {
-                        Some(v) if !v.is_zero() => {
-                            acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
-                        }
-                        _ => {
-                            acc_storage_trie.delete(&slot_trie_path)?;
-                        }
-                    }
-                }
-                state_account.storage_root = acc_storage_trie.hash();
+                state_account.storage_root = self.apply_storage_diff(*address, storage_diff)?;
                 self.state_trie
-                    .insert_rlp(&acc_info_trie_path, state_account)?;
+                    .insert_rlp(&acc_info_trie_path, state_account.clone())?;
+                self.accounts.insert(*address, state_account);
             }
         }
 
         Ok(())
     }
 
-    /// Returns the current state root.
-    pub fn state_root(&self) -> B256 {
+    fn apply_storage_diff(
+        &mut self,
+        address: Address,
+        storage_diff: &StorageDiff,
+    ) -> Result<B256, ReconstructError> {
+        let (storage_root, storage_trie_is_empty, account_storage_is_empty) = {
+            let acc_storage_trie = self.storage_trie.entry(address).or_default();
+            let account_storage = self.storage.entry(address).or_default();
+
+            for (slot_key, slot_value) in storage_diff.iter() {
+                let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
+                match slot_value {
+                    Some(v) if !v.is_zero() => {
+                        acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
+                        account_storage.insert(*slot_key, *v);
+                    }
+                    _ => {
+                        acc_storage_trie.delete(&slot_trie_path)?;
+                        account_storage.remove(slot_key);
+                    }
+                }
+            }
+
+            (
+                acc_storage_trie.hash(),
+                acc_storage_trie.is_empty(),
+                account_storage.is_empty(),
+            )
+        };
+
+        if storage_trie_is_empty {
+            self.storage_trie.remove(&address);
+        }
+        if account_storage_is_empty {
+            self.storage.remove(&address);
+        }
+
+        Ok(storage_root)
+    }
+
+    /// Computes the current state root.
+    pub fn compute_state_root(&self) -> B256 {
         self.state_trie.hash()
     }
 
-    /// Returns the current storage root for an account.
-    pub fn storage_root(&self, address: Address) -> B256 {
+    /// Computes the current storage root for an account.
+    ///
+    /// Returns [`EMPTY_ROOT`] when no storage trie is known for `address`. This is
+    /// an accessor over reconstructed state, not an absence proof for a claimed
+    /// state root.
+    pub fn compute_storage_root(&self, address: Address) -> B256 {
         self.storage_trie
             .get(&address)
             .map(|t| t.hash())
@@ -195,66 +334,24 @@ impl StateReconstructor {
     }
 
     /// Returns the value at a storage slot.
-    pub fn storage_slot(&self, address: Address, slot_key: U256) -> U256 {
-        self.storage_trie
+    ///
+    /// Returns zero when the account or slot is absent. Callers that need to
+    /// distinguish absent storage from an explicit zero value must use a richer
+    /// state witness than this reconstructed map.
+    pub fn get_storage_slot(&self, address: Address, slot_key: U256) -> U256 {
+        self.storage
             .get(&address)
-            .unwrap_or(&MptNode::default())
-            .get_rlp::<U256>(&keccak(slot_key.to_be_bytes::<32>()))
-            .unwrap_or_default()
-            .unwrap_or_default()
-    }
-
-    /// Returns the account state.
-    pub fn account(&self, address: Address) -> Option<StateAccount> {
-        self.state_trie
-            .get_rlp(&keccak(address))
+            .and_then(|account_storage| account_storage.get(&slot_key))
+            .copied()
             .unwrap_or_default()
     }
 
-    /// Creates a reconstructor from explicit canonical account and storage state.
+    /// Returns the account state when it is present in reconstructed state.
     ///
-    /// This helper exists for oracle tests that need to seed pre-state directly
-    /// from test fixtures instead of going through a chain spec or DB-backed
-    /// state source.
-    ///
-    /// Empty accounts are skipped during seeding, matching the canonical-state
-    /// oracle behavior used by the reconstruction tests.
-    #[cfg(test)]
-    pub(crate) fn from_state_parts(
-        accounts: &BTreeMap<Address, StateAccount>,
-        storage: &BTreeMap<Address, BTreeMap<U256, U256>>,
-    ) -> Result<Self, ReconstructError> {
-        let mut reconstructor = Self::new();
-
-        for (address, account) in accounts {
-            let mut state_account = account.clone();
-            if state_account.is_account_empty() {
-                continue;
-            }
-
-            let mut storage_trie = MptNode::default();
-
-            if let Some(account_storage) = storage.get(address) {
-                for (slot_key, slot_value) in account_storage {
-                    if slot_value.is_zero() {
-                        continue;
-                    }
-
-                    storage_trie.insert_rlp(&keccak(slot_key.to_be_bytes::<32>()), *slot_value)?;
-                }
-            }
-
-            state_account.storage_root = storage_trie.hash();
-            if !storage_trie.is_empty() {
-                reconstructor.storage_trie.insert(*address, storage_trie);
-            }
-
-            reconstructor
-                .state_trie
-                .insert_rlp(&keccak(address), state_account)?;
-        }
-
-        Ok(reconstructor)
+    /// `None` means the reconstructor has no account for `address`; it is not an
+    /// absence proof against an externally supplied state root.
+    pub fn get_account(&self, address: Address) -> Option<StateAccount> {
+        self.accounts.get(&address).cloned()
     }
 }
 
@@ -376,6 +473,12 @@ mod tests {
     // reconstructor. These tests verify diff application produces the expected
     // post-state inputs and roots, not that the root algorithm is independently
     // reimplemented.
+    fn reconstructor_from_state(state: &CanonicalState) -> StateReconstructor {
+        let prestate =
+            StateReconstructorPreState::new(state.accounts.clone(), state.storage.clone());
+        StateReconstructor::from_prestate(&prestate).expect("prestate must reconstruct")
+    }
+
     fn assert_reconstruction_matches(
         reconstructor: &StateReconstructor,
         expected_state: &CanonicalState,
@@ -385,7 +488,7 @@ mod tests {
     ) {
         let expected_accounts = canonical_accounts(expected_state).unwrap();
         assert_eq!(
-            reconstructor.state_root(),
+            reconstructor.compute_state_root(),
             canonical_state_root(expected_state).unwrap()
         );
 
@@ -397,7 +500,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         for address in addresses {
-            let actual_account = reconstructor.account(address);
+            let actual_account = reconstructor.get_account(address);
             let expected_account = expected_accounts.get(&address);
 
             match (actual_account, expected_account) {
@@ -406,10 +509,13 @@ mod tests {
                     assert_eq!(actual.nonce, expected.nonce);
                     assert_eq!(actual.code_hash, expected.code_hash);
                     assert_eq!(actual.storage_root, expected.storage_root);
-                    assert_eq!(reconstructor.storage_root(address), expected.storage_root);
+                    assert_eq!(
+                        reconstructor.compute_storage_root(address),
+                        expected.storage_root
+                    );
                 }
                 (None, None) => {
-                    assert_eq!(reconstructor.storage_root(address), EMPTY_ROOT);
+                    assert_eq!(reconstructor.compute_storage_root(address), EMPTY_ROOT);
                 }
                 (actual, expected) => panic!(
                     "account mismatch for {address:?}: actual={actual:?} expected={expected:?}"
@@ -425,7 +531,7 @@ mod tests {
                 .copied()
                 .unwrap_or(U256::ZERO);
             assert_eq!(
-                reconstructor.storage_slot(*address, *slot_key),
+                reconstructor.get_storage_slot(*address, *slot_key),
                 expected_value,
                 "slot mismatch for address {address:?} slot {slot_key:?}"
             );
@@ -448,6 +554,93 @@ mod tests {
     }
 
     #[test]
+    fn test_reconstructor_prestate_export_roundtrips_canonical_state() {
+        let address = addr(0x10);
+        let slot_one = slot(1);
+        let canonical_state = CanonicalState::new()
+            .with_account(address, state_account(100, 1, hash(0x20)))
+            .set_storage_slot(address, slot_one, value(7));
+
+        let reconstructor = reconstructor_from_state(&canonical_state);
+        let prestate = reconstructor.to_prestate();
+        let from_prestate = StateReconstructor::from_prestate(&prestate).unwrap();
+
+        assert_eq!(
+            from_prestate.compute_state_root(),
+            reconstructor.compute_state_root()
+        );
+        assert_eq!(
+            prestate.accounts(),
+            &canonical_accounts(&canonical_state).unwrap()
+        );
+        assert_eq!(prestate.storage(), &canonical_state.storage);
+    }
+
+    #[test]
+    fn test_reconstructor_prestate_json_roundtrip_preserves_state() {
+        let address = addr(0x18);
+        let slot_one = slot(1);
+        let canonical_state = CanonicalState::new()
+            .with_account(address, state_account(250, 3, hash(0x22)))
+            .set_storage_slot(address, slot_one, value(12));
+        let prestate = StateReconstructorPreState::new(
+            canonical_accounts(&canonical_state).unwrap(),
+            canonical_state.storage.clone(),
+        );
+
+        let encoded = serde_json::to_string(&prestate).expect("prestate serializes");
+        let decoded: StateReconstructorPreState =
+            serde_json::from_str(&encoded).expect("prestate deserializes");
+
+        assert_eq!(decoded, prestate);
+        assert_eq!(
+            StateReconstructor::from_prestate(&decoded)
+                .expect("decoded prestate reconstructs")
+                .compute_state_root(),
+            canonical_state_root(&canonical_state).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_reconstructor_prestate_export_tracks_applied_diff() {
+        let address = addr(0x17);
+        let slot_one = slot(1);
+        let slot_two = slot(2);
+        let pre_state = CanonicalState::new()
+            .with_account(address, state_account(100, 1, hash(0x21)))
+            .set_storage_slot(address, slot_one, value(5));
+        let expected_state = CanonicalState::new()
+            .with_account(address, state_account(150, 2, hash(0x21)))
+            .set_storage_slot(address, slot_two, value(9));
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, hash(0x21))),
+            Some(snapshot(150, 2, hash(0x21))),
+        );
+        storage_change(&mut block, address, slot_one, value(5), U256::ZERO);
+        storage_change(&mut block, address, slot_two, U256::ZERO, value(9));
+
+        let diff = roundtrip_batch_diff(&[block]);
+        let mut reconstructor = reconstructor_from_state(&pre_state);
+        reconstructor.apply_diff(&diff).unwrap();
+        let prestate = reconstructor.to_prestate();
+        let from_prestate = StateReconstructor::from_prestate(&prestate).unwrap();
+
+        assert_eq!(
+            from_prestate.compute_state_root(),
+            reconstructor.compute_state_root()
+        );
+        assert_eq!(
+            prestate.accounts(),
+            &canonical_accounts(&expected_state).unwrap()
+        );
+        assert_eq!(prestate.storage(), &expected_state.storage);
+    }
+
+    #[test]
     fn test_reconstruct_storage_only_change_matches_canonical_oracle() {
         let address = addr(0x11);
         let slot_one = slot(1);
@@ -465,8 +658,7 @@ mod tests {
         storage_change(&mut block, address, slot_two, U256::ZERO, value(22));
 
         let diff = roundtrip_batch_diff(&[block]);
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -493,8 +685,7 @@ mod tests {
         storage_change(&mut block, address, slot_one, value(5), U256::ZERO);
 
         let diff = roundtrip_batch_diff(&[block]);
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -534,8 +725,7 @@ mod tests {
         let diff = roundtrip_batch_diff(&[block_one, block_two]);
         assert!(diff.is_empty());
 
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -577,8 +767,7 @@ mod tests {
         let diff = roundtrip_batch_diff(&[block_one, block_two]);
         assert!(diff.is_empty());
 
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -615,8 +804,7 @@ mod tests {
         deployed_bytecode(&mut block, new_hash, bytecode(&new_bytecode));
 
         let diff = roundtrip_batch_diff(&[block]);
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -661,8 +849,7 @@ mod tests {
         storage_change(&mut block_two, address, new_slot, U256::ZERO, value(44));
 
         let diff = roundtrip_batch_diff(&[block_one, block_two]);
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -801,8 +988,7 @@ mod tests {
             );
 
             let diff = roundtrip_batch_diff(&[block]);
-            let mut reconstructor =
-                StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            let mut reconstructor = reconstructor_from_state(&pre_state);
             reconstructor.apply_diff(&diff).unwrap();
 
             assert_reconstruction_matches(
@@ -850,8 +1036,7 @@ mod tests {
 
         let diff = roundtrip_batch_diff(&[block]);
 
-        let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+        let mut reconstructor = reconstructor_from_state(&pre_state);
         reconstructor.apply_diff(&diff).unwrap();
 
         let mut state = EthereumState {
@@ -861,7 +1046,7 @@ mod tests {
         apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
 
         assert_eq!(
-            reconstructor.state_root(),
+            reconstructor.compute_state_root(),
             state.state_root(),
             "ethereum-state apply must agree with reconstructor oracle"
         );

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -232,8 +232,12 @@ impl StateReconstructor {
                         code_hash: snapshot.code_hash,
                     };
 
-                    // Skip empty accounts
+                    // Empty accounts are absent from the state trie (EIP-161).
                     if state_account.is_account_empty() {
+                        self.state_trie.delete(&acc_info_trie_path)?;
+                        self.storage_trie.remove(address);
+                        self.accounts.remove(address);
+                        self.storage.remove(address);
                         continue;
                     }
 
@@ -389,7 +393,10 @@ pub fn apply_batch_state_diff_to_ethereum_state(
                     code_hash: snapshot.code_hash,
                 };
 
+                // Empty accounts are absent from the state trie (EIP-161).
                 if state_account.is_account_empty() {
+                    state.state_trie.delete(hashed_addr.as_slice())?;
+                    state.storage_tries.remove(&hashed_addr);
                     continue;
                 }
 
@@ -638,6 +645,41 @@ mod tests {
             &canonical_accounts(&expected_state).unwrap()
         );
         assert_eq!(prestate.storage(), &expected_state.storage);
+    }
+
+    #[test]
+    fn test_reconstruct_update_to_empty_account_deletes_account() {
+        let address = addr(0x18);
+        let slot_one = slot(1);
+        let empty_code_hash = StateAccount::default().code_hash;
+        let pre_state = CanonicalState::new()
+            .with_account(address, state_account(100, 1, empty_code_hash))
+            .set_storage_slot(address, slot_one, value(5));
+        let expected_state = CanonicalState::new();
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, empty_code_hash)),
+            Some(snapshot(0, 0, empty_code_hash)),
+        );
+        storage_change(&mut block, address, slot_one, value(5), U256::ZERO);
+
+        let diff = roundtrip_batch_diff(&[block]);
+        let mut reconstructor = reconstructor_from_state(&pre_state);
+        reconstructor.apply_diff(&diff).unwrap();
+        let prestate = reconstructor.to_prestate();
+
+        assert_reconstruction_matches(
+            &reconstructor,
+            &expected_state,
+            &[(address, slot_one)],
+            &[],
+            &diff,
+        );
+        assert!(!prestate.accounts().contains_key(&address));
+        assert!(!prestate.storage().contains_key(&address));
     }
 
     #[test]
@@ -1055,6 +1097,47 @@ mod tests {
             canonical_state_root(&expected_state).unwrap(),
             "ethereum-state apply must match canonical post-state root"
         );
+    }
+
+    #[test]
+    fn apply_to_ethereum_state_deletes_account_emptied_by_diff() {
+        let address = addr(0xA2);
+        let slot_one = slot(1);
+        let empty_code_hash = StateAccount::default().code_hash;
+        let expected_state = CanonicalState::new();
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, empty_code_hash)),
+            Some(snapshot(0, 0, empty_code_hash)),
+        );
+        storage_change(&mut block, address, slot_one, value(5), U256::ZERO);
+        let diff = roundtrip_batch_diff(&[block]);
+
+        let mut state = EthereumState {
+            state_trie: Default::default(),
+            storage_tries: Default::default(),
+        };
+        let mut pre_block = block_diff();
+        account_change(
+            &mut pre_block,
+            address,
+            None,
+            Some(snapshot(100, 1, empty_code_hash)),
+        );
+        storage_change(&mut pre_block, address, slot_one, U256::ZERO, value(5));
+        let pre_diff = roundtrip_batch_diff(&[pre_block]);
+        apply_batch_state_diff_to_ethereum_state(&mut state, &pre_diff).unwrap();
+
+        apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
+
+        assert_eq!(
+            state.state_root(),
+            canonical_state_root(&expected_state).unwrap()
+        );
+        assert!(state.storage_tries.is_empty());
     }
 
     #[test]

--- a/functional-tests/common/config/constants.py
+++ b/functional-tests/common/config/constants.py
@@ -4,6 +4,9 @@ Constants used throughout the functional test suite.
 
 from enum import Enum
 
+# Default magic bytes for EE DA testing (must be 4 ASCII bytes).
+DEFAULT_DA_MAGIC_BYTES = b"ALPN"
+
 # =============================================================================
 # EVM Dev Accounts
 # =============================================================================

--- a/functional-tests/common/services/alpen_client.py
+++ b/functional-tests/common/services/alpen_client.py
@@ -39,6 +39,13 @@ class AlpenClientProps(TypedDict):
     datadir: str
     mode: str  # "sequencer" or "fullnode"
     enode: str | None
+    chain_spec: str
+    magic_bytes: bytes
+    genesis_l1_height: int | None
+    sequencer_pubkey: str
+    sequencer_privkey: str | None
+    ee_params_path: str
+    ol_rpc_url: str | None
 
 
 class AlpenClientService(RpcService):

--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -279,10 +279,10 @@ def main(argv: list[str]) -> int:
 
     # Create factories
     factories: dict[ServiceType, flexitest.Factory] = {
-        ServiceType.AlpenClient: AlpenClientFactory(range(30303, 30503)),
-        ServiceType.Bitcoin: BitcoinFactory(range(18443, 18543)),
-        ServiceType.Strata: StrataFactory(range(19443, 19543)),
-        ServiceType.StrataSigner: SignerFactory(range(19543, 19553)),
+        ServiceType.AlpenClient: AlpenClientFactory(range(30303, 30903)),
+        ServiceType.Bitcoin: BitcoinFactory(range(18443, 18743)),
+        ServiceType.Strata: StrataFactory(range(19443, 19943)),
+        ServiceType.StrataSigner: SignerFactory(range(19943, 20043)),
     }
 
     # Define global environments

--- a/functional-tests/envconfigs/alpen_client.py
+++ b/functional-tests/envconfigs/alpen_client.py
@@ -9,12 +9,13 @@ from typing import cast
 import flexitest
 
 from common.config import EeDaConfig, ServiceType
+from common.config.constants import DEFAULT_DA_MAGIC_BYTES
 from common.services.bitcoin import BitcoinService
 from factories.alpen_client import AlpenClientFactory, generate_sequencer_keypair
 from factories.bitcoin import BitcoinFactory
 
-# Default magic bytes for DA testing (must be 4 bytes)
-DEFAULT_DA_MAGIC_BYTES = b"ALPN"
+__all__ = ["AlpenClientEnv", "DEFAULT_DA_MAGIC_BYTES"]
+
 DA_WALLET_FUNDING_OUTPUTS = 25
 INITIAL_L1_MATURITY_BLOCKS = 101
 INITIAL_L1_MINE_CHUNK_SIZE = 10

--- a/functional-tests/factories/alpen_client.py
+++ b/functional-tests/factories/alpen_client.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import flexitest
 
 from common.config import EeDaConfig
-from common.config.constants import DEFAULT_EE_BLOCK_TIME_MS
+from common.config.constants import DEFAULT_DA_MAGIC_BYTES, DEFAULT_EE_BLOCK_TIME_MS
 from common.datatool import generate_ee_params
 from common.services import AlpenClientProps, AlpenClientService
 
@@ -191,6 +191,8 @@ class AlpenClientFactory(flexitest.Factory):
 
         http_url = f"http://127.0.0.1:{http_port}"
 
+        magic_bytes = da_config.magic_bytes if da_config is not None else DEFAULT_DA_MAGIC_BYTES
+        genesis_l1_height = da_config.genesis_l1_height if da_config is not None else None
         props: AlpenClientProps = {
             "http_port": http_port,
             "http_url": http_url,
@@ -198,6 +200,13 @@ class AlpenClientFactory(flexitest.Factory):
             "datadir": str(datadir),
             "mode": "sequencer",
             "enode": None,  # Will be populated after start
+            "chain_spec": custom_chain,
+            "magic_bytes": magic_bytes,
+            "genesis_l1_height": genesis_l1_height,
+            "sequencer_pubkey": sequencer_pubkey,
+            "sequencer_privkey": sequencer_privkey,
+            "ee_params_path": str(ee_params_path),
+            "ol_rpc_url": ol_endpoint,
         }
 
         # Set environment variable for sequencer private key
@@ -348,6 +357,13 @@ class AlpenClientFactory(flexitest.Factory):
             "datadir": str(datadir),
             "mode": "fullnode",
             "enode": None,
+            "chain_spec": custom_chain,
+            "magic_bytes": DEFAULT_DA_MAGIC_BYTES,
+            "genesis_l1_height": None,
+            "sequencer_pubkey": sequencer_pubkey,
+            "sequencer_privkey": None,
+            "ee_params_path": str(ee_params_path),
+            "ol_rpc_url": ol_endpoint,
         }
 
         svc = AlpenClientService(

--- a/functional-tests/run_tests.sh
+++ b/functional-tests/run_tests.sh
@@ -19,7 +19,7 @@ setup_path() {
 build() {
     # TODO(STR-3692): add conditional builds as we go
     # TODO(STR-3692): different binaries for sequencer and full nodes
-    cargo build  -F sequencer -F debug-utils -F test-mode -F debug-asm -F prover --bin strata --bin strata-signer --bin alpen-client --bin strata-datatool --bin strata-test-cli --bin strata-dbtool
+    cargo build  -F sequencer -F debug-utils -F test-mode -F debug-asm -F prover --bin strata --bin strata-signer --bin alpen-client --bin strata-datatool --bin strata-test-cli --bin strata-dbtool --bin alpen-ee-da-tool
 }
 
 # Runs tests.

--- a/functional-tests/tests/alpen_client/test_ee_predicate_fullnode_sync.py
+++ b/functional-tests/tests/alpen_client/test_ee_predicate_fullnode_sync.py
@@ -103,7 +103,7 @@ class TestEePredicateFullnodeSync(BaseTest):
         late_join_start_hash = ee_fullnode_0.get_block_by_number(late_join_start_height)["hash"]
 
         _, sequencer_pubkey = generate_sequencer_keypair()
-        factory = AlpenClientFactory(range(30700, 30800))
+        factory = AlpenClientFactory(range(31003, 31103))
         fn0_enode = ee_fullnode_0.get_enode()
 
         tmpdir = tempfile.mkdtemp(prefix="alpen_fullnode_after_vk_rotation_")

--- a/functional-tests/tests/alpen_client/test_fullnode_sync.py
+++ b/functional-tests/tests/alpen_client/test_fullnode_sync.py
@@ -84,7 +84,7 @@ class TestFullnodeSync(AlpenClientTest):
         ee_fullnode_0 = self.get_service(ServiceType.AlpenFullNode)
 
         _, pubkey = generate_sequencer_keypair()
-        factory = AlpenClientFactory(range(30600, 30700))
+        factory = AlpenClientFactory(range(30903, 31003))
 
         # Wait for initial sync
         logger.info("Waiting for initial sync...")

--- a/functional-tests/tests/alpen_ee_da_tool/__init__.py
+++ b/functional-tests/tests/alpen_ee_da_tool/__init__.py
@@ -1,0 +1,1 @@
+"""Alpen EE DA tool functional tests."""

--- a/functional-tests/tests/alpen_ee_da_tool/base.py
+++ b/functional-tests/tests/alpen_ee_da_tool/base.py
@@ -1,0 +1,29 @@
+"""Shared base class for alpen-ee-da-tool functional tests."""
+
+import flexitest
+
+from common.base_test import StrataNodeTest
+from common.config.constants import ServiceType
+from common.services import AlpenClientService, BitcoinService
+from envconfigs.el_ol import EeOLEnv
+
+
+class AlpenEeDaToolTestBase(StrataNodeTest):
+    """Shared env and service accessors for alpen-ee-da-tool functional tests."""
+
+    BATCH_SEALING_BLOCK_COUNT = 30
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(
+            EeOLEnv(
+                fullnode_count=0,
+                pre_generate_blocks=110,
+                batch_sealing_block_count=self.BATCH_SEALING_BLOCK_COUNT,
+            )
+        )
+
+    def _services(self) -> tuple[BitcoinService, AlpenClientService]:
+        return (
+            self.get_service(ServiceType.Bitcoin),
+            self.get_service(ServiceType.AlpenSequencer),
+        )

--- a/functional-tests/tests/alpen_ee_da_tool/helpers.py
+++ b/functional-tests/tests/alpen_ee_da_tool/helpers.py
@@ -1,0 +1,412 @@
+"""Helpers for invoking alpen-ee-da-tool in functional tests."""
+
+import json
+import logging
+import os
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from common.services import AlpenClientService, BitcoinService
+from tests.alpen_client.ee_da.injection import (
+    CraftedEnvelope,
+    mine_blocks,
+    mine_empty_blocks,
+    post_ee_da_envelope,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DaWindow:
+    """Inclusive L1 scan window."""
+
+    start_height: int
+    end_height: int
+
+
+@dataclass(frozen=True)
+class ReconstructedDaReport:
+    """Tool report plus the inclusive L1 end height used to produce it."""
+
+    end_height: int
+    report: dict[str, Any]
+
+
+# `strata-test-cli post-ee-da-envelope` signs reveal scripts with secret key
+# `[42; 32]`. The verifier must be configured with the matching x-only pubkey.
+TEST_ENVELOPE_PUBKEY = "5be5e9478209674a96e60f1f037f6176540fd001fa1d64694770c56a7709c42c"
+
+__all__ = [
+    "TEST_ENVELOPE_PUBKEY",
+    "DaWindow",
+    "ReconstructedDaReport",
+    "assert_published_inner_root_match",
+    "mine_empty_blocks",
+    "post_envelope_in_one_block",
+    "run_alpen_ee_da_tool",
+    "run_alpen_ee_da_tool_json",
+    "wait_for_published_inner_root_report",
+    "wait_for_reconstructed_real_da_report",
+    "wait_for_reconstructed_real_da_report_window",
+    "write_reconstruction_config",
+    "write_verification_config",
+]
+
+
+def _base_verifier_config_lines(
+    bitcoin: BitcoinService,
+    sequencer: AlpenClientService,
+    *,
+    sequencer_pubkey_override: str | None = None,
+) -> list[str]:
+    """Build config lines shared by reconstruction and verification runs."""
+    sequencer_pubkey = sequencer_pubkey_override or sequencer.props["sequencer_pubkey"]
+    sequencer_pubkey = sequencer_pubkey.removeprefix("0x")
+
+    return [
+        f'bitcoind_url = "http://127.0.0.1:{bitcoin.props["rpc_port"]}/wallet/{bitcoin.props["walletname"]}"',
+        f'bitcoind_rpc_user = "{bitcoin.props["rpc_user"]}"',
+        f'bitcoind_rpc_password = "{bitcoin.props["rpc_password"]}"',
+        f'sequencer_pubkey = "{sequencer_pubkey}"',
+        f'ee_params = "{sequencer.props["ee_params_path"]}"',
+    ]
+
+
+def _write_config_file(
+    bitcoin: BitcoinService,
+    lines: list[str],
+    *,
+    directory: str | Path | None = None,
+) -> Path:
+    """Write config lines to a test-local TOML file and return its path."""
+    root_dir = Path(directory) if directory is not None else Path(bitcoin.props["datadir"])
+    root_dir.mkdir(parents=True, exist_ok=True)
+    lines.append("")
+
+    fd, raw_path = tempfile.mkstemp(prefix="alpen-ee-da-tool-", suffix=".toml", dir=root_dir)
+    Path(raw_path).write_text(
+        "\n".join(lines),
+        encoding="utf-8",
+    )
+    os.close(fd)
+    return Path(raw_path)
+
+
+def write_reconstruction_config(
+    bitcoin: BitcoinService,
+    sequencer: AlpenClientService,
+    *,
+    directory: str | Path | None = None,
+    sequencer_pubkey_override: str | None = None,
+) -> Path:
+    """Write config for reconstruction-only runs without published-root lookup."""
+    lines = _base_verifier_config_lines(
+        bitcoin,
+        sequencer,
+        sequencer_pubkey_override=sequencer_pubkey_override,
+    )
+    return _write_config_file(bitcoin, lines, directory=directory)
+
+
+def write_verification_config(
+    bitcoin: BitcoinService,
+    sequencer: AlpenClientService,
+    *,
+    directory: str | Path | None = None,
+    sequencer_pubkey_override: str | None = None,
+) -> Path:
+    """Write config for runs that compare against published Snark account roots."""
+    ol_rpc_url = sequencer.props.get("ol_rpc_url")
+    assert ol_rpc_url is not None, (
+        "alpen-client service must expose ol_rpc_url prop; check factories/alpen_client.py"
+    )
+    lines = _base_verifier_config_lines(
+        bitcoin,
+        sequencer,
+        sequencer_pubkey_override=sequencer_pubkey_override,
+    )
+    lines.append(f'ol_rpc_url = "{ol_rpc_url}"')
+    return _write_config_file(bitcoin, lines, directory=directory)
+
+
+def run_alpen_ee_da_tool(
+    config_toml_path: str | Path,
+    start_height: int,
+    end_height: int,
+    *,
+    expected_root: str | None = None,
+    custom_chain: str | None = None,
+    snapshot: str | Path | None = None,
+    export_snapshot: str | Path | None = None,
+    output_format: str | None = None,
+    timeout: int = 120,
+) -> tuple[int, str, str]:
+    """Run alpen-ee-da-tool and return `(return_code, stdout, stderr)`."""
+    cmd = [
+        "alpen-ee-da-tool",
+        "--config",
+        str(config_toml_path),
+        "--start-height",
+        str(start_height),
+        "--end-height",
+        str(end_height),
+    ]
+    if output_format is not None:
+        cmd.extend(["--output-format", output_format])
+    if expected_root is not None:
+        cmd.extend(["--expected-root", expected_root])
+    if custom_chain is not None:
+        cmd.extend(["--custom-chain", custom_chain])
+    if snapshot is not None:
+        cmd.extend(["--snapshot", str(snapshot)])
+    if export_snapshot is not None:
+        cmd.extend(["--export-snapshot", str(export_snapshot)])
+
+    logger.info("Running command: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if result.returncode == 0 and result.stdout:
+        logger.info("Stdout: %s", result.stdout.strip())
+    elif result.stderr:
+        logger.info("Stderr: %s", result.stderr.strip())
+
+    return result.returncode, result.stdout, result.stderr
+
+
+def extract_json_from_output(output: str) -> dict[str, Any]:
+    """Parse the JSON object that spans from the first `{` to the last `}`."""
+    start = output.find("{")
+    end = output.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError(f"No JSON object found in output: {output!r}")
+    return json.loads(output[start : end + 1])
+
+
+def run_alpen_ee_da_tool_json(
+    config_toml_path: str | Path,
+    start_height: int,
+    end_height: int,
+    *,
+    expected_root: str | None = None,
+    custom_chain: str | None = None,
+    snapshot: str | Path | None = None,
+    export_snapshot: str | Path | None = None,
+    timeout: int = 120,
+) -> tuple[int, dict[str, Any], str]:
+    """Run alpen-ee-da-tool with JSON output and parse its report."""
+    code, stdout, stderr = run_alpen_ee_da_tool(
+        config_toml_path,
+        start_height,
+        end_height,
+        expected_root=expected_root,
+        custom_chain=custom_chain,
+        snapshot=snapshot,
+        export_snapshot=export_snapshot,
+        output_format="json",
+        timeout=timeout,
+    )
+    report: dict[str, Any] = {} if code != 0 else extract_json_from_output(stdout)
+    return code, report, stderr
+
+
+def assert_published_inner_root_match(report: dict[str, Any]) -> None:
+    """Assert the tool matched reconstructed and published Snark account roots."""
+    assert report["reconstructed_inner_state_root"] is not None
+    assert report["expected_inner_state_root"] is not None
+    assert report["inner_state_root_matches_expected"] is True
+    assert report.get("inner_state_root_mismatch_update_seq_no") is None
+
+
+def wait_for_published_inner_root_report(
+    bitcoin: BitcoinService,
+    sequencer: AlpenClientService,
+    config_toml_path: str | Path,
+    start_height: int,
+    end_height: int,
+    *,
+    snapshot: str | Path | None = None,
+    export_snapshot: str | Path | None = None,
+    poll_attempts: int = 20,
+    blocks_per_poll: int = 3,
+    timeout: int = 180,
+) -> dict[str, Any]:
+    """Run the tool until published Snark account root lookup catches up.
+
+    Advances the DA window between attempts so OL can finalize the epoch
+    containing the published update manifest record.
+    """
+    btc_rpc = bitcoin.create_rpc()
+    mine_address = btc_rpc.proxy.getnewaddress()
+    last_stderr = ""
+
+    for attempt in range(1, poll_attempts + 1):
+        code, report, stderr = run_alpen_ee_da_tool_json(
+            config_toml_path,
+            start_height,
+            end_height,
+            custom_chain=sequencer.props["chain_spec"],
+            snapshot=snapshot,
+            export_snapshot=export_snapshot,
+            timeout=timeout,
+        )
+        if code == 0:
+            return report
+
+        last_stderr = stderr
+        if "No canonical commitment found" in stderr:
+            raise AssertionError(
+                f"alpen-ee-da-tool hit an unexpected manifest RPC canonical-epoch error: {stderr}"
+            )
+        if "No Snark account update manifest found" not in stderr:
+            raise AssertionError(
+                "alpen-ee-da-tool failed for a non-retryable reason while waiting for "
+                f"published inner-root lookup: {stderr}"
+            )
+
+        logger.info(
+            "Attempt %s/%s: published inner root not available yet over fixed range [%s, %s]: %s",
+            attempt,
+            poll_attempts,
+            start_height,
+            end_height,
+            stderr.strip(),
+        )
+        sequencer.advance_to_next_da_window(
+            additional_blocks=3,
+            timeout_per_block=15.0,
+            timeout_slack=60,
+        )
+        btc_rpc.proxy.generatetoaddress(blocks_per_poll, mine_address)
+        time.sleep(2)
+
+    raise AssertionError(
+        "Published inner-root lookup did not catch up for alpen-ee-da-tool; "
+        f"last_stderr={last_stderr}"
+    )
+
+
+def post_envelope_in_one_block(
+    bitcoin: BitcoinService,
+    *,
+    chunks: list[bytes],
+    reveal_count: int | None = None,
+) -> tuple[DaWindow, CraftedEnvelope]:
+    """Post a crafted envelope and mine commit/reveals in the same L1 block."""
+    btc_rpc = bitcoin.create_rpc()
+    start_height = btc_rpc.proxy.getblockcount() + 1
+    envelope = post_ee_da_envelope(
+        bitcoin,
+        chunks=chunks,
+        reveal_count=reveal_count,
+        mine_mode="manual",
+    )
+    mine_blocks(bitcoin, 1)
+    end_height = btc_rpc.proxy.getblockcount()
+    return DaWindow(start_height, end_height), envelope
+
+
+def wait_for_reconstructed_real_da_report(
+    bitcoin: BitcoinService,
+    config_toml_path: str | Path,
+    start_height: int,
+    *,
+    min_last_block_num: int,
+    poll_attempts: int = 20,
+    blocks_per_poll: int = 3,
+    safe_depth: int = 2,
+    custom_chain: str = "dev",
+    timeout: int = 180,
+) -> dict[str, Any]:
+    """Mine L1 and poll alpen-ee-da-tool until real DA is reconstructed."""
+    return wait_for_reconstructed_real_da_report_window(
+        bitcoin,
+        config_toml_path,
+        start_height,
+        min_last_block_num=min_last_block_num,
+        poll_attempts=poll_attempts,
+        blocks_per_poll=blocks_per_poll,
+        safe_depth=safe_depth,
+        custom_chain=custom_chain,
+        timeout=timeout,
+    ).report
+
+
+def wait_for_reconstructed_real_da_report_window(
+    bitcoin: BitcoinService,
+    config_toml_path: str | Path,
+    start_height: int,
+    *,
+    min_last_block_num: int,
+    min_blob_count: int = 1,
+    poll_attempts: int = 20,
+    blocks_per_poll: int = 3,
+    safe_depth: int = 2,
+    custom_chain: str = "dev",
+    timeout: int = 180,
+) -> ReconstructedDaReport:
+    """Mine L1 and return the first tool report that reaches the target DA."""
+    btc_rpc = bitcoin.create_rpc()
+    mine_address = btc_rpc.proxy.getnewaddress()
+    last_stderr = ""
+    last_report: dict[str, Any] = {}
+
+    for attempt in range(1, poll_attempts + 1):
+        btc_rpc.proxy.generatetoaddress(blocks_per_poll, mine_address)
+        time.sleep(2)
+
+        tip_height = btc_rpc.proxy.getblockcount()
+        end_height = tip_height - safe_depth
+        if end_height < start_height:
+            continue
+
+        code, report, stderr = run_alpen_ee_da_tool_json(
+            config_toml_path,
+            start_height,
+            end_height,
+            custom_chain=custom_chain,
+            timeout=timeout,
+        )
+        last_stderr = stderr
+        last_report = report
+        if code != 0:
+            if "No canonical commitment found" in stderr:
+                raise AssertionError(
+                    "alpen-ee-da-tool hit an unexpected manifest RPC canonical-epoch error: "
+                    f"{stderr}"
+                )
+            logger.info(
+                "Attempt %s/%s: alpen-ee-da-tool failed over [%s, %s]: %s",
+                attempt,
+                poll_attempts,
+                start_height,
+                end_height,
+                stderr.strip(),
+            )
+            continue
+
+        applied_range = report.get("applied_range")
+        if (
+            int(report.get("blobs_reassembled", 0)) >= min_blob_count
+            and applied_range is not None
+            and int(applied_range.get("last_block_num", 0)) >= min_last_block_num
+        ):
+            return ReconstructedDaReport(end_height=end_height, report=report)
+
+        logger.info(
+            "Attempt %s/%s: report not past target block %s or blob count %s yet: %s",
+            attempt,
+            poll_attempts,
+            min_last_block_num,
+            min_blob_count,
+            report,
+        )
+
+    raise AssertionError(
+        "alpen-ee-da-tool did not reconstruct a real DA blob covering "
+        f"EVM block {min_last_block_num}; last_report={last_report}, "
+        f"last_stderr={last_stderr}"
+    )

--- a/functional-tests/tests/alpen_ee_da_tool/test_da_replay_snapshot_roundtrip.py
+++ b/functional-tests/tests/alpen_ee_da_tool/test_da_replay_snapshot_roundtrip.py
@@ -1,0 +1,186 @@
+"""Verifies alpen-ee-da-tool can export and import EE DA replay snapshots."""
+
+import logging
+from pathlib import Path
+
+import flexitest
+
+from common.config.constants import DEV_RECIPIENT_ADDRESS
+from common.evm import DEV_ACCOUNT_ADDRESS, send_eth_transfer
+from common.wait import timeout_for_expected_blocks, wait_until
+from tests.alpen_ee_da_tool.base import AlpenEeDaToolTestBase
+from tests.alpen_ee_da_tool.helpers import (
+    assert_published_inner_root_match,
+    run_alpen_ee_da_tool_json,
+    wait_for_published_inner_root_report,
+    wait_for_reconstructed_real_da_report_window,
+    write_reconstruction_config,
+    write_verification_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@flexitest.register
+class AlpenEeDaToolDaReplaySnapshotRoundtripTest(AlpenEeDaToolTestBase):
+    """Checks a genesis EE DA replay snapshot can seed a later DA replay."""
+
+    BATCH_SEALING_BLOCK_COUNT = 3
+
+    def main(self, ctx):
+        bitcoin, sequencer = self._services()
+        eth_rpc = sequencer.create_rpc()
+        discovery_config_path = write_reconstruction_config(bitcoin, sequencer)
+        verification_config_path = write_verification_config(bitcoin, sequencer)
+        genesis_l1_height = sequencer.props["genesis_l1_height"]
+        assert genesis_l1_height is not None and genesis_l1_height > 1
+
+        nonce = int(eth_rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
+        first_tx_hash = send_eth_transfer(eth_rpc, nonce, DEV_RECIPIENT_ADDRESS, 10**18)
+
+        def wait_for_transfer(tx_hash: str) -> int:
+            tx_block = None
+
+            def transfer_confirmed():
+                nonlocal tx_block
+                receipt = eth_rpc.eth_getTransactionReceipt(tx_hash)
+                if receipt is None:
+                    return False
+                assert int(receipt.get("status", "0x1"), 16) == 1, (
+                    f"transfer {tx_hash} failed with receipt {receipt}"
+                )
+                tx_block = int(receipt["blockNumber"], 16)
+                return True
+
+            wait_until(
+                transfer_confirmed,
+                error_with=f"ETH transfer {tx_hash} was not confirmed before DA polling",
+                timeout=timeout_for_expected_blocks(10, seconds_per_block=15.0, slack_seconds=60),
+                step=0.5,
+            )
+            assert tx_block is not None
+            return tx_block
+
+        first_tx_block = wait_for_transfer(first_tx_hash)
+
+        sequencer.advance_to_next_da_window(
+            additional_blocks=10,
+            timeout_per_block=15.0,
+            timeout_slack=60,
+        )
+
+        first_window = wait_for_reconstructed_real_da_report_window(
+            bitcoin,
+            discovery_config_path,
+            genesis_l1_height,
+            min_last_block_num=first_tx_block,
+            poll_attempts=20,
+            blocks_per_poll=3,
+            safe_depth=2,
+            custom_chain=sequencer.props["chain_spec"],
+            timeout=180,
+        )
+        first_scan_report = first_window.report
+        first_applied_range = first_scan_report["applied_range"]
+        assert first_scan_report["replay_start"] == "genesis"
+
+        da_snapshot_path = Path(bitcoin.props["datadir"]) / "alpen-ee-da-tool-da-snapshot.json"
+        prefix_report = wait_for_published_inner_root_report(
+            bitcoin,
+            sequencer,
+            verification_config_path,
+            genesis_l1_height,
+            first_window.end_height,
+            export_snapshot=da_snapshot_path,
+            blocks_per_poll=3,
+            timeout=180,
+        )
+        assert prefix_report["replay_start"] == "genesis"
+        assert (
+            prefix_report["reconstructed_state_root"]
+            == first_scan_report["reconstructed_state_root"]
+        )
+        assert_published_inner_root_match(prefix_report)
+        assert da_snapshot_path.exists()
+
+        second_tx_hash = send_eth_transfer(eth_rpc, nonce + 1, DEV_RECIPIENT_ADDRESS, 10**18)
+        second_tx_block = wait_for_transfer(second_tx_hash)
+
+        sequencer.advance_to_next_da_window(
+            additional_blocks=10,
+            timeout_per_block=15.0,
+            timeout_slack=60,
+        )
+
+        full_window = wait_for_reconstructed_real_da_report_window(
+            bitcoin,
+            discovery_config_path,
+            genesis_l1_height,
+            min_last_block_num=second_tx_block,
+            min_blob_count=int(first_scan_report["blobs_reassembled"]) + 1,
+            poll_attempts=20,
+            blocks_per_poll=3,
+            safe_depth=2,
+            custom_chain=sequencer.props["chain_spec"],
+            timeout=180,
+        )
+        full_scan_report = full_window.report
+        assert full_scan_report["replay_start"] == "genesis"
+        assert full_window.end_height > first_window.end_height
+
+        full_report = wait_for_published_inner_root_report(
+            bitcoin,
+            sequencer,
+            verification_config_path,
+            genesis_l1_height,
+            full_window.end_height,
+            blocks_per_poll=3,
+            timeout=180,
+        )
+        assert (
+            full_report["reconstructed_state_root"] == full_scan_report["reconstructed_state_root"]
+        )
+        assert_published_inner_root_match(full_report)
+
+        split_code, split_scan_report, split_stderr = run_alpen_ee_da_tool_json(
+            discovery_config_path,
+            first_window.end_height + 1,
+            full_window.end_height,
+            custom_chain=sequencer.props["chain_spec"],
+            snapshot=da_snapshot_path,
+            timeout=180,
+        )
+        assert split_code == 0, split_stderr
+        assert split_scan_report["replay_start"] == "snapshot"
+        assert int(split_scan_report["blobs_reassembled"]) >= 1
+        assert split_scan_report["applied_range"] is not None
+        assert (
+            int(split_scan_report["applied_range"]["first_update_seq_no"])
+            == int(first_applied_range["last_update_seq_no"]) + 1
+        )
+        assert (
+            split_scan_report["reconstructed_state_root"] == full_report["reconstructed_state_root"]
+        )
+
+        split_report = wait_for_published_inner_root_report(
+            bitcoin,
+            sequencer,
+            verification_config_path,
+            first_window.end_height + 1,
+            full_window.end_height,
+            snapshot=da_snapshot_path,
+            blocks_per_poll=3,
+            timeout=180,
+        )
+        assert split_report["replay_start"] == "snapshot"
+        assert split_report["reconstructed_state_root"] == full_report["reconstructed_state_root"]
+        assert_published_inner_root_match(split_report)
+
+        logger.info(
+            "EE DA replay split [%s, %s] + [%s, %s] matched full replay root",
+            genesis_l1_height,
+            first_window.end_height,
+            first_window.end_height + 1,
+            full_window.end_height,
+        )
+        return True

--- a/functional-tests/tests/alpen_ee_da_tool/test_no_da_window.py
+++ b/functional-tests/tests/alpen_ee_da_tool/test_no_da_window.py
@@ -1,0 +1,40 @@
+"""Verifies alpen-ee-da-tool exits cleanly for a confirmed window with no EE DA."""
+
+import flexitest
+
+from tests.alpen_ee_da_tool.base import AlpenEeDaToolTestBase
+from tests.alpen_ee_da_tool.helpers import (
+    run_alpen_ee_da_tool_json,
+    write_verification_config,
+)
+
+
+@flexitest.register
+class AlpenEeDaToolNoDaWindowTest(AlpenEeDaToolTestBase):
+    """Ensures empty DA windows return a deterministic zero-blob report."""
+
+    def main(self, ctx):
+        bitcoin, sequencer = self._services()
+        config_path = write_verification_config(bitcoin, sequencer)
+        genesis_l1_height = sequencer.props["genesis_l1_height"]
+        assert genesis_l1_height is not None and genesis_l1_height > 1
+
+        code, report, stderr = run_alpen_ee_da_tool_json(
+            config_path,
+            1,
+            genesis_l1_height - 1,
+            custom_chain=sequencer.props["chain_spec"],
+            timeout=120,
+        )
+        assert code == 0, stderr
+        assert report["replay_start"] == "genesis"
+        assert report.get("applied_range") is None
+        assert report.get("envelope_count") == 0
+        assert report.get("blobs_reassembled") == 0
+        assert report.get("expected_state_root") is None
+        assert report.get("state_root_matches_expected") is None
+        assert report.get("reconstructed_inner_state_root") is None
+        assert report.get("expected_inner_state_root") is None
+        assert report.get("inner_state_root_matches_expected") is None
+        assert report.get("inner_state_root_mismatch_update_seq_no") is None
+        return True

--- a/functional-tests/tests/alpen_ee_da_tool/test_real_da_success.py
+++ b/functional-tests/tests/alpen_ee_da_tool/test_real_da_success.py
@@ -1,0 +1,125 @@
+"""Verifies alpen-ee-da-tool reconstructs real DA posted by alpen-client."""
+
+import logging
+
+import flexitest
+
+from common.config.constants import DEV_RECIPIENT_ADDRESS
+from common.evm import DEV_ACCOUNT_ADDRESS, send_eth_transfer
+from common.wait import timeout_for_expected_blocks, wait_until
+from tests.alpen_ee_da_tool.base import AlpenEeDaToolTestBase
+from tests.alpen_ee_da_tool.helpers import (
+    assert_published_inner_root_match,
+    run_alpen_ee_da_tool_json,
+    wait_for_published_inner_root_report,
+    wait_for_reconstructed_real_da_report_window,
+    write_reconstruction_config,
+    write_verification_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@flexitest.register
+class AlpenEeDaToolRealDaSuccessTest(AlpenEeDaToolTestBase):
+    """Checks the tool can reconstruct and replay production EE DA from L1."""
+
+    BATCH_SEALING_BLOCK_COUNT = 3
+
+    def main(self, ctx):
+        bitcoin, sequencer = self._services()
+        btc_rpc = bitcoin.create_rpc()
+        eth_rpc = sequencer.create_rpc()
+        discovery_config_path = write_reconstruction_config(bitcoin, sequencer)
+        verification_config_path = write_verification_config(bitcoin, sequencer)
+        genesis_l1_height = sequencer.props["genesis_l1_height"]
+        assert genesis_l1_height is not None
+
+        nonce = int(eth_rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
+        tx_hashes = [
+            send_eth_transfer(eth_rpc, nonce + idx, DEV_RECIPIENT_ADDRESS, 10**18)
+            for idx in range(3)
+        ]
+
+        tx_blocks: dict[str, int] = {}
+
+        def all_transfers_confirmed():
+            for tx_hash in tx_hashes:
+                if tx_hash in tx_blocks:
+                    continue
+                receipt = eth_rpc.eth_getTransactionReceipt(tx_hash)
+                if receipt is None:
+                    return False
+                assert int(receipt.get("status", "0x1"), 16) == 1, (
+                    f"transfer {tx_hash} failed with receipt {receipt}"
+                )
+                tx_blocks[tx_hash] = int(receipt["blockNumber"], 16)
+            return len(tx_blocks) == len(tx_hashes)
+
+        wait_until(
+            all_transfers_confirmed,
+            error_with="ETH transfers were not confirmed before DA polling",
+            timeout=timeout_for_expected_blocks(10, seconds_per_block=15.0, slack_seconds=60),
+            step=0.5,
+        )
+        max_transfer_block = max(tx_blocks.values())
+        logger.info("Transfers confirmed through EVM block %s", max_transfer_block)
+
+        sequencer.advance_to_next_da_window(
+            additional_blocks=10,
+            timeout_per_block=15.0,
+            timeout_slack=60,
+        )
+
+        da_window = wait_for_reconstructed_real_da_report_window(
+            bitcoin,
+            discovery_config_path,
+            genesis_l1_height,
+            min_last_block_num=max_transfer_block,
+            poll_attempts=20,
+            blocks_per_poll=3,
+            safe_depth=2,
+            custom_chain=sequencer.props["chain_spec"],
+            timeout=180,
+        )
+        scan_report = da_window.report
+
+        applied_range = scan_report["applied_range"]
+        assert scan_report["replay_start"] == "genesis"
+        assert int(scan_report["envelope_count"]) >= 1
+        assert int(scan_report["blobs_reassembled"]) >= 1
+        assert int(applied_range["first_update_seq_no"]) == 0
+        assert int(applied_range["last_block_num"]) >= max_transfer_block
+
+        report = wait_for_published_inner_root_report(
+            bitcoin,
+            sequencer,
+            verification_config_path,
+            genesis_l1_height,
+            da_window.end_height,
+            blocks_per_poll=3,
+            timeout=180,
+        )
+        assert report["reconstructed_state_root"] == scan_report["reconstructed_state_root"]
+        assert_published_inner_root_match(report)
+
+        wrong_expected_root_hex = "11" * 32
+        if wrong_expected_root_hex == report["reconstructed_state_root"]:
+            wrong_expected_root_hex = "22" * 32
+        wrong_expected_root = "0x" + wrong_expected_root_hex
+        code, mismatch_report, stderr = run_alpen_ee_da_tool_json(
+            discovery_config_path,
+            genesis_l1_height,
+            da_window.end_height,
+            expected_root=wrong_expected_root,
+            custom_chain=sequencer.props["chain_spec"],
+            timeout=180,
+        )
+        assert code == 0, stderr
+        assert mismatch_report["expected_state_root"] == wrong_expected_root_hex
+        assert mismatch_report["state_root_matches_expected"] is False
+
+        # Keep the mined height observable for debugging without using Python
+        # as the reconstruction oracle.
+        logger.info("Tool reconstructed DA through L1 height %s", btc_rpc.proxy.getblockcount())
+        return True

--- a/functional-tests/tests/alpen_ee_da_tool/test_reassemble_malformed_chunks.py
+++ b/functional-tests/tests/alpen_ee_da_tool/test_reassemble_malformed_chunks.py
@@ -1,0 +1,38 @@
+"""Verifies alpen-ee-da-tool reports DA blob reassembly errors."""
+
+import flexitest
+
+from tests.alpen_ee_da_tool.base import AlpenEeDaToolTestBase
+from tests.alpen_ee_da_tool.helpers import (
+    TEST_ENVELOPE_PUBKEY,
+    post_envelope_in_one_block,
+    run_alpen_ee_da_tool,
+    write_reconstruction_config,
+)
+
+
+@flexitest.register
+class AlpenEeDaToolInvalidChunkTest(AlpenEeDaToolTestBase):
+    """Posts a complete envelope whose chunk bytes are not a valid encoded DaBlob."""
+
+    def main(self, ctx):
+        bitcoin, sequencer = self._services()
+        config_path = write_reconstruction_config(
+            bitcoin,
+            sequencer,
+            sequencer_pubkey_override=TEST_ENVELOPE_PUBKEY,
+        )
+        window, _envelope = post_envelope_in_one_block(
+            bitcoin,
+            chunks=[b"not a strata-codec DA blob"],
+        )
+
+        code, _stdout, stderr = run_alpen_ee_da_tool(
+            config_path,
+            window.start_height,
+            window.end_height,
+            timeout=120,
+        )
+        assert code == 1, f"expected reassembly failure, got {code}"
+        assert "failed to reassemble da blobs" in stderr.lower(), stderr
+        return True

--- a/functional-tests/tests/alpen_ee_da_tool/test_reorg_between_runs.py
+++ b/functional-tests/tests/alpen_ee_da_tool/test_reorg_between_runs.py
@@ -1,0 +1,56 @@
+"""Verifies alpen-ee-da-tool rereads the canonical L1 chain for a bounded range."""
+
+import flexitest
+
+from tests.alpen_ee_da_tool.base import AlpenEeDaToolTestBase
+from tests.alpen_ee_da_tool.helpers import (
+    TEST_ENVELOPE_PUBKEY,
+    mine_empty_blocks,
+    post_envelope_in_one_block,
+    run_alpen_ee_da_tool,
+    run_alpen_ee_da_tool_json,
+    write_reconstruction_config,
+)
+
+
+@flexitest.register
+class AlpenEeDaToolReorgBetweenRunsTest(AlpenEeDaToolTestBase):
+    """Invalidates a DA-bearing block and verifies the same height range changes."""
+
+    def main(self, ctx):
+        bitcoin, sequencer = self._services()
+        config_path = write_reconstruction_config(
+            bitcoin,
+            sequencer,
+            sequencer_pubkey_override=TEST_ENVELOPE_PUBKEY,
+        )
+        window, _envelope = post_envelope_in_one_block(
+            bitcoin,
+            chunks=[b"not a strata-codec DA blob"],
+        )
+
+        first_code, _first_stdout, first_stderr = run_alpen_ee_da_tool(
+            config_path,
+            window.start_height,
+            window.end_height,
+            timeout=120,
+        )
+        assert first_code == 1, first_stderr
+
+        btc_rpc = bitcoin.create_rpc()
+        invalidate_hash = btc_rpc.proxy.getblockhash(window.start_height)
+        btc_rpc.proxy.invalidateblock(invalidate_hash)
+        mine_empty_blocks(bitcoin, window.end_height - window.start_height + 1)
+
+        second_code, second_report, second_stderr = run_alpen_ee_da_tool_json(
+            config_path,
+            window.start_height,
+            window.end_height,
+            timeout=120,
+        )
+        assert second_code == 0, second_stderr
+        assert second_report["replay_start"] == "genesis"
+        assert second_report.get("envelope_count") == 0
+        assert second_report.get("blobs_reassembled") == 0
+        assert second_report.get("applied_range") is None
+        return True

--- a/functional-tests/tests/alpen_ee_da_tool/test_scan_malformed_envelopes.py
+++ b/functional-tests/tests/alpen_ee_da_tool/test_scan_malformed_envelopes.py
@@ -1,0 +1,39 @@
+"""Verifies alpen-ee-da-tool rejects incomplete confirmed EE DA envelopes."""
+
+import flexitest
+
+from tests.alpen_ee_da_tool.base import AlpenEeDaToolTestBase
+from tests.alpen_ee_da_tool.helpers import (
+    TEST_ENVELOPE_PUBKEY,
+    post_envelope_in_one_block,
+    run_alpen_ee_da_tool,
+    write_reconstruction_config,
+)
+
+
+@flexitest.register
+class AlpenEeDaToolMissingRevealTest(AlpenEeDaToolTestBase):
+    """Posts a confirmed commit with an unspent reveal slot and expects scan failure."""
+
+    def main(self, ctx):
+        bitcoin, sequencer = self._services()
+        config_path = write_reconstruction_config(
+            bitcoin,
+            sequencer,
+            sequencer_pubkey_override=TEST_ENVELOPE_PUBKEY,
+        )
+        window, _envelope = post_envelope_in_one_block(
+            bitcoin,
+            chunks=[b"missing reveal chunk"],
+            reveal_count=0,
+        )
+
+        code, _stdout, stderr = run_alpen_ee_da_tool(
+            config_path,
+            window.start_height,
+            window.end_height,
+            timeout=120,
+        )
+        assert code == 1, f"expected failure for missing reveal, got {code}"
+        assert "missingreveal" in stderr.lower().replace(" ", ""), stderr
+        return True


### PR DESCRIPTION
## Description

Adds `bin/alpen-ee-da-tool`: a verifier that reconstructs the EE execution state root from L1 DA envelopes and can compare reconstruction against manual or OL-published roots.

Comparison sources:
- `--expected-root`: manual/debug comparison against the reconstructed EE execution state root.
- `ol_rpc_url` in config: product comparison against OL-published Snark account state by fetching:
  - `strata_getSnarkAcctUpdateManifest(ee_params.account_id(), update_seq_no)`
  - `strata_getSnarkAcctInboxMsgRange(...)`
- If neither source is configured, the tool runs reconstruction-only and reports no comparison result.

Report fields separate execution-root and Snark-account-root comparisons:
- `reconstructed_state_root`
- `expected_state_root`
- `state_root_matches_expected`
- `reconstructed_inner_state_root`
- `expected_inner_state_root`
- `inner_state_root_matches_expected`
- `inner_state_root_mismatch_update_seq_no`
- `soundness_notes`

Config:
- `ee_params` supplies the EE account id and genesis metadata.
- `ol_rpc_url` enables published inner-root comparison.
- No separate `ee_snark_account_id` config field.

New crates:
- `alpen-ee-da-l1-extraction` — bounded-range L1 fetch, cross-block commit/reveal scan, blob reassembly.
- `alpen-ee-da-state-replay` — ordered DA blob replay from chain-spec genesis or explicit pre-state snapshot.

Library changes in `alpen-reth-statediff`:
- Public `StateReconstructorPreState`, `from_prestate()`, and `to_prestate()` to support snapshot import/export.
- Behavior change: empty accounts are now deleted from the state trie on update (EIP-161). Diffs that empty an account now produce a different state root than before; the previous behavior left a stale entry.

CLI:
- `--custom-chain` selects the Reth chain spec and is checked against `ee_params`.
- `--snapshot` resumes replay from a pre-state snapshot.
- `--export-snapshot` writes the final replay state for later partial replay.
- `--expected-root` remains available as a manual execution-root comparison override.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-2404](https://alpenlabs.atlassian.net/browse/STR-2404)

[STR-2404]: https://alpenlabs.atlassian.net/browse/STR-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ