### PR TITLE
chore(csm-worker): Replace anyhow errors with typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15398,6 +15398,7 @@ dependencies = [
  "serde",
  "strata-asm-common",
  "strata-asm-logs",
+ "strata-asm-manifest-types",
  "strata-asm-params",
  "strata-asm-proto-checkpoint",
  "strata-asm-proto-checkpoint-txs",
@@ -15412,6 +15413,7 @@ dependencies = [
  "strata-common",
  "strata-csm-types",
  "strata-db-store-sled",
+ "strata-db-types",
  "strata-identifiers",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
@@ -15423,6 +15425,7 @@ dependencies = [
  "strata-test-utils",
  "strata-test-utils-checkpoint",
  "strata-test-utils-l2",
+ "thiserror 2.0.18",
  "threadpool",
  "tracing",
 ]

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -10,7 +10,7 @@ use strata_asm_proto_checkpoint_types::CheckpointPayload;
 use strata_btc_types::L1BlockIdBitcoinExt;
 use strata_common::retry::{policies::ExponentialBackoff, retry_with_backoff};
 use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput};
-use strata_csm_worker::CsmWorkerContext;
+use strata_csm_worker::{CsmWorkerContext, CsmWorkerError, CsmWorkerResult};
 use strata_identifiers::Epoch;
 use strata_l1_txfmt::MagicBytes;
 use strata_primitives::{
@@ -62,7 +62,7 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         &self,
         block: &L1BlockCommitment,
         output: ClientUpdateOutput,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         self.storage
             .client_state()
             .put_update_blocking(block, output)?;
@@ -78,14 +78,14 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         commitment: EpochCommitment,
         payload: CheckpointPayload,
         l1_ref: CheckpointL1Ref,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         self.storage
             .ol_checkpoint()
             .put_checkpoint_l1_observation_blocking(commitment, payload, l1_ref)?;
         Ok(())
     }
 
-    fn get_l1_block(&self, blockid: &L1BlockId) -> anyhow::Result<Block> {
+    fn get_l1_block(&self, blockid: &L1BlockId) -> CsmWorkerResult<Block> {
         // ASM has already processed this block, so bitcoind must have it. Retry
         // with backoff to absorb transient failures (RPC timeout, replica lag).
         let hash = blockid.to_block_hash();
@@ -93,7 +93,10 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         retry_with_backoff("csm_get_l1_block", 10, &backoff, || {
             self.handle
                 .block_on(self.bitcoin_client.get_block(&hash))
-                .map_err(|e| anyhow::anyhow!("fetch L1 block {blockid}: {e}"))
+                .map_err(|e| CsmWorkerError::L1Fetch {
+                    blockid: *blockid,
+                    cause: e.to_string(),
+                })
         })
     }
 
@@ -105,32 +108,41 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         self.asm_params.magic
     }
 
-    fn get_asm_state(&self, block: &L1BlockCommitment) -> anyhow::Result<AsmState> {
+    fn get_asm_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AsmState> {
         self.storage
             .asm()
             .get_state_blocking(*block)?
-            .ok_or_else(|| anyhow::anyhow!("missing ASM state for {block}"))
+            .ok_or_else(|| CsmWorkerError::MissingData {
+                what: "ASM state",
+                detail: block.to_string(),
+            })
     }
 
-    fn get_aux_data(&self, block: &L1BlockCommitment) -> anyhow::Result<AuxData> {
+    fn get_aux_data(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AuxData> {
         self.storage
             .asm()
             .get_aux_data_blocking(*block)?
-            .ok_or_else(|| anyhow::anyhow!("missing ASM aux data for {block}"))
+            .ok_or_else(|| CsmWorkerError::MissingData {
+                what: "ASM aux data",
+                detail: block.to_string(),
+            })
     }
 
-    fn get_canonical_l1_block(&self, height: L1Height) -> anyhow::Result<L1BlockCommitment> {
+    fn get_canonical_l1_block(&self, height: L1Height) -> CsmWorkerResult<L1BlockCommitment> {
         let blkid = self
             .storage
             .l1()
             .get_canonical_blockid_at_height(height)?
-            .ok_or_else(|| anyhow::anyhow!("missing canonical L1 block at height {height}"))?;
+            .ok_or_else(|| CsmWorkerError::MissingData {
+                what: "canonical L1 block",
+                detail: format!("height {height}"),
+            })?;
         Ok(L1BlockCommitment::new(height, blkid))
     }
 
     fn fetch_most_recent_client_state(
         &self,
-    ) -> anyhow::Result<Option<(L1BlockCommitment, ClientState)>> {
+    ) -> CsmWorkerResult<Option<(L1BlockCommitment, ClientState)>> {
         Ok(self.storage.client_state().fetch_most_recent_state()?)
     }
 
@@ -138,7 +150,7 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         self.asm_params.anchor.block
     }
 
-    fn get_last_checkpoint_l1_ref_epoch(&self) -> anyhow::Result<Option<EpochCommitment>> {
+    fn get_last_checkpoint_l1_ref_epoch(&self) -> CsmWorkerResult<Option<EpochCommitment>> {
         Ok(self
             .storage
             .ol_checkpoint()
@@ -148,7 +160,7 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
     fn get_canonical_epoch_commitment_at(
         &self,
         epoch: Epoch,
-    ) -> anyhow::Result<Option<EpochCommitment>> {
+    ) -> CsmWorkerResult<Option<EpochCommitment>> {
         Ok(self
             .storage
             .ol_checkpoint()
@@ -158,7 +170,7 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
     fn get_checkpoint_l1_ref(
         &self,
         commitment: EpochCommitment,
-    ) -> anyhow::Result<Option<CheckpointL1Ref>> {
+    ) -> CsmWorkerResult<Option<CheckpointL1Ref>> {
         Ok(self
             .storage
             .ol_checkpoint()
@@ -168,7 +180,7 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
     fn get_checkpoint_payload(
         &self,
         commitment: EpochCommitment,
-    ) -> anyhow::Result<Option<CheckpointPayload>> {
+    ) -> CsmWorkerResult<Option<CheckpointPayload>> {
         Ok(self
             .storage
             .ol_checkpoint()

--- a/crates/csm-worker/Cargo.toml
+++ b/crates/csm-worker/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 strata-asm-common.workspace = true
 strata-asm-logs.workspace = true
+strata-asm-manifest-types.workspace = true
 strata-asm-proto-checkpoint.workspace = true
 strata-asm-proto-checkpoint-txs.workspace = true
 strata-asm-proto-checkpoint-types.workspace = true
@@ -16,6 +17,7 @@ strata-asm-worker.workspace = true
 strata-checkpoint-verification.workspace = true
 strata-common.workspace = true
 strata-csm-types.workspace = true
+strata-db-types.workspace = true
 strata-identifiers.workspace = true
 strata-l1-txfmt.workspace = true
 strata-primitives.workspace = true
@@ -25,6 +27,7 @@ strata-state.workspace = true
 anyhow.workspace = true
 bitcoin.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/csm-worker/src/checkpoint_extract.rs
+++ b/crates/csm-worker/src/checkpoint_extract.rs
@@ -16,6 +16,8 @@ use strata_identifiers::RBuf32;
 use strata_l1_txfmt::{MagicBytes, ParseConfig};
 use tracing::{debug, warn};
 
+use crate::errors::CsmWorkerResult;
+
 /// Identification of the L1 transaction that carries a validated checkpoint,
 /// along with its decoded payload.
 ///
@@ -124,7 +126,7 @@ fn verify_checkpoint(
     envelope: &strata_asm_proto_checkpoint_txs::EnvelopeCheckpoint,
     current_l1_height: u32,
     verified_aux_data: &VerifiedAuxData,
-) -> anyhow::Result<()> {
+) -> CsmWorkerResult<()> {
     let coverage = verify_sequencer_predicate(
         checkpoint_state.sequencer_predicate(),
         &envelope.envelope_pubkey,

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -13,19 +13,20 @@ use strata_primitives::{
 };
 use strata_state::asm_state::AsmState;
 
+use crate::errors::CsmWorkerResult;
+
 /// Operations the worker delegates to the outside world: persistence, status
 /// publishing, and L1 fetch.
 ///
 /// Kept as a trait so tests can swap in a stub without spinning up real storage
 /// or a Bitcoin RPC client.
-// TODO(STR-3491): Use typed errors instead of `anyhow!`
 pub trait CsmWorkerContext: Send + Sync {
     /// Writes a client state update for the given L1 block.
     fn put_client_state_update(
         &self,
         block: &L1BlockCommitment,
         output: ClientUpdateOutput,
-    ) -> anyhow::Result<()>;
+    ) -> CsmWorkerResult<()>;
 
     /// Publishes the current client state and the L1 block it is anchored at.
     fn publish_client_state(&self, state: ClientState, block: L1BlockCommitment);
@@ -37,10 +38,10 @@ pub trait CsmWorkerContext: Send + Sync {
         commitment: EpochCommitment,
         payload: CheckpointPayload,
         l1_ref: CheckpointL1Ref,
-    ) -> anyhow::Result<()>;
+    ) -> CsmWorkerResult<()>;
 
     /// Fetches an L1 block by its block id.
-    fn get_l1_block(&self, blockid: &L1BlockId) -> anyhow::Result<Block>;
+    fn get_l1_block(&self, blockid: &L1BlockId) -> CsmWorkerResult<Block>;
 
     /// L1 reorg-safe depth used to decide checkpoint finality.
     fn l1_reorg_safe_depth(&self) -> u32;
@@ -49,19 +50,19 @@ pub trait CsmWorkerContext: Send + Sync {
     fn magic_bytes(&self) -> MagicBytes;
 
     /// Fetches the ASM state recorded at `block`.
-    fn get_asm_state(&self, block: &L1BlockCommitment) -> anyhow::Result<AsmState>;
+    fn get_asm_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AsmState>;
 
     /// Fetches the auxiliary data ASM consumed when processing `block`.
-    fn get_aux_data(&self, block: &L1BlockCommitment) -> anyhow::Result<AuxData>;
+    fn get_aux_data(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AuxData>;
 
     /// Resolves the canonical L1 block commitment at `height`.
-    fn get_canonical_l1_block(&self, height: L1Height) -> anyhow::Result<L1BlockCommitment>;
+    fn get_canonical_l1_block(&self, height: L1Height) -> CsmWorkerResult<L1BlockCommitment>;
 
     /// Returns the most recently persisted client state, or `None` if storage
     /// has none yet.
     fn fetch_most_recent_client_state(
         &self,
-    ) -> anyhow::Result<Option<(L1BlockCommitment, ClientState)>>;
+    ) -> CsmWorkerResult<Option<(L1BlockCommitment, ClientState)>>;
 
     /// L1 block that bootstrap should anchor to when storage has no client
     /// state yet.
@@ -69,19 +70,19 @@ pub trait CsmWorkerContext: Send + Sync {
 
     /// Returns the epoch of the most recent L1-observed checkpoint, or `None`
     /// if nothing has been observed yet.
-    fn get_last_checkpoint_l1_ref_epoch(&self) -> anyhow::Result<Option<EpochCommitment>>;
+    fn get_last_checkpoint_l1_ref_epoch(&self) -> CsmWorkerResult<Option<EpochCommitment>>;
 
     /// Returns the canonical epoch commitment at `epoch`, if recorded.
     fn get_canonical_epoch_commitment_at(
         &self,
         epoch: Epoch,
-    ) -> anyhow::Result<Option<EpochCommitment>>;
+    ) -> CsmWorkerResult<Option<EpochCommitment>>;
 
     /// Returns the recorded L1 ref for an observed checkpoint at `commitment`.
     fn get_checkpoint_l1_ref(
         &self,
         commitment: EpochCommitment,
-    ) -> anyhow::Result<Option<CheckpointL1Ref>>;
+    ) -> CsmWorkerResult<Option<CheckpointL1Ref>>;
 
     /// Returns the L1-observed checkpoint payload at `commitment` (carries the
     /// tip the checkpoint declared). Paired with [`Self::get_checkpoint_l1_ref`]
@@ -89,5 +90,5 @@ pub trait CsmWorkerContext: Send + Sync {
     fn get_checkpoint_payload(
         &self,
         commitment: EpochCommitment,
-    ) -> anyhow::Result<Option<CheckpointPayload>>;
+    ) -> CsmWorkerResult<Option<CheckpointPayload>>;
 }

--- a/crates/csm-worker/src/errors.rs
+++ b/crates/csm-worker/src/errors.rs
@@ -1,0 +1,67 @@
+//! Error types for the CSM worker.
+
+use strata_asm_common::{AsmError, AuxError};
+use strata_asm_manifest_types::AsmManifestError;
+use strata_checkpoint_verification::CheckpointValidationError;
+use strata_db_types::errors::DbError;
+use strata_primitives::l1::{L1BlockCommitment, L1BlockId};
+use thiserror::Error;
+
+/// Return type for CSM worker operations.
+pub type CsmWorkerResult<T> = Result<T, CsmWorkerError>;
+
+/// Errors that can occur while the CSM worker processes ASM status updates.
+#[derive(Debug, Error)]
+pub enum CsmWorkerError {
+    /// No committed ASM block exists yet; the worker was bootstrapped without one.
+    #[error("CSM has no last committed ASM block")]
+    NoLastAsmBlock,
+
+    /// The genesis L1 block has no parent to derive a commitment from.
+    #[error("cannot derive parent for genesis L1 block {0}")]
+    GenesisHasNoParent(L1BlockCommitment),
+
+    /// No checkpoint envelope tx in the block validated for the logged tip.
+    #[error("no checkpoint envelope tx in L1 block {asm_block} validated for epoch {epoch}")]
+    NoMatchingCheckpoint {
+        asm_block: L1BlockCommitment,
+        epoch: u32,
+    },
+
+    /// The checkpoint subprotocol section was absent from the ASM state.
+    #[error("checkpoint subprotocol section missing in ASM state")]
+    MissingCheckpointSection,
+
+    /// Failed to deserialize a `CheckpointTipUpdate` log entry.
+    #[error("failed to deserialize CheckpointTipUpdate log: {0}")]
+    DeserializeTipLog(#[from] AsmManifestError),
+
+    /// Failed to decode the checkpoint subprotocol's typed state.
+    #[error("decode checkpoint subprotocol state: {0}")]
+    DecodeCheckpointSection(#[source] AsmError),
+
+    /// Verifying ASM aux data against the parent accumulator failed.
+    #[error("verify ASM aux data: {0}")]
+    VerifyAuxData(#[from] AuxError),
+
+    /// A candidate checkpoint failed validation.
+    #[error("checkpoint validation failed: {0}")]
+    CheckpointValidation(#[from] CheckpointValidationError),
+
+    /// A storage operation failed.
+    #[error("database failure: {0}")]
+    Database(#[from] DbError),
+
+    /// Fetching an L1 block from bitcoind failed. The cause is kept as a
+    /// `String` so the worker does not depend on the RPC client's error type.
+    #[error("fetch L1 block {blockid}: {cause}")]
+    L1Fetch { blockid: L1BlockId, cause: String },
+
+    /// A record the worker expected was absent.
+    #[error("missing {what}: {detail}")]
+    MissingData { what: &'static str, detail: String },
+
+    /// Other generic errors without precise types.
+    #[error("{0}")]
+    Context(String),
+}

--- a/crates/csm-worker/src/lib.rs
+++ b/crates/csm-worker/src/lib.rs
@@ -7,6 +7,7 @@
 mod checkpoint_extract;
 mod constants;
 mod context;
+mod errors;
 mod processor;
 mod service;
 mod state;
@@ -15,6 +16,7 @@ mod status;
 mod test_utils;
 
 pub use context::CsmWorkerContext;
+pub use errors::{CsmWorkerError, CsmWorkerResult};
 pub use service::CsmWorkerService;
 pub use state::CsmWorkerState;
 pub use status::CsmWorkerStatus;

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use anyhow::Context;
 use bitcoin::hashes::Hash;
 use strata_asm_common::{AsmLogEntry, Subprotocol, VerifiedAuxData};
 use strata_asm_logs::{CheckpointTipUpdate, constants::AsmLogTypeId};
@@ -16,6 +15,7 @@ use tracing::*;
 use crate::{
     checkpoint_extract::{CheckpointVerificationContext, extract_matching_checkpoint},
     context::CsmWorkerContext,
+    errors::{CsmWorkerError, CsmWorkerResult},
     state::CsmWorkerState,
 };
 
@@ -46,19 +46,16 @@ impl PendingCsmUpdate {
     }
 }
 
-// TODO(STR-3491): Use typed errors instead of `anyhow!`
 impl<C: CsmWorkerContext> CsmWorkerState<C> {
     pub(crate) fn process_log(
         &self,
         pending: &mut PendingCsmUpdate,
         log: &AsmLogEntry,
         asm_block: &L1BlockCommitment,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         match log.ty().and_then(|ty| AsmLogTypeId::try_from(ty).ok()) {
             Some(AsmLogTypeId::CheckpointTipUpdate) => {
-                let tip_upd = log.try_into_log().map_err(|e| {
-                    anyhow::anyhow!("Failed to deserialize CheckpointTipUpdate: {}", e)
-                })?;
+                let tip_upd = log.try_into_log()?;
 
                 return self.process_checkpoint_tip_log(pending, &tip_upd, asm_block);
             }
@@ -82,7 +79,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         pending: &mut PendingCsmUpdate,
         checkpoint_tip_update: &CheckpointTipUpdate,
         asm_block: &L1BlockCommitment,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         let tip = checkpoint_tip_update.tip();
         let epoch = tip.epoch;
         let _span = info_span!("process_checkpoint_tip_log", %epoch).entered();
@@ -124,7 +121,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         &mut self,
         asm_block: L1BlockCommitment,
         next_state: Arc<ClientState>,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         let state = next_state.as_ref().clone();
         self.ctx
             .put_client_state_update(&asm_block, ClientUpdateOutput::new(state.clone(), vec![]))?;
@@ -143,17 +140,15 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         &mut self,
         asm_block: L1BlockCommitment,
         logs: &[AsmLogEntry],
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         let mut pending =
             PendingCsmUpdate::new(self.last_committed_state.clone(), self.last_processed_epoch);
 
         for log in logs {
-            self.process_log(&mut pending, log, &asm_block)
-                .with_context(|| format!("processing ASM log for block {asm_block}"))?;
+            self.process_log(&mut pending, log, &asm_block)?;
         }
 
-        self.commit_block(asm_block, pending.cur_state)
-            .with_context(|| format!("committing CSM block {asm_block}"))?;
+        self.commit_block(asm_block, pending.cur_state)?;
 
         // Commit succeeded; fold pending outputs onto the worker.
         self.last_processed_epoch = pending.last_processed_epoch;
@@ -259,10 +254,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         &mut self,
         asm_block: L1BlockCommitment,
         logs: &[AsmLogEntry],
-    ) -> anyhow::Result<()> {
-        let last = self
-            .last_asm_block
-            .ok_or_else(|| anyhow::anyhow!("CSM has no last committed ASM block"))?;
+    ) -> CsmWorkerResult<()> {
+        let last = self.last_asm_block.ok_or(CsmWorkerError::NoLastAsmBlock)?;
         let last_height = last.height();
         let target_height = asm_block.height();
 
@@ -300,14 +293,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
                 (asm_block, logs.to_vec())
             } else {
                 // fetch from db.
-                let gap_block = self
-                    .ctx
-                    .get_canonical_l1_block(height)
-                    .with_context(|| format!("resolving gap L1 block at height {height}"))?;
-                let gap_state = self
-                    .ctx
-                    .get_asm_state(&gap_block)
-                    .with_context(|| format!("fetching ASM state for gap block {gap_block}"))?;
+                let gap_block = self.ctx.get_canonical_l1_block(height)?;
+                let gap_state = self.ctx.get_asm_state(&gap_block)?;
                 info!(%gap_block, "replaying ASM block skipped by status channel");
                 (gap_block, gap_state.logs().clone())
             };
@@ -319,26 +306,18 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     fn get_checkpoint_verification_context(
         &self,
         asm_block: &L1BlockCommitment,
-    ) -> anyhow::Result<CheckpointVerificationContext> {
-        let block = self
-            .ctx
-            .get_l1_block(asm_block.blkid())
-            .with_context(|| format!("fetching L1 block {asm_block} for checkpoint observation"))?;
+    ) -> CsmWorkerResult<CheckpointVerificationContext> {
+        let block = self.ctx.get_l1_block(asm_block.blkid())?;
 
         // Prepare for same checkpoint validation that ASM does.
         let parent_block = parent_commitment(asm_block, &block)?;
-        let parent_asm_state = self.ctx.get_asm_state(&parent_block).with_context(|| {
-            format!("fetching parent ASM state {parent_block} for checkpoint observation")
-        })?;
+        let parent_asm_state = self.ctx.get_asm_state(&parent_block)?;
         let checkpoint_state = decode_checkpoint_section(&parent_asm_state)?;
-        let aux_data = self.ctx.get_aux_data(asm_block).with_context(|| {
-            format!("fetching ASM aux data {asm_block} for checkpoint observation")
-        })?;
+        let aux_data = self.ctx.get_aux_data(asm_block)?;
         let verified_aux_data = VerifiedAuxData::try_new(
             &aux_data,
             &parent_asm_state.state().chain_view.history_accumulator,
-        )
-        .with_context(|| format!("verifying ASM aux data for {asm_block}"))?;
+        )?;
 
         Ok(CheckpointVerificationContext {
             block,
@@ -355,7 +334,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         pending: &mut PendingCsmUpdate,
         checkpoint_tip_update: &CheckpointTipUpdate,
         asm_block: &L1BlockCommitment,
-    ) -> anyhow::Result<L1Checkpoint> {
+    ) -> CsmWorkerResult<L1Checkpoint> {
         let tip = checkpoint_tip_update.tip();
         let _span = info_span!("mark_ol_checkpoint_l1_observed", epoch = tip.epoch).entered();
         let commitment = EpochCommitment::from_terminal(tip.epoch, *tip.l2_commitment());
@@ -371,11 +350,9 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         let extracted =
             extract_matching_checkpoint(ctx, self.ctx.magic_bytes(), tip, asm_block.height())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "no checkpoint envelope tx in L1 block {asm_block} validated for epoch {}",
-                        tip.epoch
-                    )
+                .ok_or(CsmWorkerError::NoMatchingCheckpoint {
+                    asm_block: *asm_block,
+                    epoch: tip.epoch,
                 })?;
 
         let observation = CheckpointL1Ref::new(*asm_block, extracted.txid, extracted.wtxid);
@@ -406,23 +383,23 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 fn parent_commitment(
     asm_block: &L1BlockCommitment,
     block: &bitcoin::Block,
-) -> anyhow::Result<L1BlockCommitment> {
+) -> CsmWorkerResult<L1BlockCommitment> {
     let height = asm_block.height();
     let parent_height = height
         .checked_sub(1)
-        .ok_or_else(|| anyhow::anyhow!("cannot derive parent for genesis L1 block {asm_block}"))?;
+        .ok_or(CsmWorkerError::GenesisHasNoParent(*asm_block))?;
     let parent_blkid = L1BlockId::from(Buf32::from(block.header.prev_blockhash.to_byte_array()));
     Ok(L1BlockCommitment::new(parent_height, parent_blkid))
 }
 
 /// Extracts the checkpoint subprotocol's typed state from a parent `AsmState`.
-fn decode_checkpoint_section(asm_state: &AsmState) -> anyhow::Result<CheckpointState> {
+fn decode_checkpoint_section(asm_state: &AsmState) -> CsmWorkerResult<CheckpointState> {
     asm_state
         .state()
         .find_section(CheckpointSubprotocol::ID)
-        .ok_or_else(|| anyhow::anyhow!("checkpoint subprotocol section missing in ASM state"))?
+        .ok_or(CsmWorkerError::MissingCheckpointSection)?
         .try_to_state::<CheckpointSubprotocol>()
-        .map_err(|e| anyhow::anyhow!("decode checkpoint subprotocol state: {e}"))
+        .map_err(CsmWorkerError::DecodeCheckpointSection)
 }
 
 #[cfg(test)]
@@ -447,7 +424,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use crate::{state::CsmWorkerState, test_utils::StubCtx};
+    use crate::{errors::CsmWorkerError, state::CsmWorkerState, test_utils::StubCtx};
 
     /// Reorg-safe depth used by the test stub context; the ASM params fixture
     /// carries no reorg depth (that lives in the node config at runtime).
@@ -638,7 +615,7 @@ mod tests {
             .process_log(&mut pending, &log, &asm_block)
             .expect_err("fetch failure should propagate");
         assert!(
-            err.to_string().contains("fetching L1 block"),
+            matches!(err, CsmWorkerError::L1Fetch { .. }),
             "unexpected error: {err}"
         );
 
@@ -699,7 +676,7 @@ mod tests {
             .process_log(&mut pending, &log, &asm_block)
             .expect_err("L1 fetch failure should make the log fail");
         assert!(
-            err.to_string().contains("fetching L1 block"),
+            matches!(err, CsmWorkerError::L1Fetch { .. }),
             "unexpected error: {err}"
         );
 
@@ -743,7 +720,7 @@ mod tests {
             .process_asm_block(next, &[create_non_checkpoint_log_type()])
             .expect_err("commit failure should propagate");
         assert!(
-            err.to_string().contains("committing CSM block"),
+            matches!(err, CsmWorkerError::Context(_)),
             "unexpected error: {err}"
         );
 
@@ -864,8 +841,11 @@ mod tests {
             .process_asm_block(target, &[create_non_checkpoint_log_type()])
             .expect_err("gap-fill should fail when a gap block can't be resolved");
         assert!(
-            err.to_string()
-                .contains("resolving gap L1 block at height 102"),
+            matches!(
+                err,
+                CsmWorkerError::MissingData { what, ref detail }
+                    if what == "canonical L1 block" && detail.contains("height 102")
+            ),
             "unexpected error: {err}"
         );
 

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -8,7 +8,10 @@ use strata_primitives::l1::L1BlockCommitment;
 use strata_service::{Response, Service, SyncService};
 use tracing::*;
 
-use crate::{context::CsmWorkerContext, state::CsmWorkerState, status::CsmWorkerStatus};
+use crate::{
+    context::CsmWorkerContext, errors::CsmWorkerResult, state::CsmWorkerState,
+    status::CsmWorkerStatus,
+};
 
 /// CSM worker service that acts as a listener to ASM worker status updates.
 ///
@@ -92,7 +95,7 @@ fn refresh_finalized_checkpoint<C: CsmWorkerContext>(
     state: &mut CsmWorkerState<C>,
     asm_block: L1BlockCommitment,
     finalized: L1Checkpoint,
-) -> anyhow::Result<()> {
+) -> CsmWorkerResult<()> {
     let last_seen = state.last_committed_state.get_last_checkpoint();
     let refreshed = ClientState::new(Some(finalized), last_seen);
     state.ctx.put_client_state_update(

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -7,7 +7,7 @@ use strata_identifiers::Epoch;
 use strata_primitives::{l1::is_l1_reorg_safe, prelude::*};
 use strata_service::ServiceState;
 
-use crate::{constants, context::CsmWorkerContext};
+use crate::{constants, context::CsmWorkerContext, errors::CsmWorkerResult};
 
 /// State for the CSM worker service.
 ///
@@ -47,14 +47,13 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
     pub(crate) observed_checkpoints: VecDeque<L1Checkpoint>,
 }
 
-// TODO(STR-3491): Use typed errors instead of `anyhow!`
 impl<C: CsmWorkerContext> CsmWorkerState<C> {
     /// Create a new CSM worker state.
     ///
     /// All bootstrap reads (last client state, observed checkpoint refs, params)
     /// go through `ctx`; runtime persistence and L1 fetches use the same
     /// context after construction.
-    pub fn new(ctx: C) -> anyhow::Result<Self> {
+    pub fn new(ctx: C) -> CsmWorkerResult<Self> {
         // Load the most recent client state from storage
         let (cur_block, cur_state) = ctx
             .fetch_most_recent_client_state()?
@@ -151,7 +150,7 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
     ctx: &C,
     start_epoch: Epoch,
     current_l1_tip: L1Height,
-) -> anyhow::Result<VecDeque<L1Checkpoint>> {
+) -> CsmWorkerResult<VecDeque<L1Checkpoint>> {
     let Some(last_l1_ref_commitment) = ctx.get_last_checkpoint_l1_ref_epoch()? else {
         return Ok(VecDeque::new());
     };

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -17,7 +17,10 @@ use strata_state::asm_state::AsmState;
 use strata_status::StatusChannel;
 use strata_storage::NodeStorage;
 
-use crate::context::CsmWorkerContext;
+use crate::{
+    context::CsmWorkerContext,
+    errors::{CsmWorkerError, CsmWorkerResult},
+};
 
 /// What `get_l1_block` does when called.
 enum L1Fetch {
@@ -103,9 +106,11 @@ impl CsmWorkerContext for StubCtx {
         &self,
         block: &L1BlockCommitment,
         output: ClientUpdateOutput,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         if self.fail_client_state_update {
-            return Err(anyhow::anyhow!("simulated client state update failure"));
+            return Err(CsmWorkerError::Context(
+                "simulated client state update failure".to_string(),
+            ));
         }
         self.storage
             .client_state()
@@ -122,17 +127,20 @@ impl CsmWorkerContext for StubCtx {
         commitment: EpochCommitment,
         payload: CheckpointPayload,
         l1_ref: CheckpointL1Ref,
-    ) -> anyhow::Result<()> {
+    ) -> CsmWorkerResult<()> {
         self.storage
             .ol_checkpoint()
             .put_checkpoint_l1_observation_blocking(commitment, payload, l1_ref)?;
         Ok(())
     }
 
-    fn get_l1_block(&self, _blockid: &L1BlockId) -> anyhow::Result<Block> {
+    fn get_l1_block(&self, blockid: &L1BlockId) -> CsmWorkerResult<Block> {
         match &self.l1_fetch {
             L1Fetch::Unset => panic!("test should not fetch L1 block"),
-            L1Fetch::Fail => Err(anyhow::anyhow!("simulated L1 fetch failure")),
+            L1Fetch::Fail => Err(CsmWorkerError::L1Fetch {
+                blockid: *blockid,
+                cause: "simulated L1 fetch failure".to_string(),
+            }),
         }
     }
 
@@ -144,35 +152,43 @@ impl CsmWorkerContext for StubCtx {
         self.magic
     }
 
-    fn get_asm_state(&self, block: &L1BlockCommitment) -> anyhow::Result<AsmState> {
+    fn get_asm_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AsmState> {
         self.canonical_asm_states
             .get(&block.height())
             .filter(|(blkid, _)| blkid == block.blkid())
             .map(|(_, state)| state.clone())
-            .ok_or_else(|| anyhow::anyhow!("no test ASM state configured for {block}"))
+            .ok_or_else(|| CsmWorkerError::MissingData {
+                what: "test ASM state",
+                detail: block.to_string(),
+            })
     }
 
-    fn get_aux_data(&self, block: &L1BlockCommitment) -> anyhow::Result<AuxData> {
-        Err(anyhow::anyhow!(
-            "stub get_aux_data called for {block}; tests that need aux data should use end-to-end fixtures"
-        ))
+    fn get_aux_data(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AuxData> {
+        Err(CsmWorkerError::MissingData {
+            what: "test ASM aux data",
+            detail: format!("{block}; tests that need aux data should use end-to-end fixtures"),
+        })
     }
 
-    fn get_canonical_l1_block(&self, height: L1Height) -> anyhow::Result<L1BlockCommitment> {
+    fn get_canonical_l1_block(&self, height: L1Height) -> CsmWorkerResult<L1BlockCommitment> {
         if self.canonical_fail_height == Some(height) {
-            return Err(anyhow::anyhow!(
-                "simulated canonical lookup failure at height {height}"
-            ));
+            return Err(CsmWorkerError::MissingData {
+                what: "canonical L1 block",
+                detail: format!("simulated lookup failure at height {height}"),
+            });
         }
         self.canonical_asm_states
             .get(&height)
             .map(|(blkid, _)| L1BlockCommitment::new(height, *blkid))
-            .ok_or_else(|| anyhow::anyhow!("no test canonical block configured at height {height}"))
+            .ok_or_else(|| CsmWorkerError::MissingData {
+                what: "test canonical block",
+                detail: format!("height {height}"),
+            })
     }
 
     fn fetch_most_recent_client_state(
         &self,
-    ) -> anyhow::Result<Option<(L1BlockCommitment, ClientState)>> {
+    ) -> CsmWorkerResult<Option<(L1BlockCommitment, ClientState)>> {
         Ok(self.storage.client_state().fetch_most_recent_state()?)
     }
 
@@ -180,7 +196,7 @@ impl CsmWorkerContext for StubCtx {
         self.genesis_l1_block
     }
 
-    fn get_last_checkpoint_l1_ref_epoch(&self) -> anyhow::Result<Option<EpochCommitment>> {
+    fn get_last_checkpoint_l1_ref_epoch(&self) -> CsmWorkerResult<Option<EpochCommitment>> {
         Ok(self
             .storage
             .ol_checkpoint()
@@ -190,7 +206,7 @@ impl CsmWorkerContext for StubCtx {
     fn get_canonical_epoch_commitment_at(
         &self,
         epoch: Epoch,
-    ) -> anyhow::Result<Option<EpochCommitment>> {
+    ) -> CsmWorkerResult<Option<EpochCommitment>> {
         Ok(self
             .storage
             .ol_checkpoint()
@@ -200,7 +216,7 @@ impl CsmWorkerContext for StubCtx {
     fn get_checkpoint_l1_ref(
         &self,
         commitment: EpochCommitment,
-    ) -> anyhow::Result<Option<CheckpointL1Ref>> {
+    ) -> CsmWorkerResult<Option<CheckpointL1Ref>> {
         Ok(self
             .storage
             .ol_checkpoint()
@@ -210,7 +226,7 @@ impl CsmWorkerContext for StubCtx {
     fn get_checkpoint_payload(
         &self,
         commitment: EpochCommitment,
-    ) -> anyhow::Result<Option<CheckpointPayload>> {
+    ) -> CsmWorkerResult<Option<CheckpointPayload>> {
         Ok(self
             .storage
             .ol_checkpoint()


### PR DESCRIPTION
## Description

Replaces `anyhow` error usage inside csm-worker by typed errors.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
