### PR TITLE
ci: remove dispatch-cd job from the build workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -324,43 +324,11 @@ jobs:
           echo "Successfully pushed: ${FULL_IMAGE}"
 
   # ---------------------------------------------------------------------------
-  # Dispatch CD to deployments repo
-  # ---------------------------------------------------------------------------
-  dispatch-cd:
-    name: Dispatch CD to deployments
-    needs: [build-and-push]
-    if: always() && needs.build-and-push.result == 'success'
-    runs-on: ubuntu-latest
-    permissions: {}
-    environment: prod
-    steps:
-      - name: Trigger deployments repo
-        env:
-          GH_TOKEN: ${{ secrets.DEPLOYMENTS_DISPATCH_TOKEN }}
-          SHORT_TAG: ${{ needs.build-and-push.outputs.short_tag }}
-          COMMIT_SHA: ${{ needs.build-and-push.outputs.commit_sha }}
-        run: |
-          jq -n \
-            --arg tag "$SHORT_TAG" \
-            --arg sha "$COMMIT_SHA" \
-            --arg ref "${GITHUB_REF_NAME}" \
-            '{
-              event_type: "new-arch-deploy",
-              client_payload: {
-                tag: $tag,
-                commit_sha: $sha,
-                ref: $ref
-              }
-            }' | gh api repos/alpenlabs/deployments/dispatches --method POST --input -
-
-          echo "Dispatched CD to deployments repo with tag=${SHORT_TAG}"
-
-  # ---------------------------------------------------------------------------
   # Summary
   # ---------------------------------------------------------------------------
   summary:
     name: Build Summary
-    needs: [build-and-push, dispatch-cd]
+    needs: [build-and-push]
     if: always()
     runs-on: ubuntu-latest
     permissions: {}
@@ -370,7 +338,6 @@ jobs:
           SHORT_TAG: ${{ needs.build-and-push.outputs.short_tag }}
           COMMIT_SHA: ${{ needs.build-and-push.outputs.commit_sha }}
           BUILD_RESULT: ${{ needs.build-and-push.result }}
-          CD_RESULT: ${{ needs.dispatch-cd.result }}
         run: |
           {
             echo "## Build Summary"
@@ -380,7 +347,6 @@ jobs:
             echo "| **Commit** | \`${COMMIT_SHA}\` |"
             echo "| **Image Tag** | \`${SHORT_TAG}\` |"
             echo "| **Ref** | \`${GITHUB_REF_NAME}\` |"
-            echo "| **CD Dispatch** | \`${CD_RESULT}\` |"
             echo ""
             echo "### Build Status"
             echo "Overall: **${BUILD_RESULT}**"


### PR DESCRIPTION
## Summary
Removes the `dispatch-cd` job from `.github/workflows/ci-build.yml`. After a successful build it fired a `new-arch-deploy` `repository_dispatch` to `alpenlabs/deployments` (using the `DEPLOYMENTS_DISPATCH_TOKEN`), auto-triggering a deploy. Deploy promotion is handled out of band now, so this cross-repo trigger is removed.

## Changes
- Delete the `dispatch-cd` job (the `repository_dispatch` POST to the deployments repo).
- `summary` job cleanup: drop `dispatch-cd` from `needs`, remove the `CD_RESULT` env, and drop the **CD Dispatch** row from the build summary table.

Remaining jobs: `check-new-commits`, `prepare`, `build-sp1-artifacts`, `build-and-push`, `summary`. Valid YAML; net +1 / −35 lines.

## Follow-ups (repo settings — can't change from here)
- The `DEPLOYMENTS_DISPATCH_TOKEN` secret is now unused and can be revoked.
- If branch protection lists **"Dispatch CD to deployments"** as a required status check, remove it so PRs aren't blocked waiting on a job that no longer runs.
- Companion to #1952 (which removed the deployments-repo Helm patch from `cd.yml`).