### PR TITLE
STR 3235 keep checkpoint L1 ranges non-decreasing

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -13,7 +13,7 @@ use strata_checkpoint_types::EpochSummary;
 use strata_db_types::ol_state_index::InboxMessageRecord;
 use strata_identifiers::{
     AccountId, Epoch, EpochCommitment, Hash, L1BlockCommitment, L1Height, L2BlockCommitment,
-    OLBlockCommitment, OLBlockId, OLTxId,
+    OLBlockCommitment, OLBlockId, OLTxId, RBuf32,
 };
 use strata_ledger_types::{IAccountState, ISnarkAccountState};
 use strata_ol_chain_types_new::{OLBlock, OLTransaction, TransactionPayload};
@@ -706,21 +706,26 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         let l2_start = self.get_first_l2_block_in_epoch(&epoch_summary).await?;
         let l2_range = (l2_start, *epoch_summary.terminal());
 
+        let cur_l1 = *epoch_summary.new_l1();
         let l1_start = if epoch == 0 {
-            let l1_start_height = self.genesis_l1_height.saturating_add(1);
-            let l1_start_manifest = self
-                .provider
-                .get_block_manifest_at_height(l1_start_height)
-                .await
-                .map_err(db_error)?
-                .ok_or_else(|| {
-                    not_found_error(format!(
-                        "No L1 manifest found at genesis+1 height {} for epoch 0",
-                        l1_start_height
-                    ))
-                })?;
+            if cur_l1.height() <= self.genesis_l1_height {
+                cur_l1
+            } else {
+                let l1_start_height = self.genesis_l1_height.saturating_add(1);
+                let l1_start_manifest = self
+                    .provider
+                    .get_block_manifest_at_height(l1_start_height)
+                    .await
+                    .map_err(db_error)?
+                    .ok_or_else(|| {
+                        not_found_error(format!(
+                            "No L1 manifest found at genesis+1 height {} for epoch 0",
+                            l1_start_height
+                        ))
+                    })?;
 
-            L1BlockCommitment::new(l1_start_height, *l1_start_manifest.blkid())
+                L1BlockCommitment::new(l1_start_height, *l1_start_manifest.blkid())
+            }
         } else {
             let prev_epoch = epoch - 1;
             let (_, prev_summary) = self
@@ -730,30 +735,40 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                     not_found_error(format!("No canonical summary found for epoch {prev_epoch}"))
                 })?;
 
-            let l1_start_height = prev_summary.new_l1().height().saturating_add(1);
-            let l1_start_manifest = self
-                .provider
-                .get_block_manifest_at_height(l1_start_height)
-                .await
-                .map_err(db_error)?
-                .ok_or_else(|| {
-                    not_found_error(format!(
-                        "No L1 manifest found at checkpoint start height {} for epoch {}",
-                        l1_start_height, epoch
-                    ))
-                })?;
+            let prev_l1 = *prev_summary.new_l1();
+            if cur_l1.height() <= prev_l1.height() {
+                cur_l1
+            } else {
+                let l1_start_height = prev_l1.height().saturating_add(1);
+                let l1_start_manifest = self
+                    .provider
+                    .get_block_manifest_at_height(l1_start_height)
+                    .await
+                    .map_err(db_error)?
+                    .ok_or_else(|| {
+                        not_found_error(format!(
+                            "No L1 manifest found at checkpoint start height {} for epoch {}",
+                            l1_start_height, epoch
+                        ))
+                    })?;
 
-            L1BlockCommitment::new(l1_start_height, *l1_start_manifest.blkid())
+                L1BlockCommitment::new(l1_start_height, *l1_start_manifest.blkid())
+            }
         };
-        let l1_end = *epoch_summary.new_l1();
+        let l1_end = cur_l1;
         let l1_range = (l1_start, l1_end);
+        debug_assert!(l1_range.0.height() <= l1_range.1.height());
 
-        let l1_ref = self
+        let confirmation_status = if epoch == 0 {
+            let l1_reference =
+                RpcCheckpointL1Ref::new(cur_l1, RBuf32::from([0u8; 32]), RBuf32::from([0u8; 32]));
+            RpcCheckpointConfStatus::Finalized { l1_reference }
+        } else if let Some(obs) = self
             .provider
             .get_checkpoint_l1_ref(commitment)
             .await
-            .map_err(db_error)?;
-        let confirmation_status = if let Some(obs) = l1_ref {
+            .map_err(db_error)?
+        {
             let l1_reference = RpcCheckpointL1Ref::new(obs.l1_commitment, obs.txid, obs.wtxid);
             let observed_height = obs.l1_commitment.height();
             let Some(tip) = self.provider.get_l1_tip_height().await.map_err(db_error)? else {

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -498,9 +498,24 @@ fn make_sync_status(
 }
 
 fn make_block(slot: Slot, epoch: Epoch, parent: OLBlockId) -> OLBlock {
+    make_block_with_terminal_flag(slot, epoch, parent, false)
+}
+
+fn make_terminal_block(slot: Slot, epoch: Epoch, parent: OLBlockId) -> OLBlock {
+    make_block_with_terminal_flag(slot, epoch, parent, true)
+}
+
+fn make_block_with_terminal_flag(
+    slot: Slot,
+    epoch: Epoch,
+    parent: OLBlockId,
+    is_terminal: bool,
+) -> OLBlock {
+    let mut flags = BlockFlags::zero();
+    flags.set_is_terminal(is_terminal);
     let header = OLBlockHeader::new(
         0,
-        0.into(),
+        flags,
         slot,
         epoch,
         parent,
@@ -511,6 +526,32 @@ fn make_block(slot: Slot, epoch: Epoch, parent: OLBlockId) -> OLBlock {
     let signed = SignedOLBlockHeader::new(header, Buf64::zero());
     let body = OLBlockBody::new_common(OLTxSegment::new(vec![]).expect("empty segment"));
     OLBlock::new(signed, body)
+}
+
+fn make_epoch_blocks(
+    prev_terminal: L2BlockCommitment,
+    epoch: Epoch,
+    terminal_slot: Slot,
+) -> Vec<OLBlock> {
+    let mut blocks = Vec::new();
+    let mut parent = *prev_terminal.blkid();
+    for slot in prev_terminal.slot().saturating_add(1)..=terminal_slot {
+        let block = if slot == terminal_slot {
+            make_terminal_block(slot, epoch, parent)
+        } else {
+            make_block(slot, epoch, parent)
+        };
+        parent = block.header().compute_blkid();
+        blocks.push(block);
+    }
+    blocks
+}
+
+fn with_blocks(mut provider: MockProvider, blocks: &[OLBlock]) -> MockProvider {
+    for block in blocks {
+        provider = provider.with_block_and_state(block, genesis_ol_state());
+    }
+    provider
 }
 
 fn make_block_with_gam_tx(
@@ -863,20 +904,18 @@ async fn checkpoint_info_returns_none_when_epoch_missing() {
 }
 
 #[tokio::test]
-async fn checkpoint_info_returns_expected_l1_and_l2_ranges() {
-    let prev_terminal = L2BlockCommitment::new(80, fixed_ol_block_id(0x10));
-
-    let first_epoch_block = make_block(85, 2, *prev_terminal.blkid());
-    let first_epoch_blkid = first_epoch_block.header().compute_blkid();
-    let mid_epoch_block = make_block(90, 2, first_epoch_blkid);
-    let mid_epoch_blkid = mid_epoch_block.header().compute_blkid();
-    let terminal_block = make_block(100, 2, mid_epoch_blkid);
-    let terminal = L2BlockCommitment::new(100, terminal_block.header().compute_blkid());
+async fn checkpoint_info_with_l1_advance() {
+    // With fixed-slot sealing at 10 slots/epoch, epoch 0 is slot 0, epoch 1
+    // terminates at slot 10, and epoch 2 terminates at slot 20.
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
 
     let prev_summary = EpochSummary::new(
         1,
         prev_terminal,
-        L2BlockCommitment::new(60, fixed_ol_block_id(0x11)),
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
         L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
         fixed_buf32(0x40),
     );
@@ -907,14 +946,11 @@ async fn checkpoint_info_returns_expected_l1_and_l2_ranges() {
             cur_commitment,
             prev_commitment,
         ))
-        .with_l1_tip_height(509)
+        .with_l1_tip_height(510)
         .with_epoch_commitment(1, prev_commitment)
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
         .with_epoch_summary(cur_summary)
-        .with_block_and_state(&first_epoch_block, genesis_ol_state())
-        .with_block_and_state(&mid_epoch_block, genesis_ol_state())
-        .with_block_and_state(&terminal_block, genesis_ol_state())
         .with_manifest(
             AsmManifest::new(
                 501,
@@ -925,6 +961,7 @@ async fn checkpoint_info_returns_expected_l1_and_l2_ranges() {
             .expect("test manifest should be valid"),
         )
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
+    let provider = with_blocks(provider, &epoch_blocks);
 
     let rpc = make_rpc(provider);
 
@@ -935,31 +972,74 @@ async fn checkpoint_info_returns_expected_l1_and_l2_ranges() {
         .expect("checkpoint should exist");
 
     assert_eq!(info.idx, 2);
-    assert_eq!(info.l2_range.0.slot(), 85);
+    assert_eq!(info.l2_range.0.slot(), 11);
     assert_eq!(info.l2_range.1, terminal);
     assert_eq!(info.l1_range.0.height(), 501);
     assert_eq!(info.l1_range.1.height(), 510);
 }
 
 #[tokio::test]
-async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
-    let prev_terminal = L2BlockCommitment::new(80, fixed_ol_block_id(0x10));
-    let observed_height = 505;
-    let l1_tip_height = 509;
-    let checkpoint_txid = fixed_buf32(0xAA);
-    let checkpoint_wtxid = fixed_buf32(0xBB);
-
-    let first_epoch_block = make_block(85, 2, *prev_terminal.blkid());
-    let first_epoch_blkid = first_epoch_block.header().compute_blkid();
-    let mid_epoch_block = make_block(90, 2, first_epoch_blkid);
-    let mid_epoch_blkid = mid_epoch_block.header().compute_blkid();
-    let terminal_block = make_block(100, 2, mid_epoch_blkid);
-    let terminal = L2BlockCommitment::new(100, terminal_block.header().compute_blkid());
+async fn checkpoint_info_no_l1_advance() {
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
+    let unchanged_l1 = L1BlockCommitment::new(500, fixed_l1_block_id(0x30));
 
     let prev_summary = EpochSummary::new(
         1,
         prev_terminal,
-        L2BlockCommitment::new(60, fixed_ol_block_id(0x11)),
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
+        unchanged_l1,
+        fixed_buf32(0x40),
+    );
+    let cur_summary =
+        EpochSummary::new(2, terminal, prev_terminal, unchanged_l1, fixed_buf32(0x41));
+
+    let prev_commitment = prev_summary.get_epoch_commitment();
+    let cur_commitment = cur_summary.get_epoch_commitment();
+
+    let provider = MockProvider::new()
+        .with_epoch_commitment(1, prev_commitment)
+        .with_epoch_commitment(2, cur_commitment)
+        .with_epoch_summary(prev_summary)
+        .with_epoch_summary(cur_summary);
+    let provider = with_blocks(provider, &epoch_blocks);
+
+    let rpc = make_rpc(provider);
+
+    let info = rpc
+        .get_checkpoint_info(2)
+        .await
+        .expect("checkpoint info should not error")
+        .expect("checkpoint should exist");
+
+    assert_eq!(info.idx, 2);
+    assert_eq!(info.l1_range.0, unchanged_l1);
+    assert_eq!(info.l1_range.1, unchanged_l1);
+    assert!(info.l1_range.0.height() <= info.l1_range.1.height());
+    assert!(matches!(
+        info.confirmation_status,
+        RpcCheckpointConfStatus::Pending
+    ));
+}
+
+#[tokio::test]
+async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
+    let observed_height = 505;
+    let l1_tip_height = 510;
+    let checkpoint_txid = fixed_buf32(0xAA);
+    let checkpoint_wtxid = fixed_buf32(0xBB);
+
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
+
+    let prev_summary = EpochSummary::new(
+        1,
+        prev_terminal,
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
         L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
         fixed_buf32(0x40),
     );
@@ -995,9 +1075,6 @@ async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
         .with_epoch_summary(cur_summary)
-        .with_block_and_state(&first_epoch_block, genesis_ol_state())
-        .with_block_and_state(&mid_epoch_block, genesis_ol_state())
-        .with_block_and_state(&terminal_block, genesis_ol_state())
         .with_manifest(
             AsmManifest::new(
                 501,
@@ -1008,6 +1085,7 @@ async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
             .expect("test manifest should be valid"),
         )
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
+    let provider = with_blocks(provider, &epoch_blocks);
 
     let rpc = make_rpc(provider);
 
@@ -1029,18 +1107,15 @@ async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
 
 #[tokio::test]
 async fn checkpoint_info_returns_pending_when_observation_missing() {
-    let prev_terminal = L2BlockCommitment::new(80, fixed_ol_block_id(0x10));
-    let first_epoch_block = make_block(85, 2, *prev_terminal.blkid());
-    let first_epoch_blkid = first_epoch_block.header().compute_blkid();
-    let mid_epoch_block = make_block(90, 2, first_epoch_blkid);
-    let mid_epoch_blkid = mid_epoch_block.header().compute_blkid();
-    let terminal_block = make_block(100, 2, mid_epoch_blkid);
-    let terminal = L2BlockCommitment::new(100, terminal_block.header().compute_blkid());
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
 
     let prev_summary = EpochSummary::new(
         1,
         prev_terminal,
-        L2BlockCommitment::new(60, fixed_ol_block_id(0x11)),
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
         L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
         fixed_buf32(0x40),
     );
@@ -1065,18 +1140,16 @@ async fn checkpoint_info_returns_pending_when_observation_missing() {
             cur_commitment,
             prev_commitment,
         ))
-        .with_l1_tip_height(509)
+        .with_l1_tip_height(510)
         .with_epoch_commitment(1, prev_commitment)
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
         .with_epoch_summary(cur_summary)
-        .with_block_and_state(&first_epoch_block, genesis_ol_state())
-        .with_block_and_state(&mid_epoch_block, genesis_ol_state())
-        .with_block_and_state(&terminal_block, genesis_ol_state())
         .with_manifest(
             AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
                 .expect("test manifest should be valid"),
         );
+    let provider = with_blocks(provider, &epoch_blocks);
 
     let rpc = make_rpc(provider);
 
@@ -1094,22 +1167,19 @@ async fn checkpoint_info_returns_pending_when_observation_missing() {
 
 #[tokio::test]
 async fn checkpoint_info_returns_finalized_status_when_epoch_is_finalized() {
-    let prev_terminal = L2BlockCommitment::new(80, fixed_ol_block_id(0x10));
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
     let observed_height = 505;
-    let l1_tip_height = 509;
+    let l1_tip_height = 510;
     let checkpoint_txid = fixed_buf32(0xAA);
     let checkpoint_wtxid = fixed_buf32(0xBB);
-    let first_epoch_block = make_block(85, 2, *prev_terminal.blkid());
-    let first_epoch_blkid = first_epoch_block.header().compute_blkid();
-    let mid_epoch_block = make_block(90, 2, first_epoch_blkid);
-    let mid_epoch_blkid = mid_epoch_block.header().compute_blkid();
-    let terminal_block = make_block(100, 2, mid_epoch_blkid);
-    let terminal = L2BlockCommitment::new(100, terminal_block.header().compute_blkid());
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
 
     let prev_summary = EpochSummary::new(
         1,
         prev_terminal,
-        L2BlockCommitment::new(60, fixed_ol_block_id(0x11)),
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
         L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
         fixed_buf32(0x40),
     );
@@ -1145,14 +1215,12 @@ async fn checkpoint_info_returns_finalized_status_when_epoch_is_finalized() {
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
         .with_epoch_summary(cur_summary)
-        .with_block_and_state(&first_epoch_block, genesis_ol_state())
-        .with_block_and_state(&mid_epoch_block, genesis_ol_state())
-        .with_block_and_state(&terminal_block, genesis_ol_state())
         .with_manifest(
             AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
                 .expect("test manifest should be valid"),
         )
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
+    let provider = with_blocks(provider, &epoch_blocks);
 
     let rpc = make_rpc(provider);
 
@@ -1173,39 +1241,25 @@ async fn checkpoint_info_returns_finalized_status_when_epoch_is_finalized() {
 }
 
 #[tokio::test]
-async fn checkpoint_info_epoch_0_l1_range_from_genesis() {
-    let genesis_blkid = fixed_ol_block_id(0x01);
-    let first_block = make_block(1, 0, genesis_blkid);
-    let first_blkid = first_block.header().compute_blkid();
-    let terminal_block = make_block(10, 0, first_blkid);
-    let terminal = L2BlockCommitment::new(10, terminal_block.header().compute_blkid());
-    let prev_terminal = L2BlockCommitment::new(0, genesis_blkid);
-
+async fn checkpoint_info_epoch_0_with_l1_advance() {
+    let genesis_block = make_terminal_block(0, 0, null_blkid());
+    let genesis_blkid = genesis_block.header().compute_blkid();
+    let terminal = L2BlockCommitment::new(0, genesis_blkid);
+    let advanced_l1 = L1BlockCommitment::new(5, fixed_l1_block_id(0x55));
     let summary = EpochSummary::new(
         0,
         terminal,
-        prev_terminal,
-        L1BlockCommitment::new(5, fixed_l1_block_id(0x55)),
+        OLBlockCommitment::null(),
+        advanced_l1,
         fixed_buf32(0x99),
     );
     let commitment = summary.get_epoch_commitment();
 
     let l1_start_blkid = fixed_l1_block_id(0x71);
-    let tip = OLBlockCommitment::new(20, fixed_ol_block_id(0x77));
     let provider = MockProvider::new()
-        .with_sync_status(make_sync_status(
-            tip,
-            1,
-            false,
-            commitment,
-            commitment,
-            EpochCommitment::null(),
-        ))
-        .with_l1_tip_height(10)
         .with_epoch_commitment(0, commitment)
         .with_epoch_summary(summary)
-        .with_block_and_state(&first_block, genesis_ol_state())
-        .with_block_and_state(&terminal_block, genesis_ol_state())
+        .with_block_and_state(&genesis_block, genesis_ol_state())
         .with_manifest(
             AsmManifest::new(
                 TEST_GENESIS_L1_HEIGHT + 1,
@@ -1227,28 +1281,77 @@ async fn checkpoint_info_epoch_0_l1_range_from_genesis() {
     assert_eq!(info.idx, 0);
     assert_eq!(info.l1_range.0.height(), TEST_GENESIS_L1_HEIGHT + 1);
     assert_eq!(*info.l1_range.0.blkid(), l1_start_blkid);
-    assert_eq!(info.l1_range.1.height(), 5);
-    assert_eq!(info.l2_range.0.slot(), 1);
+    assert_eq!(info.l1_range.1, advanced_l1);
+    assert_eq!(info.l2_range.0, terminal);
     assert_eq!(info.l2_range.1, terminal);
+    match info.confirmation_status {
+        RpcCheckpointConfStatus::Finalized { l1_reference } => {
+            assert_eq!(l1_reference.l1_block, advanced_l1);
+            assert_eq!(l1_reference.txid, RBuf32::from([0u8; 32]));
+            assert_eq!(l1_reference.wtxid, RBuf32::from([0u8; 32]));
+        }
+        _ => panic!("expected finalized genesis checkpoint status"),
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_info_epoch_0_l1_did_not_advance() {
+    let genesis_block = make_terminal_block(0, 0, null_blkid());
+    let genesis_blkid = genesis_block.header().compute_blkid();
+    let terminal = L2BlockCommitment::new(0, genesis_blkid);
+    let genesis_l1 = L1BlockCommitment::new(TEST_GENESIS_L1_HEIGHT, fixed_l1_block_id(0x55));
+    let summary = EpochSummary::new(
+        0,
+        terminal,
+        OLBlockCommitment::null(),
+        genesis_l1,
+        fixed_buf32(0x99),
+    );
+    let commitment = summary.get_epoch_commitment();
+
+    let provider = MockProvider::new()
+        .with_epoch_commitment(0, commitment)
+        .with_epoch_summary(summary)
+        .with_block_and_state(&genesis_block, genesis_ol_state());
+
+    let rpc = make_rpc(provider);
+
+    let info = rpc
+        .get_checkpoint_info(0)
+        .await
+        .expect("checkpoint info should not error")
+        .expect("epoch 0 checkpoint should exist");
+
+    assert_eq!(info.idx, 0);
+    assert_eq!(info.l1_range.0, genesis_l1);
+    assert_eq!(info.l1_range.1, genesis_l1);
+    assert_eq!(info.l2_range.0, terminal);
+    assert_eq!(info.l2_range.1, terminal);
+    assert!(info.l1_range.0.height() <= info.l1_range.1.height());
+    match info.confirmation_status {
+        RpcCheckpointConfStatus::Finalized { l1_reference } => {
+            assert_eq!(l1_reference.l1_block, genesis_l1);
+            assert_eq!(l1_reference.txid, RBuf32::from([0u8; 32]));
+            assert_eq!(l1_reference.wtxid, RBuf32::from([0u8; 32]));
+        }
+        _ => panic!("expected finalized genesis checkpoint status"),
+    }
 }
 
 #[tokio::test]
 async fn checkpoint_info_errors_when_l1_tip_is_below_observed_height() {
-    let prev_terminal = L2BlockCommitment::new(80, fixed_ol_block_id(0x10));
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
     let observed_height = 505;
     let checkpoint_txid = fixed_buf32(0xAA);
     let checkpoint_wtxid = fixed_buf32(0xBB);
-    let first_epoch_block = make_block(85, 2, *prev_terminal.blkid());
-    let first_epoch_blkid = first_epoch_block.header().compute_blkid();
-    let mid_epoch_block = make_block(90, 2, first_epoch_blkid);
-    let mid_epoch_blkid = mid_epoch_block.header().compute_blkid();
-    let terminal_block = make_block(100, 2, mid_epoch_blkid);
-    let terminal = L2BlockCommitment::new(100, terminal_block.header().compute_blkid());
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
 
     let prev_summary = EpochSummary::new(
         1,
         prev_terminal,
-        L2BlockCommitment::new(60, fixed_ol_block_id(0x11)),
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
         L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
         fixed_buf32(0x40),
     );
@@ -1256,7 +1359,7 @@ async fn checkpoint_info_errors_when_l1_tip_is_below_observed_height() {
         2,
         terminal,
         prev_terminal,
-        L1BlockCommitment::new(510, fixed_l1_block_id(0x31)),
+        L1BlockCommitment::new(504, fixed_l1_block_id(0x31)),
         fixed_buf32(0x41),
     );
 
@@ -1284,14 +1387,12 @@ async fn checkpoint_info_errors_when_l1_tip_is_below_observed_height() {
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
         .with_epoch_summary(cur_summary)
-        .with_block_and_state(&first_epoch_block, genesis_ol_state())
-        .with_block_and_state(&mid_epoch_block, genesis_ol_state())
-        .with_block_and_state(&terminal_block, genesis_ol_state())
         .with_manifest(
             AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
                 .expect("test manifest should be valid"),
         )
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
+    let provider = with_blocks(provider, &epoch_blocks);
 
     let rpc = make_rpc(provider);
 


### PR DESCRIPTION
## Description

Fix `strata_getCheckpointInfo` returning an inverted L1 range (and a spurious `not_found` error) for epochs where the ASM did not advance L1, and report the genesis epoch as finalized.

### Problem
The L1 range was `(prev.new_l1 + 1, cur.new_l1)`. When an epoch processes no new L1 block, `cur.new_l1 == prev.new_l1`, so start > end and the handler tried to fetch a nonexistent manifest at `prev.new_l1 + 1`, erroring. The same applied to
epoch 0 vs `genesis_l1_height` (the genesis terminal carries no manifests). Epoch 0 also fell through to `Pending` despite being finalized by definition.

### Changes

- Collapse the range to `(cur.new_l1, cur.new_l1)` when L1 doesn't advance, in both the genesis and non-genesis branches. Advancing epochs unchanged.
- Report epoch 0 as `Finalized` with a synthetic zero-`txid`/`wtxid` ref.
- Add `debug_assert!(l1_range.0.height() <= l1_range.1.height())`.
- Also clean up test code so epoch sealing policy is clear.

No wire-schema change; clients needing to distinguish genesis must special-case `idx == 0`.

## Testing
New non-advance collapse tests for genesis and non-genesis epochs.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3295](https://alpenlabs.atlassian.net/browse/STR-3235)

[STR-3295]: https://alpenlabs.atlassian.net/browse/STR-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ