### PR TITLE
feat(prover): validate predicate keys at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16431,6 +16431,7 @@ dependencies = [
 name = "strata-proofimpl-predicate-keys"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "sp1-verifier",
  "strata-predicate",
  "strata-proofimpl-alpen-acct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "strata-primitives",
  "strata-proofimpl-alpen-acct",
  "strata-proofimpl-alpen-chunk",
+ "strata-proofimpl-predicate-keys",
  "strata-service",
  "strata-snark-acct-runtime",
  "strata-snark-acct-types",
@@ -14698,6 +14699,7 @@ dependencies = [
  "strata-predicate",
  "strata-primitives",
  "strata-proofimpl-checkpoint",
+ "strata-proofimpl-predicate-keys",
  "strata-service",
  "strata-snark-acct-types",
  "strata-status",
@@ -15469,7 +15471,6 @@ dependencies = [
  "rand_core 0.6.4",
  "reth-chainspec",
  "serde_json",
- "sp1-verifier",
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-types",
  "strata-btc-types",
@@ -15485,11 +15486,11 @@ dependencies = [
  "strata-primitives",
  "strata-proofimpl-alpen-acct",
  "strata-proofimpl-checkpoint",
+ "strata-proofimpl-predicate-keys",
  "strata-snark-acct-runtime",
  "strata-sp1-guest-builder",
  "tokio",
  "zeroize",
- "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]
@@ -16424,6 +16425,19 @@ dependencies = [
  "strata-state",
  "zkaleido",
  "zkaleido-native-adapter",
+]
+
+[[package]]
+name = "strata-proofimpl-predicate-keys"
+version = "0.1.0"
+dependencies = [
+ "sp1-verifier",
+ "strata-predicate",
+ "strata-proofimpl-alpen-acct",
+ "strata-proofimpl-alpen-chunk",
+ "strata-proofimpl-checkpoint",
+ "thiserror 2.0.18",
+ "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
   "crates/proof-impl/alpen-chunk",
   "crates/proof-impl/alpen-acct",
   "crates/proof-impl/checkpoint",
+  "crates/proof-impl/predicate-keys",
   "crates/zkvm/hosts",
   "crates/reth/chainspec",
   "crates/reth/db",
@@ -199,6 +200,7 @@ strata-proofimpl-alpen-acct = { path = "crates/proof-impl/alpen-acct" }
 strata-proofimpl-alpen-chunk = { path = "crates/proof-impl/alpen-chunk" }
 strata-proofimpl-checkpoint = { path = "crates/proof-impl/checkpoint" }
 strata-proofimpl-evm-ee-stf = { path = "crates/proof-impl/evm-ee-stf" }
+strata-proofimpl-predicate-keys = { path = "crates/proof-impl/predicate-keys" }
 strata-prover-core = { path = "crates/prover-core" }
 strata-simple-ee = { path = "crates/simple-ee" }
 strata-snark-acct-runtime = { path = "crates/snark-acct-runtime" }

--- a/bin/alpen-client/Cargo.toml
+++ b/bin/alpen-client/Cargo.toml
@@ -76,6 +76,7 @@ strata-predicate.workspace = true
 strata-primitives.workspace = true
 strata-proofimpl-alpen-acct.workspace = true
 strata-proofimpl-alpen-chunk.workspace = true
+strata-proofimpl-predicate-keys.workspace = true
 strata-service.workspace = true
 strata-snark-acct-runtime.workspace = true
 strata-snark-acct-types.workspace = true

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -95,6 +95,9 @@ mod sequencer_imports {
     };
     pub(super) use strata_proofimpl_alpen_acct::EeAcctProgram;
     pub(super) use strata_proofimpl_alpen_chunk::EeChunkProgram;
+    pub(super) use strata_proofimpl_predicate_keys::{
+        NativeAlpenChunkPredicateKey, PredicateKeyProvider,
+    };
     #[cfg(feature = "sp1")]
     pub(super) use strata_zkvm_hosts::sp1::{alpen_acct_host, alpen_chunk_host};
     #[cfg(feature = "sp1")]
@@ -802,7 +805,10 @@ fn main() {
                         "EE chunk + acct provers: native host (dev/test only)"
                     );
                     let chunk = chunk_builder.native(EeChunkProgram::native_host());
-                    let acct_program = EeAcctProgram::new(EeChunkProgram::test_predicate_key());
+                    let chunk_predicate_key = NativeAlpenChunkPredicateKey
+                        .predicate_key()
+                        .expect("native chunk predicate key must be available");
+                    let acct_program = EeAcctProgram::new(chunk_predicate_key);
                     let acct = acct_builder.native(acct_program.native_host());
                     (chunk, acct)
                 } else {

--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -27,11 +27,10 @@ strata-predicate.workspace = true
 strata-primitives.workspace = true
 strata-proofimpl-alpen-acct.workspace = true
 strata-proofimpl-checkpoint.workspace = true
+strata-proofimpl-predicate-keys = { workspace = true, optional = true }
 strata-snark-acct-runtime.workspace = true
 
-sp1-verifier = { workspace = true, optional = true }
 strata-sp1-guest-builder = { path = "../../provers/sp1", optional = true }
-zkaleido-sp1-groth16-verifier = { workspace = true, optional = true }
 
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true
@@ -50,7 +49,7 @@ default = ["btc-client"]
 btc-client = ["dep:bitcoind-async-client", "dep:tokio"]
 sp1-builder = [
   "strata-sp1-guest-builder/sp1-dev",
-  "dep:sp1-verifier",
-  "dep:zkaleido-sp1-groth16-verifier",
+  "dep:strata-proofimpl-predicate-keys",
+  "strata-proofimpl-predicate-keys/sp1",
 ]
 sp1-docker-builder = ["sp1-builder", "strata-sp1-guest-builder/docker-build"]

--- a/bin/datatool/src/acct_predicate.rs
+++ b/bin/datatool/src/acct_predicate.rs
@@ -82,24 +82,14 @@ fn resolve_default() -> PredicateKey {
 
 #[cfg(feature = "sp1-builder")]
 fn build_sp1_predicate() -> PredicateKey {
-    use strata_predicate::PredicateTypeId;
     use strata_primitives::buf::Buf32;
+    use strata_proofimpl_predicate_keys::{PredicateKeyProvider, Sp1Groth16PredicateKey};
     use strata_sp1_guest_builder::GUEST_ALPEN_ACCT_VK_HASH_STR;
-    use zkaleido_sp1_groth16_verifier::SP1Groth16Verifier;
 
     let vk_buf32: Buf32 = GUEST_ALPEN_ACCT_VK_HASH_STR
         .parse()
         .expect("invalid sp1 alpen-acct verifier key hash");
-    let sp1_verifier = SP1Groth16Verifier::load(
-        &sp1_verifier::GROTH16_VK_BYTES,
-        vk_buf32.0,
-        *sp1_verifier::VK_ROOT_BYTES,
-        true,
-    )
-    .expect("Failed to load SP1 Groth16 verifier");
-    // strata-predicate's Sp1Groth16 verifier reads the condition via
-    // `SP1Groth16Verifier::parse`, i.e. the verifier's canonical uncompressed
-    // encoding.
-    let condition_bytes = sp1_verifier.to_uncompressed_bytes();
-    PredicateKey::new(PredicateTypeId::Sp1Groth16, condition_bytes)
+    Sp1Groth16PredicateKey::new(vk_buf32.0)
+        .predicate_key()
+        .expect("failed to build SP1 Groth16 account predicate")
 }

--- a/bin/datatool/src/checkpoint_predicate.rs
+++ b/bin/datatool/src/checkpoint_predicate.rs
@@ -98,26 +98,16 @@ fn resolve_default() -> PredicateKey {
 
 #[cfg(feature = "sp1-builder")]
 fn build_sp1_predicate() -> PredicateKey {
-    use strata_predicate::PredicateTypeId;
     use strata_primitives::buf::Buf32;
+    use strata_proofimpl_predicate_keys::{PredicateKeyProvider, Sp1Groth16PredicateKey};
     use strata_sp1_guest_builder::GUEST_CHECKPOINT_VK_HASH_STR;
-    use zkaleido_sp1_groth16_verifier::SP1Groth16Verifier;
 
     // Integrated prover submits checkpoint proofs, so the predicate must be
     // bound to the checkpoint program ID.
     let vk_buf32: Buf32 = GUEST_CHECKPOINT_VK_HASH_STR
         .parse()
         .expect("invalid sp1 checkpoint verifier key hash");
-    let sp1_verifier = SP1Groth16Verifier::load(
-        &sp1_verifier::GROTH16_VK_BYTES,
-        vk_buf32.0,
-        *sp1_verifier::VK_ROOT_BYTES,
-        true,
-    )
-    .expect("Failed to load SP1 Groth16 verifier");
-    // strata-predicate's Sp1Groth16 verifier reads the condition via
-    // `SP1Groth16Verifier::parse`, i.e. the verifier's canonical uncompressed
-    // encoding.
-    let condition_bytes = sp1_verifier.to_uncompressed_bytes();
-    PredicateKey::new(PredicateTypeId::Sp1Groth16, condition_bytes)
+    Sp1Groth16PredicateKey::new(vk_buf32.0)
+        .predicate_key()
+        .expect("failed to build SP1 Groth16 checkpoint predicate")
 }

--- a/bin/datatool/src/main.rs
+++ b/bin/datatool/src/main.rs
@@ -5,11 +5,7 @@
 //! This tool is intended for use in testing and development only. It generates
 //! keys and other data that should not be used in production.
 
-#[cfg(feature = "sp1-builder")]
-use sp1_verifier as _;
 use strata_btc_verification as _;
-#[cfg(feature = "sp1-builder")]
-use zkaleido_sp1_groth16_verifier as _;
 
 mod acct_predicate;
 mod args;

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -27,10 +27,12 @@ prover = [
   "dep:strata-ol-stf",
   "dep:strata-paas",
   "dep:strata-proofimpl-checkpoint",
+  "dep:strata-proofimpl-predicate-keys",
   "dep:zkaleido",
 ]
 sp1 = [
   "prover",
+  "strata-proofimpl-predicate-keys/sp1",
   "strata-paas/remote",
   "dep:strata-zkvm-hosts",
   "dep:zkaleido-sp1-host",
@@ -81,6 +83,7 @@ strata-paas = { workspace = true, optional = true }
 strata-predicate.workspace = true
 strata-primitives.workspace = true
 strata-proofimpl-checkpoint = { workspace = true, optional = true }
+strata-proofimpl-predicate-keys = { workspace = true, optional = true }
 strata-service.workspace = true
 strata-snark-acct-types.workspace = true
 strata-status.workspace = true

--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -23,10 +23,18 @@ use strata_identifiers::Epoch;
 use strata_node_context::NodeContext;
 use strata_ol_params::OLParams;
 #[cfg(feature = "prover")]
-use strata_predicate::PredicateTypeId;
+use strata_predicate::{PredicateKey, PredicateTypeId};
 use strata_primitives::{L1BlockCommitment, OLBlockCommitment};
+#[cfg(all(feature = "prover", feature = "sp1"))]
+use strata_proofimpl_predicate_keys::Sp1Groth16PredicateKey;
+#[cfg(feature = "prover")]
+use strata_proofimpl_predicate_keys::{
+    NativeCheckpointPredicateKey, PredicateKeyProvider, validate_expected_predicate_key,
+};
 use strata_status::{OLSyncStatus, OLSyncStatusUpdate, StatusChannel};
 use strata_storage::{NodeStorage, create_node_storage};
+#[cfg(all(feature = "prover", feature = "sp1"))]
+use strata_zkvm_hosts::sp1::checkpoint_host;
 use tokio::runtime::Handle;
 use tracing::{info, warn};
 
@@ -64,7 +72,7 @@ pub(crate) fn init_node_context(
     // When the integrated prover is enabled, validate that its backend matches the
     // checkpoint predicate the runtime ASM will enforce.
     #[cfg(feature = "prover")]
-    validate_integrated_prover_compatibility(&config, &asm_params)?;
+    validate_integrated_prover_compatibility(&config, &asm_params, &handle)?;
 
     let blockasm_config = config
         .sequencer
@@ -195,8 +203,10 @@ fn load_config_from_path(path: &Path) -> Result<toml::Value, InitError> {
 fn validate_integrated_prover_compatibility(
     config: &Config,
     asm_params: &AsmParams,
+    handle: &Handle,
 ) -> Result<(), InitError> {
-    let checkpoint_predicate_type = checkpoint_predicate_type_from_asm_params(asm_params)?;
+    let checkpoint_predicate = checkpoint_predicate_from_asm_params(asm_params)?;
+    let checkpoint_predicate_type = checkpoint_predicate_type(checkpoint_predicate)?;
     let expected_backend = expected_backend_for_checkpoint_predicate(checkpoint_predicate_type)?;
 
     // When the prover is not configured, validate that the checkpoint predicate
@@ -221,13 +231,21 @@ fn validate_integrated_prover_compatibility(
         )));
     }
 
+    let expected_predicate = checkpoint_predicate_key_for_backend(prover_config.backend, handle)?;
+    validate_expected_predicate_key(checkpoint_predicate, &expected_predicate).map_err(|e| {
+        InitError::InvalidProverConfig(format!(
+            "checkpoint predicate key does not match configured prover backend {:?}: {e}",
+            prover_config.backend
+        ))
+    })?;
+
     Ok(())
 }
 
 #[cfg(feature = "prover")]
-fn checkpoint_predicate_type_from_asm_params(
+fn checkpoint_predicate_from_asm_params(
     asm_params: &AsmParams,
-) -> Result<PredicateTypeId, InitError> {
+) -> Result<&PredicateKey, InitError> {
     let checkpoint_subprotocol = asm_params
         .subprotocols
         .iter()
@@ -242,7 +260,12 @@ fn checkpoint_predicate_type_from_asm_params(
             )
         })?;
 
-    let checkpoint_predicate_id = checkpoint_subprotocol.checkpoint_predicate.id();
+    Ok(&checkpoint_subprotocol.checkpoint_predicate)
+}
+
+#[cfg(feature = "prover")]
+fn checkpoint_predicate_type(predicate: &PredicateKey) -> Result<PredicateTypeId, InitError> {
+    let checkpoint_predicate_id = predicate.id();
     PredicateTypeId::try_from(checkpoint_predicate_id).map_err(|e| {
         InitError::InvalidProverConfig(format!(
             "invalid AsmParams checkpoint predicate type id {checkpoint_predicate_id}: {e}"
@@ -268,6 +291,36 @@ fn expected_backend_for_checkpoint_predicate(
             "unsupported checkpoint predicate for integrated prover: {checkpoint_predicate_type}"
         ))),
     }
+}
+
+#[cfg(feature = "prover")]
+fn checkpoint_predicate_key_for_backend(
+    backend: ProverBackend,
+    handle: &Handle,
+) -> Result<PredicateKey, InitError> {
+    match backend {
+        ProverBackend::Native => NativeCheckpointPredicateKey
+            .predicate_key()
+            .map_err(|e| InitError::InvalidProverConfig(e.to_string())),
+        ProverBackend::Sp1 => checkpoint_sp1_predicate_key(handle),
+    }
+}
+
+#[cfg(all(feature = "prover", feature = "sp1"))]
+fn checkpoint_sp1_predicate_key(handle: &Handle) -> Result<PredicateKey, InitError> {
+    use zkaleido::ZkVmExecutor;
+
+    let host = handle.block_on(checkpoint_host(zkaleido_sp1_host::SP1HostConfig::default()));
+    Sp1Groth16PredicateKey::new(host.program_id().0)
+        .predicate_key()
+        .map_err(|e| InitError::InvalidProverConfig(e.to_string()))
+}
+
+#[cfg(all(feature = "prover", not(feature = "sp1")))]
+fn checkpoint_sp1_predicate_key(_handle: &Handle) -> Result<PredicateKey, InitError> {
+    Err(InitError::InvalidProverConfig(
+        "config.prover.backend=sp1 requires building `strata` with the `sp1` feature".to_string(),
+    ))
 }
 
 fn populate_sequencer_runtime_config(config: &mut Config, args: &Args) -> Result<(), InitError> {
@@ -676,5 +729,33 @@ mod tests {
         let err = super::expected_backend_for_checkpoint_predicate(PredicateTypeId::NeverAccept)
             .unwrap_err();
         assert!(matches!(err, InitError::InvalidProverConfig(_)));
+    }
+
+    #[cfg(feature = "prover")]
+    #[test]
+    fn accepts_matching_checkpoint_predicate_key_provider() {
+        use strata_proofimpl_predicate_keys::{
+            NativeCheckpointPredicateKey, PredicateKeyProvider, validate_expected_predicate_key,
+        };
+
+        let predicate = NativeCheckpointPredicateKey.predicate_key().unwrap();
+
+        validate_expected_predicate_key(&predicate, &predicate).unwrap();
+    }
+
+    #[cfg(feature = "prover")]
+    #[test]
+    fn rejects_mismatched_checkpoint_predicate_key_provider() {
+        use strata_predicate::PredicateKey;
+        use strata_proofimpl_predicate_keys::{
+            NativeCheckpointPredicateKey, PredicateKeyProvider, validate_expected_predicate_key,
+        };
+
+        let configured = NativeCheckpointPredicateKey.predicate_key().unwrap();
+        let expected = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0u8; 32]);
+
+        let err = validate_expected_predicate_key(&configured, &expected).unwrap_err();
+
+        assert!(err.to_string().contains("predicate key mismatch"));
     }
 }

--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -13,11 +13,11 @@ use format_serde_error::SerdeError;
 use strata_asm_params::AsmParams;
 #[cfg(feature = "prover")]
 use strata_asm_params::SubprotocolInstance;
-#[cfg(feature = "prover")]
-use strata_config::ProverBackend;
 use strata_config::{
     BitcoindConfig, BlockAssemblyConfig, Config, SequencerConfig, SequencerRuntimeConfig,
 };
+#[cfg(feature = "prover")]
+use strata_config::{ProverBackend, ProverConfig};
 use strata_csm_types::{ClientState, ClientUpdateOutput, L1Status};
 use strata_identifiers::Epoch;
 use strata_node_context::NodeContext;
@@ -25,12 +25,10 @@ use strata_ol_params::OLParams;
 #[cfg(feature = "prover")]
 use strata_predicate::{PredicateKey, PredicateTypeId};
 use strata_primitives::{L1BlockCommitment, OLBlockCommitment};
-#[cfg(all(feature = "prover", feature = "sp1"))]
+#[cfg(feature = "prover")]
 use strata_proofimpl_predicate_keys::Sp1Groth16PredicateKey;
 #[cfg(feature = "prover")]
-use strata_proofimpl_predicate_keys::{
-    NativeCheckpointPredicateKey, PredicateKeyProvider, validate_expected_predicate_key,
-};
+use strata_proofimpl_predicate_keys::{NativeCheckpointPredicateKey, validate_predicate_key};
 use strata_status::{OLSyncStatus, OLSyncStatusUpdate, StatusChannel};
 use strata_storage::{NodeStorage, create_node_storage};
 #[cfg(all(feature = "prover", feature = "sp1"))]
@@ -38,6 +36,8 @@ use strata_zkvm_hosts::sp1::checkpoint_host;
 use tokio::runtime::Handle;
 use tracing::{info, warn};
 
+#[cfg(all(feature = "prover", feature = "sp1"))]
+use crate::prover::checkpoint_sp1_host_config;
 use crate::{args::*, config::*, errors::*, genesis::init_ol_genesis, init_db};
 
 /// Load config early for logging initialization
@@ -231,13 +231,7 @@ fn validate_integrated_prover_compatibility(
         )));
     }
 
-    let expected_predicate = checkpoint_predicate_key_for_backend(prover_config.backend, handle)?;
-    validate_expected_predicate_key(checkpoint_predicate, &expected_predicate).map_err(|e| {
-        InitError::InvalidProverConfig(format!(
-            "checkpoint predicate key does not match configured prover backend {:?}: {e}",
-            prover_config.backend
-        ))
-    })?;
+    validate_checkpoint_predicate_key_for_backend(checkpoint_predicate, prover_config, handle)?;
 
     Ok(())
 }
@@ -294,30 +288,45 @@ fn expected_backend_for_checkpoint_predicate(
 }
 
 #[cfg(feature = "prover")]
-fn checkpoint_predicate_key_for_backend(
-    backend: ProverBackend,
+fn validate_checkpoint_predicate_key_for_backend(
+    checkpoint_predicate: &PredicateKey,
+    prover_config: &ProverConfig,
     handle: &Handle,
-) -> Result<PredicateKey, InitError> {
-    match backend {
-        ProverBackend::Native => NativeCheckpointPredicateKey
-            .predicate_key()
-            .map_err(|e| InitError::InvalidProverConfig(e.to_string())),
-        ProverBackend::Sp1 => checkpoint_sp1_predicate_key(handle),
+) -> Result<(), InitError> {
+    match prover_config.backend {
+        ProverBackend::Native => {
+            validate_predicate_key(checkpoint_predicate, &NativeCheckpointPredicateKey)
+        }
+        ProverBackend::Sp1 => {
+            let provider = checkpoint_sp1_predicate_key_provider(prover_config, handle)?;
+            validate_predicate_key(checkpoint_predicate, &provider)
+        }
     }
+    .map_err(|e| {
+        InitError::InvalidProverConfig(format!(
+            "checkpoint predicate key does not match configured prover backend {:?}: {e}",
+            prover_config.backend
+        ))
+    })
 }
 
 #[cfg(all(feature = "prover", feature = "sp1"))]
-fn checkpoint_sp1_predicate_key(handle: &Handle) -> Result<PredicateKey, InitError> {
+fn checkpoint_sp1_predicate_key_provider(
+    prover_config: &ProverConfig,
+    handle: &Handle,
+) -> Result<Sp1Groth16PredicateKey, InitError> {
     use zkaleido::ZkVmExecutor;
 
-    let host = handle.block_on(checkpoint_host(zkaleido_sp1_host::SP1HostConfig::default()));
-    Sp1Groth16PredicateKey::new(host.program_id().0)
-        .predicate_key()
-        .map_err(|e| InitError::InvalidProverConfig(e.to_string()))
+    let sp1_config = checkpoint_sp1_host_config(prover_config);
+    let host = handle.block_on(checkpoint_host(sp1_config));
+    Ok(Sp1Groth16PredicateKey::new(host.program_id().0))
 }
 
 #[cfg(all(feature = "prover", not(feature = "sp1")))]
-fn checkpoint_sp1_predicate_key(_handle: &Handle) -> Result<PredicateKey, InitError> {
+fn checkpoint_sp1_predicate_key_provider(
+    _prover_config: &ProverConfig,
+    _handle: &Handle,
+) -> Result<Sp1Groth16PredicateKey, InitError> {
     Err(InitError::InvalidProverConfig(
         "config.prover.backend=sp1 requires building `strata` with the `sp1` feature".to_string(),
     ))

--- a/bin/strata/src/prover/mod.rs
+++ b/bin/strata/src/prover/mod.rs
@@ -21,6 +21,8 @@ use strata_storage::CheckpointProofDbManager;
 use strata_tasks::TaskExecutor;
 use tokio::{sync::watch, time};
 use tracing::{debug, info, warn};
+#[cfg(feature = "sp1")]
+use zkaleido_sp1_host::{SP1Host, SP1HostConfig};
 
 use self::{
     receipt_hook::CheckpointReceiptHook,
@@ -38,6 +40,22 @@ const PROVER_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 /// cover checkpoint proofs while still failing fast on stuck requests.
 #[cfg(feature = "sp1")]
 const DEFAULT_SP1_DEADLINE_SECS: u64 = 4 * 60 * 60;
+
+/// Returns the checkpoint SP1 proof deadline configured for this node.
+#[cfg(feature = "sp1")]
+pub(crate) fn checkpoint_sp1_proof_deadline_secs(prover_config: &ProverConfig) -> u64 {
+    prover_config
+        .sp1_proof_deadline_secs
+        .unwrap_or(DEFAULT_SP1_DEADLINE_SECS)
+}
+
+/// Builds the SP1 host config used by the checkpoint prover.
+#[cfg(feature = "sp1")]
+pub(crate) fn checkpoint_sp1_host_config(prover_config: &ProverConfig) -> SP1HostConfig {
+    SP1HostConfig::default().with_deadline(Duration::from_secs(checkpoint_sp1_proof_deadline_secs(
+        prover_config,
+    )))
+}
 
 /// Starts the integrated prover service.
 ///
@@ -86,7 +104,6 @@ pub(crate) fn start_prover_service(
         #[cfg(feature = "sp1")]
         ProverBackend::Sp1 => {
             use strata_zkvm_hosts::sp1::checkpoint_host;
-            use zkaleido_sp1_host::SP1HostConfig;
             // prover-core's `.remote(host)` takes the host by value and
             // re-wraps it in its own Arc inside RemoteStrategy. SP1Host
             // is Clone (only holds a SP1ProvingKey), so cloning from the
@@ -94,17 +111,14 @@ pub(crate) fn start_prover_service(
             // proving key + prover client over the network/local SDK), so
             // we drive it on the runtime handle. The deadline is now part
             // of `SP1HostConfig`, applied at init time rather than after.
-            let deadline_secs = prover_config
-                .sp1_proof_deadline_secs
-                .unwrap_or(DEFAULT_SP1_DEADLINE_SECS);
-            let sp1_config =
-                SP1HostConfig::default().with_deadline(Duration::from_secs(deadline_secs));
+            let deadline_secs = checkpoint_sp1_proof_deadline_secs(&prover_config);
+            let sp1_config = checkpoint_sp1_host_config(&prover_config);
             info!(deadline_secs, "sp1 prover deadline configured");
             let host_static = runctx
                 .task_manager
                 .handle()
                 .block_on(checkpoint_host(sp1_config));
-            let host: zkaleido_sp1_host::SP1Host = (**host_static).clone();
+            let host: SP1Host = (**host_static).clone();
             ProverBuilder::new(spec)
                 .task_store(task_store)
                 .receipt_hook(hook)

--- a/crates/proof-impl/predicate-keys/Cargo.toml
+++ b/crates/proof-impl/predicate-keys/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 sp1 = ["dep:sp1-verifier", "dep:zkaleido-sp1-groth16-verifier"]
 
 [dependencies]
+hex.workspace = true
 strata-predicate.workspace = true
 strata-proofimpl-alpen-acct.workspace = true
 strata-proofimpl-alpen-chunk.workspace = true

--- a/crates/proof-impl/predicate-keys/Cargo.toml
+++ b/crates/proof-impl/predicate-keys/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "strata-proofimpl-predicate-keys"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+sp1 = ["dep:sp1-verifier", "dep:zkaleido-sp1-groth16-verifier"]
+
+[dependencies]
+strata-predicate.workspace = true
+strata-proofimpl-alpen-acct.workspace = true
+strata-proofimpl-alpen-chunk.workspace = true
+strata-proofimpl-checkpoint.workspace = true
+
+sp1-verifier = { workspace = true, optional = true }
+thiserror.workspace = true
+zkaleido-sp1-groth16-verifier = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/proof-impl/predicate-keys/src/lib.rs
+++ b/crates/proof-impl/predicate-keys/src/lib.rs
@@ -20,18 +20,23 @@ pub enum PredicateKeyError {
     /// The configured predicate does not match the expected predicate.
     #[error(
         "predicate key mismatch: configured type {configured_type} condition length \
-         {configured_condition_len}, expected type {expected_type} condition length \
-         {expected_condition_len}"
+         {configured_condition_len} condition {configured_condition}, expected type \
+         {expected_type} condition length {expected_condition_len} condition \
+         {expected_condition}"
     )]
     Mismatch {
         /// Predicate type configured in params.
         configured_type: u8,
         /// Configured predicate condition byte length.
         configured_condition_len: usize,
+        /// Hex-encoded configured predicate condition.
+        configured_condition: String,
         /// Expected predicate type for the selected provider.
         expected_type: u8,
         /// Expected predicate condition byte length.
         expected_condition_len: usize,
+        /// Hex-encoded expected predicate condition.
+        expected_condition: String,
     },
 }
 
@@ -62,8 +67,10 @@ pub fn validate_expected_predicate_key(
     Err(PredicateKeyError::Mismatch {
         configured_type: configured.id(),
         configured_condition_len: configured.condition().len(),
+        configured_condition: hex::encode(configured.condition()),
         expected_type: expected.id(),
         expected_condition_len: expected.condition().len(),
+        expected_condition: hex::encode(expected.condition()),
     })
 }
 
@@ -136,5 +143,88 @@ impl PredicateKeyProvider for Sp1Groth16PredicateKey {
         Err(PredicateKeyError::FeatureDisabled(
             "SP1 predicate-key derivation requires the `sp1` feature",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_predicate::{PredicateKey, PredicateTypeId};
+
+    use super::{
+        PredicateKeyError, PredicateKeyProvider, validate_expected_predicate_key,
+        validate_predicate_key,
+    };
+
+    #[derive(Debug)]
+    struct StaticPredicateKeyProvider(PredicateKey);
+
+    impl PredicateKeyProvider for StaticPredicateKeyProvider {
+        fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn accepts_equal_predicate_keys() {
+        let predicate = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3]);
+
+        validate_expected_predicate_key(&predicate, &predicate).unwrap();
+    }
+
+    #[test]
+    fn validates_predicate_key_provider_output() {
+        let predicate = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3]);
+        let provider = StaticPredicateKeyProvider(predicate.clone());
+
+        validate_predicate_key(&predicate, &provider).unwrap();
+    }
+
+    #[test]
+    fn mismatch_reports_type_length_and_conditions() {
+        let configured = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0xaa; 32]);
+        let expected = PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![0xbb; 16]);
+
+        let err = validate_expected_predicate_key(&configured, &expected).unwrap_err();
+
+        let PredicateKeyError::Mismatch {
+            configured_type,
+            configured_condition_len,
+            configured_condition,
+            expected_type,
+            expected_condition_len,
+            expected_condition,
+        } = err
+        else {
+            panic!("expected mismatch error");
+        };
+
+        assert_eq!(configured_type, PredicateTypeId::Bip340Schnorr as u8);
+        assert_eq!(configured_condition_len, 32);
+        assert_eq!(
+            configured_condition,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(expected_type, PredicateTypeId::Sp1Groth16 as u8);
+        assert_eq!(expected_condition_len, 16);
+        assert_eq!(expected_condition, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    }
+
+    #[test]
+    fn mismatch_reports_same_type_and_length_with_different_conditions() {
+        let configured = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0xaa; 32]);
+        let expected = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0xbb; 32]);
+
+        let err = validate_expected_predicate_key(&configured, &expected)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains(
+            "configured type 10 condition length 32 condition \
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ));
+        assert!(err.contains(
+            "expected type 10 condition length 32 condition \
+             bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ));
     }
 }

--- a/crates/proof-impl/predicate-keys/src/lib.rs
+++ b/crates/proof-impl/predicate-keys/src/lib.rs
@@ -1,0 +1,140 @@
+//! Predicate-key providers for Alpen proof programs.
+
+use strata_predicate::PredicateKey;
+use strata_proofimpl_alpen_acct::EeAcctProgram;
+use strata_proofimpl_alpen_chunk::EeChunkProgram;
+use strata_proofimpl_checkpoint::program::CheckpointProgram;
+
+/// Errors returned while deriving or validating predicate keys.
+#[derive(Debug, thiserror::Error)]
+pub enum PredicateKeyError {
+    /// Failed to build an SP1 Groth16 verifier predicate condition.
+    #[cfg(feature = "sp1")]
+    #[error("failed to derive SP1 Groth16 predicate key: {0}")]
+    Sp1Verifier(String),
+
+    /// The requested provider is unavailable because a crate feature is disabled.
+    #[error("{0}")]
+    FeatureDisabled(&'static str),
+
+    /// The configured predicate does not match the expected predicate.
+    #[error(
+        "predicate key mismatch: configured type {configured_type} condition length \
+         {configured_condition_len}, expected type {expected_type} condition length \
+         {expected_condition_len}"
+    )]
+    Mismatch {
+        /// Predicate type configured in params.
+        configured_type: u8,
+        /// Configured predicate condition byte length.
+        configured_condition_len: usize,
+        /// Expected predicate type for the selected provider.
+        expected_type: u8,
+        /// Expected predicate condition byte length.
+        expected_condition_len: usize,
+    },
+}
+
+/// Provides the predicate key for a concrete proof program/backend pairing.
+pub trait PredicateKeyProvider {
+    /// Returns the predicate key expected for this provider.
+    fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError>;
+}
+
+/// Validates that a configured predicate matches a provider-derived predicate.
+pub fn validate_predicate_key(
+    configured: &PredicateKey,
+    provider: &impl PredicateKeyProvider,
+) -> Result<(), PredicateKeyError> {
+    let expected = provider.predicate_key()?;
+    validate_expected_predicate_key(configured, &expected)
+}
+
+/// Validates that a configured predicate matches an expected predicate.
+pub fn validate_expected_predicate_key(
+    configured: &PredicateKey,
+    expected: &PredicateKey,
+) -> Result<(), PredicateKeyError> {
+    if configured.id() == expected.id() && configured.condition() == expected.condition() {
+        return Ok(());
+    }
+
+    Err(PredicateKeyError::Mismatch {
+        configured_type: configured.id(),
+        configured_condition_len: configured.condition().len(),
+        expected_type: expected.id(),
+        expected_condition_len: expected.condition().len(),
+    })
+}
+
+/// Native checkpoint predicate provider used by functional-test setups.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeCheckpointPredicateKey;
+
+impl PredicateKeyProvider for NativeCheckpointPredicateKey {
+    fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError> {
+        Ok(CheckpointProgram::test_predicate_key())
+    }
+}
+
+/// Native Alpen EE chunk predicate provider used by functional-test setups.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeAlpenChunkPredicateKey;
+
+impl PredicateKeyProvider for NativeAlpenChunkPredicateKey {
+    fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError> {
+        Ok(EeChunkProgram::test_predicate_key())
+    }
+}
+
+/// Native Alpen EE account predicate provider used by functional-test setups.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeAlpenAcctPredicateKey;
+
+impl PredicateKeyProvider for NativeAlpenAcctPredicateKey {
+    fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError> {
+        Ok(EeAcctProgram::test_predicate_key())
+    }
+}
+
+/// SP1 Groth16 predicate provider for a concrete program ID.
+#[derive(Debug, Clone, Copy)]
+pub struct Sp1Groth16PredicateKey {
+    program_id: [u8; 32],
+}
+
+impl Sp1Groth16PredicateKey {
+    /// Creates an SP1 Groth16 predicate provider bound to a program ID.
+    pub fn new(program_id: [u8; 32]) -> Self {
+        Self { program_id }
+    }
+}
+
+#[cfg(feature = "sp1")]
+impl PredicateKeyProvider for Sp1Groth16PredicateKey {
+    fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError> {
+        use strata_predicate::PredicateTypeId;
+        use zkaleido_sp1_groth16_verifier::SP1Groth16Verifier;
+
+        let sp1_verifier = SP1Groth16Verifier::load(
+            &sp1_verifier::GROTH16_VK_BYTES,
+            self.program_id,
+            *sp1_verifier::VK_ROOT_BYTES,
+            true,
+        )
+        .map_err(|e| PredicateKeyError::Sp1Verifier(e.to_string()))?;
+        let condition = sp1_verifier.to_uncompressed_bytes();
+
+        Ok(PredicateKey::new(PredicateTypeId::Sp1Groth16, condition))
+    }
+}
+
+#[cfg(not(feature = "sp1"))]
+impl PredicateKeyProvider for Sp1Groth16PredicateKey {
+    fn predicate_key(&self) -> Result<PredicateKey, PredicateKeyError> {
+        let _ = self.program_id;
+        Err(PredicateKeyError::FeatureDisabled(
+            "SP1 predicate-key derivation requires the `sp1` feature",
+        ))
+    }
+}


### PR DESCRIPTION
## Description

Adds a shared predicate-key provider abstraction and uses it to validate the configured checkpoint predicate key during Strata startup.

This lets native and SP1 backends derive their expected keys through the same interface, keeps predicate-key construction reusable across binaries, and makes startup fail early when the configured checkpoint predicate key does not match the selected prover backend.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Key points:

- Adds `strata-proofimpl-predicate-keys` for native and SP1 predicate-key derivation.
- Validates Strata checkpoint predicate configuration at startup against the selected prover backend.
- Reuses the shared SP1 predicate-key provider from datatool instead of duplicating verifier-key encoding logic.
- Keeps SP1 predicate keys encoded with `SP1Groth16Verifier::to_uncompressed_bytes()`.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- STR-2061

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: I used AI assistance to help implement, review, and validate this change.

Validation:

- `just pr-lite`
- `just pr`

## Related Issues

STR-2061
