### PR TITLE
feat(ci): improve SP1 E2E failure visibility

### DIFF
--- a/.github/sp1-e2e/compose-override.yml
+++ b/.github/sp1-e2e/compose-override.yml
@@ -28,7 +28,11 @@ services:
     image: ${ECR_REGISTRY}/alpen-client:${IMAGE_TAG}
     platform: linux/amd64
     shm_size: '8gb'
-    command: []
+    command:
+      - --btcio-fee-policy
+      - fixed
+      - --btcio-fee-rate
+      - "5"
     environment:
       - SEQUENCER_MODE=true
       - NETWORK_PRIVATE_KEY=${NETWORK_PRIVATE_KEY}

--- a/.github/sp1-e2e/config.seq.toml
+++ b/.github/sp1-e2e/config.seq.toml
@@ -26,7 +26,8 @@ client_poll_dur_ms = 5_000
 
 [btcio.writer]
 write_poll_dur_ms = 5_000
-fee_policy = "bitcoind"
+fee_policy = "fixed"
+fixed_fee_rate = 5
 reveal_amount = 330
 bundle_interval_ms = 1_000
 

--- a/.github/sp1-e2e/run-test.sh
+++ b/.github/sp1-e2e/run-test.sh
@@ -13,13 +13,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 DOCKER_DIR="${REPO_ROOT}/docker"
 PROOF_TIMEOUT="${PROOF_TIMEOUT:-2400}"
+RPC_READY_TIMEOUT="${RPC_READY_TIMEOUT:-120}"
+FAILURE_REASON_FILE="${SCRIPT_DIR}/e2e-failure-reason.txt"
 
 DATATOOL_IMAGE="${ECR_REGISTRY}/strata-datatool:${IMAGE_TAG}"
 
 ALPEN_ACCOUNT_ID="0101010101010101010101010101010101010101010101010101010101010101"
 CHAIN_STATUS_PAYLOAD='{"jsonrpc":"2.0","method":"strata_getChainStatus","params":[],"id":1}'
-SNARK_STATE_PAYLOAD='{"jsonrpc":"2.0","method":"strata_getSnarkAccountState","params":["'"${ALPEN_ACCOUNT_ID}"'","latest"],"id":1}'
+SNARK_STATE_PAYLOAD='{"jsonrpc":"2.0","method":"strata_getSnarkAccountStateByTag","params":["'"${ALPEN_ACCOUNT_ID}"'","latest"],"id":1}'
 EE_BLOCK_NUMBER_PAYLOAD='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+STACK_LOG_SINCE=""
+LAST_FAILURE_REASON=""
 
 # Signet config
 export SIGNET_IMAGE="public.ecr.aws/alpenlabs/signet:tmpconf2"
@@ -41,30 +45,53 @@ export SAFE_HARBOUR_ADDRESS="0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d95
 
 # --- Low-level helpers ---
 
+record_failure() {
+    local reason="$1"
+
+    if [ ! -s "${FAILURE_REASON_FILE}" ]; then
+        printf '%s\n' "${reason}" > "${FAILURE_REASON_FILE}"
+    fi
+}
+
+fail() {
+    local reason="$1"
+
+    echo "FAIL: ${reason}"
+    record_failure "${reason}"
+    exit 1
+}
+
+on_error() {
+    local line="$1"
+    local command="$2"
+
+    record_failure "command failed at line ${line}: ${command}"
+}
+
 cleanup() {
     [ -n "${LOGS_PID:-}" ] && kill "${LOGS_PID}" 2>/dev/null || true
 
     echo "=== Collecting final state ==="
     {
         echo "--- Chain Status ---"
-        ol_rpc "${CHAIN_STATUS_PAYLOAD}" 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "(unavailable)"
+        ol_rpc "${CHAIN_STATUS_PAYLOAD}" 2>/dev/null | jq . 2>/dev/null || echo "(unavailable)"
         echo ""
         echo "--- Snark Account State ---"
-        ol_rpc "${SNARK_STATE_PAYLOAD}" 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "(unavailable)"
+        ol_rpc "${SNARK_STATE_PAYLOAD}" 2>/dev/null | jq . 2>/dev/null || echo "(unavailable)"
         echo ""
         echo "--- Bitcoin Height ---"
         btc_height 2>/dev/null || echo "(unavailable)"
         echo ""
         echo "--- EE Latest Block ---"
-        ee_rpc "${EE_BLOCK_NUMBER_PAYLOAD}" 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "(unavailable)"
+        ee_rpc "${EE_BLOCK_NUMBER_PAYLOAD}" 2>/dev/null | jq . 2>/dev/null || echo "(unavailable)"
     } > "${SCRIPT_DIR}/e2e-state.txt" 2>&1
 
     {
         echo "--- OL Params ---"
-        cat "${DOCKER_DIR}/configs/generated/ol-params.json" 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "(unavailable)"
+        cat "${DOCKER_DIR}/configs/generated/ol-params.json" 2>/dev/null | jq . 2>/dev/null || echo "(unavailable)"
         echo ""
         echo "--- ASM Params ---"
-        cat "${DOCKER_DIR}/configs/generated/asm-params.json" 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "(unavailable)"
+        cat "${DOCKER_DIR}/configs/generated/asm-params.json" 2>/dev/null | jq . 2>/dev/null || echo "(unavailable)"
     } > "${SCRIPT_DIR}/e2e-params.txt" 2>&1
 
     {
@@ -79,6 +106,7 @@ cleanup() {
     docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" down -v 2>/dev/null || true
     docker compose -f "${DOCKER_DIR}/compose-signet.yml" down -v 2>/dev/null || true
 }
+trap 'on_error "${LINENO}" "${BASH_COMMAND}"' ERR
 trap cleanup EXIT
 
 json_rpc() {
@@ -95,6 +123,26 @@ json_rpc() {
 ol_rpc() { json_rpc "$1" 8432; }
 ee_rpc() { json_rpc "$1" 8545; }
 
+assert_rpc_result() {
+    local label="$1"
+    local payload="$2"
+    local port="$3"
+    local response
+
+    if ! response=$(json_rpc "${payload}" "${port}"); then
+        LAST_FAILURE_REASON="${label} RPC request failed"
+        echo "FAIL: ${LAST_FAILURE_REASON}"
+        return 1
+    fi
+
+    local validation_error
+    validation_error=$(printf '%s' "${response}" | python3 "${SCRIPT_DIR}/validate-json-rpc.py" "${label}") || {
+        LAST_FAILURE_REASON="${validation_error}"
+        echo "FAIL: ${LAST_FAILURE_REASON}"
+        return 1
+    }
+}
+
 wait_for_service() {
     local label="$1"
     local port="$2"
@@ -105,41 +153,150 @@ wait_for_service() {
     local deadline=$((SECONDS + timeout))
     while [ $SECONDS -lt $deadline ]; do
         local payload='{"jsonrpc":"2.0","method":"'"${method}"'","params":[],"id":1}'
-        if json_rpc "${payload}" "${port}" >/dev/null 2>&1; then
+        if assert_rpc_result "${label}.${method}" "${payload}" "${port}" >/dev/null 2>&1; then
             echo "${label} ready"
             return 0
         fi
         sleep 2
     done
-    echo "FAIL: ${label} not reachable within ${timeout}s"
-    return 1
+    fail "${label} not reachable within ${timeout}s"
 }
 
 wait_for_strata()       { wait_for_service "strata"       8432 "strata_protocolVersion"; }
 wait_for_alpen_client() { wait_for_service "alpen-client" 8545 "eth_blockNumber"; }
+
+wait_for_rpc_result() {
+    local label="$1"
+    local payload="$2"
+    local port="$3"
+    local timeout="${4:-${RPC_READY_TIMEOUT}}"
+
+    echo "Waiting for ${label} RPC..."
+    local deadline=$((SECONDS + timeout))
+    while [ $SECONDS -lt $deadline ]; do
+        if assert_rpc_result "${label}" "${payload}" "${port}" >/dev/null 2>&1; then
+            echo "${label} RPC ready"
+            return 0
+        fi
+        sleep 2
+    done
+
+    fail "${LAST_FAILURE_REASON:-${label} RPC not ready within ${timeout}s}"
+}
+
+assert_required_rpc_methods() {
+    echo "=== Validating required RPC methods ==="
+    wait_for_rpc_result "strata_getChainStatus" "${CHAIN_STATUS_PAYLOAD}" 8432
+    wait_for_rpc_result "strata_getSnarkAccountState" "${SNARK_STATE_PAYLOAD}" 8432
+    wait_for_rpc_result "eth_blockNumber" "${EE_BLOCK_NUMBER_PAYLOAD}" 8545
+}
+
+compose_stack() {
+    docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" "$@"
+}
+
+stack_service_states() {
+    local service
+    local cid
+    local inspect
+
+    for service in strata strata-signer alpen-client; do
+        cid=$(compose_stack ps -q "${service}")
+        if [ -z "${cid}" ]; then
+            printf '%s\tmissing\t\t\n' "${service}"
+            continue
+        fi
+
+        inspect=$(docker inspect \
+            --format '{{.State.Status}} {{.State.ExitCode}} {{.RestartCount}}' \
+            "${cid}")
+        printf '%s\t%s\n' "${service}" "${inspect}"
+    done
+}
+
+stack_state_failure_reason() {
+    local service
+    local status
+    local exit_code
+    local restarts
+
+    while IFS=$'\t ' read -r service status exit_code restarts; do
+        if [ "${status}" = "missing" ]; then
+            echo "${service} container is missing"
+            return 0
+        fi
+        if [ "${status}" != "running" ] || [ "${exit_code}" != "0" ] || [ "${restarts}" != "0" ]; then
+            echo "${service} unhealthy: status=${status}, exit_code=${exit_code}, restarts=${restarts}"
+            return 0
+        fi
+    done
+}
+
+stack_recent_logs() {
+    if [ -n "${STACK_LOG_SINCE}" ]; then
+        compose_stack logs --since "${STACK_LOG_SINCE}" strata alpen-client 2>/dev/null || true
+    fi
+}
+
+fatal_log_failure_reason() {
+    local fatal_logs
+
+    fatal_logs=$(grep -E "critical task exited with error|chunked envelope watcher exited with error|smart fee estimate unavailable|Method not found" || true)
+    if [ -n "${fatal_logs}" ]; then
+        echo "fatal service error detected: $(printf '%s\n' "${fatal_logs}" | tail -1)"
+    fi
+}
+
+stack_failure_reason() {
+    local state_reason
+    local log_reason
+
+    state_reason=$(stack_service_states | stack_state_failure_reason)
+    if [ -n "${state_reason}" ]; then
+        echo "${state_reason}"
+        return 0
+    fi
+
+    log_reason=$(stack_recent_logs | fatal_log_failure_reason)
+    if [ -n "${log_reason}" ]; then
+        echo "${log_reason}"
+    fi
+}
+
+assert_stack_healthy_or_exit() {
+    local reason
+
+    reason=$(stack_failure_reason)
+    if [ -n "${reason}" ]; then
+        LAST_FAILURE_REASON="${reason}"
+        echo "FAIL: ${LAST_FAILURE_REASON}"
+        compose_stack logs --tail=120 strata alpen-client || true
+        fail "${LAST_FAILURE_REASON}"
+    fi
+}
 
 btc_height() {
     docker exec docker-bitcoind-1 bitcoin-cli -signet getblockcount 2>/dev/null || echo 0
 }
 
 parse_result() {
-    python3 -c "import json,sys; print(json.load(sys.stdin)['result']$1)" 2>/dev/null
+    jq -r ".result$1" 2>/dev/null
 }
 
 get_confirmed_epoch() {
-    ol_rpc "${CHAIN_STATUS_PAYLOAD}" | parse_result "['confirmed']['epoch']" || echo 0
+    ol_rpc "${CHAIN_STATUS_PAYLOAD}" | parse_result ".confirmed.epoch // 0" || echo 0
 }
 
 get_tip_epoch() {
-    ol_rpc "${CHAIN_STATUS_PAYLOAD}" | parse_result "['tip']['epoch']" || echo 0
+    ol_rpc "${CHAIN_STATUS_PAYLOAD}" | parse_result ".tip.epoch // 0" || echo 0
 }
 
 get_snark_seq_no() {
-    ol_rpc "${SNARK_STATE_PAYLOAD}" | parse_result ".get('seq_no',0)" || echo 0
+    ol_rpc "${SNARK_STATE_PAYLOAD}" | parse_result ".seq_no // 0" || echo 0
 }
 
 get_snark_update_vk() {
-    ol_rpc "${SNARK_STATE_PAYLOAD}" | parse_result "['update_vk']" || echo "unknown"
+    ol_rpc "${SNARK_STATE_PAYLOAD}" | parse_result '.update_vk // "unknown"' || echo "unknown"
 }
 
 # --- Step functions ---
@@ -170,8 +327,7 @@ start_signet_fast() {
         sleep 1
     done
     if [ "$(btc_height)" -le 101 ]; then
-        echo "FAIL: Bitcoin did not reach height 101 within 300s"
-        exit 1
+        fail "Bitcoin did not reach height 101 within 300s"
     fi
     echo "Bitcoin at height $(btc_height)"
 }
@@ -190,8 +346,7 @@ restart_signet_slow() {
         sleep 1
     done
     if [ "$(btc_height)" -eq 0 ]; then
-        echo "FAIL: Bitcoind did not come back up within 60s"
-        exit 1
+        fail "Bitcoind did not come back up within 60s"
     fi
 
     GENESIS_HEIGHT=$(btc_height)
@@ -239,8 +394,7 @@ generate_params() {
     # Verify no AlwaysAccept
     for f in configs/generated/{ol-params,asm-params}.json; do
         if grep -q "AlwaysAccept" "${f}"; then
-            echo "FAIL: AlwaysAccept found in ${f}"
-            exit 1
+            fail "AlwaysAccept found in ${f}"
         fi
     done
     echo "All params use Sp1Groth16"
@@ -263,9 +417,12 @@ start_sequencer_stack() {
     echo "=== Starting sequencer stack ==="
     cd "${REPO_ROOT}"
     docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" up -d 2>&1 | tail -3
+    STACK_LOG_SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
     wait_for_strata
     wait_for_alpen_client
+    assert_required_rpc_methods
+    assert_stack_healthy_or_exit
 
     # Stream container logs to stdout so they appear in GH Actions
     docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" logs -f &
@@ -282,6 +439,8 @@ assert_proofs() {
     local deadline=$((SECONDS + timeout))
 
     while [ $SECONDS -lt $deadline ]; do
+        assert_stack_healthy_or_exit
+
         if [ "${sau_accepted}" = false ]; then
             local seq_no
             seq_no=$(get_snark_seq_no)
@@ -308,22 +467,26 @@ assert_proofs() {
         sleep 5
     done
 
-    [ "${sau_accepted}" = false ] && echo "FAIL: SAU not accepted within ${timeout}s"
-    [ "${sau_confirmed}" = false ] && echo "FAIL: SAU epoch ${sau_epoch} not confirmed within ${timeout}s (confirmed=$(get_confirmed_epoch))"
-    exit 1
+    if [ "${sau_accepted}" = false ]; then
+        fail "SAU not accepted within ${timeout}s"
+    fi
+    if [ "${sau_confirmed}" = false ]; then
+        fail "SAU epoch ${sau_epoch} not confirmed within ${timeout}s (confirmed=$(get_confirmed_epoch))"
+    fi
 }
 
 assert_no_always_accept() {
     local vk
     vk=$(get_snark_update_vk)
     if [ "${vk}" = "AlwaysAccept" ]; then
-        echo "FAIL: Runtime update_vk is AlwaysAccept"
-        exit 1
+        fail "Runtime update_vk is AlwaysAccept"
     fi
     echo "PASS: Runtime update_vk is ${vk}"
 }
 
 # --- Orchestration ---
+
+rm -f "${FAILURE_REASON_FILE}"
 
 preflight_cleanup
 start_signet_fast

--- a/.github/sp1-e2e/run-test.sh
+++ b/.github/sp1-e2e/run-test.sh
@@ -15,6 +15,7 @@ DOCKER_DIR="${REPO_ROOT}/docker"
 PROOF_TIMEOUT="${PROOF_TIMEOUT:-2400}"
 RPC_READY_TIMEOUT="${RPC_READY_TIMEOUT:-120}"
 FAILURE_REASON_FILE="${SCRIPT_DIR}/e2e-failure-reason.txt"
+WARN_ERROR_SUMMARY_FILE="${SCRIPT_DIR}/e2e-warn-error-summary.txt"
 
 DATATOOL_IMAGE="${ECR_REGISTRY}/strata-datatool:${IMAGE_TAG}"
 
@@ -106,6 +107,7 @@ cleanup() {
     echo "=== Collecting logs ==="
     docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" logs --no-color > "${SCRIPT_DIR}/e2e-logs.txt" 2>&1 || true
     docker compose -f "${DOCKER_DIR}/compose-signet.yml" logs --no-color >> "${SCRIPT_DIR}/e2e-logs.txt" 2>&1 || true
+    python3 "${SCRIPT_DIR}/summarize-warn-error-logs.py" "${SCRIPT_DIR}/e2e-logs.txt" > "${WARN_ERROR_SUMMARY_FILE}" || true
     echo "=== Tearing down ==="
     docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" down -v 2>/dev/null || true
     docker compose -f "${DOCKER_DIR}/compose-signet.yml" down -v 2>/dev/null || true

--- a/.github/sp1-e2e/run-test.sh
+++ b/.github/sp1-e2e/run-test.sh
@@ -49,14 +49,18 @@ record_failure() {
     local reason="$1"
 
     if [ ! -s "${FAILURE_REASON_FILE}" ]; then
-        printf '%s\n' "${reason}" > "${FAILURE_REASON_FILE}"
+        printf '%s\n' "${reason}" | strip_ansi > "${FAILURE_REASON_FILE}"
     fi
+}
+
+strip_ansi() {
+    sed -E $'s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g'
 }
 
 fail() {
     local reason="$1"
 
-    echo "FAIL: ${reason}"
+    printf 'FAIL: %s\n' "${reason}" | strip_ansi
     record_failure "${reason}"
     exit 1
 }
@@ -100,8 +104,8 @@ cleanup() {
     } > "${SCRIPT_DIR}/e2e-env.txt" 2>&1
 
     echo "=== Collecting logs ==="
-    docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" logs > "${SCRIPT_DIR}/e2e-logs.txt" 2>&1 || true
-    docker compose -f "${DOCKER_DIR}/compose-signet.yml" logs >> "${SCRIPT_DIR}/e2e-logs.txt" 2>&1 || true
+    docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" logs --no-color > "${SCRIPT_DIR}/e2e-logs.txt" 2>&1 || true
+    docker compose -f "${DOCKER_DIR}/compose-signet.yml" logs --no-color >> "${SCRIPT_DIR}/e2e-logs.txt" 2>&1 || true
     echo "=== Tearing down ==="
     docker compose -f "${DOCKER_DIR}/compose-ol-el-seq.yml" -f "${SCRIPT_DIR}/compose-override.yml" down -v 2>/dev/null || true
     docker compose -f "${DOCKER_DIR}/compose-signet.yml" down -v 2>/dev/null || true
@@ -234,7 +238,7 @@ stack_state_failure_reason() {
 
 stack_recent_logs() {
     if [ -n "${STACK_LOG_SINCE}" ]; then
-        compose_stack logs --since "${STACK_LOG_SINCE}" strata alpen-client 2>/dev/null || true
+        compose_stack logs --no-color --since "${STACK_LOG_SINCE}" strata alpen-client 2>/dev/null || true
     fi
 }
 

--- a/.github/sp1-e2e/summarize-warn-error-logs.py
+++ b/.github/sp1-e2e/summarize-warn-error-logs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Groups WARN and ERROR docker compose logs by service prefix."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+LEVEL_RE = re.compile(r"\b(WARN|ERROR)\b")
+
+
+def strip_ansi(line: str) -> str:
+    return ANSI_RE.sub("", line)
+
+
+def split_service(line: str) -> tuple[str, str]:
+    service, sep, message = line.partition(" | ")
+    if not sep:
+        return "(unknown)", line.rstrip()
+    return service.rstrip(), message.rstrip()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: summarize-warn-error-logs.py <log-file>", file=sys.stderr)
+        return 2
+
+    log_path = Path(sys.argv[1])
+    if not log_path.is_file():
+        print("No logs collected.")
+        return 0
+
+    grouped: OrderedDict[str, dict[str, object]] = OrderedDict()
+
+    with log_path.open("r", encoding="utf-8", errors="replace") as logs:
+        for raw_line in logs:
+            line = strip_ansi(raw_line.rstrip("\n"))
+            match = LEVEL_RE.search(line)
+            if not match:
+                continue
+
+            service, message = split_service(line)
+            service_summary = grouped.setdefault(
+                service,
+                {"WARN": 0, "ERROR": 0, "lines": []},
+            )
+            level = match.group(1)
+            service_summary[level] = int(service_summary[level]) + 1
+            service_summary["lines"].append(f"  {level}: {message}")
+
+    if not grouped:
+        print("No WARN or ERROR logs found.")
+        return 0
+
+    print("WARN/ERROR counts by service")
+    for service, service_summary in grouped.items():
+        print(
+            f"{service}: ERROR={service_summary['ERROR']}, WARN={service_summary['WARN']}"
+        )
+
+    print()
+    print("WARN/ERROR lines by service")
+    for service, service_summary in grouped.items():
+        print()
+        print(service)
+        for line in service_summary["lines"]:
+            print(line)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/sp1-e2e/validate-json-rpc.py
+++ b/.github/sp1-e2e/validate-json-rpc.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Validates a JSON-RPC response and prints a failure reason."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def compact_json(value: Any) -> str:
+    """Returns a compact JSON string for log output."""
+
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def failure_reason(label: str, raw_response: str) -> str | None:
+    """Returns a failure reason when a response is not a successful JSON-RPC result."""
+
+    try:
+        response = json.loads(raw_response)
+    except json.JSONDecodeError as err:
+        return f"{label} RPC returned invalid JSON: {err}"
+
+    if not isinstance(response, dict):
+        return f"{label} RPC returned non-object JSON: {compact_json(response)}"
+
+    if "error" in response:
+        return f"{label} RPC returned error: {compact_json(response['error'])}"
+
+    if "result" not in response:
+        return f"{label} RPC response missing result: {compact_json(response)}"
+
+    return None
+
+
+def main() -> int:
+    """Validates stdin as a JSON-RPC response."""
+
+    if len(sys.argv) != 2:
+        print("usage: validate-json-rpc.py <label>", file=sys.stderr)
+        return 2
+
+    reason = failure_reason(sys.argv[1], sys.stdin.read())
+    if reason is None:
+        return 0
+
+    print(reason)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-sp1-e2e.yml
+++ b/.github/workflows/ci-sp1-e2e.yml
@@ -171,12 +171,32 @@ jobs:
         if: always()
         run: cat .github/sp1-e2e/e2e-env.txt 2>/dev/null || echo "No env collected"
 
+      - name: WARN/ERROR summary
+        if: always()
+        run: |
+          SUMMARY_FILE=".github/sp1-e2e/e2e-warn-error-summary.txt"
+          if [ ! -s "${SUMMARY_FILE}" ]; then
+            echo "No WARN/ERROR summary collected"
+            exit 0
+          fi
+
+          cat "${SUMMARY_FILE}"
+          {
+            echo "## WARN/ERROR log summary"
+            echo
+            echo '```text'
+            head -300 "${SUMMARY_FILE}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sp1-e2e-logs
-          path: .github/sp1-e2e/e2e-logs.txt
+          path: |
+            .github/sp1-e2e/e2e-logs.txt
+            .github/sp1-e2e/e2e-warn-error-summary.txt
           retention-days: 7
 
       - name: Notify Slack on failure

--- a/.github/workflows/ci-sp1-e2e.yml
+++ b/.github/workflows/ci-sp1-e2e.yml
@@ -190,8 +190,24 @@ jobs:
             echo "SLACK_WEBHOOK_URL not set — skipping notification"
             exit 0
           fi
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq jq > /dev/null
+          fi
+
+          REASON_FILE=".github/sp1-e2e/e2e-failure-reason.txt"
+          if [ -s "${REASON_FILE}" ]; then
+            FAILURE_REASON="$(cat "${REASON_FILE}")"
+          else
+            FAILURE_REASON="Workflow failed before SP1 E2E produced a failure reason. Check the failed job step."
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg image_tag "${IMAGE_TAG}" \
+            --arg run_url "${RUN_URL}" \
+            --arg reason "${FAILURE_REASON}" \
+            '{text: "🚨 *SP1 E2E Test Failed* — commit `\($image_tag)`\n<\($run_url)|View run>\nReason: \($reason)"}')
+
           curl -sf -X POST "${SLACK_WEBHOOK_URL}" \
             -H 'Content-Type: application/json' \
-            -d "{
-              \"text\": \"🚨 *SP1 E2E Test Failed* — commit \`${IMAGE_TAG}\`\n<${RUN_URL}|View run>\nZK proof regression detected. Investigate immediately.\"
-            }"
+            -d "${PAYLOAD}"

--- a/docker/alpen-client/entrypoint.sh
+++ b/docker/alpen-client/entrypoint.sh
@@ -32,6 +32,7 @@ if [ "${SEQUENCER_MODE}" = "true" ]; then
     BITCOIND_RPC_PASSWORD="${BITCOIND_RPC_PASSWORD:?BITCOIND_RPC_PASSWORD must be set}"
     STRATA_SUBMIT_RPC_TOKEN="${STRATA_SUBMIT_RPC_TOKEN:?STRATA_SUBMIT_RPC_TOKEN must be set}"
     EE_DA_MAGIC_BYTES="${EE_DA_MAGIC_BYTES:-ALPN}"
+    BTCIO_FEE_POLICY="${BTCIO_FEE_POLICY:-bitcoind}"
 
     set -- \
         --sequencer \
@@ -40,7 +41,24 @@ if [ "${SEQUENCER_MODE}" = "true" ]; then
         --btc-rpc-url "${BITCOIND_RPC_URL}" \
         --btc-rpc-user "${BITCOIND_RPC_USER}" \
         --btc-rpc-password "${BITCOIND_RPC_PASSWORD}" \
+        --btcio-fee-policy "${BTCIO_FEE_POLICY}" \
         "$@"
+
+    if [ -n "${BTCIO_CONF_TARGET:-}" ]; then
+        set -- "$@" --btcio-conf-target "${BTCIO_CONF_TARGET}"
+    fi
+
+    if [ -n "${BTCIO_FEE_RATE:-}" ]; then
+        set -- "$@" --btcio-fee-rate "${BTCIO_FEE_RATE}"
+    fi
+
+    if [ -n "${BTCIO_MEMPOOL_BASE_URL:-}" ]; then
+        set -- "$@" --btcio-mempool-base-url "${BTCIO_MEMPOOL_BASE_URL}"
+    fi
+
+    if [ -n "${BTCIO_MEMPOOL_TIER:-}" ]; then
+        set -- "$@" --btcio-mempool-tier "${BTCIO_MEMPOOL_TIER}"
+    fi
 fi
 
 exec alpen-client \


### PR DESCRIPTION
## Description

Improve SP1 E2E CI observability so failures report the actual reason instead of a static Slack string. The runner now validates required RPC methods early with a bounded readiness timeout, records the first concrete failure reason, avoids fresh private-signet smart-fee estimation failures when using prebuilt images, and emits a grouped WARN/ERROR log summary by service.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Validation: the SP1 E2E CI [run](https://github.com/alpenlabs/alpen/actions/runs/27188989965/job/80264393768) for the latest branch update passed, including the grouped WARN/ERROR summary path. Earlier local validation also passed for the script syntax, Python helpers, sample log summary generation, and just pr-lite.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: I used AI assistance to investigate the CI failure and draft the implementation.

## Related Issues

https://alpenlabs.atlassian.net/browse/STR-3766
