### PR TITLE
Str 3466 csm reorg handling

### DIFF
--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -146,6 +146,13 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         Ok(self.storage.client_state().fetch_most_recent_state()?)
     }
 
+    fn get_client_state_at(
+        &self,
+        block: &L1BlockCommitment,
+    ) -> CsmWorkerResult<Option<ClientState>> {
+        Ok(self.storage.client_state().get_state_blocking(*block)?)
+    }
+
     fn genesis_l1_block(&self) -> L1BlockCommitment {
         self.asm_params.anchor.block
     }

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -175,31 +175,14 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         self.asm_params.anchor.block
     }
 
-    fn get_last_checkpoint_l1_ref_epoch(&self) -> CsmWorkerResult<Option<EpochCommitment>> {
-        Ok(self
-            .storage
-            .ol_checkpoint()
-            .get_last_checkpoint_l1_ref_epoch_blocking()?)
-    }
-
-    fn get_canonical_epoch_commitment_at(
+    fn get_checkpoint_l1_refs_from(
         &self,
-        epoch: Epoch,
-    ) -> CsmWorkerResult<Option<EpochCommitment>> {
+        start_epoch: Epoch,
+    ) -> CsmWorkerResult<Vec<(EpochCommitment, CheckpointL1Ref)>> {
         Ok(self
             .storage
             .ol_checkpoint()
-            .get_canonical_epoch_commitment_at_blocking(epoch)?)
-    }
-
-    fn get_checkpoint_l1_ref(
-        &self,
-        commitment: EpochCommitment,
-    ) -> CsmWorkerResult<Option<CheckpointL1Ref>> {
-        Ok(self
-            .storage
-            .ol_checkpoint()
-            .get_checkpoint_l1_ref_blocking(commitment)?)
+            .get_checkpoint_l1_refs_from_blocking(start_epoch)?)
     }
 
     fn get_checkpoint_payload(

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -73,6 +73,11 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         self.status_channel.update_client_state(state, block);
     }
 
+    fn del_client_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<()> {
+        self.storage.client_state().del_update_blocking(block)?;
+        Ok(())
+    }
+
     fn put_checkpoint_l1_observation(
         &self,
         commitment: EpochCommitment,

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -78,6 +78,20 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
         Ok(())
     }
 
+    fn get_client_state_blocks_from(
+        &self,
+        from_block: L1BlockCommitment,
+        max_count: usize,
+    ) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
+        Ok(self
+            .storage
+            .client_state()
+            .get_updates_from(from_block, max_count)?
+            .into_iter()
+            .map(|(block, _)| block)
+            .collect())
+    }
+
     fn put_checkpoint_l1_observation(
         &self,
         commitment: EpochCommitment,

--- a/crates/consensus-logic/src/csm_worker_context.rs
+++ b/crates/consensus-logic/src/csm_worker_context.rs
@@ -128,16 +128,15 @@ impl CsmWorkerContext for CsmWorkerContextImpl {
             })
     }
 
-    fn get_canonical_l1_block(&self, height: L1Height) -> CsmWorkerResult<L1BlockCommitment> {
-        let blkid = self
+    fn get_canonical_l1_block(
+        &self,
+        height: L1Height,
+    ) -> CsmWorkerResult<Option<L1BlockCommitment>> {
+        Ok(self
             .storage
             .l1()
             .get_canonical_blockid_at_height(height)?
-            .ok_or_else(|| CsmWorkerError::MissingData {
-                what: "canonical L1 block",
-                detail: format!("height {height}"),
-            })?;
-        Ok(L1BlockCommitment::new(height, blkid))
+            .map(|blkid| L1BlockCommitment::new(height, blkid)))
     }
 
     fn fetch_most_recent_client_state(

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -56,7 +56,7 @@ fn spawn_csm_listener(
         storage.clone(),
         status_channel,
     );
-    let csm_state = CsmWorkerState::new(ctx)?;
+    let csm_state = CsmWorkerState::bootstrap(ctx)?;
 
     // Get the starting block from CSM's last processed block
     // If CSM hasn't processed any blocks yet, we get the latest ASM state from storage

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -56,7 +56,7 @@ fn spawn_csm_listener(
         storage.clone(),
         status_channel,
     );
-    let csm_state = CsmWorkerState::bootstrap(ctx)?;
+    let csm_state = CsmWorkerState::init_from_context(ctx)?;
 
     // Get the starting block from CSM's last processed block
     // If CSM hasn't processed any blocks yet, we get the latest ASM state from storage

--- a/crates/csm-types/src/client_state.rs
+++ b/crates/csm-types/src/client_state.rs
@@ -165,6 +165,10 @@ impl L1Checkpoint {
     pub fn new(tip: CheckpointTip, l1_reference: CheckpointL1Ref) -> Self {
         Self { tip, l1_reference }
     }
+
+    pub fn height(&self) -> L1Height {
+        self.l1_reference.block_height()
+    }
 }
 
 impl From<&L1Checkpoint> for EpochCommitment {

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -55,8 +55,12 @@ pub trait CsmWorkerContext: Send + Sync {
     /// Fetches the auxiliary data ASM consumed when processing `block`.
     fn get_aux_data(&self, block: &L1BlockCommitment) -> CsmWorkerResult<AuxData>;
 
-    /// Resolves the canonical L1 block commitment at `height`.
-    fn get_canonical_l1_block(&self, height: L1Height) -> CsmWorkerResult<L1BlockCommitment>;
+    /// Resolves the canonical L1 block commitment at `height`, or `None` when
+    /// no canonical block exists there (e.g. a height above a reverted tip).
+    fn get_canonical_l1_block(
+        &self,
+        height: L1Height,
+    ) -> CsmWorkerResult<Option<L1BlockCommitment>>;
 
     /// Returns the most recently persisted client state, or `None` if storage
     /// has none yet.

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -64,6 +64,12 @@ pub trait CsmWorkerContext: Send + Sync {
         &self,
     ) -> CsmWorkerResult<Option<(L1BlockCommitment, ClientState)>>;
 
+    /// Returns the client state persisted at `block`, if any.
+    fn get_client_state_at(
+        &self,
+        block: &L1BlockCommitment,
+    ) -> CsmWorkerResult<Option<ClientState>>;
+
     /// L1 block that bootstrap should anchor to when storage has no client
     /// state yet.
     fn genesis_l1_block(&self) -> L1BlockCommitment;

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -31,6 +31,14 @@ pub trait CsmWorkerContext: Send + Sync {
     /// Deletes the client state row at the given L1 block.
     fn del_client_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<()>;
 
+    /// Returns up to `max_count` persisted client-state block keys at or above
+    /// `from_block`, in ascending order.
+    fn get_client_state_blocks_from(
+        &self,
+        from_block: L1BlockCommitment,
+        max_count: usize,
+    ) -> CsmWorkerResult<Vec<L1BlockCommitment>>;
+
     /// Publishes the current client state and the L1 block it is anchored at.
     fn publish_client_state(&self, state: ClientState, block: L1BlockCommitment);
 

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -89,25 +89,15 @@ pub trait CsmWorkerContext: Send + Sync {
     /// state yet.
     fn genesis_l1_block(&self) -> L1BlockCommitment;
 
-    /// Returns the epoch of the most recent L1-observed checkpoint, or `None`
-    /// if nothing has been observed yet.
-    fn get_last_checkpoint_l1_ref_epoch(&self) -> CsmWorkerResult<Option<EpochCommitment>>;
-
-    /// Returns the canonical epoch commitment at `epoch`, if recorded.
-    fn get_canonical_epoch_commitment_at(
+    /// Returns all observed epoch commitment and L1 ref pairs at or above
+    /// `start_epoch`, ordered by ascending epoch.
+    fn get_checkpoint_l1_refs_from(
         &self,
-        epoch: Epoch,
-    ) -> CsmWorkerResult<Option<EpochCommitment>>;
-
-    /// Returns the recorded L1 ref for an observed checkpoint at `commitment`.
-    fn get_checkpoint_l1_ref(
-        &self,
-        commitment: EpochCommitment,
-    ) -> CsmWorkerResult<Option<CheckpointL1Ref>>;
+        start_epoch: Epoch,
+    ) -> CsmWorkerResult<Vec<(EpochCommitment, CheckpointL1Ref)>>;
 
     /// Returns the L1-observed checkpoint payload at `commitment` (carries the
-    /// tip the checkpoint declared). Paired with [`Self::get_checkpoint_l1_ref`]
-    /// to reconstruct the full observation record at bootstrap.
+    /// tip the checkpoint declared).
     fn get_checkpoint_payload(
         &self,
         commitment: EpochCommitment,

--- a/crates/csm-worker/src/context.rs
+++ b/crates/csm-worker/src/context.rs
@@ -28,6 +28,9 @@ pub trait CsmWorkerContext: Send + Sync {
         output: ClientUpdateOutput,
     ) -> CsmWorkerResult<()>;
 
+    /// Deletes the client state row at the given L1 block.
+    fn del_client_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<()>;
+
     /// Publishes the current client state and the L1 block it is anchored at.
     fn publish_client_state(&self, state: ClientState, block: L1BlockCommitment);
 

--- a/crates/csm-worker/src/errors.rs
+++ b/crates/csm-worker/src/errors.rs
@@ -14,8 +14,8 @@ pub type CsmWorkerResult<T> = Result<T, CsmWorkerError>;
 #[derive(Debug, Error)]
 pub enum CsmWorkerError {
     /// No committed ASM block exists yet; the worker was bootstrapped without one.
-    #[error("CSM has no last committed ASM block")]
-    NoLastAsmBlock,
+    #[error("CSM has no last committed anchor ASM block")]
+    NoAnchorAsmBlock,
 
     /// The genesis L1 block has no parent to derive a commitment from.
     #[error("cannot derive parent for genesis L1 block {0}")]
@@ -60,6 +60,13 @@ pub enum CsmWorkerError {
     /// A record the worker expected was absent.
     #[error("missing {what}: {detail}")]
     MissingData { what: &'static str, detail: String },
+
+    /// A reorg diverged at or below the finalized anchor — a protocol violation.
+    #[error("reorg past finality: finalized {finalized}, incoming {incoming}")]
+    ReorgPastFinality {
+        finalized: L1BlockCommitment,
+        incoming: L1BlockCommitment,
+    },
 
     /// Other generic errors without precise types.
     #[error("{0}")]

--- a/crates/csm-worker/src/errors.rs
+++ b/crates/csm-worker/src/errors.rs
@@ -62,7 +62,7 @@ pub enum CsmWorkerError {
     MissingData { what: &'static str, detail: String },
 
     /// A reorg diverged at or below the finalized anchor — a protocol violation.
-    #[error("reorg past finality: finalized {finalized}, incoming {incoming}")]
+    #[error("reorg past finality (finalized {finalized}, incoming {incoming})")]
     ReorgPastFinality {
         finalized: L1BlockCommitment,
         incoming: L1BlockCommitment,

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -16,7 +16,7 @@ use crate::{
     checkpoint_extract::{CheckpointVerificationContext, extract_matching_checkpoint},
     context::CsmWorkerContext,
     errors::{CsmWorkerError, CsmWorkerResult},
-    state::{CsmWorkerState, compute_reorg_floor_height, derive_state},
+    state::{CsmWorkerState, compute_reorg_floor_height, reload_client_state},
 };
 
 /// The in-flight CSM update produced by processing one ASM block's logs.
@@ -128,7 +128,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             "received asm block skipping a height: tip {last}, block {asm_block}"
         );
 
-        let state = derive_state(&self.ctx, &asm_block, &next_state)?;
+        let state = reload_client_state(&self.ctx, &asm_block, &next_state)?;
         self.ctx
             .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(state.clone()))?;
         self.recent_asm_blocks.push(asm_block);
@@ -276,7 +276,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
                 what: "client state at pivot block",
                 detail: pivot_block.to_string(),
             })?;
-        let new_clstate = derive_state(&self.ctx, &pivot_block, &pivot_clstate)?;
+        let new_clstate = reload_client_state(&self.ctx, &pivot_block, &pivot_clstate)?;
 
         // Re-persist at the pivot to overwrite the orphaned branch's row.
         self.ctx.put_client_state_update(
@@ -1365,18 +1365,19 @@ mod tests {
 
         let (mut state, storage) = create_test_state_with_ctx(|c| {
             // Fork lands at the anchor (height 100); 101 diverged. Epoch 2's
-            // checkpoint rode the orphaned branch, so its canonical commitment
-            // is gone after the reorg.
-            c.with_canonical_block(100, block_id_at(100))
+            // checkpoint rode the orphaned 101 block, so its L1 observation is
+            // not on the canonical chain (canonical 101 is a different block).
+            c.with_canonical_block(90, block_id_at(90))
+                .with_canonical_block(100, block_id_at(100))
                 .with_canonical_block(101, block_id_at(201))
-                .with_orphaned_epoch(2)
         });
         state.recent_asm_blocks = vec![anchor, orphan_tip];
 
         // CSM persisted a client state at the fork block in a prior run.
         seed_client_state_row(&storage, &anchor);
 
-        // Epoch 1 observed at L1 height 90; epoch 2 observed at the orphaned tip.
+        // Epoch 1 observed at canonical L1 height 90; epoch 2 observed at the
+        // orphaned 101 block (block_id_at(101) != canonical block_id_at(201)).
         let commitment_1 = seed_ol_checkpoint_observation(&storage, 1, 90);
         let commitment_2 = seed_ol_checkpoint_observation(&storage, 2, 101);
 

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -124,7 +124,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     ) -> CsmWorkerResult<()> {
         let state = next_state.as_ref().clone();
         self.ctx
-            .put_client_state_update(&asm_block, ClientUpdateOutput::new(state.clone(), vec![]))?;
+            .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(state.clone()))?;
 
         // The list stays contiguous: a commit either extends the tip by one or
         // replaces it at the same height (reorg). It never skips a height.
@@ -292,8 +292,9 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             return Ok(());
         }
 
-        // A clean forward extension keeps `last` on the canonical chain.
-        let last_still_canonical = self.ctx.get_canonical_l1_block(last.height())? == last;
+        // A clean forward extension keeps `last` on the canonical chain. A
+        // missing block (height above a reverted tip) means it diverged.
+        let last_still_canonical = self.ctx.get_canonical_l1_block(last.height())? == Some(last);
         let is_pure_extension = last_still_canonical && asm_block.height() > last.height();
         if !is_pure_extension {
             self.reorg_to_fork(&asm_block)?;
@@ -308,7 +309,12 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         // Replay gap blocks, then the target.
         for height in (resume_height + 1)..asm_block.height() {
-            let gap_block = self.ctx.get_canonical_l1_block(height)?;
+            let gap_block = self.ctx.get_canonical_l1_block(height)?.ok_or_else(|| {
+                CsmWorkerError::MissingData {
+                    what: "canonical L1 block",
+                    detail: format!("height {height}"),
+                }
+            })?;
             let gap_state = self.ctx.get_asm_state(&gap_block)?;
             info!(%gap_block, "replaying ASM block skipped by status channel");
             self.process_asm_logs(gap_block, gap_state.logs())?;
@@ -358,12 +364,12 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     }
 
     /// Highest list index whose block still matches the canonical L1 chain.
-    ///
-    /// `None` if even the finalized anchor (index 0) diverged.
     fn find_fork_index(&self) -> CsmWorkerResult<Option<usize>> {
         for idx in (0..self.recent_asm_blocks.len()).rev() {
             let block = self.recent_asm_blocks[idx];
-            if self.ctx.get_canonical_l1_block(block.height())? == block {
+            // A missing block (above a reverted tip) or a mismatched blkid both
+            // mean this entry diverged; keep walking down.
+            if self.ctx.get_canonical_l1_block(block.height())? == Some(block) {
                 return Ok(Some(idx));
             }
         }
@@ -480,7 +486,9 @@ mod tests {
     };
     use strata_asm_logs::constants::AsmLogTypeId;
     use strata_asm_params::AsmParams;
+    use strata_asm_proto_checkpoint_types::test_utils::create_test_checkpoint_payload;
     use strata_btc_verification::L1Anchor;
+    use strata_checkpoint_types::EpochSummary;
     use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::RBuf32;
@@ -488,7 +496,7 @@ mod tests {
     use strata_primitives::prelude::*;
     use strata_state::asm_state::AsmState;
     use strata_status::StatusChannel;
-    use strata_storage::create_node_storage;
+    use strata_storage::{NodeStorage, create_node_storage};
     use strata_test_utils::ArbitraryGenerator;
 
     use crate::{errors::CsmWorkerError, state::CsmWorkerState, test_utils::StubCtx};
@@ -1338,6 +1346,157 @@ mod tests {
 
         // Both prior entries survive and the new block is appended.
         assert_eq!(state.recent_asm_blocks, vec![anchor, last, next]);
+    }
+
+    #[test]
+    fn bootstrap_seeds_full_reorg_window() {
+        let params = create_test_params_arc();
+        let (storage, status_channel) = create_test_storage();
+
+        // depth = 3. Floor = tip - (depth - 1) = 40323,
+        // so the seeded window is [40323, 40324, 40325].
+        let tip = L1BlockCommitment::new(40325, block_id_at(25));
+        // Store initial client state to db.
+        storage
+            .client_state()
+            .put_update_blocking(
+                &tip,
+                ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
+            )
+            .expect("seed client state at tip");
+
+        // Build context.
+        let ctx = default_stub_ctx(&params, storage.clone(), status_channel)
+            .with_canonical_block(40323, block_id_at(23))
+            .with_canonical_block(40324, block_id_at(24));
+
+        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+
+        assert_eq!(
+            state.recent_asm_blocks,
+            vec![
+                L1BlockCommitment::new(40323, block_id_at(23)),
+                L1BlockCommitment::new(40324, block_id_at(24)),
+                tip,
+            ],
+            "bootstrap must seed the full reorg-safe window"
+        );
+    }
+
+    /// Seeds an OL-checkpoint observation (epoch summary + L1 ref + payload) at
+    /// `l1_height`, mirroring the wiring `load_observed_checkpoints` reads.
+    /// Returns the resulting epoch commitment.
+    fn seed_ol_checkpoint_observation(
+        storage: &NodeStorage,
+        epoch: u32,
+        l1_height: L1Height,
+    ) -> EpochCommitment {
+        let ol_checkpoint = storage.ol_checkpoint();
+        let payload = create_test_checkpoint_payload(epoch);
+        let ol_terminal = *payload.new_tip().l2_commitment();
+        let summary = EpochSummary::new(
+            epoch,
+            ol_terminal,
+            L2BlockCommitment::new(0, L2BlockId::default()),
+            L1BlockCommitment::new(l1_height, block_id_at(l1_height)),
+            Buf32::zero(),
+        );
+        let commitment = summary.get_epoch_commitment();
+        ol_checkpoint
+            .insert_epoch_summary_blocking(summary)
+            .expect("insert epoch summary");
+        ol_checkpoint
+            .put_checkpoint_l1_observation_blocking(
+                commitment,
+                payload,
+                CheckpointL1Ref::new(
+                    L1BlockCommitment::new(l1_height, block_id_at(l1_height)),
+                    RBuf32::from([epoch as u8; 32]),
+                    RBuf32::from([epoch as u8; 32]),
+                ),
+            )
+            .expect("insert epoch observation");
+        commitment
+    }
+
+    /// On the reorg path, `derive_state` re-derives cursors as of the fork block
+    /// (below the current tip), so observations recorded ABOVE the fork on the
+    /// orphaned branch must be excluded from the re-derived state.
+    ///
+    /// Without the height filter in `load_observed_checkpoints`, the above-fork
+    /// observation would leak in as the confirmed cursor.
+    #[test]
+    fn reorg_excludes_observations_above_fork() {
+        let anchor = L1BlockCommitment::new(100, block_id_at(100));
+        let orphan_tip = L1BlockCommitment::new(101, block_id_at(101));
+        let incoming = L1BlockCommitment::new(101, block_id_at(201));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            // Fork lands at the anchor (height 100); 101 diverged.
+            c.with_canonical_block(100, block_id_at(100))
+                .with_canonical_block(101, block_id_at(201))
+        });
+        state.recent_asm_blocks = vec![anchor, orphan_tip];
+
+        // Epoch 1 observed at L1 height 90 (at/below the fork at 100); epoch 2
+        // observed at the orphaned tip (height 101, above the fork). The latter
+        // is the realistic contaminant: a checkpoint genuinely seen on the
+        // orphaned branch at its tip, which the reorg discards.
+        let commitment_1 = seed_ol_checkpoint_observation(&storage, 1, 90);
+        let commitment_2 = seed_ol_checkpoint_observation(&storage, 2, 101);
+
+        state
+            .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
+            .expect("reorg should re-derive state at the fork");
+
+        // Only the at/below-fork observation survives. Epoch 1 is buried
+        // 100 - 90 = 10 >= depth, so it is both confirmed and finalized.
+        assert_eq!(
+            state.confirmed_epoch,
+            Some(commitment_1),
+            "above-fork observation must not leak in as confirmed"
+        );
+        assert_eq!(state.finalized_epoch, Some(commitment_1));
+        assert!(
+            !state
+                .observed_checkpoints
+                .iter()
+                .any(|c| EpochCommitment::from(c) == commitment_2),
+            "above-fork observation must not be queued post-reorg"
+        );
+    }
+
+    #[test]
+    fn shorter_chain_reorg_rewinds_to_fork() {
+        let anchor = L1BlockCommitment::new(40323, block_id_at(23));
+        let good_24 = L1BlockCommitment::new(40324, block_id_at(24));
+        let orphan_25 = L1BlockCommitment::new(40325, block_id_at(25));
+        // New canonical tip is 40324; 40325 was reorged away. Incoming sits
+        // below the old committed tip (40325) at a height that is canonical.
+        let incoming = L1BlockCommitment::new(40324, block_id_at(24));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            // Canonical chain only reaches 40324; 40325 is not registered.
+            c.with_canonical_block(40323, block_id_at(23))
+                .with_canonical_block(40324, block_id_at(24))
+        });
+        state.recent_asm_blocks = vec![anchor, good_24, orphan_25];
+
+        state
+            .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
+            .expect("shorter-chain reorg should rewind to the fork and commit");
+
+        assert_eq!(state.recent_asm_blocks.last(), Some(&incoming));
+        assert!(
+            !state.recent_asm_blocks.contains(&orphan_25),
+            "orphaned higher entry must be pruned"
+        );
+        let (persisted, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        assert_eq!(persisted, incoming);
     }
 
     /// `commit_block` must never skip a height: a non-contiguous commit trips

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -122,10 +122,6 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         asm_block: L1BlockCommitment,
         next_state: Arc<ClientState>,
     ) -> CsmWorkerResult<()> {
-        let state = next_state.as_ref().clone();
-        self.ctx
-            .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(state.clone()))?;
-
         // A commit either extends the tip by one or replaces it at the same
         // height (a reorg whose fork sits at the incoming height). It never
         // skips a height.
@@ -137,9 +133,12 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let same_height_reorg = asm_block.height() == last.height();
         debug_assert!(
             extends_tip || same_height_reorg,
-            "commit skipped a height: tip {last}, block {asm_block}"
+            "received asm block skipping a height: tip {last}, block {asm_block}"
         );
 
+        let state = next_state.as_ref().clone();
+        self.ctx
+            .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(state.clone()))?;
         self.recent_asm_blocks.push(asm_block);
         self.last_committed_state = next_state;
         self.prune_below_reorg_floor();
@@ -970,8 +969,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                CsmWorkerError::MissingData { what, ref detail }
-                    if what == "canonical L1 block" && detail.contains("height 102")
+                CsmWorkerError::MissingData { what, .. } if what == "canonical L1 block"
             ),
             "unexpected error: {err}"
         );
@@ -1234,9 +1232,6 @@ mod tests {
         );
     }
 
-    /// A reorg onto a strictly longer chain: the worker rewinds to the fork,
-    /// replays every gap block on the new branch, and advances the tip past the
-    /// old orphaned frontier.
     #[test]
     fn reorg_replays_gap_and_extends_past_old_tip() {
         let anchor = L1BlockCommitment::new(100, block_id_at(100));
@@ -1324,8 +1319,6 @@ mod tests {
         assert_eq!(state.recent_asm_blocks, vec![anchor, tip]);
     }
 
-    /// The fork point is the deepest still-canonical list entry, so a reorg
-    /// rewinds only as far as needed even when older entries are still good.
     #[test]
     fn reorg_anchors_at_highest_canonical_entry() {
         // Heights sit at/above the genesis anchor (40320) so nothing finalized
@@ -1359,8 +1352,6 @@ mod tests {
         );
     }
 
-    /// `reorg_to_fork` re-persists the client state at the fork block to
-    /// overwrite whatever the orphaned branch wrote there.
     #[test]
     fn reorg_repersists_state_at_fork() {
         let anchor = L1BlockCommitment::new(100, block_id_at(100));
@@ -1397,9 +1388,6 @@ mod tests {
         assert_eq!(state.recent_asm_blocks.last(), Some(&incoming));
     }
 
-    /// A pure forward extension (tip still canonical, target higher) must not
-    /// trigger a reorg rewind: the list keeps its existing entries and only
-    /// appends.
     #[test]
     fn pure_extension_does_not_reorg() {
         // Heights sit at/above the genesis anchor (40320) so nothing finalized
@@ -1420,9 +1408,6 @@ mod tests {
         assert_eq!(state.recent_asm_blocks, vec![anchor, last, next]);
     }
 
-    /// A stale lower-height status redelivered while the tip is still canonical
-    /// is an out-of-order replay, not a reorg: the worker must ignore it rather
-    /// than rewinding the cursor backwards onto the older block.
     #[test]
     fn stale_lower_height_status_is_noop_when_tip_canonical() {
         let anchor = L1BlockCommitment::new(98, block_id_at(98));
@@ -1622,7 +1607,7 @@ mod tests {
     /// the contiguity assertion in debug builds.
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "commit skipped a height")]
+    #[should_panic(expected = "skipping a height")]
     fn commit_skipping_height_panics() {
         let (mut state, _) = create_test_state();
         // Tip at 100; committing 102 skips 101.

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -1059,4 +1059,299 @@ mod tests {
         assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert!(state.observed_checkpoints.is_empty());
     }
+
+    // --- reorg handling ---
+
+    #[test]
+    fn duplicate_asm_block_is_noop() {
+        let last = L1BlockCommitment::new(100, block_id_at(100));
+        // No canonical block registered: any lookup would fail, proving the
+        // duplicate path returns before consulting the canonical chain.
+        let (mut state, storage) = create_test_state();
+        state.recent_asm_blocks = vec![last];
+
+        state
+            .process_asm_block(last, &[create_non_checkpoint_log_type()])
+            .expect("duplicate block should be a no-op and not error");
+
+        assert_eq!(state.recent_asm_blocks, vec![last]);
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&last)
+                .expect("query client state")
+                .is_none(),
+            "duplicate must not persist a client-state row"
+        );
+    }
+
+    #[test]
+    fn same_last_processed_height_reorg_replaces_tip() {
+        let anchor = L1BlockCommitment::new(99, block_id_at(99));
+        let orphan_100 = L1BlockCommitment::new(100, block_id_at(100));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            c.with_canonical_block(99, block_id_at(99))
+                .with_canonical_block(100, block_id_at(101))
+        });
+        state.recent_asm_blocks = vec![anchor, orphan_100];
+
+        // Canonical chain: anchor stays at 99, and height 100 is now a
+        // different block than the orphaned tip the worker committed.
+        let canonical_100 = L1BlockCommitment::new(100, block_id_at(101));
+
+        state
+            .process_asm_block(canonical_100, &[create_non_checkpoint_log_type()])
+            .expect("same-height reorg should rewind and re-commit");
+
+        // Orphan tip dropped; canonical block now sits at height 100.
+        assert_eq!(state.recent_asm_blocks.last(), Some(&canonical_100));
+        assert!(
+            !state.recent_asm_blocks.contains(&orphan_100),
+            "orphaned tip must be pruned from the list"
+        );
+        let (persisted, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        assert_eq!(persisted, canonical_100);
+    }
+
+    #[test]
+    fn reorg_truncates_to_fork_then_replays() {
+        let anchor = L1BlockCommitment::new(100, block_id_at(100));
+        let orphan_101 = L1BlockCommitment::new(101, block_id_at(101));
+        let orphan_102 = L1BlockCommitment::new(102, block_id_at(102));
+        let target = L1BlockCommitment::new(102, block_id_at(202));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            // Anchor at 100 stays canonical; 101 and 102 diverge.
+            c.with_canonical_block(100, block_id_at(100))
+                .with_canonical_block(101, block_id_at(201))
+                .with_canonical_block(102, block_id_at(202))
+                .with_canonical_asm_state(
+                    101,
+                    block_id_at(201),
+                    make_asm_state(vec![create_non_checkpoint_log_type()]),
+                )
+        });
+        state.recent_asm_blocks = vec![anchor, orphan_101, orphan_102];
+
+        state
+            .process_asm_block(target, &[create_non_checkpoint_log_type()])
+            .expect("reorg should truncate to fork and replay to target");
+
+        assert_eq!(state.recent_asm_blocks.last(), Some(&target));
+        assert!(
+            !state.recent_asm_blocks.contains(&orphan_101)
+                && !state.recent_asm_blocks.contains(&orphan_102),
+            "orphaned branch must be pruned"
+        );
+        // Canonical 101 was replayed before the target.
+        let (persisted, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        assert_eq!(persisted, target);
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&L1BlockCommitment::new(101, block_id_at(201)))
+                .expect("query client state")
+                .is_some(),
+            "canonical 101 should have been committed during replay"
+        );
+    }
+
+    /// A reorg onto a strictly longer chain: the worker rewinds to the fork,
+    /// replays every gap block on the new branch, and advances the tip past the
+    /// old orphaned frontier.
+    #[test]
+    fn reorg_replays_gap_and_extends_past_old_tip() {
+        let anchor = L1BlockCommitment::new(100, block_id_at(100));
+        let orphan_101 = L1BlockCommitment::new(101, block_id_at(101));
+        let orphan_102 = L1BlockCommitment::new(102, block_id_at(102));
+        // New chain forks at 100 and runs longer, ending above the old tip (102).
+        let target = L1BlockCommitment::new(105, block_id_at(205));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            // 100 stays canonical; 101..=104 are the new branch's gap blocks.
+            let mut c = c.with_canonical_block(100, block_id_at(100));
+            for height in 101..=104 {
+                c = c.with_canonical_asm_state(
+                    height,
+                    block_id_at(100 + height),
+                    make_asm_state(vec![create_non_checkpoint_log_type()]),
+                );
+            }
+            c.with_canonical_block(105, block_id_at(205))
+        });
+        state.recent_asm_blocks = vec![anchor, orphan_101, orphan_102];
+
+        state
+            .process_asm_block(target, &[create_non_checkpoint_log_type()])
+            .expect("reorg should rewind, replay the gap, and extend past the old tip");
+
+        // Tip landed at the new target, well past the old frontier.
+        assert_eq!(state.recent_asm_blocks.last(), Some(&target));
+        assert!(
+            !state.recent_asm_blocks.contains(&orphan_101)
+                && !state.recent_asm_blocks.contains(&orphan_102),
+            "orphaned branch must be pruned"
+        );
+        // Each replayed gap block on the new chain got a committed row.
+        for height in 101..=104 {
+            let block = L1BlockCommitment::new(height, block_id_at(100 + height));
+            assert!(
+                storage
+                    .client_state()
+                    .get_update_blocking(&block)
+                    .expect("query client state")
+                    .is_some(),
+                "new-chain gap block {height} should have been replayed and committed"
+            );
+        }
+        // Most-recent persisted state is keyed at the target.
+        let (persisted, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        assert_eq!(persisted, target);
+    }
+
+    #[test]
+    fn reorg_past_finality_errors() {
+        let anchor = L1BlockCommitment::new(100, block_id_at(100));
+        let tip = L1BlockCommitment::new(101, block_id_at(101));
+        let incoming = L1BlockCommitment::new(101, block_id_at(201));
+
+        // Even the anchor's height resolves to a different block, so no list
+        // entry matches the canonical chain.
+        let (mut state, _) = create_test_state_with_ctx(|c| {
+            c.with_canonical_block(100, block_id_at(150))
+                .with_canonical_block(101, block_id_at(201))
+        });
+        state.recent_asm_blocks = vec![anchor, tip];
+
+        let err = state
+            .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
+            .expect_err("reorg past finality should error");
+        assert!(
+            matches!(
+                err,
+                CsmWorkerError::ReorgPastFinality { finalized, incoming: inc }
+                    if finalized == anchor && inc == incoming
+            ),
+            "unexpected error: {err}"
+        );
+
+        // Worker stays pinned at the original list.
+        assert_eq!(state.recent_asm_blocks, vec![anchor, tip]);
+    }
+
+    /// The fork point is the deepest still-canonical list entry, so a reorg
+    /// rewinds only as far as needed even when older entries are still good.
+    #[test]
+    fn reorg_anchors_at_highest_canonical_entry() {
+        let anchor = L1BlockCommitment::new(100, block_id_at(100));
+        let good_101 = L1BlockCommitment::new(101, block_id_at(101));
+        let orphan_102 = L1BlockCommitment::new(102, block_id_at(102));
+        let target = L1BlockCommitment::new(102, block_id_at(202));
+
+        let (mut state, _) = create_test_state_with_ctx(|c| {
+            // 100 and 101 still canonical; only 102 diverged.
+            c.with_canonical_block(100, block_id_at(100))
+                .with_canonical_block(101, block_id_at(101))
+                .with_canonical_block(102, block_id_at(202))
+        });
+        state.recent_asm_blocks = vec![anchor, good_101, orphan_102];
+
+        state
+            .process_asm_block(target, &[create_non_checkpoint_log_type()])
+            .expect("reorg should anchor at the highest canonical entry");
+
+        // good_101 survived (fork point), orphan_102 replaced by target.
+        assert_eq!(
+            state.recent_asm_blocks,
+            vec![anchor, good_101, target],
+            "list should rewind only to the highest canonical entry"
+        );
+    }
+
+    /// `reorg_to_fork` re-persists the client state at the fork block to
+    /// overwrite whatever the orphaned branch wrote there.
+    #[test]
+    fn reorg_repersists_state_at_fork() {
+        let anchor = L1BlockCommitment::new(100, block_id_at(100));
+        let orphan_tip = L1BlockCommitment::new(101, block_id_at(101));
+        let incoming = L1BlockCommitment::new(101, block_id_at(201));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            c.with_canonical_block(100, block_id_at(100))
+                .with_canonical_block(101, block_id_at(201))
+        });
+        state.recent_asm_blocks = vec![anchor, orphan_tip];
+
+        // Seed a stale row at the fork block so we can see it overwritten.
+        storage
+            .client_state()
+            .put_update_blocking(
+                &anchor,
+                ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
+            )
+            .expect("seed fork row");
+
+        state
+            .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
+            .expect("reorg should re-persist at the fork");
+
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&anchor)
+                .expect("query client state")
+                .is_some(),
+            "fork block must carry a re-derived client-state row"
+        );
+        assert_eq!(state.recent_asm_blocks.last(), Some(&incoming));
+    }
+
+    /// A pure forward extension (tip still canonical, target higher) must not
+    /// trigger a reorg rewind: the list keeps its existing entries and only
+    /// appends.
+    #[test]
+    fn pure_extension_does_not_reorg() {
+        let anchor = L1BlockCommitment::new(99, block_id_at(99));
+        let last = L1BlockCommitment::new(100, block_id_at(100));
+        let next = L1BlockCommitment::new(101, block_id_at(101));
+
+        let (mut state, _) =
+            create_test_state_with_ctx(|c| c.with_canonical_block(100, block_id_at(100)));
+        state.recent_asm_blocks = vec![anchor, last];
+
+        state
+            .process_asm_block(next, &[create_non_checkpoint_log_type()])
+            .expect("pure extension should commit directly");
+
+        // Both prior entries survive and the new block is appended.
+        assert_eq!(state.recent_asm_blocks, vec![anchor, last, next]);
+    }
+
+    /// `commit_block` must never skip a height: a non-contiguous commit trips
+    /// the contiguity assertion in debug builds.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "commit skipped a height")]
+    fn commit_skipping_height_panics() {
+        let (mut state, _) = create_test_state();
+        // Tip at 100; committing 102 skips 101.
+        state.recent_asm_blocks = vec![L1BlockCommitment::new(100, block_id_at(100))];
+        let skipping = L1BlockCommitment::new(102, block_id_at(102));
+        let next_state = state.last_committed_state.clone();
+
+        let _ = state.commit_block(skipping, next_state);
+    }
 }

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -345,8 +345,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     /// Rewinds the worker to the fork point shared with the chain leading to
     /// `incoming`, re-deriving cursors and persisted state there.
     ///
-    /// Errors if the fork lies at or below the finalized anchor (index 0): a
-    /// reorg past finality is a protocol violation the worker must not absorb.
+    /// Errors if the fork lies at or below the finalized anchor (index 0).
     fn reorg_to_fork(&mut self, incoming: &L1BlockCommitment) -> CsmWorkerResult<()> {
         // No match means the divergence reaches past the finalized anchor.
         let Some(fork_idx) = self.find_fork_index()? else {
@@ -358,11 +357,16 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let fork_block = self.recent_asm_blocks[fork_idx];
 
         warn!(%fork_block, %incoming, "reorg detected; rewinding to fork point");
-        self.recent_asm_blocks.truncate(fork_idx + 1);
 
-        // Every window entry sits at or below the committed tip, so CSM
-        // persisted its client state in a prior run. A missing row means that
-        // invariant broke; surface it rather than fabricating a default state.
+        // Delete the orphaned branch's rows so a restart can't bootstrap from an
+        // orphan that's above the canonical tip.
+        let orphans = self.recent_asm_blocks.split_off(fork_idx + 1);
+        for orphan in &orphans {
+            self.ctx.del_client_state(orphan)?;
+        }
+
+        // It is expected to have client state persisted below the tip, which means below the fork
+        // point as well.
         let persisted = self.ctx.get_client_state_at(&fork_block)?;
         let fork_clstate = persisted
             .clone()
@@ -1147,6 +1151,8 @@ mod tests {
         // CSM persisted a client state at the fork block (anchor) in a prior
         // run; the reorg re-derives from it.
         seed_client_state_row(&storage, &anchor);
+        // The orphaned tip left a row behind from the prior run.
+        seed_client_state_row(&storage, &orphan_100);
 
         // Canonical chain: anchor stays at 99, and height 100 is now a
         // different block than the orphaned tip the worker committed.
@@ -1161,6 +1167,14 @@ mod tests {
         assert!(
             !state.recent_asm_blocks.contains(&orphan_100),
             "orphaned tip must be pruned from the list"
+        );
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&orphan_100)
+                .expect("query client state")
+                .is_none(),
+            "orphaned tip's row must be deleted"
         );
         let (persisted, _) = storage
             .client_state()
@@ -1460,11 +1474,13 @@ mod tests {
             )
             .expect("seed client state at tip");
 
-        // Build context with a canonical block at every intermediate height.
+        // Build context with a canonical block at every intermediate height,
+        // and at the tip so bootstrap takes the canonical (non-orphan) path.
         let mut ctx = default_stub_ctx(&params, storage.clone(), status_channel);
         for height in floor..tip.height() {
             ctx = ctx.with_canonical_block(height, block_id_at(height));
         }
+        ctx = ctx.with_canonical_block(tip.height(), *tip.blkid());
 
         let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
 
@@ -1574,6 +1590,8 @@ mod tests {
 
         // CSM persisted a client state at the fork block (good_24) in a prior run.
         seed_client_state_row(&storage, &good_24);
+        // The reorged-away tip left a higher-keyed row behind.
+        seed_client_state_row(&storage, &orphan_25);
 
         state
             .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
@@ -1583,6 +1601,14 @@ mod tests {
         assert!(
             !state.recent_asm_blocks.contains(&orphan_25),
             "orphaned higher entry must be pruned"
+        );
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&orphan_25)
+                .expect("query client state")
+                .is_none(),
+            "orphaned higher row must be deleted"
         );
         let (persisted, _) = storage
             .client_state()

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -16,7 +16,7 @@ use crate::{
     checkpoint_extract::{CheckpointVerificationContext, extract_matching_checkpoint},
     context::CsmWorkerContext,
     errors::{CsmWorkerError, CsmWorkerResult},
-    state::{CsmWorkerState, derive_state},
+    state::{CsmWorkerState, derive_state, reorg_floor_height},
 };
 
 /// The in-flight CSM update produced by processing one ASM block's logs.
@@ -141,22 +141,31 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         );
 
         self.recent_asm_blocks.push(asm_block);
-        self.prune_below_reorg_floor();
         self.last_committed_state = next_state;
+        self.prune_below_reorg_floor();
         // Publish the client state to status channel.
         self.ctx.publish_client_state(state, asm_block);
         Ok(())
     }
 
-    /// Keeps only the `depth` newest blocks: index 0 becomes the reorg-safe
-    /// floor, the deepest point a reorg could reach. Older entries can never be
-    /// reorged out, so they are dropped.
+    /// Drops blocks below the reorg-safe floor; index 0 stays the deepest point
+    /// a reorg could reach. The floor is `max(tip - depth, finalized checkpoint)`
+    /// (see [`reorg_floor_height`]), computed against the most recently
+    /// processed block, so the window never drops a block that could still
+    /// reorg yet stays bounded by `depth` when checkpoint-finality stalls.
     fn prune_below_reorg_floor(&mut self) {
-        let depth = self.ctx.l1_reorg_safe_depth().max(1) as usize;
-        let len = self.recent_asm_blocks.len();
-        if len > depth {
-            self.recent_asm_blocks.drain(..len - depth);
-        }
+        let Some(tip) = self.recent_asm_blocks.last() else {
+            return;
+        };
+        let floor = reorg_floor_height(&self.ctx, &self.last_committed_state, tip.height());
+        let keep_from = self
+            .recent_asm_blocks
+            .iter()
+            .position(|b| b.height() >= floor)
+            .unwrap_or(self.recent_asm_blocks.len());
+        // Always retain at least the tip so the window is never empty.
+        let keep_from = keep_from.min(self.recent_asm_blocks.len().saturating_sub(1));
+        self.recent_asm_blocks.drain(..keep_from);
     }
 
     /// Processes every log of a single ASM block and commits it as one unit.
@@ -351,18 +360,16 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         warn!(%fork_block, %incoming, "reorg detected; rewinding to fork point");
         self.recent_asm_blocks.truncate(fork_idx + 1);
 
-        // A fork at a seeded-but-uncommitted ancestor (e.g. right after a
-        // restart) has no persisted row. Fall back to the surviving finalized
-        // checkpoint rather than a default state, so re-derivation can't drop
-        // finality below the reorg-safe floor.
+        // Every window entry sits at or below the committed tip, so CSM
+        // persisted its client state in a prior run. A missing row means that
+        // invariant broke; surface it rather than fabricating a default state.
         let persisted = self.ctx.get_client_state_at(&fork_block)?;
-        let fork_clstate = persisted.clone().unwrap_or_else(|| {
-            warn!(%fork_block, "no persisted client state at fork; seeding from finalized floor");
-            ClientState::new(
-                self.last_committed_state.get_last_finalized_checkpoint(),
-                None,
-            )
-        });
+        let fork_clstate = persisted
+            .clone()
+            .ok_or_else(|| CsmWorkerError::MissingData {
+                what: "client state at fork block",
+                detail: fork_block.to_string(),
+            })?;
         let derived = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
         let new_clstate = derived.new_clstate;
         self.confirmed_epoch = new_clstate.get_last_epoch();
@@ -497,7 +504,7 @@ fn decode_checkpoint_section(asm_state: &AsmState) -> CsmWorkerResult<Checkpoint
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{iter::once, sync::Arc};
 
     use bitcoin::Network;
     use strata_asm_common::{
@@ -549,6 +556,19 @@ mod tests {
     /// tests can register and resolve gap blocks consistently.
     fn block_id_at(height: u32) -> L1BlockId {
         L1BlockId::from(Buf32::from([height as u8; 32]))
+    }
+
+    /// Persists an empty client-state row at `block`, mirroring what a prior
+    /// CSM run leaves behind for every committed (at/below-tip) block. The reorg
+    /// path re-derives the fork's state from this row.
+    fn seed_client_state_row(storage: &strata_storage::NodeStorage, block: &L1BlockCommitment) {
+        storage
+            .client_state()
+            .put_update_blocking(
+                block,
+                ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
+            )
+            .expect("seed client state row");
     }
 
     fn create_test_params_arc() -> Arc<AsmParams> {
@@ -1124,6 +1144,10 @@ mod tests {
         });
         state.recent_asm_blocks = vec![anchor, orphan_100];
 
+        // CSM persisted a client state at the fork block (anchor) in a prior
+        // run; the reorg re-derives from it.
+        seed_client_state_row(&storage, &anchor);
+
         // Canonical chain: anchor stays at 99, and height 100 is now a
         // different block than the orphaned tip the worker committed.
         let canonical_100 = L1BlockCommitment::new(100, block_id_at(101));
@@ -1165,6 +1189,9 @@ mod tests {
                 )
         });
         state.recent_asm_blocks = vec![anchor, orphan_101, orphan_102];
+
+        // CSM persisted a client state at the fork block in a prior run.
+        seed_client_state_row(&storage, &anchor);
 
         state
             .process_asm_block(target, &[create_non_checkpoint_log_type()])
@@ -1217,6 +1244,9 @@ mod tests {
             c.with_canonical_block(105, block_id_at(205))
         });
         state.recent_asm_blocks = vec![anchor, orphan_101, orphan_102];
+
+        // CSM persisted a client state at the fork block in a prior run.
+        seed_client_state_row(&storage, &anchor);
 
         state
             .process_asm_block(target, &[create_non_checkpoint_log_type()])
@@ -1284,27 +1314,33 @@ mod tests {
     /// rewinds only as far as needed even when older entries are still good.
     #[test]
     fn reorg_anchors_at_highest_canonical_entry() {
-        let anchor = L1BlockCommitment::new(100, block_id_at(100));
-        let good_101 = L1BlockCommitment::new(101, block_id_at(101));
-        let orphan_102 = L1BlockCommitment::new(102, block_id_at(102));
-        let target = L1BlockCommitment::new(102, block_id_at(202));
+        // Heights sit at/above the genesis anchor (40320) so nothing finalized
+        // means pruning never drops a still-canonical entry; only the reorg
+        // rewind shapes the list.
+        let anchor = L1BlockCommitment::new(40320, block_id_at(20));
+        let good_mid = L1BlockCommitment::new(40321, block_id_at(21));
+        let orphan_tip = L1BlockCommitment::new(40322, block_id_at(22));
+        let target = L1BlockCommitment::new(40322, block_id_at(202));
 
-        let (mut state, _) = create_test_state_with_ctx(|c| {
-            // 100 and 101 still canonical; only 102 diverged.
-            c.with_canonical_block(100, block_id_at(100))
-                .with_canonical_block(101, block_id_at(101))
-                .with_canonical_block(102, block_id_at(202))
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            // 40320 and 40321 still canonical; only 40322 diverged.
+            c.with_canonical_block(40320, block_id_at(20))
+                .with_canonical_block(40321, block_id_at(21))
+                .with_canonical_block(40322, block_id_at(202))
         });
-        state.recent_asm_blocks = vec![anchor, good_101, orphan_102];
+        state.recent_asm_blocks = vec![anchor, good_mid, orphan_tip];
+
+        // CSM persisted a client state at the fork block (good_mid) in a prior run.
+        seed_client_state_row(&storage, &good_mid);
 
         state
             .process_asm_block(target, &[create_non_checkpoint_log_type()])
             .expect("reorg should anchor at the highest canonical entry");
 
-        // good_101 survived (fork point), orphan_102 replaced by target.
+        // good_mid survived (fork point), orphan_tip replaced by target.
         assert_eq!(
             state.recent_asm_blocks,
-            vec![anchor, good_101, target],
+            vec![anchor, good_mid, target],
             "list should rewind only to the highest canonical entry"
         );
     }
@@ -1352,12 +1388,14 @@ mod tests {
     /// appends.
     #[test]
     fn pure_extension_does_not_reorg() {
-        let anchor = L1BlockCommitment::new(99, block_id_at(99));
-        let last = L1BlockCommitment::new(100, block_id_at(100));
-        let next = L1BlockCommitment::new(101, block_id_at(101));
+        // Heights sit at/above the genesis anchor (40320) so nothing finalized
+        // means pruning leaves every entry in place.
+        let anchor = L1BlockCommitment::new(40320, block_id_at(20));
+        let last = L1BlockCommitment::new(40321, block_id_at(21));
+        let next = L1BlockCommitment::new(40322, block_id_at(22));
 
         let (mut state, _) =
-            create_test_state_with_ctx(|c| c.with_canonical_block(100, block_id_at(100)));
+            create_test_state_with_ctx(|c| c.with_canonical_block(40321, block_id_at(21)));
         state.recent_asm_blocks = vec![anchor, last];
 
         state
@@ -1409,8 +1447,9 @@ mod tests {
         let params = create_test_params_arc();
         let (storage, status_channel) = create_test_storage();
 
-        // depth = 3. Floor = tip - (depth - 1) = 40323,
-        // so the seeded window is [40323, 40324, 40325].
+        // Nothing finalized, so the floor is the depth bound: with depth 3 and
+        // tip 40325 the window spans [40323 ..= 40325].
+        let floor = 40323;
         let tip = L1BlockCommitment::new(40325, block_id_at(25));
         // Store initial client state to db.
         storage
@@ -1421,20 +1460,20 @@ mod tests {
             )
             .expect("seed client state at tip");
 
-        // Build context.
-        let ctx = default_stub_ctx(&params, storage.clone(), status_channel)
-            .with_canonical_block(40323, block_id_at(23))
-            .with_canonical_block(40324, block_id_at(24));
+        // Build context with a canonical block at every intermediate height.
+        let mut ctx = default_stub_ctx(&params, storage.clone(), status_channel);
+        for height in floor..tip.height() {
+            ctx = ctx.with_canonical_block(height, block_id_at(height));
+        }
 
         let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
 
+        let expected: Vec<_> = (floor..tip.height())
+            .map(|height| L1BlockCommitment::new(height, block_id_at(height)))
+            .chain(once(tip))
+            .collect();
         assert_eq!(
-            state.recent_asm_blocks,
-            vec![
-                L1BlockCommitment::new(40323, block_id_at(23)),
-                L1BlockCommitment::new(40324, block_id_at(24)),
-                tip,
-            ],
+            state.recent_asm_blocks, expected,
             "bootstrap must seed the full reorg-safe window"
         );
     }
@@ -1488,6 +1527,9 @@ mod tests {
         });
         state.recent_asm_blocks = vec![anchor, orphan_tip];
 
+        // CSM persisted a client state at the fork block in a prior run.
+        seed_client_state_row(&storage, &anchor);
+
         // Epoch 1 observed at L1 height 90 (at/below the fork at 100); epoch 2
         // observed at the orphaned tip (height 101, above the fork).
         let commitment_1 = seed_ol_checkpoint_observation(&storage, 1, 90);
@@ -1529,6 +1571,9 @@ mod tests {
                 .with_canonical_block(40324, block_id_at(24))
         });
         state.recent_asm_blocks = vec![anchor, good_24, orphan_25];
+
+        // CSM persisted a client state at the fork block (good_24) in a prior run.
+        seed_client_state_row(&storage, &good_24);
 
         state
             .process_asm_block(incoming, &[create_non_checkpoint_log_type()])

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -275,7 +275,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     /// Processes `asm_block` and its logs, first replaying any ASM blocks skipped
     /// between the last committed block and `asm_block`.
     ///
-    ///  On error the cursor stays at the last contiguous block, so restarts resume safely.
+    ///  On error the worker state stays the same, so restarts resume safely.
     pub(crate) fn process_asm_block(
         &mut self,
         asm_block: L1BlockCommitment,
@@ -294,7 +294,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         // A clean forward extension keeps `last` on the canonical chain.
         let last_still_canonical = self.ctx.get_canonical_l1_block(last.height())? == last;
-        if !(asm_block.height() > last.height() && last_still_canonical) {
+        let is_pure_extension = last_still_canonical && asm_block.height() > last.height();
+        if !is_pure_extension {
             self.reorg_to_fork(&asm_block)?;
         }
 
@@ -675,7 +676,7 @@ mod tests {
         let asm_block = L1BlockCommitment::new(250, L1BlockId::default());
 
         let (mut state, storage) = create_test_state_with_ctx(|c| c.with_l1_fetch_failure());
-        state.recent_asm_blocks = Some(asm_block);
+        state.recent_asm_blocks = vec![asm_block];
         let mut pending = fresh_pending(&state);
         let err = state
             .process_log(&mut pending, &log, &asm_block)
@@ -699,6 +700,9 @@ mod tests {
     #[test]
     fn commit_block_persists_state_and_advances_cursor() {
         let (mut state, storage) = create_test_state();
+        // Seed the list tip just below the block so the commit extends it
+        // contiguously (commit_block asserts no height is skipped).
+        state.recent_asm_blocks = vec![L1BlockCommitment::new(299, block_id_at(299))];
         let asm_block = L1BlockCommitment::new(300, L1BlockId::from(Buf32::from([7; 32])));
         let next_state = state.last_committed_state.clone();
 
@@ -706,7 +710,7 @@ mod tests {
             .commit_block(asm_block, next_state)
             .expect("commit should succeed");
 
-        assert_eq!(state.recent_asm_blocks, Some(asm_block));
+        assert_eq!(state.recent_asm_blocks.last(), Some(&asm_block));
         let (persisted_block, _) = storage
             .client_state()
             .fetch_most_recent_state()
@@ -725,7 +729,7 @@ mod tests {
         let asm_block = L1BlockCommitment::new(250, L1BlockId::default());
 
         let (mut state, storage) = create_test_state_with_ctx(|c| c.with_l1_fetch_failure());
-        state.recent_asm_blocks = Some(asm_block);
+        state.recent_asm_blocks = vec![asm_block];
 
         // The genesis client-state row seeded by `create_test_storage`.
         let (before_block, _) = storage
@@ -763,9 +767,12 @@ mod tests {
     /// pre-block values must be byte-identical after the failure.
     #[test]
     fn commit_failure_leaves_cursors_unchanged() {
-        let (mut state, storage) = create_test_state_with_ctx(|c| c.with_commit_failure());
         let last = L1BlockCommitment::new(100, block_id_at(100));
-        state.recent_asm_blocks = Some(last);
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            c.with_commit_failure()
+                .with_canonical_block(100, block_id_at(100))
+        });
+        state.recent_asm_blocks = vec![last];
 
         // Seed cursors with a known baseline so we can detect any partial
         // advancement that survives the failed commit.
@@ -791,7 +798,7 @@ mod tests {
         );
 
         // Commit cursor pinned at the last committed block.
-        assert_eq!(state.recent_asm_blocks, Some(last));
+        assert_eq!(state.recent_asm_blocks.last(), Some(&last));
         // Every cursor unchanged.
         assert_eq!(state.last_processed_epoch, baseline_last_processed_epoch);
         assert_eq!(state.confirmed_epoch, baseline_confirmed_epoch);
@@ -811,16 +818,17 @@ mod tests {
     /// directly, with no gap-fill.
     #[test]
     fn contiguous_block_commits_directly() {
-        let (mut state, storage) = create_test_state();
         let last = L1BlockCommitment::new(100, block_id_at(100));
-        state.recent_asm_blocks = Some(last);
+        let (mut state, storage) =
+            create_test_state_with_ctx(|c| c.with_canonical_block(100, block_id_at(100)));
+        state.recent_asm_blocks = vec![last];
 
         let next = L1BlockCommitment::new(101, block_id_at(101));
         state
             .process_asm_block(next, &[create_non_checkpoint_log_type()])
             .expect("contiguous block should process");
 
-        assert_eq!(state.recent_asm_blocks, Some(next));
+        assert_eq!(state.recent_asm_blocks.last(), Some(&next));
         let (persisted, _) = storage
             .client_state()
             .fetch_most_recent_state()
@@ -839,7 +847,7 @@ mod tests {
         let target = L1BlockCommitment::new(104, block_id_at(104));
 
         let (mut state, storage) = create_test_state_with_ctx(|c| {
-            let mut c = c;
+            let mut c = c.with_canonical_block(100, block_id_at(100));
             for height in 101..=103 {
                 c = c.with_canonical_asm_state(
                     height,
@@ -849,14 +857,14 @@ mod tests {
             }
             c
         });
-        state.recent_asm_blocks = Some(last);
+        state.recent_asm_blocks = vec![last];
 
         state
             .process_asm_block(target, &[create_non_checkpoint_log_type()])
             .expect("gap-fill should replay skipped blocks and commit target");
 
         // Cursor advanced all the way to the target.
-        assert_eq!(state.recent_asm_blocks, Some(target));
+        assert_eq!(state.recent_asm_blocks.last(), Some(&target));
         // The last persisted client-state row is keyed on the target block,
         // and each gap block was committed in turn (105 distinct keys exist).
         let (persisted, _) = storage
@@ -888,14 +896,15 @@ mod tests {
 
         let (mut state, storage) = create_test_state_with_ctx(|c| {
             // Block 101 resolves, but 102 fails to resolve.
-            c.with_canonical_asm_state(
-                101,
-                block_id_at(101),
-                make_asm_state(vec![create_non_checkpoint_log_type()]),
-            )
-            .with_canonical_failure_at(102)
+            c.with_canonical_block(100, block_id_at(100))
+                .with_canonical_asm_state(
+                    101,
+                    block_id_at(101),
+                    make_asm_state(vec![create_non_checkpoint_log_type()]),
+                )
+                .with_canonical_failure_at(102)
         });
-        state.recent_asm_blocks = Some(last);
+        state.recent_asm_blocks = vec![last];
 
         let (before_block, _) = storage
             .client_state()
@@ -918,8 +927,8 @@ mod tests {
         // Block 101 was committed before the failure; the cursor advanced to
         // 101 but no further — it did not jump to the target.
         assert_eq!(
-            state.recent_asm_blocks,
-            Some(L1BlockCommitment::new(101, block_id_at(101)))
+            state.recent_asm_blocks.last(),
+            Some(&L1BlockCommitment::new(101, block_id_at(101)))
         );
         assert!(
             storage
@@ -932,71 +941,6 @@ mod tests {
         // Genesis row is still the most recent fully-walkable anchor's
         // predecessor; the key point is the target was never persisted.
         let _ = before_block;
-    }
-
-    /// A same-height block with a different blkid is treated as a reorged
-    /// tip: its logs are processed and the cursor advances to the new blkid.
-    #[test]
-    fn same_height_reorg_processes_new_tip() {
-        let (mut state, storage) = create_test_state();
-        let old_blkid = block_id_at(100);
-        let new_blkid = block_id_at(0xFE);
-        let last = L1BlockCommitment::new(100, old_blkid);
-        state.recent_asm_blocks = Some(last);
-
-        let reorged = L1BlockCommitment::new(100, new_blkid);
-        state
-            .process_asm_block(reorged, &[create_non_checkpoint_log_type()])
-            .expect("same-height reorg should process the new tip");
-
-        assert_eq!(
-            state.recent_asm_blocks,
-            Some(reorged),
-            "cursor must advance to the reorged-in blkid"
-        );
-        let row = storage
-            .client_state()
-            .get_update_blocking(&reorged)
-            .expect("query client state");
-        assert!(
-            row.is_some(),
-            "client-state row must be persisted under the new blkid"
-        );
-    }
-
-    /// A status for a block at or behind the last committed block is a no-op
-    #[test]
-    fn stale_or_duplicate_block_is_ignored() {
-        let (mut state, storage) = create_test_state();
-        let last = L1BlockCommitment::new(100, block_id_at(100));
-        state.recent_asm_blocks = Some(last);
-
-        let (before, _) = storage
-            .client_state()
-            .fetch_most_recent_state()
-            .expect("query client state")
-            .expect("seeded client state");
-
-        // Same height as last.
-        state
-            .process_asm_block(last, &[create_non_checkpoint_log_type()])
-            .expect("duplicate block should be a no-op");
-        // Behind last.
-        let behind = L1BlockCommitment::new(50, block_id_at(50));
-        state
-            .process_asm_block(behind, &[create_non_checkpoint_log_type()])
-            .expect("stale block should be a no-op");
-
-        assert_eq!(state.recent_asm_blocks, Some(last));
-        let (after, _) = storage
-            .client_state()
-            .fetch_most_recent_state()
-            .expect("query client state")
-            .expect("client state still present");
-        assert_eq!(
-            before, after,
-            "no commit should happen for stale/dup blocks"
-        );
     }
 
     /// Builds an observation queue entry at `epoch` anchored to L1 `height`.

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -8,7 +8,7 @@ use strata_asm_logs::{CheckpointTipUpdate, constants::AsmLogTypeId};
 use strata_asm_proto_checkpoint::{CheckpointState, CheckpointSubprotocol};
 use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
 use strata_identifiers::Epoch;
-use strata_primitives::{l1::is_l1_reorg_safe, prelude::*};
+use strata_primitives::prelude::*;
 use strata_state::asm_state::AsmState;
 use tracing::*;
 
@@ -27,10 +27,6 @@ pub(crate) struct PendingCsmUpdate {
     /// Last epoch a checkpoint log was processed for.
     pub(crate) last_processed_epoch: Option<Epoch>,
 
-    /// Checkpoint observations made during this block, applied to the worker's
-    /// finality cursors only after a successful commit.
-    pub(crate) observations: Vec<L1Checkpoint>,
-
     /// Per-block verification fixtures, built once on the first checkpoint tip log.
     pub(crate) ckpt_verification_ctx: Option<CheckpointVerificationContext>,
 }
@@ -40,7 +36,6 @@ impl PendingCsmUpdate {
         Self {
             cur_state,
             last_processed_epoch,
-            observations: Vec::new(),
             ckpt_verification_ctx: None,
         }
     }
@@ -102,9 +97,6 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         let new_checkpoint =
             self.mark_ol_checkpoint_l1_observed(pending, checkpoint_tip_update, asm_block)?;
-        // `last_finalized_checkpoint` is left as the previous value here; the
-        // service loop refreshes it once `advance_finalization` declares a new
-        // finalized epoch based on L1 depth.
         pending.cur_state = Arc::new(ClientState::new(
             pending.cur_state.get_last_finalized_checkpoint(),
             Some(new_checkpoint),
@@ -136,22 +128,18 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             "received asm block skipping a height: tip {last}, block {asm_block}"
         );
 
-        let state = next_state.as_ref().clone();
+        let state = derive_state(&self.ctx, &asm_block, &next_state)?;
         self.ctx
             .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(state.clone()))?;
         self.recent_asm_blocks.push(asm_block);
-        self.last_committed_state = next_state;
+        self.last_committed_state = Arc::new(state.clone());
         self.prune_below_reorg_floor();
-        // Publish the client state to status channel.
         self.ctx.publish_client_state(state, asm_block);
         Ok(())
     }
 
     /// Drops blocks below the reorg-safe floor; index 0 stays the deepest point
-    /// a reorg could reach. The floor is `max(tip - depth, finalized checkpoint)`
-    /// (see [`reorg_floor_height`]), computed against the most recently
-    /// processed block, so the window never drops a block that could still
-    /// reorg yet stays bounded by `depth` when checkpoint-finality stalls.
+    /// a reorg could reach.
     fn prune_below_reorg_floor(&mut self) {
         let Some(tip) = self.recent_asm_blocks.last() else {
             return;
@@ -187,98 +175,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         // Commit succeeded; fold pending outputs onto the worker.
         self.last_processed_epoch = pending.last_processed_epoch;
-        self.apply_observations(pending.observations);
 
         Ok(())
-    }
-
-    /// Folds checkpoint observations made during a successfully committed block
-    /// into the worker's finality cursors.
-    fn apply_observations(&mut self, observations: impl IntoIterator<Item = L1Checkpoint>) {
-        for checkpoint in observations {
-            self.apply_checkpoint_observation(checkpoint);
-        }
-    }
-
-    /// Folds a single checkpoint observation into the worker's finality
-    /// cursors: bumps `confirmed_epoch` monotonically and queues the
-    /// observation for incremental depth-driven finalization if it's still
-    /// ahead of `finalized_epoch` and not already present.
-    fn apply_checkpoint_observation(&mut self, checkpoint: L1Checkpoint) {
-        let commitment = EpochCommitment::from(&checkpoint);
-
-        // Update cached confirmed epoch monotonically.
-        if self
-            .confirmed_epoch
-            .is_none_or(|current| commitment.epoch() > current.epoch())
-        {
-            self.confirmed_epoch = Some(commitment);
-        }
-
-        // Queue only non-finalized candidates and avoid duplicates.
-        if self
-            .finalized_epoch
-            .is_none_or(|current| commitment.epoch() > current.epoch())
-            && !self
-                .observed_checkpoints
-                .iter()
-                .any(|existing| EpochCommitment::from(existing) == commitment)
-        {
-            self.observed_checkpoints.push_back(checkpoint);
-        }
-    }
-
-    /// Walks the observation queue and advances `finalized_epoch` for every
-    /// candidate buried at least `finality_depth` deep under `current_l1_tip`.
-    ///
-    /// Returns the most recently finalized `L1Checkpoint` if `finalized_epoch`
-    /// advanced, else `None`. The caller uses the returned record to refresh
-    /// `ClientState.last_finalized_checkpoint` so it reflects depth-driven
-    /// finality rather than the (since-removed) observation heuristic.
-    pub(crate) fn advance_finalization(
-        &mut self,
-        current_l1_tip: L1Height,
-    ) -> Option<L1Checkpoint> {
-        let prev_finalized = self.finalized_epoch;
-        let finality_depth = self.ctx.l1_reorg_safe_depth();
-        let mut latest_finalized: Option<L1Checkpoint> = None;
-
-        while let Some(candidate) = self.observed_checkpoints.front() {
-            let commitment = EpochCommitment::from(candidate);
-            if self
-                .finalized_epoch
-                .is_some_and(|current| commitment.epoch() <= current.epoch())
-            {
-                self.observed_checkpoints.pop_front();
-                continue;
-            }
-
-            if !is_l1_reorg_safe(
-                candidate.l1_reference.l1_commitment.height(),
-                current_l1_tip,
-                finality_depth,
-            ) {
-                break;
-            }
-
-            let finalized = self
-                .observed_checkpoints
-                .pop_front()
-                .expect("front returned Some above");
-            if self
-                .finalized_epoch
-                .is_none_or(|current| commitment.epoch() > current.epoch())
-            {
-                self.finalized_epoch = Some(commitment);
-            }
-            latest_finalized = Some(finalized);
-        }
-
-        if self.finalized_epoch != prev_finalized {
-            latest_finalized
-        } else {
-            None
-        }
     }
 
     /// Processes `asm_block` and its logs, first replaying any ASM blocks skipped
@@ -366,11 +264,9 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
                 what: "client state at fork block",
                 detail: fork_block.to_string(),
             })?;
-        let derived = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
-        let new_clstate = derived.new_clstate;
+        let new_clstate = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
 
-        // Re-persist at the fork to overwrite the orphaned branch's row. After
-        // this succeeds, durable storage reflects the rewound tip.
+        // Re-persist at the fork to overwrite the orphaned branch's row.
         self.ctx.put_client_state_update(
             &fork_block,
             ClientUpdateOutput::new_state(new_clstate.clone()),
@@ -384,9 +280,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         // Persistence done; commit the rewind to in-memory state.
         self.recent_asm_blocks.truncate(fork_idx + 1);
-        self.confirmed_epoch = new_clstate.get_last_epoch();
-        self.finalized_epoch = new_clstate.get_declared_final_epoch();
-        self.observed_checkpoints = derived.observed_checkpoints;
+
+        // Publish if necessary.
         if persisted.as_ref() != Some(&new_clstate) {
             self.ctx
                 .publish_client_state(new_clstate.clone(), fork_block);
@@ -432,8 +327,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         })
     }
 
-    /// Validates a checkpoint tip update against the parent ASM state, writes
-    /// the L1-ref observation to the DB, and updates the observations on the `pending` container.
+    /// Validates a checkpoint tip update against the parent ASM state and writes
+    /// the L1-ref observation to the DB.
     fn mark_ol_checkpoint_l1_observed(
         &self,
         pending: &mut PendingCsmUpdate,
@@ -468,7 +363,6 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         )?;
 
         let checkpoint = L1Checkpoint::new(*tip, observation);
-        pending.observations.push(checkpoint.clone());
 
         debug!(
             ?commitment,
@@ -827,19 +721,11 @@ mod tests {
         });
         state.recent_asm_blocks = vec![last];
 
-        // Seed cursors with a known baseline so we can detect any partial
-        // advancement that survives the failed commit.
-        let baseline_epoch = EpochCommitment::from_terminal(
-            7,
-            OLBlockCommitment::new(70, OLBlockId::from(Buf32::from([7; 32]))),
-        );
+        // Seed a cursor baseline so we can detect any partial advancement that
+        // survives the failed commit.
         state.last_processed_epoch = Some(7);
-        state.confirmed_epoch = Some(baseline_epoch);
-        state.finalized_epoch = Some(baseline_epoch);
         let baseline_last_processed_epoch = state.last_processed_epoch;
-        let baseline_confirmed_epoch = state.confirmed_epoch;
-        let baseline_finalized_epoch = state.finalized_epoch;
-        let baseline_observed_checkpoints = state.observed_checkpoints.clone();
+        let baseline_committed_state = state.last_committed_state.clone();
 
         let next = L1BlockCommitment::new(101, block_id_at(101));
         let err = state
@@ -852,11 +738,9 @@ mod tests {
 
         // Commit cursor pinned at the last committed block.
         assert_eq!(state.recent_asm_blocks.last(), Some(&last));
-        // Every cursor unchanged.
+        // Cursors unchanged.
         assert_eq!(state.last_processed_epoch, baseline_last_processed_epoch);
-        assert_eq!(state.confirmed_epoch, baseline_confirmed_epoch);
-        assert_eq!(state.finalized_epoch, baseline_finalized_epoch);
-        assert_eq!(state.observed_checkpoints, baseline_observed_checkpoints);
+        assert_eq!(state.last_committed_state, baseline_committed_state);
         assert!(
             storage
                 .client_state()
@@ -993,123 +877,6 @@ mod tests {
         // Genesis row is still the most recent fully-walkable anchor's
         // predecessor; the key point is the target was never persisted.
         let _ = before_block;
-    }
-
-    /// Builds an observation queue entry at `epoch` anchored to L1 `height`.
-    fn observation_at(epoch: u32, l1_height: L1Height) -> L1Checkpoint {
-        let l2_commitment = OLBlockCommitment::new(
-            epoch as u64 * 10,
-            OLBlockId::from(Buf32::from([epoch as u8; 32])),
-        );
-        let tip = strata_asm_proto_checkpoint_types::CheckpointTip {
-            epoch,
-            l1_height,
-            l2_commitment,
-        };
-        let l1_block = L1BlockCommitment::new(l1_height, block_id_at(l1_height));
-        let l1_ref = CheckpointL1Ref::new(
-            l1_block,
-            RBuf32::from([epoch as u8; 32]),
-            RBuf32::from([epoch as u8; 32]),
-        );
-        L1Checkpoint::new(tip, l1_ref)
-    }
-
-    /// Empty queue is a trivial no-op and never advances `finalized_epoch`.
-    #[test]
-    fn advance_finalization_empty_queue_is_noop() {
-        let (mut state, _) = create_test_state();
-        assert!(state.observed_checkpoints.is_empty());
-
-        let finalized = state.advance_finalization(1_000);
-        assert!(finalized.is_none());
-        assert_eq!(state.finalized_epoch, None);
-    }
-
-    #[test]
-    fn advance_finalization_below_depth_does_not_advance() {
-        let (mut state, _) = create_test_state();
-        state.observed_checkpoints.push_back(observation_at(1, 100));
-
-        // tip at 101 has 2 confirmations, below threshold of 3.
-        let finalized = state.advance_finalization(101);
-        assert!(finalized.is_none());
-        assert_eq!(state.finalized_epoch, None);
-        assert_eq!(state.observed_checkpoints.len(), 1);
-    }
-
-    #[test]
-    fn advance_finalization_single_advance() {
-        let (mut state, _) = create_test_state();
-        let candidate = observation_at(1, 100);
-        let commitment = EpochCommitment::from(&candidate);
-        state.observed_checkpoints.push_back(candidate.clone());
-
-        // tip at 102 has 3 confirmations = depth threshold.
-        let finalized = state.advance_finalization(102);
-        assert_eq!(finalized.as_ref(), Some(&candidate));
-        assert_eq!(state.finalized_epoch, Some(commitment));
-        assert!(state.observed_checkpoints.is_empty());
-    }
-
-    #[test]
-    fn advance_finalization_multi_advance_in_one_call() {
-        let (mut state, _) = create_test_state();
-        let candidate_1 = observation_at(1, 100);
-        let candidate_2 = observation_at(2, 101);
-        let commitment_2 = EpochCommitment::from(&candidate_2);
-        state.observed_checkpoints.push_back(candidate_1);
-        state.observed_checkpoints.push_back(candidate_2.clone());
-
-        // tip at 103 so both candidates have ≥ 3 confirmations.
-        let finalized = state.advance_finalization(103);
-        assert_eq!(finalized.as_ref(), Some(&candidate_2));
-        assert_eq!(state.finalized_epoch, Some(commitment_2));
-        assert!(state.observed_checkpoints.is_empty());
-    }
-
-    #[test]
-    fn advance_finalization_stops_at_shallow_candidate() {
-        let (mut state, _) = create_test_state();
-        let candidate_1 = observation_at(1, 100);
-        let commitment_1 = EpochCommitment::from(&candidate_1);
-        let candidate_2 = observation_at(2, 102);
-        state.observed_checkpoints.push_back(candidate_1.clone());
-        state.observed_checkpoints.push_back(candidate_2.clone());
-
-        // tip at 102 so epoch 1 has 3 confirmations (buried), epoch 2 has 1.
-        let finalized = state.advance_finalization(102);
-        assert_eq!(finalized.as_ref(), Some(&candidate_1));
-        assert_eq!(state.finalized_epoch, Some(commitment_1));
-        assert_eq!(state.observed_checkpoints.len(), 1);
-        assert_eq!(
-            state
-                .observed_checkpoints
-                .front()
-                .map(EpochCommitment::from),
-            Some(EpochCommitment::from_terminal(
-                2,
-                OLBlockCommitment::new(20, OLBlockId::from(Buf32::from([2u8; 32])))
-            ))
-        );
-    }
-
-    #[test]
-    fn advance_finalization_pops_already_finalized() {
-        let (mut state, _) = create_test_state();
-        let candidate = observation_at(1, 100);
-        let commitment_1 = EpochCommitment::from(&candidate);
-        state.finalized_epoch = Some(commitment_1);
-        // Stale entry for an epoch ≤ finalized.
-        state.observed_checkpoints.push_back(candidate);
-
-        let finalized = state.advance_finalization(200);
-        assert!(
-            finalized.is_none(),
-            "popping a stale entry must not register as an advance"
-        );
-        assert_eq!(state.finalized_epoch, Some(commitment_1));
-        assert!(state.observed_checkpoints.is_empty());
     }
 
     // --- reorg handling ---
@@ -1517,6 +1284,69 @@ mod tests {
         commitment
     }
 
+    /// Once a checkpoint finalizes via `commit_block`, the reorg window floor
+    /// sits at the finalized height. A later reorg whose fork reaches below that
+    /// floor finds no canonical match and is rejected as `ReorgPastFinality`,
+    /// rather than rolling back finalized state.
+    #[test]
+    fn reorg_below_finalized_is_rejected() {
+        // Heights sit above the genesis anchor (40320) so the genesis term of
+        // the reorg floor never dominates the finalized/depth terms.
+        let depth = TEST_L1_REORG_SAFE_DEPTH; // 3
+        let floor_start: L1Height = 40399;
+        let ckpt_height: L1Height = 40400;
+        let finalize_tip: L1Height = ckpt_height + depth - 1; // 40402
+
+        // Canonical chain diverges from the committed branch at every height in
+        // the window (ids offset by 100), so the post-finalization reorg reaches
+        // past the floor with no canonical match anywhere in the window.
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            let mut c = c;
+            for height in floor_start..=finalize_tip {
+                c = c.with_canonical_block(height, block_id_at(height + 100));
+            }
+            c
+        });
+
+        // Seed a finalized window directly: the committed branch spans
+        // floor_start..=finalize_tip, with epoch 1 (observed at ckpt_height)
+        // already finalized.
+        let commitment = seed_ol_checkpoint_observation(&storage, 1, ckpt_height);
+        state.recent_asm_blocks = (floor_start..=finalize_tip)
+            .map(|h| L1BlockCommitment::new(h, block_id_at(h)))
+            .collect();
+        let finalized = L1Checkpoint::new(
+            *create_test_checkpoint_payload(1).new_tip(),
+            storage
+                .ol_checkpoint()
+                .get_checkpoint_l1_ref_blocking(commitment)
+                .expect("ref")
+                .expect("seeded ref"),
+        );
+        state.last_committed_state = Arc::new(ClientState::new(Some(finalized), None));
+
+        // Pruning against the finalized state pins the floor at the finalized
+        // height, dropping the pre-finalization entry at 99.
+        state.prune_below_reorg_floor();
+        assert_eq!(
+            state.recent_asm_blocks[0].height(),
+            ckpt_height,
+            "window floor must pin at the finalized height"
+        );
+        seed_client_state_row(&storage, &state.recent_asm_blocks[0]);
+
+        // Incoming reorg at the tip height, on the canonical branch that
+        // diverges from every committed entry down to and below the floor.
+        let incoming = L1BlockCommitment::new(finalize_tip, block_id_at(finalize_tip + 100));
+        let err = state
+            .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
+            .expect_err("a reorg below finalized height must error");
+        assert!(
+            matches!(err, CsmWorkerError::ReorgPastFinality { .. }),
+            "unexpected error: {err}"
+        );
+    }
+
     #[test]
     fn reorg_excludes_observations_above_fork() {
         let anchor = L1BlockCommitment::new(100, block_id_at(100));
@@ -1524,17 +1354,19 @@ mod tests {
         let incoming = L1BlockCommitment::new(101, block_id_at(201));
 
         let (mut state, storage) = create_test_state_with_ctx(|c| {
-            // Fork lands at the anchor (height 100); 101 diverged.
+            // Fork lands at the anchor (height 100); 101 diverged. Epoch 2's
+            // checkpoint rode the orphaned branch, so its canonical commitment
+            // is gone after the reorg.
             c.with_canonical_block(100, block_id_at(100))
                 .with_canonical_block(101, block_id_at(201))
+                .with_orphaned_epoch(2)
         });
         state.recent_asm_blocks = vec![anchor, orphan_tip];
 
         // CSM persisted a client state at the fork block in a prior run.
         seed_client_state_row(&storage, &anchor);
 
-        // Epoch 1 observed at L1 height 90 (at/below the fork at 100); epoch 2
-        // observed at the orphaned tip (height 101, above the fork).
+        // Epoch 1 observed at L1 height 90; epoch 2 observed at the orphaned tip.
         let commitment_1 = seed_ol_checkpoint_observation(&storage, 1, 90);
         let commitment_2 = seed_ol_checkpoint_observation(&storage, 2, 101);
 
@@ -1542,21 +1374,12 @@ mod tests {
             .process_asm_block(incoming, &[create_non_checkpoint_log_type()])
             .expect("reorg should re-derive state at the fork");
 
-        // Only the at/below-fork observation survives. Epoch 1 is buried
-        // 100 - 90 = 10 >= depth, so it is both confirmed and finalized.
-        assert_eq!(
-            state.confirmed_epoch,
-            Some(commitment_1),
-            "above-fork observation must not leak in as confirmed"
-        );
-        assert_eq!(state.finalized_epoch, Some(commitment_1));
-        assert!(
-            !state
-                .observed_checkpoints
-                .iter()
-                .any(|c| EpochCommitment::from(c) == commitment_2),
-            "above-fork observation must not be queued post-reorg"
-        );
+        // Epoch 1 is buried 100 - 90 = 10 >= depth, so it is both confirmed and
+        // finalized. The orphaned epoch 2 must not leak into either.
+        let clstate = &state.last_committed_state;
+        assert_eq!(clstate.get_last_epoch(), Some(commitment_1));
+        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment_1));
+        assert_ne!(clstate.get_last_epoch(), Some(commitment_2));
     }
 
     #[test]

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -144,6 +144,12 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let Some(tip) = self.recent_asm_blocks.last() else {
             return;
         };
+        debug_assert!(
+            self.recent_asm_blocks
+                .windows(2)
+                .all(|w| w[0].height() <= w[1].height()),
+            "recent_asm_blocks must be ascending for floor pruning"
+        );
         let floor = reorg_floor_height(&self.ctx, &self.last_committed_state, tip.height());
         let keep_from = self
             .recent_asm_blocks
@@ -273,7 +279,8 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         )?;
 
         // Delete the orphaned branch's rows so a restart can't bootstrap from an
-        // orphan that's above the canonical tip.
+        // orphan that's above the canonical tip. A crash partway through is
+        // recovered by bootstrap's `delete_orphan_rows_above` on restart.
         for orphan in &self.recent_asm_blocks[fork_idx + 1..] {
             self.ctx.del_client_state(orphan)?;
         }

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -357,13 +357,6 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         warn!(%fork_block, %incoming, "reorg detected; rewinding to fork point");
 
-        // Delete the orphaned branch's rows so a restart can't bootstrap from an
-        // orphan that's above the canonical tip.
-        let orphans = self.recent_asm_blocks.split_off(fork_idx + 1);
-        for orphan in &orphans {
-            self.ctx.del_client_state(orphan)?;
-        }
-
         // It is expected to have client state persisted below the tip, which means below the fork
         // point as well.
         let persisted = self.ctx.get_client_state_at(&fork_block)?;
@@ -375,16 +368,25 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             })?;
         let derived = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
         let new_clstate = derived.new_clstate;
-        self.confirmed_epoch = new_clstate.get_last_epoch();
-        self.finalized_epoch = new_clstate.get_declared_final_epoch();
-        self.observed_checkpoints = derived.observed_checkpoints;
 
-        // Re-persist at the fork to overwrite the orphaned branch's row, but
-        // publish only when the re-derived state actually changed.
+        // Re-persist at the fork to overwrite the orphaned branch's row. After
+        // this succeeds, durable storage reflects the rewound tip.
         self.ctx.put_client_state_update(
             &fork_block,
             ClientUpdateOutput::new_state(new_clstate.clone()),
         )?;
+
+        // Delete the orphaned branch's rows so a restart can't bootstrap from an
+        // orphan that's above the canonical tip.
+        for orphan in &self.recent_asm_blocks[fork_idx + 1..] {
+            self.ctx.del_client_state(orphan)?;
+        }
+
+        // Persistence done; commit the rewind to in-memory state.
+        self.recent_asm_blocks.truncate(fork_idx + 1);
+        self.confirmed_epoch = new_clstate.get_last_epoch();
+        self.finalized_epoch = new_clstate.get_declared_final_epoch();
+        self.observed_checkpoints = derived.observed_checkpoints;
         if persisted.as_ref() != Some(&new_clstate) {
             self.ctx
                 .publish_client_state(new_clstate.clone(), fork_block);

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -126,14 +126,15 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         self.ctx
             .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(state.clone()))?;
 
-        // The list stays contiguous: a commit either extends the tip by one or
-        // replaces it at the same height (reorg). It never skips a height.
+        // A commit either extends the tip by one or replaces it at the same
+        // height (a reorg whose fork sits at the incoming height). It never
+        // skips a height.
         let last = self
             .recent_asm_blocks
             .last()
             .expect("recent_asm_blocks is non-empty");
         let extends_tip = asm_block.height() == last.height() + 1;
-        let same_height_reorg = asm_block.height() <= last.height();
+        let same_height_reorg = asm_block.height() == last.height();
         debug_assert!(
             extends_tip || same_height_reorg,
             "commit skipped a height: tip {last}, block {asm_block}"
@@ -342,23 +343,34 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         warn!(%fork_block, %incoming, "reorg detected; rewinding to fork point");
         self.recent_asm_blocks.truncate(fork_idx + 1);
 
-        let fork_clstate = self
-            .ctx
-            .get_client_state_at(&fork_block)?
-            .unwrap_or_default();
+        // A fork at a seeded-but-uncommitted ancestor (e.g. right after a
+        // restart) has no persisted row. Fall back to the surviving finalized
+        // checkpoint rather than a default state, so re-derivation can't drop
+        // finality below the reorg-safe floor.
+        let persisted = self.ctx.get_client_state_at(&fork_block)?;
+        let fork_clstate = persisted.clone().unwrap_or_else(|| {
+            warn!(%fork_block, "no persisted client state at fork; seeding from finalized floor");
+            ClientState::new(
+                self.last_committed_state.get_last_finalized_checkpoint(),
+                None,
+            )
+        });
         let derived = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
         let new_clstate = derived.new_clstate;
         self.confirmed_epoch = new_clstate.get_last_epoch();
         self.finalized_epoch = new_clstate.get_declared_final_epoch();
         self.observed_checkpoints = derived.observed_checkpoints;
 
-        // Re-persist at the fork to overwrite the orphaned branch's row.
+        // Re-persist at the fork to overwrite the orphaned branch's row, but
+        // publish only when the re-derived state actually changed.
         self.ctx.put_client_state_update(
             &fork_block,
             ClientUpdateOutput::new_state(new_clstate.clone()),
         )?;
-        self.ctx
-            .publish_client_state(new_clstate.clone(), fork_block);
+        if persisted.as_ref() != Some(&new_clstate) {
+            self.ctx
+                .publish_client_state(new_clstate.clone(), fork_block);
+        }
         self.last_committed_state = Arc::new(new_clstate);
         Ok(())
     }
@@ -1419,12 +1431,6 @@ mod tests {
         commitment
     }
 
-    /// On the reorg path, `derive_state` re-derives cursors as of the fork block
-    /// (below the current tip), so observations recorded ABOVE the fork on the
-    /// orphaned branch must be excluded from the re-derived state.
-    ///
-    /// Without the height filter in `load_observed_checkpoints`, the above-fork
-    /// observation would leak in as the confirmed cursor.
     #[test]
     fn reorg_excludes_observations_above_fork() {
         let anchor = L1BlockCommitment::new(100, block_id_at(100));
@@ -1439,9 +1445,7 @@ mod tests {
         state.recent_asm_blocks = vec![anchor, orphan_tip];
 
         // Epoch 1 observed at L1 height 90 (at/below the fork at 100); epoch 2
-        // observed at the orphaned tip (height 101, above the fork). The latter
-        // is the realistic contaminant: a checkpoint genuinely seen on the
-        // orphaned branch at its tip, which the reorg discards.
+        // observed at the orphaned tip (height 101, above the fork).
         let commitment_1 = seed_ol_checkpoint_observation(&storage, 1, 90);
         let commitment_2 = seed_ol_checkpoint_observation(&storage, 2, 101);
 

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -16,7 +16,7 @@ use crate::{
     checkpoint_extract::{CheckpointVerificationContext, extract_matching_checkpoint},
     context::CsmWorkerContext,
     errors::{CsmWorkerError, CsmWorkerResult},
-    state::{CsmWorkerState, derive_state, reorg_floor_height},
+    state::{CsmWorkerState, compute_reorg_floor_height, derive_state},
 };
 
 /// The in-flight CSM update produced by processing one ASM block's logs.
@@ -115,7 +115,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         next_state: Arc<ClientState>,
     ) -> CsmWorkerResult<()> {
         // A commit either extends the tip by one or replaces it at the same
-        // height (a reorg whose fork sits at the incoming height). It never
+        // height (a reorg whose pivot sits at the incoming height). It never
         // skips a height.
         let last = self
             .recent_asm_blocks
@@ -144,13 +144,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let Some(tip) = self.recent_asm_blocks.last() else {
             return;
         };
-        debug_assert!(
-            self.recent_asm_blocks
-                .windows(2)
-                .all(|w| w[0].height() <= w[1].height()),
-            "recent_asm_blocks must be ascending for floor pruning"
-        );
-        let floor = reorg_floor_height(&self.ctx, &self.last_committed_state, tip.height());
+        let floor = compute_reorg_floor_height(&self.ctx, &self.last_committed_state, tip.height());
         let keep_from = self
             .recent_asm_blocks
             .iter()
@@ -216,20 +210,23 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             return Ok(());
         }
 
+        // A pure extension resumes from `last`; otherwise the reorg rewinds and
+        // tells us the pivot to resume from.
         let is_pure_extension = last_still_canonical && asm_block.height() > last.height();
-        if !is_pure_extension {
-            self.reorg_to_fork(&asm_block)?;
+        let resume_block = if is_pure_extension {
+            last
+        } else {
+            self.calculate_pivot_and_reorg(&asm_block)?
+        };
+
+        // A drop-tip reorg can rewind directly onto `asm_block`; it is already
+        // committed as the pivot, so re-processing it would duplicate the entry.
+        if resume_block == asm_block {
+            return Ok(());
         }
 
-        // Non-empty: `last` was extracted above and reorg keeps the fork entry.
-        let resume_height = self
-            .recent_asm_blocks
-            .last()
-            .expect("recent_asm_blocks is non-empty")
-            .height();
-
         // Replay gap blocks, then the target.
-        for height in (resume_height + 1)..asm_block.height() {
+        for height in (resume_block.height() + 1)..asm_block.height() {
             let gap_block = self.ctx.get_canonical_l1_block(height)?.ok_or_else(|| {
                 CsmWorkerError::MissingData {
                     what: "canonical L1 block",
@@ -245,60 +242,66 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         Ok(())
     }
 
-    /// Rewinds the worker to the fork point shared with the chain leading to
-    /// `incoming`, re-deriving cursors and persisted state there.
+    /// Rewinds the worker to the pivot block — the deepest entry still on the
+    /// canonical chain leading to `incoming` — and returns it as the block to
+    /// resume processing from.
     ///
-    /// Errors if the fork lies at or below the finalized anchor (index 0).
-    fn reorg_to_fork(&mut self, incoming: &L1BlockCommitment) -> CsmWorkerResult<()> {
+    /// Side effects, all relative to the pivot: truncates `recent_asm_blocks` to
+    /// it, re-persists its client-state row, deletes the orphaned rows above it,
+    /// and resets `last_committed_state`. A crash partway through the deletes is
+    /// recovered by `delete_orphan_rows_above` on the next restart.
+    ///
+    /// Errors if the pivot lies at or below the finalized anchor (index 0).
+    fn calculate_pivot_and_reorg(
+        &mut self,
+        incoming: &L1BlockCommitment,
+    ) -> CsmWorkerResult<L1BlockCommitment> {
         // No match means the divergence reaches past the finalized anchor.
-        let Some(fork_idx) = self.find_fork_index()? else {
+        let Some(pivot_idx) = self.find_pivot_index()? else {
             return Err(CsmWorkerError::ReorgPastFinality {
                 finalized: self.recent_asm_blocks[0],
                 incoming: *incoming,
             });
         };
-        let fork_block = self.recent_asm_blocks[fork_idx];
+        let pivot_block = self.recent_asm_blocks[pivot_idx];
 
-        warn!(%fork_block, %incoming, "reorg detected; rewinding to fork point");
+        warn!(%pivot_block, %incoming, "reorg detected; rewinding to pivot block");
 
-        // It is expected to have client state persisted below the tip, which means below the fork
-        // point as well.
-        let persisted = self.ctx.get_client_state_at(&fork_block)?;
-        let fork_clstate = persisted
+        // It is expected to have client state persisted below the tip, which
+        // means below the pivot as well.
+        let persisted = self.ctx.get_client_state_at(&pivot_block)?;
+        let pivot_clstate = persisted
             .clone()
             .ok_or_else(|| CsmWorkerError::MissingData {
-                what: "client state at fork block",
-                detail: fork_block.to_string(),
+                what: "client state at pivot block",
+                detail: pivot_block.to_string(),
             })?;
-        let new_clstate = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
+        let new_clstate = derive_state(&self.ctx, &pivot_block, &pivot_clstate)?;
 
-        // Re-persist at the fork to overwrite the orphaned branch's row.
+        // Re-persist at the pivot to overwrite the orphaned branch's row.
         self.ctx.put_client_state_update(
-            &fork_block,
+            &pivot_block,
             ClientUpdateOutput::new_state(new_clstate.clone()),
         )?;
 
-        // Delete the orphaned branch's rows so a restart can't bootstrap from an
-        // orphan that's above the canonical tip. A crash partway through is
-        // recovered by bootstrap's `delete_orphan_rows_above` on restart.
-        for orphan in &self.recent_asm_blocks[fork_idx + 1..] {
+        for orphan in &self.recent_asm_blocks[pivot_idx + 1..] {
             self.ctx.del_client_state(orphan)?;
         }
 
         // Persistence done; commit the rewind to in-memory state.
-        self.recent_asm_blocks.truncate(fork_idx + 1);
+        self.recent_asm_blocks.truncate(pivot_idx + 1);
 
         // Publish if necessary.
         if persisted.as_ref() != Some(&new_clstate) {
             self.ctx
-                .publish_client_state(new_clstate.clone(), fork_block);
+                .publish_client_state(new_clstate.clone(), pivot_block);
         }
         self.last_committed_state = Arc::new(new_clstate);
-        Ok(())
+        Ok(pivot_block)
     }
 
-    /// Highest list index whose block still matches the canonical L1 chain.
-    fn find_fork_index(&self) -> CsmWorkerResult<Option<usize>> {
+    /// Highest index in recent asm blocks whose block still matches the canonical L1 chain.
+    fn find_pivot_index(&self) -> CsmWorkerResult<Option<usize>> {
         for idx in (0..self.recent_asm_blocks.len()).rev() {
             let block = self.recent_asm_blocks[idx];
             // A missing block (above a reverted tip) or a mismatched blkid both
@@ -528,7 +531,7 @@ mod tests {
         let params = create_test_params_arc();
         let (storage, status_channel) = create_test_storage();
         let ctx = default_stub_ctx(&params, storage.clone(), status_channel);
-        let state = CsmWorkerState::bootstrap(ctx).unwrap();
+        let state = CsmWorkerState::init_from_context(ctx).unwrap();
         (state, storage)
     }
 
@@ -542,7 +545,7 @@ mod tests {
         let params = create_test_params_arc();
         let (storage, status_channel) = create_test_storage();
         let ctx = configure(default_stub_ctx(&params, storage.clone(), status_channel));
-        let state = CsmWorkerState::bootstrap(ctx).unwrap();
+        let state = CsmWorkerState::init_from_context(ctx).unwrap();
         (state, storage)
     }
 
@@ -1243,7 +1246,7 @@ mod tests {
         }
         ctx = ctx.with_canonical_block(tip.height(), *tip.blkid());
 
-        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+        let state = CsmWorkerState::init_from_context(ctx).expect("bootstrap");
 
         let expected: Vec<_> = (floor..tip.height())
             .map(|height| L1BlockCommitment::new(height, block_id_at(height)))

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -507,7 +507,7 @@ mod tests {
         let params = create_test_params_arc();
         let (storage, status_channel) = create_test_storage();
         let ctx = default_stub_ctx(&params, storage.clone(), status_channel);
-        let state = CsmWorkerState::new(ctx).unwrap();
+        let state = CsmWorkerState::bootstrap(ctx).unwrap();
         (state, storage)
     }
 
@@ -521,7 +521,7 @@ mod tests {
         let params = create_test_params_arc();
         let (storage, status_channel) = create_test_storage();
         let ctx = configure(default_stub_ctx(&params, storage.clone(), status_channel));
-        let state = CsmWorkerState::new(ctx).unwrap();
+        let state = CsmWorkerState::bootstrap(ctx).unwrap();
         (state, storage)
     }
 

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -16,7 +16,7 @@ use crate::{
     checkpoint_extract::{CheckpointVerificationContext, extract_matching_checkpoint},
     context::CsmWorkerContext,
     errors::{CsmWorkerError, CsmWorkerResult},
-    state::CsmWorkerState,
+    state::{CsmWorkerState, derive_state},
 };
 
 /// The in-flight CSM update produced by processing one ASM block's logs.
@@ -125,11 +125,37 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let state = next_state.as_ref().clone();
         self.ctx
             .put_client_state_update(&asm_block, ClientUpdateOutput::new(state.clone(), vec![]))?;
-        self.last_asm_block = Some(asm_block);
+
+        // The list stays contiguous: a commit either extends the tip by one or
+        // replaces it at the same height (reorg). It never skips a height.
+        let last = self
+            .recent_asm_blocks
+            .last()
+            .expect("recent_asm_blocks is non-empty");
+        let extends_tip = asm_block.height() == last.height() + 1;
+        let same_height_reorg = asm_block.height() <= last.height();
+        debug_assert!(
+            extends_tip || same_height_reorg,
+            "commit skipped a height: tip {last}, block {asm_block}"
+        );
+
+        self.recent_asm_blocks.push(asm_block);
+        self.prune_below_reorg_floor();
         self.last_committed_state = next_state;
         // Publish the client state to status channel.
         self.ctx.publish_client_state(state, asm_block);
         Ok(())
+    }
+
+    /// Keeps only the `depth` newest blocks: index 0 becomes the reorg-safe
+    /// floor, the deepest point a reorg could reach. Older entries can never be
+    /// reorged out, so they are dropped.
+    fn prune_below_reorg_floor(&mut self) {
+        let depth = self.ctx.l1_reorg_safe_depth().max(1) as usize;
+        let len = self.recent_asm_blocks.len();
+        if len > depth {
+            self.recent_asm_blocks.drain(..len - depth);
+        }
     }
 
     /// Processes every log of a single ASM block and commits it as one unit.
@@ -255,9 +281,10 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         asm_block: L1BlockCommitment,
         logs: &[AsmLogEntry],
     ) -> CsmWorkerResult<()> {
-        let last = self.last_asm_block.ok_or(CsmWorkerError::NoLastAsmBlock)?;
-        let last_height = last.height();
-        let target_height = asm_block.height();
+        let last = *self
+            .recent_asm_blocks
+            .last()
+            .ok_or(CsmWorkerError::NoAnchorAsmBlock)?;
 
         // Exact duplicate — ASM redelivered the same status, nothing to do.
         if asm_block == last {
@@ -265,42 +292,81 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             return Ok(());
         }
 
-        // TODO(STR-3466): Strictly behind — either a stale message or a deeper reorg.
-        if target_height < last_height {
-            warn!(
-                %asm_block,
-                last_height,
-                "ASM block strictly behind last committed; skipping (possible deeper reorg)"
-            );
-            return Ok(());
+        // A clean forward extension keeps `last` on the canonical chain.
+        let last_still_canonical = self.ctx.get_canonical_l1_block(last.height())? == last;
+        if !(asm_block.height() > last.height() && last_still_canonical) {
+            self.reorg_to_fork(&asm_block)?;
         }
 
-        // Same height, different blkid — the chain reorged out our last tip.
-        // TODO(STR-3466): with this ticket the two conditionals can be collapsed into one `<=`
-        // check.
-        if target_height == last_height {
-            warn!(
-                %asm_block,
-                last_blkid = ?last.blkid(),
-                "same-height ASM block with different blkid; processing as reorged tip"
-            );
-            // Directly process the logs in one block reorg.
-            return self.process_asm_logs(asm_block, logs);
-        }
+        // Non-empty: `last` was extracted above and reorg keeps the fork entry.
+        let resume_height = self
+            .recent_asm_blocks
+            .last()
+            .expect("recent_asm_blocks is non-empty")
+            .height();
 
-        for height in (last_height + 1)..=target_height {
-            let (block, block_logs) = if height == target_height {
-                (asm_block, logs.to_vec())
-            } else {
-                // fetch from db.
-                let gap_block = self.ctx.get_canonical_l1_block(height)?;
-                let gap_state = self.ctx.get_asm_state(&gap_block)?;
-                info!(%gap_block, "replaying ASM block skipped by status channel");
-                (gap_block, gap_state.logs().clone())
-            };
-            self.process_asm_logs(block, &block_logs)?;
+        // Replay gap blocks, then the target.
+        for height in (resume_height + 1)..asm_block.height() {
+            let gap_block = self.ctx.get_canonical_l1_block(height)?;
+            let gap_state = self.ctx.get_asm_state(&gap_block)?;
+            info!(%gap_block, "replaying ASM block skipped by status channel");
+            self.process_asm_logs(gap_block, gap_state.logs())?;
         }
+        // Process the target.
+        self.process_asm_logs(asm_block, logs)?;
         Ok(())
+    }
+
+    /// Rewinds the worker to the fork point shared with the chain leading to
+    /// `incoming`, re-deriving cursors and persisted state there.
+    ///
+    /// Errors if the fork lies at or below the finalized anchor (index 0): a
+    /// reorg past finality is a protocol violation the worker must not absorb.
+    fn reorg_to_fork(&mut self, incoming: &L1BlockCommitment) -> CsmWorkerResult<()> {
+        // No match means the divergence reaches past the finalized anchor.
+        let Some(fork_idx) = self.find_fork_index()? else {
+            return Err(CsmWorkerError::ReorgPastFinality {
+                finalized: self.recent_asm_blocks[0],
+                incoming: *incoming,
+            });
+        };
+        let fork_block = self.recent_asm_blocks[fork_idx];
+
+        warn!(%fork_block, %incoming, "reorg detected; rewinding to fork point");
+        self.recent_asm_blocks.truncate(fork_idx + 1);
+
+        let fork_clstate = self
+            .ctx
+            .get_client_state_at(&fork_block)?
+            .unwrap_or_default();
+        let derived = derive_state(&self.ctx, &fork_block, &fork_clstate)?;
+        let new_clstate = derived.new_clstate;
+        self.confirmed_epoch = new_clstate.get_last_epoch();
+        self.finalized_epoch = new_clstate.get_declared_final_epoch();
+        self.observed_checkpoints = derived.observed_checkpoints;
+
+        // Re-persist at the fork to overwrite the orphaned branch's row.
+        self.ctx.put_client_state_update(
+            &fork_block,
+            ClientUpdateOutput::new_state(new_clstate.clone()),
+        )?;
+        self.ctx
+            .publish_client_state(new_clstate.clone(), fork_block);
+        self.last_committed_state = Arc::new(new_clstate);
+        Ok(())
+    }
+
+    /// Highest list index whose block still matches the canonical L1 chain.
+    ///
+    /// `None` if even the finalized anchor (index 0) diverged.
+    fn find_fork_index(&self) -> CsmWorkerResult<Option<usize>> {
+        for idx in (0..self.recent_asm_blocks.len()).rev() {
+            let block = self.recent_asm_blocks[idx];
+            if self.ctx.get_canonical_l1_block(block.height())? == block {
+                return Ok(Some(idx));
+            }
+        }
+        Ok(None)
     }
 
     fn get_checkpoint_verification_context(
@@ -609,7 +675,7 @@ mod tests {
         let asm_block = L1BlockCommitment::new(250, L1BlockId::default());
 
         let (mut state, storage) = create_test_state_with_ctx(|c| c.with_l1_fetch_failure());
-        state.last_asm_block = Some(asm_block);
+        state.recent_asm_blocks = Some(asm_block);
         let mut pending = fresh_pending(&state);
         let err = state
             .process_log(&mut pending, &log, &asm_block)
@@ -640,7 +706,7 @@ mod tests {
             .commit_block(asm_block, next_state)
             .expect("commit should succeed");
 
-        assert_eq!(state.last_asm_block, Some(asm_block));
+        assert_eq!(state.recent_asm_blocks, Some(asm_block));
         let (persisted_block, _) = storage
             .client_state()
             .fetch_most_recent_state()
@@ -659,7 +725,7 @@ mod tests {
         let asm_block = L1BlockCommitment::new(250, L1BlockId::default());
 
         let (mut state, storage) = create_test_state_with_ctx(|c| c.with_l1_fetch_failure());
-        state.last_asm_block = Some(asm_block);
+        state.recent_asm_blocks = Some(asm_block);
 
         // The genesis client-state row seeded by `create_test_storage`.
         let (before_block, _) = storage
@@ -699,7 +765,7 @@ mod tests {
     fn commit_failure_leaves_cursors_unchanged() {
         let (mut state, storage) = create_test_state_with_ctx(|c| c.with_commit_failure());
         let last = L1BlockCommitment::new(100, block_id_at(100));
-        state.last_asm_block = Some(last);
+        state.recent_asm_blocks = Some(last);
 
         // Seed cursors with a known baseline so we can detect any partial
         // advancement that survives the failed commit.
@@ -725,7 +791,7 @@ mod tests {
         );
 
         // Commit cursor pinned at the last committed block.
-        assert_eq!(state.last_asm_block, Some(last));
+        assert_eq!(state.recent_asm_blocks, Some(last));
         // Every cursor unchanged.
         assert_eq!(state.last_processed_epoch, baseline_last_processed_epoch);
         assert_eq!(state.confirmed_epoch, baseline_confirmed_epoch);
@@ -747,14 +813,14 @@ mod tests {
     fn contiguous_block_commits_directly() {
         let (mut state, storage) = create_test_state();
         let last = L1BlockCommitment::new(100, block_id_at(100));
-        state.last_asm_block = Some(last);
+        state.recent_asm_blocks = Some(last);
 
         let next = L1BlockCommitment::new(101, block_id_at(101));
         state
             .process_asm_block(next, &[create_non_checkpoint_log_type()])
             .expect("contiguous block should process");
 
-        assert_eq!(state.last_asm_block, Some(next));
+        assert_eq!(state.recent_asm_blocks, Some(next));
         let (persisted, _) = storage
             .client_state()
             .fetch_most_recent_state()
@@ -783,14 +849,14 @@ mod tests {
             }
             c
         });
-        state.last_asm_block = Some(last);
+        state.recent_asm_blocks = Some(last);
 
         state
             .process_asm_block(target, &[create_non_checkpoint_log_type()])
             .expect("gap-fill should replay skipped blocks and commit target");
 
         // Cursor advanced all the way to the target.
-        assert_eq!(state.last_asm_block, Some(target));
+        assert_eq!(state.recent_asm_blocks, Some(target));
         // The last persisted client-state row is keyed on the target block,
         // and each gap block was committed in turn (105 distinct keys exist).
         let (persisted, _) = storage
@@ -829,7 +895,7 @@ mod tests {
             )
             .with_canonical_failure_at(102)
         });
-        state.last_asm_block = Some(last);
+        state.recent_asm_blocks = Some(last);
 
         let (before_block, _) = storage
             .client_state()
@@ -852,7 +918,7 @@ mod tests {
         // Block 101 was committed before the failure; the cursor advanced to
         // 101 but no further — it did not jump to the target.
         assert_eq!(
-            state.last_asm_block,
+            state.recent_asm_blocks,
             Some(L1BlockCommitment::new(101, block_id_at(101)))
         );
         assert!(
@@ -876,7 +942,7 @@ mod tests {
         let old_blkid = block_id_at(100);
         let new_blkid = block_id_at(0xFE);
         let last = L1BlockCommitment::new(100, old_blkid);
-        state.last_asm_block = Some(last);
+        state.recent_asm_blocks = Some(last);
 
         let reorged = L1BlockCommitment::new(100, new_blkid);
         state
@@ -884,7 +950,7 @@ mod tests {
             .expect("same-height reorg should process the new tip");
 
         assert_eq!(
-            state.last_asm_block,
+            state.recent_asm_blocks,
             Some(reorged),
             "cursor must advance to the reorged-in blkid"
         );
@@ -903,7 +969,7 @@ mod tests {
     fn stale_or_duplicate_block_is_ignored() {
         let (mut state, storage) = create_test_state();
         let last = L1BlockCommitment::new(100, block_id_at(100));
-        state.last_asm_block = Some(last);
+        state.recent_asm_blocks = Some(last);
 
         let (before, _) = storage
             .client_state()
@@ -921,7 +987,7 @@ mod tests {
             .process_asm_block(behind, &[create_non_checkpoint_log_type()])
             .expect("stale block should be a no-op");
 
-        assert_eq!(state.last_asm_block, Some(last));
+        assert_eq!(state.recent_asm_blocks, Some(last));
         let (after, _) = storage
             .client_state()
             .fetch_most_recent_state()

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -296,6 +296,14 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         // A clean forward extension keeps `last` on the canonical chain. A
         // missing block (height above a reverted tip) means it diverged.
         let last_still_canonical = self.ctx.get_canonical_l1_block(last.height())? == Some(last);
+
+        // Stale redelivery: a lower-height status while the tip is still
+        // canonical is an out-of-order replay, not a reorg.
+        if last_still_canonical && asm_block.height() < last.height() {
+            debug!(%asm_block, %last, "ignoring stale lower-height ASM status");
+            return Ok(());
+        }
+
         let is_pure_extension = last_still_canonical && asm_block.height() > last.height();
         if !is_pure_extension {
             self.reorg_to_fork(&asm_block)?;
@@ -1358,6 +1366,42 @@ mod tests {
 
         // Both prior entries survive and the new block is appended.
         assert_eq!(state.recent_asm_blocks, vec![anchor, last, next]);
+    }
+
+    /// A stale lower-height status redelivered while the tip is still canonical
+    /// is an out-of-order replay, not a reorg: the worker must ignore it rather
+    /// than rewinding the cursor backwards onto the older block.
+    #[test]
+    fn stale_lower_height_status_is_noop_when_tip_canonical() {
+        let anchor = L1BlockCommitment::new(98, block_id_at(98));
+        let mid = L1BlockCommitment::new(99, block_id_at(99));
+        let tip = L1BlockCommitment::new(100, block_id_at(100));
+        // A legitimate older canonical block (height 99) redelivered out of order.
+        let stale = L1BlockCommitment::new(99, block_id_at(99));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            // Tip at 100 is still canonical (no reorg happened); 99 too.
+            c.with_canonical_block(99, block_id_at(99))
+                .with_canonical_block(100, block_id_at(100))
+        });
+        state.recent_asm_blocks = vec![anchor, mid, tip];
+
+        state
+            .process_asm_block(stale, &[create_non_checkpoint_log_type()])
+            .expect("stale lower-height status must be a no-op");
+
+        // Tip unchanged: not rewound onto the older block.
+        assert_eq!(state.recent_asm_blocks.last(), Some(&tip));
+        assert_eq!(state.recent_asm_blocks, vec![anchor, mid, tip]);
+        // No row written at the stale height, and the cursor still sits at the tip.
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&stale)
+                .expect("query client state")
+                .is_none(),
+            "stale block must not persist a client-state row"
+        );
     }
 
     #[test]

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -33,7 +33,7 @@ impl<C: CsmWorkerContext + 'static> Service for CsmWorkerService<C> {
 
     fn get_status(state: &Self::State) -> Self::Status {
         CsmWorkerStatus {
-            cur_block: state.last_asm_block,
+            cur_block: state.recent_asm_blocks.last().copied(),
             last_processed_epoch: state.last_processed_epoch.map(|e| e as u64),
             last_confirmed_epoch: state.confirmed_epoch,
             last_finalized_epoch: state.finalized_epoch,
@@ -76,8 +76,8 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
             error!(%asm_block, err = ?e, "Failed to persist refreshed finalized checkpoint");
         }
 
-        // FCM listens on checkpoint-state updates. Emit when checkpoint status changed
-        // even if client-state object itself did not change (tip-only L1 movement).
+        // Publish client state update when checkpoint status changed even if client-state object
+        // itself did not change (tip-only L1 movement).
         if confirmed_changed || newly_finalized.is_some() {
             state
                 .ctx
@@ -276,7 +276,7 @@ mod tests {
             "finalized_epoch must not advance when process_asm_block failed"
         );
         // The cursor must stay pinned at the last committed block.
-        assert_eq!(state.last_asm_block, Some(last));
+        assert_eq!(state.recent_asm_blocks, Some(last));
         // No ClientState row may exist at the failed block.
         assert!(
             storage

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -173,7 +173,7 @@ mod tests {
         )
         .with_l1_fetch_failure();
 
-        let mut state = CsmWorkerState::new(ctx).expect("bootstrap state");
+        let mut state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
 
         // Inject a queued observation deep enough that any
         // `advance_finalization` call would advance finality.

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -135,7 +135,7 @@ mod tests {
         // extension whose processing fails on the L1 fetch (not a reorg).
         .with_canonical_block(last_height, *last.blkid());
 
-        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
+        let state = CsmWorkerState::init_from_context(ctx).expect("bootstrap state");
 
         (state, storage, last)
     }
@@ -229,7 +229,7 @@ mod tests {
             params.anchor.block,
         );
 
-        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
+        let state = CsmWorkerState::init_from_context(ctx).expect("bootstrap state");
         (state, storage, last)
     }
 

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -276,7 +276,7 @@ mod tests {
             "finalized_epoch must not advance when process_asm_block failed"
         );
         // The cursor must stay pinned at the last committed block.
-        assert_eq!(state.recent_asm_blocks, Some(last));
+        assert_eq!(state.recent_asm_blocks.last(), Some(&last));
         // No ClientState row may exist at the failed block.
         assert!(
             storage

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -1,17 +1,13 @@
 //! CSM worker service implementation.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
 use strata_asm_worker::AsmWorkerStatus;
-use strata_csm_types::{ClientState, ClientUpdateOutput, L1Checkpoint};
-use strata_primitives::l1::L1BlockCommitment;
 use strata_service::{Response, Service, SyncService};
 use tracing::*;
 
 use crate::{
-    context::CsmWorkerContext,
-    errors::{CsmWorkerError, CsmWorkerResult},
-    state::CsmWorkerState,
+    context::CsmWorkerContext, errors::CsmWorkerError, state::CsmWorkerState,
     status::CsmWorkerStatus,
 };
 
@@ -34,11 +30,12 @@ impl<C: CsmWorkerContext + 'static> Service for CsmWorkerService<C> {
     type Status = CsmWorkerStatus;
 
     fn get_status(state: &Self::State) -> Self::Status {
+        let clstate = &state.last_committed_state;
         CsmWorkerStatus {
             cur_block: state.recent_asm_blocks.last().copied(),
             last_processed_epoch: state.last_processed_epoch.map(|e| e as u64),
-            last_confirmed_epoch: state.confirmed_epoch,
-            last_finalized_epoch: state.finalized_epoch,
+            last_confirmed_epoch: clstate.get_last_epoch(),
+            last_finalized_epoch: clstate.get_declared_final_epoch(),
         }
     }
 }
@@ -56,8 +53,6 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
 
         trace!("CSM is processing ASM logs.");
 
-        let prev_confirmed_epoch = state.confirmed_epoch;
-
         if let Err(e) = state.process_asm_block(asm_block, asm_status.logs()) {
             // If it is reorg past finality, halt the service.
             if matches!(e, CsmWorkerError::ReorgPastFinality { .. }) {
@@ -68,46 +63,8 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
             return Ok(Response::Continue);
         }
 
-        let newly_finalized = state.advance_finalization(asm_block.height());
-        let confirmed_changed = state.confirmed_epoch != prev_confirmed_epoch;
-
-        // If depth-driven finality advanced, refresh ClientState's
-        // `last_finalized_checkpoint` so persisted state matches the worker's
-        // depth-derived view. ClientState is the only thing downstream consumers
-        // (fork choice, chain worker, RPC) can see, so it has to carry the truth.
-        if let Some(finalized) = newly_finalized.as_ref()
-            && let Err(e) = refresh_finalized_checkpoint(state, asm_block, finalized.clone())
-        {
-            error!(%asm_block, err = ?e, "Failed to persist refreshed finalized checkpoint");
-        }
-
-        // Publish client state update when checkpoint status changed even if client-state object
-        // itself did not change (tip-only L1 movement).
-        if confirmed_changed || newly_finalized.is_some() {
-            state
-                .ctx
-                .publish_client_state(state.last_committed_state.as_ref().clone(), asm_block);
-        }
-
         Ok(Response::Continue)
     }
-}
-
-/// Rewrites the committed `ClientState` so its `last_finalized_checkpoint`
-/// matches the depth-finalized `L1Checkpoint`, then re-persists it under
-/// `asm_block`. The publish happens in the caller alongside other status edges.
-fn refresh_finalized_checkpoint<C: CsmWorkerContext>(
-    state: &mut CsmWorkerState<C>,
-    asm_block: L1BlockCommitment,
-    finalized: L1Checkpoint,
-) -> CsmWorkerResult<()> {
-    let last_seen = state.last_committed_state.get_last_checkpoint();
-    let refreshed = ClientState::new(Some(finalized), last_seen);
-    state
-        .ctx
-        .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(refreshed.clone()))?;
-    state.last_committed_state = Arc::new(refreshed);
-    Ok(())
 }
 
 #[cfg(test)]
@@ -117,9 +74,9 @@ mod tests {
     use strata_asm_logs::CheckpointTipUpdate;
     use strata_asm_proto_checkpoint_types::CheckpointTip;
     use strata_asm_worker::{AsmState, AsmWorkerStatus};
-    use strata_csm_types::{CheckpointL1Ref, ClientState, ClientUpdateOutput, L1Checkpoint};
+    use strata_csm_types::{ClientState, ClientUpdateOutput};
     use strata_db_store_sled::test_utils::get_test_sled_backend;
-    use strata_identifiers::{Buf32, L1BlockId, OLBlockId, RBuf32};
+    use strata_identifiers::{Buf32, L1BlockId, OLBlockId};
     use strata_primitives::prelude::*;
     use strata_service::{Response, SyncService};
     use strata_status::StatusChannel;
@@ -129,10 +86,9 @@ mod tests {
     use super::CsmWorkerService;
     use crate::{state::CsmWorkerState, test_utils::StubCtx};
 
-    /// Builds a worker state with an already-seeded finalizable observation in
-    /// the queue, anchored to `last` at height `last_height`. `finality_depth`
-    /// controls when the queued observation counts as finalized.
-    fn state_with_pending_finalization(
+    /// Builds a worker anchored at `last` (height `last_height`) whose ASM
+    /// block processing fails on the L1 fetch, so no block ever commits.
+    fn state_with_failing_block(
         last_height: L1Height,
         finality_depth: u32,
     ) -> (
@@ -146,8 +102,7 @@ mod tests {
         let storage = Arc::new(create_node_storage(db, pool).expect("create storage"));
 
         // Seed the genesis ClientState row keyed at `last`, so bootstrap
-        // resolves `last_asm_block = last` and the worker has no prior finality
-        // — the refresh path can only fire because of the queued observation.
+        // resolves `last_asm_block = last` with no prior finality.
         let last = L1BlockCommitment::new(last_height, L1BlockId::from(Buf32::from([7; 32])));
         storage
             .client_state()
@@ -180,29 +135,7 @@ mod tests {
         // extension whose processing fails on the L1 fetch (not a reorg).
         .with_canonical_block(last_height, *last.blkid());
 
-        let mut state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
-
-        // Inject a queued observation deep enough that any
-        // `advance_finalization` call would advance finality.
-        let epoch = 1u32;
-        let obs_height = last_height - 1;
-        let l2_commitment = OLBlockCommitment::new(
-            epoch as u64 * 10,
-            OLBlockId::from(Buf32::from([epoch as u8; 32])),
-        );
-        let tip = CheckpointTip {
-            epoch,
-            l1_height: obs_height,
-            l2_commitment,
-        };
-        let obs_block = L1BlockCommitment::new(
-            obs_height,
-            L1BlockId::from(Buf32::from([obs_height as u8; 32])),
-        );
-        let l1_ref = CheckpointL1Ref::new(obs_block, RBuf32::from([1; 32]), RBuf32::from([2; 32]));
-        state
-            .observed_checkpoints
-            .push_back(L1Checkpoint::new(tip, l1_ref));
+        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
 
         (state, storage, last)
     }
@@ -318,20 +251,15 @@ mod tests {
         assert!(matches!(response, Response::ShouldExit));
     }
 
-    /// When `process_asm_block` fails, neither finality advancement nor the
-    /// resulting `ClientState` refresh should run — otherwise we'd persist a
-    /// row keyed on a block that was never actually committed, and bootstrap
-    /// would treat it as committed on restart.
+    /// When `process_asm_block` fails, nothing commits: finality stays put and
+    /// no row is persisted at the failing block, so bootstrap doesn't treat it
+    /// as committed on restart.
     #[test]
     fn process_input_skips_finalization_when_process_asm_block_fails() {
         let last_height: L1Height = 100;
         let finality_depth: u32 = 3;
-        let (mut state, storage, last) =
-            state_with_pending_finalization(last_height, finality_depth);
+        let (mut state, storage, last) = state_with_failing_block(last_height, finality_depth);
 
-        // Target one block ahead — the queued observation at height 99 will
-        // have 3 confirmations relative to this tip, so without the gate the
-        // refresh path would persist at the failing block.
         let target = L1BlockCommitment::new(last_height + 1, L1BlockId::from(Buf32::from([8; 32])));
         let status = status_with_tip_log(target, /* epoch */ 1);
 
@@ -342,8 +270,9 @@ mod tests {
 
         // Finality must not have moved in-memory.
         assert_eq!(
-            state.finalized_epoch, None,
-            "finalized_epoch must not advance when process_asm_block failed"
+            state.last_committed_state.get_declared_final_epoch(),
+            None,
+            "finality must not advance when process_asm_block failed"
         );
         // The cursor must stay pinned at the last committed block.
         assert_eq!(state.recent_asm_blocks.last(), Some(&last));

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -9,7 +9,9 @@ use strata_service::{Response, Service, SyncService};
 use tracing::*;
 
 use crate::{
-    context::CsmWorkerContext, errors::CsmWorkerResult, state::CsmWorkerState,
+    context::CsmWorkerContext,
+    errors::{CsmWorkerError, CsmWorkerResult},
+    state::CsmWorkerState,
     status::CsmWorkerStatus,
 };
 
@@ -56,9 +58,12 @@ impl<C: CsmWorkerContext + 'static> SyncService for CsmWorkerService<C> {
 
         let prev_confirmed_epoch = state.confirmed_epoch;
 
-        // Bail before touching finality: persisting a `ClientState` row at a
-        // failed block would make bootstrap skip the retry gap-fill guarantees.
         if let Err(e) = state.process_asm_block(asm_block, asm_status.logs()) {
+            // If it is reorg past finality, halt the service.
+            if matches!(e, CsmWorkerError::ReorgPastFinality { .. }) {
+                error!(%asm_block, err = ?e, "reorg past finality; shutting down CSM worker");
+                return Ok(Response::ShouldExit);
+            }
             error!(%asm_block, err = ?e, "Failed to process ASM block");
             return Ok(Response::Continue);
         }
@@ -170,7 +175,10 @@ mod tests {
             params.magic,
             params.anchor.block,
         )
-        .with_l1_fetch_failure();
+        .with_l1_fetch_failure()
+        // Keep `last` on the canonical chain so the incoming target is a pure
+        // extension whose processing fails on the L1 fetch (not a reorg).
+        .with_canonical_block(last_height, *last.blkid());
 
         let mut state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
 
@@ -245,6 +253,69 @@ mod tests {
             },
             sections: Default::default(),
         }
+    }
+
+    /// Builds a worker whose committed tip is no longer on the canonical chain,
+    /// with no canonical entry anywhere in the reorg window, so any incoming
+    /// block forces a reorg that diverges past the finalized anchor.
+    fn state_with_reorg_past_finality() -> (
+        CsmWorkerState<StubCtx>,
+        Arc<strata_storage::NodeStorage>,
+        L1BlockCommitment,
+    ) {
+        let params = strata_test_utils_l2::gen_asm_params();
+        let db = get_test_sled_backend();
+        let pool = threadpool::ThreadPool::new(4);
+        let storage = Arc::new(create_node_storage(db, pool).expect("create storage"));
+
+        let last = L1BlockCommitment::new(100, L1BlockId::from(Buf32::from([7; 32])));
+        storage
+            .client_state()
+            .put_update_blocking(
+                &last,
+                ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
+            )
+            .expect("seed client state");
+
+        let mut arbgen = ArbitraryGenerator::new();
+        let status_channel = Arc::new(StatusChannel::new(
+            arbgen.generate(),
+            params.anchor.block,
+            arbgen.generate(),
+            None,
+            None,
+        ));
+
+        // No canonical block registered at the tip's height, so `last` reads as
+        // non-canonical and fork detection finds nothing in the window.
+        let ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            3,
+            params.magic,
+            params.anchor.block,
+        );
+
+        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap state");
+        (state, storage, last)
+    }
+
+    /// A reorg that diverges past the finalized anchor must halt the worker:
+    /// `process_input` returns `Response::ShouldExit` rather than swallowing the
+    /// error and continuing against an unsafe chain.
+    #[test]
+    fn process_input_exits_on_reorg_past_finality() {
+        let (mut state, _storage, _last) = state_with_reorg_past_finality();
+
+        // A divergent block at the tip's height triggers a same-height reorg;
+        // with no canonical entry in the window it reaches past finality.
+        let incoming = L1BlockCommitment::new(100, L1BlockId::from(Buf32::from([9; 32])));
+        let status = status_with_tip_log(incoming, /* epoch */ 1);
+
+        let response =
+            <CsmWorkerService<StubCtx> as SyncService>::process_input(&mut state, status)
+                .expect("process_input never errors — failures are surfaced as responses");
+        assert!(matches!(response, Response::ShouldExit));
     }
 
     /// When `process_asm_block` fails, neither finality advancement nor the

--- a/crates/csm-worker/src/service.rs
+++ b/crates/csm-worker/src/service.rs
@@ -98,10 +98,9 @@ fn refresh_finalized_checkpoint<C: CsmWorkerContext>(
 ) -> CsmWorkerResult<()> {
     let last_seen = state.last_committed_state.get_last_checkpoint();
     let refreshed = ClientState::new(Some(finalized), last_seen);
-    state.ctx.put_client_state_update(
-        &asm_block,
-        ClientUpdateOutput::new(refreshed.clone(), vec![]),
-    )?;
+    state
+        .ctx
+        .put_client_state_update(&asm_block, ClientUpdateOutput::new_state(refreshed.clone()))?;
     state.last_committed_state = Arc::new(refreshed);
     Ok(())
 }

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -17,10 +17,6 @@ use crate::{
 ///
 /// This state is used by the CSM worker which acts as a listener to ASM worker
 /// status updates, processing checkpoint logs from the checkpoint subprotocol.
-///
-/// Every field is either the last durably committed value or a running cursor
-/// advanced only after a successful commit. Per-block scratch state lives in
-/// `BlockScratch` and never touches this struct on failure.
 #[expect(
     missing_debug_implementations,
     reason = "context generic doesn't require Debug"
@@ -38,18 +34,6 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
 
     /// Last epoch we processed a checkpoint for.
     pub(crate) last_processed_epoch: Option<Epoch>,
-
-    /// Latest checkpoint epoch observed on L1.
-    pub(crate) confirmed_epoch: Option<EpochCommitment>,
-
-    /// Latest checkpoint epoch finalized by L1 depth, derived from observation facts and tip.
-    pub(crate) finalized_epoch: Option<EpochCommitment>,
-
-    /// Ordered observed checkpoint candidates used for incremental depth derivation.
-    ///
-    /// Items are appended after a successful block commit and consumed as
-    /// finalized depth progresses.
-    pub(crate) observed_checkpoints: VecDeque<L1Checkpoint>,
 }
 
 impl<C: CsmWorkerContext> CsmWorkerState<C> {
@@ -66,9 +50,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let (recent_l1blk, recent_clstate) =
             resolve_canonical_tip(&ctx, loaded_block, loaded_clstate)?;
 
-        let derived = derive_state(&ctx, &recent_l1blk, &recent_clstate)?;
-
-        let new_clstate = Arc::new(derived.new_clstate);
+        let new_clstate = Arc::new(derive_state(&ctx, &recent_l1blk, &recent_clstate)?);
 
         // Persist and publish only when the derived state actually changed.
         if *new_clstate != recent_clstate {
@@ -78,17 +60,12 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         }
 
         let recent_asm_blocks = init_recent_asm_blocks(&ctx, &new_clstate, recent_l1blk)?;
-        let confirmed_epoch = new_clstate.get_last_epoch();
-        let finalized_epoch = new_clstate.get_declared_final_epoch();
 
         Ok(Self {
             ctx,
             recent_asm_blocks,
             last_committed_state: new_clstate,
             last_processed_epoch: None,
-            confirmed_epoch,
-            finalized_epoch,
-            observed_checkpoints: derived.observed_checkpoints,
         })
     }
 
@@ -173,19 +150,12 @@ pub(crate) fn finalized_l1_height(clstate: &ClientState) -> Option<L1Height> {
         .map(|ckpt| ckpt.height())
 }
 
-/// Client state and surviving observation queue derived as of an L1 tip.
-pub(crate) struct DerivedState {
-    pub(crate) observed_checkpoints: VecDeque<L1Checkpoint>,
-    /// Client state rebuilt from the derived checkpoints.
-    pub(crate) new_clstate: ClientState,
-}
-
-/// Derives client state and newly observed checkpoints from storage as of `cur_block`.
+/// Derives the client state from storage as of `cur_block`.
 pub(crate) fn derive_state<C: CsmWorkerContext>(
     ctx: &C,
     cur_block: &L1BlockCommitment,
     cur_clstate: &ClientState,
-) -> CsmWorkerResult<DerivedState> {
+) -> CsmWorkerResult<ClientState> {
     let current_csm_tip = cur_block.height();
     let finality_depth = ctx.l1_reorg_safe_depth().max(1);
     let last_finalized_epoch = cur_clstate.get_declared_final_epoch();
@@ -193,10 +163,10 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
         .map(|epoch| epoch.epoch().saturating_add(1))
         .unwrap_or(0);
 
-    let mut observed_checkpoints =
+    let observed_checkpoints =
         load_observed_checkpoints(ctx, observation_start_epoch, current_csm_tip)?;
 
-    // Derive new finalized checkpoint from last finalized and finalized ones among the observed.
+    // Highest-epoch observation buried deep enough to be reorg-safe.
     let new_finalized_ckpt = observed_checkpoints
         .iter()
         .rev()
@@ -213,22 +183,7 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
         .cloned()
         .or_else(|| new_finalized_ckpt.clone());
 
-    let finalized_epoch = new_finalized_ckpt.as_ref().map(EpochCommitment::from);
-    let new_clstate = ClientState::new(new_finalized_ckpt, confirmed_ckpt);
-
-    // Drop candidates that are already finalized, leaving only newer observations
-    // for incremental finality advancement.
-    while observed_checkpoints
-        .front()
-        .is_some_and(|ckpt| finalized_epoch.is_some_and(|fin| ckpt.tip.epoch <= fin.epoch()))
-    {
-        observed_checkpoints.pop_front();
-    }
-
-    Ok(DerivedState {
-        observed_checkpoints,
-        new_clstate,
-    })
+    Ok(ClientState::new(new_finalized_ckpt, confirmed_ckpt))
 }
 
 /// Loads observed checkpoint candidates from the OL checkpoint DB via `ctx`,
@@ -288,11 +243,146 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::{CsmWorkerState, reorg_floor_height};
+    use super::{CsmWorkerState, derive_state, reorg_floor_height};
     use crate::test_utils::StubCtx;
 
     fn create_test_params() -> Arc<AsmParams> {
         Arc::new(strata_test_utils_l2::gen_asm_params())
+    }
+
+    /// Seeds an observed checkpoint at `epoch` anchored to L1 `l1_height` and
+    /// returns its epoch commitment.
+    fn seed_observation(
+        storage: &strata_storage::NodeStorage,
+        epoch: u32,
+        l1_height: L1Height,
+    ) -> EpochCommitment {
+        let ol_checkpoint = storage.ol_checkpoint();
+        let payload = create_test_checkpoint_payload(epoch);
+        let ol_terminal = *payload.new_tip().l2_commitment();
+        let summary = EpochSummary::new(
+            epoch,
+            ol_terminal,
+            L2BlockCommitment::new(0, L2BlockId::default()),
+            L1BlockCommitment::new(
+                l1_height,
+                L1BlockId::from(Buf32::from([l1_height as u8; 32])),
+            ),
+            Buf32::zero(),
+        );
+        let commitment = summary.get_epoch_commitment();
+        ol_checkpoint
+            .insert_epoch_summary_blocking(summary)
+            .expect("insert epoch summary");
+        ol_checkpoint
+            .put_checkpoint_l1_observation_blocking(
+                commitment,
+                payload,
+                CheckpointL1Ref::new(
+                    L1BlockCommitment::new(
+                        l1_height,
+                        L1BlockId::from(Buf32::from([l1_height as u8; 32])),
+                    ),
+                    RBuf32::from([epoch as u8; 32]),
+                    RBuf32::from([epoch as u8; 32]),
+                ),
+            )
+            .expect("insert epoch observation");
+        commitment
+    }
+
+    /// Builds a `StubCtx` over freshly seeded storage with reorg depth 3.
+    fn derive_ctx() -> (StubCtx, Arc<strata_storage::NodeStorage>) {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+        let ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            3,
+            params.magic,
+            params.anchor.block,
+        );
+        (ctx, storage)
+    }
+
+    /// An observation only `depth - 1` deep is not yet finalized.
+    #[test]
+    fn derive_state_below_depth_does_not_finalize() {
+        let (ctx, storage) = derive_ctx();
+        seed_observation(&storage, 1, 100);
+
+        // tip 101 -> 2 confirmations, below the depth-3 threshold.
+        let tip = L1BlockCommitment::new(101, L1BlockId::default());
+        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+
+        assert_eq!(clstate.get_declared_final_epoch(), None);
+    }
+
+    /// An observation buried `depth` deep finalizes.
+    #[test]
+    fn derive_state_finalizes_at_depth() {
+        let (ctx, storage) = derive_ctx();
+        let commitment = seed_observation(&storage, 1, 100);
+
+        // tip 102 -> 3 confirmations = depth threshold.
+        let tip = L1BlockCommitment::new(102, L1BlockId::default());
+        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+
+        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment));
+        assert_eq!(clstate.get_last_epoch(), Some(commitment));
+    }
+
+    /// With several safe observations, finality lands at the highest epoch and
+    /// confirmed tracks the latest observation seen on L1.
+    #[test]
+    fn derive_state_finalizes_highest_safe() {
+        let (ctx, storage) = derive_ctx();
+        seed_observation(&storage, 1, 100);
+        let commitment_2 = seed_observation(&storage, 2, 101);
+
+        // tip 103 -> both observations are >= depth-3 deep.
+        let tip = L1BlockCommitment::new(103, L1BlockId::default());
+        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+
+        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment_2));
+        assert_eq!(clstate.get_last_epoch(), Some(commitment_2));
+    }
+
+    /// Confirmed tracks an observation that is seen but not yet finalized, while
+    /// finality stays at the deeper one.
+    #[test]
+    fn derive_state_confirmed_ahead_of_finalized() {
+        let (ctx, storage) = derive_ctx();
+        let commitment_1 = seed_observation(&storage, 1, 100);
+        let commitment_2 = seed_observation(&storage, 2, 102);
+
+        // tip 102 -> epoch 1 is 3 deep (finalized); epoch 2 is 1 deep (seen only).
+        let tip = L1BlockCommitment::new(102, L1BlockId::default());
+        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+
+        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment_1));
+        assert_eq!(clstate.get_last_epoch(), Some(commitment_2));
+    }
+
+    /// A prior finalized checkpoint is retained when no newer observation is yet
+    /// safe to finalize.
+    #[test]
+    fn derive_state_keeps_prior_finalized() {
+        let (ctx, storage) = derive_ctx();
+        let prior = seed_observation(&storage, 1, 100);
+
+        // First derive at tip 102 finalizes epoch 1; reuse that as the baseline.
+        let tip_1 = L1BlockCommitment::new(102, L1BlockId::default());
+        let baseline = derive_state(&ctx, &tip_1, &ClientState::new(None, None)).expect("derive");
+        assert_eq!(baseline.get_declared_final_epoch(), Some(prior));
+
+        seed_observation(&storage, 2, 103);
+
+        // tip 103: epoch 2 only 1 deep, so no new finality; prior must persist.
+        let tip_2 = L1BlockCommitment::new(103, L1BlockId::default());
+        let clstate = derive_state(&ctx, &tip_2, &baseline).expect("derive");
+
+        assert_eq!(clstate.get_declared_final_epoch(), Some(prior));
     }
 
     fn create_test_storage_and_status(
@@ -394,14 +484,8 @@ mod tests {
         }
         let state = CsmWorkerState::bootstrap(ctx).expect("state init");
 
-        assert_eq!(state.confirmed_epoch, Some(commitment_2));
-        assert_eq!(state.finalized_epoch, Some(commitment_1));
-        assert_eq!(state.observed_checkpoints.len(), 1);
         assert_eq!(
-            state
-                .observed_checkpoints
-                .front()
-                .map(EpochCommitment::from),
+            state.last_committed_state.get_last_epoch(),
             Some(commitment_2)
         );
 
@@ -498,7 +582,6 @@ mod tests {
         }
         let state = CsmWorkerState::bootstrap(ctx).expect("state init");
 
-        assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert_eq!(
             state.last_committed_state.get_declared_final_epoch(),
             Some(commitment_1)

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -68,7 +68,9 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             ctx.publish_client_state(new_clstate.as_ref().clone(), recent_l1blk);
         }
 
-        let recent_asm_blocks = init_recent_processed_blocks(&ctx, recent_l1blk)?;
+        // The list starts at the committed block and refills as blocks are
+        // processed; pruning bounds it to the reorg-safe depth.
+        let recent_asm_blocks = vec![recent_l1blk];
         let confirmed_epoch = new_clstate.get_last_epoch();
         let finalized_epoch = new_clstate.get_declared_final_epoch();
 
@@ -144,24 +146,6 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
         observed_checkpoints,
         new_clstate,
     })
-}
-
-/// Builds the initial L1 block list from the reorg-safe finalized floor up to
-/// `cur_block`.
-fn init_recent_processed_blocks(
-    ctx: &impl CsmWorkerContext,
-    cur_block: L1BlockCommitment,
-) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
-    let depth = ctx.l1_reorg_safe_depth().max(1);
-    let gen_height = ctx.genesis_l1_block().height();
-    // Anchor is whichever is highest: depth from cur tip or genesis height
-    let anchor_height = cur_block.height().saturating_sub(depth - 1).max(gen_height);
-
-    let mut blocks = Vec::new();
-    for height in anchor_height..=cur_block.height() {
-        blocks.push(ctx.get_canonical_l1_block(height)?);
-    }
-    Ok(blocks)
 }
 
 /// Loads observed checkpoint candidates from the OL checkpoint DB via `ctx`,
@@ -397,13 +381,9 @@ mod tests {
             )
             .expect("insert epoch 1 observation");
 
-        // Seed the on-disk ClientState so its `last_finalized_checkpoint`
-        // already reflects epoch 1 — bootstrap should observe this and skip
-        // the refresh path.
-        let baseline = ClientState::new(
-            Some(L1Checkpoint::new(*payload_1.new_tip(), l1_ref_1)),
-            None,
-        );
+        // Seed the on-disk ClientState so both checkpoints already reflect epoch 1.
+        let epoch_1_ckpt = L1Checkpoint::new(*payload_1.new_tip(), l1_ref_1);
+        let baseline = ClientState::new(Some(epoch_1_ckpt.clone()), Some(epoch_1_ckpt));
         let baseline_block = L1BlockCommitment::new(20, L1BlockId::default());
         storage
             .client_state()

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -63,7 +63,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             delete_orphan_rows_above(&ctx, recent_l1blk)?;
         }
 
-        let new_clstate = Arc::new(derive_state(&ctx, &recent_l1blk, &recent_clstate)?);
+        let new_clstate = Arc::new(reload_client_state(&ctx, &recent_l1blk, &recent_clstate)?);
 
         // Persist and publish when the derived state changed, or to seed the
         // anchor row on empty storage — a later reorg may pivot to it and read
@@ -196,8 +196,8 @@ pub(crate) fn finalized_l1_height(clstate: &ClientState) -> Option<L1Height> {
         .map(|ckpt| ckpt.height())
 }
 
-/// Derives the client state from storage as of `cur_block`.
-pub(crate) fn derive_state<C: CsmWorkerContext>(
+/// Reloads the client state from storage as of `cur_block`.
+pub(crate) fn reload_client_state<C: CsmWorkerContext>(
     ctx: &C,
     cur_block: &L1BlockCommitment,
     cur_clstate: &ClientState,
@@ -232,42 +232,33 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
     Ok(ClientState::new(new_finalized_ckpt, confirmed_ckpt))
 }
 
-/// Loads observed checkpoint candidates from the OL checkpoint DB via `ctx`,
+/// Loads observed checkpoint candidates from CSM's own observation index,
 /// starting from `start_epoch`.
 fn load_observed_checkpoints<C: CsmWorkerContext>(
     ctx: &C,
     start_epoch: Epoch,
     cur_csm_tip: L1Height,
 ) -> CsmWorkerResult<VecDeque<L1Checkpoint>> {
-    let Some(last_ep_with_l1ref) = ctx.get_last_checkpoint_l1_ref_epoch()? else {
-        return Ok(VecDeque::new());
-    };
-    let last_checkpoint_epoch = last_ep_with_l1ref.epoch();
-
     let mut observed = VecDeque::new();
-    for epoch in start_epoch..=last_checkpoint_epoch {
-        // No canonical commitment at this epoch is expected (e.g. orphaned), so
-        // skip silently; a commitment with a missing observation is not.
-        let Some(commitment) = ctx.get_canonical_epoch_commitment_at(epoch)? else {
+    for (commitment, observation) in ctx.get_checkpoint_l1_refs_from(start_epoch)? {
+        let l1_block = observation.l1_commitment;
+
+        if l1_block.height() > cur_csm_tip {
             continue;
-        };
-        let Some(observation) = ctx.get_checkpoint_l1_ref(commitment)? else {
-            warn!(?commitment, "canonical epoch missing its L1 ref; skipping");
+        }
+
+        // Drop observations recorded on an orphaned L1 block.
+        if ctx.get_canonical_l1_block(l1_block.height())? != Some(l1_block) {
             continue;
-        };
+        }
+
         let Some(payload) = ctx.get_checkpoint_payload(commitment)? else {
             warn!(
                 ?commitment,
-                "canonical epoch missing its checkpoint payload; skipping"
+                "observed checkpoint missing its payload; skipping"
             );
             continue;
         };
-
-        // Heights are strictly increasing in epoch order, so once one exceeds
-        // the tip every later one does too.
-        if observation.l1_commitment.height() > cur_csm_tip {
-            break;
-        }
 
         observed.push_back(L1Checkpoint::new(*payload.new_tip(), observation));
     }
@@ -296,7 +287,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::{CsmWorkerState, compute_reorg_floor_height, derive_state};
+    use super::{CsmWorkerState, compute_reorg_floor_height, reload_client_state};
     use crate::test_utils::StubCtx;
 
     fn create_test_params() -> Arc<AsmParams> {
@@ -344,18 +335,77 @@ mod tests {
         commitment
     }
 
-    /// Builds a `StubCtx` over freshly seeded storage with reorg depth 3.
+    /// Builds a `StubCtx` over freshly seeded storage with reorg depth 3, with
+    /// canonical L1 blocks registered to match `seed_observation`'s blkid scheme
+    /// (`[height as u8; 32]`) so observations read as canonical.
     fn derive_ctx() -> (StubCtx, Arc<strata_storage::NodeStorage>) {
         let params = create_test_params();
         let (storage, status_channel) = create_test_storage_and_status(params.clone());
-        let ctx = StubCtx::new(
+        let mut ctx = StubCtx::new(
             storage.clone(),
             status_channel,
             3,
             params.magic,
             params.anchor.block,
         );
+        for height in 0..=200 {
+            ctx =
+                ctx.with_canonical_block(height, L1BlockId::from(Buf32::from([height as u8; 32])));
+        }
         (ctx, storage)
+    }
+
+    /// An above-tip observation encountered before a valid below-tip one (epoch
+    /// order need not match L1-height order) must not terminate the scan and
+    /// hide the valid observation.
+    #[test]
+    fn derive_state_skips_above_tip_without_hiding_later() {
+        let (ctx, storage) = derive_ctx();
+        // epoch 1 observed high (above the tip), epoch 2 observed low (canonical,
+        // buried). Iteration is epoch-ordered, so the above-tip epoch 1 comes first.
+        seed_observation(&storage, 1, 105);
+        let commitment_2 = seed_observation(&storage, 2, 100);
+
+        let tip = L1BlockCommitment::new(102, L1BlockId::default());
+        let clstate =
+            reload_client_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+
+        // epoch 2 at height 100 is buried 3 deep and must be found despite the
+        // above-tip epoch 1 appearing first.
+        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment_2));
+        assert_eq!(clstate.get_last_epoch(), Some(commitment_2));
+    }
+
+    /// A checkpoint-sync node has observations but no epoch summaries (its OL is
+    /// reconstructed from finality, which hasn't advanced yet). Finality must
+    /// still derive from the observations alone.
+    #[test]
+    fn derive_state_works_without_epoch_summaries() {
+        let (ctx, storage) = derive_ctx();
+        let ol_checkpoint = storage.ol_checkpoint();
+
+        // Record only the L1 observation (ref + payload), no epoch summary.
+        let payload = create_test_checkpoint_payload(1);
+        let commitment = EpochCommitment::from_terminal(1, *payload.new_tip().l2_commitment());
+        ol_checkpoint
+            .put_checkpoint_l1_observation_blocking(
+                commitment,
+                payload,
+                CheckpointL1Ref::new(
+                    L1BlockCommitment::new(100, L1BlockId::from(Buf32::from([100u8; 32]))),
+                    RBuf32::from([1; 32]),
+                    RBuf32::from([2; 32]),
+                ),
+            )
+            .expect("insert observation");
+
+        // tip 102 -> epoch 1 buried 3 deep, finalized despite no epoch summary.
+        let tip = L1BlockCommitment::new(102, L1BlockId::default());
+        let clstate =
+            reload_client_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+
+        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment));
+        assert_eq!(clstate.get_last_epoch(), Some(commitment));
     }
 
     /// An observation only `depth - 1` deep is not yet finalized.
@@ -366,7 +416,8 @@ mod tests {
 
         // tip 101 -> 2 confirmations, below the depth-3 threshold.
         let tip = L1BlockCommitment::new(101, L1BlockId::default());
-        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+        let clstate =
+            reload_client_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
 
         assert_eq!(clstate.get_declared_final_epoch(), None);
     }
@@ -381,7 +432,8 @@ mod tests {
 
         // tip 103 -> both observations are >= depth-3 deep.
         let tip = L1BlockCommitment::new(103, L1BlockId::default());
-        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+        let clstate =
+            reload_client_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
 
         assert_eq!(clstate.get_declared_final_epoch(), Some(commitment_2));
         assert_eq!(clstate.get_last_epoch(), Some(commitment_2));
@@ -397,7 +449,8 @@ mod tests {
 
         // tip 102 -> epoch 1 is 3 deep (finalized); epoch 2 is 1 deep (seen only).
         let tip = L1BlockCommitment::new(102, L1BlockId::default());
-        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
+        let clstate =
+            reload_client_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
 
         assert_eq!(clstate.get_declared_final_epoch(), Some(commitment_1));
         assert_eq!(clstate.get_last_epoch(), Some(commitment_2));
@@ -412,14 +465,15 @@ mod tests {
 
         // First derive at tip 102 finalizes epoch 1; reuse that as the baseline.
         let tip_1 = L1BlockCommitment::new(102, L1BlockId::default());
-        let baseline = derive_state(&ctx, &tip_1, &ClientState::new(None, None)).expect("derive");
+        let baseline =
+            reload_client_state(&ctx, &tip_1, &ClientState::new(None, None)).expect("derive");
         assert_eq!(baseline.get_declared_final_epoch(), Some(prior));
 
         seed_observation(&storage, 2, 103);
 
         // tip 103: epoch 2 only 1 deep, so no new finality; prior must persist.
         let tip_2 = L1BlockCommitment::new(103, L1BlockId::default());
-        let clstate = derive_state(&ctx, &tip_2, &baseline).expect("derive");
+        let clstate = reload_client_state(&ctx, &tip_2, &baseline).expect("derive");
 
         assert_eq!(clstate.get_declared_final_epoch(), Some(prior));
     }
@@ -476,7 +530,7 @@ mod tests {
                 commitment_1,
                 payload_1,
                 CheckpointL1Ref::new(
-                    L1BlockCommitment::new(17, L1BlockId::default()),
+                    L1BlockCommitment::new(17, L1BlockId::from(Buf32::from([17; 32]))),
                     RBuf32::from([1; 32]),
                     RBuf32::from([2; 32]),
                 ),
@@ -501,7 +555,7 @@ mod tests {
                 commitment_2,
                 payload_2,
                 CheckpointL1Ref::new(
-                    L1BlockCommitment::new(19, L1BlockId::default()),
+                    L1BlockCommitment::new(19, L1BlockId::from(Buf32::from([19; 32]))),
                     RBuf32::from([3; 32]),
                     RBuf32::from([4; 32]),
                 ),

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -41,13 +41,17 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
 }
 
 impl<C: CsmWorkerContext> CsmWorkerState<C> {
-    /// Bootstraps a new CSM worker state from worker context.
+    /// Inits a new CSM worker state from worker context.
     ///
     /// Also eagerly updates, persists and publishes the client state.
-    pub fn bootstrap(ctx: C) -> CsmWorkerResult<Self> {
-        let (loaded_block, loaded_clstate) = ctx
-            .fetch_most_recent_client_state()?
-            .unwrap_or((ctx.genesis_l1_block(), ClientState::default()));
+    pub fn init_from_context(ctx: C) -> CsmWorkerResult<Self> {
+        // This is the last block CSM committed, which may lag the L1 tip. That is
+        // fine: the first status update replays the gap to catch up, and finality
+        // is re-derived below rather than trusted from this row.
+        let loaded = ctx.fetch_most_recent_client_state()?;
+        let storage_empty = loaded.is_none();
+        let (loaded_block, loaded_clstate) =
+            loaded.unwrap_or((ctx.genesis_l1_block(), ClientState::default()));
 
         // Resolve the canonical just in case the loaded one is already orphaned.
         let (recent_l1blk, recent_clstate) =
@@ -61,14 +65,16 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
 
         let new_clstate = Arc::new(derive_state(&ctx, &recent_l1blk, &recent_clstate)?);
 
-        // Persist and publish only when the derived state actually changed.
-        if *new_clstate != recent_clstate {
+        // Persist and publish when the derived state changed, or to seed the
+        // anchor row on empty storage — a later reorg may pivot to it and read
+        // its client state back.
+        if storage_empty || *new_clstate != recent_clstate {
             let new_update = ClientUpdateOutput::new_state(new_clstate.as_ref().clone());
             ctx.put_client_state_update(&recent_l1blk, new_update)?;
             ctx.publish_client_state(new_clstate.as_ref().clone(), recent_l1blk);
         }
 
-        let recent_asm_blocks = init_recent_asm_blocks(&ctx, &new_clstate, recent_l1blk)?;
+        let recent_asm_blocks = load_recent_asm_blocks(&ctx, &new_clstate, recent_l1blk)?;
 
         Ok(Self {
             ctx,
@@ -90,7 +96,10 @@ fn resolve_canonical_tip<C: CsmWorkerContext>(
     candidate_blk: L1BlockCommitment,
     candidate_clstate: ClientState,
 ) -> CsmWorkerResult<(L1BlockCommitment, ClientState)> {
-    let floor = reorg_floor_height(ctx, &candidate_clstate, candidate_blk.height());
+    // At or below the floor a block is reorg-safe by definition, so it is taken
+    // as-is without a canonicality check. An orphan there would mean a finalized
+    // block was reorged — a finality violation outside this resolver's scope.
+    let floor = compute_reorg_floor_height(ctx, &candidate_clstate, candidate_blk.height());
     if candidate_blk.height() <= floor
         || ctx.get_canonical_l1_block(candidate_blk.height())? == Some(candidate_blk)
     {
@@ -143,12 +152,12 @@ fn delete_orphan_rows_above<C: CsmWorkerContext>(
 
 /// Builds the recent-ASM-blocks list from the reorg-safe floor (index 0) up to
 /// `tip`, the last block CSM committed client state for.
-fn init_recent_asm_blocks<C: CsmWorkerContext>(
+fn load_recent_asm_blocks<C: CsmWorkerContext>(
     ctx: &C,
     clstate: &ClientState,
     tip: L1BlockCommitment,
 ) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
-    let floor = reorg_floor_height(ctx, clstate, tip.height());
+    let floor = compute_reorg_floor_height(ctx, clstate, tip.height());
 
     let mut blocks = Vec::new();
     for height in floor..tip.height() {
@@ -168,7 +177,7 @@ fn init_recent_asm_blocks<C: CsmWorkerContext>(
 ///
 /// A block is reorg-safe once it is either buried `depth` deep under `tip` or at
 /// or below the last finalized checkpoint.
-pub(crate) fn reorg_floor_height<C: CsmWorkerContext>(
+pub(crate) fn compute_reorg_floor_height<C: CsmWorkerContext>(
     ctx: &C,
     clstate: &ClientState,
     tip: L1Height,
@@ -287,7 +296,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::{CsmWorkerState, derive_state, reorg_floor_height};
+    use super::{CsmWorkerState, compute_reorg_floor_height, derive_state};
     use crate::test_utils::StubCtx;
 
     fn create_test_params() -> Arc<AsmParams> {
@@ -512,7 +521,7 @@ mod tests {
             ctx =
                 ctx.with_canonical_block(height, L1BlockId::from(Buf32::from([height as u8; 32])));
         }
-        let state = CsmWorkerState::bootstrap(ctx).expect("state init");
+        let state = CsmWorkerState::init_from_context(ctx).expect("state init");
 
         assert_eq!(
             state.last_committed_state.get_last_epoch(),
@@ -610,7 +619,7 @@ mod tests {
             ctx =
                 ctx.with_canonical_block(height, L1BlockId::from(Buf32::from([height as u8; 32])));
         }
-        let state = CsmWorkerState::bootstrap(ctx).expect("state init");
+        let state = CsmWorkerState::init_from_context(ctx).expect("state init");
 
         assert_eq!(
             state.last_committed_state.get_declared_final_epoch(),
@@ -666,7 +675,7 @@ mod tests {
 
         let ctx = stub_ctx_at_genesis_zero(depth);
         let clstate = finalized_state_at(checkpoint);
-        assert_eq!(reorg_floor_height(&ctx, &clstate, tip), depth_floor);
+        assert_eq!(compute_reorg_floor_height(&ctx, &clstate, tip), depth_floor);
     }
 
     /// When the finalized checkpoint is deeper (higher) than the depth bound, the
@@ -680,7 +689,7 @@ mod tests {
 
         let ctx = stub_ctx_at_genesis_zero(depth);
         let clstate = finalized_state_at(checkpoint);
-        assert_eq!(reorg_floor_height(&ctx, &clstate, tip), checkpoint);
+        assert_eq!(compute_reorg_floor_height(&ctx, &clstate, tip), checkpoint);
     }
 
     /// A blkid deterministically derived from a byte tag.
@@ -697,6 +706,38 @@ mod tests {
                 ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
             )
             .expect("put client state row");
+    }
+
+    /// On empty storage, bootstrap must persist the genesis anchor row so a
+    /// later reorg that pivots back to it can read its client state instead of
+    /// failing with `MissingData`.
+    #[test]
+    fn bootstrap_persists_anchor_on_empty_storage() {
+        let params = create_test_params();
+        let db = get_test_sled_backend();
+        let pool = threadpool::ThreadPool::new(4);
+        let storage = Arc::new(create_node_storage(db, pool).expect("create storage"));
+        let mut arbgen = ArbitraryGenerator::new();
+        let status_channel = Arc::new(StatusChannel::new(
+            arbgen.generate(),
+            params.anchor.block,
+            arbgen.generate(),
+            None,
+            None,
+        ));
+
+        let genesis = params.anchor.block;
+        let ctx = StubCtx::new(storage.clone(), status_channel, 4, params.magic, genesis);
+        CsmWorkerState::init_from_context(ctx).expect("bootstrap");
+
+        assert!(
+            storage
+                .client_state()
+                .get_state_blocking(genesis)
+                .expect("query genesis row")
+                .is_some(),
+            "genesis anchor row must be persisted on empty-storage bootstrap"
+        );
     }
 
     /// A stored tip higher than the canonical tip (chain reverted below it) is an
@@ -727,7 +768,7 @@ mod tests {
         }
         ctx = ctx.with_canonical_block(40329, *canonical_tip.blkid());
 
-        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+        let state = CsmWorkerState::init_from_context(ctx).expect("bootstrap");
 
         assert_eq!(state.recent_asm_blocks.last(), Some(&canonical_tip));
         assert_ne!(state.recent_asm_blocks.last(), Some(&orphan));
@@ -757,7 +798,7 @@ mod tests {
         }
         ctx = ctx.with_canonical_block(40329, *canonical_tip.blkid());
 
-        CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+        CsmWorkerState::init_from_context(ctx).expect("bootstrap");
 
         assert!(
             storage
@@ -849,7 +890,7 @@ mod tests {
         ctx = ctx.with_canonical_block(height - 1, *fork.blkid());
         ctx = ctx.with_canonical_block(height, *canonical.blkid());
 
-        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+        let state = CsmWorkerState::init_from_context(ctx).expect("bootstrap");
 
         assert_ne!(state.recent_asm_blocks.last(), Some(&orphan));
         assert_eq!(state.recent_asm_blocks.last(), Some(&fork));

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -48,20 +48,20 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
 }
 
 impl<C: CsmWorkerContext> CsmWorkerState<C> {
-    /// Create a new CSM worker state.
+    /// Bootstraps a new CSM worker state.
     ///
     /// All bootstrap reads (last client state, observed checkpoint refs, params)
     /// go through `ctx`; runtime persistence and L1 fetches use the same
-    /// context after construction.
-    pub fn new(ctx: C) -> CsmWorkerResult<Self> {
+    /// context after construction. Also eagerly updates and publishes the client state.
+    pub fn bootstrap(ctx: C) -> CsmWorkerResult<Self> {
         // Load the most recent client state from storage
-        let (cur_block, cur_state) = ctx
+        let (cur_block, cur_clstate) = ctx
             .fetch_most_recent_client_state()?
             .unwrap_or((ctx.genesis_l1_block(), ClientState::default()));
 
         let current_l1_tip = cur_block.height();
         let finality_depth = ctx.l1_reorg_safe_depth().max(1);
-        let baseline_finalized_epoch = cur_state.get_declared_final_epoch();
+        let baseline_finalized_epoch = cur_clstate.get_declared_final_epoch();
         let observation_start_epoch = baseline_finalized_epoch
             .map(|epoch| epoch.epoch().saturating_add(1))
             .unwrap_or(0);
@@ -100,7 +100,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         {
             let refreshed = ClientState::new(
                 Some(newly_finalized.clone()),
-                cur_state.get_last_checkpoint(),
+                cur_clstate.get_last_checkpoint(),
             );
             ctx.put_client_state_update(
                 &cur_block,
@@ -109,7 +109,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             ctx.publish_client_state(refreshed.clone(), cur_block);
             Arc::new(refreshed)
         } else {
-            Arc::new(cur_state)
+            Arc::new(cur_clstate)
         };
 
         // Keep only non-finalized candidates for incremental tip-driven advancement.
@@ -336,7 +336,7 @@ mod tests {
             params.magic,
             params.anchor.block,
         );
-        let state = CsmWorkerState::new(ctx).expect("state init");
+        let state = CsmWorkerState::bootstrap(ctx).expect("state init");
 
         assert_eq!(state.confirmed_epoch, Some(commitment_2));
         assert_eq!(state.finalized_epoch, Some(commitment_1));
@@ -437,7 +437,7 @@ mod tests {
             params.magic,
             params.anchor.block,
         );
-        let state = CsmWorkerState::new(ctx).expect("state init");
+        let state = CsmWorkerState::bootstrap(ctx).expect("state init");
 
         assert_eq!(state.finalized_epoch, Some(commitment_1));
         assert_eq!(

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -72,7 +72,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             ctx.publish_client_state(new_clstate.as_ref().clone(), recent_l1blk);
         }
 
-        let recent_asm_blocks = init_recent_asm_blocks(&ctx, recent_l1blk)?;
+        let recent_asm_blocks = init_recent_asm_blocks(&ctx, &new_clstate, recent_l1blk)?;
         let confirmed_epoch = new_clstate.get_last_epoch();
         let finalized_epoch = new_clstate.get_declared_final_epoch();
 
@@ -93,17 +93,14 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     }
 }
 
-/// Builds the recent-ASM-blocks list from the reorg-safe floor(index 0) up to `tip`,
-/// filling each height from the canonical L1 chain.
+/// Builds the recent-ASM-blocks list from the reorg-safe floor (index 0) up to
+/// `tip`, the last block CSM committed client state for.
 fn init_recent_asm_blocks<C: CsmWorkerContext>(
     ctx: &C,
+    clstate: &ClientState,
     tip: L1BlockCommitment,
 ) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
-    let depth = ctx.l1_reorg_safe_depth().max(1);
-    let genesis = ctx.genesis_l1_block().height();
-    // Floor is the reorg-safe anchor, bounded below by genesis and above by
-    // `tip` so the range always yields at least `tip`.
-    let floor = tip.height().saturating_sub(depth - 1).max(genesis);
+    let floor = reorg_floor_height(ctx, clstate, tip.height());
 
     let mut blocks = Vec::new();
     for height in floor..tip.height() {
@@ -117,6 +114,29 @@ fn init_recent_asm_blocks<C: CsmWorkerContext>(
     }
     blocks.push(tip);
     Ok(blocks)
+}
+
+/// Deepest L1 height a reorg could reach under `tip` — the window's floor.
+///
+/// A block is reorg-safe once it is either buried `depth` deep under `tip` or at
+/// or below the last finalized checkpoint.
+pub(crate) fn reorg_floor_height<C: CsmWorkerContext>(
+    ctx: &C,
+    clstate: &ClientState,
+    tip: L1Height,
+) -> L1Height {
+    let depth = ctx.l1_reorg_safe_depth().max(1);
+    let genesis = ctx.genesis_l1_block().height();
+    let depth_floor = tip.saturating_sub(depth - 1);
+    let checkpoint_floor = finalized_l1_height(clstate).unwrap_or(genesis);
+    depth_floor.max(checkpoint_floor).max(genesis)
+}
+
+/// L1 height of the last finalized checkpoint, if any.
+pub(crate) fn finalized_l1_height(clstate: &ClientState) -> Option<L1Height> {
+    clstate
+        .get_last_finalized_checkpoint()
+        .map(|ckpt| ckpt.height())
 }
 
 /// Client state and surviving observation queue derived as of an L1 tip.
@@ -233,7 +253,7 @@ mod tests {
     use strata_storage::create_node_storage;
     use strata_test_utils::ArbitraryGenerator;
 
-    use super::CsmWorkerState;
+    use super::{CsmWorkerState, reorg_floor_height};
     use crate::test_utils::StubCtx;
 
     fn create_test_params() -> Arc<AsmParams> {
@@ -324,13 +344,19 @@ mod tests {
             )
             .expect("insert epoch 2 observation");
 
-        let ctx = StubCtx::new(
+        // Finality lands at epoch 1 (L1 height 17), so the reorg window spans
+        // [17 ..= 20]; register a canonical block at each intermediate height.
+        let mut ctx = StubCtx::new(
             storage.clone(),
             status_channel,
             4,
             params.magic,
             params.anchor.block,
         );
+        for height in 17..20 {
+            ctx =
+                ctx.with_canonical_block(height, L1BlockId::from(Buf32::from([height as u8; 32])));
+        }
         let state = CsmWorkerState::bootstrap(ctx).expect("state init");
 
         assert_eq!(state.confirmed_epoch, Some(commitment_2));
@@ -421,13 +447,20 @@ mod tests {
             )
             .expect("seed baseline client state");
 
-        let ctx = StubCtx::new(
+        // Baseline finality is epoch 1 (L1 height 17), so the reorg window
+        // spans [17 ..= 20]; register a canonical block at each intermediate
+        // height.
+        let mut ctx = StubCtx::new(
             storage.clone(),
             status_channel,
             4,
             params.magic,
             params.anchor.block,
         );
+        for height in 17..20 {
+            ctx =
+                ctx.with_canonical_block(height, L1BlockId::from(Buf32::from([height as u8; 32])));
+        }
         let state = CsmWorkerState::bootstrap(ctx).expect("state init");
 
         assert_eq!(state.finalized_epoch, Some(commitment_1));
@@ -445,5 +478,60 @@ mod tests {
             persisted_state, baseline,
             "bootstrap must not rewrite ClientState when baseline already matches"
         );
+    }
+
+    /// Builds a `StubCtx` rooted at genesis L1 height 0 with the given reorg depth.
+    fn stub_ctx_at_genesis_zero(depth: u32) -> StubCtx {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+        StubCtx::new(
+            storage,
+            status_channel,
+            depth,
+            params.magic,
+            L1BlockCommitment::new(0, L1BlockId::default()),
+        )
+    }
+
+    /// Builds a `ClientState` whose last finalized checkpoint sits at `l1_height`.
+    fn finalized_state_at(l1_height: L1Height) -> ClientState {
+        let payload = create_test_checkpoint_payload(1);
+        let ckpt = L1Checkpoint::new(
+            *payload.new_tip(),
+            CheckpointL1Ref::new(
+                L1BlockCommitment::new(l1_height, L1BlockId::default()),
+                RBuf32::from([1; 32]),
+                RBuf32::from([2; 32]),
+            ),
+        );
+        ClientState::new(Some(ckpt.clone()), Some(ckpt))
+    }
+
+    /// When the depth bound is deeper (lower) than the finalized checkpoint, the
+    /// depth term sets the floor.
+    #[test]
+    fn reorg_floor_height_depth_term_wins() {
+        let depth = 5;
+        let tip = 98;
+        let depth_floor = tip - (depth - 1);
+        let checkpoint = depth_floor - 4; // checkpoint sits below the depth floor
+
+        let ctx = stub_ctx_at_genesis_zero(depth);
+        let clstate = finalized_state_at(checkpoint);
+        assert_eq!(reorg_floor_height(&ctx, &clstate, tip), depth_floor);
+    }
+
+    /// When the finalized checkpoint is deeper (higher) than the depth bound, the
+    /// checkpoint term sets the floor.
+    #[test]
+    fn reorg_floor_height_checkpoint_term_wins() {
+        let depth = 5;
+        let tip = 99;
+        let depth_floor = tip - (depth - 1);
+        let checkpoint = depth_floor + 3; // checkpoint sits above the depth floor
+
+        let ctx = stub_ctx_at_genesis_zero(depth);
+        let clstate = finalized_state_at(checkpoint);
+        assert_eq!(reorg_floor_height(&ctx, &clstate, tip), checkpoint);
     }
 }

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -7,7 +7,11 @@ use strata_identifiers::Epoch;
 use strata_primitives::{l1::is_l1_reorg_safe, prelude::*};
 use strata_service::ServiceState;
 
-use crate::{constants, context::CsmWorkerContext, errors::CsmWorkerResult};
+use crate::{
+    constants,
+    context::CsmWorkerContext,
+    errors::{CsmWorkerError, CsmWorkerResult},
+};
 
 /// State for the CSM worker service.
 ///
@@ -68,9 +72,7 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             ctx.publish_client_state(new_clstate.as_ref().clone(), recent_l1blk);
         }
 
-        // The list starts at the committed block and refills as blocks are
-        // processed; pruning bounds it to the reorg-safe depth.
-        let recent_asm_blocks = vec![recent_l1blk];
+        let recent_asm_blocks = init_recent_asm_blocks(&ctx, recent_l1blk)?;
         let confirmed_epoch = new_clstate.get_last_epoch();
         let finalized_epoch = new_clstate.get_declared_final_epoch();
 
@@ -89,6 +91,32 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     pub fn get_last_asm_block(&self) -> Option<L1BlockCommitment> {
         self.recent_asm_blocks.last().copied()
     }
+}
+
+/// Builds the recent-ASM-blocks list from the reorg-safe floor(index 0) up to `tip`,
+/// filling each height from the canonical L1 chain.
+fn init_recent_asm_blocks<C: CsmWorkerContext>(
+    ctx: &C,
+    tip: L1BlockCommitment,
+) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
+    let depth = ctx.l1_reorg_safe_depth().max(1);
+    let genesis = ctx.genesis_l1_block().height();
+    // Floor is the reorg-safe anchor, bounded below by genesis and above by
+    // `tip` so the range always yields at least `tip`.
+    let floor = tip.height().saturating_sub(depth - 1).max(genesis);
+
+    let mut blocks = Vec::new();
+    for height in floor..tip.height() {
+        let block =
+            ctx.get_canonical_l1_block(height)?
+                .ok_or_else(|| CsmWorkerError::MissingData {
+                    what: "canonical L1 block",
+                    detail: format!("height {height}"),
+                })?;
+        blocks.push(block);
+    }
+    blocks.push(tip);
+    Ok(blocks)
 }
 
 /// Client state and surviving observation queue derived as of an L1 tip.

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -216,7 +216,8 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
     let finalized_epoch = new_finalized_ckpt.as_ref().map(EpochCommitment::from);
     let new_clstate = ClientState::new(new_finalized_ckpt, confirmed_ckpt);
 
-    // Keep only non-finalized candidates for incremental advancement.
+    // Drop candidates that are already finalized, leaving only newer observations
+    // for incremental finality advancement.
     while observed_checkpoints
         .front()
         .is_some_and(|ckpt| finalized_epoch.is_some_and(|fin| ckpt.tip.epoch <= fin.epoch()))

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -57,9 +57,14 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     ///
     /// Also eagerly updates, persists and publishes the client state.
     pub fn bootstrap(ctx: C) -> CsmWorkerResult<Self> {
-        let (recent_l1blk, recent_clstate) = ctx
+        let (loaded_block, loaded_clstate) = ctx
             .fetch_most_recent_client_state()?
             .unwrap_or((ctx.genesis_l1_block(), ClientState::default()));
+
+        // The stored tip may be an orphan from a reorg the node missed while
+        // down; resolve down to the latest block still on the canonical chain.
+        let (recent_l1blk, recent_clstate) =
+            resolve_canonical_tip(&ctx, loaded_block, loaded_clstate)?;
 
         let derived = derive_state(&ctx, &recent_l1blk, &recent_clstate)?;
 
@@ -91,6 +96,35 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
     pub fn get_last_asm_block(&self) -> Option<L1BlockCommitment> {
         self.recent_asm_blocks.last().copied()
     }
+}
+
+/// Resolves the latest committed block still on the canonical chain.
+fn resolve_canonical_tip<C: CsmWorkerContext>(
+    ctx: &C,
+    candidate_blk: L1BlockCommitment,
+    candidate_clstate: ClientState,
+) -> CsmWorkerResult<(L1BlockCommitment, ClientState)> {
+    let floor = reorg_floor_height(ctx, &candidate_clstate, candidate_blk.height());
+    if candidate_blk.height() <= floor
+        || ctx.get_canonical_l1_block(candidate_blk.height())? == Some(candidate_blk)
+    {
+        return Ok((candidate_blk, candidate_clstate));
+    }
+
+    // Iterate from the tip, the first appearing client state is the canonical state.
+    for height in (floor..candidate_blk.height()).rev() {
+        let Some(canonical) = ctx.get_canonical_l1_block(height)? else {
+            continue;
+        };
+        if let Some(state) = ctx.get_client_state_at(&canonical)? {
+            return Ok((canonical, state));
+        }
+    }
+
+    Err(CsmWorkerError::MissingData {
+        what: "canonical client state at or above reorg floor",
+        detail: candidate_blk.to_string(),
+    })
 }
 
 /// Builds the recent-ASM-blocks list from the reorg-safe floor (index 0) up to
@@ -152,7 +186,7 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
     cur_block: &L1BlockCommitment,
     cur_clstate: &ClientState,
 ) -> CsmWorkerResult<DerivedState> {
-    let current_l1_tip = cur_block.height();
+    let current_csm_tip = cur_block.height();
     let finality_depth = ctx.l1_reorg_safe_depth().max(1);
     let last_finalized_epoch = cur_clstate.get_declared_final_epoch();
     let observation_start_epoch = last_finalized_epoch
@@ -160,17 +194,17 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
         .unwrap_or(0);
 
     let mut observed_checkpoints =
-        load_observed_checkpoints(ctx, observation_start_epoch, current_l1_tip)?;
+        load_observed_checkpoints(ctx, observation_start_epoch, current_csm_tip)?;
 
     // Derive new finalized checkpoint from last finalized and finalized ones among the observed.
     let new_finalized_ckpt = observed_checkpoints
         .iter()
         .rev()
-        .find(|ckpt| is_l1_reorg_safe(ckpt.height(), current_l1_tip, finality_depth))
-        .cloned()
+        .find(|ckpt| is_l1_reorg_safe(ckpt.height(), current_csm_tip, finality_depth))
         .filter(|obs_ckpt| {
             last_finalized_epoch.is_none_or(|last_fin| last_fin.epoch() < obs_ckpt.tip.epoch)
         })
+        .cloned()
         .or_else(|| cur_clstate.get_last_finalized_checkpoint());
 
     // Confirmed: the latest observation seen on L1, else the finalized one.
@@ -201,7 +235,7 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
 fn load_observed_checkpoints<C: CsmWorkerContext>(
     ctx: &C,
     start_epoch: Epoch,
-    current_l1_tip: L1Height,
+    cur_csm_tip: L1Height,
 ) -> CsmWorkerResult<VecDeque<L1Checkpoint>> {
     let Some(last_ep_with_l1ref) = ctx.get_last_checkpoint_l1_ref_epoch()? else {
         return Ok(VecDeque::new());
@@ -222,7 +256,7 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
 
         // Heights are strictly increasing in epoch order, so once one exceeds
         // the tip every later one does too.
-        if observation.l1_commitment.height() > current_l1_tip {
+        if observation.l1_commitment.height() > cur_csm_tip {
             break;
         }
 
@@ -533,5 +567,93 @@ mod tests {
         let ctx = stub_ctx_at_genesis_zero(depth);
         let clstate = finalized_state_at(checkpoint);
         assert_eq!(reorg_floor_height(&ctx, &clstate, tip), checkpoint);
+    }
+
+    /// A blkid deterministically derived from a byte tag.
+    fn blkid(tag: u8) -> L1BlockId {
+        L1BlockId::from(Buf32::from([tag; 32]))
+    }
+
+    /// Persists an empty client-state row at `block`.
+    fn put_client_state_row(storage: &strata_storage::NodeStorage, block: &L1BlockCommitment) {
+        storage
+            .client_state()
+            .put_update_blocking(
+                block,
+                ClientUpdateOutput::new(ClientState::new(None, None), vec![]),
+            )
+            .expect("put client state row");
+    }
+
+    /// A stored tip higher than the canonical tip (chain reverted below it) is an
+    /// orphan; bootstrap must anchor to the highest canonical row, not the orphan.
+    #[test]
+    fn bootstrap_ignores_higher_orphan_after_shorter_reorg() {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+
+        // Genesis 40320, depth 4: floor for tip 40330 is 40327, so 40330 is
+        // above the floor and the orphan path is exercised.
+        let canonical_tip = L1BlockCommitment::new(40329, blkid(201));
+        let orphan = L1BlockCommitment::new(40330, blkid(202));
+
+        put_client_state_row(&storage, &canonical_tip);
+        put_client_state_row(&storage, &orphan);
+
+        // Canonical chain only reaches 40329; nothing at the orphan's height.
+        let mut ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            4,
+            params.magic,
+            params.anchor.block,
+        );
+        for height in 40326..=40329 {
+            ctx = ctx.with_canonical_block(height, blkid(height as u8));
+        }
+        ctx = ctx.with_canonical_block(40329, *canonical_tip.blkid());
+
+        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+
+        assert_eq!(state.recent_asm_blocks.last(), Some(&canonical_tip));
+        assert_ne!(state.recent_asm_blocks.last(), Some(&orphan));
+    }
+
+    /// Two rows at the same height: the orphan sorts higher so `get_latest`
+    /// returns it, but bootstrap must anchor to the canonical-blkid block.
+    #[test]
+    fn bootstrap_ignores_same_height_orphan() {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+
+        // Canonical fork point one below; the canonical row at the same height
+        // sorts lower than the orphan, which `get_latest` returns.
+        let height = 40330;
+        let canonical = L1BlockCommitment::new(height, blkid(0x01));
+        let orphan = L1BlockCommitment::new(height, blkid(0xff));
+        let fork = L1BlockCommitment::new(height - 1, blkid(0x10));
+
+        put_client_state_row(&storage, &fork);
+        put_client_state_row(&storage, &canonical);
+        put_client_state_row(&storage, &orphan);
+
+        // Canonical chain: the fork at H-1 and a different blkid at H.
+        let mut ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            4,
+            params.magic,
+            params.anchor.block,
+        );
+        for h in 40326..height {
+            ctx = ctx.with_canonical_block(h, blkid(h as u8));
+        }
+        ctx = ctx.with_canonical_block(height - 1, *fork.blkid());
+        ctx = ctx.with_canonical_block(height, *canonical.blkid());
+
+        let state = CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+
+        assert_ne!(state.recent_asm_blocks.last(), Some(&orphan));
+        assert_eq!(state.recent_asm_blocks.last(), Some(&fork));
     }
 }

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -25,8 +25,9 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
     /// External services and configuration.
     pub(crate) ctx: C,
 
-    /// Last ASM block committed. Advanced only by a successful commit.
-    pub(crate) last_asm_block: Option<L1BlockCommitment>,
+    /// Recently processed ASM blocks, oldest first. Index 0 is the reorg-safe
+    /// finalized anchor. Advanced only by a successful commit.
+    pub(crate) recent_asm_blocks: Vec<L1BlockCommitment>,
 
     /// Last durably committed client state.
     pub(crate) last_committed_state: Arc<ClientState>,
@@ -48,113 +49,132 @@ pub struct CsmWorkerState<C: CsmWorkerContext> {
 }
 
 impl<C: CsmWorkerContext> CsmWorkerState<C> {
-    /// Bootstraps a new CSM worker state.
+    /// Bootstraps a new CSM worker state from worker context.
     ///
-    /// All bootstrap reads (last client state, observed checkpoint refs, params)
-    /// go through `ctx`; runtime persistence and L1 fetches use the same
-    /// context after construction. Also eagerly updates and publishes the client state.
+    /// Also eagerly updates, persists and publishes the client state.
     pub fn bootstrap(ctx: C) -> CsmWorkerResult<Self> {
-        // Load the most recent client state from storage
-        let (cur_block, cur_clstate) = ctx
+        let (recent_l1blk, recent_clstate) = ctx
             .fetch_most_recent_client_state()?
             .unwrap_or((ctx.genesis_l1_block(), ClientState::default()));
 
-        let current_l1_tip = cur_block.height();
-        let finality_depth = ctx.l1_reorg_safe_depth().max(1);
-        let baseline_finalized_epoch = cur_clstate.get_declared_final_epoch();
-        let observation_start_epoch = baseline_finalized_epoch
-            .map(|epoch| epoch.epoch().saturating_add(1))
-            .unwrap_or(0);
+        let derived = derive_state(&ctx, &recent_l1blk, &recent_clstate)?;
 
-        let mut observed_checkpoints =
-            load_observed_checkpoints(&ctx, observation_start_epoch, current_l1_tip)?;
+        let new_clstate = Arc::new(derived.new_clstate);
 
-        let finalized_from_l1_refs = derive_finalized_checkpoint(
-            observed_checkpoints.iter(),
-            current_l1_tip,
-            finality_depth,
-        )
-        .cloned();
-        let finalized_from_l1_refs_epoch =
-            finalized_from_l1_refs.as_ref().map(EpochCommitment::from);
-        let finalized_epoch =
-            max_epoch_commitment(baseline_finalized_epoch, finalized_from_l1_refs_epoch);
-
-        // Confirmed means "observed on L1" and may be finalized. If we only loaded
-        // observations after finalized, fall back to finalized when no newer observed entry exists.
-        let confirmed_epoch = observed_checkpoints
-            .back()
-            .map(EpochCommitment::from)
-            .or(finalized_epoch);
-
-        // If derived finality outpaces what's persisted, refresh ClientState
-        // before pruning so downstream readers (chain worker, RPC, status
-        // channel) don't lag the worker's view. Without this, a restart that
-        // happens after the observation was committed but before
-        // `refresh_finalized_checkpoint` durably landed would prune the
-        // candidate here and leave `ClientState::get_declared_final_epoch`
-        // behind until a later epoch finalized.
-        let last_committed_state = if let Some(newly_finalized) = finalized_from_l1_refs.as_ref()
-            && baseline_finalized_epoch
-                .is_none_or(|baseline| baseline.epoch() < newly_finalized.tip.epoch)
-        {
-            let refreshed = ClientState::new(
-                Some(newly_finalized.clone()),
-                cur_clstate.get_last_checkpoint(),
-            );
-            ctx.put_client_state_update(
-                &cur_block,
-                ClientUpdateOutput::new(refreshed.clone(), vec![]),
-            )?;
-            ctx.publish_client_state(refreshed.clone(), cur_block);
-            Arc::new(refreshed)
-        } else {
-            Arc::new(cur_clstate)
-        };
-
-        // Keep only non-finalized candidates for incremental tip-driven advancement.
-        if let Some(finalized) = finalized_epoch {
-            while observed_checkpoints
-                .front()
-                .is_some_and(|checkpoint| checkpoint.tip.epoch <= finalized.epoch())
-            {
-                observed_checkpoints.pop_front();
-            }
+        // Persist and publish only when the derived state actually changed.
+        if *new_clstate != recent_clstate {
+            let new_update = ClientUpdateOutput::new_state(new_clstate.as_ref().clone());
+            ctx.put_client_state_update(&recent_l1blk, new_update)?;
+            ctx.publish_client_state(new_clstate.as_ref().clone(), recent_l1blk);
         }
+
+        let recent_asm_blocks = init_recent_processed_blocks(&ctx, recent_l1blk)?;
+        let confirmed_epoch = new_clstate.get_last_epoch();
+        let finalized_epoch = new_clstate.get_declared_final_epoch();
 
         Ok(Self {
             ctx,
-            last_asm_block: Some(cur_block),
-            last_committed_state,
+            recent_asm_blocks,
+            last_committed_state: new_clstate,
             last_processed_epoch: None,
             confirmed_epoch,
             finalized_epoch,
-            observed_checkpoints,
+            observed_checkpoints: derived.observed_checkpoints,
         })
     }
 
     /// Get the last ASM block that was processed.
     pub fn get_last_asm_block(&self) -> Option<L1BlockCommitment> {
-        self.last_asm_block
+        self.recent_asm_blocks.last().copied()
     }
+}
+
+/// Client state and surviving observation queue derived as of an L1 tip.
+pub(crate) struct DerivedState {
+    pub(crate) observed_checkpoints: VecDeque<L1Checkpoint>,
+    /// Client state rebuilt from the derived checkpoints.
+    pub(crate) new_clstate: ClientState,
+}
+
+/// Derives client state and newly observed checkpoints from storage as of `cur_block`.
+pub(crate) fn derive_state<C: CsmWorkerContext>(
+    ctx: &C,
+    cur_block: &L1BlockCommitment,
+    cur_clstate: &ClientState,
+) -> CsmWorkerResult<DerivedState> {
+    let current_l1_tip = cur_block.height();
+    let finality_depth = ctx.l1_reorg_safe_depth().max(1);
+    let last_finalized_epoch = cur_clstate.get_declared_final_epoch();
+    let observation_start_epoch = last_finalized_epoch
+        .map(|epoch| epoch.epoch().saturating_add(1))
+        .unwrap_or(0);
+
+    let mut observed_checkpoints =
+        load_observed_checkpoints(ctx, observation_start_epoch, current_l1_tip)?;
+
+    // Derive new finalized checkpoint from last finalized and finalized ones among the observed.
+    let new_finalized_ckpt = observed_checkpoints
+        .iter()
+        .rev()
+        .find(|ckpt| is_l1_reorg_safe(ckpt.height(), current_l1_tip, finality_depth))
+        .cloned()
+        .filter(|obs_ckpt| {
+            last_finalized_epoch.is_none_or(|last_fin| last_fin.epoch() < obs_ckpt.tip.epoch)
+        })
+        .or_else(|| cur_clstate.get_last_finalized_checkpoint());
+
+    // Confirmed: the latest observation seen on L1, else the finalized one.
+    let confirmed_ckpt = observed_checkpoints
+        .back()
+        .cloned()
+        .or_else(|| new_finalized_ckpt.clone());
+
+    let finalized_epoch = new_finalized_ckpt.as_ref().map(EpochCommitment::from);
+    let new_clstate = ClientState::new(new_finalized_ckpt, confirmed_ckpt);
+
+    // Keep only non-finalized candidates for incremental advancement.
+    while observed_checkpoints
+        .front()
+        .is_some_and(|ckpt| finalized_epoch.is_some_and(|fin| ckpt.tip.epoch <= fin.epoch()))
+    {
+        observed_checkpoints.pop_front();
+    }
+
+    Ok(DerivedState {
+        observed_checkpoints,
+        new_clstate,
+    })
+}
+
+/// Builds the initial L1 block list from the reorg-safe finalized floor up to
+/// `cur_block`.
+fn init_recent_processed_blocks(
+    ctx: &impl CsmWorkerContext,
+    cur_block: L1BlockCommitment,
+) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
+    let depth = ctx.l1_reorg_safe_depth().max(1);
+    let gen_height = ctx.genesis_l1_block().height();
+    // Anchor is whichever is highest: depth from cur tip or genesis height
+    let anchor_height = cur_block.height().saturating_sub(depth - 1).max(gen_height);
+
+    let mut blocks = Vec::new();
+    for height in anchor_height..=cur_block.height() {
+        blocks.push(ctx.get_canonical_l1_block(height)?);
+    }
+    Ok(blocks)
 }
 
 /// Loads observed checkpoint candidates from the OL checkpoint DB via `ctx`,
 /// starting from `start_epoch`.
-///
-/// Only epochs with both a canonical commitment and a complete observation
-/// (payload + L1 ref) are included. Used at startup to populate the
-/// incremental finalization queue and reconstruct the latest finalized
-/// `L1Checkpoint` view of `ClientState`.
 fn load_observed_checkpoints<C: CsmWorkerContext>(
     ctx: &C,
     start_epoch: Epoch,
     current_l1_tip: L1Height,
 ) -> CsmWorkerResult<VecDeque<L1Checkpoint>> {
-    let Some(last_l1_ref_commitment) = ctx.get_last_checkpoint_l1_ref_epoch()? else {
+    let Some(last_ep_with_l1ref) = ctx.get_last_checkpoint_l1_ref_epoch()? else {
         return Ok(VecDeque::new());
     };
-    let last_checkpoint_epoch = last_l1_ref_commitment.epoch();
+    let last_checkpoint_epoch = last_ep_with_l1ref.epoch();
 
     let mut observed = VecDeque::new();
     for epoch in start_epoch..=last_checkpoint_epoch {
@@ -168,53 +188,16 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
             continue;
         };
 
+        // Heights are strictly increasing in epoch order, so once one exceeds
+        // the tip every later one does too.
         if observation.l1_commitment.height() > current_l1_tip {
-            continue;
+            break;
         }
 
         observed.push_back(L1Checkpoint::new(*payload.new_tip(), observation));
     }
 
     Ok(observed)
-}
-
-/// Returns the latest observation whose L1 ref meets the depth threshold.
-///
-/// Iterates forward; the last match wins (latest finalized).
-fn derive_finalized_checkpoint<'a, I>(
-    observed: I,
-    current_l1_tip: L1Height,
-    finality_depth: u32,
-) -> Option<&'a L1Checkpoint>
-where
-    I: Iterator<Item = &'a L1Checkpoint>,
-{
-    let mut latest_finalized = None;
-
-    for checkpoint in observed {
-        if is_l1_reorg_safe(
-            checkpoint.l1_reference.l1_commitment.height(),
-            current_l1_tip,
-            finality_depth,
-        ) {
-            latest_finalized = Some(checkpoint);
-        }
-    }
-
-    latest_finalized
-}
-
-/// Returns the epoch commitment with the higher epoch number, or whichever is `Some`.
-fn max_epoch_commitment(
-    left: Option<EpochCommitment>,
-    right: Option<EpochCommitment>,
-) -> Option<EpochCommitment> {
-    match (left, right) {
-        (Some(a), Some(b)) => Some(if a.epoch() >= b.epoch() { a } else { b }),
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (None, None) => None,
-    }
 }
 
 impl<C: CsmWorkerContext + 'static> ServiceState for CsmWorkerState<C> {

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -6,12 +6,16 @@ use strata_csm_types::{ClientState, ClientUpdateOutput, L1Checkpoint};
 use strata_identifiers::Epoch;
 use strata_primitives::{l1::is_l1_reorg_safe, prelude::*};
 use strata_service::ServiceState;
+use tracing::warn;
 
 use crate::{
     constants,
     context::CsmWorkerContext,
     errors::{CsmWorkerError, CsmWorkerResult},
 };
+
+/// Number of client-state rows fetched per batch while deleting orphans.
+const ORPHAN_SCAN_BATCH: usize = 64;
 
 /// State for the CSM worker service.
 ///
@@ -45,14 +49,12 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             .fetch_most_recent_client_state()?
             .unwrap_or((ctx.genesis_l1_block(), ClientState::default()));
 
-        // The stored tip may be an orphan from a reorg the node missed while
-        // down; resolve down to the latest block still on the canonical chain.
+        // Resolve the canonical just in case the loaded one is already orphaned.
         let (recent_l1blk, recent_clstate) =
             resolve_canonical_tip(&ctx, loaded_block, loaded_clstate)?;
 
         // A resolved-down tip means the loaded block was an orphan; delete the
-        // orphaned rows above the canonical tip so `fetch_most_recent_state`
-        // (and the status channel it seeds at startup) sees the canonical state.
+        // orphaned rows above the canonical tip.
         if recent_l1blk != loaded_block {
             delete_orphan_rows_above(&ctx, recent_l1blk)?;
         }
@@ -111,13 +113,7 @@ fn resolve_canonical_tip<C: CsmWorkerContext>(
     })
 }
 
-/// Number of client-state rows fetched per batch while deleting orphans.
-const ORPHAN_SCAN_BATCH: usize = 64;
-
 /// Deletes every persisted client-state row strictly above `canonical_tip`.
-///
-/// Scans in batches so the orphan branch is fully removed regardless of its
-/// depth, rather than truncated at a single fetch limit.
 fn delete_orphan_rows_above<C: CsmWorkerContext>(
     ctx: &C,
     canonical_tip: L1BlockCommitment,
@@ -168,7 +164,7 @@ fn init_recent_asm_blocks<C: CsmWorkerContext>(
     Ok(blocks)
 }
 
-/// Deepest L1 height a reorg could reach under `tip` — the window's floor.
+/// Deepest L1 height a reorg could reach under csm-observed `tip`.
 ///
 /// A block is reorg-safe once it is either buried `depth` deep under `tip` or at
 /// or below the last finalized checkpoint.
@@ -218,7 +214,7 @@ pub(crate) fn derive_state<C: CsmWorkerContext>(
         .cloned()
         .or_else(|| cur_clstate.get_last_finalized_checkpoint());
 
-    // Confirmed: the latest observation seen on L1, else the finalized one.
+    // Confirmed: the latest observation seen on L1.
     let confirmed_ckpt = observed_checkpoints
         .back()
         .cloned()
@@ -241,13 +237,20 @@ fn load_observed_checkpoints<C: CsmWorkerContext>(
 
     let mut observed = VecDeque::new();
     for epoch in start_epoch..=last_checkpoint_epoch {
+        // No canonical commitment at this epoch is expected (e.g. orphaned), so
+        // skip silently; a commitment with a missing observation is not.
         let Some(commitment) = ctx.get_canonical_epoch_commitment_at(epoch)? else {
             continue;
         };
         let Some(observation) = ctx.get_checkpoint_l1_ref(commitment)? else {
+            warn!(?commitment, "canonical epoch missing its L1 ref; skipping");
             continue;
         };
         let Some(payload) = ctx.get_checkpoint_payload(commitment)? else {
+            warn!(
+                ?commitment,
+                "canonical epoch missing its checkpoint payload; skipping"
+            );
             continue;
         };
 
@@ -357,20 +360,6 @@ mod tests {
         let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
 
         assert_eq!(clstate.get_declared_final_epoch(), None);
-    }
-
-    /// An observation buried `depth` deep finalizes.
-    #[test]
-    fn derive_state_finalizes_at_depth() {
-        let (ctx, storage) = derive_ctx();
-        let commitment = seed_observation(&storage, 1, 100);
-
-        // tip 102 -> 3 confirmations = depth threshold.
-        let tip = L1BlockCommitment::new(102, L1BlockId::default());
-        let clstate = derive_state(&ctx, &tip, &ClientState::new(None, None)).expect("derive");
-
-        assert_eq!(clstate.get_declared_final_epoch(), Some(commitment));
-        assert_eq!(clstate.get_last_epoch(), Some(commitment));
     }
 
     /// With several safe observations, finality lands at the highest epoch and

--- a/crates/csm-worker/src/state.rs
+++ b/crates/csm-worker/src/state.rs
@@ -50,6 +50,13 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
         let (recent_l1blk, recent_clstate) =
             resolve_canonical_tip(&ctx, loaded_block, loaded_clstate)?;
 
+        // A resolved-down tip means the loaded block was an orphan; delete the
+        // orphaned rows above the canonical tip so `fetch_most_recent_state`
+        // (and the status channel it seeds at startup) sees the canonical state.
+        if recent_l1blk != loaded_block {
+            delete_orphan_rows_above(&ctx, recent_l1blk)?;
+        }
+
         let new_clstate = Arc::new(derive_state(&ctx, &recent_l1blk, &recent_clstate)?);
 
         // Persist and publish only when the derived state actually changed.
@@ -102,6 +109,40 @@ fn resolve_canonical_tip<C: CsmWorkerContext>(
         what: "canonical client state at or above reorg floor",
         detail: candidate_blk.to_string(),
     })
+}
+
+/// Number of client-state rows fetched per batch while deleting orphans.
+const ORPHAN_SCAN_BATCH: usize = 64;
+
+/// Deletes every persisted client-state row strictly above `canonical_tip`.
+///
+/// Scans in batches so the orphan branch is fully removed regardless of its
+/// depth, rather than truncated at a single fetch limit.
+fn delete_orphan_rows_above<C: CsmWorkerContext>(
+    ctx: &C,
+    canonical_tip: L1BlockCommitment,
+) -> CsmWorkerResult<()> {
+    let mut cursor = canonical_tip;
+    loop {
+        let batch = ctx.get_client_state_blocks_from(cursor, ORPHAN_SCAN_BATCH)?;
+        let full = batch.len() >= ORPHAN_SCAN_BATCH;
+        let mut advanced = false;
+        for block in batch {
+            if block > canonical_tip {
+                ctx.del_client_state(&block)?;
+            }
+            if block > cursor {
+                cursor = block;
+                advanced = true;
+            }
+        }
+        // The scan is inclusive of `cursor`, so a batch that adds no higher
+        // block means nothing remains above it.
+        if !advanced || !full {
+            break;
+        }
+    }
+    Ok(())
 }
 
 /// Builds the recent-ASM-blocks list from the reorg-safe floor (index 0) up to
@@ -701,6 +742,90 @@ mod tests {
 
         assert_eq!(state.recent_asm_blocks.last(), Some(&canonical_tip));
         assert_ne!(state.recent_asm_blocks.last(), Some(&orphan));
+    }
+
+    /// Bootstrap deletes orphan rows above the canonical tip, so a subsequent
+    /// `fetch_most_recent_state` returns the canonical row rather than the orphan.
+    #[test]
+    fn bootstrap_deletes_orphan_rows() {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+
+        let canonical_tip = L1BlockCommitment::new(40329, blkid(201));
+        let orphan = L1BlockCommitment::new(40330, blkid(202));
+        put_client_state_row(&storage, &canonical_tip);
+        put_client_state_row(&storage, &orphan);
+
+        let mut ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            4,
+            params.magic,
+            params.anchor.block,
+        );
+        for height in 40326..=40329 {
+            ctx = ctx.with_canonical_block(height, blkid(height as u8));
+        }
+        ctx = ctx.with_canonical_block(40329, *canonical_tip.blkid());
+
+        CsmWorkerState::bootstrap(ctx).expect("bootstrap");
+
+        assert!(
+            storage
+                .client_state()
+                .get_update_blocking(&orphan)
+                .expect("query orphan")
+                .is_none(),
+            "orphan row must be deleted"
+        );
+        let (recent, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query")
+            .expect("row");
+        assert_eq!(recent, canonical_tip);
+    }
+
+    /// An orphan branch deeper than one scan batch is fully deleted, proving the
+    /// batched scan terminates and does not truncate. Exercises the deletion
+    /// helper directly, since `resolve_canonical_tip` caps orphan depth at the
+    /// reorg window before bootstrap would reach this path.
+    #[test]
+    fn delete_orphan_rows_spans_multiple_batches() {
+        let params = create_test_params();
+        let (storage, status_channel) = create_test_storage_and_status(params.clone());
+
+        let canonical_tip = L1BlockCommitment::new(40329, blkid(201));
+        put_client_state_row(&storage, &canonical_tip);
+
+        // Seed more orphan rows than a single scan batch holds.
+        let orphan_count = (super::ORPHAN_SCAN_BATCH + 5) as u32;
+        for i in 0..orphan_count {
+            let orphan = L1BlockCommitment::new(
+                40330 + i,
+                L1BlockId::from(Buf32::from([(i % 251 + 3) as u8; 32])),
+            );
+            put_client_state_row(&storage, &orphan);
+        }
+
+        let ctx = StubCtx::new(
+            storage.clone(),
+            status_channel,
+            4,
+            params.magic,
+            params.anchor.block,
+        );
+        super::delete_orphan_rows_above(&ctx, canonical_tip).expect("delete orphans");
+
+        let (recent, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query")
+            .expect("row");
+        assert_eq!(
+            recent, canonical_tip,
+            "every orphan row above the canonical tip must be deleted"
+        );
     }
 
     /// Two rows at the same height: the orphan sorts higher so `get_latest`

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -189,7 +189,11 @@ impl CsmWorkerContext for StubCtx {
         }
         self.canonical_blocks
             .get(&height)
-            .or_else(|| self.canonical_asm_states.get(&height).map(|(blkid, _)| blkid))
+            .or_else(|| {
+                self.canonical_asm_states
+                    .get(&height)
+                    .map(|(blkid, _)| blkid)
+            })
             .map(|blkid| L1BlockCommitment::new(height, *blkid))
             .ok_or_else(|| CsmWorkerError::MissingData {
                 what: "test canonical block",

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -1,9 +1,6 @@
 //! Shared test helpers for the CSM worker.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use bitcoin::Block;
 use strata_asm_common::AuxData;
@@ -52,9 +49,6 @@ pub(crate) struct StubCtx {
     /// When set, `put_client_state_update` fails, simulating a commit failure
     /// after a block's logs were processed.
     fail_client_state_update: bool,
-    /// Epochs whose canonical commitment reads as absent, modeling an OL reorg
-    /// that orphaned the epoch's checkpoint.
-    orphaned_epochs: HashSet<Epoch>,
 }
 
 impl StubCtx {
@@ -76,15 +70,7 @@ impl StubCtx {
             canonical_blocks: HashMap::new(),
             canonical_fail_height: None,
             fail_client_state_update: false,
-            orphaned_epochs: HashSet::new(),
         }
-    }
-
-    /// Marks `epoch`'s canonical commitment as absent, as if an OL reorg
-    /// orphaned its checkpoint.
-    pub(crate) fn with_orphaned_epoch(mut self, epoch: Epoch) -> Self {
-        self.orphaned_epochs.insert(epoch);
-        self
     }
 
     /// Configures `get_l1_block` to return an error on any blockid.
@@ -251,34 +237,14 @@ impl CsmWorkerContext for StubCtx {
         self.genesis_l1_block
     }
 
-    fn get_last_checkpoint_l1_ref_epoch(&self) -> CsmWorkerResult<Option<EpochCommitment>> {
-        Ok(self
-            .storage
-            .ol_checkpoint()
-            .get_last_checkpoint_l1_ref_epoch_blocking()?)
-    }
-
-    fn get_canonical_epoch_commitment_at(
+    fn get_checkpoint_l1_refs_from(
         &self,
-        epoch: Epoch,
-    ) -> CsmWorkerResult<Option<EpochCommitment>> {
-        if self.orphaned_epochs.contains(&epoch) {
-            return Ok(None);
-        }
+        start_epoch: Epoch,
+    ) -> CsmWorkerResult<Vec<(EpochCommitment, CheckpointL1Ref)>> {
         Ok(self
             .storage
             .ol_checkpoint()
-            .get_canonical_epoch_commitment_at_blocking(epoch)?)
-    }
-
-    fn get_checkpoint_l1_ref(
-        &self,
-        commitment: EpochCommitment,
-    ) -> CsmWorkerResult<Option<CheckpointL1Ref>> {
-        Ok(self
-            .storage
-            .ol_checkpoint()
-            .get_checkpoint_l1_ref_blocking(commitment)?)
+            .get_checkpoint_l1_refs_from_blocking(start_epoch)?)
     }
 
     fn get_checkpoint_payload(

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -40,6 +40,9 @@ pub(crate) struct StubCtx {
     l1_fetch: L1Fetch,
     /// Canonical ASM states keyed by L1 height, used to serve gap-fill walks.
     canonical_asm_states: HashMap<L1Height, (L1BlockId, AsmState)>,
+    /// Canonical block ids keyed by L1 height, for fork-detection lookups that
+    /// don't need a full ASM state.
+    canonical_blocks: HashMap<L1Height, L1BlockId>,
     /// Height at which `get_canonical_l1_block` should fail, simulating a gap
     /// block that can't be resolved.
     canonical_fail_height: Option<L1Height>,
@@ -64,6 +67,7 @@ impl StubCtx {
             genesis_l1_block,
             l1_fetch: L1Fetch::Unset,
             canonical_asm_states: HashMap::new(),
+            canonical_blocks: HashMap::new(),
             canonical_fail_height: None,
             fail_client_state_update: false,
         }
@@ -83,6 +87,12 @@ impl StubCtx {
         state: AsmState,
     ) -> Self {
         self.canonical_asm_states.insert(height, (blkid, state));
+        self
+    }
+
+    /// Registers a canonical block id at `height` for fork-detection lookups.
+    pub(crate) fn with_canonical_block(mut self, height: L1Height, blkid: L1BlockId) -> Self {
+        self.canonical_blocks.insert(height, blkid);
         self
     }
 
@@ -177,9 +187,10 @@ impl CsmWorkerContext for StubCtx {
                 detail: format!("simulated lookup failure at height {height}"),
             });
         }
-        self.canonical_asm_states
+        self.canonical_blocks
             .get(&height)
-            .map(|(blkid, _)| L1BlockCommitment::new(height, *blkid))
+            .or_else(|| self.canonical_asm_states.get(&height).map(|(blkid, _)| blkid))
+            .map(|blkid| L1BlockCommitment::new(height, *blkid))
             .ok_or_else(|| CsmWorkerError::MissingData {
                 what: "test canonical block",
                 detail: format!("height {height}"),

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -132,6 +132,11 @@ impl CsmWorkerContext for StubCtx {
         self.status_channel.update_client_state(state, block);
     }
 
+    fn del_client_state(&self, block: &L1BlockCommitment) -> CsmWorkerResult<()> {
+        self.storage.client_state().del_update_blocking(block)?;
+        Ok(())
+    }
+
     fn put_checkpoint_l1_observation(
         &self,
         commitment: EpochCommitment,

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -151,6 +151,20 @@ impl CsmWorkerContext for StubCtx {
         Ok(())
     }
 
+    fn get_client_state_blocks_from(
+        &self,
+        from_block: L1BlockCommitment,
+        max_count: usize,
+    ) -> CsmWorkerResult<Vec<L1BlockCommitment>> {
+        Ok(self
+            .storage
+            .client_state()
+            .get_updates_from(from_block, max_count)?
+            .into_iter()
+            .map(|(block, _)| block)
+            .collect())
+    }
+
     fn put_checkpoint_l1_observation(
         &self,
         commitment: EpochCommitment,

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -192,6 +192,13 @@ impl CsmWorkerContext for StubCtx {
         Ok(self.storage.client_state().fetch_most_recent_state()?)
     }
 
+    fn get_client_state_at(
+        &self,
+        block: &L1BlockCommitment,
+    ) -> CsmWorkerResult<Option<ClientState>> {
+        Ok(self.storage.client_state().get_state_blocking(*block)?)
+    }
+
     fn genesis_l1_block(&self) -> L1BlockCommitment {
         self.genesis_l1_block
     }

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -1,6 +1,9 @@
 //! Shared test helpers for the CSM worker.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use bitcoin::Block;
 use strata_asm_common::AuxData;
@@ -49,6 +52,9 @@ pub(crate) struct StubCtx {
     /// When set, `put_client_state_update` fails, simulating a commit failure
     /// after a block's logs were processed.
     fail_client_state_update: bool,
+    /// Epochs whose canonical commitment reads as absent, modeling an OL reorg
+    /// that orphaned the epoch's checkpoint.
+    orphaned_epochs: HashSet<Epoch>,
 }
 
 impl StubCtx {
@@ -70,7 +76,15 @@ impl StubCtx {
             canonical_blocks: HashMap::new(),
             canonical_fail_height: None,
             fail_client_state_update: false,
+            orphaned_epochs: HashSet::new(),
         }
+    }
+
+    /// Marks `epoch`'s canonical commitment as absent, as if an OL reorg
+    /// orphaned its checkpoint.
+    pub(crate) fn with_orphaned_epoch(mut self, epoch: Epoch) -> Self {
+        self.orphaned_epochs.insert(epoch);
+        self
     }
 
     /// Configures `get_l1_block` to return an error on any blockid.
@@ -234,6 +248,9 @@ impl CsmWorkerContext for StubCtx {
         &self,
         epoch: Epoch,
     ) -> CsmWorkerResult<Option<EpochCommitment>> {
+        if self.orphaned_epochs.contains(&epoch) {
+            return Ok(None);
+        }
         Ok(self
             .storage
             .ol_checkpoint()

--- a/crates/csm-worker/src/test_utils.rs
+++ b/crates/csm-worker/src/test_utils.rs
@@ -180,25 +180,25 @@ impl CsmWorkerContext for StubCtx {
         })
     }
 
-    fn get_canonical_l1_block(&self, height: L1Height) -> CsmWorkerResult<L1BlockCommitment> {
+    fn get_canonical_l1_block(
+        &self,
+        height: L1Height,
+    ) -> CsmWorkerResult<Option<L1BlockCommitment>> {
         if self.canonical_fail_height == Some(height) {
             return Err(CsmWorkerError::MissingData {
                 what: "canonical L1 block",
                 detail: format!("simulated lookup failure at height {height}"),
             });
         }
-        self.canonical_blocks
+        Ok(self
+            .canonical_blocks
             .get(&height)
             .or_else(|| {
                 self.canonical_asm_states
                     .get(&height)
                     .map(|(blkid, _)| blkid)
             })
-            .map(|blkid| L1BlockCommitment::new(height, *blkid))
-            .ok_or_else(|| CsmWorkerError::MissingData {
-                what: "test canonical block",
-                detail: format!("height {height}"),
-            })
+            .map(|blkid| L1BlockCommitment::new(height, *blkid)))
     }
 
     fn fetch_most_recent_client_state(

--- a/crates/db/store-sled/src/client_state/db.rs
+++ b/crates/db/store-sled/src/client_state/db.rs
@@ -25,7 +25,8 @@ impl ClientStateDatabase for ClientStateDBSled {
     }
 
     fn get_latest_client_state(&self) -> DbResult<Option<(L1BlockCommitment, ClientState)>> {
-        // Relying on the lexicographical order of L1BlockCommitment.
+        // The seek-key codec sorts rows by numeric height, so the last entry is
+        // the highest block.
         let mut iter = self.client_update_tree.iter().rev();
         let res = iter.next().map(|r| r.map(|(k, v)| (k, v.into_state())));
         Ok(res.transpose()?)

--- a/crates/db/store-sled/src/client_state/schemas.rs
+++ b/crates/db/store-sled/src/client_state/schemas.rs
@@ -1,9 +1,9 @@
 use strata_csm_types::ClientUpdateOutput;
 use strata_primitives::l1::L1BlockCommitment;
 
-use crate::define_table_with_default_codec;
+use crate::define_table_with_seek_key_codec;
 
-define_table_with_default_codec!(
+define_table_with_seek_key_codec!(
     /// Table to store client state updates.
     (ClientUpdateOutputSchema) L1BlockCommitment => ClientUpdateOutput
 );

--- a/crates/db/store-sled/src/ol_checkpoint/db.rs
+++ b/crates/db/store-sled/src/ol_checkpoint/db.rs
@@ -399,6 +399,21 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
         Ok(max_commitment)
     }
 
+    fn get_checkpoint_l1_refs_from(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<(EpochCommitment, CheckpointL1Ref)>> {
+        let mut refs = Vec::new();
+        for item in self.l1_ref_tree.iter() {
+            let (commitment, l1_ref) = item?;
+            if commitment.epoch() >= start_epoch {
+                refs.push((commitment, l1_ref));
+            }
+        }
+        refs.sort_by_key(|(commitment, _)| commitment.epoch());
+        Ok(refs)
+    }
+
     fn del_checkpoint_l1_ref(&self, epoch: EpochCommitment) -> DbResult<bool> {
         self.config.with_retry((&self.l1_ref_tree,), |(lot,)| {
             if !lot.contains_key(&epoch)? {

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -276,6 +276,13 @@ pub trait OLCheckpointDatabase: Send + Sync + 'static {
     /// Get the highest epoch commitment that has an L1 ref.
     fn get_last_checkpoint_l1_ref_epoch(&self) -> DbResult<Option<EpochCommitment>>;
 
+    /// Get all observed `(epoch commitment, L1 ref)` pairs at or above
+    /// `start_epoch`, ordered by ascending epoch.
+    fn get_checkpoint_l1_refs_from(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<(EpochCommitment, CheckpointL1Ref)>>;
+
     /// Delete an OL checkpoint L1 ref by epoch commitment.
     ///
     /// Returns true if it existed and was deleted.

--- a/crates/storage/src/managers/client_state.rs
+++ b/crates/storage/src/managers/client_state.rs
@@ -90,12 +90,33 @@ impl ClientStateManager {
         Ok(state)
     }
 
+    /// Deletes the client update at `block`, keeping caches and the current
+    /// state tracker coherent.
+    pub fn del_update_blocking(&self, block: &L1BlockCommitment) -> DbResult<()> {
+        let height = block.height();
+        self.ops.del_client_update_blocking(*block)?;
+        self.update_cache.purge_blocking(&height);
+        self.state_cache.purge_blocking(&height);
+        self.reset_cur_state_blocking()?;
+        Ok(())
+    }
+
     fn maybe_update_cur_state_blocking(&self, height: L1Height, state: &Arc<ClientState>) -> bool {
         let mut cur = self.cur_state.blocking_lock();
         cur.maybe_update(height, state)
     }
 
-    /// Returns either pre-genesis init [`ClientState`] or the one with the biggest height.
+    /// Recomputes the current-state tracker from storage after a deletion.
+    fn reset_cur_state_blocking(&self) -> DbResult<()> {
+        let mut cur = self.cur_state.blocking_lock();
+        *cur = CurStateTracker::new_empty();
+        if let Some((blk, cs)) = self.ops.get_latest_client_state_blocking()? {
+            cur.set(blk.height(), Arc::new(cs));
+        }
+        Ok(())
+    }
+
+    /// Returns either pre-genesis init [`ClientState`] or the one with the greatest key.
     pub fn fetch_most_recent_state(&self) -> DbResult<Option<(L1BlockCommitment, ClientState)>> {
         self.ops.get_latest_client_state_blocking()
     }
@@ -144,5 +165,63 @@ impl CurStateTracker {
             self.set(idx, state.clone());
         }
         should
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_db_types::traits::DatabaseBackend;
+    use strata_identifiers::L1BlockId;
+
+    use super::*;
+
+    fn setup_manager() -> ClientStateManager {
+        let pool = ThreadPool::new(1);
+        let db = Arc::new(get_test_sled_backend());
+        ClientStateManager::new(pool, db.client_state_db()).expect("open client state manager")
+    }
+
+    fn block_at(height: L1Height) -> L1BlockCommitment {
+        L1BlockCommitment::new(
+            height,
+            L1BlockId::from(strata_identifiers::Buf32::from([height as u8; 32])),
+        )
+    }
+
+    fn empty_update() -> ClientUpdateOutput {
+        ClientUpdateOutput::new(ClientState::new(None, None), vec![])
+    }
+
+    #[test]
+    fn del_update_removes_row_and_resets_latest() {
+        let manager = setup_manager();
+        let low = block_at(10);
+        let high = block_at(20);
+
+        manager
+            .put_update_blocking(&low, empty_update())
+            .expect("put low");
+        manager
+            .put_update_blocking(&high, empty_update())
+            .expect("put high");
+
+        manager.del_update_blocking(&high).expect("delete high");
+
+        assert!(
+            manager
+                .get_update_blocking(&high)
+                .expect("query high")
+                .is_none(),
+            "deleted row must be gone"
+        );
+        let (latest_block, _) = manager
+            .fetch_most_recent_state()
+            .expect("query latest")
+            .expect("latest row");
+        assert_eq!(
+            latest_block, low,
+            "latest must fall back to the remaining row"
+        );
     }
 }

--- a/crates/storage/src/managers/ol_checkpoint.rs
+++ b/crates/storage/src/managers/ol_checkpoint.rs
@@ -346,6 +346,15 @@ impl OLCheckpointManager {
         self.ops.get_last_checkpoint_l1_ref_epoch_blocking()
     }
 
+    /// Gets all observed `(epoch commitment, L1 ref)` pairs at or above
+    /// `start_epoch`, ordered by ascending epoch.
+    pub fn get_checkpoint_l1_refs_from_blocking(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<(EpochCommitment, CheckpointL1Ref)>> {
+        self.ops.get_checkpoint_l1_refs_from_blocking(start_epoch)
+    }
+
     /// Deletes an OL checkpoint L1 ref by epoch commitment.
     pub async fn del_checkpoint_l1_ref_async(&self, epoch: EpochCommitment) -> DbResult<bool> {
         self.ops.del_checkpoint_l1_ref_async(epoch).await

--- a/crates/storage/src/ops/ol_checkpoint.rs
+++ b/crates/storage/src/ops/ol_checkpoint.rs
@@ -28,6 +28,7 @@ inst_ops_simple! {
         put_checkpoint_l1_ref(epoch: EpochCommitment, l1_ref: CheckpointL1Ref) => ();
         get_checkpoint_l1_ref(epoch: EpochCommitment) => Option<CheckpointL1Ref>;
         get_last_checkpoint_l1_ref_epoch() => Option<EpochCommitment>;
+        get_checkpoint_l1_refs_from(start_epoch: Epoch) => Vec<(EpochCommitment, CheckpointL1Ref)>;
         del_checkpoint_l1_ref(epoch: EpochCommitment) => bool;
         del_checkpoint_l1_refs_from_epoch(start_epoch: Epoch) => Vec<EpochCommitment>;
         put_checkpoint_l1_observation(commitment: EpochCommitment, payload: CheckpointPayload, l1_ref: CheckpointL1Ref) => ();


### PR DESCRIPTION
## Description
CSM previously only kept track of the last asm block processed and this made it unable to properly handle reorgs. The main change this PR makes is that it replaces the last processed asm blocks to a `recently_processed_asm_blocks: Vec<L1BlockCommitment>` which keeps track of processed asm blocks, anchored at the last finalized l1 block(which is the first item in the list).

Reorg handling does not goes beyond the finalized L1 block(the first item in the list).

**AI usase**: This was created with the help of claude code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
