### PR TITLE
STR 3716 Include manifests in OL blocks as soon as they are ready

### DIFF
--- a/bin/strata/src/sequencer/node_context.rs
+++ b/bin/strata/src/sequencer/node_context.rs
@@ -209,7 +209,7 @@ mod tests {
     use strata_csm_types::{ClientState, L1Status};
     use strata_identifiers::{Buf32, Buf64, L1BlockCommitment, L1BlockId};
     use strata_ol_block_assembly::{
-        BlockCompletionData, BlockasmBuilder, FixedSlotSealing,
+        BlockCompletionData, BlockasmBuilder, FixedSlotSealing, LimitAwareSealing,
         test_utils::{MockMempoolProvider, TestStorageFixtureBuilder},
     };
     use strata_ol_params::OLParams;
@@ -234,7 +234,7 @@ mod tests {
             Arc::new(BlockAssemblyConfig::new(Duration::from_millis(1_000))),
             storage,
             Arc::new(MockMempoolProvider::new()),
-            FixedSlotSealing::new(10),
+            LimitAwareSealing::new(FixedSlotSealing::new(10)),
             state_provider,
             SequencerConfig::default(),
             PredicateKey::always_accept(),

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -36,7 +36,7 @@ mod sequencer_services {
     use strata_db_types::traits::DatabaseBackend;
     use strata_node_context::NodeContext;
     use strata_ol_block_assembly::{
-        BlockasmBuilder, BlockasmHandle, FixedSlotSealing, MempoolProviderImpl,
+        BlockasmBuilder, BlockasmHandle, FixedSlotSealing, LimitAwareSealing, MempoolProviderImpl,
     };
     use strata_ol_mempool::MempoolHandle;
     use strata_ol_state_provider::OLStateManagerProviderImpl;
@@ -194,7 +194,7 @@ mod sequencer_services {
         };
 
         let mempool_provider = MempoolProviderImpl::new(mempool_handle);
-        let epoch_sealing = FixedSlotSealing::new(slots_per_epoch);
+        let epoch_sealing = LimitAwareSealing::new(FixedSlotSealing::new(slots_per_epoch));
         let state_provider = OLStateManagerProviderImpl::new(nodectx.storage().ol_state().clone());
 
         let l1_reorg_safe_depth = nodectx.config().btcio.l1_reorg_safe_depth;

--- a/crates/chain-worker-new/src/errors.rs
+++ b/crates/chain-worker-new/src/errors.rs
@@ -68,8 +68,7 @@ pub enum WorkerError {
     #[error("checkpoint payload L1 range inverted at epoch {epoch} (from {from}, to {to})")]
     L1RangeInverted { epoch: Epoch, from: u32, to: u32 },
 
-    /// The L1 range exceeds the safety cap; defends against an outsized range
-    /// from a malformed payload.
+    /// The L1 manifest range exceeds the epoch manifest limit.
     #[error("epoch L1 manifest range too large at epoch {epoch} ({len} blocks, max {max})")]
     L1RangeTooLarge { epoch: Epoch, len: u32, max: u32 },
 
@@ -80,10 +79,6 @@ pub enum WorkerError {
         #[source]
         source: CodecError,
     },
-
-    /// Failed to assemble the manifest container from fetched L1 manifests.
-    #[error("build manifest container at epoch {epoch}: {detail}")]
-    ManifestContainerBuild { epoch: Epoch, detail: String },
 
     /// Failed to compute a state root during reconstruction.
     /// `stage` discriminates the call site (e.g. "indexer", "final").

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -12,6 +12,7 @@
 use std::collections::HashMap;
 
 use strata_acct_types::AccountSerial;
+use strata_asm_common::AsmManifest;
 use strata_asm_proto_checkpoint_types::{CheckpointSidecar, CheckpointTip};
 use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
@@ -20,8 +21,8 @@ use strata_identifiers::{Buf32, Epoch, OLBlockCommitment};
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_msg_fmt::{Msg, MsgRef};
 use strata_ol_chain_types_new::{
-    BlockFlags, MAX_SEALING_MANIFEST_COUNT, OLAsmManifestContainer, OLBlock, OLBlockHeader, OLLog,
-    OLLogType, SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SnarkAccountUpdateLogData,
+    BlockFlags, MAX_SEALING_MANIFEST_COUNT, OLBlock, OLBlockHeader, OLLog, OLLogType,
+    SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SnarkAccountUpdateLogData,
 };
 use strata_ol_da::{OLDaSchemeV1, decode_ol_da_payload_bytes};
 use strata_ol_state_support_types::{
@@ -479,7 +480,7 @@ pub(crate) fn apply_checkpoint_epoch(
             source,
         }
     })?;
-    let (manifest_cont, epoch_info) =
+    let (manifests, epoch_info) =
         assemble_da_inputs(ctx, epoch, &base_state, sidecar, tip, prev_terminal)?;
 
     // The sidecar carries logs in its own wire type; convert to the OL chain-types
@@ -499,12 +500,7 @@ pub(crate) fn apply_checkpoint_epoch(
     // run apply_da_epoch, then extract the batch and indexer writes.
     let tracking_state = WriteTrackingState::new_empty(&base_state);
     let mut indexer_state = IndexerState::new(tracking_state);
-    apply_da_epoch::<_, OLDaSchemeV1>(
-        &mut indexer_state,
-        &epoch_info,
-        da_payload,
-        manifest_cont.manifests(),
-    )?;
+    apply_da_epoch::<_, OLDaSchemeV1>(&mut indexer_state, &epoch_info, da_payload, &manifests)?;
     let indexer_state_root =
         indexer_state
             .compute_state_root()
@@ -582,11 +578,12 @@ pub(crate) fn apply_checkpoint_epoch(
     })
 }
 
-/// Validates the epoch's L1 range and builds the manifest container and
-/// [`EpochInfo`] used to drive [`apply_da_epoch`].
+/// Validates the epoch's L1 range and builds the manifest list and [`EpochInfo`]
+/// used to drive [`apply_da_epoch`].
 ///
-/// Fails if the L1 range derived from the base state and payload tip is
-/// inverted or exceeds [`MAX_SEALING_MANIFEST_COUNT`].
+/// The manifests cover the whole epoch, so this intentionally uses a [`Vec`]
+/// instead of the per-block `OLAsmManifestContainer`. The range is still capped
+/// by the epoch manifest limit before any manifests are fetched.
 fn assemble_da_inputs(
     ctx: &impl ChainWorkerContext,
     epoch: EpochCommitment,
@@ -594,36 +591,34 @@ fn assemble_da_inputs(
     sidecar: &CheckpointSidecar,
     tip: &CheckpointTip,
     prev_terminal: OLBlockCommitment,
-) -> WorkerResult<(OLAsmManifestContainer, EpochInfo)> {
-    let from_height = base_state.last_l1_height().checked_add(1).ok_or_else(|| {
-        WorkerError::Unexpected(format!(
-            "L1 height overflow at base state for {epoch}: {}",
-            base_state.last_l1_height()
-        ))
-    })?;
+) -> WorkerResult<(Vec<AsmManifest>, EpochInfo)> {
+    let base_l1_height = base_state.last_l1_height();
     let to_height = tip.l1_height();
-    if to_height < from_height {
+    if to_height < base_l1_height {
         return Err(WorkerError::L1RangeInverted {
             epoch: epoch.epoch(),
-            from: from_height,
+            from: base_l1_height.saturating_add(1),
             to: to_height,
         });
     }
-    let range_len = to_height - from_height + 1;
-    if range_len > MAX_SEALING_MANIFEST_COUNT as u32 {
-        return Err(WorkerError::L1RangeTooLarge {
-            epoch: epoch.epoch(),
-            len: range_len,
-            max: MAX_SEALING_MANIFEST_COUNT as u32,
-        });
-    }
-    let manifests = ctx.fetch_l1_manifests(from_height, to_height)?;
-    let manifest_cont = OLAsmManifestContainer::new(manifests).map_err(|e| {
-        WorkerError::ManifestContainerBuild {
-            epoch: epoch.epoch(),
-            detail: e.to_string(),
+    let manifests = if to_height == base_l1_height {
+        Vec::new()
+    } else {
+        let from_height = base_l1_height.checked_add(1).ok_or_else(|| {
+            WorkerError::Unexpected(format!(
+                "L1 height overflow at base state for {epoch}: {base_l1_height}",
+            ))
+        })?;
+        let range_len = to_height - from_height + 1;
+        if range_len > MAX_SEALING_MANIFEST_COUNT as u32 {
+            return Err(WorkerError::L1RangeTooLarge {
+                epoch: epoch.epoch(),
+                len: range_len,
+                max: MAX_SEALING_MANIFEST_COUNT as u32,
+            });
         }
-    })?;
+        ctx.fetch_l1_manifests(from_height, to_height)?
+    };
 
     let terminal = tip.l2_commitment();
     let terminal_info = BlockInfo::new(
@@ -633,7 +628,7 @@ fn assemble_da_inputs(
     );
     let epoch_info = EpochInfo::new(terminal_info, prev_terminal);
 
-    Ok((manifest_cont, epoch_info))
+    Ok((manifests, epoch_info))
 }
 
 /// Cross-checks the reconstructed epoch against the checkpoint's bindings.

--- a/crates/chain-worker-new/src/tests/apply_checkpoint.rs
+++ b/crates/chain-worker-new/src/tests/apply_checkpoint.rs
@@ -20,14 +20,14 @@ use std::collections::HashMap;
 use strata_acct_types::AccountId;
 use strata_asm_common::AsmManifest;
 use strata_asm_proto_checkpoint_types::{
-    CheckpointPayload, CheckpointSidecar, OLLog, SimpleWithdrawalIntentLogData,
+    CheckpointPayload, CheckpointSidecar, CheckpointTip, OLLog, SimpleWithdrawalIntentLogData,
     TerminalHeaderComplement,
 };
 use strata_checkpoint_types::EpochSummary;
 use strata_codec::encode_to_vec;
 use strata_identifiers::{Buf32, Epoch, EpochCommitment, OLBlockCommitment, OLBlockId};
 use strata_ledger_types::IStateAccessor;
-use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
+use strata_ol_chain_types_new::{MAX_SEALING_MANIFEST_COUNT, OLBlock, OLBlockHeader};
 use strata_ol_state_support_types::{IndexerWrites, MemoryStateBaseLayer};
 use strata_ol_state_types::OLState;
 
@@ -194,6 +194,24 @@ fn test_apply_checkpoint_deposit_manifest_only() {
 }
 
 #[test]
+fn test_apply_checkpoint_replays_empty_l1_range() {
+    let built = build_epoch(EpochShape::NoNewManifests);
+    assert!(
+        built.manifests_by_height.is_empty(),
+        "fixture should seal without new L1 manifests"
+    );
+    assert_eq!(
+        built.checkpoint_payload.new_tip().l1_height(),
+        built.prev_summary.new_l1().height(),
+        "checkpoint tip should not advance L1 height"
+    );
+    let (ctx, epoch) = mock_for(&built);
+
+    let artifacts = apply_checkpoint_epoch(&ctx, epoch).expect("apply_checkpoint_epoch");
+    assert_consistent(&built, &artifacts);
+}
+
+#[test]
 fn test_apply_checkpoint_snark_multi_update_and_deposit() {
     let built = build_epoch(EpochShape::SnarkMultiUpdateAndDeposit);
     let (ctx, epoch) = mock_for(&built);
@@ -218,6 +236,83 @@ fn test_apply_checkpoint_snark_multi_update_and_deposit() {
             .len(),
         2,
         "block sync should produce one snark record per update tx"
+    );
+}
+
+#[test]
+fn test_apply_checkpoint_replays_manifests_spread_across_non_terminal_blocks() {
+    let built = build_epoch(EpochShape::ManifestsInNonTerminalBlocks);
+    assert!(
+        built.manifests_by_height.len() > 1,
+        "fixture should spread manifests across multiple blocks"
+    );
+    let (ctx, epoch) = mock_for(&built);
+
+    let artifacts = apply_checkpoint_epoch(&ctx, epoch).expect("apply_checkpoint_epoch");
+    assert_consistent(&built, &artifacts);
+}
+
+#[test]
+fn test_apply_checkpoint_rejects_manifests_exceeding_epoch_cap() {
+    let built = build_epoch(EpochShape::ManifestsExceedEpochCap);
+    assert_eq!(
+        built.manifests_by_height.len(),
+        MAX_SEALING_MANIFEST_COUNT as usize + 1,
+        "fixture should exceed the epoch manifest cap"
+    );
+    let (ctx, epoch) = mock_for(&built);
+
+    let err = apply_checkpoint_epoch(&ctx, epoch).expect_err("range should exceed manifest cap");
+    assert!(
+        matches!(
+            err,
+            WorkerError::L1RangeTooLarge {
+                len,
+                max,
+                ..
+            } if len == MAX_SEALING_MANIFEST_COUNT as u32 + 1
+                && max == MAX_SEALING_MANIFEST_COUNT as u32
+        ),
+        "expected L1RangeTooLarge, got {err:?}"
+    );
+}
+
+#[test]
+fn test_apply_checkpoint_missing_manifest_still_errors() {
+    let built = build_epoch(EpochShape::ManifestsInNonTerminalBlocks);
+    let missing_height = built.manifests_by_height[1].0;
+    let (mut ctx, epoch) = mock_for(&built);
+    ctx.manifests.remove(&missing_height);
+
+    let err = apply_checkpoint_epoch(&ctx, epoch).expect_err("missing manifest should fail");
+    assert!(
+        matches!(err, WorkerError::MissingDependency("mock l1 manifest")),
+        "expected missing manifest dependency, got {err:?}"
+    );
+}
+
+#[test]
+fn test_apply_checkpoint_inverted_l1_range_still_errors() {
+    let mut built = build_epoch(EpochShape::DepositManifestOnly);
+    let payload = built.checkpoint_payload.clone();
+    let base_l1_height = built.prev_summary.new_l1().height();
+    let inverted_tip = CheckpointTip::new(
+        payload.new_tip().epoch,
+        base_l1_height - 1,
+        *payload.new_tip().l2_commitment(),
+    );
+    built.checkpoint_payload = CheckpointPayload::new(
+        inverted_tip,
+        payload.sidecar().clone(),
+        payload.proof().to_vec(),
+    )
+    .expect("rebuild payload with inverted L1 tip");
+    let (ctx, epoch) = mock_for(&built);
+
+    let err = apply_checkpoint_epoch(&ctx, epoch).expect_err("inverted L1 range should fail");
+    assert!(
+        matches!(err, WorkerError::L1RangeInverted { from: 2, to: 0, .. }),
+        "expected inverted L1 range, got {err:?}"
     );
 }
 

--- a/crates/chain-worker-new/src/tests/fixture.rs
+++ b/crates/chain-worker-new/src/tests/fixture.rs
@@ -20,7 +20,7 @@ use strata_identifiers::{
     Buf32, Epoch, EpochCommitment, L1BlockCommitment, OLBlockCommitment, SubjectId,
 };
 use strata_ledger_types::IStateAccessor;
-use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
+use strata_ol_chain_types_new::{MAX_SEALING_MANIFEST_COUNT, OLBlock, OLBlockHeader};
 use strata_ol_da::OLDaPayloadV1;
 use strata_ol_state_support_types::{
     DaAccumulatingState, IndexerState, IndexerWrites, MemoryStateBaseLayer, WriteTrackingState,
@@ -33,8 +33,8 @@ use strata_ol_stf::{
         TEST_RECIPIENT_ID, TEST_SNARK_ACCOUNT_ID, epoch_runner_run_block as run_block,
         epoch_runner_run_genesis as run_genesis, epoch_runner_run_terminal as run_terminal,
         epoch_runner_seed_accounts as seed_accounts, get_snark_state_expect, make_account_id,
-        make_deposit_manifest_for_account, make_genesis_state, make_state_root,
-        snark_inbox_msg_with_data,
+        make_deposit_manifest_for_account, make_empty_manifest, make_genesis_state,
+        make_state_root, snark_inbox_msg_with_data,
     },
     verify_block,
 };
@@ -45,9 +45,21 @@ pub enum EpochShape {
     /// Empty filler blocks plus a terminal carrying a deposit manifest. No
     /// snark updates: covers the path where `ol_logs` is empty.
     DepositManifestOnly,
+
+    /// Empty filler blocks plus an empty terminal. Covers a sealed epoch with
+    /// no new L1 manifests.
+    NoNewManifests,
+
     /// Multiple OL txs, plus a terminal deposit manifest. Exercises per-update record
     /// reconstruction from `ol_logs` (N > 1) alongside deposit-manifest indexing.
     SnarkMultiUpdateAndDeposit,
+
+    /// ASM manifests are carried by non-terminal blocks; the terminal block has no
+    /// manifests.
+    ManifestsInNonTerminalBlocks,
+
+    /// More ASM manifests than the epoch manifest cap allows.
+    ManifestsExceedEpochCap,
 }
 
 /// One built OL epoch with the reference values for cross-mode comparison.
@@ -92,7 +104,7 @@ pub fn build_epoch(shape: EpochShape) -> BuiltEpoch {
 
     // Build the epoch's blocks per shape.
     let mut blocks: Vec<OLBlock> = Vec::new();
-    let terminal_manifest = match shape {
+    let manifests_by_height = match shape {
         EpochShape::DepositManifestOnly => {
             let mut prev = genesis.header().clone();
             for _ in 0..4 {
@@ -106,7 +118,20 @@ pub fn build_epoch(shape: EpochShape) -> BuiltEpoch {
                 BitcoinAmount::from_sat(150_000_000),
             );
             run_terminal(&mut state, &mut blocks, &prev, manifest.clone());
-            manifest
+            vec![(TERMINAL_L1_HEIGHT, manifest)]
+        }
+        EpochShape::NoNewManifests => {
+            let mut prev = genesis.header().clone();
+            for _ in 0..4 {
+                prev = run_block(&mut state, &mut blocks, &prev, BlockComponents::new_empty());
+            }
+            run_block(
+                &mut state,
+                &mut blocks,
+                &prev,
+                BlockComponents::new_empty().as_terminal(),
+            );
+            Vec::new()
         }
         EpochShape::SnarkMultiUpdateAndDeposit => {
             let prev = run_snark_multi_update_blocks(&mut state, &mut blocks, genesis.header());
@@ -118,7 +143,73 @@ pub fn build_epoch(shape: EpochShape) -> BuiltEpoch {
                 BitcoinAmount::from_sat(150_000_000),
             );
             run_terminal(&mut state, &mut blocks, &prev, manifest.clone());
-            manifest
+            vec![(TERMINAL_L1_HEIGHT, manifest)]
+        }
+        EpochShape::ManifestsInNonTerminalBlocks => {
+            let mut prev = genesis.header().clone();
+            let manifest_a = make_empty_manifest(TERMINAL_L1_HEIGHT, 2);
+            prev = run_block(
+                &mut state,
+                &mut blocks,
+                &prev,
+                BlockComponents::new_manifests(vec![manifest_a.clone()]),
+            );
+
+            let manifest_b = make_empty_manifest(TERMINAL_L1_HEIGHT + 1, 3);
+            prev = run_block(
+                &mut state,
+                &mut blocks,
+                &prev,
+                BlockComponents::new_manifests(vec![manifest_b.clone()]),
+            );
+            run_block(
+                &mut state,
+                &mut blocks,
+                &prev,
+                BlockComponents::new_empty().as_terminal(),
+            );
+
+            vec![
+                (TERMINAL_L1_HEIGHT, manifest_a),
+                (TERMINAL_L1_HEIGHT + 1, manifest_b),
+            ]
+        }
+        EpochShape::ManifestsExceedEpochCap => {
+            let max_per_block = MAX_SEALING_MANIFEST_COUNT as u32;
+            let mut manifests_by_height =
+                Vec::with_capacity(MAX_SEALING_MANIFEST_COUNT as usize + 1);
+
+            let first_chunk: Vec<_> = (TERMINAL_L1_HEIGHT..TERMINAL_L1_HEIGHT + max_per_block)
+                .map(|height| {
+                    let manifest = make_empty_manifest(height, height as u8);
+                    manifests_by_height.push((height, manifest.clone()));
+                    manifest
+                })
+                .collect();
+            let mut prev = run_block(
+                &mut state,
+                &mut blocks,
+                genesis.header(),
+                BlockComponents::new_manifests(first_chunk),
+            );
+
+            let overflow_height = TERMINAL_L1_HEIGHT + max_per_block;
+            let overflow_manifest = make_empty_manifest(overflow_height, overflow_height as u8);
+            manifests_by_height.push((overflow_height, overflow_manifest.clone()));
+            prev = run_block(
+                &mut state,
+                &mut blocks,
+                &prev,
+                BlockComponents::new_manifests(vec![overflow_manifest]),
+            );
+            run_block(
+                &mut state,
+                &mut blocks,
+                &prev,
+                BlockComponents::new_empty().as_terminal(),
+            );
+
+            manifests_by_height
         }
     };
 
@@ -172,8 +263,14 @@ pub fn build_epoch(shape: EpochShape) -> BuiltEpoch {
     // DA blob and per-update OL logs the checkpoint payload carries.
     let (da_blob, ol_logs) = rebuild_da_and_logs(&pre_epoch_layer, &blocks, genesis.header());
 
-    let checkpoint_payload =
-        assemble_checkpoint_payload(da_blob, ol_logs, &terminal_header, terminal_commitment);
+    let tip_l1_height = post_epoch_l1.height();
+    let checkpoint_payload = assemble_checkpoint_payload(
+        da_blob,
+        ol_logs,
+        &terminal_header,
+        terminal_commitment,
+        tip_l1_height,
+    );
 
     BuiltEpoch {
         epoch_commitment,
@@ -181,7 +278,7 @@ pub fn build_epoch(shape: EpochShape) -> BuiltEpoch {
         prev_summary,
         prev_terminal: genesis_commitment,
         pre_epoch_state,
-        manifests_by_height: vec![(TERMINAL_L1_HEIGHT, terminal_manifest)],
+        manifests_by_height,
         checkpoint_payload,
         block_sync_state_root,
         block_sync_summary,
@@ -195,6 +292,7 @@ fn assemble_checkpoint_payload(
     ol_logs: Vec<CheckpointOLLog>,
     terminal_header: &OLBlockHeader,
     terminal_commitment: OLBlockCommitment,
+    tip_l1_height: u32,
 ) -> CheckpointPayload {
     let complement = TerminalHeaderComplement::new(
         terminal_header.timestamp(),
@@ -204,11 +302,7 @@ fn assemble_checkpoint_payload(
     );
     let sidecar =
         CheckpointSidecar::new(da_blob, ol_logs, complement).expect("build checkpoint sidecar");
-    let tip = CheckpointTip::new(
-        terminal_header.epoch(),
-        TERMINAL_L1_HEIGHT,
-        terminal_commitment,
-    );
+    let tip = CheckpointTip::new(terminal_header.epoch(), tip_l1_height, terminal_commitment);
     CheckpointPayload::new(tip, sidecar, Vec::new()).expect("build checkpoint payload")
 }
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -16,7 +16,7 @@ use strata_ledger_types::{
 use strata_ol_chain_types_new::*;
 use strata_ol_mempool::MempoolTxInvalidReason;
 use strata_ol_state_support_types::{DaAccumulatingState, WriteTrackingState};
-use strata_ol_state_types::WriteBatch;
+use strata_ol_state_types::{MAX_PENDING_ASM_LOGS, WriteBatch};
 use strata_ol_stf::*;
 use strata_snark_acct_types as _;
 use tracing::{debug, error, warn};
@@ -25,12 +25,12 @@ use crate::{
     AccumulatorProofGenerator, BlockAssemblyResult, BlockAssemblyStateAccess, MempoolProvider,
     checkpoint_size::LogMetrics,
     context::BlockAssemblyAnchorContext,
-    da_tracker::AccumulatedDaData,
     epoch_sealing::{
         EpochSealingLimitAction, EpochSealingLimitVerdict, EpochSealingPolicy,
         EpochSealingResourceStats,
     },
     error::BlockAssemblyError,
+    resource_state::{AccumulatedDaData, EpochResourceState},
     types::{BlockGenerationConfig, BlockTemplateResult, FailedMempoolTx, FullBlockTemplate},
 };
 
@@ -45,6 +45,24 @@ struct ProcessTransactionsOutput<S: IStateAccessor> {
     /// Accumulated da data after processing all transactions.
     accumulated_da: AccumulatedDaData,
     /// Non-cadence limits requesting an epoch seal, if any.
+    sealing_limit_verdict: EpochSealingLimitVerdict,
+}
+
+/// Inputs consumed while finalizing a block template.
+struct BuildBlockTemplateInput<A> {
+    accumulated_batch: WriteBatch<A>,
+    output_buffer: ExecOutputBuffer,
+    successful_txs: Vec<OLTransaction>,
+    is_terminal: bool,
+    manifest_container: Option<OLAsmManifestContainer>,
+}
+
+/// ASM manifests selected for the candidate OL block.
+///
+/// The selected manifests are still raw manifests; the caller wraps them in an
+/// [`OLAsmManifestContainer`] when the sequence is non-empty.
+struct SelectedAsmManifests {
+    manifests: Vec<AsmManifest>,
     sealing_limit_verdict: EpochSealingLimitVerdict,
 }
 
@@ -148,8 +166,8 @@ pub(crate) struct ConstructBlockOutput<S> {
         expect(dead_code, reason = "only used by tests")
     )]
     pub(crate) post_state: S,
-    /// Accumulated DA data for the constructed block.
-    pub(crate) accumulated_da: AccumulatedDaData,
+    /// Resource state for the constructed block's epoch.
+    pub(crate) resource_state: EpochResourceState,
 }
 
 /// Generate a block template from the given configuration.
@@ -167,7 +185,7 @@ pub(crate) async fn generate_block_template_inner<C, E>(
     epoch_sealing_policy: &E,
     sequencer_config: &SequencerConfig,
     block_generation_config: BlockGenerationConfig,
-    parent_da: AccumulatedDaData,
+    resource_state_before_block: EpochResourceState,
     bridge_params: BridgeParams,
 ) -> BlockAssemblyResult<BlockTemplateResult>
 where
@@ -206,7 +224,7 @@ where
         block_slot,
         block_epoch,
         mempool_txs,
-        parent_da,
+        resource_state_before_block,
         bridge_params,
     )
     .await?;
@@ -214,7 +232,7 @@ where
     Ok(BlockTemplateResult::new(
         output.template,
         output.failed_txs,
-        output.accumulated_da,
+        output.resource_state,
     ))
 }
 
@@ -247,8 +265,9 @@ pub(crate) fn calculate_block_slot_and_epoch<S: IStateAccessor>(
 /// 2. Executes block initialization (epoch initial + block start)
 /// 3. Validates each transaction against accumulated state
 /// 4. Filters out invalid transactions (proof failures, execution failures)
-/// 5. Applies the sealing policy and fetches L1 manifests for terminal blocks
-/// 6. Builds the complete block with only valid transactions
+/// 5. Fetches and admits buried ASM manifests for this block
+/// 6. Applies the sealing policy
+/// 7. Builds the complete block with only valid transactions
 #[expect(clippy::too_many_arguments, reason = "can't get around the args")]
 #[tracing::instrument(
     skip_all,
@@ -266,7 +285,7 @@ pub(crate) async fn construct_block<C, E>(
     block_slot: Slot,
     block_epoch: Epoch,
     mempool_txs: Vec<(OLTxId, OLTransaction)>,
-    parent_da: AccumulatedDaData,
+    resource_state_before_block: EpochResourceState,
     bridge_params: BridgeParams,
 ) -> BlockAssemblyResult<ConstructBlockOutput<C::State>>
 where
@@ -299,9 +318,11 @@ where
     let output_buffer = ExecOutputBuffer::new_empty();
 
     // Phase 1: Execute block initialization (epoch initial + block start).
-    // `AccumulatedDaData` flows through each phase, accumulating state diffs and logs.
+    // Resource state flows through each phase, accumulating state diffs, logs, and manifest count.
+    let epoch_cumulative_da = resource_state_before_block.da().clone();
+    let epoch_cumulative_manifest_count = resource_state_before_block.manifest_count();
     let (accumulated_batch, accumulated_da) =
-        execute_block_initialization(parent_state.as_ref(), &block_context, parent_da);
+        execute_block_initialization(parent_state.as_ref(), &block_context, epoch_cumulative_da);
 
     // Phase 2: Process transactions, filtering out invalid ones.
     let ProcessTransactionsOutput {
@@ -309,7 +330,7 @@ where
         failed_txs,
         accumulated_batch,
         accumulated_da,
-        sealing_limit_verdict,
+        mut sealing_limit_verdict,
     } = process_transactions(
         ctx,
         epoch_sealing_policy,
@@ -319,11 +340,32 @@ where
         accumulated_batch,
         mempool_txs,
         accumulated_da,
+        epoch_cumulative_manifest_count,
         bridge_params,
     );
 
-    // Phase 3: Ask the sealing policy whether this block should be terminal. Fetch manifests for
-    // the terminal block (possibly empty if L1 is slow).
+    // Phase 3: Fetch buried ASM manifests for this block. Manifest selection may also request
+    // that this block becomes terminal.
+    let SelectedAsmManifests {
+        manifests: selected_asm_manifests,
+        sealing_limit_verdict: manifest_limit_verdict,
+    } = fetch_asm_manifests_for_block(
+        ctx,
+        epoch_sealing_policy,
+        parent_state.as_ref(),
+        epoch_cumulative_manifest_count,
+    )
+    .await?;
+    sealing_limit_verdict.merge(manifest_limit_verdict);
+    let selected_asm_manifest_count = u32::try_from(selected_asm_manifests.len())
+        .expect("selected ASM manifest count fits in u32");
+    let manifest_container = if selected_asm_manifests.is_empty() {
+        None
+    } else {
+        Some(OLAsmManifestContainer::new(selected_asm_manifests)?)
+    };
+
+    // Phase 4: Ask the sealing policy whether this block should be terminal.
     let sealing_decision =
         epoch_sealing_policy.should_seal_epoch(block_slot, &sealing_limit_verdict);
     let should_seal = sealing_decision.should_seal();
@@ -334,13 +376,8 @@ where
         should_seal,
         "epoch seal decision"
     );
-    let manifest_container = if should_seal {
-        fetch_asm_manifests_for_terminal_block(ctx, parent_state.as_ref()).await?
-    } else {
-        None
-    };
 
-    // Phase 4: Finalize block construction.
+    // Phase 5: Finalize block construction.
     // Clone output_buffer: the clone goes to build_block_template (which adds manifest logs
     // for the header), the original is consumed below to append this block's tx logs to DA.
     debug!(
@@ -354,59 +391,164 @@ where
         config,
         &block_context,
         &parent_state,
-        accumulated_batch,
-        output_buffer.clone(),
-        successful_txs,
-        should_seal,
-        manifest_container,
+        BuildBlockTemplateInput {
+            accumulated_batch,
+            output_buffer: output_buffer.clone(),
+            successful_txs,
+            is_terminal: should_seal,
+            manifest_container,
+        },
     )?;
 
-    // Append this block's logs to accumulated DA.
+    // Append this block's logs to accumulated DA and package the epoch resource state.
     let mut accumulated_da = accumulated_da;
     accumulated_da.append_logs(&output_buffer.into_logs());
+    let resource_state = EpochResourceState::new(
+        accumulated_da,
+        epoch_cumulative_manifest_count
+            .checked_add(selected_asm_manifest_count)
+            .expect("epoch ASM manifest count fits in u32"),
+    );
 
     Ok(ConstructBlockOutput {
         template,
         failed_txs,
         post_state,
-        accumulated_da,
+        resource_state,
     })
 }
 
-/// Fetches ASM manifests for a terminal block using `BlockAssemblyAnchorContext`.
+/// Fetches ASM manifests for a block using [`BlockAssemblyAnchorContext`].
 ///
-/// Terminal blocks include up to [`MAX_SEALING_MANIFEST_COUNT`] L1 blocks processed since the
-/// last terminal block.
-async fn fetch_asm_manifests_for_terminal_block<
-    C: BlockAssemblyAnchorContext,
-    S: IStateAccessor,
->(
+/// Each block may include a contiguous sequence of buried manifests after the
+/// parent state's last accepted L1 height. The sequence is capped by the per-block
+/// SSZ bound and by remaining pending ASM-log capacity.
+///
+/// `epoch_cumulative_manifest_count` is the number of ASM manifests already carried
+/// by preceding blocks in the current epoch.
+async fn fetch_asm_manifests_for_block<C, E, S>(
     ctx: &C,
+    epoch_sealing_policy: &E,
     parent_state: &S,
-) -> BlockAssemblyResult<Option<OLAsmManifestContainer>> {
+    epoch_cumulative_manifest_count: u32,
+) -> BlockAssemblyResult<SelectedAsmManifests>
+where
+    C: BlockAssemblyAnchorContext,
+    E: EpochSealingPolicy,
+    S: IStateAccessor,
+{
     let last_l1_height = parent_state.last_l1_height();
     let start_height = last_l1_height
         .checked_add(1)
         .ok_or_else(|| BlockAssemblyError::Other("l1 height overflow".to_string()))?;
 
     // Fetch manifests using BlockAssemblyAnchorContext trait
-    let manifests = ctx
+    let fetched_asm_manifests = ctx
         .fetch_asm_manifests_from(start_height, MAX_SEALING_MANIFEST_COUNT as u32)
         .await?;
 
-    let total_logs: usize = manifests.iter().map(|m| m.logs().len()).sum();
-    debug!(
-        start_height,
-        manifest_count = manifests.len(),
-        total_logs,
-        "fetched asm manifests for terminal block",
+    let fetched_asm_manifest_count = fetched_asm_manifests.len();
+    let fetched_asm_log_count: usize = fetched_asm_manifests.iter().map(|m| m.logs().len()).sum();
+
+    let remaining_pending_asm_log_slots =
+        (MAX_PENDING_ASM_LOGS as usize).saturating_sub(parent_state.pending_asm_logs_len());
+    let SelectedAsmManifests {
+        manifests: selected_asm_manifests,
+        sealing_limit_verdict,
+    } = select_asm_manifests(
+        epoch_sealing_policy,
+        fetched_asm_manifests,
+        remaining_pending_asm_log_slots,
+        epoch_cumulative_manifest_count,
     );
 
-    let container = OLAsmManifestContainer::new(manifests)?;
+    let selected_asm_manifest_count = selected_asm_manifests.len();
+    let selected_asm_log_count: usize = selected_asm_manifests.iter().map(|m| m.logs().len()).sum();
+    debug!(
+        start_height,
+        fetched_asm_manifest_count,
+        fetched_asm_log_count,
+        selected_asm_manifest_count,
+        selected_asm_log_count,
+        ?sealing_limit_verdict,
+        "fetched and selected asm manifests for block",
+    );
 
-    // Return the container regardless of whether manifests is empty or not. Because otherwise, if
-    // for some reasons L1 is slow, epoch sealing policy is not respected.
-    Ok(Some(container))
+    Ok(SelectedAsmManifests {
+        manifests: selected_asm_manifests,
+        sealing_limit_verdict,
+    })
+}
+
+/// Selects ASM manifests for the candidate OL block.
+///
+/// Pending ASM-log capacity is a hard admission bound only: when the next
+/// manifest would overflow the pending-log queue, selection stops and the block
+/// does not seal for that reason. The manifest-count sealing rule can request
+/// either including the boundary manifest and sealing or rejecting the boundary
+/// manifest and sealing with the previously selected manifests.
+///
+/// `epoch_cumulative_manifest_count` is the number of ASM manifests already carried
+/// by preceding blocks in the current epoch.
+///
+/// Selection does not budget terminal ASM-log drain output. The OL STF currently
+/// applies buffered ASM-log drain as state effects only, without OL logs or
+/// checkpoint DA output; if that invariant changes, selection must budget that
+/// output before admitting ASM manifests.
+fn select_asm_manifests<E: EpochSealingPolicy>(
+    epoch_sealing_policy: &E,
+    candidate_asm_manifests: Vec<AsmManifest>,
+    remaining_pending_asm_log_slots: usize,
+    epoch_cumulative_manifest_count: u32,
+) -> SelectedAsmManifests {
+    let mut selected_asm_manifests = Vec::new();
+    let mut selected_asm_log_count = 0usize;
+    let mut sealing_limit_verdict = EpochSealingLimitVerdict::within_limits();
+
+    for candidate_asm_manifest in candidate_asm_manifests {
+        let candidate_asm_log_count = candidate_asm_manifest.logs().len();
+        if selected_asm_log_count.saturating_add(candidate_asm_log_count)
+            > remaining_pending_asm_log_slots
+        {
+            // Pending ASM-log capacity is a hard admission bound, not a sealing trigger. Stop
+            // manifest inclusion and leave the remaining manifests for a later block; the epoch
+            // still seals only through cadence or another sealing limit.
+            break;
+        }
+
+        let candidate_manifest_count = epoch_cumulative_manifest_count
+            .saturating_add(
+                u32::try_from(selected_asm_manifests.len())
+                    .expect("selected ASM manifest count fits in u32"),
+            )
+            .saturating_add(1);
+        // Candidate count includes the manifest currently being evaluated: it is the
+        // epoch-cumulative manifest total if this candidate is admitted.
+        let stats =
+            EpochSealingResourceStats::new(0, LogMetrics::default(), candidate_manifest_count);
+        let verdict = epoch_sealing_policy.check_limits(&stats);
+
+        match verdict.most_restrictive_action() {
+            EpochSealingLimitAction::RejectCandidate => {
+                sealing_limit_verdict.merge(verdict);
+                break;
+            }
+            EpochSealingLimitAction::SealAfterAdmit => {
+                selected_asm_manifests.push(candidate_asm_manifest);
+                sealing_limit_verdict.merge(verdict);
+                break;
+            }
+            EpochSealingLimitAction::Continue => {
+                selected_asm_log_count += candidate_asm_log_count;
+                selected_asm_manifests.push(candidate_asm_manifest);
+            }
+        }
+    }
+
+    SelectedAsmManifests {
+        manifests: selected_asm_manifests,
+        sealing_limit_verdict,
+    }
 }
 
 /// Executes block initialization (epoch initial + block start) on a fresh write batch.
@@ -463,6 +605,7 @@ fn process_transactions<P, E, S>(
     accumulated_batch: WriteBatch<S::AccountState>,
     mempool_txs: Vec<(OLTxId, OLTransaction)>,
     accumulated_da: AccumulatedDaData,
+    epoch_cumulative_manifest_count: u32,
     bridge_params: BridgeParams,
 ) -> ProcessTransactionsOutput<S>
 where
@@ -553,9 +696,11 @@ where
                 let mut tentative = log_metrics;
                 tentative.add_logs(&tx_logs);
                 let da_diff_size = staging_state.accumulator().estimated_encoded_size();
-                let epoch_manifest_count = 0;
-                let stats =
-                    EpochSealingResourceStats::new(da_diff_size, tentative, epoch_manifest_count);
+                let stats = EpochSealingResourceStats::new(
+                    da_diff_size,
+                    tentative,
+                    epoch_cumulative_manifest_count,
+                );
                 let verdict = epoch_sealing_policy.check_limits(&stats);
 
                 match verdict.checkpoint_size_action() {
@@ -652,23 +797,23 @@ where
 /// Builds the final block template from accumulated state and transactions.
 ///
 /// Returns `(template, final_state)` where `final_state` is the post-block state.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "block template construction consumes outputs from separate assembly phases"
-)]
 fn build_block_template<S>(
     config: &BlockGenerationConfig,
     block_context: &BlockContext<'_>,
     parent_state: &Arc<S>,
-    accumulated_batch: WriteBatch<S::AccountState>,
-    output_buffer: ExecOutputBuffer,
-    successful_txs: Vec<OLTransaction>,
-    is_terminal: bool,
-    manifest_container: Option<OLAsmManifestContainer>,
+    input: BuildBlockTemplateInput<S::AccountState>,
 ) -> BlockAssemblyResult<(FullBlockTemplate, S)>
 where
     S: BlockAssemblyStateAccess,
 {
+    let BuildBlockTemplateInput {
+        accumulated_batch,
+        output_buffer,
+        successful_txs,
+        is_terminal,
+        manifest_container,
+    } = input;
+
     // Clone parent state and apply accumulated batch to get state after transactions
     let mut final_state = parent_state.as_ref().clone();
     final_state.apply_write_batch(accumulated_batch)?;
@@ -862,13 +1007,14 @@ mod tests {
     const CHECKPOINT_MSG_VALUE_SATS: u64 = 100_000_000;
 
     use strata_acct_types::*;
+    use strata_asm_manifest_types::AsmLogEntry;
     use strata_asm_proto_checkpoint_types::MAX_OL_LOGS_PER_CHECKPOINT;
     use strata_identifiers::{Buf32, L1BlockId, L1Height, OLBlockId};
     use strata_ol_chain_types_new::{MAX_LOGS_PER_BLOCK, MAX_SEALING_MANIFEST_COUNT, OLLog};
     use strata_ol_state_support_types::MemoryStateBaseLayer;
 
     use super::*;
-    use crate::test_utils::*;
+    use crate::{FixedSlotSealing, LimitAwareSealing, test_utils::*};
 
     type OlWriteBatch = WriteBatch<<MemoryStateBaseLayer as IStateAccessor>::AccountState>;
 
@@ -1446,23 +1592,32 @@ mod tests {
         );
     }
 
-    // Helper to validate terminal block with L1 updates
-    fn check_terminal_block_with_manifests(
+    // Helper to validate ASM manifest contents independently of terminality.
+    fn check_block_asm_manifests(
         block_template: &FullBlockTemplate,
         expected_heights: &[L1Height],
     ) {
         let body = block_template.body();
         let manifest_cont = body.manifests();
+        if expected_heights.is_empty() {
+            assert!(
+                manifest_cont.is_none(),
+                "Block should not carry an empty manifest container"
+            );
+            return;
+        }
+
         assert!(
             manifest_cont.is_some(),
-            "Terminal block should contain manifests"
+            "Block should contain ASM manifests {:?}",
+            expected_heights
         );
 
         let manifests = manifest_cont.unwrap().manifests();
         assert_eq!(
             manifests.len(),
             expected_heights.len(),
-            "Should have {} L1 manifests",
+            "Should have {} ASM manifests",
             expected_heights.len()
         );
 
@@ -1477,19 +1632,30 @@ mod tests {
         }
     }
 
-    // Helper to validate non-terminal block without L1 updates
-    fn check_non_terminal_block(block_template: &FullBlockTemplate) {
-        let body = block_template.body();
+    // Helper to validate non-terminality independently of manifest presence.
+    fn check_non_terminal_header(block_template: &FullBlockTemplate) {
         assert!(
-            body.manifests().is_none(),
-            "Non-terminal block should NOT contain manifests"
+            !block_template.header().is_terminal(),
+            "Block should not be terminal"
         );
+    }
+
+    fn check_terminal_header(block_template: &FullBlockTemplate) {
+        assert!(
+            block_template.header().is_terminal(),
+            "Block should be terminal"
+        );
+    }
+
+    fn raw_asm_log(seed: u8) -> AsmLogEntry {
+        AsmLogEntry::from_raw(vec![seed]).expect("raw test ASM log should fit")
     }
 
     // Helper to build blocks from start_commitment up to (but not including) target_slot.
     // Stores blocks and states so subsequent blocks can find their parent.
     async fn build_blocks_to_slot(env: &mut TestEnv, target_slot: u64) -> OLBlockCommitment {
         let mut current_commitment = env.parent_commitment();
+        let mut resource_state = EpochResourceState::new_empty();
 
         let start_slot = if current_commitment.is_null() {
             0
@@ -1499,10 +1665,15 @@ mod tests {
 
         for slot in start_slot..target_slot {
             let output = env
-                .construct_empty_block()
+                .construct_empty_block_with_resource_state(resource_state)
                 .await
                 .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
 
+            resource_state = if output.template.header().is_terminal() {
+                EpochResourceState::new_empty()
+            } else {
+                output.resource_state.clone()
+            };
             current_commitment = env.persist(&output).await;
         }
 
@@ -1536,7 +1707,8 @@ mod tests {
 
         let block_template = result.unwrap().into_template();
         check_block_slot_epoch(&block_template, 1, 1);
-        check_non_terminal_block(&block_template);
+        check_non_terminal_header(&block_template);
+        check_block_asm_manifests(&block_template, &[2, 3]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1588,105 +1760,105 @@ mod tests {
 
         let block_template = result.unwrap().into_template();
         check_block_slot_epoch(&block_template, 10, 1);
-        // After genesis processes manifest 1, only manifests 2 and 3 remain
-        check_terminal_block_with_manifests(&block_template, &[2, 3]);
+        check_terminal_header(&block_template);
+        check_block_asm_manifests(&block_template, &[]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_block_below_max_sealing_manifests() {
+    async fn test_non_terminal_block_below_max_sealing_manifests() {
         let manifest_count = SEALING_MANIFEST_CAP - 1;
         let env_builder = TestStorageFixtureBuilder::new()
             .with_genesis_parent_and_l1_manifest_count(manifest_count);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
         let parent_l1_height = env.parent_last_l1_height().await;
         let output = env
             .construct_empty_block()
             .await
-            .expect("terminal block generation should succeed");
+            .expect("block generation should succeed");
 
         let expected_heights: Vec<L1Height> =
             ((parent_l1_height + 1)..=(parent_l1_height + manifest_count)).collect();
-        check_terminal_block_with_manifests(&output.template, &expected_heights);
+        check_non_terminal_header(&output.template);
+        check_block_asm_manifests(&output.template, &expected_heights);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_block_caps_at_max_sealing_manifests() {
+    async fn test_manifest_budget_caps_and_seals_block() {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP + 1);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
         let parent_l1_height = env.parent_last_l1_height().await;
         let output = env
             .construct_empty_block()
             .await
-            .expect("terminal block generation should succeed");
+            .expect("block generation should succeed");
 
         let expected_heights: Vec<L1Height> =
             ((parent_l1_height + 1)..=(parent_l1_height + SEALING_MANIFEST_CAP)).collect();
-        check_terminal_block_with_manifests(&output.template, &expected_heights);
+        check_terminal_header(&output.template);
+        check_block_asm_manifests(&output.template, &expected_heights);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_block_at_exact_max_boundary() {
+    async fn test_manifest_budget_seals_at_exact_max_boundary() {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
         let parent_l1_height = env.parent_last_l1_height().await;
         let output = env
             .construct_empty_block()
             .await
-            .expect("terminal block generation should succeed");
+            .expect("block generation should succeed");
 
         let expected_heights: Vec<L1Height> =
             ((parent_l1_height + 1)..=(parent_l1_height + SEALING_MANIFEST_CAP)).collect();
-        check_terminal_block_with_manifests(&output.template, &expected_heights);
+        check_terminal_header(&output.template);
+        check_block_asm_manifests(&output.template, &expected_heights);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_consecutive_terminal_blocks_drain_backlog() {
+    async fn test_manifest_backlog_drains_across_blocks() {
         let rollover_count: L1Height = 2;
         let env_builder = TestStorageFixtureBuilder::new()
             .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP + rollover_count);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
         let first_parent_l1_height = env.parent_last_l1_height().await;
         let first_output = env
             .construct_empty_block()
             .await
-            .expect("first terminal block generation should succeed");
+            .expect("first block generation should succeed");
         let first_expected_heights: Vec<L1Height> = ((first_parent_l1_height + 1)
             ..=(first_parent_l1_height + SEALING_MANIFEST_CAP))
             .collect();
-        check_terminal_block_with_manifests(&first_output.template, &first_expected_heights);
+        check_terminal_header(&first_output.template);
+        check_block_asm_manifests(&first_output.template, &first_expected_heights);
         env.persist(&first_output).await;
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 20).await;
         let second_parent_l1_height = env.parent_last_l1_height().await;
         let second_output = env
             .construct_empty_block()
             .await
-            .expect("second terminal block generation should succeed");
+            .expect("second block generation should succeed");
         let second_expected_heights: Vec<L1Height> =
             ((second_parent_l1_height + 1)..=(second_parent_l1_height + rollover_count)).collect();
-        check_terminal_block_with_manifests(&second_output.template, &second_expected_heights);
+        check_non_terminal_header(&second_output.template);
+        check_block_asm_manifests(&second_output.template, &second_expected_heights);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_fetch_stops_at_cap() {
+    async fn test_manifest_fetch_stops_at_cap() {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_genesis_parent_and_l1_manifest_count(SEALING_MANIFEST_CAP + 1);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
         let parent_l1_height = env.parent_last_l1_height().await;
         let first_height_past_cap = parent_l1_height + SEALING_MANIFEST_CAP + 1;
 
@@ -1704,28 +1876,25 @@ mod tests {
         // ASM tip still points at the original height's blkid; the fetch path only reads its
         // height.
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
         let output = env
             .construct_empty_block()
             .await
-            .expect("terminal block generation should not read past cap");
+            .expect("block generation should not read past cap");
 
         let expected_heights: Vec<L1Height> =
             ((parent_l1_height + 1)..=(parent_l1_height + SEALING_MANIFEST_CAP)).collect();
-        check_terminal_block_with_manifests(&output.template, &expected_heights);
+        check_block_asm_manifests(&output.template, &expected_heights);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_block_manifest_boundary_from_last_l1_height() {
+    async fn test_manifest_boundary_from_last_l1_height() {
         // Set last_l1_height to 2, but only provide manifests starting at 3.
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
             .with_asm_manifests([1, 2])
             .with_l1_manifest_height_range(3..=4);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
-
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         let result = env
             .generate_block_template()
@@ -1733,13 +1902,64 @@ mod tests {
             .expect("Block generation should succeed");
 
         let block_template = result.into_template();
-        check_terminal_block_with_manifests(&block_template, &[3, 4]);
+        check_block_asm_manifests(&block_template, &[3, 4]);
+    }
+
+    #[test]
+    fn test_pending_asm_log_capacity_limits_selected_manifests() {
+        let policy = LimitAwareSealing::new(FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH));
+        let selected = select_asm_manifests(
+            &policy,
+            vec![
+                create_l1_manifest_with_logs(2, vec![raw_asm_log(1)]),
+                create_l1_manifest_with_logs(3, vec![raw_asm_log(2)]),
+                create_l1_manifest_with_logs(4, vec![raw_asm_log(3)]),
+            ],
+            2,
+            0,
+        );
+
+        assert_eq!(
+            selected
+                .manifests
+                .iter()
+                .map(|manifest| manifest.height())
+                .collect::<Vec<_>>(),
+            vec![2, 3],
+            "selection should keep only the prefix that fits pending ASM-log capacity"
+        );
+        assert_eq!(
+            selected.sealing_limit_verdict.most_restrictive_action(),
+            EpochSealingLimitAction::Continue,
+            "pending ASM-log capacity should not request epoch sealing"
+        );
+    }
+
+    #[test]
+    fn test_full_pending_asm_log_capacity_selects_no_manifests_without_sealing() {
+        let policy = LimitAwareSealing::new(FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH));
+        let selected = select_asm_manifests(
+            &policy,
+            vec![create_l1_manifest_with_logs(2, vec![raw_asm_log(1)])],
+            0,
+            0,
+        );
+
+        assert!(
+            selected.manifests.is_empty(),
+            "selection should be empty when no pending ASM-log capacity remains"
+        );
+        assert_eq!(
+            selected.sealing_limit_verdict.most_restrictive_action(),
+            EpochSealingLimitAction::Continue,
+            "pending ASM-log capacity should not request epoch sealing"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_no_new_manifests() {
+    async fn test_terminal_block_omits_manifests_when_none_new() {
         // Parent already tracks manifests up to ASM tip height 3.
-        // Terminal fetch starts at 4, so L1 update must be present with an empty container.
+        // The terminal block should be valid without emitting an empty manifest container.
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(1)
             .with_l1_manifest_height_range(1..=3)
@@ -1754,11 +1974,12 @@ mod tests {
             .expect("terminal block generation should succeed");
 
         let template = output.into_template();
-        check_terminal_block_with_manifests(&template, &[]);
+        check_terminal_header(&template);
+        check_block_asm_manifests(&template, &[]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_start_above_latest_asm_height() {
+    async fn test_terminal_block_omits_manifests_when_start_above_asm_tip() {
         // Parent state claims a last_l1_height above ASM tip.
         // Fetch should return an empty manifest set (not an error).
         let env_builder = TestStorageFixtureBuilder::new()
@@ -1775,11 +1996,12 @@ mod tests {
             .expect("terminal block generation should succeed");
 
         let template = output.into_template();
-        check_terminal_block_with_manifests(&template, &[]);
+        check_terminal_header(&template);
+        check_block_asm_manifests(&template, &[]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_missing_manifest_in_range_errors() {
+    async fn test_missing_manifest_in_expected_range_errors() {
         // Parent last_l1_height = 1, ASM tip = 2, so terminal fetch expects manifest at height 2.
         // Corrupt L1 canonical chain so height 2 points to a blockid with no manifest body.
         let env_builder = TestStorageFixtureBuilder::new()
@@ -1787,7 +2009,7 @@ mod tests {
             .with_l1_manifest_height_range(1..=2)
             .with_asm_manifests([1]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
-        let mut env = TestEnv::from_fixture(fixture, parent_commitment);
+        let env = TestEnv::from_fixture(fixture, parent_commitment);
 
         let missing_manifest_blkid = L1BlockId::from(Buf32::from([0xAB; 32]));
         env.storage()
@@ -1801,11 +2023,10 @@ mod tests {
             .await
             .expect("insert missing-manifest canonical entry at height 2");
 
-        let _current_commitment = build_blocks_to_slot(&mut env, 10).await;
         let err = env
             .generate_block_template()
             .await
-            .expect_err("missing manifest in expected terminal range should error");
+            .expect_err("missing manifest in expected block range should error");
 
         assert!(
             matches!(err, BlockAssemblyError::Db(DbError::Other(_))),
@@ -1814,7 +2035,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_terminal_empty_block_invariants() {
+    async fn test_terminal_empty_block_omits_manifest_container() {
         let env_builder = TestStorageFixtureBuilder::new()
             .with_parent_slot(0)
             .with_l1_manifest_height_range(1..=3);
@@ -1833,8 +2054,8 @@ mod tests {
 
         assert_eq!(tx_count, 0, "terminal empty block should have zero txs");
         assert!(
-            body.manifests().is_some(),
-            "terminal block should include manifests even when tx segment is empty"
+            body.manifests().is_none(),
+            "terminal block should omit the manifest container when no new manifests are available"
         );
         assert!(
             template.header().is_terminal(),
@@ -1861,14 +2082,16 @@ mod tests {
 
         let block_template = result.unwrap().into_template();
         check_block_slot_epoch(&block_template, 11, 2);
-        check_non_terminal_block(&block_template);
+        check_non_terminal_header(&block_template);
+        check_block_asm_manifests(&block_template, &[]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_non_terminal_empty_block_invariants() {
         let env_builder = TestStorageFixtureBuilder::new()
-            .with_parent_slot(0)
-            .with_l1_manifest_height_range(1..=3);
+            .with_parent_slot(1)
+            .with_l1_manifest_height_range(1..=3)
+            .with_asm_manifests([1, 2, 3]);
         let (fixture, parent_commitment) = env_builder.build_fixture().await;
         let env = TestEnv::from_fixture(fixture, parent_commitment);
 
@@ -1884,7 +2107,7 @@ mod tests {
         assert_eq!(tx_count, 0, "non-terminal empty block should have zero txs");
         assert!(
             body.manifests().is_none(),
-            "non-terminal empty block should not include manifests"
+            "non-terminal empty block should not include manifests when none are newly buried"
         );
         assert!(
             !template.header().is_terminal(),
@@ -1951,9 +2174,12 @@ mod tests {
             MempoolTxInvalidReason::Invalid,
         )];
 
-        let result =
-            BlockTemplateResult::new(template, failed_txs.clone(), AccumulatedDaData::new_empty());
-        let (out_template, out_failed, _da) = result.into_parts();
+        let result = BlockTemplateResult::new(
+            template,
+            failed_txs.clone(),
+            EpochResourceState::new_empty(),
+        );
+        let (out_template, out_failed, _resource_state) = result.into_parts();
 
         assert_eq!(
             out_template.get_blockid(),
@@ -2320,12 +2546,15 @@ mod tests {
             .expect("block 1 should construct");
         let included1 = included_txids(&output1.template);
         assert_eq!(included1.len(), 1);
-        let parent_da_2 = output1.accumulated_da.clone();
+        let resource_state_after_block1 = output1.resource_state.clone();
         let _current_commitment = env.persist(&output1).await;
 
         // Build block 2 with seq_no=1 against the state produced by block 1.
         let output2 = env
-            .construct_block_with_da(vec![(tx_seq1_id, tx_seq1)], parent_da_2)
+            .construct_block_with_resource_state(
+                vec![(tx_seq1_id, tx_seq1)],
+                resource_state_after_block1,
+            )
             .await
             .expect("block 2 should construct");
         let included2 = included_txids(&output2.template);
@@ -2580,6 +2809,7 @@ mod tests {
             accumulated_batch,
             vec![(txid, tx)],
             AccumulatedDaData::new_empty(),
+            0,
             BridgeParams::default(),
         );
 
@@ -2638,6 +2868,7 @@ mod tests {
             accumulated_batch,
             vec![(tx_fill_id, tx_fill), (tx_overflow_id, tx_overflow)],
             AccumulatedDaData::new_empty(),
+            0,
             BridgeParams::default(),
         );
 
@@ -2684,6 +2915,7 @@ mod tests {
             accumulated_batch,
             vec![(txid, tx)],
             AccumulatedDaData::new_empty(),
+            0,
             BridgeParams::default(),
         );
 
@@ -2725,6 +2957,7 @@ mod tests {
             accumulated_batch,
             mempool_txs,
             seeded_da,
+            0,
             BridgeParams::default(),
         )
     }

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -22,11 +22,14 @@ use strata_snark_acct_types as _;
 use tracing::{debug, error, warn};
 
 use crate::{
-    AccumulatorProofGenerator, BlockAssemblyResult, BlockAssemblyStateAccess, EpochSealingPolicy,
-    MempoolProvider,
-    checkpoint_size::{CheckpointSizeVerdict, LogMetrics, checkpoint_size_verdict},
+    AccumulatorProofGenerator, BlockAssemblyResult, BlockAssemblyStateAccess, MempoolProvider,
+    checkpoint_size::LogMetrics,
     context::BlockAssemblyAnchorContext,
     da_tracker::AccumulatedDaData,
+    epoch_sealing::{
+        EpochSealingLimitAction, EpochSealingLimitVerdict, EpochSealingPolicy,
+        EpochSealingResourceStats,
+    },
     error::BlockAssemblyError,
     types::{BlockGenerationConfig, BlockTemplateResult, FailedMempoolTx, FullBlockTemplate},
 };
@@ -41,8 +44,8 @@ struct ProcessTransactionsOutput<S: IStateAccessor> {
     accumulated_batch: WriteBatch<S::AccountState>,
     /// Accumulated da data after processing all transactions.
     accumulated_da: AccumulatedDaData,
-    /// Whether the estimated checkpoint payload is approaching the L1 envelope limit.
-    checkpoint_size_limit_reached: bool,
+    /// Non-cadence limits requesting an epoch seal, if any.
+    sealing_limit_verdict: EpochSealingLimitVerdict,
 }
 
 /// Maps an [`ExecError`] to a [`MempoolTxInvalidReason`].
@@ -194,7 +197,7 @@ where
     // 3. Get transactions from mempool
     let mempool_txs = MempoolProvider::get_transactions(ctx, max_txs_per_block).await?;
 
-    // 4. Construct block (handles terminal detection and manifest fetching internally)
+    // 4. Construct block using the sealing policy decision and manifest fetch gate.
     let output = construct_block(
         ctx,
         epoch_sealing_policy,
@@ -244,7 +247,7 @@ pub(crate) fn calculate_block_slot_and_epoch<S: IStateAccessor>(
 /// 2. Executes block initialization (epoch initial + block start)
 /// 3. Validates each transaction against accumulated state
 /// 4. Filters out invalid transactions (proof failures, execution failures)
-/// 5. Detects terminal blocks and fetches L1 manifests
+/// 5. Applies the sealing policy and fetches L1 manifests for terminal blocks
 /// 6. Builds the complete block with only valid transactions
 #[expect(clippy::too_many_arguments, reason = "can't get around the args")]
 #[tracing::instrument(
@@ -306,9 +309,10 @@ where
         failed_txs,
         accumulated_batch,
         accumulated_da,
-        checkpoint_size_limit_reached,
+        sealing_limit_verdict,
     } = process_transactions(
         ctx,
+        epoch_sealing_policy,
         &block_context,
         &output_buffer,
         parent_state.as_ref(),
@@ -318,11 +322,18 @@ where
         bridge_params,
     );
 
-    // Phase 3: Seal the epoch if the policy says so or the checkpoint payload is near the
-    // L1 envelope limit. Fetch manifests for the terminal block (possibly empty if L1 is slow).
-    let should_seal =
-        epoch_sealing_policy.should_seal_epoch(block_slot) || checkpoint_size_limit_reached;
-    debug!(%block_slot, checkpoint_size_limit_reached, should_seal, "epoch seal decision");
+    // Phase 3: Ask the sealing policy whether this block should be terminal. Fetch manifests for
+    // the terminal block (possibly empty if L1 is slow).
+    let sealing_decision =
+        epoch_sealing_policy.should_seal_epoch(block_slot, &sealing_limit_verdict);
+    let should_seal = sealing_decision.should_seal();
+    debug!(
+        %block_slot,
+        ?sealing_limit_verdict,
+        ?sealing_decision,
+        should_seal,
+        "epoch seal decision"
+    );
     let manifest_container = if should_seal {
         fetch_asm_manifests_for_terminal_block(ctx, parent_state.as_ref()).await?
     } else {
@@ -335,7 +346,8 @@ where
     debug!(
         successful_tx_count = successful_txs.len(),
         failed_tx_count = failed_txs.len(),
-        is_terminal = manifest_container.is_some(),
+        is_terminal = should_seal,
+        has_manifests = manifest_container.is_some(),
         "block construction summary",
     );
     let (template, post_state) = build_block_template(
@@ -345,6 +357,7 @@ where
         accumulated_batch,
         output_buffer.clone(),
         successful_txs,
+        should_seal,
         manifest_container,
     )?;
 
@@ -441,8 +454,9 @@ where
     fields(component = "ol_block_assembly", tx_count = mempool_txs.len())
 )]
 #[expect(clippy::too_many_arguments, reason = "all arguments are required")]
-fn process_transactions<P, S>(
+fn process_transactions<P, E, S>(
     proof_gen: &P,
+    epoch_sealing_policy: &E,
     block_context: &BlockContext<'_>,
     output_buffer: &ExecOutputBuffer,
     parent_state: &S,
@@ -453,12 +467,13 @@ fn process_transactions<P, S>(
 ) -> ProcessTransactionsOutput<S>
 where
     P: AccumulatorProofGenerator,
+    E: EpochSealingPolicy,
     S: BlockAssemblyStateAccess,
     <<S as IStateAccessor>::AccountState as IAccountStateMut>::SnarkAccountStateMut: Clone,
 {
     let mut successful_txs = Vec::new();
     let mut failed_txs = Vec::new();
-    let mut checkpoint_size_limit_reached = false;
+    let mut sealing_limit_verdict = EpochSealingLimitVerdict::within_limits();
 
     // Track log metrics incrementally for checkpoint size estimation.
     let mut log_metrics = LogMetrics::from_logs(accumulated_da.logs());
@@ -538,10 +553,13 @@ where
                 let mut tentative = log_metrics;
                 tentative.add_logs(&tx_logs);
                 let da_diff_size = staging_state.accumulator().estimated_encoded_size();
-                let verdict = checkpoint_size_verdict(da_diff_size, &tentative);
+                let epoch_manifest_count = 0;
+                let stats =
+                    EpochSealingResourceStats::new(da_diff_size, tentative, epoch_manifest_count);
+                let verdict = epoch_sealing_policy.check_limits(&stats);
 
-                match verdict {
-                    CheckpointSizeVerdict::HardLimitExceeded => {
+                match verdict.checkpoint_size_action() {
+                    EpochSealingLimitAction::RejectCandidate => {
                         debug!(
                             da_diff_size,
                             ?tentative,
@@ -551,10 +569,10 @@ where
                             WriteTrackingState::new(parent_state, backup_batch),
                             backup_accumulator,
                         );
-                        checkpoint_size_limit_reached = true;
+                        sealing_limit_verdict = verdict;
                         break;
                     }
-                    CheckpointSizeVerdict::SoftLimitReached => {
+                    EpochSealingLimitAction::SealAfterAdmit => {
                         debug!(
                             da_diff_size,
                             ?tentative,
@@ -569,10 +587,10 @@ where
                         } else {
                             successful_txs.push(tx);
                         }
-                        checkpoint_size_limit_reached = true;
+                        sealing_limit_verdict = verdict;
                         break;
                     }
-                    CheckpointSizeVerdict::WithinLimits => {
+                    EpochSealingLimitAction::Continue => {
                         if output_buffer.emit_logs(tx_logs).is_err() {
                             debug!(?txid, "block log cap exceeded, rolling back tx");
                             staging_state = DaAccumulatingState::new_with_accumulator(
@@ -627,13 +645,17 @@ where
         failed_txs,
         accumulated_batch,
         accumulated_da,
-        checkpoint_size_limit_reached,
+        sealing_limit_verdict,
     }
 }
 
 /// Builds the final block template from accumulated state and transactions.
 ///
 /// Returns `(template, final_state)` where `final_state` is the post-block state.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "block template construction consumes outputs from separate assembly phases"
+)]
 fn build_block_template<S>(
     config: &BlockGenerationConfig,
     block_context: &BlockContext<'_>,
@@ -641,6 +663,7 @@ fn build_block_template<S>(
     accumulated_batch: WriteBatch<S::AccountState>,
     output_buffer: ExecOutputBuffer,
     successful_txs: Vec<OLTransaction>,
+    is_terminal: bool,
     manifest_container: Option<OLAsmManifestContainer>,
 ) -> BlockAssemblyResult<(FullBlockTemplate, S)>
 where
@@ -649,13 +672,6 @@ where
     // Clone parent state and apply accumulated batch to get state after transactions
     let mut final_state = parent_state.as_ref().clone();
     final_state.apply_write_batch(accumulated_batch)?;
-
-    // Assembly policy: a block that carries manifests is treated as the epoch
-    // terminal. The STF decouples manifest inclusion from terminality (logs are
-    // buffered into intraepoch state regardless), but block assembly currently
-    // only emits manifests at epoch boundaries, so this preserves the existing
-    // external behavior while leaving the infrastructure free to change later.
-    let is_terminal = manifest_container.is_some();
 
     // Buffer any manifests carried by this block into intraepoch state.
     if let Some(mc) = &manifest_container {
@@ -706,7 +722,8 @@ where
     }
     let body_root = body.compute_hash_commitment();
 
-    // Terminality is the explicit assembly policy decision above.
+    // Terminality is the explicit assembly decision, independent of whether the
+    // block happens to carry manifests.
     let mut flags = BlockFlags::zero();
     flags.set_is_terminal(is_terminal);
 
@@ -2556,6 +2573,7 @@ mod tests {
 
         let out = process_transactions(
             env.ctx(),
+            env.epoch_sealing_policy(),
             &block_context,
             &output_buffer,
             parent_state.as_ref(),
@@ -2613,6 +2631,7 @@ mod tests {
 
         let out = process_transactions(
             env.ctx(),
+            env.epoch_sealing_policy(),
             &block_context,
             &output_buffer,
             parent_state.as_ref(),
@@ -2658,6 +2677,7 @@ mod tests {
 
         let out = process_transactions(
             env.ctx(),
+            env.epoch_sealing_policy(),
             &block_context,
             &output_buffer,
             parent_state.as_ref(),
@@ -2698,6 +2718,7 @@ mod tests {
 
         process_transactions(
             env.ctx(),
+            env.epoch_sealing_policy(),
             &block_context,
             &output_buffer,
             parent_state.as_ref(),
@@ -2749,8 +2770,11 @@ mod tests {
             "deferred tx should not be marked invalid"
         );
         assert!(
-            out.checkpoint_size_limit_reached,
-            "soft verdict should mark checkpoint_size_limit_reached"
+            matches!(
+                out.sealing_limit_verdict.checkpoint_size_action(),
+                EpochSealingLimitAction::SealAfterAdmit
+            ),
+            "soft verdict should request checkpoint-size sealing"
         );
     }
 
@@ -2803,8 +2827,11 @@ mod tests {
             "hard-limit rollback should not mark tx invalid"
         );
         assert!(
-            out.checkpoint_size_limit_reached,
-            "hard verdict should mark checkpoint_size_limit_reached"
+            matches!(
+                out.sealing_limit_verdict.checkpoint_size_action(),
+                EpochSealingLimitAction::RejectCandidate
+            ),
+            "hard verdict should request checkpoint-size sealing"
         );
     }
 

--- a/crates/ol/block-assembly/src/epoch_sealing.rs
+++ b/crates/ol/block-assembly/src/epoch_sealing.rs
@@ -1,22 +1,357 @@
 //! Epoch sealing policy for OL block assembly.
 //!
-//! The sealing policy determines when an epoch should be sealed (i.e., when to create
-//! a terminal block). This is a batch production concern, not an STF concern.
+//! The sealing policy determines when an epoch should be sealed, i.e. when to
+//! create a terminal block. This is a batch production concern, not an STF
+//! concern.
 
-use std::fmt::Debug;
+use std::{cmp::Ordering, fmt::Debug};
 
 use strata_identifiers::Slot;
+use strata_ol_chain_types_new::MAX_SEALING_MANIFEST_COUNT;
 
-/// Trait for deciding when to seal an epoch.
+use crate::checkpoint_size::{CheckpointSizeVerdict, LogMetrics, checkpoint_size_verdict};
+
+/// Resource stats used by sealing-limit rules.
 ///
-/// Implementations define the threshold logic for determining when an epoch
-/// should be sealed (e.g., by slot count, DA size, or a combination).
-pub trait EpochSealingPolicy: Send + Sync + Debug + 'static {
-    /// Returns `true` if a terminal block should be created at this slot.
-    fn should_seal_epoch(&self, slot: Slot) -> bool;
+/// All values are epoch-cumulative for the candidate state being checked.
+/// Block assembly builds this snapshot incrementally before admitting a
+/// candidate resource, such as a transaction or manifest prefix.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EpochSealingResourceStats {
+    da_diff_size: usize,
+    log: LogMetrics,
+    manifest_count: u32,
 }
 
-/// Fixed slot-count sealing policy.
+impl EpochSealingResourceStats {
+    /// Creates a new resource stats snapshot.
+    pub(crate) fn new(da_diff_size: usize, log: LogMetrics, manifest_count: u32) -> Self {
+        Self {
+            da_diff_size,
+            log,
+            manifest_count,
+        }
+    }
+
+    /// Returns the estimated DA diff size.
+    pub(crate) fn da_diff_size(&self) -> usize {
+        self.da_diff_size
+    }
+
+    /// Returns the OL log metrics.
+    pub(crate) fn log(&self) -> &LogMetrics {
+        &self.log
+    }
+
+    /// Returns the ASM manifest count.
+    pub(crate) fn manifest_count(&self) -> u32 {
+        self.manifest_count
+    }
+}
+
+/// A candidate admission action requested by a sealing limit.
+///
+/// Variants are ordered so `max()` yields the most restrictive action.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum EpochSealingLimitAction {
+    /// The candidate remains below the sealing threshold.
+    #[default]
+    Continue,
+
+    /// Admit the candidate and seal this block.
+    SealAfterAdmit,
+
+    /// Reject the candidate and seal with the state before it.
+    RejectCandidate,
+}
+
+impl EpochSealingLimitAction {
+    fn should_seal(self) -> bool {
+        self != Self::Continue
+    }
+}
+
+/// Epoch sealing limit identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EpochSealingLimit {
+    /// Estimated checkpoint payload or sidecar size.
+    CheckpointSize,
+
+    /// Epoch-cumulative ASM manifest count.
+    ManifestCount,
+}
+
+/// Verdict from checking candidate values against sealing limits.
+///
+/// The verdict preserves checkpoint-size and manifest-count actions separately
+/// so multiple crossed limits can be observed together.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EpochSealingLimitVerdict {
+    actions: Vec<(EpochSealingLimit, EpochSealingLimitAction)>,
+}
+
+impl EpochSealingLimitVerdict {
+    /// Creates a verdict with no limits reached.
+    pub(crate) fn within_limits() -> Self {
+        Self::default()
+    }
+
+    fn from_actions(
+        actions: impl IntoIterator<Item = (EpochSealingLimit, EpochSealingLimitAction)>,
+    ) -> Self {
+        let mut verdict = Self::within_limits();
+        for (limit, action) in actions {
+            verdict.record(limit, action);
+        }
+        verdict
+    }
+
+    fn record(&mut self, limit: EpochSealingLimit, action: EpochSealingLimitAction) {
+        if action == EpochSealingLimitAction::Continue {
+            return;
+        }
+
+        if let Some((_, existing)) = self
+            .actions
+            .iter_mut()
+            .find(|(existing_limit, _)| *existing_limit == limit)
+        {
+            *existing = (*existing).max(action);
+        } else {
+            self.actions.push((limit, action));
+        }
+    }
+
+    /// Merges another verdict into this one, keeping the stricter action for duplicate limits.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "manifest admission wires this in the next commit")
+    )]
+    pub(crate) fn merge(&mut self, other: Self) {
+        for (limit, action) in other.actions {
+            self.record(limit, action);
+        }
+    }
+
+    fn should_seal(&self) -> bool {
+        self.most_restrictive_action().should_seal()
+    }
+
+    /// Returns the checkpoint-size limit action.
+    pub(crate) fn checkpoint_size_action(&self) -> EpochSealingLimitAction {
+        self.action_for(EpochSealingLimit::CheckpointSize)
+    }
+
+    /// Returns the manifest-count limit action.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "manifest admission wires this in the next commit")
+    )]
+    pub(crate) fn manifest_count_action(&self) -> EpochSealingLimitAction {
+        self.action_for(EpochSealingLimit::ManifestCount)
+    }
+
+    fn action_for(&self, limit: EpochSealingLimit) -> EpochSealingLimitAction {
+        self.actions
+            .iter()
+            .find_map(|(id, action)| (*id == limit).then_some(*action))
+            .unwrap_or_default()
+    }
+
+    fn actions(&self) -> impl Iterator<Item = (EpochSealingLimit, EpochSealingLimitAction)> + '_ {
+        self.actions.iter().copied()
+    }
+
+    fn most_restrictive_action(&self) -> EpochSealingLimitAction {
+        self.actions()
+            .map(|(_, action)| action)
+            .max()
+            .unwrap_or_default()
+    }
+
+    fn seal_trigger(&self) -> Option<EpochSealTrigger> {
+        self.should_seal()
+            .then(|| EpochSealTrigger::Limits(self.clone()))
+    }
+}
+
+/// Trigger that requested an epoch seal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EpochSealTrigger {
+    /// The configured sealing cadence requested a terminal block.
+    Cadence,
+    /// One or more non-cadence limits requested a terminal block.
+    Limits(EpochSealingLimitVerdict),
+}
+
+/// Decision returned by an [`EpochSealingPolicy`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EpochSealingDecision {
+    /// Seal the epoch for the given trigger.
+    Seal(EpochSealTrigger),
+
+    /// Keep building non-terminal blocks.
+    Continue,
+}
+
+impl EpochSealingDecision {
+    /// Returns `true` when this decision seals the epoch.
+    pub(crate) fn should_seal(&self) -> bool {
+        matches!(self, Self::Seal(_))
+    }
+}
+
+/// Trait for fixed epoch sealing cadence.
+pub trait CadencePolicy: Send + Sync + Debug + 'static {
+    /// Returns `true` if this cadence seals at `slot`.
+    fn seals_at_slot(&self, slot: Slot) -> bool;
+}
+
+/// Trait for a concrete sealing-limit rule.
+pub(crate) trait SealingLimitRule: Send + Sync + Debug + 'static {
+    /// Returns the limit checked by this rule.
+    fn limit(&self) -> EpochSealingLimit;
+
+    /// Checks the resource stats against this rule.
+    fn check(&self, stats: &EpochSealingResourceStats) -> EpochSealingLimitAction;
+}
+
+/// Checkpoint-size sealing limit rule.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct CheckpointSizeRule;
+
+impl SealingLimitRule for CheckpointSizeRule {
+    fn limit(&self) -> EpochSealingLimit {
+        EpochSealingLimit::CheckpointSize
+    }
+
+    fn check(&self, stats: &EpochSealingResourceStats) -> EpochSealingLimitAction {
+        match checkpoint_size_verdict(stats.da_diff_size(), stats.log()) {
+            CheckpointSizeVerdict::WithinLimits => EpochSealingLimitAction::Continue,
+            CheckpointSizeVerdict::SoftLimitReached => EpochSealingLimitAction::SealAfterAdmit,
+            CheckpointSizeVerdict::HardLimitExceeded => EpochSealingLimitAction::RejectCandidate,
+        }
+    }
+}
+
+/// Epoch-cumulative ASM manifest-count sealing limit rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ManifestCountRule {
+    max_epoch_manifests: u32,
+}
+
+impl ManifestCountRule {
+    /// Creates a new manifest-count rule.
+    ///
+    /// `max_epoch_manifests` is a sealing budget, not the per-block SSZ
+    /// container bound. The default currently uses the same numeric value until
+    /// a separate configured budget is introduced.
+    fn new(max_epoch_manifests: u32) -> Self {
+        Self {
+            max_epoch_manifests,
+        }
+    }
+}
+
+impl Default for ManifestCountRule {
+    fn default() -> Self {
+        Self::new(MAX_SEALING_MANIFEST_COUNT as u32)
+    }
+}
+
+impl SealingLimitRule for ManifestCountRule {
+    fn limit(&self) -> EpochSealingLimit {
+        EpochSealingLimit::ManifestCount
+    }
+
+    fn check(&self, stats: &EpochSealingResourceStats) -> EpochSealingLimitAction {
+        match stats.manifest_count().cmp(&self.max_epoch_manifests) {
+            Ordering::Less => EpochSealingLimitAction::Continue,
+            Ordering::Equal => EpochSealingLimitAction::SealAfterAdmit,
+            Ordering::Greater => EpochSealingLimitAction::RejectCandidate,
+        }
+    }
+}
+
+/// Construction-time context for sealing limit checks.
+#[derive(Debug)]
+struct EpochSealingPolicyContext {
+    limits: Vec<Box<dyn SealingLimitRule>>,
+}
+
+impl Default for EpochSealingPolicyContext {
+    fn default() -> Self {
+        Self {
+            limits: vec![
+                Box::new(CheckpointSizeRule),
+                Box::new(ManifestCountRule::default()),
+            ],
+        }
+    }
+}
+
+impl EpochSealingPolicyContext {
+    fn check_limits(&self, stats: &EpochSealingResourceStats) -> EpochSealingLimitVerdict {
+        EpochSealingLimitVerdict::from_actions(
+            self.limits
+                .iter()
+                .map(|rule| (rule.limit(), rule.check(stats))),
+        )
+    }
+}
+
+/// Trait for deciding when to seal an epoch.
+pub trait EpochSealingPolicy: Send + Sync + Debug + 'static {
+    /// Checks candidate resource stats against sealing limits.
+    fn check_limits(&self, stats: &EpochSealingResourceStats) -> EpochSealingLimitVerdict;
+
+    /// Decides whether a terminal block should be created.
+    fn should_seal_epoch(
+        &self,
+        slot: Slot,
+        limit_verdict: &EpochSealingLimitVerdict,
+    ) -> EpochSealingDecision;
+}
+
+/// Sealing policy that combines a cadence policy with sealing-limit rules.
+#[derive(Debug)]
+pub struct LimitAwareSealing<C: CadencePolicy> {
+    cadence: C,
+    context: EpochSealingPolicyContext,
+}
+
+impl<C: CadencePolicy> LimitAwareSealing<C> {
+    /// Creates a limit-aware policy with default sealing-limit rules.
+    pub fn new(cadence: C) -> Self {
+        Self::with_context(cadence, EpochSealingPolicyContext::default())
+    }
+
+    fn with_context(cadence: C, context: EpochSealingPolicyContext) -> Self {
+        Self { cadence, context }
+    }
+}
+
+impl<C: CadencePolicy> EpochSealingPolicy for LimitAwareSealing<C> {
+    fn check_limits(&self, stats: &EpochSealingResourceStats) -> EpochSealingLimitVerdict {
+        self.context.check_limits(stats)
+    }
+
+    fn should_seal_epoch(
+        &self,
+        slot: Slot,
+        limit_verdict: &EpochSealingLimitVerdict,
+    ) -> EpochSealingDecision {
+        if let Some(trigger) = limit_verdict.seal_trigger() {
+            EpochSealingDecision::Seal(trigger)
+        } else if self.cadence.seals_at_slot(slot) {
+            EpochSealingDecision::Seal(EpochSealTrigger::Cadence)
+        } else {
+            EpochSealingDecision::Continue
+        }
+    }
+}
+
+/// Fixed slot-count sealing cadence.
 ///
 /// Seals an epoch at slots that are multiples of `slots_per_epoch`.
 /// This includes genesis (slot 0) since `0.is_multiple_of(n)` is true.
@@ -26,7 +361,7 @@ pub struct FixedSlotSealing {
 }
 
 impl FixedSlotSealing {
-    /// Creates a new fixed slot sealing policy.
+    /// Creates a new fixed slot sealing cadence.
     ///
     /// # Panics
     ///
@@ -35,29 +370,26 @@ impl FixedSlotSealing {
         assert!(slots_per_epoch > 0, "slots_per_epoch must be > 0");
         Self { slots_per_epoch }
     }
-
-    /// Returns the configured slots per epoch.
-    pub fn slots_per_epoch(&self) -> u64 {
-        self.slots_per_epoch
-    }
 }
 
-impl EpochSealingPolicy for FixedSlotSealing {
-    fn should_seal_epoch(&self, slot: Slot) -> bool {
+impl CadencePolicy for FixedSlotSealing {
+    fn seals_at_slot(&self, slot: Slot) -> bool {
         // Terminal slots are multiples of slots_per_epoch: 0, N, 2N, 3N, ...
-        // Genesis (slot 0) is terminal since 0.is_multiple_of(n) == true
+        // Genesis (slot 0) is terminal since 0.is_multiple_of(n) == true.
         slot.is_multiple_of(self.slots_per_epoch)
     }
 }
 
 #[cfg(test)]
 mod fixed_slot_sealing_tests {
+    use strata_asm_proto_checkpoint_types::MAX_OL_LOGS_PER_CHECKPOINT;
+
     use super::*;
 
     #[test]
     fn test_genesis_is_terminal() {
         let sealing = FixedSlotSealing::new(10);
-        assert!(sealing.should_seal_epoch(0));
+        assert!(sealing.seals_at_slot(0));
     }
 
     #[test]
@@ -65,7 +397,7 @@ mod fixed_slot_sealing_tests {
         let sealing = FixedSlotSealing::new(10);
         for slot in 1..10 {
             assert!(
-                !sealing.should_seal_epoch(slot),
+                !sealing.seals_at_slot(slot),
                 "slot {slot} should not be terminal"
             );
         }
@@ -74,17 +406,170 @@ mod fixed_slot_sealing_tests {
     #[test]
     fn test_epoch_boundaries() {
         let sealing = FixedSlotSealing::new(10);
-        // Terminal slots: 0, 10, 20, 30, ...
-        assert!(sealing.should_seal_epoch(0));
-        assert!(sealing.should_seal_epoch(10));
-        assert!(sealing.should_seal_epoch(20));
-        assert!(sealing.should_seal_epoch(30));
+        assert!(sealing.seals_at_slot(0));
+        assert!(sealing.seals_at_slot(10));
+        assert!(sealing.seals_at_slot(20));
+        assert!(sealing.seals_at_slot(30));
 
-        // Non-terminal around boundaries
-        assert!(!sealing.should_seal_epoch(9));
-        assert!(!sealing.should_seal_epoch(11));
-        assert!(!sealing.should_seal_epoch(19));
-        assert!(!sealing.should_seal_epoch(21));
+        assert!(!sealing.seals_at_slot(9));
+        assert!(!sealing.seals_at_slot(11));
+        assert!(!sealing.seals_at_slot(19));
+        assert!(!sealing.seals_at_slot(21));
+    }
+
+    #[test]
+    fn test_checkpoint_size_limit_seals_through_policy_decision() {
+        let sealing = LimitAwareSealing::new(FixedSlotSealing::new(10));
+        let stats = EpochSealingResourceStats::new(
+            0,
+            LogMetrics {
+                count: MAX_OL_LOGS_PER_CHECKPOINT as usize,
+                ..Default::default()
+            },
+            0,
+        );
+        let verdict = sealing.check_limits(&stats);
+        let decision = sealing.should_seal_epoch(1, &verdict);
+
+        assert_eq!(
+            verdict.checkpoint_size_action(),
+            EpochSealingLimitAction::RejectCandidate,
+            "checkpoint hard limit should reject the current candidate"
+        );
+        assert_eq!(
+            decision,
+            EpochSealingDecision::Seal(EpochSealTrigger::Limits(verdict))
+        );
+    }
+
+    #[test]
+    fn test_multiple_limits_are_preserved_in_policy_decision() {
+        let sealing = LimitAwareSealing::new(FixedSlotSealing::new(10));
+        let stats = EpochSealingResourceStats::new(
+            0,
+            LogMetrics {
+                count: MAX_OL_LOGS_PER_CHECKPOINT as usize,
+                ..Default::default()
+            },
+            MAX_SEALING_MANIFEST_COUNT as u32,
+        );
+        let verdict = sealing.check_limits(&stats);
+
+        assert_eq!(
+            verdict.checkpoint_size_action(),
+            EpochSealingLimitAction::RejectCandidate
+        );
+        assert!(verdict.actions().any(|(limit, action)| {
+            limit == EpochSealingLimit::ManifestCount
+                && action == EpochSealingLimitAction::SealAfterAdmit
+        }));
+
+        let decision = sealing.should_seal_epoch(1, &verdict);
+        assert_eq!(
+            decision,
+            EpochSealingDecision::Seal(EpochSealTrigger::Limits(verdict))
+        );
+    }
+
+    #[test]
+    fn test_manifest_count_rule_actions() {
+        let rule = ManifestCountRule::new(3);
+
+        assert_eq!(
+            rule.check(&EpochSealingResourceStats::new(0, LogMetrics::default(), 2)),
+            EpochSealingLimitAction::Continue
+        );
+        assert_eq!(
+            rule.check(&EpochSealingResourceStats::new(0, LogMetrics::default(), 3)),
+            EpochSealingLimitAction::SealAfterAdmit
+        );
+        assert_eq!(
+            rule.check(&EpochSealingResourceStats::new(0, LogMetrics::default(), 4)),
+            EpochSealingLimitAction::RejectCandidate
+        );
+    }
+
+    #[test]
+    fn test_duplicate_limit_action_keeps_most_restrictive() {
+        let verdict = EpochSealingLimitVerdict::from_actions([
+            (
+                EpochSealingLimit::CheckpointSize,
+                EpochSealingLimitAction::SealAfterAdmit,
+            ),
+            (
+                EpochSealingLimit::CheckpointSize,
+                EpochSealingLimitAction::RejectCandidate,
+            ),
+        ]);
+
+        assert_eq!(
+            verdict.checkpoint_size_action(),
+            EpochSealingLimitAction::RejectCandidate
+        );
+    }
+
+    #[test]
+    fn test_merge_preserves_distinct_limits() {
+        let mut tx_verdict = EpochSealingLimitVerdict::from_actions([(
+            EpochSealingLimit::CheckpointSize,
+            EpochSealingLimitAction::SealAfterAdmit,
+        )]);
+        let manifest_verdict = EpochSealingLimitVerdict::from_actions([(
+            EpochSealingLimit::ManifestCount,
+            EpochSealingLimitAction::RejectCandidate,
+        )]);
+
+        tx_verdict.merge(manifest_verdict);
+
+        assert_eq!(
+            tx_verdict.checkpoint_size_action(),
+            EpochSealingLimitAction::SealAfterAdmit
+        );
+        assert_eq!(
+            tx_verdict.manifest_count_action(),
+            EpochSealingLimitAction::RejectCandidate
+        );
+        assert!(tx_verdict.should_seal());
+    }
+
+    #[test]
+    fn test_merge_keeps_most_restrictive_duplicate_limit() {
+        let mut verdict = EpochSealingLimitVerdict::from_actions([(
+            EpochSealingLimit::ManifestCount,
+            EpochSealingLimitAction::SealAfterAdmit,
+        )]);
+        let stricter = EpochSealingLimitVerdict::from_actions([(
+            EpochSealingLimit::ManifestCount,
+            EpochSealingLimitAction::RejectCandidate,
+        )]);
+
+        verdict.merge(stricter);
+
+        assert_eq!(
+            verdict.manifest_count_action(),
+            EpochSealingLimitAction::RejectCandidate
+        );
+    }
+
+    #[test]
+    fn test_cadence_seals_through_policy_decision() {
+        let sealing = LimitAwareSealing::new(FixedSlotSealing::new(10));
+        let verdict = EpochSealingLimitVerdict::within_limits();
+        let decision = sealing.should_seal_epoch(10, &verdict);
+
+        assert_eq!(
+            decision,
+            EpochSealingDecision::Seal(EpochSealTrigger::Cadence)
+        );
+    }
+
+    #[test]
+    fn test_policy_decision_non_terminal() {
+        let sealing = LimitAwareSealing::new(FixedSlotSealing::new(10));
+        let verdict = EpochSealingLimitVerdict::within_limits();
+        let decision = sealing.should_seal_epoch(1, &verdict);
+
+        assert_eq!(decision, EpochSealingDecision::Continue);
     }
 
     #[test]

--- a/crates/ol/block-assembly/src/epoch_sealing.rs
+++ b/crates/ol/block-assembly/src/epoch_sealing.rs
@@ -15,7 +15,7 @@ use crate::checkpoint_size::{CheckpointSizeVerdict, LogMetrics, checkpoint_size_
 ///
 /// All values are epoch-cumulative for the candidate state being checked.
 /// Block assembly builds this snapshot incrementally before admitting a
-/// candidate resource, such as a transaction or manifest prefix.
+/// candidate resource, such as a transaction or manifest sequence.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct EpochSealingResourceStats {
     da_diff_size: usize,
@@ -122,11 +122,7 @@ impl EpochSealingLimitVerdict {
         }
     }
 
-    /// Merges another verdict into this one, keeping the stricter action for duplicate limits.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "manifest admission wires this in the next commit")
-    )]
+    /// Merges another verdict into this one, keeping the stricter action for each limit.
     pub(crate) fn merge(&mut self, other: Self) {
         for (limit, action) in other.actions {
             self.record(limit, action);
@@ -143,10 +139,7 @@ impl EpochSealingLimitVerdict {
     }
 
     /// Returns the manifest-count limit action.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "manifest admission wires this in the next commit")
-    )]
+    #[cfg(test)]
     pub(crate) fn manifest_count_action(&self) -> EpochSealingLimitAction {
         self.action_for(EpochSealingLimit::ManifestCount)
     }
@@ -162,7 +155,7 @@ impl EpochSealingLimitVerdict {
         self.actions.iter().copied()
     }
 
-    fn most_restrictive_action(&self) -> EpochSealingLimitAction {
+    pub(crate) fn most_restrictive_action(&self) -> EpochSealingLimitAction {
         self.actions()
             .map(|(_, action)| action)
             .max()

--- a/crates/ol/block-assembly/src/lib.rs
+++ b/crates/ol/block-assembly/src/lib.rs
@@ -5,11 +5,11 @@ mod builder;
 mod checkpoint_size;
 mod command;
 mod context;
-mod da_tracker;
 mod epoch_sealing;
 mod error;
 mod handle;
 mod mempool_provider;
+mod resource_state;
 mod service;
 mod state;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/ol/block-assembly/src/lib.rs
+++ b/crates/ol/block-assembly/src/lib.rs
@@ -23,7 +23,7 @@ pub use context::{
     AccumulatorProofGenerator, BlockAssemblyAnchorContext, BlockAssemblyContext,
     BlockAssemblyStateAccess,
 };
-pub use epoch_sealing::{EpochSealingPolicy, FixedSlotSealing};
+pub use epoch_sealing::{CadencePolicy, EpochSealingPolicy, FixedSlotSealing, LimitAwareSealing};
 pub use error::BlockAssemblyError;
 pub use handle::BlockasmHandle;
 pub use mempool_provider::{MempoolProvider, MempoolProviderImpl};

--- a/crates/ol/block-assembly/src/resource_state.rs
+++ b/crates/ol/block-assembly/src/resource_state.rs
@@ -10,44 +10,103 @@ use strata_primitives::nonempty_vec::NonEmptyVec;
 
 use crate::{BlockAssemblyAnchorContext, BlockAssemblyError, BlockAssemblyStateAccess};
 
+/// An 'append-only' container of state diff and OL logs accumulated DA data for some epoch.
 #[derive(Clone, Debug)]
-pub(crate) struct EpochDaTracker {
-    block_da_map: HashMap<OLBlockId, AccumulatedDaData>,
+pub(crate) struct AccumulatedDaData {
+    accumulator: EpochDaAccumulator,
+    logs: Vec<OLLog>,
 }
 
-impl EpochDaTracker {
+impl AccumulatedDaData {
+    pub(crate) fn new_empty() -> Self {
+        Self::new(EpochDaAccumulator::default(), Vec::default())
+    }
+
+    pub(crate) fn new(accumulator: EpochDaAccumulator, logs: Vec<OLLog>) -> Self {
+        Self { accumulator, logs }
+    }
+
+    pub(crate) fn into_parts(self) -> (EpochDaAccumulator, Vec<OLLog>) {
+        (self.accumulator, self.logs)
+    }
+
+    pub(crate) fn logs(&self) -> &[OLLog] {
+        &self.logs
+    }
+
+    pub(crate) fn append_logs(&mut self, new_logs: &[OLLog]) {
+        self.logs.extend_from_slice(new_logs);
+    }
+}
+
+/// Epoch-cumulative resource state needed to assemble the next OL block.
+#[derive(Clone, Debug)]
+pub(crate) struct EpochResourceState {
+    /// Epoch DA state, also used as the threaded parent-DA accumulator.
+    da: AccumulatedDaData,
+
+    /// Epoch-cumulative count of ASM manifests included so far.
+    manifest_count: u32,
+}
+
+impl EpochResourceState {
+    pub(crate) fn new_empty() -> Self {
+        Self::new(AccumulatedDaData::new_empty(), 0)
+    }
+
+    pub(crate) fn new(da: AccumulatedDaData, manifest_count: u32) -> Self {
+        Self { da, manifest_count }
+    }
+
+    pub(crate) fn da(&self) -> &AccumulatedDaData {
+        &self.da
+    }
+
+    pub(crate) fn manifest_count(&self) -> u32 {
+        self.manifest_count
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EpochResourceTracker {
+    block_resource_state_map: HashMap<OLBlockId, EpochResourceState>,
+}
+
+impl EpochResourceTracker {
     pub(crate) fn new_empty() -> Self {
         Self::new(HashMap::default())
     }
 
-    pub(crate) fn new(block_da_map: HashMap<OLBlockId, AccumulatedDaData>) -> Self {
-        Self { block_da_map }
+    pub(crate) fn new(block_resource_state_map: HashMap<OLBlockId, EpochResourceState>) -> Self {
+        Self {
+            block_resource_state_map,
+        }
     }
 
-    pub(crate) fn get_accumulated_da(&self, blkid: OLBlockId) -> Option<&AccumulatedDaData> {
-        self.block_da_map.get(&blkid)
+    pub(crate) fn get_resource_state(&self, blkid: OLBlockId) -> Option<&EpochResourceState> {
+        self.block_resource_state_map.get(&blkid)
     }
 
-    pub(crate) fn set_accumulated_da(&mut self, blkid: OLBlockId, da: AccumulatedDaData) {
-        self.block_da_map.insert(blkid, da);
+    pub(crate) fn set_resource_state(&mut self, blkid: OLBlockId, state: EpochResourceState) {
+        self.block_resource_state_map.insert(blkid, state);
     }
 
-    /// Removes accumulated DA for a block id, if present.
-    pub(crate) fn remove_accumulated_da(&mut self, blkid: OLBlockId) {
-        self.block_da_map.remove(&blkid);
+    /// Removes resource state for a block id, if present.
+    pub(crate) fn remove_resource_state(&mut self, blkid: OLBlockId) {
+        self.block_resource_state_map.remove(&blkid);
     }
 
-    /// Inserts the entry for given block id and also removes the entry for parent if exists. This
-    /// method is used to optimize memory usage because in the next assembly we would require
-    /// accumulation upto the current block and not the parent block.
-    pub(crate) fn set_accumulated_da_and_remove_parent_entry(
+    /// Inserts resource state for `blkid` and removes the parent entry, if present.
+    ///
+    /// The next assembly step needs state up to the current block, not its parent.
+    pub(crate) fn set_resource_state_and_remove_parent_entry(
         &mut self,
         blkid: OLBlockId,
         parent: OLBlockId,
-        da: AccumulatedDaData,
+        state: EpochResourceState,
     ) {
-        self.set_accumulated_da(blkid, da);
-        self.block_da_map.remove(&parent);
+        self.set_resource_state(blkid, state);
+        self.block_resource_state_map.remove(&parent);
     }
 }
 
@@ -55,6 +114,52 @@ impl EpochDaTracker {
 pub(crate) struct EpochBlocks {
     pub(crate) blocks: NonEmptyVec<OLBlock>,
     pub(crate) epoch_parent: OLBlockHeader,
+}
+
+/// Rebuilds epoch resource state for `target_blkid` by replaying all epoch
+/// blocks from the epoch boundary up to and including `target_blkid`.
+pub(crate) async fn rebuild_epoch_resource_state_upto<C: BlockAssemblyAnchorContext>(
+    blkid: OLBlockCommitment,
+    epoch: Epoch,
+    bridge_params: BridgeParams,
+    ctx: &C,
+) -> Result<EpochResourceState, BlockAssemblyError>
+where
+    C::State: BlockAssemblyStateAccess,
+    <C::State as IStateAccessorMut>::AccountStateMut: Clone,
+    <<C::State as IStateAccessorMut>::AccountStateMut as IAccountStateMut>::SnarkAccountStateMut:
+        Clone,
+{
+    let epoch_blocks = collect_epoch_blocks_until(blkid.blkid, epoch, ctx).await?;
+    let initial_state = fetch_state(&epoch_blocks.epoch_parent, ctx).await?;
+
+    let mut da_state = DaAccumulatingState::new(Arc::unwrap_or_clone(initial_state));
+    let batch_logs = execute_block_batch_predrain(
+        &mut da_state,
+        &epoch_blocks.blocks,
+        &epoch_blocks.epoch_parent,
+        bridge_params,
+    )
+    .map_err(|e| BlockAssemblyError::Other(format!("epoch block replay failed: {e}")))?;
+
+    let (accumulator, _) = da_state.into_parts();
+    let manifest_count = epoch_blocks
+        .blocks
+        .iter()
+        .filter_map(|block| block.body().manifests())
+        .try_fold(0u32, |count, manifests| {
+            let block_count = u32::try_from(manifests.manifests().len()).map_err(|_| {
+                BlockAssemblyError::Other("block manifest count exceeds u32".to_string())
+            })?;
+            count.checked_add(block_count).ok_or_else(|| {
+                BlockAssemblyError::Other("epoch manifest count overflow".to_string())
+            })
+        })?;
+
+    Ok(EpochResourceState::new(
+        AccumulatedDaData::new(accumulator, batch_logs),
+        manifest_count,
+    ))
 }
 
 /// Walks backward from `from_blkid` collecting blocks until a terminal block or genesis. Errors
@@ -109,37 +214,6 @@ async fn collect_epoch_blocks_until<C: BlockAssemblyAnchorContext>(
     Ok(epoch_blocks)
 }
 
-/// Rebuilds accumulated DA for `target_blkid` by replaying all epoch blocks
-/// from the epoch boundary up to and including `target_blkid`.
-pub(crate) async fn rebuild_accumulated_da_upto<C: BlockAssemblyAnchorContext>(
-    blkid: OLBlockCommitment,
-    epoch: Epoch,
-    bridge_params: BridgeParams,
-    ctx: &C,
-) -> Result<AccumulatedDaData, BlockAssemblyError>
-where
-    C::State: BlockAssemblyStateAccess,
-    <C::State as IStateAccessorMut>::AccountStateMut: Clone,
-    <<C::State as IStateAccessorMut>::AccountStateMut as IAccountStateMut>::SnarkAccountStateMut:
-        Clone,
-{
-    let epoch_blocks = collect_epoch_blocks_until(blkid.blkid, epoch, ctx).await?;
-    let initial_state = fetch_state(&epoch_blocks.epoch_parent, ctx).await?;
-
-    let mut da_state = DaAccumulatingState::new(Arc::unwrap_or_clone(initial_state));
-    let batch_logs = execute_block_batch_predrain(
-        &mut da_state,
-        &epoch_blocks.blocks,
-        &epoch_blocks.epoch_parent,
-        bridge_params,
-    )
-    .map_err(|e| BlockAssemblyError::Other(format!("epoch block replay failed: {e}")))?;
-
-    let (accumulator, _) = da_state.into_parts();
-
-    Ok(AccumulatedDaData::new(accumulator, batch_logs))
-}
-
 /// Fetches the state for `blk_header`.
 async fn fetch_state<C: BlockAssemblyAnchorContext>(
     blk_header: &OLBlockHeader,
@@ -151,35 +225,6 @@ async fn fetch_state<C: BlockAssemblyAnchorContext>(
         .await?
         .ok_or(BlockAssemblyError::EpochBoundaryStateNotFound(blkid))?;
     Ok(ol_state)
-}
-
-/// An 'append-only' container of state diff and OL logs accumulated DA data for some epoch.
-#[derive(Clone, Debug)]
-pub(crate) struct AccumulatedDaData {
-    accumulator: EpochDaAccumulator,
-    logs: Vec<OLLog>,
-}
-
-impl AccumulatedDaData {
-    pub(crate) fn new_empty() -> Self {
-        Self::new(EpochDaAccumulator::default(), Vec::default())
-    }
-
-    pub(crate) fn new(accumulator: EpochDaAccumulator, logs: Vec<OLLog>) -> Self {
-        Self { accumulator, logs }
-    }
-
-    pub(crate) fn into_parts(self) -> (EpochDaAccumulator, Vec<OLLog>) {
-        (self.accumulator, self.logs)
-    }
-
-    pub(crate) fn logs(&self) -> &[OLLog] {
-        &self.logs
-    }
-
-    pub(crate) fn append_logs(&mut self, new_logs: &[OLLog]) {
-        self.logs.extend_from_slice(new_logs);
-    }
 }
 
 #[cfg(test)]
@@ -279,10 +324,14 @@ mod tests {
         env.put_block(boundary).await;
         env.put_block(target).await;
 
-        let err =
-            rebuild_accumulated_da_upto(target_commitment, 2, BridgeParams::default(), env.ctx())
-                .await
-                .expect_err("missing boundary state should fail rebuild");
+        let err = rebuild_epoch_resource_state_upto(
+            target_commitment,
+            2,
+            BridgeParams::default(),
+            env.ctx(),
+        )
+        .await
+        .expect_err("missing boundary state should fail rebuild");
         assert!(
             matches!(err, BlockAssemblyError::EpochBoundaryStateNotFound(_)),
             "expected EpochBoundaryStateNotFound(_), got: {err:?}"
@@ -295,25 +344,25 @@ mod tests {
         let child = test_blkid(11);
         let unrelated = test_blkid(12);
 
-        let mut tracker = EpochDaTracker::new_empty();
-        tracker.set_accumulated_da(parent, AccumulatedDaData::new_empty());
-        tracker.set_accumulated_da(unrelated, AccumulatedDaData::new_empty());
-        tracker.set_accumulated_da_and_remove_parent_entry(
+        let mut tracker = EpochResourceTracker::new_empty();
+        tracker.set_resource_state(parent, EpochResourceState::new_empty());
+        tracker.set_resource_state(unrelated, EpochResourceState::new_empty());
+        tracker.set_resource_state_and_remove_parent_entry(
             child,
             parent,
-            AccumulatedDaData::new_empty(),
+            EpochResourceState::new_empty(),
         );
 
         assert!(
-            tracker.get_accumulated_da(parent).is_none(),
+            tracker.get_resource_state(parent).is_none(),
             "parent entry must be removed"
         );
         assert!(
-            tracker.get_accumulated_da(child).is_some(),
+            tracker.get_resource_state(child).is_some(),
             "child entry must be inserted"
         );
         assert!(
-            tracker.get_accumulated_da(unrelated).is_some(),
+            tracker.get_resource_state(unrelated).is_some(),
             "unrelated entries must remain"
         );
     }

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -63,8 +63,8 @@ where
             let expired_template_ids = state.state_mut().cleanup_expired_templates();
             for template_id in expired_template_ids {
                 state
-                    .epoch_da_tracker_mut()
-                    .remove_accumulated_da(template_id);
+                    .epoch_resource_tracker_mut()
+                    .remove_resource_state(template_id);
             }
         }
 
@@ -155,8 +155,8 @@ where
         });
     }
 
-    let parent_da = state
-        .fetch_epoch_da_until_parent(config.parent_block_commitment())
+    let resource_state_before_block = state
+        .fetch_epoch_resource_state_until_parent(config.parent_block_commitment())
         .await?;
 
     let result = generate_block_template_inner(
@@ -164,12 +164,12 @@ where
         state.epoch_sealing_policy(),
         state.sequencer_config(),
         config,
-        parent_da,
+        resource_state_before_block,
         *state.ol_params().bridge_params(),
     )
     .await?;
 
-    let (full_template, failed_txs, accumulated_da) = result.into_parts();
+    let (full_template, failed_txs, resource_state) = result.into_parts();
 
     // Report failed transactions back to mempool.
     if !failed_txs.is_empty() {
@@ -186,15 +186,15 @@ where
         .state_mut()
         .insert_template(template_id, full_template.clone())?;
 
-    // Store accumulated DA for the new block, removing parent entry.
+    // Store resource state for the new block, removing the parent entry.
     state
-        .epoch_da_tracker_mut()
-        .set_accumulated_da_and_remove_parent_entry(template_id, parent_blkid, accumulated_da);
+        .epoch_resource_tracker_mut()
+        .set_resource_state_and_remove_parent_entry(template_id, parent_blkid, resource_state);
 
     for evicted_template_id in evicted_template_ids {
         state
-            .epoch_da_tracker_mut()
-            .remove_accumulated_da(evicted_template_id);
+            .epoch_resource_tracker_mut()
+            .remove_resource_state(evicted_template_id);
     }
 
     Ok(full_template)
@@ -241,15 +241,15 @@ fn complete_block_template<M: MempoolProvider, E: EpochSealingPolicy, S>(
     Ok(template_ref.complete_block_template(completion_data))
 }
 
-/// Records that a block has been stored for a template and removes its accumulated DA entry.
+/// Records that a block has been stored for a template and removes its resource state entry.
 fn record_persisted_block<M: MempoolProvider, E: EpochSealingPolicy, S>(
     state: &mut BlockasmServiceState<M, E, S>,
     template_id: OLBlockId,
 ) -> Result<(), BlockAssemblyError> {
     state.state_mut().record_persisted_block(template_id)?;
     state
-        .epoch_da_tracker_mut()
-        .remove_accumulated_da(template_id);
+        .epoch_resource_tracker_mut()
+        .remove_resource_state(template_id);
     Ok(())
 }
 
@@ -284,8 +284,8 @@ mod tests {
     use super::*;
     use crate::{
         command::create_completion,
-        da_tracker::AccumulatedDaData,
         epoch_sealing::{FixedSlotSealing, LimitAwareSealing},
+        resource_state::EpochResourceState,
         state::BlockasmServiceState,
         test_utils::{
             MempoolSnarkTxBuilder, MockMempoolFailMode, MockMempoolProvider,
@@ -402,7 +402,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_process_input_cleanup_evicts_expired_da_tracker_entry() {
+    async fn test_process_input_cleanup_evicts_expired_resource_state_entry() {
         let (mut state, _mempool, env, _sk) = build_service_state(false).await;
         let config = BlockGenerationConfig::new(env.parent_commitment());
         let template = generate_block_template(&mut state, config)
@@ -412,8 +412,8 @@ mod tests {
         let parent = *template.header().parent_blkid();
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(template_id)
                 .is_some(),
             "generated template should have tracked DA entry"
         );
@@ -441,8 +441,8 @@ mod tests {
         );
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(template_id)
                 .is_none(),
             "expired template cleanup should evict DA tracker entry"
         );
@@ -457,12 +457,12 @@ mod tests {
             .await
             .expect("first generation should succeed");
         let template_id = first.get_blockid();
-        let tracked_da = state
-            .epoch_da_tracker()
-            .get_accumulated_da(template_id)
-            .expect("first generation should store accumulated DA for template id");
+        let tracked_state = state
+            .epoch_resource_tracker()
+            .get_resource_state(template_id)
+            .expect("first generation should store resource state for template id");
         assert_eq!(
-            tracked_da.logs().len(),
+            tracked_state.da().logs().len(),
             0,
             "empty mempool generation should store zero DA logs"
         );
@@ -493,8 +493,8 @@ mod tests {
         let first_template_id = first.get_blockid();
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(first_template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(first_template_id)
                 .is_some(),
             "first generation should store accumulated DA entry"
         );
@@ -520,15 +520,15 @@ mod tests {
         );
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(first_template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(first_template_id)
                 .is_none(),
             "same-parent replacement should evict old DA tracker entry"
         );
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(second_template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(second_template_id)
                 .is_some(),
             "new template should retain DA tracker entry"
         );
@@ -546,8 +546,8 @@ mod tests {
             .insert_template(stale_template_id, stale_template)
             .expect("stale test template insert should succeed");
         state
-            .epoch_da_tracker_mut()
-            .set_accumulated_da(stale_template_id, AccumulatedDaData::new_empty());
+            .epoch_resource_tracker_mut()
+            .set_resource_state(stale_template_id, EpochResourceState::new_empty());
         state
             .state_mut()
             .set_template_created_at_for_test(
@@ -570,8 +570,8 @@ mod tests {
         );
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(stale_template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(stale_template_id)
                 .is_none(),
             "insert-time cleanup should evict stale DA tracker entry"
         );
@@ -732,8 +732,8 @@ mod tests {
         assert_eq!(cached_template.get_blockid(), template_id);
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(template_id)
                 .is_some(),
             "completion should not evict DA tracker entry before storage succeeds"
         );
@@ -749,8 +749,8 @@ mod tests {
         );
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(template_id)
                 .is_none(),
             "successful completion should evict DA tracker entry"
         );
@@ -803,8 +803,8 @@ mod tests {
         );
         assert!(
             state
-                .epoch_da_tracker()
-                .get_accumulated_da(template_id)
+                .epoch_resource_tracker()
+                .get_resource_state(template_id)
                 .is_none(),
             "recording persisted block should evict DA tracker entry"
         );

--- a/crates/ol/block-assembly/src/service.rs
+++ b/crates/ol/block-assembly/src/service.rs
@@ -285,19 +285,20 @@ mod tests {
     use crate::{
         command::create_completion,
         da_tracker::AccumulatedDaData,
-        epoch_sealing::FixedSlotSealing,
+        epoch_sealing::{FixedSlotSealing, LimitAwareSealing},
         state::BlockasmServiceState,
         test_utils::{
             MempoolSnarkTxBuilder, MockMempoolFailMode, MockMempoolProvider,
-            TEST_BLOCK_TEMPLATE_TTL, TestAccount, TestEnv, TestStorageFixtureBuilder,
-            create_test_template, create_test_template_with_parent, test_account_id,
+            TEST_BLOCK_TEMPLATE_TTL, TEST_SLOTS_PER_EPOCH, TestAccount, TestEnv,
+            TestStorageFixtureBuilder, create_test_template, create_test_template_with_parent,
+            test_account_id,
         },
         types::BlockCompletionData,
     };
 
     type TestServiceState = BlockasmServiceState<
         Arc<MockMempoolProvider>,
-        FixedSlotSealing,
+        LimitAwareSealing<FixedSlotSealing>,
         OLStateManagerProviderImpl,
     >;
 
@@ -331,7 +332,7 @@ mod tests {
             env.sequencer_config().clone(),
             sequencer_predicate,
             env.ctx_arc(),
-            env.epoch_sealing_policy().clone(),
+            LimitAwareSealing::new(FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH)),
         );
 
         (state, mempool, env, signing_key)

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -19,8 +19,8 @@ use tracing::warn;
 use crate::{
     BlockAssemblyAnchorContext, BlockAssemblyStateAccess, EpochSealingPolicy, MempoolProvider,
     context::BlockAssemblyContext,
-    da_tracker::{AccumulatedDaData, EpochDaTracker, rebuild_accumulated_da_upto},
     error::BlockAssemblyError,
+    resource_state::{EpochResourceState, EpochResourceTracker, rebuild_epoch_resource_state_upto},
     types::FullBlockTemplate,
 };
 
@@ -287,7 +287,7 @@ pub(crate) struct BlockasmServiceState<M: MempoolProvider, E: EpochSealingPolicy
     ctx: Arc<BlockAssemblyContext<M, S>>,
     epoch_sealing_policy: E,
     state: BlockAssemblyState,
-    epoch_da_tracker: EpochDaTracker,
+    epoch_resource_tracker: EpochResourceTracker,
 }
 
 impl<M: MempoolProvider, E: EpochSealingPolicy, S> Debug for BlockasmServiceState<M, E, S> {
@@ -322,7 +322,7 @@ impl<M: MempoolProvider, E: EpochSealingPolicy, S> BlockasmServiceState<M, E, S>
             ctx,
             epoch_sealing_policy,
             state: BlockAssemblyState::new(ttl),
-            epoch_da_tracker: EpochDaTracker::new_empty(),
+            epoch_resource_tracker: EpochResourceTracker::new_empty(),
         }
     }
 
@@ -350,12 +350,12 @@ impl<M: MempoolProvider, E: EpochSealingPolicy, S> BlockasmServiceState<M, E, S>
         &mut self.state
     }
 
-    pub(crate) fn epoch_da_tracker(&self) -> &EpochDaTracker {
-        &self.epoch_da_tracker
+    pub(crate) fn epoch_resource_tracker(&self) -> &EpochResourceTracker {
+        &self.epoch_resource_tracker
     }
 
-    pub(crate) fn epoch_da_tracker_mut(&mut self) -> &mut EpochDaTracker {
-        &mut self.epoch_da_tracker
+    pub(crate) fn epoch_resource_tracker_mut(&mut self) -> &mut EpochResourceTracker {
+        &mut self.epoch_resource_tracker
     }
 }
 
@@ -368,12 +368,14 @@ where
     <<S::State as IStateAccessorMut>::AccountStateMut as IAccountStateMut>::SnarkAccountStateMut:
         Clone,
 {
-    /// Resolves accumulated DA upto a block: returns cached data, rebuilds by re-executing epoch
-    /// blocks, or creates fresh data if parent is terminal.
-    pub(crate) async fn fetch_epoch_da_until_parent(
+    /// Resolves epoch resource state up to a block.
+    ///
+    /// Returns cached state, rebuilds by re-executing epoch blocks, or creates
+    /// fresh state if the parent is terminal.
+    pub(crate) async fn fetch_epoch_resource_state_until_parent(
         &self,
         parent_blkid: OLBlockCommitment,
-    ) -> Result<AccumulatedDaData, BlockAssemblyError> {
+    ) -> Result<EpochResourceState, BlockAssemblyError> {
         let parent_blk = self
             .context()
             .fetch_ol_block(parent_blkid.blkid)
@@ -384,17 +386,17 @@ where
 
         // If parent block is terminal then we are in the new epoch and thus start afresh.
         if parent_header.is_terminal() {
-            Ok(AccumulatedDaData::new_empty())
+            Ok(EpochResourceState::new_empty())
         } else {
-            // Parent is not terminal, so we try to fetch accumulated da for the epoch.
+            // Parent is not terminal, so we try to fetch resource state for the epoch.
             let cur_epoch = parent_header.epoch();
             match self
-                .epoch_da_tracker()
-                .get_accumulated_da(parent_blkid.blkid)
+                .epoch_resource_tracker()
+                .get_resource_state(parent_blkid.blkid)
             {
-                Some(da) => Ok(da.clone()),
+                Some(resource_state) => Ok(resource_state.clone()),
                 None => {
-                    rebuild_accumulated_da_upto(
+                    rebuild_epoch_resource_state_upto(
                         parent_blkid,
                         cur_epoch,
                         *self.ol_params().bridge_params(),
@@ -430,7 +432,7 @@ mod tests {
     use crate::{
         FixedSlotSealing, LimitAwareSealing,
         block_assembly::generate_block_template_inner,
-        da_tracker::AccumulatedDaData,
+        resource_state::{AccumulatedDaData, EpochResourceState},
         test_utils::{
             MockMempoolProvider, TEST_BLOCK_TEMPLATE_TTL, TEST_SLOTS_PER_EPOCH, TestEnv,
             TestStorageFixtureBuilder, create_test_template, create_test_template_with_parent,
@@ -449,6 +451,10 @@ mod tests {
             EpochDaAccumulator::default(),
             vec![OLLog::new(AccountSerial::from(4242_u32), vec![1, 2, 3])],
         )
+    }
+
+    fn sample_resource_state() -> EpochResourceState {
+        EpochResourceState::new(sample_accumulated_da(), 0)
     }
 
     fn create_test_template_with_parent_and_slot(
@@ -821,13 +827,13 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_fetch_da_terminal_parent_empty() {
+    async fn test_fetch_resource_state_terminal_parent_empty() {
         let (mut state, env) = build_service_state_with_env(0).await;
 
-        // Even if tracker has an entry, terminal-parent path must return fresh empty DA.
+        // Even if the tracker has an entry, the terminal-parent path must return fresh empty state.
         state
-            .epoch_da_tracker_mut()
-            .set_accumulated_da(*env.parent_commitment().blkid(), sample_accumulated_da());
+            .epoch_resource_tracker_mut()
+            .set_resource_state(*env.parent_commitment().blkid(), sample_resource_state());
 
         let parent_block = state
             .context()
@@ -840,18 +846,23 @@ mod tests {
             "test setup requires terminal parent"
         );
 
-        let da = state
-            .fetch_epoch_da_until_parent(env.parent_commitment())
+        let resource_state = state
+            .fetch_epoch_resource_state_until_parent(env.parent_commitment())
             .await
-            .expect("terminal parent should return empty DA");
+            .expect("terminal parent should return empty state");
         assert!(
-            da.logs().is_empty(),
+            resource_state.da().logs().is_empty(),
             "terminal-parent path must reset accumulated DA"
+        );
+        assert_eq!(
+            resource_state.manifest_count(),
+            0,
+            "terminal-parent path must reset manifest count"
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_fetch_da_cache_hit() {
+    async fn test_fetch_resource_state_cache_hit() {
         let (mut state, env) = build_service_state_with_env(1).await;
 
         let parent_block = state
@@ -865,25 +876,30 @@ mod tests {
             "test setup requires non-terminal parent"
         );
 
-        let cached_da = sample_accumulated_da();
-        let expected_logs = cached_da.logs().to_vec();
+        let cached_state = EpochResourceState::new(sample_accumulated_da(), 7);
+        let expected_logs = cached_state.da().logs().to_vec();
         state
-            .epoch_da_tracker_mut()
-            .set_accumulated_da(*env.parent_commitment().blkid(), cached_da);
+            .epoch_resource_tracker_mut()
+            .set_resource_state(*env.parent_commitment().blkid(), cached_state);
 
-        let da = state
-            .fetch_epoch_da_until_parent(env.parent_commitment())
+        let resource_state = state
+            .fetch_epoch_resource_state_until_parent(env.parent_commitment())
             .await
             .expect("cache-hit path should succeed");
         assert_eq!(
-            da.logs(),
+            resource_state.da().logs(),
             expected_logs.as_slice(),
             "cache-hit path should return tracker data without rebuild"
+        );
+        assert_eq!(
+            resource_state.manifest_count(),
+            7,
+            "cache-hit path should preserve cached manifest count"
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_fetch_da_cache_miss_rebuild() {
+    async fn test_fetch_resource_state_cache_miss_rebuild() {
         let (state, env) = build_service_state_with_env(0).await;
 
         let config = BlockGenerationConfig::new(env.parent_commitment());
@@ -892,7 +908,7 @@ mod tests {
             env.epoch_sealing_policy(),
             env.sequencer_config(),
             config,
-            AccumulatedDaData::new_empty(),
+            EpochResourceState::new_empty(),
             *state.ol_params().bridge_params(),
         )
         .await
@@ -912,18 +928,18 @@ mod tests {
         let child_block = OLBlock::new(signed_header, child_template.body().clone());
         env.put_block(child_block).await;
 
-        let da = state
-            .fetch_epoch_da_until_parent(child_commitment)
+        let resource_state = state
+            .fetch_epoch_resource_state_until_parent(child_commitment)
             .await
             .expect("cache-miss rebuild should succeed");
         assert!(
-            da.logs().is_empty(),
+            resource_state.da().logs().is_empty(),
             "empty-child rebuild should produce empty logs"
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_fetch_da_missing_parent_not_found() {
+    async fn test_fetch_resource_state_missing_parent_not_found() {
         let (state, env) = build_service_state_with_env(0).await;
         let missing = OLBlockCommitment::new(
             env.parent_commitment().slot() + 100,
@@ -931,7 +947,7 @@ mod tests {
         );
 
         let err = state
-            .fetch_epoch_da_until_parent(missing)
+            .fetch_epoch_resource_state_until_parent(missing)
             .await
             .expect_err("missing parent should fail");
         assert!(

--- a/crates/ol/block-assembly/src/state.rs
+++ b/crates/ol/block-assembly/src/state.rs
@@ -428,19 +428,19 @@ mod tests {
 
     use super::*;
     use crate::{
-        FixedSlotSealing,
+        FixedSlotSealing, LimitAwareSealing,
         block_assembly::generate_block_template_inner,
         da_tracker::AccumulatedDaData,
         test_utils::{
-            MockMempoolProvider, TEST_BLOCK_TEMPLATE_TTL, TestEnv, TestStorageFixtureBuilder,
-            create_test_template, create_test_template_with_parent,
+            MockMempoolProvider, TEST_BLOCK_TEMPLATE_TTL, TEST_SLOTS_PER_EPOCH, TestEnv,
+            TestStorageFixtureBuilder, create_test_template, create_test_template_with_parent,
         },
         types::BlockGenerationConfig,
     };
 
     type TestServiceState = BlockasmServiceState<
         Arc<MockMempoolProvider>,
-        FixedSlotSealing,
+        LimitAwareSealing<FixedSlotSealing>,
         OLStateManagerProviderImpl,
     >;
 
@@ -484,7 +484,7 @@ mod tests {
             env.sequencer_config().clone(),
             PredicateKey::always_accept(),
             env.ctx_arc(),
-            env.epoch_sealing_policy().clone(),
+            LimitAwareSealing::new(FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH)),
         );
 
         (state, env)

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -71,7 +71,7 @@ pub(crate) fn create_test_genesis_state() -> MemoryStateBaseLayer {
 }
 
 use crate::{
-    BlockAssemblyResult, FixedSlotSealing, MempoolProvider,
+    BlockAssemblyResult, FixedSlotSealing, LimitAwareSealing, MempoolProvider,
     block_assembly::{
         ConstructBlockOutput, calculate_block_slot_and_epoch, construct_block,
         generate_block_template_inner,
@@ -80,6 +80,8 @@ use crate::{
     da_tracker::AccumulatedDaData,
     types::{BlockGenerationConfig, BlockTemplateResult, FullBlockTemplate},
 };
+
+type TestEpochSealingPolicy = LimitAwareSealing<FixedSlotSealing>;
 
 /// Creates a test account ID with the given seed byte.
 pub(crate) fn test_account_id(id: u8) -> AccountId {
@@ -893,7 +895,7 @@ pub(crate) struct TestEnv {
     ctx: Arc<BlockAssemblyContextImpl>,
     mempool: Arc<MockMempoolProvider>,
     sequencer_config: SequencerConfig,
-    epoch_sealing_policy: FixedSlotSealing,
+    epoch_sealing_policy: TestEpochSealingPolicy,
     parent_commitment: OLBlockCommitment,
 }
 
@@ -910,7 +912,9 @@ impl TestEnv {
             ctx: Arc::new(ctx),
             mempool,
             sequencer_config: SequencerConfig::default(),
-            epoch_sealing_policy: FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH),
+            epoch_sealing_policy: LimitAwareSealing::new(FixedSlotSealing::new(
+                TEST_SLOTS_PER_EPOCH,
+            )),
             parent_commitment,
         }
     }
@@ -995,7 +999,7 @@ impl TestEnv {
     }
 
     /// Returns epoch sealing policy.
-    pub(crate) fn epoch_sealing_policy(&self) -> &FixedSlotSealing {
+    pub(crate) fn epoch_sealing_policy(&self) -> &TestEpochSealingPolicy {
         &self.epoch_sealing_policy
     }
 
@@ -1526,7 +1530,7 @@ pub(crate) fn seeded_da(n: usize) -> AccumulatedDaData {
 /// Assembles a block for `config` using tx list and parent DA snapshot.
 pub(crate) async fn assemble_block_with_txs(
     ctx: &BlockAssemblyContextImpl,
-    epoch_sealing_policy: &FixedSlotSealing,
+    epoch_sealing_policy: &TestEpochSealingPolicy,
     config: &BlockGenerationConfig,
     txs: Vec<(OLTxId, OLTransaction)>,
     parent_da: AccumulatedDaData,

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -29,7 +29,7 @@ use strata_acct_types::{
 use strata_asm_common::{
     AnchorState, AsmHistoryAccumulatorState, ChainViewState, HeaderVerificationState,
 };
-use strata_asm_manifest_types::AsmManifest;
+use strata_asm_manifest_types::{AsmLogEntry, AsmManifest};
 use strata_btc_verification::L1Anchor;
 use strata_codec::encode_to_vec;
 use strata_config::SequencerConfig;
@@ -77,7 +77,7 @@ use crate::{
         generate_block_template_inner,
     },
     context::{BlockAssemblyAnchorContext, BlockAssemblyContext},
-    da_tracker::AccumulatedDaData,
+    resource_state::{AccumulatedDaData, EpochResourceState},
     types::{BlockGenerationConfig, BlockTemplateResult, FullBlockTemplate},
 };
 
@@ -735,23 +735,43 @@ pub(crate) async fn setup_asm_state_with_l1_manifests(
     start: L1Height,
     end: L1Height,
 ) -> L1BlockCommitment {
-    // Create and store ASM manifests
-    let mut last_blkid = L1BlockId::from(Buf32::zero());
-    for height in start..=end {
-        // Generate deterministic but unique block ID for each height
-        let mut block_bytes = [0u8; 32];
-        block_bytes[0] = height as u8;
-        block_bytes[1] = (height >> 8) as u8;
-        last_blkid = L1BlockId::from(Buf32::from(block_bytes));
+    let manifests = (start..=end)
+        .map(|height| create_l1_manifest_with_logs(height, vec![]))
+        .collect();
 
-        let manifest = AsmManifest::new(
-            height,
-            last_blkid,
-            WtxidsRoot::from(Buf32::from([0u8; 32])),
-            vec![],
-        )
-        .expect("test manifest should be valid");
+    setup_asm_state_with_l1_manifests_list(storage, manifests).await
+}
 
+/// Creates a deterministic test L1 ASM manifest carrying `logs`.
+pub(crate) fn create_l1_manifest_with_logs(
+    height: L1Height,
+    logs: Vec<AsmLogEntry>,
+) -> AsmManifest {
+    // Generate deterministic but unique block ID for each height.
+    let mut block_bytes = [0u8; 32];
+    block_bytes[0] = height as u8;
+    block_bytes[1] = (height >> 8) as u8;
+    let blkid = L1BlockId::from(Buf32::from(block_bytes));
+
+    AsmManifest::new(
+        height,
+        blkid,
+        WtxidsRoot::from(Buf32::from([0u8; 32])),
+        logs,
+    )
+    .expect("test manifest should be valid")
+}
+
+async fn setup_asm_state_with_l1_manifests_list(
+    storage: &NodeStorage,
+    manifests: Vec<AsmManifest>,
+) -> L1BlockCommitment {
+    let last_manifest = manifests
+        .last()
+        .expect("test must seed at least one L1 manifest");
+    let l1_commitment = L1BlockCommitment::new(last_manifest.height(), *last_manifest.blkid());
+
+    for manifest in manifests {
         storage
             .l1()
             .put_block_data_async(manifest.clone())
@@ -759,13 +779,10 @@ pub(crate) async fn setup_asm_state_with_l1_manifests(
             .expect("Failed to store L1 manifest");
         storage
             .l1()
-            .extend_canonical_chain_async(manifest.blkid(), height)
+            .extend_canonical_chain_async(manifest.blkid(), manifest.height())
             .await
             .expect("Failed to extend L1 canonical chain");
     }
-
-    // Store ASM state at the highest L1 block
-    let l1_commitment = L1BlockCommitment::new(end, last_blkid);
 
     // Create minimal ASM state for testing
     let pow_state = HeaderVerificationState::init(L1Anchor {
@@ -1008,17 +1025,18 @@ impl TestEnv {
         BlockGenerationConfig::new(self.parent_commitment())
     }
 
-    /// Generates block template from mempool using current parent commitment and empty parent DA.
+    /// Generates block template from mempool using current parent commitment and empty epoch
+    /// resource state.
     pub(crate) async fn generate_block_template(&self) -> BlockAssemblyResult<BlockTemplateResult> {
-        self.generate_block_template_with_da(AccumulatedDaData::new_empty())
+        self.generate_block_template_with_resource_state(EpochResourceState::new_empty())
             .await
     }
 
-    /// Generates block template from mempool using current parent commitment and explicit parent
-    /// DA.
-    pub(crate) async fn generate_block_template_with_da(
+    /// Generates block template from mempool using current parent commitment and explicit epoch
+    /// resource state before the candidate block.
+    pub(crate) async fn generate_block_template_with_resource_state(
         &self,
-        parent_da: AccumulatedDaData,
+        resource_state_before_block: EpochResourceState,
     ) -> BlockAssemblyResult<BlockTemplateResult> {
         let config = self.parent_config();
         generate_block_template_inner(
@@ -1026,23 +1044,23 @@ impl TestEnv {
             self.epoch_sealing_policy(),
             self.sequencer_config(),
             config,
-            parent_da,
+            resource_state_before_block,
             BridgeParams::default(),
         )
         .await
     }
 
     /// Constructs a block directly from explicit txs using current parent commitment and empty
-    /// parent DA.
+    /// epoch resource state.
     pub(crate) async fn construct_block(
         &self,
         txs: impl IntoIterator<Item = (OLTxId, OLTransaction)>,
     ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
-        self.construct_block_with_da(txs, AccumulatedDaData::new_empty())
+        self.construct_block_with_resource_state(txs, EpochResourceState::new_empty())
             .await
     }
 
-    /// Constructs an empty block using current parent commitment and empty parent DA.
+    /// Constructs an empty block using current parent commitment and empty epoch resource state.
     pub(crate) async fn construct_empty_block(
         &self,
     ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
@@ -1050,20 +1068,52 @@ impl TestEnv {
             .await
     }
 
-    /// Constructs an empty block using current parent commitment and explicit parent DA.
+    /// Constructs an empty block using current parent commitment and explicit epoch DA before the
+    /// candidate block.
     pub(crate) async fn construct_empty_block_with_da(
         &self,
-        parent_da: AccumulatedDaData,
+        epoch_cumulative_da: AccumulatedDaData,
     ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
-        self.construct_block_with_da(iter::empty::<(OLTxId, OLTransaction)>(), parent_da)
-            .await
+        self.construct_empty_block_with_resource_state(EpochResourceState::new(
+            epoch_cumulative_da,
+            0,
+        ))
+        .await
     }
 
-    /// Constructs a block directly from explicit txs and parent DA using current parent commitment.
+    /// Constructs a block directly from explicit txs and epoch DA before the candidate block using
+    /// current parent commitment.
     pub(crate) async fn construct_block_with_da(
         &self,
         txs: impl IntoIterator<Item = (OLTxId, OLTransaction)>,
-        parent_da: AccumulatedDaData,
+        epoch_cumulative_da: AccumulatedDaData,
+    ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
+        self.construct_block_with_resource_state(
+            txs,
+            EpochResourceState::new(epoch_cumulative_da, 0),
+        )
+        .await
+    }
+
+    /// Constructs an empty block using current parent commitment and explicit epoch resource
+    /// state before the candidate block.
+    pub(crate) async fn construct_empty_block_with_resource_state(
+        &self,
+        resource_state_before_block: EpochResourceState,
+    ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
+        self.construct_block_with_resource_state(
+            iter::empty::<(OLTxId, OLTransaction)>(),
+            resource_state_before_block,
+        )
+        .await
+    }
+
+    /// Constructs a block directly from explicit txs and epoch resource state before the
+    /// candidate block.
+    pub(crate) async fn construct_block_with_resource_state(
+        &self,
+        txs: impl IntoIterator<Item = (OLTxId, OLTransaction)>,
+        resource_state_before_block: EpochResourceState,
     ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
         let config = self.parent_config();
         assemble_block_with_txs(
@@ -1071,7 +1121,7 @@ impl TestEnv {
             self.epoch_sealing_policy(),
             &config,
             txs.into_iter().collect(),
-            parent_da,
+            resource_state_before_block,
         )
         .await
     }
@@ -1503,7 +1553,8 @@ pub(crate) fn extract_withdrawal_intents(
     Result<SimpleWithdrawalIntentLogData, LogDecodeError>,
 )> {
     output
-        .accumulated_da
+        .resource_state
+        .da()
         .logs()
         .iter()
         .filter_map(|log| {
@@ -1527,13 +1578,14 @@ pub(crate) fn seeded_da(n: usize) -> AccumulatedDaData {
 
 // ===== Assembly Pipeline Helper =====
 
-/// Assembles a block for `config` using tx list and parent DA snapshot.
+/// Assembles a block for `config` using tx list and epoch resource state before the candidate
+/// block.
 pub(crate) async fn assemble_block_with_txs(
     ctx: &BlockAssemblyContextImpl,
     epoch_sealing_policy: &TestEpochSealingPolicy,
     config: &BlockGenerationConfig,
     txs: Vec<(OLTxId, OLTransaction)>,
-    parent_da: AccumulatedDaData,
+    resource_state_before_block: EpochResourceState,
 ) -> BlockAssemblyResult<ConstructBlockOutput<MemoryStateBaseLayer>> {
     let parent_state = ctx
         .fetch_state_for_tip(config.parent_block_commitment())
@@ -1551,7 +1603,7 @@ pub(crate) async fn assemble_block_with_txs(
         block_slot,
         block_epoch,
         txs,
-        parent_da,
+        resource_state_before_block,
         BridgeParams::default(),
     )
     .await

--- a/crates/ol/block-assembly/src/tests/da.rs
+++ b/crates/ol/block-assembly/src/tests/da.rs
@@ -15,7 +15,7 @@ use strata_ol_stf::execute_block_batch_predrain;
 
 use crate::{
     context::BlockAssemblyAnchorContext,
-    da_tracker::{AccumulatedDaData, rebuild_accumulated_da_upto},
+    resource_state::{AccumulatedDaData, EpochResourceState, rebuild_epoch_resource_state_upto},
     test_utils::{
         DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
         TestStorageFixtureBuilder, block_and_post_state_from_output, generate_message_entries,
@@ -32,18 +32,20 @@ fn finalize_da_to_bytes(accumulator: EpochDaAccumulator, state: MemoryStateBaseL
         .expect("should produce a blob")
 }
 
-/// Builds blocks from the env parent commitment up to (not including) `target_slot`, threading DA.
-/// Returns `(final_commitment, accumulated_da, Vec<(block, post_state)>)`.
-async fn build_blocks_with_da_and_artifacts(
+/// Builds blocks from the env parent commitment up to (not including) `target_slot`, threading
+/// resource state.
+///
+/// Returns `(final_commitment, resource_state, Vec<(block, post_state)>)`.
+async fn build_blocks_with_resource_state_and_artifacts(
     env: &mut TestEnv,
     target_slot: u64,
 ) -> (
     OLBlockCommitment,
-    AccumulatedDaData,
+    EpochResourceState,
     Vec<(OLBlock, MemoryStateBaseLayer)>,
 ) {
     let mut current_commitment = env.parent_commitment();
-    let mut accumulated_da = AccumulatedDaData::new_empty();
+    let mut resource_state = EpochResourceState::new_empty();
     let mut artifacts = Vec::new();
 
     let start_slot = if current_commitment.is_null() {
@@ -54,18 +56,18 @@ async fn build_blocks_with_da_and_artifacts(
 
     for slot in start_slot..target_slot {
         let output = env
-            .construct_empty_block_with_da(accumulated_da)
+            .construct_empty_block_with_resource_state(resource_state)
             .await
             .unwrap_or_else(|e| panic!("Block construction at slot {slot} failed: {e:?}"));
         let (block, post_state) = block_and_post_state_from_output(&output);
         let new_commitment = env.persist(&output).await;
 
         artifacts.push((block, post_state));
-        accumulated_da = output.accumulated_da;
+        resource_state = output.resource_state;
         current_commitment = new_commitment;
     }
 
-    (current_commitment, accumulated_da, artifacts)
+    (current_commitment, resource_state, artifacts)
 }
 
 /// Core correctness: DA accumulated incrementally during block assembly must produce
@@ -80,14 +82,14 @@ async fn test_da_incremental_matches_replay() {
 
     // Build blocks 1..5, threading DA through each.
     let start_commitment = env.parent_commitment();
-    let (_final_commitment, incremental_da, artifacts) =
-        build_blocks_with_da_and_artifacts(&mut env, 5).await;
+    let (_final_commitment, block_assembled_state, artifacts) =
+        build_blocks_with_resource_state_and_artifacts(&mut env, 5).await;
 
     // Get the post-state of the last block for finalization.
     let (_, last_post_state) = artifacts.last().unwrap();
 
     // Finalize incremental accumulator to bytes.
-    let (incremental_acc, incremental_logs) = incremental_da.into_parts();
+    let (incremental_acc, incremental_logs) = block_assembled_state.da().clone().into_parts();
     let incremental_blob = finalize_da_to_bytes(incremental_acc, last_post_state.clone());
 
     // Replay: use DaAccumulatingState to re-execute all blocks.
@@ -150,11 +152,11 @@ async fn test_da_resets_at_epoch_boundary() {
     let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
     // Build blocks 1..10 (slots before the terminal block), threading DA.
-    let (pre_terminal_commitment, epoch1_da, _epoch1_artifacts) =
-        build_blocks_with_da_and_artifacts(&mut env, 10).await;
+    let (pre_terminal_commitment, epoch1_state, _epoch1_artifacts) =
+        build_blocks_with_resource_state_and_artifacts(&mut env, 10).await;
 
     // Epoch 1 DA accumulator should have slot changes from blocks 1-9.
-    let (epoch1_acc, _) = epoch1_da.clone().into_parts();
+    let (epoch1_acc, _) = epoch1_state.da().clone().into_parts();
     let epoch1_pre_terminal_state = env
         .ctx()
         .fetch_state_for_tip(pre_terminal_commitment)
@@ -166,7 +168,7 @@ async fn test_da_resets_at_epoch_boundary() {
 
     // Build terminal block (slot 10) with epoch 1 DA.
     let terminal_output = env
-        .construct_empty_block_with_da(epoch1_da)
+        .construct_empty_block_with_resource_state(epoch1_state)
         .await
         .expect("terminal block construction should succeed");
 
@@ -180,7 +182,7 @@ async fn test_da_resets_at_epoch_boundary() {
         .expect("epoch 2 block construction should succeed");
 
     // Epoch 2 DA should only contain slot 11's changes, not epoch 1's.
-    let (epoch2_acc, epoch2_logs) = epoch2_output.accumulated_da.into_parts();
+    let (epoch2_acc, epoch2_logs) = epoch2_output.resource_state.da().clone().into_parts();
     let epoch2_blob = finalize_da_to_bytes(epoch2_acc, epoch2_output.post_state);
 
     // The two blobs must differ: epoch 1 accumulated 9 slot changes, epoch 2 has 1.
@@ -252,10 +254,10 @@ async fn test_da_rollback_on_failed_tx() {
         .expect("valid-only block construction should succeed");
 
     // Finalize both DA accumulators and compare.
-    let (acc_both, _) = output_both.accumulated_da.into_parts();
+    let (acc_both, _) = output_both.resource_state.da().clone().into_parts();
     let blob_both = finalize_da_to_bytes(acc_both, output_both.post_state);
 
-    let (acc_valid, _) = output_valid_only.accumulated_da.into_parts();
+    let (acc_valid, _) = output_valid_only.resource_state.da().clone().into_parts();
     let blob_valid = finalize_da_to_bytes(acc_valid, output_valid_only.post_state);
 
     assert_eq!(
@@ -264,7 +266,7 @@ async fn test_da_rollback_on_failed_tx() {
     );
 }
 
-/// `rebuild_accumulated_da_upto` must produce the same DA as incremental accumulation.
+/// `rebuild_epoch_resource_state_upto` must produce the same DA as incremental accumulation.
 ///
 /// This exercises the `collect_epoch_blocks_until` -> `execute_block_batch` path,
 /// which previously had a bug where the first epoch block's header was passed as the
@@ -278,23 +280,27 @@ async fn test_rebuild_da_matches_incremental() {
     let mut env = TestEnv::from_fixture(fixture, parent_commitment);
 
     // Build blocks 1..5, threading DA incrementally.
-    let (final_commitment, incremental_da, artifacts) =
-        build_blocks_with_da_and_artifacts(&mut env, 5).await;
+    let (final_commitment, block_assembled_state, artifacts) =
+        build_blocks_with_resource_state_and_artifacts(&mut env, 5).await;
 
     let (_, last_post_state) = artifacts.last().unwrap();
 
     // Finalize incremental accumulator.
-    let (incremental_acc, incremental_logs) = incremental_da.into_parts();
+    let (incremental_acc, incremental_logs) = block_assembled_state.da().clone().into_parts();
     let incremental_blob = finalize_da_to_bytes(incremental_acc, last_post_state.clone());
 
     // Rebuild DA from scratch using the production code path.
     let epoch = artifacts[0].0.header().epoch();
-    let rebuilt_da =
-        rebuild_accumulated_da_upto(final_commitment, epoch, BridgeParams::default(), env.ctx())
-            .await
-            .expect("rebuild_accumulated_da_upto should succeed");
+    let rebuilt_state = rebuild_epoch_resource_state_upto(
+        final_commitment,
+        epoch,
+        BridgeParams::default(),
+        env.ctx(),
+    )
+    .await
+    .expect("rebuild_epoch_resource_state_upto should succeed");
 
-    let (rebuilt_acc, rebuilt_logs) = rebuilt_da.into_parts();
+    let (rebuilt_acc, rebuilt_logs) = rebuilt_state.da().clone().into_parts();
     let rebuilt_blob = finalize_da_to_bytes(rebuilt_acc, last_post_state.clone());
 
     assert_eq!(
@@ -304,5 +310,14 @@ async fn test_rebuild_da_matches_incremental() {
     assert_eq!(
         incremental_logs, rebuilt_logs,
         "Rebuilt logs must match incrementally accumulated logs"
+    );
+    assert_eq!(
+        block_assembled_state.manifest_count(),
+        rebuilt_state.manifest_count(),
+        "Rebuilt manifest count must match block-assembled manifest count"
+    );
+    assert!(
+        block_assembled_state.manifest_count() > 0,
+        "test fixture should exercise nonzero manifest-count rebuilding"
     );
 }

--- a/crates/ol/block-assembly/src/tests/effects.rs
+++ b/crates/ol/block-assembly/src/tests/effects.rs
@@ -7,7 +7,7 @@ use strata_ol_mempool::MempoolTxInvalidReason;
 use strata_ol_state_support_types::EpochDaAccumulator;
 
 use crate::{
-    da_tracker::AccumulatedDaData,
+    resource_state::AccumulatedDaData,
     test_utils::{
         DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
         TestStorageFixtureBuilder, account_balance, extract_withdrawal_intents, included_txids,
@@ -212,7 +212,7 @@ async fn test_hard_limit_rollback_discards_tx2_log() {
     );
 
     assert_eq!(
-        output.accumulated_da.logs().len(),
+        output.resource_state.da().logs().len(),
         seeded_count + 1,
         "only tx1's snark-update log should be appended; tx2 was rolled back"
     );

--- a/crates/ol/block-assembly/src/tests/mempool.rs
+++ b/crates/ol/block-assembly/src/tests/mempool.rs
@@ -8,7 +8,7 @@ use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
 use strata_ol_mempool::{MempoolTxInvalidReason, OLMempoolError};
 
 use crate::{
-    BlockAssemblyError, FixedSlotSealing,
+    BlockAssemblyError, FixedSlotSealing, LimitAwareSealing,
     block_assembly::generate_block_template_inner,
     context::BlockAssemblyContext,
     da_tracker::AccumulatedDaData,
@@ -61,7 +61,7 @@ async fn test_state_provider_failure_propagates() {
         1,
         OLBlockId::from(Buf32::from([7; 32])),
     ));
-    let epoch_sealing_policy = FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH);
+    let epoch_sealing_policy = LimitAwareSealing::new(FixedSlotSealing::new(TEST_SLOTS_PER_EPOCH));
     let sequencer_config = SequencerConfig::default();
 
     let err = generate_block_template_inner(

--- a/crates/ol/block-assembly/src/tests/mempool.rs
+++ b/crates/ol/block-assembly/src/tests/mempool.rs
@@ -11,7 +11,7 @@ use crate::{
     BlockAssemblyError, FixedSlotSealing, LimitAwareSealing,
     block_assembly::generate_block_template_inner,
     context::BlockAssemblyContext,
-    da_tracker::AccumulatedDaData,
+    resource_state::EpochResourceState,
     test_utils::{
         FailingStateProvider, MempoolSnarkTxBuilder, MockMempoolFailMode, MockMempoolProvider,
         TEST_SLOTS_PER_EPOCH, TestAccount, TestEnv, TestStorageFixtureBuilder, create_test_storage,
@@ -40,7 +40,7 @@ async fn test_missing_parent_fails() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -69,7 +69,7 @@ async fn test_state_provider_failure_propagates() {
         &epoch_sealing_policy,
         &sequencer_config,
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -93,7 +93,7 @@ async fn test_get_transactions_failure_propagates() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -133,7 +133,7 @@ async fn test_generation_stage_does_not_report_invalid_txs() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -166,7 +166,7 @@ async fn test_no_report_when_all_txs_valid() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -206,7 +206,7 @@ async fn test_exact_failed_txs_payload() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -255,7 +255,7 @@ async fn test_mixed_failures_keep_order_and_reason() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -298,7 +298,7 @@ async fn test_max_txs_returns_only_fetched_failures() {
         env.epoch_sealing_policy(),
         &sequencer_config,
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -335,7 +335,7 @@ async fn test_exec_failure_maps_to_failed() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -369,7 +369,7 @@ async fn test_duplicate_txid_one_fails() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await
@@ -406,7 +406,7 @@ async fn test_duplicate_txid_both_fail() {
         env.epoch_sealing_policy(),
         env.sequencer_config(),
         config,
-        AccumulatedDaData::new_empty(),
+        EpochResourceState::new_empty(),
         BridgeParams::default(),
     )
     .await

--- a/crates/ol/block-assembly/src/tests/messaging.rs
+++ b/crates/ol/block-assembly/src/tests/messaging.rs
@@ -75,7 +75,7 @@ async fn test_multi_sender_attribution() {
     );
 
     // Persist block 1 + post-state as parent for block 2.
-    let parent_da_2 = output_block1.accumulated_da.clone();
+    let resource_state_after_block1 = output_block1.resource_state.clone();
     let _current_commitment = env.persist(&output_block1).await;
 
     // Mirror expected entries into storage MMR for block-2 proof generation.
@@ -94,7 +94,10 @@ async fn test_multi_sender_attribution() {
     let tx_receiver_id = tx_receiver.compute_txid();
 
     let output_block2 = env
-        .construct_block_with_da(vec![(tx_receiver_id, tx_receiver)], parent_da_2)
+        .construct_block_with_resource_state(
+            vec![(tx_receiver_id, tx_receiver)],
+            resource_state_after_block1,
+        )
         .await
         .expect("block 2 should construct and process attributed messages");
     let included_block2 = included_txids(&output_block2.template);

--- a/crates/ol/block-assembly/src/types.rs
+++ b/crates/ol/block-assembly/src/types.rs
@@ -5,7 +5,7 @@ use strata_identifiers::{Buf64, OLBlockCommitment, OLBlockId, OLTxId};
 use strata_ol_chain_types_new::{OLBlock, OLBlockBody, OLBlockHeader, SignedOLBlockHeader};
 use strata_ol_mempool::MempoolTxInvalidReason;
 
-use crate::da_tracker::AccumulatedDaData;
+use crate::resource_state::EpochResourceState;
 
 /// Represents a complete block template containing header and body.
 ///
@@ -149,7 +149,7 @@ pub(crate) type FailedMempoolTx = (OLTxId, MempoolTxInvalidReason);
 pub(crate) struct BlockTemplateResult {
     template: FullBlockTemplate,
     failed_txs: Vec<FailedMempoolTx>,
-    accumulated_da: AccumulatedDaData,
+    resource_state: EpochResourceState,
 }
 
 impl BlockTemplateResult {
@@ -157,12 +157,12 @@ impl BlockTemplateResult {
     pub(crate) fn new(
         template: FullBlockTemplate,
         failed_txs: Vec<FailedMempoolTx>,
-        accumulated_da: AccumulatedDaData,
+        resource_state: EpochResourceState,
     ) -> Self {
         Self {
             template,
             failed_txs,
-            accumulated_da,
+            resource_state,
         }
     }
 
@@ -179,7 +179,9 @@ impl BlockTemplateResult {
     }
 
     /// Consumes self and returns all components.
-    pub(crate) fn into_parts(self) -> (FullBlockTemplate, Vec<FailedMempoolTx>, AccumulatedDaData) {
-        (self.template, self.failed_txs, self.accumulated_da)
+    pub(crate) fn into_parts(
+        self,
+    ) -> (FullBlockTemplate, Vec<FailedMempoolTx>, EpochResourceState) {
+        (self.template, self.failed_txs, self.resource_state)
     }
 }

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -291,9 +291,7 @@ where
     }
 
     fn try_append_pending_asm_log(&mut self, entry: PendingAsmLog) -> StateResult<()> {
-        if self.pending_asm_logs_full() {
-            return Err(StateError::PendingAsmLogsFull);
-        }
+        ensure_pending_asm_log_slot_available(self.pending_asm_logs_len())?;
         self.batch
             .intraepoch_writes_mut()
             .appended_pending_asm_logs
@@ -341,6 +339,14 @@ where
             .create_account_from_data(id, new_acct_data, serial);
         Ok(serial)
     }
+}
+
+fn ensure_pending_asm_log_slot_available(current_len: usize) -> StateResult<()> {
+    if current_len as u64 >= MAX_PENDING_ASM_LOGS {
+        return Err(StateError::PendingAsmLogsFull);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -753,26 +759,9 @@ mod tests {
     fn test_append_returns_full_at_capacity() {
         use strata_ol_state_types::MAX_PENDING_ASM_LOGS;
 
-        let base = create_test_base_layer();
-        let diff = BatchDiffState::new(&base, &[]);
-        let mut tracking = WriteTrackingState::new_empty(&diff);
-
-        // Pre-load batch up to MAX-1 to keep the test cheap; the capacity check
-        // doesn't depend on actually pushing MAX entries since we manipulate the
-        // batch state directly.
-        for i in 0..(MAX_PENDING_ASM_LOGS - 1) {
-            tracking
-                .try_append_pending_asm_log(pending_log((i & 0xff) as u8))
-                .expect("append within capacity");
-        }
-        assert!(!tracking.pending_asm_logs_full());
-
-        tracking
-            .try_append_pending_asm_log(pending_log(0))
-            .expect("final slot");
-        assert!(tracking.pending_asm_logs_full());
-
-        let overflow = tracking.try_append_pending_asm_log(pending_log(0));
+        ensure_pending_asm_log_slot_available(MAX_PENDING_ASM_LOGS as usize - 1)
+            .expect("one slot remains");
+        let overflow = ensure_pending_asm_log_slot_available(MAX_PENDING_ASM_LOGS as usize);
         assert!(matches!(overflow, Err(StateError::PendingAsmLogsFull)));
     }
 }

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -159,13 +159,7 @@ impl OLState {
             self.intraepoch.pending_asm_logs().len() as u64
         };
         let appended_logs = intraepoch_writes.appended_pending_asm_logs.len() as u64;
-        if starting_logs + appended_logs > MAX_PENDING_ASM_LOGS {
-            return Err(StateError::PendingAsmLogsOverflow {
-                current: starting_logs,
-                adding: appended_logs,
-                max: MAX_PENDING_ASM_LOGS,
-            });
-        }
+        ensure_pending_asm_logs_fit(starting_logs, appended_logs)?;
 
         Ok(())
     }
@@ -306,6 +300,18 @@ impl OLState {
             .map(|_| ())
             .ok_or(StateError::MissingAccount(*id))
     }
+}
+
+fn ensure_pending_asm_logs_fit(current: u64, adding: u64) -> StateResult<()> {
+    if current.saturating_add(adding) > MAX_PENDING_ASM_LOGS {
+        return Err(StateError::PendingAsmLogsOverflow {
+            current,
+            adding,
+            max: MAX_PENDING_ASM_LOGS,
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -467,26 +473,10 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_batch_pending_asm_logs_overflow_errors() {
-        use strata_asm_manifest_types::AsmLogEntry;
-        use strata_ledger_types::PendingAsmLog;
-
-        let mut state = create_test_genesis_state();
-
-        // Build a batch that appends one more pending ASM log than the buffer
-        // can hold. The fresh state starts with an empty buffer and we don't
-        // reset, so the appended count alone must exceed the cap.
+    fn test_pending_asm_logs_overflow_errors() {
         let overflow_count = MAX_PENDING_ASM_LOGS + 1;
-        let mut batch = WriteBatch::default();
-        let logs = &mut batch.intraepoch_writes_mut().appended_pending_asm_logs;
-        for _ in 0..overflow_count {
-            let entry = AsmLogEntry::from_raw(vec![]).expect("test: empty log entry");
-            logs.push(PendingAsmLog::new(0, entry));
-        }
 
-        // The safety check should reject this before any mutation happens.
-        let err = state
-            .apply_write_batch(batch)
+        let err = ensure_pending_asm_logs_fit(0, overflow_count)
             .expect_err("test: expected pending ASM logs overflow");
         assert!(matches!(
             err,

--- a/crates/ol/state-types/ssz/state.ssz
+++ b/crates/ol/state-types/ssz/state.ssz
@@ -6,7 +6,10 @@ import strata_snark_acct_types
 
 MAX_LEDGER_ACCOUNTS = 1 << 24
 MAX_ACCOUNT_SERIALS = 1 << 24
-MAX_PENDING_ASM_LOGS = 1 << 16
+
+### Buffers one full epoch's manifest budget under the expected heavy-manifest case:
+### 2048 ASM manifests with up to 128 logs each, i.e. 2048 * 128 = 1 << 18 pending logs.
+MAX_PENDING_ASM_LOGS = 1 << 18
 
 ### Top-level OL state
 class OLState(Container):

--- a/crates/ol/stf/src/tests/asm_manifests.rs
+++ b/crates/ol/stf/src/tests/asm_manifests.rs
@@ -4,14 +4,21 @@ use strata_acct_types::{AccountSerial, BitcoinAmount};
 use strata_asm_common::AsmLogEntry;
 use strata_asm_logs::{CheckpointTipUpdate, constants::AsmLogTypeId};
 use strata_asm_proto_checkpoint_types::CheckpointTip;
+use strata_bridge_params::BridgeParams;
+use strata_codec::decode_buf_exact;
 use strata_identifiers::{
     Buf32, EpochCommitment, L1Height, OLBlockCommitment, OLBlockId, SubjectId,
 };
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_msg_fmt::MAX_TYPE;
 use strata_ol_chain_types_new::MAX_SEALING_MANIFEST_COUNT;
+use strata_ol_da::OLDaPayloadV1;
+use strata_ol_state_support_types::DaAccumulatingState;
 
-use crate::{assembly::BlockComponents, context::BlockInfo, errors::ExecError, test_utils::*};
+use crate::{
+    assembly::BlockComponents, context::BlockInfo, errors::ExecError, execute_block_batch_predrain,
+    test_utils::*,
+};
 
 const GENESIS_MANIFEST_SENTINEL_COUNT: u64 = 1;
 
@@ -175,6 +182,95 @@ fn test_manifest_processing_skips_unknown_serial_deposit() {
     assert_eq!(account_state.inbox_mmr().num_entries(), 0);
     assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(100_000_000));
     assert_eq!(state.last_l1_height(), 1);
+}
+
+#[test]
+fn test_deposit_terminal_drain_has_no_logs_or_predrain_effects() {
+    let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
+    let deposit_amount = BitcoinAmount::from_sat(100_000_000);
+    let mut fixture = OLStfFixture::builder()
+        .with_genesis_snark_account(snark_acct_id, |acct| {
+            acct.with_balance(BitcoinAmount::zero())
+        })
+        .execute_genesis();
+    let snark_serial = fixture.account_serial(snark_acct_id);
+    let parent_state = fixture.state().clone();
+    let parent_header = fixture.parent_header().clone();
+
+    let output = fixture
+        .child_block()
+        .terminal()
+        .with_manifest(make_deposit_manifest_for_account(
+            1,
+            1,
+            snark_serial,
+            SubjectId::from([42u8; 32]),
+            deposit_amount,
+        ))
+        .execute_with_outputs();
+
+    assert_eq!(
+        output.log_count(),
+        0,
+        "ASM deposit terminal drain must not emit OL logs"
+    );
+    assert_eq!(fixture.account_balance(snark_acct_id), deposit_amount);
+
+    let mut predrain_state = DaAccumulatingState::new(parent_state);
+    let predrain_logs = execute_block_batch_predrain(
+        &mut predrain_state,
+        &[to_ol_block(output.completed_block())],
+        &parent_header,
+        BridgeParams::default(),
+    )
+    .expect("pre-drain checkpoint replay should succeed");
+    assert_eq!(
+        predrain_logs.len(),
+        0,
+        "checkpoint pre-drain replay must not include ASM drain logs"
+    );
+    let da_blob = predrain_state
+        .take_completed_epoch_da_blob()
+        .expect("checkpoint DA finalization should succeed")
+        .expect("checkpoint DA blob should encode");
+    let da_payload: OLDaPayloadV1 =
+        decode_buf_exact(&da_blob).expect("checkpoint DA payload should decode");
+    assert!(
+        da_payload
+            .state_diff
+            .ledger
+            .account_diffs
+            .entries()
+            .is_empty(),
+        "checkpoint pre-drain DA must not include ASM drain account diffs"
+    );
+    assert!(
+        da_payload
+            .state_diff
+            .ledger
+            .new_accounts
+            .entries()
+            .is_empty(),
+        "checkpoint pre-drain DA must not include ASM drain account creations"
+    );
+    let predrain_account = predrain_state
+        .inner()
+        .get_account_state(snark_acct_id)
+        .expect("account lookup should succeed")
+        .expect("snark account should exist");
+    assert_eq!(
+        predrain_account.balance(),
+        BitcoinAmount::zero(),
+        "checkpoint pre-drain replay must not apply ASM drain state effects"
+    );
+    let predrain_snark_account = predrain_account
+        .as_snark_account()
+        .expect("account should be a snark account");
+    assert_eq!(
+        predrain_snark_account.inbox_mmr().num_entries(),
+        0,
+        "checkpoint pre-drain replay must not apply ASM drain inbox effects"
+    );
 }
 
 #[test]

--- a/functional-tests/tests/strata/helpers.py
+++ b/functional-tests/tests/strata/helpers.py
@@ -12,12 +12,13 @@ from envconfigs.strata import StrataEnvConfig
 logger = logging.getLogger(__name__)
 
 
-def assert_terminal_block_l1_update(
+def assert_terminal_epoch_l1_update(
     rpc: JsonRpcClient,
     target_slot: int,
-    min_l1_manifests_in_terminal_block: int,
+    slots_per_epoch: int,
+    min_l1_manifests_in_epoch: int,
 ) -> None:
-    """Asserts a canonical terminal block exposes the expected L1 update."""
+    """Asserts a canonical terminal epoch exposes the expected L1 update."""
 
     block = rpc.strata_getBlockBySlot(target_slot)
     assert block is not None, f"terminal slot {target_slot} is missing from canonical chain"
@@ -26,15 +27,23 @@ def assert_terminal_block_l1_update(
     assert header["slot"] == target_slot, f"unexpected terminal block header: {header}"
     assert header["is_terminal"] is True, f"slot {target_slot} is not terminal: {header}"
 
-    manifests = block.get("manifests")
-    assert manifests is not None, f"terminal slot {target_slot} has no manifests: {block}"
+    first_epoch_slot = target_slot - slots_per_epoch + 1
+    epoch_manifest_count = 0
+    for slot in range(first_epoch_slot, target_slot + 1):
+        epoch_block = rpc.strata_getBlockBySlot(slot)
+        assert epoch_block is not None, f"slot {slot} is missing from canonical chain"
 
-    manifest_count = manifests.get("manifest_count")
-    assert (
-        isinstance(manifest_count, int) and manifest_count >= min_l1_manifests_in_terminal_block
-    ), (
-        f"terminal slot {target_slot} included {manifest_count!r} L1 manifests, "
-        f"expected at least {min_l1_manifests_in_terminal_block}: {block}"
+        manifests = epoch_block.get("manifests")
+        if manifests is not None:
+            manifest_count = manifests.get("manifest_count")
+            assert isinstance(manifest_count, int), (
+                f"slot {slot} has an invalid manifest count {manifest_count!r}: {epoch_block}"
+            )
+            epoch_manifest_count += manifest_count
+
+    assert epoch_manifest_count >= min_l1_manifests_in_epoch, (
+        f"epoch ending at terminal slot {target_slot} included {epoch_manifest_count} "
+        f"L1 manifests, expected at least {min_l1_manifests_in_epoch}"
     )
 
     status = rpc.strata_getChainStatus()
@@ -45,9 +54,9 @@ def assert_terminal_block_l1_update(
     )
 
     logger.info(
-        "asserted terminal slot %s with %s L1 manifests",
+        "asserted terminal slot %s after epoch included %s L1 manifests",
         target_slot,
-        manifest_count,
+        epoch_manifest_count,
     )
 
 
@@ -64,7 +73,7 @@ class TerminalBlockAssemblyBase(StrataNodeTest):
     l1_mining_interval_seconds: float
     terminal_blocks_to_validate: int
     terminal_slot_timeout_seconds: int
-    min_l1_manifests_in_terminal_block: int
+    min_l1_manifests_in_epoch: int
 
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env(
@@ -110,10 +119,11 @@ class TerminalBlockAssemblyBase(StrataNodeTest):
                 terminal_slot,
             )
 
-            assert_terminal_block_l1_update(
+            assert_terminal_epoch_l1_update(
                 rpc,
                 terminal_slot,
-                self.min_l1_manifests_in_terminal_block,
+                self.epoch_sealing.slots_per_epoch,
+                self.min_l1_manifests_in_epoch,
             )
             target_slot = self.epoch_sealing.next_terminal_slot_after(terminal_slot)
 

--- a/functional-tests/tests/strata/test_terminal_block_assembly_fast_l1.py
+++ b/functional-tests/tests/strata/test_terminal_block_assembly_fast_l1.py
@@ -14,5 +14,5 @@ class TerminalBlockAssemblyFastL1Test(TerminalBlockAssemblyBase):
     l1_mining_interval_seconds = 2.0
     terminal_blocks_to_validate = 2
     terminal_slot_timeout_seconds = 180
-    # Conservative floor: fast L1 should pack several manifests into each terminal block.
-    min_l1_manifests_in_terminal_block = 2
+    # Conservative floor: fast L1 should contribute several manifests to each epoch.
+    min_l1_manifests_in_epoch = 2

--- a/functional-tests/tests/strata/test_terminal_block_assembly_slow_l1.py
+++ b/functional-tests/tests/strata/test_terminal_block_assembly_slow_l1.py
@@ -12,5 +12,5 @@ class TerminalBlockAssemblySlowL1Test(TerminalBlockAssemblyBase):
     l1_mining_interval_seconds = 20.0
     terminal_blocks_to_validate = 1
     terminal_slot_timeout_seconds = 120
-    # Baseline floor: slow L1 should still contribute a manifest to the terminal block.
-    min_l1_manifests_in_terminal_block = 1
+    # Baseline floor: slow L1 should still contribute a manifest to the epoch.
+    min_l1_manifests_in_epoch = 1


### PR DESCRIPTION
## Description

STR-3308 (#1864) let the OL STF buffer ASM manifest logs from any block, but block assembly still emitted ASM manifests only on terminal blocks. This PR includes buried/mature ASM manifests as soon as they mature, in any OL block, advancing the L1/MMR cursor earlier to reduce EE-update and withdrawal latency.

Manifests are still only included once buried below `l1_reorg_safe_depth` (STR-3555). Manifest effects still land at the epoch-terminal drain; only inclusion and cursor advancement move earlier.

### Changes

1. **refactor(ol/block-assembly): centralize epoch sealing decisions** — separates pure cadence from limit-aware sealing. `LimitAwareSealing` composes cadence with checkpoint-size and manifest-count limit rules, and terminality now comes from an explicit `EpochSealingDecision`, not manifest presence.

2. **feat(ol/block-assembly): include ASM manifests per block** — fetches buried ASM manifests every block and selects a prefix bounded by pending-ASM-log capacity and the epoch manifest budget. Epoch resource totals are threaded across blocks and reset at epoch boundaries. Non-terminal blocks may carry manifests; terminal blocks may have no manifests; empty manifest containers are omitted.

3. **fix(chain-worker-new): replay epoch manifests without per-block cap** — DA reconstruction passes epoch manifests as a `Vec<AsmManifest>` to `apply_da_epoch` instead of wrapping them in the per-block SSZ manifest container, so epochs with manifests spread across blocks or exceeding the per-block container bound reconstruct correctly. Empty L1 ranges are valid when an epoch seals without new buried manifests.

4. **fix(ol/state-types): raise pending ASM log buffer** — raises `MAX_PENDING_ASM_LOGS` from `1 << 16` to `1 << 18`, enough for the expected heavy-manifest case of 2048 manifests with 128 logs each. This changes the `OLState` SSZ root shape.

### Testing

Covers per-block inclusion, manifest-budget sealing, backlog draining across epochs, pending-log prefix limiting, epoch-resource reset, empty manifest containers, empty checkpoint-sync L1 ranges, and DA reconstruction with spread/over-cap manifests.

Targeted crate suites pass. The slow/fast terminal-block functional tests now validate manifest inclusion across the completed epoch instead of requiring manifests on the terminal block itself, and both targeted functional tests pass.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

We have tested 128 logs per manifest in #1930. So setting `MAX_PENDING_ASM_LOGS = 128 * MAX_SEALING_MANIFEST_COUNT = 1 << 18`.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3716](https://alpenlabs.atlassian.net/browse/STR-3716)

[STR-3716]: https://alpenlabs.atlassian.net/browse/STR-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ