### PR TITLE
fix(functional-tests): discover only registered test modules

### DIFF
--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 import flexitest
-from flexitest.runtime import load_candidate_modules, scan_dir_for_modules
+from flexitest.runtime import load_module_at, scan_dir_for_modules
 
 # Import environments
 from common.config import EpochSealingConfig, ServiceType
@@ -190,6 +190,22 @@ def filter_tests(
     return filtered
 
 
+def load_candidate_test_modules(modules: dict[str, str]) -> list[str]:
+    """Load modules and return only names that registered runnable tests."""
+    registered_start = len(flexitest._TEST_UNITS)
+    for name, path in modules.items():
+        load_module_at(name, path)
+
+    test_names = []
+    seen = set()
+    for test_class in flexitest._TEST_UNITS[registered_start:]:
+        test_name = test_class.__module__
+        if test_name not in seen:
+            test_names.append(test_name)
+            seen.add(test_name)
+    return test_names
+
+
 def list_tests(modules: dict[str, str], test_dir: str) -> None:
     """
     List all available tests with their groups.
@@ -256,6 +272,8 @@ def main(argv: list[str]) -> int:
     # Handle --list mode
     if args.list:
         modules = flexitest.runtime.scan_dir_for_modules(test_dir)
+        candidate_names = frozenset(load_candidate_test_modules(modules))
+        modules = {name: path for name, path in modules.items() if name in candidate_names}
         list_tests(modules, test_dir)
         return 0
 
@@ -373,7 +391,7 @@ def main(argv: list[str]) -> int:
                 print("\nUse --list to see available tests and groups.")
             return 1
 
-        tests = load_candidate_modules(filtered_modules)
+        tests = load_candidate_test_modules(filtered_modules)
         runtime.prepare_registered_tests()
 
     # Run tests


### PR DESCRIPTION
## Description

Fix functional-test discovery so helper modules are not scheduled as tests.

Discovery now selects modules based on actual `@flexitest.register` registrations instead of imported `*Test` symbols. This prevents crashes like `KeyError: 'helpers'` when helper modules import base test classes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
