### PR TITLE
backport: feat(dbtool): add delete-ol-block command to prune orphaned fork blocks

### DIFF
--- a/bin/strata-dbtool/src/cli.rs
+++ b/bin/strata-dbtool/src/cli.rs
@@ -20,7 +20,7 @@ use crate::cmd::{
         EeDeleteAcctProofArgs, EeDeleteChunkReceiptArgs, EeGetAcctProofArgs, EeGetChunkReceiptArgs,
     },
     l1::{GetL1BlockArgs, GetL1SummaryArgs},
-    ol::{GetOLBlockArgs, GetOLBlocksAtSlotArgs, GetOLSummaryArgs},
+    ol::{DeleteOLBlockArgs, GetOLBlockArgs, GetOLBlocksAtSlotArgs, GetOLSummaryArgs},
     ol_state::{GetOLStateArgs, RevertOLStateArgs},
     prover_task::{
         AbandonProverTaskArgs, AbandonProverTasksArgs, BackfillCheckpointProofTaskArgs,
@@ -59,6 +59,7 @@ pub(crate) enum Command {
     GetOlBlock(GetOLBlockArgs),
     GetOlBlocksAtSlot(GetOLBlocksAtSlotArgs),
     GetOlSummary(GetOLSummaryArgs),
+    DeleteOlBlock(DeleteOLBlockArgs),
     GetClientStateUpdate(GetClientStateUpdateArgs),
     GetCheckpoint(GetCheckpointArgs),
     GetCheckpointsSummary(GetCheckpointsSummaryArgs),

--- a/bin/strata-dbtool/src/cmd/ol.rs
+++ b/bin/strata-dbtool/src/cmd/ol.rs
@@ -9,7 +9,7 @@ use crate::{
     cli::OutputFormat,
     cmd::checkpoint::get_last_ol_checkpoint_epoch,
     output::{
-        ol::{OLBlockInfo, OLBlocksAtSlotInfo, OLSummaryInfo},
+        ol::{OLBlockDeleteInfo, OLBlockInfo, OLBlocksAtSlotInfo, OLSummaryInfo},
         output,
     },
     utils::block_id::parse_ol_block_id,
@@ -48,6 +48,28 @@ pub(crate) struct GetOLBlocksAtSlotArgs {
     /// OL slot
     #[argh(positional)]
     pub(crate) slot: Slot,
+
+    /// output format: "porcelain" (default) or "json"
+    #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
+    pub(crate) output_format: OutputFormat,
+}
+
+/// Delete one OL block (block data, status, and slot-index entry).
+///
+/// Intended for pruning an orphaned sibling block left behind by a reorg,
+/// e.g. when the slot index still lists the orphan ahead of the canonical
+/// block. Refuses to delete a block that is alone at its slot or that has a
+/// stored child.
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "delete-ol-block")]
+pub(crate) struct DeleteOLBlockArgs {
+    /// OL block id (hex)
+    #[argh(positional)]
+    pub(crate) block_id: String,
+
+    /// force execution (without this flag, only a dry run is performed)
+    #[argh(switch, short = 'f')]
+    pub(crate) force: bool,
 
     /// output format: "porcelain" (default) or "json"
     #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
@@ -179,6 +201,69 @@ pub(crate) fn get_ol_blocks_at_slot(
         block_ids: &block_ids,
     };
 
+    output(&info, args.output_format)
+}
+
+/// Deletes one OL block after checking it is a childless sibling fork.
+pub(crate) fn delete_ol_block(
+    db: &impl DatabaseBackend,
+    args: DeleteOLBlockArgs,
+) -> Result<(), DisplayedError> {
+    let block_id = parse_ol_block_id(&args.block_id)?;
+
+    let block = get_ol_block_data(db, block_id)?.ok_or_else(|| {
+        DisplayedError::UserError("OL block with id not found".to_string(), Box::new(block_id))
+    })?;
+    let slot = block.header().slot();
+
+    let blocks_at_slot = db
+        .ol_block_db()
+        .get_blocks_at_height(slot)
+        .internal_error(format!("Failed to get blocks at slot {slot}"))?;
+
+    // Deleting the only block at a slot would punch a hole in the chain.
+    let remaining_block_ids: Vec<OLBlockId> = blocks_at_slot
+        .iter()
+        .copied()
+        .filter(|id| *id != block_id)
+        .collect();
+    if remaining_block_ids.is_empty() {
+        return Err(DisplayedError::UserError(
+            "Refusing to delete the only block at slot".to_string(),
+            Box::new(slot),
+        ));
+    }
+
+    // A stored child means this block is (or was) extended by some chain;
+    // deleting it would leave that child without a parent in the database.
+    let blocks_at_next_slot = db
+        .ol_block_db()
+        .get_blocks_at_height(slot + 1)
+        .internal_error(format!("Failed to get blocks at slot {}", slot + 1))?;
+    for child_id in blocks_at_next_slot {
+        let Some(child) = get_ol_block_data(db, child_id)? else {
+            continue;
+        };
+        if *child.header().parent_blkid() == block_id {
+            return Err(DisplayedError::UserError(
+                "Refusing to delete block with a stored child".to_string(),
+                Box::new(child_id),
+            ));
+        }
+    }
+
+    if args.force {
+        db.ol_block_db()
+            .del_block_data(block_id)
+            .internal_error("Failed to delete OL block")?;
+    }
+
+    let info = OLBlockDeleteInfo {
+        block_id: &block_id,
+        slot,
+        remaining_block_ids: &remaining_block_ids,
+        dry_run: !args.force,
+    };
     output(&info, args.output_format)
 }
 

--- a/bin/strata-dbtool/src/main.rs
+++ b/bin/strata-dbtool/src/main.rs
@@ -30,7 +30,7 @@ use crate::{
             ee_delete_acct_proof, ee_delete_chunk_receipt, ee_get_acct_proof, ee_get_chunk_receipt,
         },
         l1::{get_l1_block, get_l1_summary},
-        ol::{get_ol_block, get_ol_blocks_at_slot, get_ol_summary},
+        ol::{delete_ol_block, get_ol_block, get_ol_blocks_at_slot, get_ol_summary},
         ol_state::{get_ol_state, revert_ol_state},
         prover_task::{
             abandon_prover_task, abandon_prover_tasks, backfill_checkpoint_proof_task,
@@ -61,6 +61,7 @@ fn main() {
             with_ol_db(&datadir, |db| get_ol_blocks_at_slot(db, args))
         }
         Command::GetOlSummary(args) => with_ol_db(&datadir, |db| get_ol_summary(db, args)),
+        Command::DeleteOlBlock(args) => with_ol_db(&datadir, |db| delete_ol_block(db, args)),
         Command::GetL1Block(args) => with_ol_db(&datadir, |db| get_l1_block(db, args)),
         Command::GetL1Summary(args) => with_ol_db(&datadir, |db| get_l1_summary(db, args)),
         Command::GetWriterSummary(args) => with_ol_db(&datadir, |db| get_writer_summary(db, args)),

--- a/bin/strata-dbtool/src/output/ol.rs
+++ b/bin/strata-dbtool/src/output/ol.rs
@@ -46,6 +46,15 @@ pub(crate) struct OLBlocksAtSlotInfo<'a> {
     pub(crate) block_ids: &'a [OLBlockId],
 }
 
+/// Result of deleting one OL block.
+#[derive(serde::Serialize)]
+pub(crate) struct OLBlockDeleteInfo<'a> {
+    pub(crate) block_id: &'a OLBlockId,
+    pub(crate) slot: Slot,
+    pub(crate) remaining_block_ids: &'a [OLBlockId],
+    pub(crate) dry_run: bool,
+}
+
 impl<'a> Formattable for OLBlockInfo<'a> {
     fn format_porcelain(&self) -> String {
         let mut output = Vec::new();
@@ -142,6 +151,29 @@ impl Formattable for OLBlocksAtSlotInfo<'_> {
                 format!("{block_id:?}"),
             ));
         }
+
+        output.join("\n")
+    }
+}
+
+impl Formattable for OLBlockDeleteInfo<'_> {
+    fn format_porcelain(&self) -> String {
+        let mut output = Vec::new();
+
+        output.push(porcelain_field("block_id", format!("{:?}", self.block_id)));
+        output.push(porcelain_field("slot", self.slot));
+
+        for (index, block_id) in self.remaining_block_ids.iter().enumerate() {
+            output.push(porcelain_field(
+                &format!("remaining_block_ids.{index}"),
+                format!("{block_id:?}"),
+            ));
+        }
+
+        output.push(porcelain_field(
+            "dry_run",
+            super::helpers::porcelain_bool(self.dry_run),
+        ));
 
         output.join("\n")
     }


### PR DESCRIPTION
Backport of #1979

---

Add a dbtool subcommand that deletes a single OL block (block data, status, and slot-index entry) via del_block_data. This repairs databases where a reorg left an orphaned sibling ahead of the canonical block in the slot index, causing canonical-block-at-slot resolution (STR-2105) to serve the orphan from getBlockBySlot and getBlocksSummaries.

The command is dry-run by default (-f to execute) and refuses to delete a block that is alone at its slot or that has a stored child.