### PR TITLE
backport(chain-worker): persist terminal output before epoch finalization

### DIFF
--- a/bin/strata/src/fcm.rs
+++ b/bin/strata/src/fcm.rs
@@ -105,6 +105,31 @@ impl FcmStorage for StrataFcmContext {
             .await
     }
 
+    async fn get_block_high_watermark(&self) -> DbResult<Option<OLBlockCommitment>> {
+        self.storage
+            .ol_block()
+            .get_block_high_watermark_async()
+            .await
+    }
+
+    async fn rollback_block_state_indexing(
+        &self,
+        epoch: Epoch,
+        cutoff: OLBlockCommitment,
+    ) -> DbResult<()> {
+        self.storage
+            .ol_state_indexing()
+            .rollback_to_block_async(epoch, cutoff)
+            .await
+    }
+
+    async fn del_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<bool> {
+        self.storage
+            .ol_checkpoint()
+            .del_epoch_summary_async(epoch)
+            .await
+    }
+
     async fn get_toplevel_ol_state(
         &self,
         commitment: OLBlockCommitment,

--- a/bin/strata/src/sequencer/block_producer.rs
+++ b/bin/strata/src/sequencer/block_producer.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 use anyhow::{Context, Result, anyhow, bail};
 use strata_consensus_logic::{FcmServiceHandle, message::ForkChoiceMessage};
 use strata_db_types::traits::BlockStatus;
-use strata_identifiers::{OLBlockCommitment, OLBlockId};
+use strata_identifiers::{EpochCommitment, OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_new::OLBlock;
 use strata_ol_sequencer::{SequencerBuilder, SequencerServiceStatus};
 use strata_service::ServiceMonitor;
@@ -96,6 +96,50 @@ async fn process_startup_high_watermark_block(
             Ok(())
         }
         HighWatermarkBlockAction::Clear => {
+            // Drop the invalid block's state-indexing writes before clearing
+            // the high-watermark, so the replacement block built for this
+            // slot doesn't conflict against stale indexing rows. Idempotent;
+            // also covers a crash between the FCM-side rollback and clear.
+            let block = block.expect("decide_startup_high_watermark_block_action checked presence");
+            let cutoff = OLBlockCommitment::new(
+                high_watermark.slot().saturating_sub(1),
+                *block.header().parent_blkid(),
+            );
+            storage
+                .ol_state_indexing()
+                .rollback_to_block_async(block.header().epoch(), cutoff)
+                .await
+                .inspect_err(|err| {
+                    error!(
+                        block_id = %block_id,
+                        slot = high_watermark.slot(),
+                        %err,
+                        "failed to roll back state indexing for invalid high-watermark OL block on startup; replacement generation for this slot remains blocked"
+                    );
+                })
+                .context("failed to roll back state indexing for invalid high-watermark OL block on startup")?;
+
+            // An invalid terminal block may have stored its epoch summary
+            // before being rejected. Drop it so it cannot shadow the
+            // replacement terminal's summary in canonical lookups.
+            if block.header().is_terminal() {
+                let summary_commitment =
+                    EpochCommitment::new(block.header().epoch(), high_watermark.slot(), block_id);
+                storage
+                    .ol_checkpoint()
+                    .del_epoch_summary_async(summary_commitment)
+                    .await
+                    .inspect_err(|err| {
+                        error!(
+                            block_id = %block_id,
+                            slot = high_watermark.slot(),
+                            %err,
+                            "failed to delete epoch summary of invalid high-watermark OL terminal block on startup; replacement generation for this slot remains blocked"
+                        );
+                    })
+                    .context("failed to delete epoch summary of invalid high-watermark OL terminal block on startup")?;
+            }
+
             let cleared = storage
                 .ol_block()
                 .clear_block_high_watermark_async(high_watermark)

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -264,12 +264,6 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
         Ok(())
     }
 
-    fn fetch_summary(&self, epoch: &EpochCommitment) -> WorkerResult<EpochSummary> {
-        self.ol_checkpoint_mgr
-            .get_epoch_summary_blocking(*epoch)?
-            .ok_or(WorkerError::MissingEpochSummary(*epoch))
-    }
-
     fn fetch_canonical_epoch_summary_at(&self, epoch: u32) -> WorkerResult<Option<EpochSummary>> {
         let commitment = self
             .ol_checkpoint_mgr
@@ -281,8 +275,7 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
         }
     }
 
-    fn merge_epoch_data(&self, epoch: &EpochCommitment) -> WorkerResult<()> {
-        let summary = self.fetch_summary(epoch)?;
+    fn merge_epoch_data(&self, summary: &EpochSummary) -> WorkerResult<()> {
         let terminal = *summary.terminal();
         let prev_terminal = *summary.prev_terminal();
 

--- a/crates/chain-worker-new/src/state.rs
+++ b/crates/chain-worker-new/src/state.rs
@@ -169,190 +169,7 @@ impl ChainWorkerServiceState {
         block_commitment: &OLBlockCommitment,
     ) -> WorkerResult<()> {
         self.check_initialized()?;
-
-        let blkid = block_commitment.blkid();
-        debug!(%blkid, "Trying to execute block");
-
-        // Fetch block and parent context
-        let (block, parent_header, parent_commitment) =
-            self.fetch_block_with_parent(block_commitment)?;
-
-        // Execute STF and get output and new state
-        let (output, new_state) =
-            self.execute_stf(&block, parent_header.as_ref(), parent_commitment)?;
-
-        // Handle epoch terminal if needed
-        debug!(slot=%block.header().slot(), is_terminal=%block.header().is_terminal(), "Checking if block is terminal");
-        if block.header().is_terminal() {
-            self.handle_terminal_block_exec_post_ops(&block, &output, &new_state)?;
-            // Send the epoch commitment to receiver
-            // TODO(STR-3673): it seems to be done for each block at the moment. Ideally we would do
-            // it just here.
-        }
-
-        // Persist results (including the full state)
-        self.persist_execution_output(&block, *block_commitment, &output, new_state)?;
-
-        // Merge the epoch's write batches into the terminal state. Must run
-        // after persist_execution_output, since the merge reads every block's
-        // write batch including the terminal block's, stored just above.
-        if block.header().is_terminal() {
-            let epoch = EpochCommitment {
-                epoch: block.header().epoch(),
-                last_slot: block_commitment.slot(),
-                last_blkid: *block_commitment.blkid(),
-            };
-            self.ctx.merge_epoch_data(&epoch)?;
-        }
-
-        Ok(())
-    }
-
-    /// Fetches a block and its parent header from the context.
-    ///
-    /// Returns the block, optional parent header, and parent commitment.
-    fn fetch_block_with_parent(
-        &self,
-        block_commitment: &OLBlockCommitment,
-    ) -> WorkerResult<(OLBlock, Option<OLBlockHeader>, OLBlockCommitment)> {
-        let blkid = block_commitment.blkid();
-
-        let block = self
-            .ctx
-            .fetch_block(blkid)?
-            .ok_or(WorkerError::MissingOLBlock(*blkid))?;
-
-        let parent_blkid = block.header().parent_blkid();
-        let parent_commitment = if parent_blkid.is_null() {
-            OLBlockCommitment::null()
-        } else {
-            // Parent slot is the block's slot - 1.
-            let parent_slot = block.header().slot().saturating_sub(1);
-            OLBlockCommitment::new(parent_slot, *parent_blkid)
-        };
-
-        let parent_header = if parent_commitment.is_null() {
-            None
-        } else {
-            Some(
-                self.ctx
-                    .fetch_header(parent_commitment.blkid())?
-                    .ok_or(WorkerError::MissingOLBlock(*parent_commitment.blkid()))?,
-            )
-        };
-
-        Ok((block, parent_header, parent_commitment))
-    }
-
-    /// Executes the STF on a block and returns the execution output.
-    ///
-    /// This fetches parent state, builds the state stack, runs verification,
-    /// and extracts the resulting write batch and indexer writes.
-    #[instrument(
-        skip_all,
-        fields(
-            slot = block.header().slot(),
-            epoch = block.header().epoch(),
-            is_terminal = block.header().is_terminal(),
-            %parent_commitment,
-        ),
-        err,
-    )]
-    fn execute_stf(
-        &self,
-        block: &OLBlock,
-        parent_header: Option<&OLBlockHeader>,
-        parent_commitment: OLBlockCommitment,
-    ) -> WorkerResult<(OLBlockExecutionOutput, OLState)> {
-        // Fetch parent state and wrap in MemoryStateBaseLayer for IStateAccessor
-        let parent_state_raw = self
-            .ctx
-            .fetch_ol_state(parent_commitment)?
-            .ok_or(WorkerError::MissingPreState(parent_commitment))?;
-        let parent_state = MemoryStateBaseLayer::new(parent_state_raw);
-
-        // Execute and extract outputs
-        let (write_batch, indexer_writes, logs) = run_stf_verification(
-            &parent_state,
-            block,
-            parent_header,
-            self.ctx.bridge_params(),
-        )?;
-
-        // Apply write batch to parent state to get new state
-        let mut new_state = parent_state;
-        new_state
-            .apply_write_batch(write_batch.clone())
-            .map_err(|source| WorkerError::ApplyWriteBatch {
-                commitment: parent_commitment,
-                source,
-            })?;
-        let new_state = new_state.into_inner();
-
-        // Use the state root from the header (verify_block validated it).
-        // Note: logs are validated internally by verify_block via the logs_root commitment.
-        let computed_state_root = *block.header().state_root();
-
-        Ok((
-            OLBlockExecutionOutput::new(computed_state_root, write_batch, indexer_writes, logs),
-            new_state,
-        ))
-    }
-
-    /// Persists the execution output and state to storage.
-    ///
-    /// Handles crash-restart cases like indexing already applied or wrong indexing applied
-    /// gracefully.
-    fn persist_execution_output(
-        &self,
-        block: &OLBlock,
-        block_commitment: OLBlockCommitment,
-        output: &OLBlockExecutionOutput,
-        new_state: OLState,
-    ) -> WorkerResult<()> {
-        match self.ctx.store_block_output(block, block_commitment, output) {
-            Ok(()) => {}
-            Err(WorkerError::Database(DbError::BlockIndexingConflict {
-                attempted,
-                last_applied,
-                ..
-            })) if attempted == block_commitment && last_applied == block_commitment => {
-                debug!(
-                    %block_commitment,
-                    "block indexing already applied for this exact block; \
-                     treating as crash-restart retry and continuing persist"
-                );
-            }
-            Err(e) => return Err(e),
-        }
-
-        self.ctx.store_toplevel_state(block_commitment, new_state)?;
-
-        Ok(())
-    }
-
-    /// Takes the block and post-state and inserts database entries to reflect
-    /// the epoch being finished on-chain.
-    ///
-    /// Returns the completed epoch's commitment so the caller can merge its
-    /// epoch data once the terminal block's write batch is persisted.
-    fn handle_terminal_block_exec_post_ops(
-        &mut self,
-        block: &OLBlock,
-        last_block_output: &OLBlockExecutionOutput,
-        new_state: &OLState,
-    ) -> WorkerResult<EpochCommitment> {
-        let completed_epoch = block.header().epoch();
-
-        let prev_terminal = get_prev_terminal(&self.ctx, completed_epoch)?;
-        let summary =
-            build_epoch_summary(block.header(), last_block_output, new_state, prev_terminal);
-        let epoch = summary.get_epoch_commitment();
-
-        debug!(?summary, "completed chain epoch");
-        self.ctx.store_summary(summary)?;
-
-        Ok(epoch)
+        exec_block(&self.ctx, self.ctx.bridge_params(), block_commitment)
     }
 
     /// Updates the current tip as managed by the worker.
@@ -364,7 +181,7 @@ impl ChainWorkerServiceState {
     /// Marks an epoch as finalized(buried).
     ///
     /// By the time this runs the epoch's terminal state has already been merged
-    /// and stored — by [`Self::handle_terminal_block_exec_post_ops`] for full
+    /// and stored — by [`handle_terminal_block_exec_post_ops`] for full
     /// sync, or by `apply_checkpoint` for checkpoint sync. This verifies that
     /// state is present, then records the epoch as finalized.
     pub(crate) fn finalize_epoch(&mut self, epoch: EpochCommitment) -> WorkerResult<()> {
@@ -396,6 +213,203 @@ impl ChainWorkerServiceState {
 
         Ok(())
     }
+}
+
+/// Executes a block via the OL STF and persists its outputs.
+///
+/// For terminal blocks the execution output is persisted *before* the epoch
+/// post-ops run: [`handle_terminal_block_exec_post_ops`] stamps the epoch
+/// commitment onto the indexing row that persisting a block of the epoch
+/// creates. In a single-block epoch (e.g. one sealed immediately by the
+/// checkpoint size policy) this block's persist is the only thing that
+/// creates that row, so stamping first fails with a missing-row error.
+pub(crate) fn exec_block(
+    ctx: &impl ChainWorkerContext,
+    bridge_params: BridgeParams,
+    block_commitment: &OLBlockCommitment,
+) -> WorkerResult<()> {
+    let blkid = block_commitment.blkid();
+    debug!(%blkid, "Trying to execute block");
+
+    // Fetch block and parent context
+    let (block, parent_header, parent_commitment) = fetch_block_with_parent(ctx, block_commitment)?;
+
+    // Execute STF and get output and new state
+    let (output, new_state) = execute_stf(
+        ctx,
+        bridge_params,
+        &block,
+        parent_header.as_ref(),
+        parent_commitment,
+    )?;
+
+    let is_terminal = block.header().is_terminal();
+    debug!(slot=%block.header().slot(), is_terminal, "Checking if block is terminal");
+
+    if is_terminal {
+        // Persist results (including the full state) before the terminal
+        // post-ops; see the doc comment above.
+        persist_execution_output(ctx, &block, *block_commitment, &output, new_state.clone())?;
+
+        // Handle epoch terminal
+        // TODO(STR-3673): the epoch commitment seems to be sent to the
+        // receiver for each block at the moment. Ideally we would do it just
+        // here.
+        handle_terminal_block_exec_post_ops(ctx, &block, &output, &new_state)?;
+    } else {
+        // Persist results (including the full state)
+        persist_execution_output(ctx, &block, *block_commitment, &output, new_state)?;
+    }
+
+    Ok(())
+}
+
+/// Fetches a block and its parent header from the context.
+///
+/// Returns the block, optional parent header, and parent commitment.
+fn fetch_block_with_parent(
+    ctx: &impl ChainWorkerContext,
+    block_commitment: &OLBlockCommitment,
+) -> WorkerResult<(OLBlock, Option<OLBlockHeader>, OLBlockCommitment)> {
+    let blkid = block_commitment.blkid();
+
+    let block = ctx
+        .fetch_block(blkid)?
+        .ok_or(WorkerError::MissingOLBlock(*blkid))?;
+
+    let parent_blkid = block.header().parent_blkid();
+    let parent_commitment = if parent_blkid.is_null() {
+        OLBlockCommitment::null()
+    } else {
+        // Parent slot is the block's slot - 1.
+        let parent_slot = block.header().slot().saturating_sub(1);
+        OLBlockCommitment::new(parent_slot, *parent_blkid)
+    };
+
+    let parent_header = if parent_commitment.is_null() {
+        None
+    } else {
+        Some(
+            ctx.fetch_header(parent_commitment.blkid())?
+                .ok_or(WorkerError::MissingOLBlock(*parent_commitment.blkid()))?,
+        )
+    };
+
+    Ok((block, parent_header, parent_commitment))
+}
+
+/// Executes the STF on a block and returns the execution output.
+///
+/// This fetches parent state, builds the state stack, runs verification,
+/// and extracts the resulting write batch and indexer writes.
+#[instrument(
+    skip_all,
+    fields(
+        slot = block.header().slot(),
+        epoch = block.header().epoch(),
+        is_terminal = block.header().is_terminal(),
+        %parent_commitment,
+    ),
+    err,
+)]
+fn execute_stf(
+    ctx: &impl ChainWorkerContext,
+    bridge_params: BridgeParams,
+    block: &OLBlock,
+    parent_header: Option<&OLBlockHeader>,
+    parent_commitment: OLBlockCommitment,
+) -> WorkerResult<(OLBlockExecutionOutput, OLState)> {
+    // Fetch parent state and wrap in MemoryStateBaseLayer for IStateAccessor
+    let parent_state_raw = ctx
+        .fetch_ol_state(parent_commitment)?
+        .ok_or(WorkerError::MissingPreState(parent_commitment))?;
+    let parent_state = MemoryStateBaseLayer::new(parent_state_raw);
+
+    // Execute and extract outputs
+    let (write_batch, indexer_writes, logs) =
+        run_stf_verification(&parent_state, block, parent_header, bridge_params)?;
+
+    // Apply write batch to parent state to get new state
+    let mut new_state = parent_state;
+    new_state
+        .apply_write_batch(write_batch.clone())
+        .map_err(|source| WorkerError::ApplyWriteBatch {
+            commitment: parent_commitment,
+            source,
+        })?;
+    let new_state = new_state.into_inner();
+
+    // Use the state root from the header (verify_block validated it).
+    // Note: logs are validated internally by verify_block via the logs_root commitment.
+    let computed_state_root = *block.header().state_root();
+
+    Ok((
+        OLBlockExecutionOutput::new(computed_state_root, write_batch, indexer_writes, logs),
+        new_state,
+    ))
+}
+
+/// Persists the execution output and state to storage.
+///
+/// Handles crash-restart cases like indexing already applied or wrong indexing applied
+/// gracefully.
+fn persist_execution_output(
+    ctx: &impl ChainWorkerContext,
+    block: &OLBlock,
+    block_commitment: OLBlockCommitment,
+    output: &OLBlockExecutionOutput,
+    new_state: OLState,
+) -> WorkerResult<()> {
+    match ctx.store_block_output(block, block_commitment, output) {
+        Ok(()) => {}
+        Err(WorkerError::Database(DbError::BlockIndexingConflict {
+            attempted,
+            last_applied,
+            ..
+        })) if attempted == block_commitment && last_applied == block_commitment => {
+            debug!(
+                %block_commitment,
+                "block indexing already applied for this exact block; \
+                 treating as crash-restart retry and continuing persist"
+            );
+        }
+        Err(e) => return Err(e),
+    }
+
+    ctx.store_toplevel_state(block_commitment, new_state)?;
+
+    Ok(())
+}
+
+/// Takes the block and post-state and inserts database entries to reflect
+/// the epoch being finished on-chain.
+///
+/// Expects the terminal block's own output to be persisted already: the merge
+/// reads every block's write batch including the terminal block's, and epoch
+/// finalization stamps the epoch commitment onto an existing indexing row.
+///
+/// The summary is stored last, after the epoch data merge: a stored summary
+/// (and the notification it emits) indicates the whole epoch finalization
+/// persisted. A failure anywhere earlier leaves no summary behind for a
+/// block that may then be rejected.
+fn handle_terminal_block_exec_post_ops(
+    ctx: &impl ChainWorkerContext,
+    block: &OLBlock,
+    last_block_output: &OLBlockExecutionOutput,
+    new_state: &OLState,
+) -> WorkerResult<()> {
+    let completed_epoch = block.header().epoch();
+
+    let prev_terminal = get_prev_terminal(ctx, completed_epoch)?;
+    let summary = build_epoch_summary(block.header(), last_block_output, new_state, prev_terminal);
+
+    // Merge the epoch's write batches into the terminal state.
+    ctx.merge_epoch_data(&summary)?;
+
+    debug!(?summary, "completed chain epoch");
+    ctx.store_summary(summary)?;
+
+    Ok(())
 }
 
 /// Gets the terminal commitment of the epoch before `cur_epoch`.

--- a/crates/chain-worker-new/src/tests/apply_checkpoint.rs
+++ b/crates/chain-worker-new/src/tests/apply_checkpoint.rs
@@ -144,11 +144,7 @@ impl ChainWorkerContext for MockChainWorkerContext {
         unimplemented!("not used by apply_checkpoint_epoch")
     }
 
-    fn fetch_summary(&self, _epoch: &EpochCommitment) -> WorkerResult<EpochSummary> {
-        unimplemented!("not used by apply_checkpoint_epoch")
-    }
-
-    fn merge_epoch_data(&self, _epoch: &EpochCommitment) -> WorkerResult<()> {
+    fn merge_epoch_data(&self, _summary: &EpochSummary) -> WorkerResult<()> {
         unimplemented!("not used by apply_checkpoint_epoch")
     }
 

--- a/crates/chain-worker-new/src/tests/exec_block.rs
+++ b/crates/chain-worker-new/src/tests/exec_block.rs
@@ -1,0 +1,231 @@
+//! Regression tests for the block-sync exec path ordering.
+//!
+//! A single-block epoch — the terminal block is also the epoch's first block,
+//! as produced when the checkpoint size policy seals an epoch immediately —
+//! must persist the terminal block's output before epoch finalization runs:
+//! the epoch commitment is stamped onto the indexing row that persisting a
+//! block of the epoch creates, and in a single-block epoch no earlier block
+//! has created that row.
+
+use std::{collections::HashMap, sync::Mutex};
+
+use strata_acct_types::BitcoinAmount;
+use strata_asm_common::AsmManifest;
+use strata_asm_proto_checkpoint_types::CheckpointPayload;
+use strata_bridge_params::BridgeParams;
+use strata_checkpoint_types::EpochSummary;
+use strata_db_types::errors::DbError;
+use strata_identifiers::{
+    Epoch, EpochCommitment, L1BlockCommitment, OLBlockCommitment, OLBlockId, SubjectId,
+};
+use strata_ol_chain_types_new::{OLBlock, OLBlockHeader};
+use strata_ol_state_types::{OLAccountState, OLState, WriteBatch};
+use strata_ol_stf::test_utils::{
+    EPOCH_RUNNER_TERMINAL_L1_HEIGHT as TERMINAL_L1_HEIGHT, epoch_runner_run_genesis as run_genesis,
+    epoch_runner_run_terminal as run_terminal, epoch_runner_seed_accounts as seed_accounts,
+    make_deposit_manifest_for_account, make_genesis_state,
+};
+
+use crate::{
+    WorkerError, WorkerResult, output::OLBlockExecutionOutput, state::exec_block,
+    traits::ChainWorkerContext,
+};
+
+/// A [`ChainWorkerContext`] that enforces the OL state indexing DB's write
+/// ordering contract: stamping an epoch commitment ([`Self::store_summary`])
+/// errors unless some block of that epoch had its indexing writes applied
+/// first ([`Self::store_block_output`]), mirroring `set_epoch_commitment` on
+/// the sled-backed store.
+struct OrderEnforcingContext {
+    /// Blocks served to [`ChainWorkerContext::fetch_block`].
+    blocks: HashMap<OLBlockId, OLBlock>,
+    /// Headers served to [`ChainWorkerContext::fetch_header`].
+    headers: HashMap<OLBlockId, OLBlockHeader>,
+    /// States served to [`ChainWorkerContext::fetch_ol_state`].
+    states: HashMap<OLBlockCommitment, OLState>,
+    /// Canonical summaries served per epoch index.
+    canonical_summaries: HashMap<Epoch, EpochSummary>,
+    /// Epochs with at least one block's indexing writes applied.
+    indexed_epochs: Mutex<Vec<Epoch>>,
+    /// Summaries accepted by [`ChainWorkerContext::store_summary`].
+    stored_summaries: Mutex<Vec<EpochSummary>>,
+    /// Epochs passed to [`ChainWorkerContext::merge_epoch_data`].
+    merged_epochs: Mutex<Vec<EpochCommitment>>,
+}
+
+impl ChainWorkerContext for OrderEnforcingContext {
+    fn fetch_block(&self, blkid: &OLBlockId) -> WorkerResult<Option<OLBlock>> {
+        Ok(self.blocks.get(blkid).cloned())
+    }
+
+    fn fetch_header(&self, blkid: &OLBlockId) -> WorkerResult<Option<OLBlockHeader>> {
+        Ok(self.headers.get(blkid).cloned())
+    }
+
+    fn fetch_ol_state(&self, commitment: OLBlockCommitment) -> WorkerResult<Option<OLState>> {
+        Ok(self.states.get(&commitment).cloned())
+    }
+
+    fn fetch_canonical_epoch_summary_at(&self, epoch: Epoch) -> WorkerResult<Option<EpochSummary>> {
+        Ok(self.canonical_summaries.get(&epoch).cloned())
+    }
+
+    fn store_block_output(
+        &self,
+        block: &OLBlock,
+        _commitment: OLBlockCommitment,
+        _output: &OLBlockExecutionOutput,
+    ) -> WorkerResult<()> {
+        self.indexed_epochs
+            .lock()
+            .unwrap()
+            .push(block.header().epoch());
+        Ok(())
+    }
+
+    fn store_toplevel_state(
+        &self,
+        _commitment: OLBlockCommitment,
+        _state: OLState,
+    ) -> WorkerResult<()> {
+        Ok(())
+    }
+
+    fn store_summary(&self, summary: EpochSummary) -> WorkerResult<()> {
+        let commitment = summary.get_epoch_commitment();
+        let epoch = commitment.epoch();
+        if !self.indexed_epochs.lock().unwrap().contains(&epoch) {
+            return Err(WorkerError::Database(DbError::Other(format!(
+                "no epoch indexing data for epoch {epoch}"
+            ))));
+        }
+        // Pins the intended ordering rather than a DB contract: the summary
+        // must be the last durable step, after the epoch data merge, so a
+        // merge failure can never leave a summary behind for a block that
+        // then gets rejected.
+        if !self.merged_epochs.lock().unwrap().contains(&commitment) {
+            return Err(WorkerError::Database(DbError::Other(format!(
+                "summary stored before epoch data merge for epoch {epoch}"
+            ))));
+        }
+        self.stored_summaries.lock().unwrap().push(summary);
+        Ok(())
+    }
+
+    fn merge_epoch_data(&self, summary: &EpochSummary) -> WorkerResult<()> {
+        self.merged_epochs
+            .lock()
+            .unwrap()
+            .push(summary.get_epoch_commitment());
+        Ok(())
+    }
+
+    // Methods below are not exercised by the block exec path.
+
+    fn fetch_blocks_at_slot(&self, _slot: u64) -> WorkerResult<Vec<OLBlockId>> {
+        unimplemented!("not used by exec_block")
+    }
+
+    fn fetch_chain_tip(&self) -> WorkerResult<Option<OLBlockCommitment>> {
+        unimplemented!("not used by exec_block")
+    }
+
+    fn fetch_write_batch(
+        &self,
+        _commitment: OLBlockCommitment,
+    ) -> WorkerResult<Option<WriteBatch<OLAccountState>>> {
+        unimplemented!("not used by exec_block")
+    }
+
+    fn prefill_l1_block_refs_mmr(&self) -> WorkerResult<()> {
+        unimplemented!("not used by exec_block")
+    }
+
+    fn fetch_checkpoint_payload(
+        &self,
+        _epoch: &EpochCommitment,
+    ) -> WorkerResult<Option<CheckpointPayload>> {
+        unimplemented!("not used by exec_block")
+    }
+
+    fn fetch_l1_manifests(&self, _from: u32, _to: u32) -> WorkerResult<Vec<AsmManifest>> {
+        unimplemented!("not used by exec_block")
+    }
+
+    fn apply_epoch_indexing(
+        &self,
+        _epoch: &EpochCommitment,
+        _output: &OLBlockExecutionOutput,
+    ) -> WorkerResult<()> {
+        unimplemented!("not used by exec_block")
+    }
+}
+
+/// Executing a terminal block that is also its epoch's first block must
+/// succeed: the block's own indexing persist creates the epoch row that epoch
+/// finalization stamps.
+#[test]
+fn test_exec_single_block_epoch_persists_before_summary() {
+    let mut state = make_genesis_state();
+    let snark_serial = seed_accounts(&mut state);
+    let genesis = run_genesis(&mut state);
+    let genesis_header = genesis.header().clone();
+    let pre_epoch_state = state.clone().into_inner();
+
+    // Build epoch 1 as a single terminal block directly on genesis.
+    let mut blocks: Vec<OLBlock> = Vec::new();
+    let manifest = make_deposit_manifest_for_account(
+        TERMINAL_L1_HEIGHT,
+        0,
+        snark_serial,
+        SubjectId::from([42u8; 32]),
+        BitcoinAmount::from_sat(150_000_000),
+    );
+    run_terminal(&mut state, &mut blocks, &genesis_header, manifest);
+    let terminal_block = blocks.pop().expect("terminal block built");
+    let terminal_header = terminal_block.header().clone();
+    let terminal_commitment =
+        OLBlockCommitment::new(terminal_header.slot(), terminal_header.compute_blkid());
+    assert!(terminal_header.is_terminal(), "epoch 1 block is terminal");
+    assert_eq!(terminal_header.epoch(), 1, "single-block epoch 1");
+
+    // Genesis (epoch 0) commitment and summary, for `get_prev_terminal`.
+    let genesis_commitment =
+        OLBlockCommitment::new(genesis_header.slot(), genesis_header.compute_blkid());
+    let genesis_epoch_state = pre_epoch_state.epoch_state();
+    let genesis_l1 = L1BlockCommitment::new(
+        genesis_epoch_state.last_l1_height(),
+        *genesis_epoch_state.last_l1_blkid(),
+    );
+    let genesis_summary = EpochSummary::new(
+        0,
+        genesis_commitment,
+        OLBlockCommitment::null(),
+        genesis_l1,
+        *genesis_header.state_root(),
+    );
+
+    let ctx = OrderEnforcingContext {
+        blocks: HashMap::from([(*terminal_commitment.blkid(), terminal_block)]),
+        headers: HashMap::from([(*genesis_commitment.blkid(), genesis_header)]),
+        states: HashMap::from([(genesis_commitment, pre_epoch_state)]),
+        canonical_summaries: HashMap::from([(0, genesis_summary)]),
+        indexed_epochs: Mutex::new(Vec::new()),
+        stored_summaries: Mutex::new(Vec::new()),
+        merged_epochs: Mutex::new(Vec::new()),
+    };
+
+    exec_block(&ctx, BridgeParams::default(), &terminal_commitment)
+        .expect("single-block epoch executes");
+
+    let summaries = ctx.stored_summaries.lock().unwrap();
+    assert_eq!(summaries.len(), 1, "exactly one epoch summary stored");
+    let epoch = summaries[0].get_epoch_commitment();
+    assert_eq!(epoch.epoch(), 1);
+    assert_eq!(epoch.to_block_commitment(), terminal_commitment);
+    assert_eq!(
+        ctx.merged_epochs.lock().unwrap().as_slice(),
+        &[epoch],
+        "epoch data merged before the summary was stored"
+    );
+}

--- a/crates/chain-worker-new/src/tests/mod.rs
+++ b/crates/chain-worker-new/src/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Test modules for the chain worker.
 
 mod apply_checkpoint;
+mod exec_block;
 mod fixture;

--- a/crates/chain-worker-new/src/traits.rs
+++ b/crates/chain-worker-new/src/traits.rs
@@ -74,16 +74,21 @@ pub trait ChainWorkerContext: Send + Sync + 'static {
     // =========================================================================
 
     /// Stores an epoch summary in the database.
+    ///
+    /// Called as the last durable step of terminal block execution: a stored
+    /// summary indicates the whole epoch finalization persisted.
     fn store_summary(&self, summary: EpochSummary) -> WorkerResult<()>;
-
-    /// Fetches a specific epoch summary by its commitment.
-    fn fetch_summary(&self, epoch: &EpochCommitment) -> WorkerResult<EpochSummary>;
 
     /// Fetches canonical epoch summary for an epoch index.
     fn fetch_canonical_epoch_summary_at(&self, epoch: Epoch) -> WorkerResult<Option<EpochSummary>>;
 
-    /// Merges write batches of an epoch and stores the result.
-    fn merge_epoch_data(&self, epoch: &EpochCommitment) -> WorkerResult<()>;
+    /// Merges write batches of the epoch described by `summary` and stores
+    /// the merged state at the epoch's terminal commitment.
+    ///
+    /// Takes the summary by value-reference rather than reading it from
+    /// storage so it can run before [`store_summary`](Self::store_summary),
+    /// keeping the summary the last durable step.
+    fn merge_epoch_data(&self, summary: &EpochSummary) -> WorkerResult<()>;
 
     /// Seeds the DB-side L1 block refs MMR mirror with sentinel leaves matching
     /// the in-state MMR's genesis prefill. Called once at chain worker init.

--- a/crates/consensus-logic/src/fcm/context.rs
+++ b/crates/consensus-logic/src/fcm/context.rs
@@ -30,6 +30,31 @@ pub trait FcmStorage: UnfinalizedOLBlockSource {
 
     async fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool>;
 
+    /// Returns the latest OL block committed through the high-watermark path,
+    /// if any.
+    async fn get_block_high_watermark(&self) -> DbResult<Option<OLBlockCommitment>>;
+
+    /// Rolls back per-block OL state-indexing writes in `epoch` attributed to
+    /// blocks with slots strictly greater than `cutoff.slot()`.
+    ///
+    /// Called when a block is marked invalid to drop its indexing writes, so
+    /// a replacement block at the same slot can apply its own without
+    /// conflicting against the indexing high-watermark. Idempotent; a no-op
+    /// when the rejected block never reached the persist step.
+    async fn rollback_block_state_indexing(
+        &self,
+        epoch: Epoch,
+        cutoff: OLBlockCommitment,
+    ) -> DbResult<()>;
+
+    /// Deletes the epoch summary keyed by exactly this epoch commitment.
+    ///
+    /// Called when a terminal block is marked invalid to drop the summary it
+    /// may have stored before failing, so a stale summary cannot shadow the
+    /// replacement terminal's summary in canonical epoch lookups. Returns
+    /// `true` when a summary existed and was deleted.
+    async fn del_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<bool>;
+
     async fn get_toplevel_ol_state(
         &self,
         commitment: OLBlockCommitment,

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -208,7 +208,13 @@ async fn process_fc_message<C: FcmContext>(
             };
 
             let block = OLBlockCommitment::new(slot, *blkid);
-            set_block_status_and_clear_invalid_high_watermark(fcm_state, block, status).await?;
+            set_block_status_and_clear_invalid_high_watermark(
+                fcm_state,
+                &block_bundle,
+                block,
+                status,
+            )
+            .await?;
             if ok {
                 counter!("strata_fcm_blocks_accepted_total").increment(1);
             } else {
@@ -222,6 +228,7 @@ async fn process_fc_message<C: FcmContext>(
 
 async fn set_block_status_and_clear_invalid_high_watermark<C: FcmContext>(
     fcm_state: &FcmServiceState<C>,
+    bundle: &OLBlock,
     block: OLBlockCommitment,
     status: BlockStatus,
 ) -> anyhow::Result<bool> {
@@ -234,6 +241,70 @@ async fn set_block_status_and_clear_invalid_high_watermark<C: FcmContext>(
         // TODO(STR-2141): `BlockStatus::Invalid` also represents local execution failures.
         // Revisit high-watermark clearing once FCM distinguishes consensus-invalid blocks
         // from transient execution failures.
+
+        // A rejected terminal block may have stored its epoch summary before
+        // failing (the summary is the last exec step, but post-exec failures
+        // can still invalidate the block afterwards). Drop it so it cannot
+        // shadow the replacement terminal's summary in canonical lookups.
+        // Keyed exactly by the rejected block's own commitment, this can
+        // never touch another block's summary, so it runs regardless of the
+        // high-watermark gate below.
+        if bundle.header().is_terminal() {
+            let summary_commitment =
+                EpochCommitment::new(bundle.header().epoch(), block.slot(), *block.blkid());
+            let deleted = fcm_state
+                .ctx()
+                .del_epoch_summary(summary_commitment)
+                .await
+                .inspect_err(|err| {
+                    error!(
+                        %block,
+                        %err,
+                        "failed to delete epoch summary of invalid OL terminal block"
+                    );
+                })
+                .context("failed to delete epoch summary of invalid OL terminal block")?;
+            if deleted {
+                info!(%block, "deleted epoch summary of invalid OL terminal block");
+            }
+        }
+
+        // The cleanup below only applies to the block the sequencer is
+        // currently stuck on. An invalid block that is not the high-watermark
+        // (e.g. a stale or forked proposal arriving after a valid block at
+        // this slot was accepted) must not trigger a rollback: the indexing
+        // rows past its parent slot belong to the accepted canonical chain.
+        let high_watermark = fcm_state.ctx().get_block_high_watermark().await?;
+        if high_watermark != Some(block) {
+            debug!(%block, "invalid OL block is not the high-watermark; skipping indexing rollback");
+            return Ok(updated);
+        }
+
+        // Drop any state-indexing writes the rejected block persisted before
+        // it failed, so a replacement block at this slot doesn't conflict
+        // against the indexing high-watermark. The high-watermark is advanced
+        // when a block is stored and execution follows storage, so with the
+        // rejected block at the high-watermark the epoch's indexing writes
+        // past its parent slot can only be its own. Must land before the
+        // high-watermark clear below, since the clear is what unblocks
+        // building the replacement.
+        let cutoff = OLBlockCommitment::new(
+            block.slot().saturating_sub(1),
+            *bundle.header().parent_blkid(),
+        );
+        fcm_state
+            .ctx()
+            .rollback_block_state_indexing(bundle.header().epoch(), cutoff)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    %block,
+                    %err,
+                    "failed to roll back state indexing for invalid OL block; replacement generation for this slot remains blocked"
+                );
+            })
+            .context("failed to roll back state indexing for invalid OL block")?;
+
         let cleared = fcm_state
             .ctx()
             .clear_block_high_watermark(block)
@@ -319,8 +390,13 @@ async fn handle_new_block<C: FcmContext>(
             .set_block_status(*blkid, BlockStatus::Valid)
             .await?;
     } else {
-        set_block_status_and_clear_invalid_high_watermark(fcm_state, bc, BlockStatus::Invalid)
-            .await?;
+        set_block_status_and_clear_invalid_high_watermark(
+            fcm_state,
+            bundle,
+            bc,
+            BlockStatus::Invalid,
+        )
+        .await?;
         return Ok(false);
     }
 
@@ -681,6 +757,8 @@ mod tests {
         block_high_watermark: Option<OLBlockCommitment>,
         states: HashMap<OLBlockCommitment, Arc<OLState>>,
         canonical_epochs: HashMap<Epoch, EpochCommitment>,
+        indexing_rollbacks: Vec<(Epoch, OLBlockCommitment)>,
+        epoch_summary_deletes: Vec<EpochCommitment>,
     }
 
     impl StubFcmStorage {
@@ -751,6 +829,14 @@ mod tests {
 
         fn block_high_watermark(&self) -> Option<OLBlockCommitment> {
             self.inner.lock().unwrap().block_high_watermark
+        }
+
+        fn indexing_rollbacks(&self) -> Vec<(Epoch, OLBlockCommitment)> {
+            self.inner.lock().unwrap().indexing_rollbacks.clone()
+        }
+
+        fn epoch_summary_deletes(&self) -> Vec<EpochCommitment> {
+            self.inner.lock().unwrap().epoch_summary_deletes.clone()
         }
     }
 
@@ -844,6 +930,28 @@ mod tests {
             Ok(true)
         }
 
+        async fn get_block_high_watermark(&self) -> DbResult<Option<OLBlockCommitment>> {
+            Ok(self.inner.lock().unwrap().block_high_watermark)
+        }
+
+        async fn rollback_block_state_indexing(
+            &self,
+            epoch: Epoch,
+            cutoff: OLBlockCommitment,
+        ) -> DbResult<()> {
+            self.inner
+                .lock()
+                .unwrap()
+                .indexing_rollbacks
+                .push((epoch, cutoff));
+            Ok(())
+        }
+
+        async fn del_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<bool> {
+            self.inner.lock().unwrap().epoch_summary_deletes.push(epoch);
+            Ok(false)
+        }
+
         async fn get_toplevel_ol_state(
             &self,
             commitment: OLBlockCommitment,
@@ -926,6 +1034,24 @@ mod tests {
 
         async fn clear_block_high_watermark(&self, expected: OLBlockCommitment) -> DbResult<bool> {
             self.storage.clear_block_high_watermark(expected).await
+        }
+
+        async fn get_block_high_watermark(&self) -> DbResult<Option<OLBlockCommitment>> {
+            self.storage.get_block_high_watermark().await
+        }
+
+        async fn rollback_block_state_indexing(
+            &self,
+            epoch: Epoch,
+            cutoff: OLBlockCommitment,
+        ) -> DbResult<()> {
+            self.storage
+                .rollback_block_state_indexing(epoch, cutoff)
+                .await
+        }
+
+        async fn del_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<bool> {
+            self.storage.del_epoch_summary(epoch).await
         }
 
         async fn get_toplevel_ol_state(
@@ -1427,6 +1553,23 @@ mod tests {
         OLBlock::new(SignedOLBlockHeader::new(header, Buf64::zero()), body)
     }
 
+    fn make_terminal_storage_block(slot: Slot, parent: OLBlockId) -> OLBlock {
+        let body = OLBlockBody::new_common(OLTxSegment::new(vec![]).expect("empty tx segment"));
+        let mut flags = BlockFlags::from(0);
+        flags.set_is_terminal(true);
+        let header = OLBlockHeader::new(
+            1_000 + slot,
+            flags,
+            slot,
+            0,
+            parent,
+            body.compute_hash_commitment(),
+            Buf32::zero(),
+            Buf32::zero(),
+        );
+        OLBlock::new(SignedOLBlockHeader::new(header, Buf64::zero()), body)
+    }
+
     fn sign_block(block: &OLBlock, signing_key: &Buf32) -> Buf64 {
         let msg: Buf32 = block.header().compute_blkid().into();
         sign_schnorr_sig(&msg, signing_key)
@@ -1588,6 +1731,189 @@ mod tests {
             Some(BlockStatus::Invalid)
         );
         assert_eq!(ctx.storage().block_high_watermark(), None);
+        // The rejected block's indexing writes are rolled back to its parent,
+        // so a replacement block at the same slot can apply its own.
+        assert_eq!(
+            ctx.storage().indexing_rollbacks(),
+            vec![(0, genesis_commitment)]
+        );
+        // Non-terminal blocks never store a summary, so none is deleted.
+        assert!(ctx.storage().epoch_summary_deletes().is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn process_fc_message_deletes_summary_for_invalid_terminal_block() -> anyhow::Result<()> {
+        let pk = make_keypair().pk;
+        let genesis = make_storage_block(0, OLBlockId::from(Buf32::zero()));
+        let genesis_blkid = genesis.header().compute_blkid();
+        let genesis_commitment = OLBlockCommitment::new(genesis.header().slot(), genesis_blkid);
+        let genesis_epoch = EpochCommitment::new(0, genesis_commitment.slot(), genesis_blkid);
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(genesis_epoch))
+                .with_last_confirmed_epoch(Some(genesis_epoch)),
+        );
+
+        let block = make_terminal_storage_block(1, genesis_blkid);
+        let blkid = block.header().compute_blkid();
+        let block_commitment = OLBlockCommitment::new(block.header().slot(), blkid);
+
+        ctx.storage().put_executed_block(
+            genesis,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        ctx.storage().put_ol_block(block);
+        ctx.storage().set_block_high_watermark(block_commitment);
+        ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+
+        let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
+
+        process_fc_message(&ForkChoiceMessage::NewBlock(blkid), &mut fcm_state).await?;
+
+        assert_eq!(
+            ctx.storage().get_block_status(blkid).await?,
+            Some(BlockStatus::Invalid)
+        );
+        assert_eq!(ctx.storage().block_high_watermark(), None);
+        assert_eq!(
+            ctx.storage().indexing_rollbacks(),
+            vec![(0, genesis_commitment)]
+        );
+        // A rejected terminal block's epoch summary is dropped so it cannot
+        // shadow the replacement terminal's summary in canonical lookups.
+        assert_eq!(
+            ctx.storage().epoch_summary_deletes(),
+            vec![EpochCommitment::new(0, 1, blkid)]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn process_fc_message_skips_indexing_rollback_for_non_high_watermark_block(
+    ) -> anyhow::Result<()> {
+        let pk = make_keypair().pk;
+        let genesis = make_storage_block(0, OLBlockId::from(Buf32::zero()));
+        let genesis_blkid = genesis.header().compute_blkid();
+        let genesis_commitment = OLBlockCommitment::new(genesis.header().slot(), genesis_blkid);
+        let genesis_epoch = EpochCommitment::new(0, genesis_commitment.slot(), genesis_blkid);
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(genesis_epoch))
+                .with_last_confirmed_epoch(Some(genesis_epoch)),
+        );
+
+        // An accepted canonical block holds the high-watermark at slot 1...
+        let canonical = make_storage_block(1, genesis_blkid);
+        let canonical_commitment = OLBlockCommitment::new(
+            canonical.header().slot(),
+            canonical.header().compute_blkid(),
+        );
+
+        // ...and an unsigned fork block at the same slot arrives afterwards.
+        let fork = make_storage_block(1, OLBlockId::from(Buf32::from([7u8; 32])));
+        let fork_blkid = fork.header().compute_blkid();
+        assert_ne!(fork_blkid, *canonical_commitment.blkid());
+
+        ctx.storage().put_executed_block(
+            genesis,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        ctx.storage().put_executed_block(
+            canonical,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        ctx.storage().put_ol_block(fork);
+        ctx.storage().set_block_high_watermark(canonical_commitment);
+        ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+
+        let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
+
+        process_fc_message(&ForkChoiceMessage::NewBlock(fork_blkid), &mut fcm_state).await?;
+
+        assert_eq!(
+            ctx.storage().get_block_status(fork_blkid).await?,
+            Some(BlockStatus::Invalid)
+        );
+        // The fork block is not the high-watermark: the canonical chain's
+        // indexing rows must stay untouched and the high-watermark kept.
+        assert_eq!(ctx.storage().indexing_rollbacks(), vec![]);
+        assert_eq!(
+            ctx.storage().block_high_watermark(),
+            Some(canonical_commitment)
+        );
+        // Non-terminal blocks never store a summary, so none is deleted.
+        assert!(ctx.storage().epoch_summary_deletes().is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn process_fc_message_deletes_summary_for_invalid_non_high_watermark_terminal_block(
+    ) -> anyhow::Result<()> {
+        let pk = make_keypair().pk;
+        let genesis = make_storage_block(0, OLBlockId::from(Buf32::zero()));
+        let genesis_blkid = genesis.header().compute_blkid();
+        let genesis_commitment = OLBlockCommitment::new(genesis.header().slot(), genesis_blkid);
+        let genesis_epoch = EpochCommitment::new(0, genesis_commitment.slot(), genesis_blkid);
+        let ctx = Arc::new(
+            StubFcmContext::new()
+                .with_last_finalized_epoch(Some(genesis_epoch))
+                .with_last_confirmed_epoch(Some(genesis_epoch)),
+        );
+
+        // An accepted canonical block holds the high-watermark at slot 1...
+        let canonical = make_storage_block(1, genesis_blkid);
+        let canonical_commitment = OLBlockCommitment::new(
+            canonical.header().slot(),
+            canonical.header().compute_blkid(),
+        );
+
+        // ...and an unsigned *terminal* fork block at the same slot arrives.
+        let fork = make_terminal_storage_block(1, OLBlockId::from(Buf32::from([7u8; 32])));
+        let fork_blkid = fork.header().compute_blkid();
+
+        ctx.storage().put_executed_block(
+            genesis,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        ctx.storage().put_executed_block(
+            canonical,
+            make_genesis_state().state().clone(),
+            BlockStatus::Valid,
+        );
+        ctx.storage().put_ol_block(fork);
+        ctx.storage().set_block_high_watermark(canonical_commitment);
+        ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+
+        let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
+
+        process_fc_message(&ForkChoiceMessage::NewBlock(fork_blkid), &mut fcm_state).await?;
+
+        assert_eq!(
+            ctx.storage().get_block_status(fork_blkid).await?,
+            Some(BlockStatus::Invalid)
+        );
+        // The exact-keyed summary delete runs even though the fork is not the
+        // high-watermark: a stale summary keyed by the rejected terminal must
+        // not shadow canonical epoch lookups.
+        assert_eq!(
+            ctx.storage().epoch_summary_deletes(),
+            vec![EpochCommitment::new(0, 1, fork_blkid)]
+        );
+        // The suffix-shaped cleanup stays gated: no indexing rollback and the
+        // canonical high-watermark is kept.
+        assert_eq!(ctx.storage().indexing_rollbacks(), vec![]);
+        assert_eq!(
+            ctx.storage().block_high_watermark(),
+            Some(canonical_commitment)
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Backport of https://github.com/alpenlabs/alpen/pull/1973

I had to squash the original commits by @storopoli to avoid painful cherry-picking.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
