### PR TITLE
[DOCS] [DRAFT]: paas better retries

### DIFF
--- a/crates/paas/README.md
+++ b/crates/paas/README.md
@@ -2,36 +2,38 @@
 
 Prover-as-a-Service. Turns a `Prover<S>` from
 [prover-core](../prover-core/README.md) into a managed service with command
-channels, periodic retries, and health monitoring.
+channels, periodic retry/recheck ticks, and health monitoring.
 
 ## Why does this exist?
 
-prover-core is a library — it knows how to prove things, but it has no runtime,
-no event loop, and no concept of a long-running service. If you want to run a
-prover inside an application that accepts work over time, something needs to own
-the lifecycle: receiving commands, driving periodic maintenance (retries, crash
-recovery), and giving callers a clean async handle.
+prover-core is a library — it knows how to prove things and how to handle every
+flavor of failure, but it has no runtime, no event loop, and no concept of a
+long-running service. Something has to own the lifecycle: receive commands, drive
+the periodic `tick()` that fires retries, dependency rechecks, and crash
+recovery, and hand callers a clean async handle.
 
-That's PaaS. It's a thin service wrapper (~320 lines) that bridges prover-core
-into the Service Framework (SF), so provers can be launched, monitored, and
-controlled alongside the rest of the node's services.
+That's PaaS. A thin service wrapper that bridges prover-core into the Service
+Framework (SF), so provers launch, monitor, and shut down alongside the rest of
+the node's services.
 
 ## How it fits together
 
 ```
-prover-core                          paas
-┌──────────────────────────┐        ┌──────────────────────────────┐
-│ ProofSpec trait           │        │ ProverServiceBuilder          │
-│ Prover<S>                │───────▶│ ProverHandle<S>               │
-│ ProverBuilder             │        │ SF service (async, ticking)   │
-│ ProveStrategy (nat/rem)   │        └──────────────────────────────┘
-│ TaskStore, ReceiptStore   │
+prover-core                              paas
+┌──────────────────────────┐            ┌──────────────────────────────┐
+│ ProofSpec (resolve_input) │            │ ProverServiceBuilder          │
+│ Prover<S>                │───────────▶│ ProverHandle<S>               │
+│ ProverBuilder             │            │ SF service (command / ticking)│
+│ ProveStrategy (nat/rem)   │            │  └─ tick() ⇒ retries,         │
+│ retry/blocked/checkpoint  │            │     rechecks, recovery        │
+│ TaskStore, ReceiptStore   │            └──────────────────────────────┘
 └──────────────────────────┘
- Knows: proving, retries,            Knows: SF lifecycle, command
- task lifecycle, recovery            routing, tick scheduling
+ Knows: proving, the retry/blocked/      Knows: SF lifecycle, command
+ resubmit decision, recovery             routing, tick scheduling
 ```
 
-prover-core does all the real work. PaaS just gives it a place to live.
+prover-core does all the real work — including all retry, blocked-dependency, and
+checkpoint logic. PaaS just gives it a place to live and a clock to tick on.
 
 ## Getting started
 
@@ -49,18 +51,24 @@ let handle = ProverServiceBuilder::new(prover)
     .await?;
 ```
 
-The tick interval controls how often PaaS calls `prover.tick()` to scan for
-retriable tasks and perform startup recovery. If you don't set one, the service
-runs in command-only mode — no retries, no recovery, just direct commands. Good
-for one-shot provers in tests.
+The tick interval controls how often PaaS calls `prover.tick()`. The tick is the
+heartbeat for everything time-driven in prover-core: re-spawning tasks whose
+backoff has elapsed (`TransientFailure`), rechecking tasks waiting on a
+dependency (`Blocked`), and one-shot startup crash recovery. If you don't set
+one, the service runs in command-only mode — no retries, no rechecks, no
+recovery; good for one-shot provers in tests. (Launching with a retry config but
+no tick interval is rejected — retries would never fire.)
+
+`RetryConfig` carries the full retry policy — resume/resubmit budgets, jittered
+backoff, the blocked-recheck cadence, and the in-attempt local-retry budget.
+See [prover-core's README](../prover-core/README.md#retryconfig-knobs) for the
+knobs; PaaS just hands the config to the prover and calls `tick()`.
 
 ### Using the handle
 
-`ProverHandle<S>` is what consumers hold onto. It's generic over the spec only —
-the zkVM host type is already erased inside the prover.
-
-The entire API is keyed by your domain task type — no UUIDs, no intermediate
-identifiers. You submit a task, wait for that task, get the receipt by that task.
+`ProverHandle<S>` is what consumers hold. It's generic over the spec only — the
+zkVM host type is already erased inside the prover. The entire API is keyed by
+your domain task type: no UUIDs, no intermediate identifiers.
 
 ```rust
 // Sequential — prove one thing and wait
@@ -73,11 +81,11 @@ match result {
 // Fan-out — submit many, wait for all, typed results back
 let chunks: Vec<_> = (0..n).map(|i| ChunkTask { batch_id, chunk_idx: i }).collect();
 for c in &chunks {
-    handle.submit(c.clone()).await?;  // idempotent — double-submit is a no-op
+    handle.submit(c.clone()).await?;   // idempotent — double-submit is a no-op
 }
 handle.wait_for_tasks(&chunks).await?;
 
-// Get receipt by task — no UUID lookup needed
+// Get receipt by task — no UUID lookup
 let receipt = handle.get_receipt(&chunks[0])?;
 ```
 
@@ -85,21 +93,23 @@ The full API:
 
 | Method | Description |
 |--------|-------------|
-| `submit(task)` | Spawn a background prove. Idempotent — submitting the same task twice is a no-op. |
-| `execute(task)` | Submit + block until done. Returns `TaskResult<Task>`. |
-| `wait_for_tasks(tasks)` | Block until all tasks reach a terminal state. Watch-channel based, zero-poll. |
+| `submit(task)` | Spawn a background prove. Idempotent. |
+| `execute(task)` | Submit + block until terminal. Returns `TaskResult<Task>`. |
+| `wait_for_tasks(tasks)` | Block until all reach a terminal state. Watch-channel, zero-poll. A `Blocked` task is *not* terminal — the wait stays parked. |
 | `get_receipt(task)` | Read the stored receipt (requires a configured `ReceiptStore`). |
-| `get_status(task)` | Current task status. |
+| `get_status(task)` | Current `TaskStatus` (`Pending`/`Proving`/`Blocked`/`Completed`/`TransientFailure`/`PermanentFailure`). |
 
 `submit` and `execute` go through the SF command channel. `wait_for_tasks`,
-`get_receipt`, and `get_status` read directly from shared prover state — no channel round-trip.
+`get_receipt`, and `get_status` read directly from shared prover state — no
+channel round-trip.
 
 ## Real-world examples
 
 ### OL checkpoint prover
 
-Sequential, one epoch at a time. Uses a `ReceiptHook` to side-write proofs into
-the domain's ProofDB.
+Sequential, one epoch at a time. A `ReceiptHook` side-writes proofs into the
+domain's ProofDB. `resolve_input` returns `Blocked` while an epoch isn't yet
+finalized, so the task waits instead of churning through the retry budget.
 
 ```rust
 let prover = ProverBuilder::new(CheckpointSpec { storage })
@@ -117,33 +127,39 @@ handle.execute(epoch).await?;
 
 ### EE chunk/acct pipeline
 
-Fan-out chunks in parallel, barrier, then aggregate. The shared receipt store is
-the glue — the acct spec reads chunk receipts during `fetch_input`.
+Fan-out chunks, then aggregate into an acct proof. The shared receipt store is
+the glue: the acct spec reads chunk receipts during `resolve_input`. When a chunk
+receipt isn't present yet, the acct spec returns `InputResolution::Blocked` —
+so the acct task **parks and rechecks on a steady cadence**, instead of faking a
+`TransientFailure` and riding exponential-backoff-to-an-hour. Dependency-waiting
+stops polluting failure metrics.
 
 ```rust
 let receipt_store = Arc::new(SledReceiptStore::new(db));
 
-// Chunk prover writes receipts
+// Chunk prover writes receipts.
 let chunk_prover = ProverBuilder::new(ChunkSpec { block_storage })
     .receipt_store(receipt_store.clone())
+    .retry(RetryConfig::default())
     .native(EeChunkProgram::native_host());
 let chunk_handle = ProverServiceBuilder::new(chunk_prover)
-    .launch(&executor).await?;
+    .tick_interval(Duration::from_secs(5)).launch(&executor).await?;
 
-// Acct prover reads chunk receipts in fetch_input
-let acct_prover = ProverBuilder::new(AcctSpec { batch_storage, receipt_store: receipt_store.clone() })
-    .receipt_store(receipt_store)
+// Acct prover reads chunk receipts in resolve_input; missing ones ⇒ Blocked.
+let acct_prover = ProverBuilder::new(AcctSpec {
+        batch_storage,
+        chunk_receipts: receipt_store.clone(),
+    })
+    .receipt_hook(AcctProofDbHook { proof_db })
+    .retry(RetryConfig::default())
     .native(EeAcctProgram::native_host());
 let acct_handle = ProverServiceBuilder::new(acct_prover)
-    .launch(&executor).await?;
+    .tick_interval(Duration::from_secs(5)).launch(&executor).await?;
 
-// Orchestrate: fan-out chunks → barrier → aggregate
-let chunks: Vec<_> = (0..num_chunks)
-    .map(|i| ChunkTask { batch_id, chunk_idx: i })
-    .collect();
-join_all(chunks.iter().map(|c| chunk_handle.submit(c.clone()))).await;
-chunk_handle.wait_for_tasks(&chunks).await?;
-acct_handle.execute(AcctTask { batch_id }).await?;
+// Submit the whole batch up front. Chunks prove in parallel; the acct task
+// blocks on missing chunk receipts and unblocks itself as they land.
+for c in &chunks { chunk_handle.submit(c.clone()).await?; }
+acct_handle.submit(AcctTask { batch_id }).await?;
 ```
 
 ### Switching to remote proving
@@ -153,43 +169,47 @@ The spec stays identical. Only the builder call changes:
 ```rust
 let prover = ProverBuilder::new(spec)
     .receipt_store(sled_store)
-    .task_store(persistent_task_store)
+    .task_store(persistent_task_store)   // so remote ProofIds survive restarts
     .retry(RetryConfig::default())
-    .remote(sp1_host);   // instead of .native(host)
+    .remote(sp1_host);                   // instead of .native(host)
 ```
 
-Requires the `remote` feature on prover-core.
+Requires the `remote` feature on prover-core. The in-attempt local-retry tier
+and the long-lived runtime that hosts the SP1 gRPC channel are both internal to
+the remote strategy — no PaaS-side change.
 
 ## Feature status
 
 ### Implemented
 
-- **Service Framework integration** — two service modes, both fully wired:
-  - *Command-only* — no ticking, commands only. Good for one-shot provers and tests.
-  - *Ticking* — commands + periodic `prover.tick()` for retry scanning and crash recovery.
-- **Command routing** — `Submit` and `Execute` commands flow through a typed async
-  channel. Completion senders return results directly to the caller.
-- **ProverHandle** — cloneable, generic over spec only. Five methods: `submit`,
-  `execute`, `wait_for_tasks`, `get_receipt`, `get_status`. Channel-based for
-  commands, direct-read for queries (zero-copy, no round-trip).
-- **Tick scheduling** — configurable interval via the builder. Drives retries and
-  recovery without background threads.
-- **Service status** — reports task count via `get_status()`. Available on both
-  service modes.
+- **Service Framework integration** — two modes:
+  - *Command-only* — no ticking. Good for one-shot provers and tests.
+  - *Ticking* — commands + periodic `tick()` for retry/recheck scanning and crash
+    recovery.
+- **Command routing** — `Submit` and `Execute` flow through a typed async channel;
+  completion senders return results to the caller.
+- **ProverHandle** — cloneable, generic over spec only. Channel-based for
+  commands, direct-read for queries (no round-trip).
+- **Tick scheduling** — configurable interval; drives retries, dependency
+  rechecks, and recovery without background threads.
+- **Service status** — task count via `get_status()`, on both modes.
 
 ### Planned
 
-- **Health check API** — the `ServiceMonitor` is already held internally but not
-  exposed on the handle. A dedicated `health()` method would let consumers and
-  orchestrators check liveness without going through the command channel.
-- **Graceful shutdown** — coordinated drain of in-flight tasks before service teardown,
+- **Health check API** — the `ServiceMonitor` is held internally but not exposed
+  on the handle; a `health()` method would let orchestrators check liveness
+  without the command channel.
+- **Graceful shutdown** — coordinated drain of in-flight tasks before teardown,
   so remote proofs aren't abandoned mid-poll.
-- **RPC bridge** — a thin adapter to expose `submit`/`execute`/`get_receipt` over
-  JSON-RPC or gRPC, so provers can be driven from external tooling.
+- **RPC bridge** — a thin adapter exposing `submit`/`execute`/`get_receipt` over
+  JSON-RPC or gRPC for external tooling.
 
 ## What PaaS does NOT do
 
-- **Proving** — that's prover-core's strategy layer.
-- **Pipeline orchestration** — consumer code decides what depends on what.
-- **Receipt storage logic** — prover-core's `ReceiptStore` and `ReceiptHook`.
+- **Proving** — prover-core's strategy layer.
+- **The retry / blocked / resubmit / checkpoint decisions** — all prover-core.
+  PaaS only provides the clock (`tick`) that fires them.
+- **Pipeline orchestration** — consumer code decides what to submit; the `Blocked`
+  state handles cross-task dependency waits.
 - **RPC** — the binary crate's concern.
+</content>

--- a/crates/prover-core/README.md
+++ b/crates/prover-core/README.md
@@ -1,18 +1,25 @@
 # strata-prover-core
 
 The core proving engine for Strata. Each prover instance handles one proof type
-end-to-end: fetching inputs, generating proofs (locally or via a remote backend),
-storing receipts, and retrying on failure.
+end-to-end: assembling inputs, generating proofs (locally or via a remote
+backend), persisting receipts, and — the bulk of this crate — deciding *what to
+do when something goes wrong*.
 
 ## What problem does this solve?
 
-Proof generation involves a lot of moving parts — input preparation, host selection,
-error handling, retries, persistence, crash recovery. Without a shared engine, every
-consumer (checkpoint prover, EE chunk prover, etc.) would re-implement all of that.
+Proof generation has a lot of moving parts: input assembly, host selection,
+receipt persistence, crash recovery, and — most subtly — failure handling.
+Failures are not uniform. "The chunk I depend on isn't proven yet", "the gRPC
+connection blipped", "the proving network expired my request", and "the guest
+panicked" are four completely different situations that each want a different
+response. Without a shared engine every consumer (checkpoint prover, EE chunk
+prover, EE acct prover, …) would re-implement all of it, usually by collapsing
+every failure into one "retry with backoff" hammer.
 
-prover-core extracts the common lifecycle so consumers only define **what** to prove
-and **how to get the input**. Everything else — scheduling, retry, storage, host
-dispatch — is handled here.
+prover-core extracts the common lifecycle so consumers only declare **what** to
+prove and **how to assemble the input**. Everything else — scheduling, the
+retry/blocked/resubmit decision, backoff, persistence, host dispatch, crash
+recovery — lives here, and treats each kind of failure on its own terms.
 
 ## How it relates to zkaleido
 
@@ -23,14 +30,14 @@ a pluggable strategy layer.
 ```
                       zkaleido land                    prover-core land
                  ┌───────────────────────┐      ┌──────────────────────────┐
- Consumer ──────▶│ ZkVmProgram::Input    │─────▶│ ProofSpec::fetch_input   │
+ Consumer ──────▶│ ZkVmProgram::Input    │─────▶│ ProofSpec::resolve_input │
                  └───────────────────────┘      └────────────┬─────────────┘
-                                                             │
+                                                             │ InputResolution
                  ┌───────────────────────┐      ┌────────────▼─────────────┐
                  │ ZkVmHost / RemoteHost │◀─────│ ProveStrategy::prove()   │
-                 │ prove / start+poll    │      │ (NativeStrategy or       │
-                 └───────────┬───────────┘      │  RemoteStrategy)         │
-                             │                  └────────────┬─────────────┘
+                 │ prove / start+poll    │      │ (Native or Remote)       │
+                 └───────────┬───────────┘      └────────────┬─────────────┘
+                             │ ZkVmError                      │ classified
                  ┌───────────▼───────────┐      ┌────────────▼─────────────┐
                  │ ProofReceiptWithMeta   │─────▶│ ReceiptStore / Hook      │
                  └───────────────────────┘      └──────────────────────────┘
@@ -42,6 +49,8 @@ The key zkaleido types prover-core depends on:
   Consumed via `ProofSpec::Program`.
 - **`ZkVmHost`** / **`ZkVmRemoteHost`** — local and remote proving backends.
   Captured inside strategy implementations at build time.
+- **`ZkVmError`** / **`RemoteProofFailureReason`** — the *typed* failure surface
+  prover-core classifies into a retry decision (see [Failure classification](#failure-classification-the-heart-of-the-crate)).
 - **`ProofReceiptWithMetadata`** — the proof artifact that comes out the other end.
 
 ## Core concepts
@@ -52,21 +61,37 @@ A `ProofSpec` is the single trait consumers implement. It answers three question
 
 1. What identifies a task? (`type Task`)
 2. What program runs? (`type Program`)
-3. How do you get the input? (`fn fetch_input`)
+3. How do you assemble the input — and is it even ready? (`fn resolve_input`)
 
 ```rust
 #[async_trait]
 pub trait ProofSpec: Send + Sync + 'static {
     // Into<Vec<u8>> + TryFrom<Vec<u8>> for byte-key storage.
-    // Must be deterministic (same task → same bytes).
+    // Must be deterministic (same task → same bytes): borsh/bincode, not JSON.
     type Task: Clone + Debug + Display + Eq + Hash + Send + Sync
         + Into<Vec<u8>> + TryFrom<Vec<u8>> + 'static;
     type Program: ZkVmProgram<Input: Send + Sync> + Send + Sync + 'static;
 
-    async fn fetch_input(
+    async fn resolve_input(
         &self,
         task: &Self::Task,
-    ) -> ProverResult<<Self::Program as ZkVmProgram>::Input>;
+    ) -> ProverResult<InputResolution<<Self::Program as ZkVmProgram>::Input>>;
+}
+```
+
+The consumer speaks **domain facts**, not retry vocabulary. `resolve_input`
+returns one of three outcomes, and the library decides scheduling:
+
+```rust
+pub enum InputResolution<I> {
+    /// Input assembled — proceed to prove.
+    Ready(I),
+    /// A dependency isn't available yet. NOT a failure: the task parks in
+    /// `Blocked` and is rechecked on a steady cadence, without burning the
+    /// retry budget. `recheck_after` overrides the default cadence per task.
+    Blocked { reason: String, recheck_after: Option<Duration> },
+    /// This task can never produce valid input — terminal.
+    Rejected { reason: String },
 }
 ```
 
@@ -77,104 +102,152 @@ struct CheckpointSpec { storage: Arc<NodeStorage> }
 
 #[async_trait]
 impl ProofSpec for CheckpointSpec {
-    type Task = Epoch;
+    type Task = EpochCommitment;
     type Program = CheckpointProgram;
 
-    async fn fetch_input(&self, epoch: &Epoch) -> ProverResult<CheckpointProverInput> {
-        let header = self.storage.get_epoch_header(epoch)
-            .map_err(|e| ProverError::TransientFailure(e.to_string()))?;
-        let state = self.storage.get_state_at(epoch)
-            .map_err(|e| ProverError::TransientFailure(e.to_string()))?;
-        Ok(CheckpointProverInput { header, state })
+    async fn resolve_input(
+        &self,
+        epoch: &EpochCommitment,
+    ) -> ProverResult<InputResolution<CheckpointProverInput>> {
+        // `?` propagates an *infra* error (a DB read failed) — the library
+        // retries it. Domain verdicts go through `InputResolution`, never `Err`.
+        let Some(summary) = self.storage.epoch_summary(epoch)? else {
+            // The epoch isn't finalized yet. Wait for it — this is not a failure.
+            return Ok(InputResolution::Blocked {
+                reason: format!("epoch {epoch} not finalized yet"),
+                recheck_after: None,
+            });
+        };
+        if summary.is_malformed() {
+            return Ok(InputResolution::Rejected { reason: "corrupt summary".into() });
+        }
+        Ok(InputResolution::Ready(build_input(summary)))
     }
 }
 ```
 
 That's the entire integration surface. No storage wiring, no host selection, no
-retry logic.
+retry/backoff logic — and crucially, no confusing "is a missing dependency a
+transient failure?" decision: it's `Blocked`.
 
-### How proving actually happens
+> Migrating a spec that still classifies its own errors (returning
+> `ProverError::transient(..)` / `permanent(..)`)? `InputResolution::from_result`
+> bridges a legacy `Result<Input>` into a resolution: `Ok` → `Ready`, a permanent
+> failure → `Rejected`, a transient one → `Blocked`, infra errors stay `Err`.
 
-Internally, the prover bridges zkaleido's host layer through a crate-private
-`ProveStrategy` glue. The host type is captured at build time and erased, so
-`Prover<S>` has no host type parameter. Two strategies ship:
+### Failure classification — the heart of the crate
 
-- **native** — calls `ZkVmProgram::prove()` directly. Good for tests, dev,
-  and local proving.
-- **remote** (behind the `remote` feature) — drives the async
-  `start_proving` → poll `get_status` → `get_proof` cycle for backends like the
-  SP1 network.
-
-Consumers never name the strategy type directly; they pick one via the builder.
-
-### Adding a new host (e.g. RISC0 remote, custom backend)
-
-Adding a new proving backend doesn't require touching prover-core at all — it's
-entirely a zkaleido concern. The steps:
-
-1. **Implement `ZkVmHost`** in zkaleido for local execution, or `ZkVmRemoteHost`
-   for an async remote backend. This is where the actual zkVM integration lives:
-   input preparation, proof generation, status polling, receipt retrieval.
-2. **Pass it to the builder** — `.native(your_host)` or `.remote(your_host)`.
-   That's it. prover-core erases the host type internally and the rest of the
-   system (specs, task lifecycle, PaaS) is completely unaware.
-
-For example, a RISC0 remote prover would implement `ZkVmRemoteHost` with
-`start_proving` submitting to Bonsai, `get_status` polling the Bonsai API, and
-`get_proof` downloading the receipt. The consumer code and PaaS wiring stay identical
-— only the `.remote(risc0_bonsai_host)` builder call changes.
-
-If neither built-in strategy fits (e.g. a backend with a fundamentally different
-execution model), you can implement `ProveStrategy<S>` directly and pass it to
-`ProverBuilder::build()`.
-
-### Task-based API — no UUIDs, no mapping
-
-The entire API is keyed by your domain task type (`H::Task`), not opaque UUIDs.
-You submit an `Epoch`, you wait for an `Epoch`, you get the receipt by `Epoch`.
-No intermediate identifiers, no mapping tables, no string juggling.
+A "failure" during proving is classified into exactly one **action**, decided
+from the *typed* upstream error (not from which call-site produced it):
 
 ```rust
-// Submit and wait — you work with your own types, always
-handle.submit(ChunkTask { batch_id, chunk_idx: 0 }).await?;
-handle.submit(ChunkTask { batch_id, chunk_idx: 1 }).await?;
-
-let tasks = vec![
-    ChunkTask { batch_id, chunk_idx: 0 },
-    ChunkTask { batch_id, chunk_idx: 1 },
-];
-let results = handle.wait_for_tasks(&tasks).await?;
-
-// TaskResult gives you back your typed task
-match &results[0] {
-    TaskResult::Completed { task } => println!("done: {task}"),
-    TaskResult::Failed { task, error } => println!("{task} failed: {error}"),
+pub enum FailureAction {
+    /// Retry, resuming any saved remote state (re-poll the same request).
+    RetryResume,
+    /// Retry after discarding saved remote state, so the next attempt submits a
+    /// fresh request (the prior one expired / hit no capacity / was reverted).
+    RetryFresh,
+    /// Terminal — do not retry.
+    Permanent,
 }
-
-// Get receipt by task — no UUID lookup
-let receipt = handle.get_receipt(&tasks[0])?;
 ```
 
-This makes consumer code shorter and crash recovery simpler — the task store
-is keyed by the serialized task, so after a restart the prover can deserialize
-tasks directly from storage without an in-memory mapping table.
+`ProverError::Failed { action, msg }` carries that decision. The single source
+of truth is the `classify` module, which maps `zkaleido::ZkVmError` and
+`RemoteProofFailureReason` to an action:
 
-`ProofSpec::Task` requires `Into<Vec<u8>> + TryFrom<Vec<u8>>` for storage
-serialization. The representation must be deterministic (borsh, bincode — not
-serde_json).
+| Upstream signal | Action | Why |
+|---|---|---|
+| `NetworkRetryableError`, `ProofNotReady` | `RetryResume` | transient transport / not ready yet |
+| `ProofGenerationError`, `InvalidELF`, `InvalidInput`, `InvalidVerifyingKey` | `Permanent` | the submission/env is bad; resubmitting won't help |
+| `InvalidProofReceipt`, `ProofVerificationError`, `OutputExtractionError`, `ExecutionError` | `Permanent` | the proof we got is broken, or the guest faulted |
+| status `Unexecutable` | `Permanent` | guest can't run |
+| status `Unfulfillable` / `Expired` / `Reverted` | `RetryFresh` | request is dead but the input is fine — resubmit |
+
+Strategy code reports *what happened*; this module decides *what to do*. This
+fixes a class of bugs where the decision was made positionally — e.g. a 503 on
+artifact download being marked permanent (and the finished proof abandoned), or
+a genuinely fatal `ProofGenerationError` being retried for the whole budget.
+
+### Two-tier retry
+
+Not every hiccup deserves the heavyweight, persistent, tick-driven machinery.
+Retries happen at two tiers:
+
+```
+   task-level tier        ┌─────────────────────────────────────────────┐
+   (cross-attempt,        │ persistent state machine (TaskStore)         │
+    survives crashes,     │ Pending → Proving → Completed                │
+    tick-driven)          │            ↘ Blocked / TransientFailure       │
+                          │ handles: dependency waits, resubmit, recovery │
+                          └───────────────▲─────────────────────────────┘
+                                          │ escalate only if persistent
+   in-attempt tier        ┌───────────────┴─────────────────────────────┐
+   (in-process, fast,     │ short local retry around idempotent polls    │
+    invisible to the SM)  │ get_status / get_proof — few attempts, jitter │
+                          └──────────────────────────────────────────────┘
+```
+
+- **In-attempt (`LocalRetryConfig`)** — `RemoteStrategy` wraps the idempotent
+  remote polls (`get_status`, `get_proof`) in a short in-process retry on
+  `RetryResume` errors. This recovers blips the backend itself gives up on fast
+  (notably SP1 marking "Service was not ready: transport error" *permanent*)
+  without tearing down the whole attempt to the slow task tier.
+- **Task-level** — only sees failures that survived the local tier, plus the
+  things that genuinely need persistence: dependency waits (`Blocked`), resubmit
+  (`RetryFresh`), and crash recovery. Exponential backoff with jitter.
+
+### Jitter, and differentiated budgets
+
+- **Jitter** (`jitter_frac`, default ±20%) spreads the wake-ups of tasks that
+  failed on the same tick, so they don't retry in a synchronized stampede
+  against a shared backend. The offset is deterministic per task (FNV-1a over
+  the key), so it's reproducible without an RNG.
+- **Separate budgets**: `max_retries` (resume-class, default 15) vs
+  `max_resubmits` (resubmit-class, default 3). A resubmit re-runs the *whole*
+  proof, so it gets a much smaller budget than a cheap re-poll.
+
+### Resume vs. resubmit
+
+Remote proofs persist their `ProofId` (in the task record's `metadata`). On a
+`RetryResume` the next attempt resumes polling that same id — no double
+submission, no double cost. On a `RetryFresh` the saved id is cleared first
+(`TaskStore::clear_metadata`), so the next attempt submits a brand-new request
+— used when the prior request is dead (expired/unfulfillable/reverted).
+
+### Stage checkpointing
+
+The pipeline is `resolve_input → prove → receipt_store.put → receipt_hook →
+Completed`. If proving already succeeded on a prior attempt, the receipt is in
+the receipt store; on the next run prover-core skips `resolve_input` and the
+(expensive) prove entirely and re-runs only the hook. A transient receipt-hook
+failure therefore never re-proves. (Requires a configured `ReceiptStore`.)
 
 ### Task lifecycle
 
-Every task moves through a simple state machine:
-
 ```
-Pending → Proving → Completed
-                 ↘ TransientFailure (retried → back to Proving)
-                 ↘ PermanentFailure (terminal)
+Pending ─▶ Proving ─▶ Completed                       (terminal)
+   ▲          │  ╲
+   │          │   ╲─▶ Blocked ──────────┐  (waiting on a dependency; rechecked,
+   │          │        ▲                │   does NOT consume the retry budget)
+   │          │        └────────────────┘
+   │          ├─▶ TransientFailure ──────┐ (retry/resubmit after backoff)
+   └──────────┴────────────────◀─────────┘
+              ╲─▶ PermanentFailure                    (terminal)
 ```
 
-Retries are passive — `tick()` scans for retriable tasks and re-spawns them.
-No background scheduler thread.
+`Proving` and `TransientFailure` carry both a `retry_count` and a
+`resubmit_count`, so the budgets survive a mid-attempt crash. Re-runs are
+passive: PaaS calls `tick()` on an interval, which scans for tasks whose
+recheck/backoff time has elapsed (`TaskStatus::wants_rescan` — transient
+failures *and* blocked tasks) and re-spawns them. No background scheduler thread.
+
+### Crash recovery
+
+On the first tick after startup, `recover()` re-spawns every unfinished
+(`Pending`/`Proving`) task. A task found mid-`Proving` is counted as a synthetic
+transient failure (bumping `retry_count`) so a crash loop is bounded by
+`max_retries`. Blocked tasks are picked up by the normal recheck scan.
 
 ### Prover and ProverBuilder
 
@@ -182,11 +255,11 @@ You build a prover by combining a spec with a strategy and optional extensions:
 
 ```rust
 let prover = ProverBuilder::new(spec)
-    .receipt_store(sled_store)           // opt-in: receipt persistence by task
+    .receipt_store(sled_store)           // opt-in: receipt persistence (+ checkpointing)
     .receipt_hook(checkpoint_db_hook)    // opt-in: domain-specific side-write
     .task_store(sled_task_store)         // default: InMemoryTaskStore
     .retry(RetryConfig::default())
-    .native(host);                       // or .remote(host)
+    .native(host);                       // or .remote(host) / .remote_with_interval(host, dur)
 ```
 
 The consumer API is intentionally small:
@@ -194,79 +267,129 @@ The consumer API is intentionally small:
 | Method | What it does |
 |--------|-------------|
 | `submit(task)` | Spawn a background prove. Idempotent — submitting the same task twice is a no-op. |
-| `execute(task)` | Submit + block until done. Returns `TaskResult<Task>`. |
-| `wait_for_tasks(tasks)` | Block until all tasks reach a terminal state (watch-channel, zero-poll). |
+| `execute(task)` | Submit + block until terminal. Returns `TaskResult<Task>`. |
+| `wait_for_tasks(tasks)` | Block until all tasks reach a terminal state (watch-channel, zero-poll). Blocked is *not* terminal — waiters keep waiting. |
 | `get_receipt(task)` | Read the stored receipt (requires a configured `ReceiptStore`). |
 | `get_status(task)` | Current `TaskStatus` for a task. |
+
+### RetryConfig knobs
+
+```rust
+RetryConfig {
+    max_retries: 15,            // resume-class budget (cheap re-polls)
+    base_delay_secs: 5,         // exponential backoff base …
+    multiplier: 1.5,            //   … grows ×1.5 per attempt …
+    max_delay_secs: 3600,       //   … capped at 1h
+    jitter_frac: 0.2,           // ±20% randomized spread on each delay
+    max_resubmits: 3,           // resubmit-class budget (each re-runs the proof)
+    blocked_recheck_secs: 10,   // steady recheck cadence for Blocked tasks
+    local: LocalRetryConfig {   // in-attempt tier for idempotent remote polls
+        max_attempts: 5,
+        base_delay_ms: 500,
+        max_delay_ms: 10_000,
+    },
+}
+```
+
+Every field has a default that reproduces sensible behavior; `RetryConfig::default()`
+is the drop-in starting point.
+
+## How proving actually happens
+
+Internally the prover bridges zkaleido's host layer through a crate-private
+`ProveStrategy`. The host type is captured at build time and erased, so
+`Prover<S>` has no host type parameter. Two strategies ship:
+
+- **native** — calls `ZkVmProgram::prove()` directly. Good for tests, dev, and
+  local proving.
+- **remote** (behind the `remote` feature) — drives the async `start_proving` →
+  poll `get_status` → `get_proof` cycle for backends like the SP1 network.
+  `ZkVmRemoteProver` exposes `!Send` futures, so each prove runs on a `LocalSet`
+  on a **single long-lived runtime** owned by the strategy (built once, dropped
+  via `shutdown_background`). This matters: SP1 SDK ≥6.2 caches its gRPC channel
+  process-wide, and a per-call runtime would kill that channel's background
+  worker after the first prove — every later call then failing with "Service was
+  not ready: transport error".
+
+### Adding a new host (e.g. RISC0 remote, custom backend)
+
+Adding a proving backend doesn't touch prover-core — it's a zkaleido concern:
+
+1. **Implement `ZkVmHost`** (local) or `ZkVmRemoteHost` (async remote) in
+   zkaleido. This is where the real zkVM integration lives: input prep, proof
+   generation, status polling, receipt retrieval. Map your backend's failures
+   onto `ZkVmError` variants thoughtfully — that's what drives the retry
+   decision (see [Failure classification](#failure-classification-the-heart-of-the-crate)).
+2. **Pass it to the builder** — `.native(your_host)` or `.remote(your_host)`.
+
+A RISC0 remote prover would implement `ZkVmRemoteHost` with `start_proving`
+submitting to Bonsai, `get_status` polling the Bonsai API, and `get_proof`
+downloading the receipt. Consumer code and PaaS wiring stay identical — only the
+`.remote(risc0_bonsai_host)` builder call changes.
 
 ## Optional extensions
 
 ### ReceiptStore
 
 Persists proof receipts keyed by task (serialized to bytes). When configured,
-prover-core auto-stores after proving and exposes `get_receipt(task)` on the handle.
-
-`InMemoryReceiptStore` ships for tests. For production, implement against your DB.
+prover-core auto-stores after proving, exposes `get_receipt(task)` on the handle,
+and enables [stage checkpointing](#stage-checkpointing). `InMemoryReceiptStore`
+ships for tests; implement against your DB for production.
 
 ### ReceiptHook
 
 A typed callback that fires after a receipt is stored. Receives the full
-`H::Task`, so it can write to domain-specific storage (e.g., a ProofDB keyed
-by epoch). Most consumers don't need this — `ReceiptStore` + `get_receipt`
-is usually enough.
+`H::Task`, so it can write to domain-specific storage (e.g. a ProofDB keyed by
+epoch). Most consumers don't need this — `ReceiptStore` + `get_receipt` is
+usually enough.
 
-## Task persistence
+### TaskStore
 
-`TaskStore` handles task record persistence. One implementation ships:
-
-- **`InMemoryTaskStore`** — default, for tests and dev.
-
-For production, implement `TaskStore` against your DB (records are borsh-friendly
-byte-keyed values; the node's storage manager implements the trait directly).
-
-Task records include an optional `metadata` field for strategy-specific state
-(e.g., a remote `ProofId` for resuming polls after a restart).
+Persists task records. `InMemoryTaskStore` ships for tests; the node's storage
+managers implement the trait against sled for production. Records are
+borsh-friendly byte-keyed values and carry an optional `metadata` field for
+strategy state (the remote `ProofId`); `clear_metadata` drops it for the
+resubmit path.
 
 ## Feature flags
 
 | Feature | What it enables |
 |---------|----------------|
-| `remote` | `RemoteStrategy` and `ProverBuilder::remote()`. Pulls in `zkaleido/remote-prover`. |
+| `remote` | `RemoteStrategy`, `ProverBuilder::remote()` / `remote_with_interval()`, and the in-attempt retry tier. Pulls in `zkaleido/remote-prover`. |
 
 ## What prover-core does
 
-**Runs proofs.** Locally via `NativeStrategy` (any `ZkVmHost`) or remotely via
-`RemoteStrategy` (`start_proving` → poll → `get_proof`, behind the `remote` feature).
-The host type is erased at build time — consumer code never sees it.
-
-**Manages task lifecycle.** `Pending → Proving → Completed / Failed`. Idempotent
-submission (same task twice is a no-op), watch-channel notifications (zero-poll),
-and typed `TaskResult<Task>` back to the caller.
-
-**Retries on failure.** Transient errors get exponential backoff. `tick()` scans
-for retriable tasks passively — no background scheduler threads.
-
-**Survives crashes.** On restart, deserializes in-progress tasks directly from
-their storage keys and re-spawns them. Remote proofs resume polling from the
-saved `ProofId` instead of re-submitting — no double compute, no double cost.
-
-**Persists state.** `TaskStore` (in-memory default, consumer-provided for production) tracks
-task records. `ReceiptStore` (opt-in) persists proof receipts keyed by task.
-`ReceiptHook` (opt-in) fires typed callbacks after receipt storage for
-domain-specific side-writes.
+- **Runs proofs** locally (`NativeStrategy`) or remotely (`RemoteStrategy`), host
+  type erased at build time.
+- **Classifies failures** from the typed error into resume / resubmit / permanent
+  — one decision, one place — and distinguishes "blocked on a dependency" (not a
+  failure at all) from "failed".
+- **Retries in two tiers**: fast in-process retries for idempotent polls, durable
+  tick-driven retries with jittered backoff and separate resume/resubmit budgets
+  for everything else.
+- **Doesn't re-prove needlessly**: resumes remote polls from the saved `ProofId`,
+  and checkpoints the receipt so post-prove failures skip straight to the hook.
+- **Survives crashes**: re-spawns unfinished tasks on restart from their storage
+  keys; remote proofs resume their existing request.
+- **Persists state** via `TaskStore` / `ReceiptStore` / `ReceiptHook` (in-memory
+  defaults, consumer-provided for production).
 
 ### Planned
 
-- **Send futures for remote proving** — `ZkVmRemoteProver` currently uses `?Send`
-  futures, forcing one OS thread + runtime per remote proof. A one-line fix in
-  zkaleido (`type Input: Send + Sync`) would allow all remote polls to share the
-  main tokio runtime.
-- **Metrics instrumentation** — counters for tasks submitted/completed/failed, histograms
-  for proving duration. The hooks are natural extension points.
+- **Send futures for remote proving** — once zkaleido's `ZkVmRemoteProver`
+  becomes `Send` (a tagged release after `v0.1-beta.3`), the per-prove `LocalSet`
+  can be dropped and remote proofs can run directly on the app's main runtime.
+- **Distinct `AwaitingResubmit` state** — currently resubmit reuses
+  `TransientFailure` with a cleared `ProofId`; a dedicated state would sharpen
+  observability.
+- **Metrics instrumentation** — counters per `(proof_type, action)`, histograms
+  of attempts-to-success and proving duration.
 
 ## What prover-core does NOT do
 
 - **Service lifecycle** (start, stop, health) — that's PaaS.
 - **Tick scheduling** — PaaS calls `tick()` on an interval.
-- **Pipeline orchestration** (chunk → acct dependencies) — consumer code.
-- **RPC exposure** — consumer's binary.
+- **Pipeline orchestration** (chunk → acct dependencies) — consumer code (and the
+  `Blocked` state, which lets a downstream task wait on an upstream one cleanly).
+- **RPC exposure** — the consumer's binary.
+</content>


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Actualize both crate READMEs:
- prover-core: ProofSpec::resolve_input returning InputResolution { Ready | Blocked | Rejected }; FailureAction classification from typed ZkVmError/RemoteProofFailureReason; two-tier retry (in-attempt local + task-level); jitter; separate resume vs resubmit budgets; resume-vs-resubmit metadata handling; stage checkpointing; the long-lived remote runtime; updated lifecycle diagram (Blocked) and RetryConfig knob table.
- paas: tick now drives retries + dependency rechecks + recovery; examples use resolve_input; EE chunk/acct example shows the acct task parking on Blocked while chunk receipts are missing instead of faking a TransientFailure.

the actual implementation is WIP here #1964 . In this PR there are only the docs changes (that actually allow to judge on the changes conceptually).


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
