### PR TITLE
refactor(mmr): consume strata-merkle-node-store for position types and proof algorithms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,7 +3610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3619,7 +3619,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6073,7 +6073,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7739,7 +7739,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9104,7 +9104,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9141,7 +9141,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -15567,6 +15567,7 @@ dependencies = [
  "strata-identifiers",
  "strata-l1-txfmt",
  "strata-merkle",
+ "strata-merkle-node-store",
  "strata-ol-chain-types-new",
  "strata-ol-state-types",
  "strata-paas",
@@ -15817,6 +15818,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tree_hash 0.16.0",
  "tree_hash_derive 0.16.0",
+]
+
+[[package]]
+name = "strata-merkle-node-store"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
+dependencies = [
+ "strata-merkle",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -16661,6 +16671,7 @@ dependencies = [
  "strata-db-types",
  "strata-identifiers",
  "strata-merkle",
+ "strata-merkle-node-store",
  "strata-ol-chain-types-new",
  "strata-ol-state-types",
  "strata-paas",
@@ -18517,7 +18528,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,7 @@ strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "legacy_compact",
 ], tag = "v0.1.0-alpha-rc25" }
+strata-merkle-node-store = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
 strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
 strata-msg-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc25" }
 strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [

--- a/crates/db/store-sled/src/mmr_index/db.rs
+++ b/crates/db/store-sled/src/mmr_index/db.rs
@@ -104,16 +104,22 @@ impl MmrIndexDatabase for MmrIndexDb {
                 for node_ref in &nodes {
                     let mmr_id = node_ref.id().clone();
                     let requested_pos = node_ref.pos();
-                    let mut current = Some(requested_pos);
 
                     // Walk upward from the requested node and stop at the first absent parent.
-                    while let Some(pos) = current {
+                    let mut pos = requested_pos;
+                    loop {
                         let Some(hash) = nt.get(&(mmr_id.clone(), pos))? else {
                             break;
                         };
                         out.get_or_create_table_mut(mmr_id.clone())
                             .put_node(pos, hash);
-                        current = pos.parent();
+                        // A real MMR never reaches the height ceiling; guard
+                        // against it so `parent()` (which panics at u8::MAX)
+                        // stays unreachable even on corrupt input.
+                        if pos.height() == u8::MAX {
+                            break;
+                        }
+                        pos = pos.parent();
                     }
 
                     // Preimages are leaf-only and optional for this fetch.
@@ -259,19 +265,22 @@ mod tests {
         let mut batch = MmrBatchWrite::default();
         {
             let mmr_batch = batch.entry(mmr_id.clone());
-            mmr_batch.put_node(leaf.node_pos(), Hash::from([4u8; 32]));
+            mmr_batch.put_node(leaf.to_node_pos(), Hash::from([4u8; 32]));
             mmr_batch.put_preimage(leaf, preimage.clone());
         }
         db.apply_update(batch).expect("seed node+preimage");
 
         let without_preimages = db
             .fetch_node_paths(
-                vec![MmrNodePos::new(mmr_id.clone(), leaf.node_pos())],
+                vec![MmrNodePos::new(mmr_id.clone(), leaf.to_node_pos())],
                 false,
             )
             .expect("fetch without preimages");
         let with_preimages = db
-            .fetch_node_paths(vec![MmrNodePos::new(mmr_id.clone(), leaf.node_pos())], true)
+            .fetch_node_paths(
+                vec![MmrNodePos::new(mmr_id.clone(), leaf.to_node_pos())],
+                true,
+            )
             .expect("fetch with preimages");
 
         let table_without = without_preimages.get_table(&mmr_id).expect("table without");

--- a/crates/db/store-sled/src/mmr_index/schemas.rs
+++ b/crates/db/store-sled/src/mmr_index/schemas.rs
@@ -1,14 +1,15 @@
 use strata_db_types::{LeafPos, NodePos, RawMmrId};
 use strata_primitives::buf::Buf32;
+use typed_sled::codec::{CodecError, KeyCodec};
 
-use crate::define_table_with_seek_key_codec;
+use crate::{define_table_with_seek_key_codec, define_table_without_codec, impl_borsh_value_codec};
 
-define_table_with_seek_key_codec!(
+define_table_without_codec!(
     /// MMR index node storage: (mmr_id, node_pos) -> hash
     (MmrIndexNodeSchema) (RawMmrId, NodePos) => Buf32
 );
 
-define_table_with_seek_key_codec!(
+define_table_without_codec!(
     /// MMR index preimage storage: (mmr_id, leaf_pos) -> preimage bytes
     (MmrIndexPreimageSchema) (RawMmrId, LeafPos) => Vec<u8>
 );
@@ -17,3 +18,156 @@ define_table_with_seek_key_codec!(
     /// MMR index leaf count storage: mmr_id -> leaf count
     (MmrIndexLeafCountSchema) RawMmrId => u64
 );
+
+impl_borsh_value_codec!(MmrIndexNodeSchema, Buf32);
+impl_borsh_value_codec!(MmrIndexPreimageSchema, Vec<u8>);
+
+// The position types live in `strata-merkle-node-store` and carry no `serde`
+// impls, so the generic bincode seek-key codec cannot be used for the scoped
+// `(mmr_id, pos)` keys. Encode them by hand instead, using the position's own
+// `to_key`/`index` byte layout.
+//
+// The byte layout is identical to the previous bincode (fixint, big-endian)
+// encoding — `mmr_id_len(u64 BE) || mmr_id_bytes || pos_bytes`, where
+// `pos_bytes` is `height || index_be` for a node and `index_be` for a leaf —
+// so existing databases need no migration. The regression tests below pin this.
+
+/// Frames a scoped key as `mmr_id_len(u64 BE) || mmr_id_bytes || tail`.
+fn encode_scoped_key(mmr_id: &RawMmrId, tail: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + mmr_id.len() + tail.len());
+    out.extend_from_slice(&(mmr_id.len() as u64).to_be_bytes());
+    out.extend_from_slice(mmr_id);
+    out.extend_from_slice(tail);
+    out
+}
+
+/// Splits a scoped key into its `mmr_id` and the fixed-length position tail.
+fn split_scoped_key<'a>(
+    data: &'a [u8],
+    tail_len: usize,
+    schema: &'static str,
+) -> Result<(RawMmrId, &'a [u8]), CodecError> {
+    let len_prefix = 8;
+    if data.len() < len_prefix {
+        return Err(CodecError::InvalidKeyLength {
+            schema,
+            expected: len_prefix,
+            actual: data.len(),
+        });
+    }
+
+    let id_len = u64::from_be_bytes(data[..len_prefix].try_into().expect("8-byte length prefix"));
+    let id_len = usize::try_from(id_len).map_err(|_| CodecError::InvalidKeyLength {
+        schema,
+        expected: usize::MAX,
+        actual: data.len(),
+    })?;
+
+    let expected = len_prefix + id_len + tail_len;
+    if data.len() != expected {
+        return Err(CodecError::InvalidKeyLength {
+            schema,
+            expected,
+            actual: data.len(),
+        });
+    }
+
+    let mmr_id = data[len_prefix..len_prefix + id_len].to_vec();
+    let tail = &data[len_prefix + id_len..];
+    Ok((mmr_id, tail))
+}
+
+impl KeyCodec<MmrIndexNodeSchema> for (RawMmrId, NodePos) {
+    fn encode_key(&self) -> Result<Vec<u8>, CodecError> {
+        Ok(encode_scoped_key(&self.0, &self.1.to_key()))
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self, CodecError> {
+        let (mmr_id, tail) = split_scoped_key(data, 9, MmrIndexNodeSchema::tree_name())?;
+        let height = tail[0];
+        let index = u64::from_be_bytes(tail[1..9].try_into().expect("8-byte index"));
+        Ok((mmr_id, NodePos::new(height, index)))
+    }
+}
+
+impl KeyCodec<MmrIndexPreimageSchema> for (RawMmrId, LeafPos) {
+    fn encode_key(&self) -> Result<Vec<u8>, CodecError> {
+        Ok(encode_scoped_key(&self.0, &self.1.index().to_be_bytes()))
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self, CodecError> {
+        let (mmr_id, tail) = split_scoped_key(data, 8, MmrIndexPreimageSchema::tree_name())?;
+        let index = u64::from_be_bytes(tail[..8].try_into().expect("8-byte index"));
+        Ok((mmr_id, LeafPos::new(index)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The expected byte vectors below pin the exact on-disk key layout, which
+    // matches the prior bincode (fixint, big-endian) encoding of the old
+    // serde-backed keys: `mmr_id_len(u64 BE) || mmr_id_bytes || pos_bytes`.
+    // Any drift here means existing databases would silently fail to read.
+
+    #[test]
+    fn node_key_matches_on_disk_layout() {
+        let mmr_id: RawMmrId = vec![0xAA, 0xBB, 0xCC];
+        let pos = NodePos::new(2, 0x0102_0304_0506_0708);
+
+        let encoded = (mmr_id.clone(), pos).encode_key().expect("encode node key");
+        #[rustfmt::skip]
+        let expected = vec![
+            0, 0, 0, 0, 0, 0, 0, 3, // mmr_id length (u64 BE)
+            0xAA, 0xBB, 0xCC,       // mmr_id bytes
+            0x02,                   // node height
+            1, 2, 3, 4, 5, 6, 7, 8, // node index (u64 BE)
+        ];
+        assert_eq!(
+            encoded, expected,
+            "node key layout drifted from on-disk format"
+        );
+
+        let (decoded_id, decoded_pos) =
+            <(RawMmrId, NodePos)>::decode_key(&encoded).expect("decode node key");
+        assert_eq!(decoded_id, mmr_id);
+        assert_eq!(decoded_pos, pos);
+    }
+
+    #[test]
+    fn leaf_key_matches_on_disk_layout() {
+        let mmr_id: RawMmrId = vec![0x01, 0x02];
+        let leaf = LeafPos::new(0x0807_0605_0403_0201);
+
+        let encoded = (mmr_id.clone(), leaf)
+            .encode_key()
+            .expect("encode leaf key");
+        #[rustfmt::skip]
+        let expected = vec![
+            0, 0, 0, 0, 0, 0, 0, 2, // mmr_id length (u64 BE)
+            1, 2,                   // mmr_id bytes
+            8, 7, 6, 5, 4, 3, 2, 1, // leaf index (u64 BE)
+        ];
+        assert_eq!(
+            encoded, expected,
+            "leaf key layout drifted from on-disk format"
+        );
+
+        let (decoded_id, decoded_leaf) =
+            <(RawMmrId, LeafPos)>::decode_key(&encoded).expect("decode leaf key");
+        assert_eq!(decoded_id, mmr_id);
+        assert_eq!(decoded_leaf, leaf);
+    }
+
+    #[test]
+    fn empty_mmr_id_round_trips() {
+        let mmr_id: RawMmrId = vec![];
+        let pos = NodePos::new(0, 0);
+        let encoded = (mmr_id.clone(), pos).encode_key().expect("encode");
+        let (decoded_id, decoded_pos) =
+            <(RawMmrId, NodePos)>::decode_key(&encoded).expect("decode");
+        assert_eq!(decoded_id, mmr_id);
+        assert_eq!(decoded_pos, pos);
+    }
+}

--- a/crates/db/types/Cargo.toml
+++ b/crates/db/types/Cargo.toml
@@ -14,6 +14,7 @@ strata-codec.workspace = true
 strata-csm-types.workspace = true
 strata-identifiers.workspace = true
 strata-l1-txfmt.workspace = true
+strata-merkle-node-store.workspace = true
 strata-ol-chain-types-new.workspace = true
 strata-ol-state-types.workspace = true
 strata-paas.workspace = true

--- a/crates/db/types/src/errors.rs
+++ b/crates/db/types/src/errors.rs
@@ -143,7 +143,7 @@ pub enum DbError {
     MmrIndexOutOfRange { requested: u64, cur: u64 },
 
     /// MMR preimage payload not found at leaf position.
-    #[error("MMR preimage payload not found at leaf position {0}")]
+    #[error("MMR preimage payload not found at leaf position {0:?}")]
     MmrPayloadNotFound(LeafPos),
 
     /// Tree position is out of bounds for current MMR size.
@@ -155,7 +155,7 @@ pub enum DbError {
     MmrInvalidRange { start: u64, end: u64 },
 
     /// MMR node not found at the given tree position.
-    #[error("MMR node not found at position {0}")]
+    #[error("MMR node not found at position {0:?}")]
     MmrNodeNotFound(NodePos),
 
     /// MMR index batch precondition failed.

--- a/crates/db/types/src/mmr_index.rs
+++ b/crates/db/types/src/mmr_index.rs
@@ -2,10 +2,11 @@
 //!
 //! These are the primitive types used by [`crate::traits::MmrIndexDatabase`] and its callers.
 
-use std::{collections::BTreeMap, fmt};
+use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_identifiers::{AccountId, Hash};
+pub use strata_merkle_node_store::{LeafPos, NodePos};
 
 /// Opaque serialized form of [`MmrId`], used as a database key.
 pub type RawMmrId = Vec<u8>;
@@ -44,158 +45,6 @@ pub fn num_leaves_to_mmr_size(leaves_count: u64) -> u64 {
     );
     let peak_count = leaves_count.count_ones() as u64;
     2 * leaves_count - peak_count
-}
-
-/// Zero-based index of a leaf in an MMR (always at height 0).
-///
-/// A thin newtype over `u64` that prevents accidental use of internal-node
-/// positions in preimage APIs, which are leaf-only by definition.
-#[derive(
-    Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
-#[serde(transparent)]
-pub struct LeafPos(u64);
-
-impl LeafPos {
-    /// Constructs a leaf position from a zero-based leaf index.
-    pub fn new(index: u64) -> Self {
-        Self(index)
-    }
-
-    /// Returns the zero-based leaf index.
-    pub fn index(self) -> u64 {
-        self.0
-    }
-
-    /// Returns this leaf's position in the full MMR node tree (height 0).
-    pub fn node_pos(self) -> NodePos {
-        NodePos::new(0, self.0)
-    }
-}
-
-impl fmt::Display for LeafPos {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "leaf({})", self.0)
-    }
-}
-
-impl fmt::Debug for LeafPos {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LeafPos({})", self.0)
-    }
-}
-
-/// Structured position of a node in an MMR, given by `(height, index)`.
-///
-/// `height` is 0 for leaves. `index` is the zero-based offset within the
-/// level at `height`. Fields are private to keep the encoding details stable.
-#[derive(
-    Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
-pub struct NodePos {
-    height: u8,
-    index: u64,
-}
-
-impl NodePos {
-    /// Constructs a node position from height and index.
-    pub fn new(height: u8, index: u64) -> Self {
-        Self { height, index }
-    }
-
-    /// Returns the height of this node (0 = leaf).
-    pub fn height(self) -> u8 {
-        self.height
-    }
-
-    /// Returns the zero-based index within this node's level.
-    pub fn index(self) -> u64 {
-        self.index
-    }
-
-    /// Returns this node's parent position, or `None` on height overflow.
-    pub fn parent(self) -> Option<Self> {
-        Some(Self {
-            height: self.height.checked_add(1)?,
-            index: self.index >> 1,
-        })
-    }
-
-    /// Returns this node's parent position, panicking on height overflow.
-    pub fn parent_unchecked(self) -> Self {
-        assert!(
-            self.height < u8::MAX,
-            "NodePos::parent_unchecked height overflow"
-        );
-        Self {
-            height: self.height + 1,
-            index: self.index >> 1,
-        }
-    }
-
-    /// Returns true if this node is the left child of its parent.
-    pub fn is_left_child(self) -> bool {
-        self.index.is_multiple_of(2)
-    }
-
-    /// Returns this node's sibling position.
-    pub fn neighbor(self) -> Self {
-        Self {
-            height: self.height,
-            index: self.index ^ 1,
-        }
-    }
-
-    /// Returns this node's left child when `height > 0`.
-    pub fn left_child(self) -> Option<Self> {
-        if self.height == 0 {
-            return None;
-        }
-
-        debug_assert!(
-            self.index <= (u64::MAX / 2),
-            "NodePos::left_child index overflow"
-        );
-
-        Some(Self {
-            height: self.height - 1,
-            index: self.index * 2,
-        })
-    }
-
-    /// Returns this node's right child when `height > 0`.
-    pub fn right_child(self) -> Option<Self> {
-        if self.height == 0 {
-            return None;
-        }
-
-        debug_assert!(
-            self.index <= ((u64::MAX - 1) / 2),
-            "NodePos::right_child index overflow"
-        );
-
-        Some(Self {
-            height: self.height - 1,
-            index: self.index * 2 + 1,
-        })
-    }
-
-    /// Returns both children of this node when `height > 0`.
-    pub fn children(self) -> Option<(Self, Self)> {
-        Some((self.left_child()?, self.right_child()?))
-    }
-}
-
-impl fmt::Display for NodePos {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "node(h={}, i={})", self.height, self.index)
-    }
-}
-
-impl fmt::Debug for NodePos {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "NodePos(h={}, i={})", self.height, self.index)
-    }
 }
 
 /// Scoped node reference for a specific MMR namespace.
@@ -473,56 +322,10 @@ mod tests {
         prop::array::uniform32(0u8..).prop_map(Hash::from)
     }
 
+    // NOTE: `NodePos`/`LeafPos` position math (parent/sibling/children/etc.) is
+    // owned and tested by the `strata-merkle-node-store` crate. These tests
+    // cover only the local batch/table types built on those positions.
     proptest! {
-        #[test]
-        fn prop_parent_height_and_index(h in 0u8..10u8, i in 0u64..1024u64) {
-            let node = NodePos::new(h, i);
-            let parent = node.parent().unwrap();
-            prop_assert_eq!(parent.height(), h + 1);
-            prop_assert_eq!(parent.index(), i >> 1);
-        }
-
-        #[test]
-        fn prop_neighbor_same_height_xor_index(h in 0u8..=10u8, i in 0u64..1024u64) {
-            let node = NodePos::new(h, i);
-            let nb = node.neighbor();
-            prop_assert_eq!(nb.height(), h);
-            prop_assert_eq!(nb.index(), i ^ 1);
-        }
-
-        #[test]
-        fn prop_left_right_child_positions(h in 1u8..=10u8, i in 0u64..512u64) {
-            let node = NodePos::new(h, i);
-            let lc = node.left_child().unwrap();
-            let rc = node.right_child().unwrap();
-            prop_assert_eq!(lc.height(), h - 1);
-            prop_assert_eq!(rc.height(), h - 1);
-            prop_assert_eq!(lc.index(), i * 2);
-            prop_assert_eq!(rc.index(), i * 2 + 1);
-        }
-
-        #[test]
-        fn prop_leaf_has_no_children(i in 0u64..1024u64) {
-            let leaf = NodePos::new(0, i);
-            prop_assert!(leaf.left_child().is_none());
-            prop_assert!(leaf.right_child().is_none());
-            prop_assert!(leaf.children().is_none());
-        }
-
-        #[test]
-        fn prop_children_agrees_with_left_right(h in 1u8..=10u8, i in 0u64..512u64) {
-            let node = NodePos::new(h, i);
-            let (lc, rc) = node.children().unwrap();
-            prop_assert_eq!(lc, node.left_child().unwrap());
-            prop_assert_eq!(rc, node.right_child().unwrap());
-        }
-
-        #[test]
-        fn prop_is_left_child_iff_even_index(h in 0u8..=10u8, i in 0u64..1024u64) {
-            let node = NodePos::new(h, i);
-            prop_assert_eq!(node.is_left_child(), i % 2 == 0);
-        }
-
         #[test]
         fn prop_put_node_overwrites(
             pos in node_pos_strat(),
@@ -591,19 +394,6 @@ mod tests {
             expected.dedup();
             prop_assert_eq!(keys, expected);
         }
-    }
-
-    #[test]
-    fn parent_returns_none_on_overflow() {
-        let node = NodePos::new(u8::MAX, 0);
-        assert!(node.parent().is_none());
-    }
-
-    #[test]
-    #[should_panic(expected = "NodePos::parent_unchecked height overflow")]
-    fn parent_unchecked_panics_on_overflow() {
-        let node = NodePos::new(u8::MAX, 0);
-        let _ = node.parent_unchecked();
     }
 
     #[test]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -15,6 +15,7 @@ strata-db-store-sled.workspace = true
 strata-db-types.workspace = true
 strata-identifiers.workspace = true
 strata-merkle = { workspace = true, features = ["ssz"] }
+strata-merkle-node-store.workspace = true
 strata-ol-chain-types-new = { workspace = true, features = ["test-utils"] }
 strata-ol-state-types.workspace = true
 strata-paas.workspace = true

--- a/crates/storage/src/managers/mmr_algorithm.rs
+++ b/crates/storage/src/managers/mmr_algorithm.rs
@@ -1,12 +1,19 @@
 //! MMR index algorithm for the storage manager layer.
 //!
-//! This module is `NodePos`/`LeafPos`-native at its public boundary.
+//! This module is `NodePos`/`LeafPos`-native at its public boundary. The pure
+//! position math and the append/proof walks are provided by
+//! [`strata_merkle_node_store`]; this module adapts them to the prefetched
+//! [`NodeTable`] snapshots and `DbError` contract the manager uses, and adds the
+//! pop algorithm (which the node-store crate does not provide).
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, convert::Infallible};
 
-use strata_db_types::{errors::MmrError, DbError, DbResult, LeafPos, NodePos, NodeTable};
+use strata_db_types::{DbError, DbResult, LeafPos, NodePos, NodeTable};
 use strata_identifiers::Hash;
-use strata_merkle::{MerkleHasher, MerkleProofB32 as MerkleProof, Sha256Hasher};
+use strata_merkle::{MerkleProofB32 as MerkleProof, Sha256Hasher};
+use strata_merkle_node_store::{
+    assemble_proof, proof_positions, write_plan, MmrError as NodeStoreMmrError,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppendPlan {
@@ -21,60 +28,26 @@ pub(crate) struct PopPlan {
     pub(crate) nodes_to_remove: Vec<NodePos>,
 }
 
-fn compute_highest_mountain_size(leaves: u64) -> u64 {
-    debug_assert!(
-        leaves > 0,
-        "compute_highest_mountain_size: leaves must be > 0"
-    );
-    1u64 << (63 - leaves.leading_zeros())
-}
-
-pub(crate) fn compute_peak_positions(leaf_count: u64) -> Vec<NodePos> {
-    if leaf_count == 0 {
-        return Vec::new();
-    }
-
-    let mut peaks = Vec::new();
-    let mut start_leaf = 0u64;
-    let mut remaining = leaf_count;
-
-    while remaining > 0 {
-        let size = compute_highest_mountain_size(remaining);
-        let height = size.trailing_zeros() as u8;
-        peaks.push(NodePos::new(height, start_leaf >> height));
-
-        debug_assert!(
-            start_leaf.checked_add(size).is_some(),
-            "compute_peak_positions: start_leaf + size overflow"
-        );
-        start_leaf += size;
-        remaining -= size;
-    }
-
-    peaks
-}
-
-fn compute_peak_for_leaf(leaf_index: u64, leaf_count: u64) -> Result<NodePos, MmrError> {
-    if leaf_index >= leaf_count {
-        return Err(MmrError::LeafNotFound(leaf_index));
-    }
-
-    let mut start_leaf = 0u64;
-    let mut remaining = leaf_count;
-
-    while remaining > 0 {
-        let size = compute_highest_mountain_size(remaining);
-        let end_leaf = start_leaf + size;
-        if leaf_index < end_leaf {
-            let height = size.trailing_zeros() as u8;
-            return Ok(NodePos::new(height, start_leaf >> height));
+/// Maps a node-store [`write_plan`] error into the manager's `DbError`.
+///
+/// `write_plan` over a consistent store can only fail with
+/// [`NodeStoreMmrError::NodeMissing`] (a corrupt store, surfaced as
+/// [`DbError::MmrNodeNotFound`]); the backend error is [`Infallible`] here. The
+/// remaining variants are not reachable for an append but are mapped defensively
+/// to keep the match exhaustive.
+fn map_write_plan_err(err: NodeStoreMmrError<Infallible>) -> DbError {
+    match err {
+        NodeStoreMmrError::NodeMissing(pos) => DbError::MmrNodeNotFound(pos),
+        NodeStoreMmrError::Backend(never) => match never {},
+        NodeStoreMmrError::LeafOutOfRange { index, leaf_count }
+        | NodeStoreMmrError::LeafGap { index, leaf_count } => DbError::MmrIndexOutOfRange {
+            requested: index,
+            cur: leaf_count,
+        },
+        NodeStoreMmrError::MaxCapacity => {
+            DbError::Other("MMR has reached max capacity".to_string())
         }
-
-        start_leaf = end_leaf;
-        remaining -= size;
     }
-
-    Err(MmrError::LeafNotFound(leaf_index))
 }
 
 fn require_node_hash(table: &NodeTable, pos: NodePos) -> DbResult<[u8; 32]> {
@@ -85,15 +58,11 @@ fn require_node_hash(table: &NodeTable, pos: NodePos) -> DbResult<[u8; 32]> {
 }
 
 pub(crate) fn compute_append_fetch_positions(leaf_count: u64) -> Vec<NodePos> {
-    let mut positions = Vec::new();
-    let mut current_pos = LeafPos::new(leaf_count).node_pos();
-
-    while !current_pos.is_left_child() {
-        positions.push(current_pos.neighbor());
-        current_pos = current_pos.parent_unchecked();
-    }
-
-    positions
+    // Appending leaf `leaf_count` recomputes exactly the ancestors on that
+    // leaf's proof path in the resulting MMR, so its sibling positions are the
+    // nodes the append must read.
+    let new_count = leaf_count.checked_add(1).expect("MMR leaf count overflow");
+    proof_positions(leaf_count, new_count)
 }
 
 pub(crate) fn compute_pop_fetch_positions(leaf_count: u64) -> Vec<NodePos> {
@@ -101,7 +70,7 @@ pub(crate) fn compute_pop_fetch_positions(leaf_count: u64) -> Vec<NodePos> {
         return Vec::new();
     }
 
-    vec![LeafPos::new(leaf_count - 1).node_pos()]
+    vec![LeafPos::new(leaf_count - 1).to_node_pos()]
 }
 
 pub(crate) fn compute_append_plan(
@@ -110,22 +79,17 @@ pub(crate) fn compute_append_plan(
     table: &NodeTable,
 ) -> DbResult<AppendPlan> {
     let leaf_pos = LeafPos::new(leaf_count);
+    let new_count = leaf_count.checked_add(1).expect("MMR leaf count overflow");
 
-    let mut nodes_to_write = vec![(leaf_pos.node_pos(), Hash::from(hash))];
-    let mut current_pos = leaf_pos.node_pos();
-    let mut current_hash = hash;
+    let writes = write_plan::<Sha256Hasher, Infallible>(leaf_count, hash, new_count, |pos| {
+        Ok(table.get_node(pos).map(|h| h.0))
+    })
+    .map_err(map_write_plan_err)?;
 
-    while !current_pos.is_left_child() {
-        let sibling_pos = current_pos.neighbor();
-        let sibling_hash = require_node_hash(table, sibling_pos)?;
-        let parent_hash = Sha256Hasher::hash_node(sibling_hash, current_hash);
-        let parent_pos = current_pos.parent_unchecked();
-
-        nodes_to_write.push((parent_pos, parent_hash.into()));
-
-        current_pos = parent_pos;
-        current_hash = parent_hash;
-    }
+    let nodes_to_write = writes
+        .into_iter()
+        .map(|(pos, node_hash)| (pos, Hash::from(node_hash)))
+        .collect();
 
     Ok(AppendPlan {
         leaf_pos,
@@ -140,13 +104,13 @@ pub(crate) fn compute_pop_plan(leaf_count: u64, table: &NodeTable) -> DbResult<O
 
     let leaf_pos = LeafPos::new(leaf_count - 1);
     let mut nodes_to_remove = Vec::new();
-    let leaf_node_pos = leaf_pos.node_pos();
+    let leaf_node_pos = leaf_pos.to_node_pos();
     let leaf_hash = require_node_hash(table, leaf_node_pos)?;
     nodes_to_remove.push(leaf_node_pos);
 
     let mut current_pos = leaf_node_pos;
     while !current_pos.is_left_child() {
-        current_pos = current_pos.parent_unchecked();
+        current_pos = current_pos.parent();
         // Every removed node must exist in the pre-fetched table so we can
         // enforce a matching precondition before deletion.
         let _ = require_node_hash(table, current_pos)?;
@@ -165,18 +129,20 @@ pub(crate) fn generate_proof(
     leaf_count: u64,
     table: &NodeTable,
 ) -> DbResult<MerkleProof> {
-    let peak_pos = compute_peak_for_leaf(leaf_index, leaf_count)?;
-
-    let mut cohashes = Vec::new();
-    let mut current_pos = LeafPos::new(leaf_index).node_pos();
-
-    while current_pos != peak_pos {
-        let sibling_pos = current_pos.neighbor();
-        cohashes.push(require_node_hash(table, sibling_pos)?);
-        current_pos = current_pos.parent_unchecked();
+    if leaf_index >= leaf_count {
+        return Err(DbError::MmrLeafNotFound(leaf_index));
     }
 
-    Ok(MerkleProof::from_cohashes(cohashes, leaf_index))
+    let mut cohashes = Vec::new();
+    for pos in proof_positions(leaf_index, leaf_count) {
+        cohashes.push(require_node_hash(table, pos)?);
+    }
+
+    // `assemble_proof` yields the generic `MerkleProof<[u8; 32]>`; convert it to
+    // the SSZ wire type (`MerkleProofB32`) the manager returns.
+    Ok(MerkleProof::from_generic(&assemble_proof(
+        leaf_index, cohashes,
+    )))
 }
 
 /// Generates proofs for all leaves in `[start, end]` (both inclusive).
@@ -207,16 +173,11 @@ pub(crate) fn compute_proof_fetch_positions(
     leaf_index: u64,
     leaf_count: u64,
 ) -> DbResult<Vec<NodePos>> {
-    let peak_pos = compute_peak_for_leaf(leaf_index, leaf_count)?;
-    let mut positions = Vec::new();
-    let mut current_pos = LeafPos::new(leaf_index).node_pos();
-
-    while current_pos != peak_pos {
-        positions.push(current_pos.neighbor());
-        current_pos = current_pos.parent_unchecked();
+    if leaf_index >= leaf_count {
+        return Err(DbError::MmrLeafNotFound(leaf_index));
     }
 
-    Ok(positions)
+    Ok(proof_positions(leaf_index, leaf_count))
 }
 
 pub(crate) fn compute_proofs_fetch_positions(

--- a/crates/storage/src/managers/mmr_index.rs
+++ b/crates/storage/src/managers/mmr_index.rs
@@ -8,6 +8,7 @@ use strata_db_types::{
 };
 use strata_identifiers::Hash;
 use strata_merkle::{MerkleHasher, MerkleProofB32 as MerkleProof, Sha256Hasher};
+use strata_merkle_node_store::peak_positions;
 use threadpool::ThreadPool;
 use tokio::task::spawn_blocking;
 
@@ -186,7 +187,7 @@ impl MmrIndexManager {
                 mmr_algorithm::compute_append_plan(request.hash.0, leaf_count, &node_table)?;
 
             let mmr_batch = batch.entry(mmr_id);
-            mmr_batch.add_node_precond(append_plan.leaf_pos.node_pos(), None);
+            mmr_batch.add_node_precond(append_plan.leaf_pos.to_node_pos(), None);
             mmr_batch.set_expected_leaf_count(leaf_count);
             mmr_batch.set_leaf_count(leaf_count + 1);
 
@@ -279,7 +280,7 @@ impl MmrIndexHandle {
         let mut batch = MmrBatchWrite::from_preconds_table(prefetched);
         let mmr_batch = batch.entry(mmr_id);
 
-        mmr_batch.add_node_precond(result.leaf_pos.node_pos(), None);
+        mmr_batch.add_node_precond(result.leaf_pos.to_node_pos(), None);
         mmr_batch.set_expected_leaf_count(leaf_count);
         mmr_batch.set_leaf_count(leaf_count + 1);
         for (node_pos, node_hash) in result.nodes_to_write {
@@ -341,7 +342,7 @@ impl MmrIndexHandle {
         if expected_idx < leaf_count {
             let Some(existing_hash) = self.get_leaf_blocking(expected_idx)? else {
                 return Err(DbError::MmrNodeNotFound(
-                    LeafPos::new(expected_idx).node_pos(),
+                    LeafPos::new(expected_idx).to_node_pos(),
                 ));
             };
 
@@ -461,7 +462,7 @@ impl MmrIndexHandle {
     }
 
     pub fn get_leaf_blocking(&self, leaf_index: u64) -> DbResult<Option<Hash>> {
-        self.get_node_blocking(LeafPos::new(leaf_index).node_pos())
+        self.get_node_blocking(LeafPos::new(leaf_index).to_node_pos())
     }
 
     pub fn get_node_blocking(&self, pos: NodePos) -> DbResult<Option<Hash>> {
@@ -555,7 +556,7 @@ impl MmrIndexHandle {
 
         let mut positions =
             mmr_algorithm::compute_proofs_fetch_positions(start, end, at_leaf_count)?;
-        positions.extend((start..=end).map(|i| LeafPos::new(i).node_pos()));
+        positions.extend((start..=end).map(|i| LeafPos::new(i).to_node_pos()));
 
         let prefetched = self.fetch_node_paths_blocking(positions, false)?;
         let node_table = Self::get_scoped_node_table(&prefetched, &self.mmr_id_bytes());
@@ -563,7 +564,7 @@ impl MmrIndexHandle {
         for (offset, expected_hash) in expected_hashes.iter().enumerate() {
             let idx = start + offset as u64;
             let actual = node_table
-                .get_node(LeafPos::new(idx).node_pos())
+                .get_node(LeafPos::new(idx).to_node_pos())
                 .copied()
                 .ok_or(DbError::MmrLeafNotFound(idx))?;
             if actual != *expected_hash {
@@ -596,7 +597,7 @@ impl MmrIndexHandle {
                     cur: at_leaf_count,
                 });
             }
-            positions.insert(LeafPos::new(*idx).node_pos());
+            positions.insert(LeafPos::new(*idx).to_node_pos());
             for pos in mmr_algorithm::compute_proof_fetch_positions(*idx, at_leaf_count)? {
                 positions.insert(pos);
             }
@@ -607,7 +608,7 @@ impl MmrIndexHandle {
 
         for (idx, expected_hash) in indices_and_hashes {
             let actual = node_table
-                .get_node(LeafPos::new(*idx).node_pos())
+                .get_node(LeafPos::new(*idx).to_node_pos())
                 .copied()
                 .ok_or(DbError::MmrLeafNotFound(*idx))?;
             if actual != *expected_hash {
@@ -671,12 +672,13 @@ impl MmrIndexHandle {
 
     pub fn get_state_at(&self, at_leaf_count: u64) -> DbResult<MmrStateView> {
         let mmr_id = self.mmr_id_bytes();
-        let peak_positions = mmr_algorithm::compute_peak_positions(at_leaf_count);
-        let prefetched = self.fetch_node_paths_blocking(peak_positions.iter().copied(), false)?;
+        let peak_node_positions = peak_positions(at_leaf_count);
+        let prefetched =
+            self.fetch_node_paths_blocking(peak_node_positions.iter().copied(), false)?;
         let node_table = Self::get_scoped_node_table(&prefetched, &mmr_id);
 
-        let mut peaks = Vec::with_capacity(peak_positions.len());
-        for peak_pos in peak_positions {
+        let mut peaks = Vec::with_capacity(peak_node_positions.len());
+        for peak_pos in peak_node_positions {
             let peak_hash = node_table
                 .get_node(peak_pos)
                 .copied()


### PR DESCRIPTION
## Description

`NodePos`, `LeafPos`, the peak math, and the MMR write/proof-path walks were defined both locally (in `strata-db-types` and the `strata-storage` manager) and in the new `strata-merkle-node-store` crate, which arrives with the rc25 dependency bump (#1965, the base of this stacked PR). Duplicating consensus-critical MMR proof code is a correctness hazard — the two copies can drift — so this consolidates on the crate as the single source of truth.

What changed:

- `strata-db-types` drops its local `NodePos`/`LeafPos` definitions and re-exports the crate's, so every `strata_db_types::{NodePos, LeafPos}` import keeps working unchanged.
- The storage manager's append and proof planning is rebuilt on the crate's `write_plan`, `proof_positions`, `assemble_proof`, and `peak_positions`; the duplicated peak/mountain math is deleted.
- Only the pop path (which the crate does not provide) and the manager's CAS/preimage/multi-MMR orchestration stay local, now built on the crate's primitives.

### Type of Change

- [x] Refactor

## Notes to Reviewers

This is a stacked PR — its base is `chore/bump-strata-deps` (#1965), not `main`, so the diff shows only the de-duplication. Please merge #1965 first (or rebase this onto `main` afterward).

Two things worth a careful look:

- **No DB migration.** The crate's position types carry no `serde`, so the sled `(mmr_id, pos)` keys use hand-written `KeyCodec`s instead of the bincode seek-key macro. The encoded byte layout (`mmr_id_len(u64 BE) || mmr_id_bytes || pos_bytes`) is identical to the previous bincode (fixint, big-endian) output, so existing databases read back unchanged. `crates/db/store-sled/src/mmr_index/schemas.rs` has regression tests that pin the exact on-disk bytes.
- **Algorithm equivalence.** The append cascade and proof-path walks now route through the crate. Equivalence with the prior local implementations was verified analytically and is backed upstream by the crate's replay-reference proptests against `strata-merkle`. The manager's append/proof tests and the store-sled DB-contract proptests pass unchanged. One behavioral note: `compute_append_plan`/`compute_append_fetch_positions` now `expect` on `leaf_count + 1` overflow (an explicit panic at the astronomically-unreachable `u64::MAX` ceiling, where the old code overflowed in debug only).

Is this PR addressing any specification, design doc or external reference document?

- [x] No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

This PR was prepared with the assistance of Claude Code.

## Related Issues

Stacked on #1965.