### PR TITLE
feat(evm): price bridgeout precompile gas

### DIFF
--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -6,6 +6,13 @@ use strata_primitives::bitcoin_bosd::Descriptor;
 
 use crate::{constants::BRIDGEOUT_PRECOMPILE_ADDRESS, utils::wei_to_sats};
 
+// REVIEW(STR-3676): Replace these draft values with protocol-approved launch constants.
+/// Fixed raw EVM gas charged for bridge-out precompile execution.
+const BRIDGEOUT_BASE_GAS: u64 = 10_000;
+
+/// Raw EVM gas charged per calldata byte handled by the bridge-out precompile.
+const BRIDGEOUT_CALLDATA_BYTE_GAS: u64 = 16;
+
 /// Custom precompile to burn rollup native token and add bridge out intent of equal amount.
 /// Bridge out intent is created during block payload generation.
 /// This precompile validates transaction and burns the bridge out amount.
@@ -18,6 +25,11 @@ pub(crate) fn bridge_context_call(
     denomination_wei: U256,
     max_withdrawal_wei: Option<U256>,
 ) -> PrecompileResult {
+    let gas_cost = bridgeout_gas_cost(input.data.len())?;
+    if gas_cost > input.gas {
+        return Err(PrecompileError::OutOfGas);
+    }
+
     let calldata = WithdrawalCalldata::decode(input.data).ok_or_else(|| {
         PrecompileError::other(
             "Calldata too short: expected at least 5 bytes (4 operator + 1 BOSD)",
@@ -62,10 +74,17 @@ pub(crate) fn bridge_context_call(
             PrecompileError::Fatal("Failed to reset BRIDGEOUT_ADDRESS account balance".into())
         })?;
 
-    // TODO(STR-3676): Properly calculate and deduct gas for the bridge out operation
-    let gas_cost = 0;
-
     Ok(PrecompileOutput::new(gas_cost, Bytes::new()))
+}
+
+fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
+    let calldata_len = u64::try_from(calldata_len)
+        .map_err(|_| PrecompileError::Fatal("Bridgeout calldata length exceeds u64".into()))?;
+
+    BRIDGEOUT_CALLDATA_BYTE_GAS
+        .checked_mul(calldata_len)
+        .and_then(|calldata_gas| BRIDGEOUT_BASE_GAS.checked_add(calldata_gas))
+        .ok_or_else(|| PrecompileError::Fatal("Bridgeout gas cost overflow".into()))
 }
 
 /// Validates that the withdrawal amount is a positive exact multiple of the denomination
@@ -176,6 +195,29 @@ mod tests {
         // Exactly 4 bytes (operator only, no BOSD)
         let data = vec![0x00, 0x00, 0x00, 0x05];
         assert!(WithdrawalCalldata::decode(&data).is_none());
+    }
+
+    #[test]
+    fn test_bridgeout_gas_cost_includes_base_and_calldata_bytes() {
+        let calldata_len = 4 + VALID_P2WPKH_BOSD.len();
+
+        assert_eq!(
+            bridgeout_gas_cost(calldata_len).unwrap(),
+            BRIDGEOUT_BASE_GAS + BRIDGEOUT_CALLDATA_BYTE_GAS * calldata_len as u64
+        );
+    }
+
+    #[test]
+    fn test_bridgeout_gas_cost_scales_with_calldata_len() {
+        let short = bridgeout_gas_cost(5).unwrap();
+        let long = bridgeout_gas_cost(6).unwrap();
+
+        assert_eq!(long - short, BRIDGEOUT_CALLDATA_BYTE_GAS);
+    }
+
+    #[test]
+    fn test_bridgeout_gas_cost_rejects_overflow() {
+        assert!(bridgeout_gas_cost(usize::MAX).is_err());
     }
 
     // --- withdrawal amount validation tests ---


### PR DESCRIPTION
## Description

Price bridge-out precompile execution in raw EVM gas instead of returning zero gas. The bridge-out precompile now computes a deterministic gas cost before validation or state/log side effects, rejects calls with insufficient gas, and returns the computed cost through `PrecompileOutput`.

The current implementation uses a protocol-constant proposal:

```text
bridgeout_gas = 10_000 + 16 * calldata_len
```

This is intentionally kept as code constants, not runtime config, because precompile gas accounting is consensus-visible. The Notion fee model says Alpen-only precompiles should be repriced/reviewed before launch, while DA/proving/OL overhead stay outside raw EVM gas as `non_execution_fee`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Open question: are `BRIDGEOUT_BASE_GAS = 10_000` and `BRIDGEOUT_CALLDATA_BYTE_GAS = 16` acceptable launch constants, or should protocol/product choose different values?

The shape is `base + calldata-byte cost` so the fixed bridge-out operation is not free and longer BOSD/calldata payloads do not cost the same as short payloads. Non-execution costs from the Alpen L2 Fee Model are deliberately not included in this precompile gas value.

Validation:

- `cargo test -p alpen-reth-evm precompiles::bridge::`
- `cargo fmt --check --package alpen-reth-evm`

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://alpenlabs.atlassian.net/browse/STR-3676
- https://app.notion.com/p/Alpen-L2-Fee-Model-333901ba000f80d899b7c628cf0469d9

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: I used AI assistance to inspect the existing precompile and fee-model code, map the Notion fee model to raw precompile gas, and draft this implementation.

## Related Issues

https://alpenlabs.atlassian.net/browse/STR-3676
