### PR TITLE
chore(deps): bump strata-common (rc25), asm (alpha.13), zkaleido (beta.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15463,7 +15463,6 @@ dependencies = [
  "argh",
  "bitcoin",
  "bitcoind-async-client",
- "borsh",
  "rand_core 0.6.4",
  "reth-chainspec",
  "serde_json",
@@ -16603,7 +16602,6 @@ name = "strata-sp1-guest-builder"
 version = "0.3.0-alpha.1"
 dependencies = [
  "bincode",
- "borsh",
  "cargo_metadata 0.19.2",
  "cfg-if",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-sp1-host",
 ]
 
@@ -1305,7 +1305,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -7177,15 +7177,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
+ "indexmap 2.13.0",
+ "metrics",
+ "metrics-util 0.19.1",
+ "quanta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+dependencies = [
+ "base64 0.22.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
  "indexmap 2.13.0",
  "ipnet",
  "metrics",
- "metrics-util 0.19.1",
+ "metrics-util 0.20.1",
  "quanta",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -7233,6 +7247,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "metrics",
+ "quanta",
  "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
@@ -11076,7 +11091,7 @@ dependencies = [
  "http 1.4.0",
  "jsonrpsee-server",
  "metrics",
- "metrics-exporter-prometheus",
+ "metrics-exporter-prometheus 0.16.2",
  "metrics-process",
  "metrics-util 0.19.1",
  "procfs 0.17.0",
@@ -14696,7 +14711,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-sp1-host",
 ]
 
@@ -14725,7 +14740,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -14752,12 +14767,12 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25)",
  "strata-identifiers",
  "strata-msg-fmt",
  "strata-predicate",
@@ -14766,7 +14781,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -14788,7 +14803,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14807,7 +14822,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -14828,7 +14843,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14850,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14875,7 +14890,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -14888,7 +14903,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14901,14 +14916,14 @@ dependencies = [
  "strata-codec",
  "strata-crypto",
  "strata-l1-txfmt",
- "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12)",
+ "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -14926,7 +14941,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -14942,7 +14957,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -14955,13 +14970,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25)",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
  "thiserror 2.0.18",
@@ -14970,7 +14985,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "borsh",
  "proptest",
@@ -14992,7 +15007,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-debug-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "serde",
@@ -15011,7 +15026,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-txs-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "rand 0.8.5",
@@ -15023,7 +15038,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -15036,7 +15051,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec-debug"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -15047,7 +15062,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -15060,14 +15075,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "anyhow",
  "bitcoin",
  "borsh",
  "serde",
  "strata-asm-common",
- "strata-asm-manifest-types",
  "strata-asm-stf",
  "strata-btc-types",
  "strata-btc-verification",
@@ -15094,7 +15108,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -15114,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -15212,13 +15226,13 @@ dependencies = [
  "ssz_derive",
  "strata-crypto",
  "strata-identifiers",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "ssz",
@@ -15247,7 +15261,7 @@ version = "0.3.0-alpha.1"
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -15256,7 +15270,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -15275,7 +15289,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "borsh",
  "ssz",
@@ -15354,7 +15368,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -15473,7 +15487,7 @@ dependencies = [
  "strata-sp1-guest-builder",
  "tokio",
  "zeroize",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]
@@ -15505,7 +15519,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -15529,7 +15543,7 @@ dependencies = [
  "strata-primitives",
  "strata-state",
  "strata-test-utils",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -15559,7 +15573,7 @@ dependencies = [
  "strata-storage-common",
  "thiserror 2.0.18",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -15588,7 +15602,7 @@ dependencies = [
  "strata-primitives",
  "tracing-subscriber 0.3.23",
  "typed-sled",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -15704,7 +15718,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -15738,7 +15752,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -15747,7 +15761,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -15772,7 +15786,7 @@ dependencies = [
 [[package]]
 name = "strata-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
@@ -15786,7 +15800,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -15806,11 +15820,11 @@ dependencies = [
 [[package]]
 name = "strata-metrics"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "metrics",
  "metrics-exporter-otel",
- "metrics-exporter-prometheus",
+ "metrics-exporter-prometheus 0.18.1",
  "metrics-util 0.20.1",
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
@@ -15839,7 +15853,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -15974,8 +15988,6 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -16273,10 +16285,9 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
- "borsh",
  "hex",
  "k256",
  "serde",
@@ -16289,7 +16300,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tree_hash 0.16.0",
  "tree_hash_derive 0.16.0",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1)",
+ "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]
@@ -16329,7 +16340,7 @@ dependencies = [
  "strata-predicate",
  "strata-snark-acct-runtime",
  "strata-snark-acct-types",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -16355,7 +16366,7 @@ dependencies = [
  "strata-ee-chunk-runtime",
  "strata-evm-ee",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -16380,7 +16391,7 @@ dependencies = [
  "strata-ol-state-types",
  "strata-ol-stf",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -16408,7 +16419,7 @@ dependencies = [
  "strata-ol-bridge-types",
  "strata-primitives",
  "strata-state",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -16423,7 +16434,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -16468,14 +16479,14 @@ dependencies = [
  "strata-zkvm-hosts",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-sp1-host",
 ]
 
 [[package]]
 name = "strata-service"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "anyhow",
  "futures",
@@ -16600,7 +16611,7 @@ dependencies = [
  "sp1-helper",
  "sp1-sdk",
  "sp1-verifier",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]
@@ -16657,7 +16668,7 @@ dependencies = [
  "threadpool",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -16675,7 +16686,7 @@ dependencies = [
 [[package]]
 name = "strata-tasks"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -16735,7 +16746,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-arb"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",
@@ -16744,7 +16755,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "strata-identifiers",
@@ -16767,7 +16778,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btcio"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -16781,7 +16792,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-checkpoint"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.12#4fc78f05f185516f9ef61b99417872e17c4559f8"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "borsh",
  "k256",
@@ -19299,18 +19310,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
-dependencies = [
- "bincode",
- "borsh",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "zkaleido"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -19324,7 +19324,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "tracing",
 ]
@@ -19332,34 +19332,19 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
-dependencies = [
- "blake3",
- "borsh",
- "hex",
- "serde",
- "sha2",
- "substrate-bn",
- "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1)",
-]
-
-[[package]]
-name = "zkaleido-sp1-groth16-verifier"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "blake3",
  "borsh",
@@ -19368,13 +19353,13 @@ dependencies = [
  "sha2",
  "substrate-bn",
  "thiserror 2.0.18",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-host"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -19386,7 +19371,7 @@ dependencies = [
  "sp1-sdk",
  "sp1-verifier",
  "tokio",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,50 +215,52 @@ strata-test-utils-ssz = { path = "crates/test-utils/ssz" }
 strata-zkvm-hosts = { path = "crates/zkvm/hosts" }
 
 # strata-common
-strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
 strata-codec = { git = "https://github.com/alpenlabs/strata-common", features = [
   "derive",
-], tag = "v0.1.0-alpha-rc23" }
-strata-codec-tests = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+], tag = "v0.1.0-alpha-rc25" }
+strata-codec-tests = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "legacy_compact",
-], tag = "v0.1.0-alpha-rc23" }
-strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-msg-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-service = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
-strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+], tag = "v0.1.0-alpha-rc25" }
+strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-msg-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [
+  "serde",
+], tag = "v0.1.0-alpha-rc25" }
+strata-service = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
+strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
 
 # asm
-strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-logs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-manifest-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-admin = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-admin-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-bridge-v1-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-bridge-v1-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-checkpoint-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-debug-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-proto-txs-test-utils = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-spec-debug = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-stf = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-btc-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-checkpoint-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-test-utils-btc = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
-strata-test-utils-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.12" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-logs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-manifest-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-admin = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-admin-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-bridge-v1-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-bridge-v1-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-checkpoint-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-debug-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-proto-txs-test-utils = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-spec-debug = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-stf = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-btc-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-checkpoint-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-test-utils-btc = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
+strata-test-utils-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.1-alpha.13" }
 
 # sled wrapper
 typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }
@@ -267,10 +269,10 @@ typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }
 zkaleido = { git = "https://github.com/alpenlabs/zkaleido", features = [
   "arbitrary",
   "ssz",
-], tag = "v0.1-beta.3" }
-zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+], tag = "v0.1-beta.4" }
+zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
 
 make_buf = { git = "https://github.com/alpenlabs/make_buf", version = "1.0.2" }
 

--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -29,7 +29,6 @@ strata-proofimpl-alpen-acct.workspace = true
 strata-proofimpl-checkpoint.workspace = true
 strata-snark-acct-runtime.workspace = true
 
-borsh = { workspace = true, optional = true }
 sp1-verifier = { workspace = true, optional = true }
 strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }
 zkaleido-sp1-groth16-verifier = { workspace = true, optional = true }
@@ -51,7 +50,6 @@ default = ["btc-client"]
 btc-client = ["dep:bitcoind-async-client", "dep:tokio"]
 sp1-builder = [
   "strata-sp1-guest-builder/sp1-dev",
-  "dep:borsh",
   "dep:sp1-verifier",
   "dep:zkaleido-sp1-groth16-verifier",
 ]

--- a/bin/datatool/src/acct_predicate.rs
+++ b/bin/datatool/src/acct_predicate.rs
@@ -97,9 +97,9 @@ fn build_sp1_predicate() -> PredicateKey {
         true,
     )
     .expect("Failed to load SP1 Groth16 verifier");
-    // strata-predicate's Sp1Groth16 verifier expects a borsh-serialized
-    // `SP1Groth16Verifier`, not raw VK bytes.
-    let condition_bytes = borsh::to_vec(&sp1_verifier)
-        .expect("failed to borsh-serialize SP1Groth16Verifier for acct predicate");
+    // strata-predicate's Sp1Groth16 verifier reads the condition via
+    // `SP1Groth16Verifier::parse`, i.e. the verifier's canonical uncompressed
+    // encoding.
+    let condition_bytes = sp1_verifier.to_uncompressed_bytes();
     PredicateKey::new(PredicateTypeId::Sp1Groth16, condition_bytes)
 }

--- a/bin/datatool/src/checkpoint_predicate.rs
+++ b/bin/datatool/src/checkpoint_predicate.rs
@@ -115,9 +115,9 @@ fn build_sp1_predicate() -> PredicateKey {
         true,
     )
     .expect("Failed to load SP1 Groth16 verifier");
-    // strata-predicate's Sp1Groth16 verifier expects a borsh-serialized
-    // `SP1Groth16Verifier`, not raw VK bytes.
-    let condition_bytes = borsh::to_vec(&sp1_verifier)
-        .expect("failed to borsh-serialize SP1Groth16Verifier for checkpoint predicate");
+    // strata-predicate's Sp1Groth16 verifier reads the condition via
+    // `SP1Groth16Verifier::parse`, i.e. the verifier's canonical uncompressed
+    // encoding.
+    let condition_bytes = sp1_verifier.to_uncompressed_bytes();
     PredicateKey::new(PredicateTypeId::Sp1Groth16, condition_bytes)
 }

--- a/crates/consensus-logic/src/asm_worker_context.rs
+++ b/crates/consensus-logic/src/asm_worker_context.rs
@@ -2,8 +2,13 @@
 
 use std::sync::Arc;
 
+use bitcoin::block::Header;
 use bitcoind_async_client::{client::Client, traits::Reader};
-use strata_asm_worker::{AsmState as WorkerAsmState, WorkerContext, WorkerError, WorkerResult};
+use strata_asm_common::{AsmManifest, AsmManifestHash, AuxData};
+use strata_asm_worker::{
+    AnchorStateStore, AsmState as WorkerAsmState, AuxDataStore, L1DataProvider, ManifestMmrStore,
+    WorkerError, WorkerResult,
+};
 use strata_btc_types::L1BlockIdBitcoinExt;
 use strata_common::retry::{policies::ExponentialBackoff, retry_with_backoff};
 use strata_db_types::DbError;
@@ -45,7 +50,7 @@ impl AsmWorkerCtx {
     }
 }
 
-impl WorkerContext for AsmWorkerCtx {
+impl L1DataProvider for AsmWorkerCtx {
     fn get_l1_block(&self, blockid: &L1BlockId) -> WorkerResult<bitcoin::Block> {
         let hash = blockid.to_block_hash();
         let backoff = ExponentialBackoff::new(200, 15, 10);
@@ -59,33 +64,17 @@ impl WorkerContext for AsmWorkerCtx {
         })
     }
 
-    fn get_latest_asm_state(&self) -> WorkerResult<Option<(L1BlockCommitment, WorkerAsmState)>> {
-        self.asmman
-            .fetch_most_recent_state_blocking()
-            .map_err(conv_db_err)
-            .map(|state| state.map(|(block, state)| (block, storage_to_worker_state(state))))
-    }
-
-    fn get_anchor_state(&self, blockid: &L1BlockCommitment) -> WorkerResult<WorkerAsmState> {
-        self.asmman
-            .get_state_blocking(*blockid)
-            .map_err(conv_db_err)?
-            .map(storage_to_worker_state)
-            .ok_or(WorkerError::MissingAsmState(*blockid.blkid()))
-    }
-
-    fn store_anchor_state(
-        &self,
-        blockid: &L1BlockCommitment,
-        state: &WorkerAsmState,
-    ) -> WorkerResult<()> {
-        self.asmman
-            .put_state_blocking(*blockid, worker_to_storage_state(state))
-            .map_err(conv_db_err)
-    }
-
-    fn store_l1_manifest(&self, manifest: strata_asm_common::AsmManifest) -> WorkerResult<()> {
-        self.l1man.put_block_data(manifest).map_err(conv_db_err)
+    fn get_l1_block_header(&self, blockid: &L1BlockId) -> WorkerResult<Header> {
+        let hash = blockid.to_block_hash();
+        let backoff = ExponentialBackoff::new(200, 15, 10);
+        retry_with_backoff("asm_get_l1_block_header", 10, &backoff, || {
+            self.handle
+                .block_on(self.bitcoin_client.get_block_header(&hash))
+                .map_err(|e| {
+                    tracing::warn!(%blockid, ?e, "failed to fetch L1 block header for ASM");
+                    WorkerError::MissingL1Block(*blockid)
+                })
+        })
     }
 
     fn get_network(&self) -> WorkerResult<bitcoin::Network> {
@@ -112,14 +101,98 @@ impl WorkerContext for AsmWorkerCtx {
 
         Ok(RawBitcoinTx::from(tx))
     }
+}
 
-    fn append_manifest_to_mmr(&self, manifest_hash: Hash) -> WorkerResult<u64> {
-        self.mmr_handle
-            .append_leaf_blocking(manifest_hash)
-            .map_err(|e| {
-                error!(?e, "Failed to append leaf to MMR");
+impl AnchorStateStore for AsmWorkerCtx {
+    fn get_latest_asm_state(&self) -> WorkerResult<Option<(L1BlockCommitment, WorkerAsmState)>> {
+        self.asmman
+            .fetch_most_recent_state_blocking()
+            .map_err(conv_db_err)
+            .map(|state| state.map(|(block, state)| (block, storage_to_worker_state(state))))
+    }
+
+    fn get_anchor_state(&self, blockid: &L1BlockCommitment) -> WorkerResult<WorkerAsmState> {
+        self.asmman
+            .get_state_blocking(*blockid)
+            .map_err(conv_db_err)?
+            .map(storage_to_worker_state)
+            .ok_or(WorkerError::MissingAsmState(*blockid.blkid()))
+    }
+
+    fn store_anchor_state(
+        &self,
+        blockid: &L1BlockCommitment,
+        state: &WorkerAsmState,
+    ) -> WorkerResult<()> {
+        self.asmman
+            .put_state_blocking(*blockid, worker_to_storage_state(state))
+            .map_err(conv_db_err)
+    }
+}
+
+impl ManifestMmrStore for AsmWorkerCtx {
+    fn put_manifest(&self, manifest: AsmManifest) -> WorkerResult<()> {
+        self.l1man.put_block_data(manifest).map_err(conv_db_err)
+    }
+
+    /// Writes a manifest hash as the height-indexed MMR leaf for `height`.
+    ///
+    /// The backing [`MmrIndexHandle`] is append-only (plus `pop`), so the
+    /// height-indexed contract is mapped onto it positionally: with the genesis
+    /// prefill in place, leaf index equals L1 height. A `height` at the current
+    /// end appends; a `height` below it (an L1 reorg replacing the block at an
+    /// already-seen height) pops every leaf from `height` up before re-appending,
+    /// which is safe because the worker rewrites leaves from the reorg fork point
+    /// forward and the dropped leaves belong to the abandoned branch; a `height`
+    /// past the end is rejected to avoid a gap in the height-to-index mapping.
+    ///
+    /// # Crash safety
+    ///
+    /// The pop-then-append overwrite is not atomic, but it is crash-safe by the
+    /// worker's commit ordering: `apply_block` records the manifest (this call)
+    /// before it stores the anchor state, and a block counts as processed only
+    /// once its anchor state is stored. A crash mid-overwrite leaves the block
+    /// uncommitted, so the next sync re-runs it and re-invokes this with the same
+    /// `(height, hash)`; popping back to `height` then appending reproduces the
+    /// same leaf from any intermediate leaf count, so the re-run is idempotent.
+    ///
+    /// NOTE: a native height-indexed `put_leaf(height, hash)` on
+    /// [`MmrIndexHandle`] (as the ASM runner's `SledAsmManifestMmrDb` provides)
+    /// would collapse this to a single write.
+    fn put_manifest_hash(&self, height: u64, hash: AsmManifestHash) -> WorkerResult<()> {
+        let leaf = Hash::from(hash);
+        let leaf_count = self.mmr_handle.get_num_leaves_blocking().map_err(|e| {
+            error!(?e, "Failed to read manifest MMR leaf count");
+            WorkerError::DbError
+        })?;
+
+        if height > leaf_count {
+            return Err(WorkerError::ManifestIndexOutOfBound {
+                index: height,
+                max: leaf_count,
+            });
+        }
+
+        for _ in height..leaf_count {
+            self.mmr_handle.pop_leaf_blocking().map_err(|e| {
+                error!(?e, "Failed to pop leaf from MMR");
                 WorkerError::DbError
-            })
+            })?;
+        }
+
+        self.mmr_handle.append_leaf_blocking(leaf).map_err(|e| {
+            error!(?e, "Failed to append leaf to MMR");
+            WorkerError::DbError
+        })?;
+
+        Ok(())
+    }
+
+    fn manifest_mmr_leaf_count(&self) -> WorkerResult<u64> {
+        self.mmr_handle.get_num_leaves_blocking().map_err(|e| {
+            error!(?e, "Failed to read manifest MMR leaf count");
+            WorkerError::DbError
+        })
     }
 
     fn generate_mmr_proof_at(
@@ -135,30 +208,30 @@ impl WorkerContext for AsmWorkerCtx {
             })
     }
 
-    fn get_manifest_hash(&self, index: u64) -> WorkerResult<Option<Hash>> {
-        self.mmr_handle.get_leaf_blocking(index).map_err(|e| {
-            error!(?e, index, "Failed to get leaf hash from MMR");
-            WorkerError::DbError
-        })
+    fn get_manifest_hash(&self, index: u64) -> WorkerResult<AsmManifestHash> {
+        self.mmr_handle
+            .get_leaf_blocking(index)
+            .map_err(|e| {
+                error!(?e, index, "Failed to get leaf hash from MMR");
+                WorkerError::DbError
+            })?
+            .map(AsmManifestHash::from)
+            .ok_or(WorkerError::ManifestHashNotFound { index })
     }
+}
 
-    fn store_aux_data(
-        &self,
-        blockid: &L1BlockCommitment,
-        data: &strata_asm_common::AuxData,
-    ) -> WorkerResult<()> {
+impl AuxDataStore for AsmWorkerCtx {
+    fn store_aux_data(&self, blockid: &L1BlockCommitment, data: &AuxData) -> WorkerResult<()> {
         self.asmman
             .put_aux_data_blocking(*blockid, data.clone())
             .map_err(conv_db_err)
     }
 
-    fn get_aux_data(
-        &self,
-        blockid: &L1BlockCommitment,
-    ) -> WorkerResult<Option<strata_asm_common::AuxData>> {
+    fn get_aux_data(&self, blockid: &L1BlockCommitment) -> WorkerResult<AuxData> {
         self.asmman
             .get_aux_data_blocking(*blockid)
-            .map_err(conv_db_err)
+            .map_err(conv_db_err)?
+            .ok_or(WorkerError::MissingAuxData(*blockid))
     }
 }
 

--- a/crates/ol/checkpoint/Cargo.toml
+++ b/crates/ol/checkpoint/Cargo.toml
@@ -25,8 +25,6 @@ strata-tasks.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-zkaleido.workspace = true
-zkaleido-sp1-groth16-verifier.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ol/checkpoint/src/context.rs
+++ b/crates/ol/checkpoint/src/context.rs
@@ -16,10 +16,6 @@ use strata_ol_stf::execute_block_batch_predrain;
 use strata_primitives::nonempty_vec::NonEmptyVec;
 use strata_storage::NodeStorage;
 use tracing::{debug, warn};
-use zkaleido::{ProofReceiptWithMetadata, ZkVm};
-use zkaleido_sp1_groth16_verifier::{
-    GROTH16_PROOF_COMPRESSED_SIZE, GROTH16_PROOF_UNCOMPRESSED_SIZE, VK_HASH_PREFIX_LENGTH,
-};
 
 pub(crate) type StateDiffRaw = Vec<u8>;
 
@@ -178,34 +174,13 @@ impl CheckpointWorkerContextImpl {
         }
     }
 
-    /// Normalizes proof bytes for checkpoint payload encoding.
-    ///
-    /// SP1 Groth16 proofs persisted by the SP1 host include a 4-byte verifying-key hash prefix.
-    /// ASM checkpoint predicate verification expects the raw Groth16 witness bytes (128/256 bytes),
-    /// so strip that SP1 prefix when present. The producing backend is read off the receipt's
-    /// metadata rather than carried in the proof key.
-    fn payload_proof_bytes(receipt: &ProofReceiptWithMetadata) -> Vec<u8> {
-        let proof_bytes = receipt.receipt().proof().as_bytes();
-        let prefixed_compressed_len = GROTH16_PROOF_COMPRESSED_SIZE + VK_HASH_PREFIX_LENGTH;
-        let prefixed_uncompressed_len = GROTH16_PROOF_UNCOMPRESSED_SIZE + VK_HASH_PREFIX_LENGTH;
-
-        if matches!(receipt.metadata().zkvm(), ZkVm::SP1)
-            && (proof_bytes.len() == prefixed_compressed_len
-                || proof_bytes.len() == prefixed_uncompressed_len)
-        {
-            return proof_bytes[VK_HASH_PREFIX_LENGTH..].to_vec();
-        }
-
-        proof_bytes.to_vec()
-    }
-
     /// Attempts to read a non-empty proof from the proof DB for the given epoch commitment.
     ///
     /// Returns `Ok(Some(bytes))` if a valid proof is found, `Ok(None)` if no
     /// proof is available yet.
     fn try_read_proof(&self, commitment: EpochCommitment) -> anyhow::Result<Option<Vec<u8>>> {
         if let Some(receipt) = self.storage.checkpoint_proof().get_proof(&commitment)? {
-            let proof_bytes = Self::payload_proof_bytes(&receipt);
+            let proof_bytes = receipt.receipt().proof().as_bytes().to_vec();
             if proof_bytes.is_empty() {
                 warn!(%commitment, "empty proof receipt found");
                 return Ok(None);

--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -22,7 +22,7 @@ strata-ol-msg-types.workspace = true
 strata-ol-params = { workspace = true, optional = true }
 strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
-strata-predicate = { workspace = true, features = ["all"] }
+strata-predicate.workspace = true
 strata-snark-acct-sys.workspace = true
 strata-snark-acct-types.workspace = true
 

--- a/provers/sp1/Cargo.toml
+++ b/provers/sp1/Cargo.toml
@@ -8,7 +8,6 @@ once_cell = "1.21.4"
 
 [build-dependencies]
 bincode.workspace = true
-borsh.workspace = true
 cargo_metadata = "0.19.1"
 cfg-if.workspace = true
 sha2.workspace = true

--- a/provers/sp1/build.rs
+++ b/provers/sp1/build.rs
@@ -311,10 +311,11 @@ fn get_mock_elf_contents_and_vk_hash() -> ([u32; 8], String, [u8; 32]) {
 }
 
 /// Computes the Groth16 verifying key condition bytes for the given BN254
-/// program ID. The output is a borsh-serialized [`SP1Groth16Verifier`] that
-/// the runtime `Sp1Groth16` predicate verifier in `strata-predicate` decodes
-/// via `borsh::from_slice`. The verifier object embeds the SP1 circuit VK
-/// merged with the program-specific ID and the VK root.
+/// program ID. The output is the canonical uncompressed encoding of an
+/// [`SP1Groth16Verifier`] that the runtime `Sp1Groth16` predicate verifier in
+/// `strata-predicate` decodes via `SP1Groth16Verifier::parse`. The verifier
+/// object embeds the SP1 circuit VK merged with the program-specific ID and the
+/// VK root.
 #[cfg(all(feature = "sp1-dev", not(debug_assertions)))]
 fn compute_groth16_condition(program_id: &[u8; 32]) -> Vec<u8> {
     let sp1_verifier = SP1Groth16Verifier::load(
@@ -325,7 +326,7 @@ fn compute_groth16_condition(program_id: &[u8; 32]) -> Vec<u8> {
     )
     .expect("Failed to load SP1 Groth16 verifier");
 
-    borsh::to_vec(&sp1_verifier).expect("failed to borsh-serialize SP1Groth16Verifier")
+    sp1_verifier.to_uncompressed_bytes()
 }
 
 /// Returns empty condition bytes in debug/mock builds.

--- a/provers/sp1/guest-alpen-acct/Cargo.lock
+++ b/provers/sp1/guest-alpen-acct/Cargo.lock
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.11.0",
@@ -4989,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5009,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5159,7 +5159,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5180,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5214,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -5247,11 +5247,12 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
- "borsh",
  "hex",
+ "k256",
  "serde",
+ "signature",
  "ssz",
  "ssz_codegen",
  "ssz_derive",
@@ -5297,7 +5298,7 @@ dependencies = [
  "strata-predicate",
  "strata-snark-acct-runtime",
  "strata-snark-acct-types",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -6188,18 +6189,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
-dependencies = [
- "bincode",
- "borsh",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "zkaleido"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -6212,19 +6202,19 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "blake3",
  "borsh",
@@ -6232,21 +6222,21 @@ dependencies = [
  "serde",
  "sha2",
  "substrate-bn",
- "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1)",
+ "thiserror 2.0.18",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "cfg-if",
  "serde",
  "sha2",
  "sp1-zkvm",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]

--- a/provers/sp1/guest-alpen-acct/Cargo.toml
+++ b/provers/sp1/guest-alpen-acct/Cargo.toml
@@ -6,11 +6,11 @@ version = "0.1.0"
 [workspace]
 
 [dependencies]
-strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23", features = [
+strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25", features = [
   "sp1-groth16",
 ] }
 strata-proofimpl-alpen-acct = { path = "../../../crates/proof-impl/alpen-acct" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0" }

--- a/provers/sp1/guest-alpen-chunk/Cargo.lock
+++ b/provers/sp1/guest-alpen-chunk/Cargo.lock
@@ -4942,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.11.0",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4989,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5114,7 +5114,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5135,7 +5135,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5156,7 +5156,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5190,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -5223,11 +5223,12 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
- "borsh",
  "hex",
+ "k256",
  "serde",
+ "signature",
  "ssz",
  "ssz_codegen",
  "ssz_derive",
@@ -5236,6 +5237,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
+ "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]
@@ -6159,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -6172,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "k256",
@@ -6182,9 +6184,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "zkaleido-sp1-groth16-verifier"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
+dependencies = [
+ "blake3",
+ "borsh",
+ "hex",
+ "serde",
+ "sha2",
+ "substrate-bn",
+ "thiserror 2.0.18",
+ "zkaleido",
+]
+
+[[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "cfg-if",

--- a/provers/sp1/guest-alpen-chunk/Cargo.toml
+++ b/provers/sp1/guest-alpen-chunk/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-alpen-chunk = { path = "../../../crates/proof-impl/alpen-chunk" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0" }

--- a/provers/sp1/guest-checkpoint/Cargo.lock
+++ b/provers/sp1/guest-checkpoint/Cargo.lock
@@ -1406,7 +1406,7 @@ name = "sizzle-parser"
 version = "0.16.0"
 source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1584,7 +1584,7 @@ dependencies = [
  "serde",
  "smallvec",
  "ssz_primitives",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
  "serde_derive",
  "ssz",
  "ssz_primitives",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
 ]
 
@@ -1656,7 +1656,7 @@ dependencies = [
  "strata-codec",
  "strata-identifiers",
  "strata-merkle",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -1681,7 +1681,7 @@ dependencies = [
  "strata-l1-txfmt",
  "strata-merkle",
  "strata-msg-fmt",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tree_hash",
  "tree_hash_derive",
@@ -1691,12 +1691,12 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25)",
  "strata-identifiers",
  "strata-msg-fmt",
  "strata-predicate",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "borsh",
  "serde",
@@ -1718,7 +1718,7 @@ dependencies = [
  "strata-crypto",
  "strata-identifiers",
  "strata-msg-fmt",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.11.0",
@@ -1737,28 +1737,28 @@ dependencies = [
  "ssz_derive",
  "strata-btc-types",
  "strata-identifiers",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25)",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "borsh",
  "serde",
@@ -1770,7 +1770,8 @@ dependencies = [
  "strata-asm-manifest-types",
  "strata-codec",
  "strata-identifiers",
- "thiserror 2.0.18",
+ "strata-msg-fmt",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -1782,13 +1783,13 @@ dependencies = [
  "serde",
  "ssz",
  "ssz_derive",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1801,14 +1802,14 @@ dependencies = [
  "strata-codec",
  "strata-identifiers",
  "strata-l1-txfmt",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
 ]
 
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.13#7d7968a48e571ae9e3e107d1b32f4aae27b09e0d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1819,22 +1820,22 @@ dependencies = [
  "strata-btc-types",
  "strata-crypto",
  "strata-identifiers",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "strata-codec-derive",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1853,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "borsh",
  "ssz",
@@ -1864,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1877,7 +1878,7 @@ dependencies = [
  "ssz",
  "ssz_derive",
  "strata-identifiers",
- "thiserror 2.0.18",
+ "thiserror",
  "zeroize",
 ]
 
@@ -1886,13 +1887,13 @@ name = "strata-da-framework"
 version = "0.1.0"
 dependencies = [
  "strata-codec",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -1913,22 +1914,22 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "bitcoin",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "borsh",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1941,13 +1942,13 @@ dependencies = [
  "strata-identifiers",
  "strata-predicate",
  "strata-snark-acct-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
  "borsh",
  "digest",
@@ -1959,7 +1960,7 @@ dependencies = [
  "ssz_primitives",
  "ssz_types",
  "strata-codec",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -1967,9 +1968,9 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1985,7 +1986,7 @@ dependencies = [
  "strata-codec",
  "strata-identifiers",
  "strata-primitives",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2003,8 +2004,9 @@ dependencies = [
  "strata-codec",
  "strata-crypto",
  "strata-identifiers",
+ "strata-msg-fmt",
  "strata-predicate",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -2025,7 +2027,7 @@ dependencies = [
  "strata-ledger-types",
  "strata-predicate",
  "strata-snark-acct-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2061,7 +2063,7 @@ dependencies = [
  "strata-ol-state-types",
  "strata-predicate",
  "strata-snark-acct-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2074,6 +2076,7 @@ dependencies = [
  "ssz_primitives",
  "ssz_types",
  "strata-acct-types",
+ "strata-asm-manifest-types",
  "strata-codec",
  "strata-codec-utils 0.1.0",
  "strata-identifiers",
@@ -2113,9 +2116,8 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
 dependencies = [
- "borsh",
  "hex",
  "k256",
  "serde",
@@ -2125,7 +2127,7 @@ dependencies = [
  "ssz_derive",
  "ssz_primitives",
  "ssz_types",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
  "zkaleido-sp1-groth16-verifier",
@@ -2143,7 +2145,7 @@ dependencies = [
  "strata-btc-types",
  "strata-crypto",
  "strata-identifiers",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2164,7 +2166,7 @@ dependencies = [
  "strata-ol-state-types",
  "strata-ol-stf",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -2190,7 +2192,7 @@ dependencies = [
  "ssz_types",
  "strata-acct-types",
  "strata-identifiers",
- "thiserror 2.0.18",
+ "thiserror",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -2266,31 +2268,11 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2396,7 +2378,7 @@ dependencies = [
  "smallvec",
  "ssz",
  "ssz_primitives",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2527,31 +2509,20 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
-dependencies = [
- "bincode",
- "borsh",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "zkaleido"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "arbitrary",
  "bincode",
  "borsh",
  "serde",
  "ssz",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "tracing",
 ]
@@ -2559,19 +2530,19 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "blake3",
  "borsh",
@@ -2579,21 +2550,21 @@ dependencies = [
  "serde",
  "sha2",
  "substrate-bn",
- "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1)",
+ "thiserror",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
 dependencies = [
  "bincode",
  "cfg-if",
  "serde",
  "sha2",
  "sp1-zkvm",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido",
 ]
 
 [[patch.unused]]

--- a/provers/sp1/guest-checkpoint/Cargo.toml
+++ b/provers/sp1/guest-checkpoint/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 strata-proofimpl-checkpoint = { path = "../../../crates/proof-impl/checkpoint" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0" }


### PR DESCRIPTION
## Summary

Bumps the pinned dependencies and adapts the code to their API changes: **strata-common** `v0.1.0-alpha-rc23` → `v0.1.0-alpha-rc25`, **asm** `v0.1-alpha.12` → `v0.1-alpha.13`, and **zkaleido** `v0.1-beta.3` → `v0.1-beta.4` — across the workspace and the out-of-workspace SP1 guest manifests.

## Changes

**asm alpha.13 — `WorkerContext` split into concern traits.** The umbrella `WorkerContext` is now a blanket impl over `L1DataProvider`, `AnchorStateStore`, `ManifestMmrStore`, and `AuxDataStore`. `AsmWorkerCtx` is split into the four impls, adding the new `get_l1_block_header` and `manifest_mmr_leaf_count` methods. The manifest MMR write is now height-indexed (`put_manifest_hash(height, hash)`); since the local `MmrIndexHandle` is append-only, it is mapped positionally — append at the tip, or pop back to `height` then append on an L1 reorg (the worker rewrites leaves forward from the fork point, so dropped leaves belong to the abandoned branch). This pop-then-append overwrite is non-atomic but crash-safe: `apply_block` records the manifest before storing the anchor state (the commit point), so a crash mid-overwrite leaves the block uncommitted and the next sync re-runs it idempotently. A `NOTE` flags that a native height-indexed `put_leaf` would make it a single write.

**rc25 — `strata-predicate` default features.** rc25 drops `serde` from the predicate crate's defaults and renames the `all` feature. `PredicateKey` is (de)serialized across the workspace (ol-params, ol-rpc-types, alpen-chunk, …), which previously came for free via the default and now only compiled in full-workspace builds via feature unification. Re-enabled `serde` on the workspace `strata-predicate` dependency (matching how `strata-codec` / `strata-merkle` declare needed features there), and dropped the now-removed `all` feature from `strata-ol-stf`.

**rc25 — Sp1Groth16 predicate condition encoding.** rc25 switches the `Sp1Groth16` predicate condition from a borsh-serialized verifier (rc23) to the verifier's canonical uncompressed encoding (`SP1Groth16Verifier::parse` / `to_uncompressed_bytes`). The borsh form still compiles (the verifier is `BorshSerialize`) but produces a condition rc25 cannot parse, so every producer is switched to `to_uncompressed_bytes`: the datatool checkpoint/acct predicate builders, and `provers/sp1/build.rs`, which bakes the per-guest `*_VK_CONDITION` constants — including the chunk VK condition the alpen-acct guest verifies chunk proofs against. The now-unused `borsh` deps are dropped.

**zkaleido beta.4 — checkpoint proof bytes.** The groth16 verifier now accepts the SP1 verifying-key-hash prefix directly, so the checkpoint payload passes the stored proof bytes through unmodified instead of stripping the prefix, and drops the `zkaleido` / `zkaleido-sp1-groth16-verifier` deps from the checkpoint crate.

**SP1 guest manifests.** The `provers/sp1/guest-*` packages have their own workspaces and lockfiles, so they pin the git deps independently; bumped `strata-predicate` to rc25 and `zkaleido-sp1-guest-env` to beta.4 there to keep them in lockstep with the workspace.

## Testing

- `cargo check --workspace --all-targets --all-features` — clean
- `cargo clippy --workspace --lib --bins --examples --tests --benches --all-features -- -D warnings` — clean
- `cargo check --locked` — lockfile in sync

The SP1 guest packages build out-of-workspace and are not covered by the checks above. The `provers/sp1/build.rs` condition baking is `#[cfg(all(feature = "sp1-dev", not(debug_assertions)))]`, so it is not exercised by debug checks and needs the SP1 toolchain (release + `sp1-dev`) to compile; the change is type-identical to the compile-verified datatool fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
