### PR TITLE
refactor(bridge): remove txid from withdrawal intents

### DIFF
--- a/crates/alpen-ee/block-assembly/src/package.rs
+++ b/crates/alpen-ee/block-assembly/src/package.rs
@@ -55,19 +55,26 @@ pub(crate) fn build_block_outputs<TPayload: EnginePayload>(
 ) -> ExecOutputs {
     let mut outputs = ExecOutputs::new_empty();
     for withdrawal_intent in payload.withdrawal_intents() {
+        let dest_desc_len = withdrawal_intent.destination.to_bytes().len();
         let Some(msg_payload) = create_withdrawal_init_message_payload(
             withdrawal_intent.destination.clone(),
             BitcoinAmount::from_sat(withdrawal_intent.amt),
             withdrawal_intent.selected_operator,
         ) else {
-            warn!("skipping withdrawal: failed to create withdrawal message");
+            warn!(
+                amount_sat = withdrawal_intent.amt,
+                selected_operator = withdrawal_intent.selected_operator.raw(),
+                dest_desc_len,
+                destination = ?withdrawal_intent.destination,
+                "skipping withdrawal: failed to create withdrawal message",
+            );
             continue;
         };
         info!(
             amount_sat = withdrawal_intent.amt,
             selected_operator = withdrawal_intent.selected_operator.raw(),
-            dest_desc_len = withdrawal_intent.destination.to_bytes().len(),
-            %bridge_gateway_account_id,
+            dest_desc_len,
+            destination = ?withdrawal_intent.destination,
             "created withdrawal output message for bridge gateway",
         );
         outputs.add_message(OutputMessage::new(bridge_gateway_account_id, msg_payload));

--- a/crates/alpen-ee/block-assembly/src/package.rs
+++ b/crates/alpen-ee/block-assembly/src/package.rs
@@ -60,14 +60,10 @@ pub(crate) fn build_block_outputs<TPayload: EnginePayload>(
             BitcoinAmount::from_sat(withdrawal_intent.amt),
             withdrawal_intent.selected_operator,
         ) else {
-            warn!(
-                withdrawal_txid = %withdrawal_intent.withdrawal_txid,
-                "skipping withdrawal: failed to create withdrawal message"
-            );
+            warn!("skipping withdrawal: failed to create withdrawal message");
             continue;
         };
         info!(
-            withdrawal_txid = ?withdrawal_intent.withdrawal_txid,
             amount_sat = withdrawal_intent.amt,
             selected_operator = withdrawal_intent.selected_operator.raw(),
             dest_desc_len = withdrawal_intent.destination.to_bytes().len(),

--- a/crates/bridge-types/src/bridge_ops.rs
+++ b/crates/bridge-types/src/bridge_ops.rs
@@ -4,7 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use strata_identifiers::SubjectId;
-use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32, l1::BitcoinAmount};
+use strata_primitives::{bitcoin_bosd::Descriptor, l1::BitcoinAmount};
 
 use crate::OperatorSelection;
 
@@ -28,9 +28,6 @@ pub struct WithdrawalIntent {
     /// Destination [`Descriptor`] for the withdrawal
     destination: Descriptor,
 
-    /// withdrawal request transaction id
-    withdrawal_txid: Buf32,
-
     /// User's operator selection for withdrawal assignment.
     selected_operator: OperatorSelection,
 }
@@ -39,13 +36,11 @@ impl WithdrawalIntent {
     pub fn new(
         amt: BitcoinAmount,
         destination: Descriptor,
-        withdrawal_txid: Buf32,
         selected_operator: OperatorSelection,
     ) -> Self {
         Self {
             amt,
             destination,
-            withdrawal_txid,
             selected_operator,
         }
     }
@@ -60,10 +55,6 @@ impl WithdrawalIntent {
 
     pub fn destination(&self) -> &Descriptor {
         &self.destination
-    }
-
-    pub fn withdrawal_txid(&self) -> &Buf32 {
-        &self.withdrawal_txid
     }
 
     pub fn selected_operator(&self) -> OperatorSelection {
@@ -136,7 +127,7 @@ impl DepositIntent {
 mod tests {
     use proptest::prelude::*;
     use ssz::{Decode, Encode};
-    use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32, l1::BitcoinAmount};
+    use strata_primitives::{bitcoin_bosd::Descriptor, l1::BitcoinAmount};
 
     use super::WithdrawalIntent;
     use crate::OperatorSelection;
@@ -163,13 +154,11 @@ mod tests {
         fn withdrawal_intent_ssz_roundtrip(
             amt in any::<u64>(),
             destination in descriptor_strategy(),
-            withdrawal_txid in any::<[u8; 32]>(),
             selected_operator in operator_selection_strategy(),
         ) {
             let intent = WithdrawalIntent::new(
                 BitcoinAmount::from_sat(amt),
                 destination,
-                Buf32::from(withdrawal_txid),
                 selected_operator,
             );
 
@@ -185,7 +174,6 @@ mod tests {
         let encoded = (
             BitcoinAmount::from_sat(42),
             vec![0xFFu8; 3],
-            Buf32::from([7u8; 32]),
             OperatorSelection::any(),
         )
             .as_ssz_bytes();

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -270,7 +270,7 @@ mod tests {
     use strata_msg_fmt::{Msg, MsgRef};
     use strata_ol_bridge_types::OperatorSelection;
     use strata_ol_msg_types::OLMessageExt;
-    use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32};
+    use strata_primitives::bitcoin_bosd::Descriptor;
 
     use super::*;
     use crate::types::{EvmBlock, EvmBlockBody, EvmHeader, EvmPartialState};
@@ -296,7 +296,6 @@ mod tests {
         let intent = alpen_reth_primitives::WithdrawalIntent {
             amt: withdrawal_sats,
             selected_operator: OperatorSelection::any(),
-            withdrawal_txid: Buf32::new([0x44; 32]),
             destination,
         };
 

--- a/crates/proof-impl/evm-ee-stf/src/utils.rs
+++ b/crates/proof-impl/evm-ee-stf/src/utils.rs
@@ -15,7 +15,6 @@ pub fn generate_exec_update(el_proof_pp: &EvmBlockStfOutput) -> ExecSegment {
             WithdrawalIntent::new(
                 BitcoinAmount::from_sat(intent.amt),
                 intent.destination.clone(),
-                intent.withdrawal_txid,
                 intent.selected_operator,
             )
         })

--- a/crates/reth/evm/src/utils.rs
+++ b/crates/reth/evm/src/utils.rs
@@ -7,7 +7,7 @@ use reth_primitives::{Receipt, TransactionSigned};
 use revm_primitives::{alloy_primitives::Bloom, Address, U256};
 use strata_identifiers::{SubjectId, SubjectIdBytes, SUBJ_ID_LEN};
 use strata_ol_bridge_types::OperatorSelection;
-use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32};
+use strata_primitives::bitcoin_bosd::Descriptor;
 
 use crate::constants::BRIDGEOUT_PRECOMPILE_ADDRESS;
 
@@ -50,8 +50,7 @@ pub fn extract_withdrawal_intents<'a>(
     transactions
         .iter()
         .zip(receipts.iter())
-        .flat_map(|(tx, receipt)| {
-            let txid = Buf32((*tx.hash()).into());
+        .flat_map(|(_tx, receipt)| {
             receipt.logs.iter().filter_map(move |log| {
                 if log.address != BRIDGEOUT_PRECOMPILE_ADDRESS {
                     return None;
@@ -63,7 +62,6 @@ pub fn extract_withdrawal_intents<'a>(
                 Some(WithdrawalIntent {
                     amt: event.amount,
                     destination,
-                    withdrawal_txid: txid,
                     selected_operator: OperatorSelection::from_raw(event.selectedOperator),
                 })
             })

--- a/crates/reth/primitives/src/lib.rs
+++ b/crates/reth/primitives/src/lib.rs
@@ -7,7 +7,7 @@ use std::mem::size_of;
 use alloy_sol_types::sol;
 use serde::{Deserialize, Serialize};
 use strata_ol_bridge_types::OperatorSelection;
-use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32};
+use strata_primitives::bitcoin_bosd::Descriptor;
 
 /// Type for withdrawal_intents in rpc.
 /// Distinct from `strata_ol_bridge_types::WithdrawalIntent`
@@ -19,9 +19,6 @@ pub struct WithdrawalIntent {
 
     /// User's operator selection for withdrawal assignment.
     pub selected_operator: OperatorSelection,
-
-    /// Withdrawal request transaction id.
-    pub withdrawal_txid: Buf32,
 
     /// Dynamic-sized bytes BOSD descriptor for the withdrawal destinations in L1.
     pub destination: Descriptor,


### PR DESCRIPTION
## Description

Removes the originating EVM transaction hash from withdrawal intent data that is passed through the bridge/EVM execution path.

The withdrawal intent is produced from the bridgeout precompile event and consumed by layers above it as an intent, not as a originating EVM transaction. Keeping a `withdrawal_txid` field in those structs made that boundary look more concrete than it is and required carrying a placeholder value through the stack.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- Removes `withdrawal_txid` from the shared bridge withdrawal intent type.
- Removes the same field from the Reth withdrawal intent primitive and the extraction/forwarding path.
- Leaves withdrawal intent semantics focused on recipient, amount, and operator index.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://alpenlabs.atlassian.net/browse/STR-1911

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

Validation:

- `just pr`

AI assistance notice: I used AI assistance to help inspect the withdrawal intent flow, update the code, and run validation.

## Related Issues

- STR-1911
