### PR TITLE
refactor(ol): make asm checkpoint-types source of truth for OL log payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15936,6 +15936,7 @@ dependencies = [
  "ssz_types",
  "strata-acct-types",
  "strata-asm-common",
+ "strata-asm-proto-checkpoint-types",
  "strata-codec",
  "strata-crypto",
  "strata-identifiers",

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -22,8 +22,7 @@ use strata_identifiers::{AccountId, Hash, OLBlockCommitment, OLBlockId};
 use strata_msg_fmt::{Msg, MsgRef};
 use strata_node_context::NodeContext;
 use strata_ol_chain_types_new::{
-    OLBlock, OLBlockHeader, OLLog, OLLogType, SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID,
-    SnarkAccountUpdateLogData,
+    OLBlock, OLBlockHeader, OLLog, SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SnarkAccountUpdateLogData,
 };
 use strata_ol_params::OLParams;
 use strata_ol_state_types::{MMR_SENTINEL_DUMMY_LEAF_HASH, OLAccountState, OLState, WriteBatch};
@@ -456,7 +455,7 @@ fn collect_snark_update_logs<'a>(
     for log in logs {
         let msg = MsgRef::try_from(log.payload())?;
         if msg.ty() == SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID {
-            out.push(SnarkAccountUpdateLogData::try_decode_log(&msg)?);
+            out.push(log.try_into_log::<SnarkAccountUpdateLogData>()?);
         }
     }
     Ok(out)
@@ -662,7 +661,7 @@ mod tests {
 
         // The matching log carries the extra_data that must end up in the index record.
         let log_data = SnarkAccountUpdateLogData::new(next_read_idx, extra.clone()).unwrap();
-        let log = OLLog::new(serial, log_data.encode_log().unwrap());
+        let log = OLLog::from_log(serial, &log_data).unwrap();
 
         let output = OLBlockExecutionOutput::new(
             Buf32::zero(),

--- a/crates/chain-worker-new/src/errors.rs
+++ b/crates/chain-worker-new/src/errors.rs
@@ -166,7 +166,7 @@ pub enum WorkerError {
 
     /// A snark-account update log failed to decode while sourcing index `extra_data`.
     #[error("failed to decode snark-account update log: {0}")]
-    SnarkUpdateLogDecode(#[from] strata_ol_chain_types_new::LogDecodeError),
+    SnarkUpdateLogDecode(#[from] strata_ol_chain_types_new::OLLogDecodeError),
 
     /// The emitted snark-account update logs could not be paired 1:1 with the tracked snark
     /// state updates when sourcing index `extra_data`.

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -21,7 +21,7 @@ use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_msg_fmt::{Msg, MsgRef};
 use strata_ol_chain_types_new::{
     BlockFlags, MAX_SEALING_MANIFEST_COUNT, OLAsmManifestContainer, OLBlock, OLBlockHeader, OLLog,
-    OLLogType, SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SnarkAccountUpdateLogData,
+    SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SnarkAccountUpdateLogData,
 };
 use strata_ol_da::{OLDaSchemeV1, decode_ol_da_payload_bytes};
 use strata_ol_state_support_types::{
@@ -776,7 +776,7 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
             );
             continue;
         }
-        let log_data = SnarkAccountUpdateLogData::try_decode_log(&msg)?;
+        let log_data = log.try_into_log::<SnarkAccountUpdateLogData>()?;
 
         let account_id = state
             .find_account_id_by_serial(serial)

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -41,12 +41,12 @@ use strata_identifiers::{
 };
 use strata_l1_txfmt::MagicBytes;
 use strata_ledger_types::*;
-use strata_msg_fmt::{Msg, MsgRef, OwnedMsg};
+use strata_msg_fmt::{Msg, OwnedMsg};
 use strata_ol_chain_types_new::{
-    ClaimList, LogDecodeError, OLBlock, OLBlockBody, OLLog, OLLogType, OLTransaction,
-    OLTransactionData, OLTxSegment, ProofSatisfierList, SauTxLedgerRefs, SauTxOperationData,
-    SauTxPayload, SauTxProofState, SauTxUpdateData, SignedOLBlockHeader,
-    SimpleWithdrawalIntentLogData, TransactionPayload, TxProofs, test_utils as ol_test_utils,
+    ClaimList, OLBlock, OLBlockBody, OLLog, OLLogDecodeError, OLTransaction, OLTransactionData,
+    OLTxSegment, ProofSatisfierList, SauTxLedgerRefs, SauTxOperationData, SauTxPayload,
+    SauTxProofState, SauTxUpdateData, SignedOLBlockHeader, SimpleWithdrawalIntentLogData,
+    TransactionPayload, TxProofs, test_utils as ol_test_utils,
 };
 use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
 use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, WithdrawalMsgData};
@@ -1496,17 +1496,17 @@ pub(crate) fn extract_withdrawal_intents(
     output: &ConstructBlockOutput<MemoryStateBaseLayer>,
 ) -> Vec<(
     AccountSerial,
-    Result<SimpleWithdrawalIntentLogData, LogDecodeError>,
+    Result<SimpleWithdrawalIntentLogData, OLLogDecodeError>,
 )> {
     output
         .accumulated_da
         .logs()
         .iter()
         .filter_map(|log| {
-            let msg = MsgRef::try_from(log.payload()).ok()?;
-            match SimpleWithdrawalIntentLogData::try_decode_log(&msg) {
-                // A type mismatch just means this log isn't a withdrawal intent; skip it.
-                Err(LogDecodeError::TypeMismatch(..)) => None,
+            match log.try_into_log::<SimpleWithdrawalIntentLogData>() {
+                // A type mismatch (or a non-envelope payload) just means this log isn't a
+                // withdrawal intent; skip it.
+                Err(OLLogDecodeError::TypeMismatch { .. } | OLLogDecodeError::Envelope(_)) => None,
                 result => Some((log.account_serial(), result)),
             }
         })

--- a/crates/ol/chain-types/Cargo.toml
+++ b/crates/ol/chain-types/Cargo.toml
@@ -12,6 +12,7 @@ ssz_primitives.workspace = true
 ssz_types.workspace = true
 strata-acct-types.workspace = true
 strata-asm-common.workspace = true
+strata-asm-proto-checkpoint-types.workspace = true
 strata-codec.workspace = true
 strata-crypto.workspace = true
 strata-identifiers.workspace = true

--- a/crates/ol/chain-types/src/lib.rs
+++ b/crates/ol/chain-types/src/lib.rs
@@ -13,9 +13,15 @@ mod validation;
 pub mod test_utils;
 
 pub use error::ChainTypesError;
-// Re-export commitment types from identifiers
 // Re-export AsmManifest from asm-common (canonical source)
 pub use strata_asm_common::AsmManifest;
+// Re-export the canonical OL log-payload types from the checkpoint subprotocol crate, which is
+// the source of truth for the types shared with checkpoint verification.
+pub use strata_asm_proto_checkpoint_types::{
+    OLLogDecodeError, OLLogType, SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID,
+    SimpleWithdrawalIntentLogData,
+};
+// Re-export commitment types from identifiers
 pub use strata_identifiers::{
     Epoch, EpochCommitment, L1BlockCommitment, L1BlockId, OLBlockCommitment, OLBlockId, OLTxId,
     Slot,

--- a/crates/ol/chain-types/src/log.rs
+++ b/crates/ol/chain-types/src/log.rs
@@ -1,6 +1,9 @@
 use ssz_types::VariableList;
 use strata_acct_types::AccountSerial;
+use strata_asm_proto_checkpoint_types::{OLLogDecodeError, OLLogType};
+use strata_codec::{decode_buf_exact, encode_to_vec};
 use strata_identifiers::Buf32;
+use strata_msg_fmt::{Msg, MsgRef, OwnedMsg, TypeId};
 use tree_hash::{Sha256Hasher, TreeHash};
 
 use crate::ssz_generated::ssz::log::OLLog;
@@ -19,6 +22,48 @@ impl OLLog {
 
     pub fn payload(&self) -> &[u8] {
         &self.payload
+    }
+
+    /// Builds an [`OLLog`] whose payload is the msg-fmt envelope for a typed OL log.
+    ///
+    /// The payload is `TypeId(T::TY) ++ ssz(log)`, so consumers dispatch on the log type via
+    /// [`OLLog::try_into_log`]. Mirrors `OLLog::from_log` in
+    /// [`strata_asm_proto_checkpoint_types`].
+    pub fn from_log<T: OLLogType>(
+        account_serial: AccountSerial,
+        log: &T,
+    ) -> Result<Self, OLLogDecodeError> {
+        let body = encode_to_vec(log)?;
+        let payload = OwnedMsg::new(T::TY, body)?.to_vec();
+        Ok(Self::new(account_serial, payload))
+    }
+
+    /// Tries to interpret the payload bytes as a msg-fmt message.
+    ///
+    /// Returns `None` if the payload is not a valid envelope.
+    pub fn try_as_msg(&self) -> Option<MsgRef<'_>> {
+        MsgRef::try_from(self.payload()).ok()
+    }
+
+    /// Returns the envelope type id, if the payload is a valid msg-fmt message.
+    pub fn ty(&self) -> Option<TypeId> {
+        self.try_as_msg().map(|msg| msg.ty())
+    }
+
+    /// Decodes the payload as a specific typed OL log.
+    ///
+    /// Parses the msg-fmt envelope, checks the type id matches `T::TY`, and decodes the body.
+    /// Returns [`OLLogDecodeError::TypeMismatch`] when the envelope carries a different log type.
+    pub fn try_into_log<T: OLLogType>(&self) -> Result<T, OLLogDecodeError> {
+        let msg = MsgRef::try_from(self.payload())?;
+        let found = msg.ty();
+        if found != T::TY {
+            return Err(OLLogDecodeError::TypeMismatch {
+                expected: T::TY,
+                found,
+            });
+        }
+        Ok(decode_buf_exact(msg.body())?)
     }
 
     /// Computes the hash commitment of this log using SSZ tree hash.
@@ -45,9 +90,13 @@ mod tests {
     use proptest::prelude::*;
     use ssz::{Decode, Encode};
     use strata_acct_types::AccountSerial;
+    use strata_asm_proto_checkpoint_types::{
+        OLLogDecodeError, SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID, SimpleWithdrawalIntentLogData,
+    };
     use strata_test_utils_ssz::ssz_proptest;
 
     use super::OLLog;
+    use crate::{SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SnarkAccountUpdateLogData};
 
     fn ollog_strategy() -> impl Strategy<Value = OLLog> {
         (
@@ -97,6 +146,78 @@ mod tests {
                 log1.compute_hash_commitment(),
                 log3.compute_hash_commitment()
             );
+        }
+    }
+
+    /// Exercises the typed-log envelope round-trip carried by [`OLLog`], using a checkpoint-shared
+    /// payload type ([`SimpleWithdrawalIntentLogData`]) and an OL-block-local one
+    /// ([`SnarkAccountUpdateLogData`]).
+    mod typed_log {
+        use super::*;
+
+        #[test]
+        fn test_withdrawal_envelope_round_trip() {
+            let serial = AccountSerial::from(7u32);
+            let log_data = SimpleWithdrawalIntentLogData::new(100_000, b"bc1qdest".to_vec(), 3)
+                .expect("dest within bounds");
+
+            let log = OLLog::from_log(serial, &log_data).expect("from_log should succeed");
+            assert_eq!(log.account_serial(), serial);
+            assert_eq!(log.ty(), Some(SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID));
+
+            let decoded = log
+                .try_into_log::<SimpleWithdrawalIntentLogData>()
+                .expect("try_into_log should succeed");
+            assert_eq!(decoded, log_data);
+        }
+
+        #[test]
+        fn test_snark_envelope_round_trip() {
+            let serial = AccountSerial::from(9u32);
+            let log_data =
+                SnarkAccountUpdateLogData::new(42, b"extra".to_vec()).expect("within bounds");
+
+            let log = OLLog::from_log(serial, &log_data).expect("from_log should succeed");
+            assert_eq!(log.ty(), Some(SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID));
+
+            let decoded = log
+                .try_into_log::<SnarkAccountUpdateLogData>()
+                .expect("try_into_log should succeed");
+            assert_eq!(decoded, log_data);
+        }
+
+        #[test]
+        fn test_envelope_type_mismatch() {
+            let withdrawal = SimpleWithdrawalIntentLogData::new(10, b"d".to_vec(), 1)
+                .expect("dest within bounds");
+            let log = OLLog::from_log(AccountSerial::from(0u32), &withdrawal)
+                .expect("from_log should succeed");
+
+            // Decoding as the wrong log type reports a type mismatch rather than a spurious decode.
+            let err = log
+                .try_into_log::<SnarkAccountUpdateLogData>()
+                .expect_err("decoding as the wrong type should fail");
+            assert!(matches!(
+                err,
+                OLLogDecodeError::TypeMismatch { expected, found }
+                    if expected == SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID
+                        && found == SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID
+            ));
+
+            // And decoding as the right type still works.
+            log.try_into_log::<SimpleWithdrawalIntentLogData>()
+                .expect("try_into_log should succeed");
+        }
+
+        #[test]
+        fn test_non_envelope_payload_is_not_a_msg() {
+            // A raw, non-envelope payload has no type id and fails typed decoding.
+            let log = OLLog::new(AccountSerial::from(1u32), vec![]);
+            assert_eq!(log.ty(), None);
+            assert!(matches!(
+                log.try_into_log::<SimpleWithdrawalIntentLogData>(),
+                Err(OLLogDecodeError::Envelope(_))
+            ));
         }
     }
 }

--- a/crates/ol/chain-types/src/log_payloads.rs
+++ b/crates/ol/chain-types/src/log_payloads.rs
@@ -1,14 +1,16 @@
 //! Log payload types for orchestration layer logs.
+//!
+//! The canonical log-payload types shared with checkpoint verification
+//! ([`OLLogType`], [`SimpleWithdrawalIntentLogData`], the type-id namespace, and
+//! [`OLLogDecodeError`]) live in [`strata_asm_proto_checkpoint_types`] and are re-exported from the
+//! crate root. This module only holds the OL-block-local log types that are not consumed by
+//! checkpoint verification, such as [`SnarkAccountUpdateLogData`].
 
-use std::iter;
-
-use strata_codec::{Codec, CodecError, VarVec, decode_buf_exact};
-use strata_msg_fmt::{Msg, MsgRef, TypeId, try_encode_into_buf};
+use strata_asm_proto_checkpoint_types::OLLogType;
+use strata_codec::{Codec, VarVec};
+use strata_msg_fmt::TypeId;
 
 use crate::{SAU_MAX_EXTRA_DATA_BYTES, SauTxUpdateData};
-
-/// Maximum byte length for a withdrawal destination BOSD descriptor.
-const MAX_DEST_BYTES: u32 = 255;
 
 /// Maximum byte length for snark account update extra data (matches
 /// `SAU_MAX_EXTRA_DATA_BYTES` from the SSZ spec).
@@ -17,99 +19,12 @@ const MAX_EXTRA_DATA_BYTES: u32 = SAU_MAX_EXTRA_DATA_BYTES as u32;
 /// Bounded [`VarVec`] holding SAU extra data.
 pub type ExtraDataBufVec = VarVec<u8, { MAX_EXTRA_DATA_BYTES }>;
 
-/// Bounded [`VarVec`] holding withdrawal intent destination BOSD.
-pub type DestinationBufVec = VarVec<u8, { MAX_DEST_BYTES }>;
-
-/// msg-fmt type id for [`SimpleWithdrawalIntentLogData`].
-pub const SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID: TypeId = 0x01;
-
 /// msg-fmt type id for [`SnarkAccountUpdateLogData`].
+///
+/// Shares the OL log type-id namespace with
+/// [`SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID`](strata_asm_proto_checkpoint_types::SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID).
+/// This log is emitted within OL blocks but is not consumed by checkpoint verification.
 pub const SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID: TypeId = 0x02;
-
-/// Error decoding a typed log payload from a msg-fmt message.
-#[derive(Debug, thiserror::Error)]
-pub enum LogDecodeError {
-    /// The message's type id did not match the expected log type.
-    #[error("log type mismatch (expected {0}, got {1})")]
-    TypeMismatch(TypeId, TypeId),
-
-    /// The message body failed to decode.
-    #[error("failed to decode log body: {0}")]
-    Decode(#[from] CodecError),
-}
-
-/// A typed orchestration-layer log payload.
-///
-/// Each impl carries a [`TypeId`] that tags it within an [`OLLog`](crate::OLLog) payload, encoded
-/// using the `strata_msg_fmt` envelope (type prefix + SSZ body). This lets consumers parse a log
-/// payload once and dispatch on its type id rather than guessing the concrete type from the raw
-/// bytes.
-pub trait OLLogType: Codec {
-    /// The msg-fmt type id identifying this log payload.
-    const LOG_TYPE_ID: TypeId;
-
-    /// Encodes this payload into a msg-fmt envelope (type prefix followed by the SSZ body).
-    fn encode_log(&self) -> Result<Vec<u8>, CodecError> {
-        let mut buf = Vec::new();
-        // Write the msg-fmt type prefix, then encode the body directly into the same buffer to
-        // avoid a separate allocation and copy of the body.
-        try_encode_into_buf(Self::LOG_TYPE_ID, iter::empty(), &mut buf)
-            .expect("ol log: type id must be within msg-fmt bounds");
-        self.encode(&mut buf)?;
-        Ok(buf)
-    }
-
-    /// Attempts to decode this payload from a parsed msg-fmt message.
-    ///
-    /// Returns [`LogDecodeError::TypeMismatch`] if the message's type id does not match
-    /// [`Self::LOG_TYPE_ID`], or [`LogDecodeError::Decode`] if the type id matches but the body
-    /// fails to decode.
-    fn try_decode_log(msg: &MsgRef<'_>) -> Result<Self, LogDecodeError> {
-        if msg.ty() != Self::LOG_TYPE_ID {
-            return Err(LogDecodeError::TypeMismatch(Self::LOG_TYPE_ID, msg.ty()));
-        }
-        Ok(decode_buf_exact(msg.body())?)
-    }
-}
-
-/// Payload for a simple withdrawal intent log.
-///
-/// Emitted by the OL STF when a withdrawal message is processed at the bridge
-/// gateway account.
-#[derive(Debug, Clone, PartialEq, Eq, Codec)]
-pub struct SimpleWithdrawalIntentLogData {
-    /// Amount being withdrawn (sats).
-    pub amt: u64,
-
-    /// Destination BOSD.
-    pub dest: DestinationBufVec,
-
-    /// User's selected operator index for withdrawal assignment.
-    // TODO(STR-1861): encode as varint to reduce DA cost in checkpoint payloads.
-    pub selected_operator: u32,
-}
-
-impl SimpleWithdrawalIntentLogData {
-    /// Create a new simple withdrawal intent log data instance.
-    pub fn new(amt: u64, dest: Vec<u8>, selected_operator: u32) -> Option<Self> {
-        let dest = VarVec::from_vec(dest)?;
-        Some(Self {
-            amt,
-            dest,
-            selected_operator,
-        })
-    }
-
-    /// Get the withdrawal amount.
-    pub fn amt(&self) -> u64 {
-        self.amt
-    }
-
-    /// Get the destination as bytes.
-    pub fn dest(&self) -> &[u8] {
-        self.dest.as_ref()
-    }
-}
 
 /// Payload for a snark account update log.
 ///
@@ -152,12 +67,8 @@ impl SnarkAccountUpdateLogData {
     }
 }
 
-impl OLLogType for SimpleWithdrawalIntentLogData {
-    const LOG_TYPE_ID: TypeId = SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID;
-}
-
 impl OLLogType for SnarkAccountUpdateLogData {
-    const LOG_TYPE_ID: TypeId = SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID;
+    const TY: TypeId = SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID;
 }
 
 #[cfg(test)]
@@ -166,18 +77,6 @@ mod tests {
     use strata_codec::{decode_buf_exact, encode_to_vec};
 
     use super::*;
-
-    fn withdrawal_strategy() -> impl Strategy<Value = SimpleWithdrawalIntentLogData> {
-        (
-            any::<u64>(),
-            prop::collection::vec(any::<u8>(), 0..=MAX_DEST_BYTES as usize),
-            any::<u32>(),
-        )
-            .prop_map(|(amt, dest, selected_operator)| {
-                SimpleWithdrawalIntentLogData::new(amt, dest, selected_operator)
-                    .expect("dest within bounds")
-            })
-    }
 
     fn snark_update_strategy() -> impl Strategy<Value = SnarkAccountUpdateLogData> {
         (
@@ -188,76 +87,6 @@ mod tests {
                 SnarkAccountUpdateLogData::new(new_msg_idx, extra_data)
                     .expect("extra data within bounds")
             })
-    }
-
-    #[test]
-    fn test_simple_withdrawal_intent_log_data_codec() {
-        // Create test data
-        let log_data = SimpleWithdrawalIntentLogData {
-            amt: 100_000_000, // 1 BTC
-            dest: VarVec::from_vec(b"bc1qtest123456789".to_vec()).unwrap(),
-            selected_operator: 42,
-        };
-
-        // Encode
-        let encoded = encode_to_vec(&log_data).unwrap();
-
-        // Decode
-        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
-
-        // Verify round-trip
-        assert_eq!(decoded.amt, log_data.amt);
-        assert_eq!(decoded.dest.as_ref(), log_data.dest.as_ref());
-        assert_eq!(decoded.selected_operator, log_data.selected_operator);
-    }
-
-    #[test]
-    fn test_simple_withdrawal_intent_empty_dest() {
-        // Test with empty destination (probably invalid, but codec should handle it)
-        let log_data = SimpleWithdrawalIntentLogData {
-            amt: 50_000,
-            dest: VarVec::from_vec(vec![]).unwrap(),
-            selected_operator: 0,
-        };
-
-        let encoded = encode_to_vec(&log_data).unwrap();
-        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
-
-        assert_eq!(decoded.amt, 50_000);
-        assert!(decoded.dest.is_empty());
-    }
-
-    #[test]
-    fn test_simple_withdrawal_intent_max_values() {
-        // Test with maximum values
-        let log_data = SimpleWithdrawalIntentLogData {
-            amt: u64::MAX,
-            dest: VarVec::from_vec(vec![255u8; 200]).unwrap(),
-            selected_operator: u32::MAX,
-        };
-
-        let encoded = encode_to_vec(&log_data).unwrap();
-        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
-
-        assert_eq!(decoded.amt, u64::MAX);
-        assert_eq!(decoded.dest.len(), 200);
-        assert_eq!(decoded.dest.as_ref(), &vec![255u8; 200][..]);
-    }
-
-    #[test]
-    fn test_simple_withdrawal_intent_zero_amount() {
-        // Test with zero amount
-        let log_data = SimpleWithdrawalIntentLogData {
-            amt: 0,
-            dest: VarVec::from_vec(b"addr1test".to_vec()).unwrap(),
-            selected_operator: 5,
-        };
-
-        let encoded = encode_to_vec(&log_data).unwrap();
-        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
-
-        assert_eq!(decoded.amt, 0);
-        assert_eq!(decoded.dest.as_ref(), b"addr1test");
     }
 
     #[test]
@@ -311,44 +140,6 @@ mod tests {
     }
 
     #[test]
-    fn test_log_envelope_round_trip() {
-        let snark = SnarkAccountUpdateLogData {
-            new_msg_idx: 7,
-            extra_data: VarVec::from_vec(b"abc".to_vec()).unwrap(),
-        };
-        let encoded = snark.encode_log().unwrap();
-
-        // Envelope carries the type id prefix.
-        let msg = MsgRef::try_from(encoded.as_slice()).unwrap();
-        assert_eq!(msg.ty(), SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID);
-
-        let decoded = SnarkAccountUpdateLogData::try_decode_log(&msg).unwrap();
-        assert_eq!(decoded, snark);
-    }
-
-    #[test]
-    fn test_log_decode_type_mismatch() {
-        let withdrawal = SimpleWithdrawalIntentLogData {
-            amt: 10,
-            dest: VarVec::from_vec(b"d".to_vec()).unwrap(),
-            selected_operator: 1,
-        };
-        let encoded = withdrawal.encode_log().unwrap();
-        let msg = MsgRef::try_from(encoded.as_slice()).unwrap();
-
-        // Decoding as the wrong log type reports a type mismatch rather than a spurious decode.
-        let err = SnarkAccountUpdateLogData::try_decode_log(&msg).unwrap_err();
-        assert!(matches!(
-            err,
-            LogDecodeError::TypeMismatch(SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, ty)
-                if ty == SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID
-        ));
-
-        // And decoding as the right type still works.
-        SimpleWithdrawalIntentLogData::try_decode_log(&msg).unwrap();
-    }
-
-    #[test]
     fn test_snark_account_update_zero_msg_idx() {
         // Test with zero message index
         let log_data = SnarkAccountUpdateLogData {
@@ -365,57 +156,11 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_withdrawal_log_envelope_round_trip(log_data in withdrawal_strategy()) {
-            let encoded = log_data.encode_log().expect("encode_log should succeed");
-
-            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
-            prop_assert_eq!(msg.ty(), SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID);
-
-            let decoded = SimpleWithdrawalIntentLogData::try_decode_log(&msg)
-                .expect("try_decode_log should succeed");
+        fn test_snark_update_codec_round_trip(log_data in snark_update_strategy()) {
+            let encoded = encode_to_vec(&log_data).expect("encode should succeed");
+            let decoded: SnarkAccountUpdateLogData =
+                decode_buf_exact(&encoded).expect("decode should succeed");
             prop_assert_eq!(decoded, log_data);
-        }
-
-        #[test]
-        fn test_snark_update_log_envelope_round_trip(log_data in snark_update_strategy()) {
-            let encoded = log_data.encode_log().expect("encode_log should succeed");
-
-            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
-            prop_assert_eq!(msg.ty(), SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID);
-
-            let decoded = SnarkAccountUpdateLogData::try_decode_log(&msg)
-                .expect("try_decode_log should succeed");
-            prop_assert_eq!(decoded, log_data);
-        }
-
-        /// Decoding a withdrawal envelope as a snark update (and vice versa) reports a type
-        /// mismatch rather than a spurious decode.
-        #[test]
-        fn test_withdrawal_log_decode_type_mismatch(log_data in withdrawal_strategy()) {
-            let encoded = log_data.encode_log().expect("encode_log should succeed");
-            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
-
-            let err = SnarkAccountUpdateLogData::try_decode_log(&msg)
-                .expect_err("decoding as the wrong type should fail");
-            prop_assert!(matches!(
-                err,
-                LogDecodeError::TypeMismatch(SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, ty)
-                    if ty == SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID
-            ));
-        }
-
-        #[test]
-        fn test_snark_update_log_decode_type_mismatch(log_data in snark_update_strategy()) {
-            let encoded = log_data.encode_log().expect("encode_log should succeed");
-            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
-
-            let err = SimpleWithdrawalIntentLogData::try_decode_log(&msg)
-                .expect_err("decoding as the wrong type should fail");
-            prop_assert!(matches!(
-                err,
-                LogDecodeError::TypeMismatch(SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID, ty)
-                    if ty == SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID
-            ));
         }
     }
 }

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -144,11 +144,9 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     let selected_operator = withdrawal_data.selected_operator();
     let dest = withdrawal_data.into_dest_desc();
     let dest_desc_len = dest.len();
-    let log_data = SimpleWithdrawalIntentLogData {
-        amt: amt_raw,
-        selected_operator,
-        dest,
-    };
+    let log_data =
+        SimpleWithdrawalIntentLogData::new(amt_raw, dest.into_inner(), selected_operator)
+            .expect("withdrawal destination fits within log bounds");
     context.emit_typed_log(BRIDGE_GATEWAY_ACCT_SERIAL, &log_data)?;
     info!(
         %sender,

--- a/crates/ol/stf/src/output.rs
+++ b/crates/ol/stf/src/output.rs
@@ -3,7 +3,7 @@
 use std::{cell::RefCell, iter};
 
 use strata_acct_types::AccountSerial;
-use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, OLLog, OLLogType};
+use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, OLLog, OLLogDecodeError, OLLogType};
 
 use crate::errors::{ExecError, ExecResult};
 
@@ -72,8 +72,13 @@ pub trait OutputCtx {
 
     /// Records a typed log.  Returns an error if the block log cap would be exceeded.
     fn emit_typed_log(&self, source: AccountSerial, body: &impl OLLogType) -> ExecResult<()> {
-        let encoded_body = body.encode_log()?;
-        self.emit_log(OLLog::new(source, encoded_body))
+        let log = OLLog::from_log(source, body).map_err(|err| match err {
+            OLLogDecodeError::Codec(err) => ExecError::Codec(err),
+            // Encoding a typed log with a valid const type id never mismatches or fails to build
+            // the msg-fmt envelope.
+            err => unreachable!("typed log encode produced a decode-side error: {err}"),
+        })?;
+        self.emit_log(log)
     }
 }
 

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -76,7 +76,7 @@ use strata_identifiers::{
 };
 use strata_ledger_types::*;
 use strata_merkle::{CompactMmr64, MerkleProof, Mmr};
-use strata_msg_fmt::{Msg, MsgRef, OwnedMsg};
+use strata_msg_fmt::{Msg, OwnedMsg};
 use strata_ol_bridge_types::DepositDescriptor;
 use strata_ol_chain_types_new::*;
 use strata_ol_msg_types::{
@@ -1538,10 +1538,7 @@ impl FixtureGenesisOutput {
             .logs()
             .iter()
             .filter(|l| l.account_serial() == serial)
-            .find_map(|l| {
-                let msg = MsgRef::try_from(l.payload()).ok()?;
-                T::try_decode_log(&msg).ok()
-            })
+            .find_map(|l| l.try_into_log::<T>().ok())
     }
 
     /// Decodes the typed log emitted by `serial`, panicking if it is missing.
@@ -1578,10 +1575,7 @@ impl FixtureBlockOutput {
             .logs()
             .iter()
             .filter(|l| l.account_serial() == serial)
-            .find_map(|l| {
-                let msg = MsgRef::try_from(l.payload()).ok()?;
-                T::try_decode_log(&msg).ok()
-            })
+            .find_map(|l| l.try_into_log::<T>().ok())
     }
 
     /// Returns true if any emitted log uses `serial`.


### PR DESCRIPTION
## Description

The OL log-payload layer was defined twice — once in `strata-ol-chain-types-new` and once in the upstream `strata-asm-proto-checkpoint-types` (`alpenlabs/asm`): the `OLLogType` trait, `SimpleWithdrawalIntentLogData`, the `SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID` type id, and the log-decode error. These are a wire contract shared with checkpoint verification, so two independent copies can silently drift apart (e.g. a type-id or field change on one side makes withdrawal intents undecodable on the other).

This PR makes `strata-asm-proto-checkpoint-types` the single source of truth for those types. `strata-ol-chain-types-new` now re-exports them instead of redefining them. Because asm's `OLLogType` trait is minimal (just the type id), the typed-log encode/decode that previously lived on chain-types' trait moves onto chain-types' `OLLog` as `from_log`/`try_into_log`, mirroring asm's own `OLLog` API. Consumers in `ol/stf`, `ol/block-assembly`, and `chain-worker-new` are updated to the relocated API.

No wire formats change. `SimpleWithdrawalIntentLogData`'s `dest` bound goes from 255 to the asm default (`u32::MAX`); this only loosens decode-side validation and is byte-compatible for existing values.

### Type of Change

- [x] Refactor

## Notes to Reviewers

**Why `SimpleWithdrawalIntentLogData` belongs in asm.** ASM checkpoint verification has to *interpret* withdrawal-intent logs — it decodes `SimpleWithdrawalIntentLogData` out of the checkpoint sidecar's `OLLog`s to validate withdrawals. So that type (plus the trait, type id, and decode error it rides on) has to be defined where ASM can reach it, i.e. in `strata-asm-proto-checkpoint-types`. Keeping a second copy in the OL repo was the duplication this PR removes.

**Why other OL logs are not moved.** `SnarkAccountUpdateLogData` (type id `0x02`) is emitted within OL blocks but is *not* consumed by ASM checkpoint verification today, so it stays in `strata-ol-chain-types-new` and just implements asm's re-exported `OLLogType`. Only the subset ASM actually interprets has been hoisted upstream.

**`OLLog` is intentionally NOT deduplicated.** The two `OLLog` containers look identical but carry different payload caps and serve different layers:
- chain-types `OLLog`: `MAX_LOG_PAYLOAD_LEN = 4 KiB`, block-level logs — must hold snark-account updates whose `extra_data` reaches ~1 KiB.
- checkpoint-types `OLLog`: `MAX_LOG_PAYLOAD_LEN = 512 B`, checkpoint sidecar — withdrawal-only.

Collapsing chain's `OLLog` onto asm's would lower the block-level cap to 512 B and panic on real snark-update logs, and asm is an upstream dependency we can't widen from this repo. The existing chain→checkpoint `OLLog` conversion in `ol/checkpoint/src/state.rs` stays as the deliberate layer boundary.

**Open question for discussion.** As more OL log types appear, we need a clear convention for where each log-payload type lives: stays OL-local vs. hoisted into asm once ASM needs to interpret it. Right now the split is "asm owns what ASM interprets; OL owns the rest," but that's implicit. Worth deciding whether to (a) formalize this rule, (b) carve out a dedicated shared crate for the OL↔ASM log contract, or (c) document it in the relevant SPS (SPS-ol-chain-structures / SPS-62). Flagging here and starting a thread so we converge before the next log type lands.

Is this PR addressing any specification, design doc or external reference document?

- [ ] Yes
- [x] No

(Touches the OL↔ASM log contract described in SPS-ol-chain-structures / SPS-62, but does not change either spec.)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
