### PR TITLE
fix(btcio): resolve STR-3691 cleanup TODOs

### DIFF
--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -13,6 +13,7 @@ use strata_primitives::l1::{L1BlockCommitment, L1Height};
 use strata_state::BlockSubmitter;
 use strata_status::StatusChannel;
 use strata_storage::NodeStorage;
+use thiserror::Error;
 use tokio::time::sleep;
 use tracing::*;
 
@@ -63,6 +64,20 @@ impl ReaderValidation {
             expected_l1_anchor,
         }
     }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+enum ReaderError {
+    #[error(
+        "btcio: unable to find common L1 block with Bitcoin client chain \
+         (client height {client_height}, reader best height {reader_best_height}, \
+         known depth {known_depth})"
+    )]
+    PivotNotFound {
+        client_height: L1Height,
+        reader_best_height: L1Height,
+        known_depth: usize,
+    },
 }
 
 /// The main task that initializes the reader state and starts reading from bitcoin.
@@ -269,9 +284,18 @@ async fn poll_for_new_blocks<R: Reader>(
             return Ok(vec![revert_ev]);
         }
     } else {
-        // TODO(STR-3691): make this case a bit more structured
-        error!("unable to find common block with client chain, something is seriously wrong here!");
-        bail!("things are broken with l1 reader");
+        let reader_best_height = state.best_block_idx();
+        let known_depth = state.iter_blocks_back().count();
+        let err = ReaderError::PivotNotFound {
+            client_height,
+            reader_best_height,
+            known_depth,
+        };
+        error!(
+            client_height,
+            reader_best_height, known_depth, "unable to find common block with client chain"
+        );
+        return Err(err.into());
     }
 
     debug!(%client_height, "have new blocks");
@@ -362,13 +386,20 @@ async fn process_block<R: Reader>(
 
 #[cfg(test)]
 mod tests {
-    use strata_csm_types::{ClientState, ClientUpdateOutput};
+    use std::{collections::VecDeque, sync::Arc};
+
+    use bitcoin::{hashes::Hash, BlockHash, Network};
+    use strata_config::btcio::ReaderConfig;
+    use strata_csm_types::{ClientState, ClientUpdateOutput, L1Status};
     use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_l1_txfmt::MagicBytes;
     use strata_primitives::l1::{L1BlockCommitment, L1BlockId};
+    use strata_status::StatusChannel;
     use strata_storage::{create_node_storage, NodeStorage};
     use threadpool::ThreadPool;
 
     use super::*;
+    use crate::test_utils::TestBitcoinClient;
 
     fn test_storage() -> NodeStorage {
         create_node_storage(get_test_sled_backend(), ThreadPool::new(1))
@@ -379,15 +410,46 @@ mod tests {
         L1BlockCommitment::new(height, L1BlockId::default())
     }
 
-    fn store_client_state(storage: &NodeStorage, height: L1Height) {
+    async fn store_client_state(storage: &NodeStorage, height: L1Height) {
         let block = l1_block(height);
         storage
             .client_state()
-            .put_update_blocking(
+            .put_update_async(
                 &block,
                 ClientUpdateOutput::new_state(ClientState::default()),
             )
+            .await
             .expect("test: put client state");
+    }
+
+    async fn store_l1_canonical(storage: &NodeStorage, height: L1Height) {
+        storage
+            .l1()
+            .extend_canonical_chain_async(&L1BlockId::default(), height)
+            .await
+            .expect("test: extend canonical chain");
+    }
+
+    fn block_hash(byte: u8) -> BlockHash {
+        BlockHash::from_byte_array([byte; 32])
+    }
+
+    fn reader_context(storage: NodeStorage) -> ReaderContext<TestBitcoinClient> {
+        ReaderContext {
+            client: Arc::new(TestBitcoinClient::new(0)),
+            storage: Arc::new(storage),
+            config: Arc::new(ReaderConfig::default()),
+            btcio_params: BtcioParams::new(2, MagicBytes::new(*b"ALPN"), 0),
+            expected_network: Network::Regtest,
+            expected_l1_anchor: l1_block(0),
+            status_channel: StatusChannel::new(
+                ClientState::default(),
+                l1_block(0),
+                L1Status::default(),
+                None,
+                None,
+            ),
+        }
     }
 
     #[test]
@@ -417,5 +479,25 @@ mod tests {
         let target = calculate_target_next_block(&storage, 42).expect("test: target block");
 
         assert_eq!(target, 42);
+    }
+
+    #[tokio::test]
+    async fn poll_for_new_blocks_reports_structured_pivot_failure() {
+        let ctx = reader_context(test_storage());
+        let mut state = ReaderState::new(3, 2, VecDeque::from([block_hash(1), block_hash(2)]), 0);
+        let mut status_updates = Vec::new();
+
+        let err = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect_err("test: pivot failure");
+
+        assert_eq!(
+            err.downcast_ref::<ReaderError>(),
+            Some(&ReaderError::PivotNotFound {
+                client_height: 100,
+                reader_best_height: 2,
+                known_depth: 2,
+            })
+        );
     }
 }

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -106,17 +106,55 @@ pub async fn bitcoin_data_reader_task<E: BlockSubmitter>(
 }
 
 /// Calculates target next block to start polling l1 from.
-fn calculate_target_next_block(
+async fn calculate_target_next_block(
     storage: &NodeStorage,
     genesis_l1_height: L1Height,
 ) -> anyhow::Result<L1Height> {
-    let target_next_block = storage
-        .client_state()
-        .fetch_most_recent_state()?
-        .map(|(block, _)| block.height().saturating_add(1))
+    let client_state_target = calculate_client_state_target(storage).await?;
+    let stored_l1_target = storage
+        .l1()
+        .get_canonical_chain_tip_async()
+        .await?
+        .map(|(height, _)| height.saturating_add(1))
+        .unwrap_or(genesis_l1_height);
+    let target_next_block = client_state_target
         .unwrap_or(genesis_l1_height)
+        .max(stored_l1_target)
         .max(genesis_l1_height);
     Ok(target_next_block)
+}
+
+async fn calculate_client_state_target(storage: &NodeStorage) -> anyhow::Result<Option<L1Height>> {
+    let Some((block, _)) = storage
+        .client_state()
+        .fetch_most_recent_state_async()
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    match storage
+        .l1()
+        .get_canonical_blockid_at_height_async(block.height())
+        .await?
+    {
+        Some(blockid) if blockid == *block.blkid() => Ok(Some(block.height().saturating_add(1))),
+        Some(blockid) => {
+            warn!(
+                client_state_block = %block,
+                canonical_l1_blkid = %blockid,
+                "ignoring latest client-state height because it is not on the stored L1 canonical chain"
+            );
+            Ok(None)
+        }
+        None => {
+            warn!(
+                client_state_block = %block,
+                "ignoring latest client-state height because its L1 block is not stored as canonical"
+            );
+            Ok(None)
+        }
+    }
 }
 
 /// Inner function that actually does the reading task.
@@ -452,33 +490,66 @@ mod tests {
         }
     }
 
-    #[test]
-    fn calculate_target_next_block_falls_back_to_genesis_without_client_state() {
+    #[tokio::test]
+    async fn calculate_target_next_block_falls_back_to_genesis_without_client_state() {
         let storage = test_storage();
 
-        let target = calculate_target_next_block(&storage, 42).expect("test: target block");
+        let target = calculate_target_next_block(&storage, 42)
+            .await
+            .expect("test: target block");
 
         assert_eq!(target, 42);
     }
 
-    #[test]
-    fn calculate_target_next_block_uses_latest_client_state_height() {
+    #[tokio::test]
+    async fn calculate_target_next_block_uses_latest_client_state_height() {
         let storage = test_storage();
-        store_client_state(&storage, 100);
+        store_client_state(&storage, 100).await;
+        store_l1_canonical(&storage, 100).await;
 
-        let target = calculate_target_next_block(&storage, 42).expect("test: target block");
+        let target = calculate_target_next_block(&storage, 42)
+            .await
+            .expect("test: target block");
 
         assert_eq!(target, 101);
     }
 
-    #[test]
-    fn calculate_target_next_block_clamps_pregenesis_client_state_to_genesis() {
+    #[tokio::test]
+    async fn calculate_target_next_block_ignores_client_state_without_l1_canonical_anchor() {
         let storage = test_storage();
-        store_client_state(&storage, 10);
+        store_client_state(&storage, 100).await;
 
-        let target = calculate_target_next_block(&storage, 42).expect("test: target block");
+        let target = calculate_target_next_block(&storage, 42)
+            .await
+            .expect("test: target block");
 
         assert_eq!(target, 42);
+    }
+
+    #[tokio::test]
+    async fn calculate_target_next_block_clamps_pregenesis_client_state_to_genesis() {
+        let storage = test_storage();
+        store_client_state(&storage, 10).await;
+        store_l1_canonical(&storage, 10).await;
+
+        let target = calculate_target_next_block(&storage, 42)
+            .await
+            .expect("test: target block");
+
+        assert_eq!(target, 42);
+    }
+
+    #[tokio::test]
+    async fn calculate_target_next_block_does_not_replay_stored_l1_tip() {
+        let storage = test_storage();
+        store_client_state(&storage, 100).await;
+        store_l1_canonical(&storage, 111).await;
+
+        let target = calculate_target_next_block(&storage, 42)
+            .await
+            .expect("test: target block");
+
+        assert_eq!(target, 112);
     }
 
     #[tokio::test]

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -12,7 +12,7 @@ use strata_config::btcio::ReaderConfig;
 use strata_primitives::l1::{L1BlockCommitment, L1Height};
 use strata_state::BlockSubmitter;
 use strata_status::StatusChannel;
-use strata_storage::{L1BlockManager, NodeStorage};
+use strata_storage::NodeStorage;
 use tokio::time::sleep;
 use tracing::*;
 
@@ -76,7 +76,7 @@ pub async fn bitcoin_data_reader_task<E: BlockSubmitter>(
     event_submitter: Arc<E>,
 ) -> anyhow::Result<()> {
     let target_next_block =
-        calculate_target_next_block(storage.l1().as_ref(), btcio_params.genesis_l1_height())?;
+        calculate_target_next_block(storage.as_ref(), btcio_params.genesis_l1_height()).await?;
 
     let ctx = ReaderContext {
         client,
@@ -92,15 +92,15 @@ pub async fn bitcoin_data_reader_task<E: BlockSubmitter>(
 
 /// Calculates target next block to start polling l1 from.
 fn calculate_target_next_block(
-    l1_manager: &L1BlockManager,
-    horz_height: L1Height,
+    storage: &NodeStorage,
+    genesis_l1_height: L1Height,
 ) -> anyhow::Result<L1Height> {
-    // TODO(STR-3691): switch to checking the L1 tip in the consensus/client state
-    let target_next_block = l1_manager
-        .get_canonical_chain_tip()?
-        .map(|(height, _)| height + 1)
-        .unwrap_or(horz_height);
-    assert!(target_next_block >= horz_height);
+    let target_next_block = storage
+        .client_state()
+        .fetch_most_recent_state()?
+        .map(|(block, _)| block.height().saturating_add(1))
+        .unwrap_or(genesis_l1_height)
+        .max(genesis_l1_height);
     Ok(target_next_block)
 }
 
@@ -358,4 +358,64 @@ async fn process_block<R: Reader>(
     let block_ev = L1Event::BlockData(block_data, state.epoch());
 
     Ok((block_ev, l1blkid))
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_csm_types::{ClientState, ClientUpdateOutput};
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_primitives::l1::{L1BlockCommitment, L1BlockId};
+    use strata_storage::{create_node_storage, NodeStorage};
+    use threadpool::ThreadPool;
+
+    use super::*;
+
+    fn test_storage() -> NodeStorage {
+        create_node_storage(get_test_sled_backend(), ThreadPool::new(1))
+            .expect("test: create node storage")
+    }
+
+    fn l1_block(height: L1Height) -> L1BlockCommitment {
+        L1BlockCommitment::new(height, L1BlockId::default())
+    }
+
+    fn store_client_state(storage: &NodeStorage, height: L1Height) {
+        let block = l1_block(height);
+        storage
+            .client_state()
+            .put_update_blocking(
+                &block,
+                ClientUpdateOutput::new_state(ClientState::default()),
+            )
+            .expect("test: put client state");
+    }
+
+    #[test]
+    fn calculate_target_next_block_falls_back_to_genesis_without_client_state() {
+        let storage = test_storage();
+
+        let target = calculate_target_next_block(&storage, 42).expect("test: target block");
+
+        assert_eq!(target, 42);
+    }
+
+    #[test]
+    fn calculate_target_next_block_uses_latest_client_state_height() {
+        let storage = test_storage();
+        store_client_state(&storage, 100);
+
+        let target = calculate_target_next_block(&storage, 42).expect("test: target block");
+
+        assert_eq!(target, 101);
+    }
+
+    #[test]
+    fn calculate_target_next_block_clamps_pregenesis_client_state_to_genesis() {
+        let storage = test_storage();
+        store_client_state(&storage, 10);
+
+        let target = calculate_target_next_block(&storage, 42).expect("test: target block");
+
+        assert_eq!(target, 42);
+    }
 }

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -688,9 +688,12 @@ mod tests {
     use std::sync::Arc;
 
     use bitcoin::{
-        absolute::LockTime, script, secp256k1::constants::SCHNORR_SIGNATURE_SIZE,
-        taproot::ControlBlock, transaction::Version, Address, Network, OutPoint, ScriptBuf,
-        Sequence, Transaction, TxIn, TxOut, Witness,
+        absolute::LockTime,
+        script,
+        secp256k1::{constants::SCHNORR_SIGNATURE_SIZE, Secp256k1, SecretKey},
+        taproot::ControlBlock,
+        transaction::Version,
+        Address, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
     };
     use bitcoind_async_client::corepc_types::model::ListUnspentItem;
     use strata_l1_txfmt::{MagicBytes, TagData, TagDataRef};
@@ -767,6 +770,32 @@ mod tests {
         ];
 
         (ctx, body, signature, utxos)
+    }
+
+    fn test_payload() -> L1Payload {
+        let tag = TagData::new(1, 1, vec![]).unwrap();
+        L1Payload::new(vec![vec![0u8; 150]], tag).unwrap()
+    }
+
+    fn test_envelope_pubkey() -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x01; 32]).unwrap();
+        let (pubkey, _) = sk.x_only_public_key(&secp);
+        pubkey
+    }
+
+    fn test_envelope_config(
+        ctx: &WriterContext<TestBitcoinClient>,
+        envelope_pubkey: Option<XOnlyPublicKey>,
+    ) -> EnvelopeConfig {
+        EnvelopeConfig::new(
+            MagicBytes::new(*b"ALPN"),
+            ctx.sequencer_address.clone(),
+            Network::Regtest,
+            FeeRate::from_sat_per_vb_u32(1_000),
+            546,
+            envelope_pubkey,
+        )
     }
 
     #[test]
@@ -894,25 +923,91 @@ mod tests {
     }
 
     #[test]
+    fn test_create_envelope_transactions_requires_envelope_pubkey() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let env_config = test_envelope_config(&ctx, None);
+
+        let res = super::create_envelope_transactions(&env_config, &test_payload(), utxos);
+
+        assert!(matches!(res, Err(EnvelopeError::MissingEnvelopePubkey)));
+    }
+
+    #[test]
+    fn test_build_commit_transaction_filters_unusable_utxos() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let mut unspendable = utxos[0].clone();
+        unspendable.spendable = false;
+        let mut unsolvable = utxos[1].clone();
+        unsolvable.solvable = false;
+        let viable = utxos[2].clone();
+
+        let (tx, consumed) = super::build_commit_transaction(
+            vec![unspendable, unsolvable, viable.clone()],
+            ctx.sequencer_address.clone(),
+            ctx.sequencer_address.clone(),
+            500_000_000,
+            FeeRate::from_sat_per_vb_u32(1),
+        )
+        .unwrap();
+
+        assert_eq!(consumed, vec![viable.clone()]);
+        assert_eq!(tx.input.len(), 1);
+        assert_eq!(tx.input[0].previous_output.txid, viable.txid);
+    }
+
+    #[test]
+    fn test_build_commit_transaction_rejects_insufficient_filtered_utxos() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let mut dust = utxos[2].clone();
+        dust.amount = Amount::from_sat(BITCOIN_DUST_LIMIT);
+
+        let res = super::build_commit_transaction(
+            vec![dust],
+            ctx.sequencer_address.clone(),
+            ctx.sequencer_address.clone(),
+            500_000_000,
+            FeeRate::from_sat_per_vb_u32(1),
+        );
+
+        assert!(matches!(res, Err(EnvelopeError::NotEnoughUtxos(_, 0))));
+    }
+
+    #[test]
+    fn test_build_reveal_transaction_rejects_dust_input() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let mut dust = utxos[2].clone();
+        dust.amount = Amount::from_sat(BITCOIN_DUST_LIMIT - 1);
+        let input_tx = get_txn_from_utxo(&dust, &ctx.sequencer_address);
+        let reveal_script = ScriptBuf::from_hex("62a58f2674fd840b6144bea2e63ebd35c16d7fd40252a2f28b2a01a648df356343e47976d7906a0e688bf5e134b6fd21bd365c016b57b1ace85cf30bf1206e27").unwrap();
+        let tag = TagDataRef::new(1, 1, &[]).unwrap();
+        let tag_script = ParseConfig::new((*b"ALPN").into())
+            .encode_script_buf(&tag)
+            .unwrap();
+        let control_block = ControlBlock::decode(&[
+            193, 165, 246, 250, 6, 222, 28, 9, 130, 28, 217, 67, 171, 11, 229, 62, 48, 206, 219,
+            111, 155, 208, 6, 7, 119, 63, 146, 90, 227, 254, 231, 232, 249,
+        ])
+        .unwrap();
+
+        let res = super::build_reveal_transaction(
+            input_tx,
+            ctx.sequencer_address.clone(),
+            ctx.config.reveal_amount,
+            FeeRate::from_sat_per_vb_u32(1),
+            &reveal_script,
+            tag_script,
+            &control_block,
+        );
+
+        assert!(matches!(res, Err(EnvelopeError::NotEnoughUtxos(_, _))));
+    }
+
+    #[test]
     fn test_create_envelope_transactions() {
         let (ctx, _, _, utxos) = get_mock_data();
 
-        let tag = TagData::new(1, 1, vec![]).unwrap();
-        // Use 150 bytes to meet minimum envelope payload size of 126 bytes
-        let payload = L1Payload::new(vec![vec![0u8; 150]], tag).unwrap();
-
-        use bitcoin::secp256k1::{Secp256k1, SecretKey};
-        let secp = Secp256k1::new();
-        let sk = SecretKey::from_slice(&[0x01; 32]).unwrap();
-        let (pubkey, _) = sk.x_only_public_key(&secp);
-        let env_config = EnvelopeConfig::new(
-            MagicBytes::new(*b"ALPN"),
-            ctx.sequencer_address.clone(),
-            Network::Regtest,
-            FeeRate::from_sat_per_vb_u32(1_000),
-            546,
-            Some(pubkey),
-        );
+        let payload = test_payload();
+        let env_config = test_envelope_config(&ctx, Some(test_envelope_pubkey()));
         let unsigned =
             super::create_envelope_transactions(&env_config, &payload, utxos.to_vec()).unwrap();
 
@@ -958,5 +1053,24 @@ mod tests {
         assert_ne!(unsigned.sighash, Buf32::zero());
     }
 
-    // TODO(STR-3691): make the tests more comprehensive
+    #[test]
+    fn test_attach_reveal_signature_populates_witness() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let payload = test_payload();
+        let env_config = test_envelope_config(&ctx, Some(test_envelope_pubkey()));
+        let mut unsigned =
+            super::create_envelope_transactions(&env_config, &payload, utxos.to_vec()).unwrap();
+
+        super::attach_reveal_signature(
+            &mut unsigned.reveal_tx,
+            &unsigned.reveal_script,
+            &unsigned.taproot_spend_info,
+            &[0x11; SCHNORR_SIGNATURE_SIZE],
+        )
+        .unwrap();
+
+        let witness = &unsigned.reveal_tx.input[0].witness;
+        assert_eq!(witness.len(), 3);
+        assert_eq!(witness.iter().next().unwrap().len(), SCHNORR_SIGNATURE_SIZE);
+    }
 }

--- a/crates/btcio/src/writer/bundler/logic.rs
+++ b/crates/btcio/src/writer/bundler/logic.rs
@@ -15,7 +15,7 @@ pub(crate) async fn process_unbundled_entries(
     ops: &EnvelopeDataOps,
     unbundled: Vec<IntentEntry>,
 ) -> DbResult<Vec<IntentEntry>> {
-    for mut entry in unbundled {
+    for entry in unbundled {
         // Check it is actually unbundled, omit if bundled
         if entry.status != IntentStatus::Unbundled {
             continue;
@@ -24,21 +24,16 @@ pub(crate) async fn process_unbundled_entries(
         // intents and create payload entries accordingly
         let payload_entry = BundledPayloadEntry::new_unsigned(entry.payload().clone());
 
-        // TODO(STR-3691): the following block till "Atomic Ends" should be atomic.
-        let idx = ops.get_next_payload_idx_async().await?;
-        ops.put_payload_entry_async(idx, payload_entry).await?;
+        let intent_commitment = *entry.intent.commitment();
+        let idx = ops
+            .bundle_intent_payload_async(intent_commitment, entry, payload_entry)
+            .await?;
         info!(
             component = "btcio_writer_bundler",
-            intent_commitment = %entry.intent.commitment(),
+            %intent_commitment,
             payload_idx = idx,
             "bundled L1 intent into payload entry"
         );
-
-        // Set the entry to be bundled so that it won't be processed next time.
-        entry.status = IntentStatus::Bundled(idx);
-        ops.put_intent_entry_async(*entry.intent.commitment(), entry)
-            .await?;
-        // Atomic Ends.
     }
     // Return empty Vec because each entry is being bundled right now. This might be different in
     // future.

--- a/crates/db/store-sled/src/writer/db.rs
+++ b/crates/db/store-sled/src/writer/db.rs
@@ -2,7 +2,7 @@ use strata_db_types::{
     DbResult,
     errors::DbError,
     traits::L1WriterDatabase,
-    types::{BundledPayloadEntry, IntentEntry},
+    types::{BundledPayloadEntry, IntentEntry, IntentStatus},
 };
 use strata_primitives::buf::Buf32;
 
@@ -55,6 +55,30 @@ impl L1WriterDatabase for L1WriterDBSled {
                     Ok(nxt)
                 })?;
         Ok(idx)
+    }
+
+    fn bundle_intent_payload(
+        &self,
+        intent_id: Buf32,
+        intent_entry: IntentEntry,
+        payload_entry: BundledPayloadEntry,
+    ) -> DbResult<u64> {
+        let next_payload_idx = self
+            .payload_tree
+            .last()?
+            .map(first)
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+
+        self.config
+            .with_retry((&self.payload_tree, &self.intent_tree), |(pt, it)| {
+                let payload_idx = find_next_available_id(&pt, next_payload_idx)?;
+                pt.insert(&payload_idx, &payload_entry)?;
+                let mut bundled_intent_entry = intent_entry.clone();
+                bundled_intent_entry.status = IntentStatus::Bundled(payload_idx);
+                it.insert(&intent_id, &bundled_intent_entry)?;
+                Ok(payload_idx)
+            })
     }
 
     fn get_intent_by_id(&self, id: Buf32) -> DbResult<Option<IntentEntry>> {

--- a/crates/db/tests/src/l1_writer_tests.rs
+++ b/crates/db/tests/src/l1_writer_tests.rs
@@ -1,6 +1,6 @@
 use strata_db_types::{
     traits::L1WriterDatabase,
-    types::{BundledPayloadEntry, IntentEntry},
+    types::{BundledPayloadEntry, IntentEntry, IntentStatus},
 };
 use strata_primitives::buf::Buf32;
 use strata_test_utils::ArbitraryGenerator;
@@ -186,6 +186,54 @@ pub fn test_put_intent_entry(db: &impl L1WriterDatabase) {
 
     let retrieved = db.get_intent_by_id(intent_id).unwrap().unwrap();
     assert_eq!(retrieved, intent);
+}
+
+pub fn test_bundle_intent_payload(db: &impl L1WriterDatabase) {
+    let first_payload: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+    let second_payload: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+    db.put_payload_entry(0, first_payload)
+        .expect("test: seed first payload");
+    db.put_payload_entry(1, second_payload)
+        .expect("test: seed second payload");
+
+    let mut intent: IntentEntry = ArbitraryGenerator::new().generate();
+    intent.status = IntentStatus::Unbundled;
+    let intent_id = *intent.intent.commitment();
+    let intent_idx = db
+        .put_intent_entry(intent_id, intent.clone())
+        .expect("test: seed intent");
+    let expected_payload_idx = db
+        .get_next_payload_idx()
+        .expect("test: get next payload idx");
+
+    let payload_entry = BundledPayloadEntry::new_unsigned(intent.payload().clone());
+    let payload_idx = db
+        .bundle_intent_payload(intent_id, intent.clone(), payload_entry.clone())
+        .expect("test: bundle intent payload");
+
+    assert_eq!(payload_idx, expected_payload_idx);
+    assert_eq!(
+        db.get_payload_entry_by_idx(payload_idx)
+            .expect("test: get payload"),
+        Some(payload_entry)
+    );
+
+    let stored_intent = db
+        .get_intent_by_id(intent_id)
+        .expect("test: get intent")
+        .expect("test: stored intent");
+    assert_eq!(stored_intent.status, IntentStatus::Bundled(payload_idx));
+    assert_eq!(stored_intent.intent, intent.intent);
+    assert_eq!(
+        db.get_intent_by_idx(intent_idx)
+            .expect("test: get intent by idx"),
+        Some(stored_intent)
+    );
+    assert_eq!(
+        db.get_next_intent_idx().expect("test: get next intent idx"),
+        intent_idx + 1,
+        "bundling should not insert a duplicate intent index entry"
+    );
 }
 
 pub fn test_del_intent_entry_single(db: &impl L1WriterDatabase) {
@@ -441,6 +489,12 @@ macro_rules! l1_writer_db_tests {
         fn test_put_intent_entry() {
             let db = $setup_expr;
             $crate::l1_writer_tests::test_put_intent_entry(&db);
+        }
+
+        #[test]
+        fn test_bundle_intent_payload() {
+            let db = $setup_expr;
+            $crate::l1_writer_tests::test_bundle_intent_payload(&db);
         }
 
         #[test]

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -354,6 +354,16 @@ pub trait L1WriterDatabase: Send + Sync + 'static {
     /// Store the [`IntentEntry`].
     fn put_intent_entry(&self, payloadid: Buf32, payloadentry: IntentEntry) -> DbResult<u64>;
 
+    /// Atomically stores a payload entry and marks an existing intent as bundled.
+    ///
+    /// Returns the payload index allocated for the new [`BundledPayloadEntry`].
+    fn bundle_intent_payload(
+        &self,
+        intent_id: Buf32,
+        intent_entry: IntentEntry,
+        payloadentry: BundledPayloadEntry,
+    ) -> DbResult<u64>;
+
     /// Get a [`IntentEntry`] by its hash
     fn get_intent_by_id(&self, id: Buf32) -> DbResult<Option<IntentEntry>>;
 

--- a/crates/storage/src/managers/client_state.rs
+++ b/crates/storage/src/managers/client_state.rs
@@ -90,6 +90,24 @@ impl ClientStateManager {
         Ok(state)
     }
 
+    pub async fn put_update_async(
+        &self,
+        block: &L1BlockCommitment,
+        update: ClientUpdateOutput,
+    ) -> DbResult<Arc<ClientState>> {
+        // FIXME(STR-3679): this is a lot of cloning, good thing the type isn't gigantic,
+        // still feels bad though
+        let state = Arc::new(update.state().clone());
+        let height = block.height();
+        self.ops
+            .put_client_update_async(*block, update.clone())
+            .await?;
+        self.maybe_update_cur_state_async(height, &state).await;
+        self.update_cache.insert_async(height, Some(update)).await;
+        self.state_cache.insert_async(height, state.clone()).await;
+        Ok(state)
+    }
+
     /// Deletes the client update at `block`, keeping caches and the current
     /// state tracker coherent.
     pub fn del_update_blocking(&self, block: &L1BlockCommitment) -> DbResult<()> {
@@ -106,6 +124,15 @@ impl ClientStateManager {
         cur.maybe_update(height, state)
     }
 
+    async fn maybe_update_cur_state_async(
+        &self,
+        height: L1Height,
+        state: &Arc<ClientState>,
+    ) -> bool {
+        let mut cur = self.cur_state.lock().await;
+        cur.maybe_update(height, state)
+    }
+
     /// Recomputes the current-state tracker from storage after a deletion.
     fn reset_cur_state_blocking(&self) -> DbResult<()> {
         let mut cur = self.cur_state.blocking_lock();
@@ -119,6 +146,13 @@ impl ClientStateManager {
     /// Returns either pre-genesis init [`ClientState`] or the one with the greatest key.
     pub fn fetch_most_recent_state(&self) -> DbResult<Option<(L1BlockCommitment, ClientState)>> {
         self.ops.get_latest_client_state_blocking()
+    }
+
+    /// Returns either pre-genesis init [`ClientState`] or the one with the greatest key.
+    pub async fn fetch_most_recent_state_async(
+        &self,
+    ) -> DbResult<Option<(L1BlockCommitment, ClientState)>> {
+        self.ops.get_latest_client_state_async().await
     }
 
     /// Returns [`ClientUpdateOutput`] entries starting from a given block up to a maximum count.

--- a/crates/storage/src/ops/writer.rs
+++ b/crates/storage/src/ops/writer.rs
@@ -14,6 +14,7 @@ inst_ops_simple! {
         get_payload_entry_by_idx(idx: u64) => Option<BundledPayloadEntry>;
         get_next_payload_idx() => u64;
         put_intent_entry(id: Buf32, entry: IntentEntry) => u64;
+        bundle_intent_payload(id: Buf32, entry: IntentEntry, payloadentry: BundledPayloadEntry) => u64;
         get_intent_by_id(id: Buf32) => Option<IntentEntry>;
         get_intent_by_idx(idx: u64) => Option<IntentEntry>;
         get_next_intent_idx() => u64;


### PR DESCRIPTION
## Description

Resolves the btcio cleanup items tracked by STR-3691.

This PR:
- Makes L1 intent bundling atomic by adding a storage-level `bundle_intent_payload` operation.
- Starts the L1 reader from the latest persisted client-state L1 anchor instead of the raw L1 DB tip.
- Replaces the reader's generic no-pivot failure with structured error context.
- Expands envelope builder test coverage around pubkey requirements, UTXO filtering, insufficient funds, reveal dust handling, and witness population.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The storage change intentionally keeps the existing intent index entry and only updates the intent row status during bundling, so bundling does not create duplicate intent index entries.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance was used to implement the STR-3691 cleanup and split the changes into atomic commits.


## Related Issues

STR-3691
