### PR TITLE
STR 3370, STR 3580 FCM replay unvalidated blocks and improve logging 

### DIFF
--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -164,7 +164,12 @@ async fn process_fc_message<C: FcmContext>(
                     // problem checking the block in general and it could be
                     // valid or invalid, but we're kinda sloppy with errors
                     // here so let's try to avoid crashing the FCM task?
-                    error!(%slot, %blkid, "error processing block, interpreting as invalid\n{e:?}");
+                    error!(
+                        %slot,
+                        %blkid,
+                        err = ?e,
+                        "error processing block, interpreting as invalid"
+                    );
                     false
                 }
             };
@@ -275,27 +280,65 @@ async fn set_block_status_and_clear_invalid_high_watermark<C: FcmContext>(
 async fn handle_new_state_update<C: FcmContext>(
     fcm_state: &mut FcmServiceState<C>,
 ) -> anyhow::Result<()> {
-    let Some(new_fin_epoch) = fcm_state.ctx().last_finalized_epoch() else {
+    let Some(observed_finalized_epoch) = fcm_state.ctx().last_finalized_epoch() else {
         debug!("got new CSM state, but finalized epoch still unset, ignoring");
         return Ok(());
     };
 
-    info!(?new_fin_epoch, "got new finalized block");
-    fcm_state.attach_epoch_pending_finalization(new_fin_epoch);
+    let current_finalized_epoch = *fcm_state.chain_tracker().finalized_epoch();
+    if observed_finalized_epoch == current_finalized_epoch {
+        debug!(
+            ?current_finalized_epoch,
+            ?observed_finalized_epoch,
+            "no new finalized epoch in CSM update"
+        );
+        return Ok(());
+    }
 
+    let latest_observed_finalized_epoch = *fcm_state.latest_observed_finalized_epoch();
+    if observed_finalized_epoch == latest_observed_finalized_epoch {
+        debug!(
+            ?observed_finalized_epoch,
+            "observed finalized epoch is already recorded, checking finalization progress"
+        );
+        check_finalization_progress(fcm_state, observed_finalized_epoch).await?;
+        return Ok(());
+    }
+
+    if !fcm_state.record_observed_finalized_epoch(observed_finalized_epoch) {
+        return Ok(());
+    }
+
+    info!(?observed_finalized_epoch, "observed new finalized epoch");
+    check_finalization_progress(fcm_state, observed_finalized_epoch).await?;
+
+    Ok(())
+}
+
+async fn check_finalization_progress<C: FcmContext>(
+    fcm_state: &mut FcmServiceState<C>,
+    observed_finalized_epoch: EpochCommitment,
+) -> anyhow::Result<()> {
     match handle_epoch_finalization(fcm_state).await {
         Err(err) => {
             error!(%err, "failed to finalize epoch");
         }
-        Ok(Some(finalized_epoch)) if finalized_epoch == new_fin_epoch => {
-            debug!(?finalized_epoch, "finalized latest epoch");
+        Ok(Some(finalized_epoch)) if finalized_epoch == observed_finalized_epoch => {
+            debug!(
+                ?finalized_epoch,
+                "FCM caught up to observed finalized epoch"
+            );
         }
         Ok(Some(finalized_epoch)) => {
-            debug!(?finalized_epoch, "finalized earlier epoch");
+            debug!(
+                ?finalized_epoch,
+                ?observed_finalized_epoch,
+                "FCM finalized earlier recorded epoch; still behind observed finalized epoch"
+            );
         }
         Ok(None) => {
             // there were no epochs that could be finalized
-            warn!("did not finalize epoch");
+            debug!(?observed_finalized_epoch, "no finalization progress");
         }
     };
 
@@ -421,9 +464,7 @@ async fn handle_epoch_finalization<C: FcmContext>(
 
     fcm_state.finalize_epoch(next_finalizable_epoch).await?;
 
-    info!(?next_finalizable_epoch, "updated finalized tip");
-    //trace!(?fin_report, "finalization report");
-    // TODO(STR-3580): do something with the finalization report?
+    info!(?next_finalizable_epoch, "advanced finalized epoch");
 
     Ok(Some(next_finalizable_epoch))
 }
@@ -663,7 +704,7 @@ mod tests {
         SignedOLBlockHeader,
     };
     use strata_ol_state_support_types::MemoryStateBaseLayer;
-    use strata_ol_state_types::OLState;
+    use strata_ol_state_types::{OLAccountState, OLState, WriteBatch};
     use strata_ol_stf::{
         test_utils::{execute_block, make_genesis_state},
         BlockComponents, BlockInfo, CompletedBlock,
@@ -1053,9 +1094,19 @@ mod tests {
         timestamp: u64,
         slot: u64,
     ) -> ExecutedBlock {
+        execute_test_block_in_epoch(state, parent, timestamp, slot, 1)
+    }
+
+    fn execute_test_block_in_epoch(
+        state: &mut MemoryStateBaseLayer,
+        parent: &OLBlock,
+        timestamp: u64,
+        slot: u64,
+        epoch: Epoch,
+    ) -> ExecutedBlock {
         let completed = execute_block(
             state,
-            &BlockInfo::new(timestamp, slot, 1),
+            &BlockInfo::new(timestamp, slot, epoch),
             Some(parent.header()),
             BlockComponents::new_empty(),
         )
@@ -1200,6 +1251,100 @@ mod tests {
         fn tracker_through_x4(&self) -> UnfinalizedBlockTracker {
             tracker_with_blocks(&self.genesis, &[&self.x1, &self.x2, &self.x3, &self.x4])
         }
+    }
+
+    #[test]
+    fn record_observed_finalized_epoch_classifies_ordering() {
+        let chain = LinearChain::new();
+        let fixture = chain.fixture_without_x4();
+        let finalized_epoch =
+            EpochCommitment::new(1, chain.x1.commitment().slot(), chain.x1.blkid());
+        let tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
+        let mut fcm_state = fixture.fcm_state_at(tracker, &chain.x1);
+
+        assert!(!fcm_state.record_observed_finalized_epoch(finalized_epoch));
+
+        let strict_regression = EpochCommitment::new(0, 0, chain.genesis.blkid());
+        assert!(!fcm_state.record_observed_finalized_epoch(strict_regression));
+
+        let epoch_up_slot_flat =
+            EpochCommitment::new(2, finalized_epoch.last_slot(), chain.x2.blkid());
+        assert!(!fcm_state.record_observed_finalized_epoch(epoch_up_slot_flat));
+
+        let slot_up_epoch_flat = EpochCommitment::new(
+            finalized_epoch.epoch(),
+            chain.x2.commitment().slot(),
+            chain.x2.blkid(),
+        );
+        assert!(!fcm_state.record_observed_finalized_epoch(slot_up_epoch_flat));
+
+        let strict_advance =
+            EpochCommitment::new(2, chain.x2.commitment().slot(), chain.x2.blkid());
+        assert!(fcm_state.record_observed_finalized_epoch(strict_advance));
+        assert_eq!(*fcm_state.latest_observed_finalized_epoch(), strict_advance);
+    }
+
+    #[tokio::test]
+    async fn handle_new_state_update_ignores_repeated_finalized_epoch() -> anyhow::Result<()> {
+        let (genesis, _) = execute_test_genesis();
+        let genesis_epoch = EpochCommitment::new(0, 0, genesis.blkid());
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(genesis_epoch))
+                .with_last_confirmed_epoch(Some(genesis_epoch)),
+        );
+        seed_executed_block(ctx.storage(), &genesis, BlockStatus::Valid);
+        ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+
+        let tracker = empty_tracker(&genesis);
+        let inner = FcmInnerState::new(
+            tracker,
+            genesis.commitment(),
+            Arc::new(genesis.state.clone()),
+            Vec::new(),
+        );
+        let mut fcm_state = FcmServiceState::new(ctx.clone(), PredicateKey::always_accept(), inner);
+
+        handle_new_state_update(&mut fcm_state).await?;
+
+        assert!(ctx.finalized_epochs().is_empty());
+        assert_eq!(*fcm_state.latest_observed_finalized_epoch(), genesis_epoch);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handle_new_state_update_retries_pending_finalized_epoch() -> anyhow::Result<()> {
+        let chain = LinearChain::new();
+        let pending_epoch = EpochCommitment::new(1, chain.x1.commitment().slot(), chain.x1.blkid());
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(pending_epoch))
+                .with_last_confirmed_epoch(Some(pending_epoch)),
+        );
+        let tracker = tracker_with_blocks(&chain.genesis, &[&chain.x1, &chain.x2]);
+        let mut finalizable_state = chain.x2.state.clone();
+        let mut epoch_update = WriteBatch::<OLAccountState>::default();
+        epoch_update.epochal_writes_mut().cur_epoch = Some(2);
+        finalizable_state
+            .apply_write_batch(epoch_update)
+            .expect("test epoch update applies");
+
+        let inner = FcmInnerState::new(
+            tracker,
+            chain.x2.commitment(),
+            Arc::new(finalizable_state),
+            Vec::new(),
+        );
+        let mut fcm_state = FcmServiceState::new(ctx.clone(), PredicateKey::always_accept(), inner);
+        assert!(fcm_state.record_observed_finalized_epoch(pending_epoch));
+
+        handle_new_state_update(&mut fcm_state).await?;
+
+        assert_eq!(ctx.finalized_epochs(), vec![pending_epoch]);
+        assert_eq!(*fcm_state.chain_tracker().finalized_epoch(), pending_epoch);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -69,6 +69,7 @@ pub async fn start_fcm_service<C: FcmContext>(
         .with_input(fcm_input)
         .launch_async("fcm", texec.as_ref())
         .await?;
+
     Ok(FcmServiceHandle {
         service_monitor,
         fcm_tx,
@@ -98,7 +99,24 @@ impl<C: FcmContext> Service for FcmService<C> {
 }
 
 impl<C: FcmContext> AsyncService for FcmService<C> {
-    async fn on_launch(_state: &mut Self::State) -> anyhow::Result<()> {
+    async fn on_launch(state: &mut Self::State) -> anyhow::Result<()> {
+        let startup_replay_candidates = state.take_startup_replay_candidates();
+        if startup_replay_candidates.is_empty() {
+            return Ok(());
+        }
+
+        let replay_candidate_count = startup_replay_candidates.len();
+        for blkid in startup_replay_candidates {
+            let msg = ForkChoiceMessage::NewBlock(blkid);
+            process_fc_message(&msg, state)
+                .await
+                .with_context(|| format!("failed to replay startup OL block {blkid}"))?;
+        }
+
+        debug!(
+            replay_candidate_count,
+            "processed startup replay candidates"
+        );
         Ok(())
     }
 
@@ -1002,6 +1020,7 @@ mod tests {
                 tracker,
                 cur_block.commitment(),
                 Arc::new(cur_block.state.clone()),
+                Vec::new(),
             );
             FcmServiceState::new(self.ctx.clone(), PredicateKey::always_accept(), inner)
         }
@@ -1425,6 +1444,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn on_launch_replays_startup_candidates_and_drains_them() -> anyhow::Result<()> {
+        let genesis = make_storage_block(0, OLBlockId::from(Buf32::zero()));
+        let genesis_blkid = genesis.header().compute_blkid();
+        let genesis_commitment = OLBlockCommitment::new(genesis.header().slot(), genesis_blkid);
+        let genesis_epoch = EpochCommitment::new(0, genesis_commitment.slot(), genesis_blkid);
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(genesis_epoch))
+                .with_last_confirmed_epoch(Some(genesis_epoch)),
+        );
+
+        let block1 = make_storage_block(1, genesis_blkid);
+        let blkid1 = block1.header().compute_blkid();
+        let commitment1 = OLBlockCommitment::new(block1.header().slot(), blkid1);
+        let block2 = make_storage_block(2, blkid1);
+        let blkid2 = block2.header().compute_blkid();
+        let commitment2 = OLBlockCommitment::new(block2.header().slot(), blkid2);
+
+        ctx.storage().put_executed_block(
+            genesis,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        for (block, commitment) in [(block1, commitment1), (block2, commitment2)] {
+            let blkid = block.header().compute_blkid();
+            ctx.storage().put_ol_block(block);
+            ctx.storage()
+                .set_block_status(blkid, BlockStatus::Unchecked)
+                .await?;
+            ctx.storage()
+                .put_toplevel_ol_state(commitment, make_genesis_state().state().clone());
+        }
+        ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+
+        let mut fcm_state =
+            init_fcm_service_state(PredicateKey::always_accept(), ctx.clone()).await?;
+
+        <FcmService<StubFcmContext> as AsyncService>::on_launch(&mut fcm_state).await?;
+
+        assert_eq!(ctx.executed_blocks(), vec![commitment1, commitment2]);
+        assert_eq!(ctx.safe_tip_updates(), vec![commitment1, commitment2]);
+        assert_eq!(fcm_state.cur_best_block(), commitment2);
+        assert_eq!(fcm_state.take_startup_replay_candidates(), Vec::new());
+        assert_eq!(
+            ctx.storage().get_block_status(blkid1).await?,
+            Some(BlockStatus::Valid)
+        );
+        assert_eq!(
+            ctx.storage().get_block_status(blkid2).await?,
+            Some(BlockStatus::Valid)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn stub_storage_round_trips_blocks_and_statuses() {
         let storage = StubFcmStorage::new();
         let block = make_storage_block(1, OLBlockId::from(Buf32::zero()));
@@ -1516,12 +1591,17 @@ mod tests {
         );
         ctx.storage().put_ol_block(block);
         ctx.storage()
+            .set_block_status(blkid, BlockStatus::Unchecked)
+            .await
+            .expect("set unchecked status");
+        ctx.storage()
             .put_toplevel_ol_state(block_commitment, make_genesis_state().state().clone());
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
 
         let mut fcm_state = init_fcm_service_state(PredicateKey::always_accept(), ctx.clone())
             .await
             .expect("FCM state initializes from stub context");
+        assert_eq!(fcm_state.take_startup_replay_candidates(), vec![blkid]);
 
         process_fc_message(&ForkChoiceMessage::NewBlock(blkid), &mut fcm_state)
             .await
@@ -1567,10 +1647,14 @@ mod tests {
             BlockStatus::Valid,
         );
         ctx.storage().put_ol_block(block);
+        ctx.storage()
+            .set_block_status(blkid, BlockStatus::Unchecked)
+            .await?;
         ctx.storage().set_block_high_watermark(block_commitment);
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
 
         let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
+        assert_eq!(fcm_state.take_startup_replay_candidates(), vec![blkid]);
 
         process_fc_message(&ForkChoiceMessage::NewBlock(blkid), &mut fcm_state).await?;
 

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -30,18 +30,23 @@ impl<C: FcmContext> FcmServiceState<C> {
         self.inner_state.cur_olstate.clone()
     }
 
-    /// Gets the most recently finalized epoch, even if it's one that we haven't
-    /// accepted as a new base yet due to missing intermediary blocks.
-    fn get_most_recently_finalized_epoch(&self) -> &EpochCommitment {
+    /// Gets the latest finalized epoch observed by FCM.
+    ///
+    /// This may be newer than [`UnfinalizedBlockTracker::finalized_epoch`] when
+    /// CSM has reported a finalized epoch but FCM's finalized epoch has not
+    /// advanced to it yet because the terminal block is not finalizable.
+    pub(crate) fn latest_observed_finalized_epoch(&self) -> &EpochCommitment {
         self.inner_state
             .epochs_pending_finalization
             .back()
             .unwrap_or(self.inner_state.chain_tracker.finalized_epoch())
     }
 
-    /// Does handling to accept an epoch as finalized before we've actually validated it.
-    pub(crate) fn attach_epoch_pending_finalization(&mut self, epoch: EpochCommitment) -> bool {
-        let last_finalized_epoch = self.get_most_recently_finalized_epoch();
+    /// Records a finalized epoch observed from FCM's context.
+    ///
+    /// Returns whether the epoch was queued for FCM finalization.
+    pub(crate) fn record_observed_finalized_epoch(&mut self, epoch: EpochCommitment) -> bool {
+        let latest_observed_finalized_epoch = self.latest_observed_finalized_epoch();
 
         if epoch.is_null() {
             warn!("tried to finalize null epoch");
@@ -49,11 +54,35 @@ impl<C: FcmContext> FcmServiceState<C> {
         }
 
         // Some checks to make sure we don't go backwards.
-        if last_finalized_epoch.last_slot() > 0 {
-            let epoch_advances = epoch.epoch() > last_finalized_epoch.epoch();
-            let block_advances = epoch.last_slot() > last_finalized_epoch.last_slot();
+        if latest_observed_finalized_epoch.last_slot() > 0 {
+            let epoch_advances = epoch.epoch() > latest_observed_finalized_epoch.epoch();
+            let block_advances = epoch.last_slot() > latest_observed_finalized_epoch.last_slot();
+
+            if epoch == *latest_observed_finalized_epoch {
+                debug!(
+                    ?latest_observed_finalized_epoch,
+                    "finalized epoch already observed, ignoring"
+                );
+                return false;
+            }
+
             if !epoch_advances || !block_advances {
-                warn!(?last_finalized_epoch, received = ?epoch, "received invalid or out of order epoch");
+                let epoch_regresses = epoch.epoch() < latest_observed_finalized_epoch.epoch();
+                let block_regresses =
+                    epoch.last_slot() < latest_observed_finalized_epoch.last_slot();
+                if epoch_regresses && block_regresses {
+                    warn!(
+                        ?latest_observed_finalized_epoch,
+                        received = ?epoch,
+                        "received out-of-order epoch"
+                    );
+                } else {
+                    warn!(
+                        ?latest_observed_finalized_epoch,
+                        received = ?epoch,
+                        "received inconsistent epoch ordering"
+                    );
+                }
                 return false;
             }
         }

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc, time};
+use std::{collections::VecDeque, mem, sync::Arc, time};
 
 use anyhow::anyhow;
 use metrics::{counter, gauge};
@@ -72,6 +72,10 @@ impl<C: FcmContext> FcmServiceState<C> {
 
     pub(crate) fn cur_best_block(&self) -> OLBlockCommitment {
         self.inner_state.cur_best_block
+    }
+
+    pub(crate) fn take_startup_replay_candidates(&mut self) -> Vec<OLBlockId> {
+        mem::take(&mut self.inner_state.startup_replay_candidates)
     }
 
     pub(crate) fn chain_tracker_mut(&mut self) -> &mut UnfinalizedBlockTracker {
@@ -212,6 +216,7 @@ pub(crate) struct FcmInnerState {
     chain_tracker: UnfinalizedBlockTracker,
     cur_best_block: L2BlockCommitment,
     cur_olstate: Arc<OLState>,
+    startup_replay_candidates: Vec<OLBlockId>,
     epochs_pending_finalization: VecDeque<EpochCommitment>,
 }
 
@@ -220,11 +225,13 @@ impl FcmInnerState {
         chain_tracker: UnfinalizedBlockTracker,
         cur_best_block: L2BlockCommitment,
         cur_olstate: Arc<OLState>,
+        startup_replay_candidates: Vec<OLBlockId>,
     ) -> Self {
         Self {
             chain_tracker,
             cur_best_block,
             cur_olstate,
+            startup_replay_candidates,
             epochs_pending_finalization: VecDeque::new(),
         }
     }
@@ -254,7 +261,7 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
 
     // Populate the unfinalized block tracker.
     let mut chain_tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
-    chain_tracker
+    let startup_replay_candidates = chain_tracker
         .load_unfinalized_ol_blocks_async(fcm_ctx.as_ref())
         .await?;
 
@@ -268,7 +275,12 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
         .await?
         .ok_or(Error::MissingOLState(tip_blkid))?;
 
-    let fcm_inner = FcmInnerState::new(chain_tracker, cur_tip_block, ol_state);
+    let fcm_inner = FcmInnerState::new(
+        chain_tracker,
+        cur_tip_block,
+        ol_state,
+        startup_replay_candidates,
+    );
     gauge!("strata_ol_tip_slot").set(cur_tip_block.slot() as f64);
     gauge!("strata_fcm_finalized_epoch").set(finalized_epoch.epoch() as f64);
     gauge!("strata_fcm_finalized_slot").set(finalized_epoch.last_slot() as f64);

--- a/crates/consensus-logic/src/unfinalized_tracker/ol.rs
+++ b/crates/consensus-logic/src/unfinalized_tracker/ol.rs
@@ -7,6 +7,7 @@ use strata_storage::OLBlockManager;
 use tracing::{debug, error, warn};
 
 use super::UnfinalizedBlockTracker;
+use crate::errors::ChainTipError;
 
 #[async_trait]
 pub trait UnfinalizedOLBlockSource: Send + Sync {
@@ -36,8 +37,9 @@ impl UnfinalizedBlockTracker {
     pub async fn load_unfinalized_ol_blocks_async(
         &mut self,
         source: &(impl UnfinalizedOLBlockSource + ?Sized),
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<OLBlockId>> {
         let mut height = self.finalized_epoch().last_slot() + 1;
+        let mut replay_candidates = Vec::new();
 
         loop {
             let blkids = match source.get_blocks_at_height(height).await {
@@ -56,19 +58,26 @@ impl UnfinalizedBlockTracker {
             for blkid in blkids {
                 // Check the status so we can skip trying to attach blocks we
                 // don't care about.
-                //
-                // TODO(STR-3370): if a block doesn't have a concrete status (either
-                // missing or explicit unchecked) should we put it into a queue
-                // to be processed?
                 match source.get_block_status(blkid).await {
-                    Ok(Some(status)) => {
-                        if status != BlockStatus::Valid {
-                            debug!(%blkid, "skipping attaching block not known to be valid");
-                            continue;
+                    Ok(Some(BlockStatus::Valid)) => {}
+                    Ok(Some(BlockStatus::Unchecked)) => {
+                        if source.get_ol_block(blkid).await?.is_some() {
+                            debug!(%blkid, "queueing unchecked block for startup replay");
+                            replay_candidates.push(blkid);
+                        } else {
+                            warn!(
+                                %blkid,
+                                "unchecked block is indexed but missing block data, skipping startup replay"
+                            );
                         }
+                        continue;
                     }
-                    Ok(_) => {
-                        debug!(%blkid, "block status not available, will check later");
+                    Ok(Some(BlockStatus::Invalid)) => {
+                        debug!(%blkid, "skipping invalid block");
+                        continue;
+                    }
+                    Ok(None) => {
+                        warn!(%blkid, "block is indexed but missing status row, skipping");
                         continue;
                     }
                     Err(e) => {
@@ -85,16 +94,182 @@ impl UnfinalizedBlockTracker {
                         blkid,
                         *block.header().parent_blkid(),
                     ) {
-                        warn!(%blkid, err = %e, "failed to attach block, continuing");
+                        match e {
+                            ChainTipError::AttachMissingParent(_, parent_blkid) => {
+                                warn!(
+                                    %blkid,
+                                    %parent_blkid,
+                                    "valid block is missing its parent during startup load, skipping"
+                                );
+                            }
+                            err => warn!(%blkid, err = %err, "failed to attach block, continuing"),
+                        }
                     }
                 } else {
-                    error!(%blkid, "missing expected block from database!  wtf?");
+                    warn!(%blkid, "valid block is indexed but missing block data, skipping");
                 }
             }
 
             height += 1;
         }
 
-        Ok(())
+        Ok(replay_candidates)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use async_trait::async_trait;
+    use strata_db_types::{traits::BlockStatus, DbResult};
+    use strata_ol_chain_types_new::{
+        BlockFlags, OLBlock, OLBlockBody, OLBlockHeader, OLTxSegment, SignedOLBlockHeader,
+    };
+    use strata_primitives::{Buf32, Buf64, EpochCommitment, OLBlockId};
+
+    use super::{UnfinalizedBlockTracker, UnfinalizedOLBlockSource};
+
+    #[derive(Default)]
+    struct TestBlockSource {
+        blocks_by_slot: BTreeMap<u64, Vec<OLBlockId>>,
+        statuses: HashMap<OLBlockId, BlockStatus>,
+        blocks: HashMap<OLBlockId, OLBlock>,
+    }
+
+    impl TestBlockSource {
+        fn insert_block(&mut self, block: OLBlock, status: Option<BlockStatus>) -> OLBlockId {
+            let blkid = block.header().compute_blkid();
+            self.blocks_by_slot
+                .entry(block.header().slot())
+                .or_default()
+                .push(blkid);
+            self.blocks.insert(blkid, block);
+            if let Some(status) = status {
+                self.statuses.insert(blkid, status);
+            }
+            blkid
+        }
+
+        fn insert_indexed_id(&mut self, slot: u64, blkid: OLBlockId, status: Option<BlockStatus>) {
+            self.blocks_by_slot.entry(slot).or_default().push(blkid);
+            if let Some(status) = status {
+                self.statuses.insert(blkid, status);
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UnfinalizedOLBlockSource for TestBlockSource {
+        async fn get_blocks_at_height(&self, slot: u64) -> DbResult<Vec<OLBlockId>> {
+            Ok(self.blocks_by_slot.get(&slot).cloned().unwrap_or_default())
+        }
+
+        async fn get_block_status(&self, blkid: OLBlockId) -> DbResult<Option<BlockStatus>> {
+            Ok(self.statuses.get(&blkid).copied())
+        }
+
+        async fn get_ol_block(&self, blkid: OLBlockId) -> DbResult<Option<OLBlock>> {
+            Ok(self.blocks.get(&blkid).cloned())
+        }
+    }
+
+    fn make_block(slot: u64, parent: OLBlockId, salt: u8) -> OLBlock {
+        let body = OLBlockBody::new_common(OLTxSegment::new(vec![]).expect("empty tx segment"));
+        let header = OLBlockHeader::new(
+            1_000 + slot,
+            BlockFlags::from(0),
+            slot,
+            0,
+            parent,
+            body.compute_hash_commitment(),
+            Buf32::from([salt; 32]),
+            Buf32::zero(),
+        );
+        OLBlock::new(SignedOLBlockHeader::new(header, Buf64::zero()), body)
+    }
+
+    #[tokio::test]
+    async fn loader_surfaces_only_unchecked_blocks_with_data() {
+        let genesis_blkid = OLBlockId::from(Buf32::zero());
+        let finalized_epoch = EpochCommitment::new(0, 0, genesis_blkid);
+        let mut tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
+        let mut source = TestBlockSource::default();
+
+        let valid_block = make_block(1, genesis_blkid, 1);
+        let valid_blkid = source.insert_block(valid_block, Some(BlockStatus::Valid));
+
+        let unchecked_block = make_block(2, valid_blkid, 2);
+        let unchecked_blkid = source.insert_block(unchecked_block, Some(BlockStatus::Unchecked));
+
+        let invalid_block = make_block(2, valid_blkid, 3);
+        let invalid_blkid = source.insert_block(invalid_block, Some(BlockStatus::Invalid));
+
+        let missing_status_block = make_block(2, valid_blkid, 4);
+        let missing_status_blkid = source.insert_block(missing_status_block, None);
+
+        let missing_data_blkid = OLBlockId::from(Buf32::from([5; 32]));
+        source.insert_indexed_id(2, missing_data_blkid, Some(BlockStatus::Unchecked));
+
+        let replay_candidates = tracker
+            .load_unfinalized_ol_blocks_async(&source)
+            .await
+            .expect("loader succeeds");
+
+        assert_eq!(replay_candidates, vec![unchecked_blkid]);
+        assert!(tracker.is_seen_block(&valid_blkid));
+        assert!(!tracker.is_seen_block(&unchecked_blkid));
+        assert!(!tracker.is_seen_block(&invalid_blkid));
+        assert!(!tracker.is_seen_block(&missing_status_blkid));
+        assert!(!tracker.is_seen_block(&missing_data_blkid));
+    }
+
+    #[tokio::test]
+    async fn loader_returns_unchecked_replay_candidates_in_slot_scan_order() {
+        let genesis_blkid = OLBlockId::from(Buf32::zero());
+        let finalized_epoch = EpochCommitment::new(0, 0, genesis_blkid);
+        let mut tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
+        let mut source = TestBlockSource::default();
+
+        let block1 = make_block(1, genesis_blkid, 1);
+        let blkid1 = block1.header().compute_blkid();
+        let block2 = make_block(2, blkid1, 2);
+        let blkid2 = block2.header().compute_blkid();
+        let block3 = make_block(3, blkid2, 3);
+        let blkid3 = block3.header().compute_blkid();
+
+        source.insert_block(block3, Some(BlockStatus::Unchecked));
+        source.insert_block(block1, Some(BlockStatus::Unchecked));
+        source.insert_block(block2, Some(BlockStatus::Unchecked));
+
+        let replay_candidates = tracker
+            .load_unfinalized_ol_blocks_async(&source)
+            .await
+            .expect("loader succeeds");
+
+        assert_eq!(replay_candidates, vec![blkid1, blkid2, blkid3]);
+        assert!(!tracker.is_seen_block(&blkid1));
+        assert!(!tracker.is_seen_block(&blkid2));
+        assert!(!tracker.is_seen_block(&blkid3));
+    }
+
+    #[tokio::test]
+    async fn loader_skips_valid_block_with_missing_parent() {
+        let genesis_blkid = OLBlockId::from(Buf32::zero());
+        let finalized_epoch = EpochCommitment::new(0, 0, genesis_blkid);
+        let mut tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
+        let mut source = TestBlockSource::default();
+
+        let missing_parent = OLBlockId::from(Buf32::from([9; 32]));
+        let valid_orphan = make_block(1, missing_parent, 1);
+        let valid_orphan_blkid = source.insert_block(valid_orphan, Some(BlockStatus::Valid));
+
+        let replay_candidates = tracker
+            .load_unfinalized_ol_blocks_async(&source)
+            .await
+            .expect("loader succeeds");
+
+        assert!(replay_candidates.is_empty());
+        assert!(!tracker.is_seen_block(&valid_orphan_blkid));
     }
 }


### PR DESCRIPTION
## Description

**STR-3370 — replay unvalidated OL blocks on startup.** A block persisted but not yet validated stays `Unchecked`; if the node restarted before validating it, the unfinalized-tree loader skipped it and nothing re-queued it, orphaning the block. The loader now collects `Unchecked` blocks (with data), in slot order, as replay candidates, attaches `Valid`, skips `Invalid`, and logs `None`/missing-data as a DB inconsistency. The candidates are stored on the FCM state, and the FCM service's `on_launch` hook reprocesses them through the normal validation path before the input loop starts — so they replay ahead of any live block/CSM message, without prefilling the command queue.

**STR-3580 — accurate finalization logging.** A CSM update with no new finalized epoch used to log `warn!` "invalid or out of order epoch" + "did not finalize epoch", falsely implying a problem. `handle_new_state_update` now returns early at `debug!` when the observed epoch already matches the applied finalized epoch, retries finalization when it only matches an epoch still pending locally, and routes ordering decisions through `record_observed_finalized_epoch`, which distinguishes an already-recorded epoch (`debug!`) from genuine out-of-order / inconsistent ordering (`warn!`).

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3370](https://alpenlabs.atlassian.net/browse/STR-3370)
[STR-3580](https://alpenlabs.atlassian.net/browse/STR-3580)

[STR-3370]: https://alpenlabs.atlassian.net/browse/STR-3370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ