### PR TITLE
STR-3238: fail closed on invalid withdrawal BOSD

### DIFF
--- a/.github/params/templates/prod/ol-params.json
+++ b/.github/params/templates/prod/ol-params.json
@@ -17,6 +17,7 @@
   "last_l1_block": "__LAST_L1_BLOCK__",
   "bridge_params": {
     "denomination": 200000000,
-    "max_withdrawal_amount": 1000000000
+    "max_withdrawal_amount": 1000000000,
+    "max_withdrawal_descriptor_len": 81
   }
 }

--- a/.github/params/templates/staging-v2/ol-params.json
+++ b/.github/params/templates/staging-v2/ol-params.json
@@ -17,6 +17,7 @@
   "last_l1_block": "__LAST_L1_BLOCK__",
   "bridge_params": {
     "denomination": 100000000,
-    "max_withdrawal_amount": 1000000000
+    "max_withdrawal_amount": 1000000000,
+    "max_withdrawal_descriptor_len": 81
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16301,6 +16301,7 @@ dependencies = [
  "strata-ol-state-support-types",
  "strata-ol-state-types",
  "strata-predicate",
+ "strata-primitives",
  "strata-snark-acct-sys",
  "strata-snark-acct-types",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16474,6 +16474,7 @@ dependencies = [
  "rsp-client-executor",
  "serde",
  "serde_json",
+ "strata-bridge-params",
  "strata-ol-bridge-types",
  "strata-primitives",
  "strata-state",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15739,6 +15739,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strata-acct-types",
+ "strata-bridge-params",
  "strata-codec",
  "strata-ee-acct-types",
  "strata-ee-chain-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
  "strata-identifiers",
  "strata-ol-bridge-types",
  "strata-primitives",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -15106,7 +15107,6 @@ name = "strata-bridge-params"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "borsh",
  "serde",
  "serde_json",
  "ssz",
@@ -15740,7 +15740,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strata-acct-types",
- "strata-bridge-params",
  "strata-codec",
  "strata-ee-acct-types",
  "strata-ee-chain-types",
@@ -16282,6 +16281,7 @@ dependencies = [
 name = "strata-ol-stf"
 version = "0.1.0"
 dependencies = [
+ "bitcoin-bosd 0.11.0",
  "ssz_primitives",
  "ssz_types",
  "strata-acct-types",
@@ -16302,7 +16302,6 @@ dependencies = [
  "strata-ol-state-support-types",
  "strata-ol-state-types",
  "strata-predicate",
- "strata-primitives",
  "strata-snark-acct-sys",
  "strata-snark-acct-types",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15106,6 +15106,7 @@ name = "strata-bridge-params"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "borsh",
  "serde",
  "serde_json",
  "ssz",

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -10,7 +10,9 @@ pub const DEFAULT_FINALITY_DEPTH: u32 = 6;
 
 pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 
-pub use strata_bridge_params::{DEFAULT_DENOMINATION_SATS, DEFAULT_MAX_WITHDRAWAL_SATS};
+pub use strata_bridge_params::{
+    DEFAULT_DENOMINATION_SATS, DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN, DEFAULT_MAX_WITHDRAWAL_SATS,
+};
 
 /// Fee to cover the mining fees for creating the deposit transaction from the deposit request
 /// transaction. This includes the cost for the bridge to spend the deposit request output into the

--- a/bin/alpen-cli/src/settings.rs
+++ b/bin/alpen-cli/src/settings.rs
@@ -70,6 +70,8 @@ pub struct SettingsFromFile {
     pub withdrawal_denomination_sats: Option<u64>,
     /// Maximum withdrawal amount in satoshis. Defaults to 1_000_000_000 (10 BTC).
     pub max_withdrawal_amount_sats: Option<u64>,
+    /// Maximum withdrawal BOSD descriptor length in bytes, including the type tag.
+    pub max_withdrawal_descriptor_len: Option<u32>,
     /// Path to the ASM params JSON file.
     pub asm_params_path: Option<PathBuf>,
     /// Seed that can be passed directly for functional test.
@@ -216,13 +218,16 @@ impl Settings {
                 .map(Amount::from_sat)
                 .unwrap_or(DEFAULT_BRIDGE_FEE),
             finality_depth: from_file.finality_depth.unwrap_or(DEFAULT_FINALITY_DEPTH),
-            bridge_params: BridgeParams::new(
+            bridge_params: BridgeParams::new_with_descriptor_limit(
                 from_file
                     .withdrawal_denomination_sats
                     .unwrap_or(DEFAULT_DENOMINATION_SATS),
                 from_file
                     .max_withdrawal_amount_sats
                     .or(Some(DEFAULT_MAX_WITHDRAWAL_SATS)),
+                from_file
+                    .max_withdrawal_descriptor_len
+                    .unwrap_or(DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN),
             )
             .expect("invalid withdrawal params in config"),
             network,
@@ -253,6 +258,7 @@ mod tests {
             mempool_endpoint = "https://bitcoin.testnet.alpenlabs.io"
             blockscout_endpoint = "https://explorer.testnet.alpenlabs.io"
             bridge_pubkey = "1d3e9c0417ba7d3551df5a1cc1dbe227aa4ce89161762454d92bfc2b1d5886f7"
+            max_withdrawal_descriptor_len = 81
             seed = "000102030405060708090a0b0c0d0e0f"
         "#;
 
@@ -273,5 +279,9 @@ mod tests {
         assert_eq!(parsed.alpen_endpoint, reparsed.alpen_endpoint);
         assert_eq!(parsed.faucet_endpoint, reparsed.faucet_endpoint);
         assert_eq!(parsed.bridge_pubkey.0, reparsed.bridge_pubkey.0);
+        assert_eq!(
+            parsed.max_withdrawal_descriptor_len,
+            reparsed.max_withdrawal_descriptor_len
+        );
     }
 }

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -70,7 +70,10 @@ use reth_cli_util::sigsegv_handler;
 use reth_network::{protocol::IntoRlpxSubProtocol, NetworkProtocols};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_provider::CanonStateSubscriptions;
-use strata_bridge_params::{BridgeParams, DEFAULT_DENOMINATION_SATS, DEFAULT_MAX_WITHDRAWAL_SATS};
+use strata_bridge_params::{
+    BridgeParams, DEFAULT_DENOMINATION_SATS, DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
+    DEFAULT_MAX_WITHDRAWAL_SATS,
+};
 #[cfg(feature = "sequencer")]
 use strata_btcio::{
     broadcaster::BroadcasterBuilder, writer::chunked_envelope::create_chunked_envelope_task,
@@ -196,6 +199,12 @@ fn main() {
                 Some(v) => Some(v),
                 None => Some(DEFAULT_MAX_WITHDRAWAL_SATS),
             };
+            let bridge_params = BridgeParams::new_with_descriptor_limit(
+                ext.bridge_denomination,
+                resolved_max_withdrawal,
+                ext.max_withdrawal_descriptor_len,
+            )
+            .expect("invalid withdrawal params");
 
             let datadir = builder.config().datadir().data_dir().to_path_buf();
 
@@ -379,10 +388,7 @@ fn main() {
             .await
             .map_err(|e| eyre::eyre!("failed to start ol tracker service: {e}"))?;
 
-            let evm_factory = AlpenEvmFactory::from_bridge_params(
-                &BridgeParams::new(ext.bridge_denomination, resolved_max_withdrawal)
-                    .expect("invalid withdrawal params"),
-            );
+            let evm_factory = AlpenEvmFactory::from_bridge_params(&bridge_params);
             let node_args = AlpenNodeArgs {
                 sequencer_http: ext.sequencer_http.clone(),
                 evm_factory,
@@ -693,10 +699,6 @@ fn main() {
                     use alpen_reth_exex::alloy2reth::IntoRspChainConfig as _;
                     ext.custom_chain.genesis().config.clone().into_rsp()
                 };
-
-                let bridge_params =
-                    BridgeParams::new(ext.bridge_denomination, resolved_max_withdrawal)
-                        .expect("invalid withdrawal params");
 
                 let chunk_builder = ProverBuilder::new(ChunkSpec::new(
                     chunk_storage_dyn.clone(),
@@ -1084,6 +1086,10 @@ pub struct AdditionalConfig {
     #[arg(long, default_value_t = DEFAULT_DENOMINATION_SATS)]
     pub bridge_denomination: u64,
 
+    /// Maximum withdrawal BOSD descriptor length in bytes, including the type tag.
+    #[arg(long, default_value_t = DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN)]
+    pub max_withdrawal_descriptor_len: u32,
+
     /// Maximum withdrawal amount in satoshis.
     ///
     /// When omitted, defaults to 1_000_000_000 (10 BTC) at runtime.
@@ -1213,6 +1219,43 @@ fn validate_ee_params_genesis(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod additional_config_tests {
+    use super::*;
+
+    const SEQUENCER_PUBKEY: &str =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+
+    fn parse_additional_config(args: &[&str]) -> AdditionalConfig {
+        let mut argv = vec![
+            "alpen-client",
+            "--ee-params",
+            "/tmp/ee-params.json",
+            "--sequencer-pubkey",
+            SEQUENCER_PUBKEY,
+        ];
+        argv.extend_from_slice(args);
+        <AdditionalConfig as clap::Parser>::parse_from(argv)
+    }
+
+    #[test]
+    fn max_withdrawal_descriptor_len_defaults_to_policy_limit() {
+        let config = parse_additional_config(&[]);
+
+        assert_eq!(
+            config.max_withdrawal_descriptor_len,
+            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
+        );
+    }
+
+    #[test]
+    fn max_withdrawal_descriptor_len_can_be_configured() {
+        let config = parse_additional_config(&["--max-withdrawal-descriptor-len", "100"]);
+
+        assert_eq!(config.max_withdrawal_descriptor_len, 100);
+    }
 }
 
 /// Run node with logging

--- a/crates/bridge-params/Cargo.toml
+++ b/crates/bridge-params/Cargo.toml
@@ -8,7 +8,6 @@ workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-borsh.workspace = true
 serde.workspace = true
 ssz.workspace = true
 ssz_derive.workspace = true

--- a/crates/bridge-params/Cargo.toml
+++ b/crates/bridge-params/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
+borsh.workspace = true
 serde.workspace = true
 ssz.workspace = true
 ssz_derive.workspace = true

--- a/crates/bridge-params/src/lib.rs
+++ b/crates/bridge-params/src/lib.rs
@@ -2,7 +2,6 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use borsh::{BorshDeserialize, BorshSerialize, io};
 use serde::{Deserialize, Serialize, de::Error as DeError};
 use ssz_derive::{Decode, Encode};
 use thiserror::Error;
@@ -31,13 +30,6 @@ struct BridgeParamsRaw {
     max_withdrawal_descriptor_len: u32,
 }
 
-/// Legacy raw mirror used to decode params encoded before descriptor limits.
-#[derive(Decode, Encode)]
-struct LegacyBridgeParamsRaw {
-    denomination: u64,
-    max_withdrawal_amount: Option<u64>,
-}
-
 impl<'de> Deserialize<'de> for BridgeParams {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let raw = BridgeParamsRaw::deserialize(deserializer)?;
@@ -60,41 +52,13 @@ impl ssz::Decode for BridgeParams {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        if let Ok(raw) = BridgeParamsRaw::from_ssz_bytes(bytes) {
-            return Self::new_with_descriptor_limit(
-                raw.denomination,
-                raw.max_withdrawal_amount,
-                raw.max_withdrawal_descriptor_len,
-            )
-            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()));
-        }
-
-        let raw = LegacyBridgeParamsRaw::from_ssz_bytes(bytes)?;
-        Self::new(raw.denomination, raw.max_withdrawal_amount)
-            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
-    }
-}
-
-impl BorshSerialize for BridgeParams {
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        BorshSerialize::serialize(&self.denomination, writer)?;
-        BorshSerialize::serialize(&self.max_withdrawal_amount, writer)?;
-        BorshSerialize::serialize(&self.max_withdrawal_descriptor_len, writer)
-    }
-}
-
-impl BorshDeserialize for BridgeParams {
-    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let denomination = u64::deserialize_reader(reader)?;
-        let max_withdrawal_amount = Option::<u64>::deserialize_reader(reader)?;
-        let max_withdrawal_descriptor_len = u32::deserialize_reader(reader)?;
-
+        let raw = BridgeParamsRaw::from_ssz_bytes(bytes)?;
         Self::new_with_descriptor_limit(
-            denomination,
-            max_withdrawal_amount,
-            max_withdrawal_descriptor_len,
+            raw.denomination,
+            raw.max_withdrawal_amount,
+            raw.max_withdrawal_descriptor_len,
         )
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+        .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
     }
 }
 
@@ -341,19 +305,5 @@ mod tests {
         let encoded = ssz::Encode::as_ssz_bytes(&bp);
         let decoded = <BridgeParams as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
         assert_eq!(bp, decoded);
-    }
-
-    #[test]
-    fn ssz_legacy_decode_uses_default_descriptor_len() {
-        let legacy = LegacyBridgeParamsRaw {
-            denomination: 100_000_000,
-            max_withdrawal_amount: Some(1_000_000_000),
-        };
-        let encoded = ssz::Encode::as_ssz_bytes(&legacy);
-        let decoded = <BridgeParams as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
-        assert_eq!(
-            decoded.max_withdrawal_descriptor_len(),
-            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
-        );
     }
 }

--- a/crates/bridge-params/src/lib.rs
+++ b/crates/bridge-params/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+use borsh::{BorshDeserialize, BorshSerialize, io};
 use serde::{Deserialize, Serialize, de::Error as DeError};
 use ssz_derive::{Decode, Encode};
 use thiserror::Error;
@@ -71,6 +72,29 @@ impl ssz::Decode for BridgeParams {
         let raw = LegacyBridgeParamsRaw::from_ssz_bytes(bytes)?;
         Self::new(raw.denomination, raw.max_withdrawal_amount)
             .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
+    }
+}
+
+impl BorshSerialize for BridgeParams {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        BorshSerialize::serialize(&self.denomination, writer)?;
+        BorshSerialize::serialize(&self.max_withdrawal_amount, writer)?;
+        BorshSerialize::serialize(&self.max_withdrawal_descriptor_len, writer)
+    }
+}
+
+impl BorshDeserialize for BridgeParams {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let denomination = u64::deserialize_reader(reader)?;
+        let max_withdrawal_amount = Option::<u64>::deserialize_reader(reader)?;
+        let max_withdrawal_descriptor_len = u32::deserialize_reader(reader)?;
+
+        Self::new_with_descriptor_limit(
+            denomination,
+            max_withdrawal_amount,
+            max_withdrawal_descriptor_len,
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
     }
 }
 

--- a/crates/bridge-params/src/lib.rs
+++ b/crates/bridge-params/src/lib.rs
@@ -6,22 +6,33 @@ use serde::{Deserialize, Serialize, de::Error as DeError};
 use ssz_derive::{Decode, Encode};
 use thiserror::Error;
 
-/// Bridge denomination and optional maximum withdrawal amount, in satoshis.
+/// Bridge denomination and withdrawal policy parameters.
 ///
 /// Constructed via [`BridgeParams::new`] which validates the invariants:
 /// - `denomination` must be non-zero
 /// - If `max_withdrawal_amount` is set, it must be `>= denomination` and a multiple of it
+/// - `max_withdrawal_descriptor_len` must fit within the withdrawal message descriptor cap
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Encode)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BridgeParams {
     denomination: u64,
     max_withdrawal_amount: Option<u64>,
+    max_withdrawal_descriptor_len: u32,
 }
 
 /// Raw mirror for deserialization. Serde and SSZ decode into this first,
-/// then validate via [`BridgeParams::new`].
+/// then validate via [`BridgeParams::new_with_descriptor_limit`].
 #[derive(Deserialize, Decode)]
 struct BridgeParamsRaw {
+    denomination: u64,
+    max_withdrawal_amount: Option<u64>,
+    #[serde(default = "default_max_withdrawal_descriptor_len")]
+    max_withdrawal_descriptor_len: u32,
+}
+
+/// Legacy raw mirror used to decode params encoded before descriptor limits.
+#[derive(Decode, Encode)]
+struct LegacyBridgeParamsRaw {
     denomination: u64,
     max_withdrawal_amount: Option<u64>,
 }
@@ -29,7 +40,12 @@ struct BridgeParamsRaw {
 impl<'de> Deserialize<'de> for BridgeParams {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let raw = BridgeParamsRaw::deserialize(deserializer)?;
-        Self::new(raw.denomination, raw.max_withdrawal_amount).map_err(DeError::custom)
+        Self::new_with_descriptor_limit(
+            raw.denomination,
+            raw.max_withdrawal_amount,
+            raw.max_withdrawal_descriptor_len,
+        )
+        .map_err(DeError::custom)
     }
 }
 
@@ -43,17 +59,39 @@ impl ssz::Decode for BridgeParams {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        let raw = BridgeParamsRaw::from_ssz_bytes(bytes)?;
+        if let Ok(raw) = BridgeParamsRaw::from_ssz_bytes(bytes) {
+            return Self::new_with_descriptor_limit(
+                raw.denomination,
+                raw.max_withdrawal_amount,
+                raw.max_withdrawal_descriptor_len,
+            )
+            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()));
+        }
+
+        let raw = LegacyBridgeParamsRaw::from_ssz_bytes(bytes)?;
         Self::new(raw.denomination, raw.max_withdrawal_amount)
             .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
     }
 }
 
 impl BridgeParams {
-    /// Creates a new [`BridgeParams`] after validating invariants.
+    /// Creates a new [`BridgeParams`] using the default descriptor length limit.
     pub fn new(
         denomination: u64,
         max_withdrawal_amount: Option<u64>,
+    ) -> Result<Self, BridgeParamsError> {
+        Self::new_with_descriptor_limit(
+            denomination,
+            max_withdrawal_amount,
+            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
+        )
+    }
+
+    /// Creates a new [`BridgeParams`] after validating invariants.
+    pub fn new_with_descriptor_limit(
+        denomination: u64,
+        max_withdrawal_amount: Option<u64>,
+        max_withdrawal_descriptor_len: u32,
     ) -> Result<Self, BridgeParamsError> {
         if denomination == 0 {
             return Err(BridgeParamsError::ZeroDenomination);
@@ -66,9 +104,19 @@ impl BridgeParams {
                 return Err(BridgeParamsError::MaxNotMultiple { denomination, max });
             }
         }
+        if max_withdrawal_descriptor_len == 0 {
+            return Err(BridgeParamsError::ZeroMaxWithdrawalDescriptorLen);
+        }
+        if max_withdrawal_descriptor_len > MAX_WITHDRAWAL_DESCRIPTOR_LEN {
+            return Err(BridgeParamsError::MaxWithdrawalDescriptorLenTooLarge {
+                max: max_withdrawal_descriptor_len,
+                cap: MAX_WITHDRAWAL_DESCRIPTOR_LEN,
+            });
+        }
         Ok(Self {
             denomination,
             max_withdrawal_amount,
+            max_withdrawal_descriptor_len,
         })
     }
 
@@ -80,6 +128,10 @@ impl BridgeParams {
         self.max_withdrawal_amount
     }
 
+    pub fn max_withdrawal_descriptor_len(&self) -> u32 {
+        self.max_withdrawal_descriptor_len
+    }
+
     /// Returns whether a withdrawal amount (in sats) is valid.
     pub fn validate_withdrawal_amount(&self, amount_sats: u64) -> bool {
         amount_sats > 0
@@ -87,6 +139,11 @@ impl BridgeParams {
             && self
                 .max_withdrawal_amount
                 .is_none_or(|cap| amount_sats <= cap)
+    }
+
+    /// Returns whether a withdrawal destination BOSD descriptor byte length is valid.
+    pub fn validate_withdrawal_descriptor_len(&self, len: usize) -> bool {
+        len > 0 && len <= self.max_withdrawal_descriptor_len as usize
     }
 }
 
@@ -96,11 +153,22 @@ pub const DEFAULT_DENOMINATION_SATS: u64 = 100_000_000;
 /// Default maximum withdrawal amount: 10 BTC in satoshis.
 pub const DEFAULT_MAX_WITHDRAWAL_SATS: u64 = 1_000_000_000;
 
+/// Default maximum BOSD descriptor length for withdrawals, including the type tag.
+pub const DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN: u32 = 81;
+
+/// Maximum BOSD descriptor length accepted by withdrawal message data.
+pub const MAX_WITHDRAWAL_DESCRIPTOR_LEN: u32 = 255;
+
+const fn default_max_withdrawal_descriptor_len() -> u32 {
+    DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
+}
+
 impl Default for BridgeParams {
     fn default() -> Self {
         Self {
             denomination: DEFAULT_DENOMINATION_SATS,
             max_withdrawal_amount: Some(DEFAULT_MAX_WITHDRAWAL_SATS),
+            max_withdrawal_descriptor_len: DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
         }
     }
 }
@@ -115,6 +183,12 @@ pub enum BridgeParamsError {
 
     #[error("max_withdrawal_amount ({max}) is not a multiple of denomination ({denomination})")]
     MaxNotMultiple { denomination: u64, max: u64 },
+
+    #[error("max_withdrawal_descriptor_len must not be zero")]
+    ZeroMaxWithdrawalDescriptorLen,
+
+    #[error("max_withdrawal_descriptor_len ({max}) exceeds descriptor cap ({cap})")]
+    MaxWithdrawalDescriptorLenTooLarge { max: u32, cap: u32 },
 }
 
 #[cfg(test)]
@@ -141,6 +215,27 @@ mod tests {
     }
 
     #[test]
+    fn default_descriptor_len_is_81() {
+        assert_eq!(
+            BridgeParams::default().max_withdrawal_descriptor_len(),
+            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
+        );
+        assert_eq!(
+            BridgeParams::new(100_000_000, Some(1_000_000_000))
+                .unwrap()
+                .max_withdrawal_descriptor_len(),
+            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
+        );
+    }
+
+    #[test]
+    fn valid_custom_descriptor_len() {
+        let w = BridgeParams::new_with_descriptor_limit(100_000_000, None, 100).unwrap();
+        assert!(w.validate_withdrawal_descriptor_len(100));
+        assert!(!w.validate_withdrawal_descriptor_len(101));
+    }
+
+    #[test]
     fn zero_denomination_rejected() {
         assert!(BridgeParams::new(0, None).is_err());
     }
@@ -160,6 +255,23 @@ mod tests {
         let w = BridgeParams::new(100_000_000, Some(100_000_000)).unwrap();
         assert!(w.validate_withdrawal_amount(100_000_000));
         assert!(!w.validate_withdrawal_amount(200_000_000));
+    }
+
+    #[test]
+    fn zero_descriptor_len_rejected() {
+        assert!(BridgeParams::new_with_descriptor_limit(100_000_000, None, 0).is_err());
+    }
+
+    #[test]
+    fn descriptor_len_over_cap_rejected() {
+        assert!(
+            BridgeParams::new_with_descriptor_limit(
+                100_000_000,
+                None,
+                MAX_WITHDRAWAL_DESCRIPTOR_LEN + 1
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -183,10 +295,41 @@ mod tests {
     }
 
     #[test]
+    fn serde_missing_descriptor_len_uses_default() {
+        let json = r#"{"denomination":100000000,"max_withdrawal_amount":null}"#;
+        let bp: BridgeParams = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            bp.max_withdrawal_descriptor_len(),
+            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
+        );
+    }
+
+    #[test]
+    fn serde_rejects_invalid_descriptor_len() {
+        let json = r#"{"denomination":100000000,"max_withdrawal_amount":null,"max_withdrawal_descriptor_len":256}"#;
+        assert!(serde_json::from_str::<BridgeParams>(json).is_err());
+    }
+
+    #[test]
     fn ssz_roundtrip() {
-        let bp = BridgeParams::new(100_000_000, Some(1_000_000_000)).unwrap();
+        let bp =
+            BridgeParams::new_with_descriptor_limit(100_000_000, Some(1_000_000_000), 100).unwrap();
         let encoded = ssz::Encode::as_ssz_bytes(&bp);
         let decoded = <BridgeParams as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
         assert_eq!(bp, decoded);
+    }
+
+    #[test]
+    fn ssz_legacy_decode_uses_default_descriptor_len() {
+        let legacy = LegacyBridgeParamsRaw {
+            denomination: 100_000_000,
+            max_withdrawal_amount: Some(1_000_000_000),
+        };
+        let encoded = ssz::Encode::as_ssz_bytes(&legacy);
+        let decoded = <BridgeParams as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(
+            decoded.max_withdrawal_descriptor_len(),
+            DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN
+        );
     }
 }

--- a/crates/evm-ee/Cargo.toml
+++ b/crates/evm-ee/Cargo.toml
@@ -9,7 +9,6 @@ alpen-ee-da-types.workspace = true
 
 # Strata crates
 strata-acct-types.workspace = true
-strata-bridge-params.workspace = true
 strata-codec.workspace = true
 strata-ee-acct-types.workspace = true
 strata-ee-chain-types.workspace = true

--- a/crates/evm-ee/Cargo.toml
+++ b/crates/evm-ee/Cargo.toml
@@ -9,6 +9,7 @@ alpen-ee-da-types.workspace = true
 
 # Strata crates
 strata-acct-types.workspace = true
+strata-bridge-params.workspace = true
 strata-codec.workspace = true
 strata-ee-acct-types.workspace = true
 strata-ee-chain-types.workspace = true

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -9,7 +9,10 @@ use alloy_consensus::Block as AlloyBlock;
 use alpen_reth_evm::{evm::AlpenEvmFactory, extract_withdrawal_intents};
 use reth_chainspec::ChainSpec;
 use reth_consensus_common::validation::validate_body_against_header;
-use reth_evm::execute::{BasicBlockExecutor, BlockExecutionOutput, Executor};
+use reth_evm::{
+    ConfigureEvm,
+    execute::{BasicBlockExecutor, BlockExecutionOutput, Executor},
+};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_primitives::{
     EthPrimitives, Receipt as EthereumReceipt, RecoveredBlock, TransactionSigned,
@@ -17,7 +20,6 @@ use reth_primitives::{
 use revm::database::WrapDatabaseRef;
 use rsp_client_executor::BlockValidator;
 use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, MsgPayload};
-use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::{
     EnvError, EnvResult, ExecBlock, ExecBlockOutput, ExecPayload, ExecutionEnvironment,
@@ -39,7 +41,6 @@ use crate::{
 pub struct EvmExecutionEnvironment {
     /// EVM configuration with AlpenEvmFactory (contains chain spec)
     evm_config: EthEvmConfig<ChainSpec, AlpenEvmFactory>,
-    bridge_params: BridgeParams,
 }
 
 /// Converts withdrawal intents to messages sent to the bridge gateway account.
@@ -75,12 +76,8 @@ impl EvmExecutionEnvironment {
     /// Creates a new EvmExecutionEnvironment with the given chain specification
     /// and EVM factory.
     pub fn new(chain_spec: Arc<ChainSpec>, evm_factory: AlpenEvmFactory) -> Self {
-        let bridge_params = *evm_factory.bridge_params();
         let evm_config = EthEvmConfig::new_with_evm_factory(chain_spec, evm_factory);
-        Self {
-            evm_config,
-            bridge_params,
-        }
+        Self { evm_config }
     }
 
     fn validate_execution_inputs(
@@ -146,7 +143,7 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
         let withdrawal_intents = extract_withdrawal_intents(
             &transactions,
             &execution_output.receipts,
-            &self.bridge_params,
+            self.evm_config.evm_factory().bridge_params(),
         )
         .map_err(|_| EnvError::InvalidBlock)?;
 

--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -17,6 +17,7 @@ use reth_primitives::{
 use revm::database::WrapDatabaseRef;
 use rsp_client_executor::BlockValidator;
 use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, MsgPayload};
+use strata_bridge_params::BridgeParams;
 use strata_codec::encode_to_vec;
 use strata_ee_acct_types::{
     EnvError, EnvResult, ExecBlock, ExecBlockOutput, ExecPayload, ExecutionEnvironment,
@@ -38,6 +39,7 @@ use crate::{
 pub struct EvmExecutionEnvironment {
     /// EVM configuration with AlpenEvmFactory (contains chain spec)
     evm_config: EthEvmConfig<ChainSpec, AlpenEvmFactory>,
+    bridge_params: BridgeParams,
 }
 
 /// Converts withdrawal intents to messages sent to the bridge gateway account.
@@ -73,8 +75,12 @@ impl EvmExecutionEnvironment {
     /// Creates a new EvmExecutionEnvironment with the given chain specification
     /// and EVM factory.
     pub fn new(chain_spec: Arc<ChainSpec>, evm_factory: AlpenEvmFactory) -> Self {
+        let bridge_params = *evm_factory.bridge_params();
         let evm_config = EthEvmConfig::new_with_evm_factory(chain_spec, evm_factory);
-        Self { evm_config }
+        Self {
+            evm_config,
+            bridge_params,
+        }
     }
 
     fn validate_execution_inputs(
@@ -137,8 +143,12 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
 
         // Step 5: Collect withdrawal intents.
         let transactions = block.into_transactions();
-        let withdrawal_intents =
-            extract_withdrawal_intents(&transactions, &execution_output.receipts).collect();
+        let withdrawal_intents = extract_withdrawal_intents(
+            &transactions,
+            &execution_output.receipts,
+            &self.bridge_params,
+        )
+        .map_err(|_| EnvError::InvalidBlock)?;
 
         // Step 6: Convert execution outcome to HashedPostState.
         let block_number = header_intrinsics.number();

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -2786,7 +2786,7 @@ mod tests {
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
 
         // Create a tx with 5 withdrawal messages (= 5 logs).
-        let withdrawal_dest = b"bc1qlogcapoverflow".to_vec();
+        let withdrawal_dest = make_p2wpkh_bosd_descriptor(0x14);
         let tx = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
             .with_withdrawals(5, 100_000_000, withdrawal_dest)
@@ -2839,7 +2839,7 @@ mod tests {
         let block_context = BlockContext::new(&block_info, Some(&parent_header));
 
         // First tx: 10 withdrawal messages = 10 logs.
-        let withdrawal_dest = b"bc1qlogcapfull".to_vec();
+        let withdrawal_dest = make_p2wpkh_bosd_descriptor(0x15);
         let tx_fill = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
             .with_withdrawals(10, 100_000_000, withdrawal_dest.clone())
@@ -2894,7 +2894,7 @@ mod tests {
 
         let tx = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
-            .with_withdrawal(100_000_000, b"bc1qlogcapreached".to_vec())
+            .with_withdrawal(100_000_000, make_p2wpkh_bosd_descriptor(0x16))
             .build();
         let txid = tx.compute_txid();
 
@@ -2964,9 +2964,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_checkpoint_soft_commits_then_stops() {
-        const CHECKPOINT_WITHDRAWAL_DEST: &[u8] = b"bc1qcheckpointlimit";
         let account_id = test_account_id(9);
-        let withdrawal_dest = CHECKPOINT_WITHDRAWAL_DEST.to_vec();
+        let withdrawal_dest = make_p2wpkh_bosd_descriptor(0x17);
         let tx1 = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
             .with_withdrawal(CHECKPOINT_MSG_VALUE_SATS, withdrawal_dest.clone())
@@ -3013,9 +3012,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_checkpoint_hard_rolls_back_then_stops() {
-        const CHECKPOINT_WITHDRAWAL_DEST: &[u8] = b"bc1qcheckpointlimit";
         let account_id = test_account_id(10);
-        let withdrawal_dest = CHECKPOINT_WITHDRAWAL_DEST.to_vec();
+        let withdrawal_dest = make_p2wpkh_bosd_descriptor(0x18);
         let tx1 = MempoolSnarkTxBuilder::new(account_id)
             .with_seq_no(0)
             .with_withdrawal(CHECKPOINT_MSG_VALUE_SATS, withdrawal_dest.clone())

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -812,6 +812,13 @@ async fn setup_asm_state_with_l1_manifests_list(
 /// Default balance for test accounts (100 billion sats).
 pub(crate) const DEFAULT_ACCOUNT_BALANCE: u64 = 100_000_000_000;
 
+/// Builds a valid P2WPKH BOSD descriptor for withdrawal tests.
+pub(crate) fn make_p2wpkh_bosd_descriptor(byte: u8) -> Vec<u8> {
+    let mut dest_desc = vec![byte; 21];
+    dest_desc[0] = 0x03;
+    dest_desc
+}
+
 /// Typed account setup used by test environment builders.
 #[derive(Clone)]
 pub(crate) struct TestAccount {

--- a/crates/ol/block-assembly/src/tests/effects.rs
+++ b/crates/ol/block-assembly/src/tests/effects.rs
@@ -11,7 +11,7 @@ use crate::{
     test_utils::{
         DEFAULT_ACCOUNT_BALANCE, MempoolSnarkTxBuilder, TestAccount, TestEnv,
         TestStorageFixtureBuilder, account_balance, extract_withdrawal_intents, included_txids,
-        test_account_id,
+        make_p2wpkh_bosd_descriptor, test_account_id,
     },
 };
 
@@ -69,7 +69,7 @@ async fn test_transfer_balances_update() {
 async fn test_withdrawal_log_content() {
     let sender = test_account_id(3);
     let withdrawal_sats = 100_000_000u64;
-    let withdrawal_dest = b"bc1qeffectswithdrawal".to_vec();
+    let withdrawal_dest = make_p2wpkh_bosd_descriptor(0x14);
 
     let env = build_effects_env([TestAccount::new(sender, DEFAULT_ACCOUNT_BALANCE)]).await;
 
@@ -182,7 +182,7 @@ async fn test_hard_limit_rollback_discards_tx2_log() {
     // This tx would emit a bridge-gateway withdrawal log if committed.
     let tx2 = MempoolSnarkTxBuilder::new(account)
         .with_seq_no(1)
-        .with_withdrawal(withdrawal_sats, b"bc1qhardlimitrollback".to_vec())
+        .with_withdrawal(withdrawal_sats, make_p2wpkh_bosd_descriptor(0x15))
         .build();
     let tx2_id = tx2.compute_txid();
 

--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bitcoin-bosd.workspace = true
 ssz_primitives = { workspace = true, optional = true }
 ssz_types = { workspace = true, optional = true }
 strata-acct-types.workspace = true
@@ -23,7 +24,6 @@ strata-ol-params = { workspace = true, optional = true }
 strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
 strata-predicate.workspace = true
-strata-primitives.workspace = true
 strata-snark-acct-sys.workspace = true
 strata-snark-acct-types.workspace = true
 

--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -23,6 +23,7 @@ strata-ol-params = { workspace = true, optional = true }
 strata-ol-state-support-types = { workspace = true, optional = true }
 strata-ol-state-types.workspace = true
 strata-predicate.workspace = true
+strata-primitives.workspace = true
 strata-snark-acct-sys.workspace = true
 strata-snark-acct-types.workspace = true
 

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -7,6 +7,7 @@ use strata_ledger_types::*;
 use strata_msg_fmt::MsgRef;
 use strata_ol_chain_types_new::SimpleWithdrawalIntentLogData;
 use strata_ol_msg_types::OLMessageExt;
+use strata_primitives::bitcoin_bosd::Descriptor;
 use strata_snark_acct_sys as snark_sys;
 use tracing::*;
 
@@ -131,11 +132,30 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
 
     // 2. Validate the withdrawal amount against params.
     let amt_raw: u64 = payload.value().into();
-    let valid = context
-        .bridge_params()
-        .is_some_and(|wp| wp.validate_withdrawal_amount(amt_raw));
-    if !valid {
+    let Some(bridge_params) = context.bridge_params() else {
+        warn!(%sender, %amt_raw, "limboing withdrawal without bridge params sent to bridge gateway acct");
+        handle_misplaced_funds(state, coin)?;
+        return Ok(());
+    };
+
+    if !bridge_params.validate_withdrawal_amount(amt_raw) {
         warn!(%sender, %amt_raw, "limboing bad amount sent to bridge gateway acct");
+        handle_misplaced_funds(state, coin)?;
+        return Ok(());
+    }
+
+    // 3. Validate the withdrawal descriptor against the configured BOSD policy.
+    let dest_desc = withdrawal_data.dest_desc();
+    let dest_desc_len = dest_desc.len();
+    if !bridge_params.validate_withdrawal_descriptor_len(dest_desc_len)
+        || Descriptor::from_bytes(dest_desc).is_err()
+    {
+        warn!(
+            %sender,
+            %amt_raw,
+            dest_desc_len,
+            "limboing bad destination descriptor sent to bridge gateway acct",
+        );
         handle_misplaced_funds(state, coin)?;
         return Ok(());
     }
@@ -143,7 +163,6 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     // 4. If it is, then we can emit a OL log with the amount and destination.
     let selected_operator = withdrawal_data.selected_operator();
     let dest = withdrawal_data.into_dest_desc();
-    let dest_desc_len = dest.len();
     let log_data = SimpleWithdrawalIntentLogData {
         amt: amt_raw,
         selected_operator,

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -1,5 +1,6 @@
 //! Account-specific interaction handling, such as messages.
 
+use bitcoin_bosd::Descriptor;
 use strata_acct_types::{
     AccountId, BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BitcoinAmount, MsgPayload,
 };
@@ -7,7 +8,6 @@ use strata_ledger_types::*;
 use strata_msg_fmt::MsgRef;
 use strata_ol_chain_types_new::SimpleWithdrawalIntentLogData;
 use strata_ol_msg_types::OLMessageExt;
-use strata_primitives::bitcoin_bosd::Descriptor;
 use strata_snark_acct_sys as snark_sys;
 use tracing::*;
 

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -244,6 +244,13 @@ pub fn make_withdrawal_payload(dest_desc: Vec<u8>) -> Vec<u8> {
         .to_vec()
 }
 
+/// Builds a valid P2WPKH BOSD descriptor for withdrawal tests.
+pub fn make_p2wpkh_bosd_descriptor(byte: u8) -> Vec<u8> {
+    let mut dest_desc = vec![byte; 21];
+    dest_desc[0] = 0x03;
+    dest_desc
+}
+
 /// Builds terminal genesis components with one empty manifest at L1 height 1.
 pub fn build_terminal_genesis_components() -> BlockComponents {
     BlockComponents::new_manifests(vec![make_empty_manifest(1, 0)]).as_terminal()

--- a/crates/ol/stf/src/tests/deposit_withdrawal.rs
+++ b/crates/ol/stf/src/tests/deposit_withdrawal.rs
@@ -1,6 +1,7 @@
 //! Deposit-withdraw tests for end-to-end workflows.
 
 use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BitcoinAmount};
+use strata_bridge_params::DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN;
 use strata_identifiers::SubjectId;
 use strata_ledger_types::{ISnarkAccountState, IStateAccessor};
 use strata_msg_fmt::{Msg, OwnedMsg};
@@ -50,7 +51,7 @@ fn test_snark_account_deposit_and_withdrawal() {
     let deposit_msg_proof = inbox_tracker.add_message(&deposit_msg);
 
     let withdrawal_amount = BitcoinAmount::from_sat(100_000_000); // Withdraw exactly 1 BTC.
-    let withdrawal_dest_desc = b"bc1qexample".to_vec();
+    let withdrawal_dest_desc = make_p2wpkh_bosd_descriptor(0x14);
     let withdrawal_payload = make_withdrawal_payload(withdrawal_dest_desc.clone());
 
     let output = fixture
@@ -161,6 +162,87 @@ fn test_bridge_gateway_non_denomination_withdrawal_is_silently_dropped() {
     assert_eq!(
         fixture.account_balance(snark_acct_id),
         BitcoinAmount::from_sat(50_000_000)
+    );
+    assert_eq!(
+        *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
+        1
+    );
+}
+
+#[test]
+fn test_bridge_gateway_oversized_withdrawal_descriptor_is_silently_dropped() {
+    let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
+
+    let mut fixture = OLStfFixture::builder()
+        .with_genesis_snark_account(snark_acct_id, |acct| {
+            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+        })
+        .execute_genesis();
+
+    let mut oversized_descriptor = vec![0u8; DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN as usize + 1];
+    oversized_descriptor[0] = 0x00;
+
+    let limbo_before = fixture.state().limbo_funds();
+    let output = fixture
+        .child_block()
+        .with_sau(snark_acct_id, |sau| {
+            sau.output_message(
+                BRIDGE_GATEWAY_ACCT_ID,
+                BitcoinAmount::from_sat(100_000_000),
+                make_withdrawal_payload(oversized_descriptor),
+            )
+            .with_state_root(make_state_root(2))
+        })
+        .execute_with_outputs();
+
+    assert_no_bridge_gateway_logs(&output);
+    assert_eq!(
+        fixture.state().limbo_funds(),
+        BitcoinAmount::from_sat(limbo_before.to_sat() + 100_000_000),
+        "oversized withdrawal descriptor should sweep value into limbo"
+    );
+    assert_eq!(
+        fixture.account_balance(snark_acct_id),
+        BitcoinAmount::zero()
+    );
+    assert_eq!(
+        *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
+        1
+    );
+}
+
+#[test]
+fn test_bridge_gateway_malformed_withdrawal_descriptor_is_silently_dropped() {
+    let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
+
+    let mut fixture = OLStfFixture::builder()
+        .with_genesis_snark_account(snark_acct_id, |acct| {
+            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+        })
+        .execute_genesis();
+
+    let limbo_before = fixture.state().limbo_funds();
+    let output = fixture
+        .child_block()
+        .with_sau(snark_acct_id, |sau| {
+            sau.output_message(
+                BRIDGE_GATEWAY_ACCT_ID,
+                BitcoinAmount::from_sat(100_000_000),
+                make_withdrawal_payload(vec![0x03, 0x01, 0x02, 0x03]),
+            )
+            .with_state_root(make_state_root(2))
+        })
+        .execute_with_outputs();
+
+    assert_no_bridge_gateway_logs(&output);
+    assert_eq!(
+        fixture.state().limbo_funds(),
+        BitcoinAmount::from_sat(limbo_before.to_sat() + 100_000_000),
+        "malformed withdrawal descriptor should sweep value into limbo"
+    );
+    assert_eq!(
+        fixture.account_balance(snark_acct_id),
+        BitcoinAmount::zero()
     );
     assert_eq!(
         *fixture.expect_snark_account(snark_acct_id).seqno().inner(),

--- a/crates/ol/stf/src/tests/verify_body.rs
+++ b/crates/ol/stf/src/tests/verify_body.rs
@@ -510,7 +510,7 @@ fn with_withdrawal_log_saus<'a>(
                 sau = sau.output_message(
                     BRIDGE_GATEWAY_ACCT_ID,
                     BitcoinAmount::from_sat(WITHDRAWAL_LOG_AMOUNT),
-                    make_withdrawal_payload(b"bc1qlogcap".to_vec()),
+                    make_withdrawal_payload(make_p2wpkh_bosd_descriptor(0x15)),
                 );
             }
             sau.with_state_root(state_root).with_proof(proof)

--- a/crates/proof-impl/evm-ee-stf/Cargo.toml
+++ b/crates/proof-impl/evm-ee-stf/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 alpen-reth-evm.workspace = true
 alpen-reth-primitives.workspace = true
+strata-bridge-params.workspace = true
 strata-ol-bridge-types.workspace = true
 strata-primitives.workspace = true
 strata-state.workspace = true

--- a/crates/proof-impl/evm-ee-stf/src/executor.rs
+++ b/crates/proof-impl/evm-ee-stf/src/executor.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use alloy_consensus::{BlockHeader, EthBlock, Header, TxReceipt};
 use alpen_reth_evm::{evm::AlpenEvmFactory, extract_withdrawal_intents};
 use reth_chainspec::ChainSpec;
-use reth_evm::{
-    execute::{BasicBlockExecutor, BlockExecutionError, ExecutionOutcome, Executor},
-    ConfigureEvm,
-};
+use reth_evm::execute::{BasicBlockExecutor, BlockExecutionError, ExecutionOutcome, Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_primitives::EthPrimitives;
 use reth_primitives_traits::block::Block;
@@ -18,6 +15,7 @@ use rsp_client_executor::{
     io::{EthClientExecutorInput, WitnessInput},
     profile_report, BlockValidator, FromInput,
 };
+use strata_bridge_params::BridgeParams;
 
 use crate::EvmBlockStfOutput;
 
@@ -30,11 +28,15 @@ pub const ACCRUE_LOG_BLOOM: &str = "accrue logs bloom";
 pub const COMPUTE_STATE_ROOT: &str = "compute state root";
 pub const COLLECT_WITHDRAWAL_INTENTS: &str = "collect withdrawal intents";
 
-pub fn process_block(mut input: EthClientExecutorInput) -> Result<EvmBlockStfOutput, ClientError> {
+pub fn process_block(
+    mut input: EthClientExecutorInput,
+    bridge_params: BridgeParams,
+) -> Result<EvmBlockStfOutput, ClientError> {
     let chain_spec: Arc<ChainSpec> = Arc::new((&input.genesis).try_into().unwrap());
-    let evm_config =
-        EthEvmConfig::new_with_evm_factory(chain_spec.clone(), AlpenEvmFactory::default());
-    let bridge_params = *evm_config.evm_factory().bridge_params();
+    let evm_config = EthEvmConfig::new_with_evm_factory(
+        chain_spec.clone(),
+        AlpenEvmFactory::from_bridge_params(&bridge_params),
+    );
 
     let sealed_headers = input.sealed_headers().collect::<Vec<_>>();
 

--- a/crates/proof-impl/evm-ee-stf/src/executor.rs
+++ b/crates/proof-impl/evm-ee-stf/src/executor.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use alloy_consensus::{BlockHeader, EthBlock, Header, TxReceipt};
 use alpen_reth_evm::{evm::AlpenEvmFactory, extract_withdrawal_intents};
 use reth_chainspec::ChainSpec;
-use reth_evm::execute::{BasicBlockExecutor, ExecutionOutcome, Executor};
+use reth_evm::{
+    execute::{BasicBlockExecutor, BlockExecutionError, ExecutionOutcome, Executor},
+    ConfigureEvm,
+};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_primitives::EthPrimitives;
 use reth_primitives_traits::block::Block;
@@ -31,6 +34,7 @@ pub fn process_block(mut input: EthClientExecutorInput) -> Result<EvmBlockStfOut
     let chain_spec: Arc<ChainSpec> = Arc::new((&input.genesis).try_into().unwrap());
     let evm_config =
         EthEvmConfig::new_with_evm_factory(chain_spec.clone(), AlpenEvmFactory::default());
+    let bridge_params = *evm_config.evm_factory().bridge_params();
 
     let sealed_headers = input.sealed_headers().collect::<Vec<_>>();
 
@@ -71,7 +75,8 @@ pub fn process_block(mut input: EthClientExecutorInput) -> Result<EvmBlockStfOut
     // Accumulate withdrawal intents from the executed transactions.
     let withdrawal_intents = profile_report!(COLLECT_WITHDRAWAL_INTENTS, {
         let transactions = block.into_transactions();
-        extract_withdrawal_intents(&transactions, &execution_output.receipts).collect::<Vec<_>>()
+        extract_withdrawal_intents(&transactions, &execution_output.receipts, &bridge_params)
+            .map_err(BlockExecutionError::other)?
     });
 
     // Convert the output to an execution outcome.

--- a/crates/proof-impl/evm-ee-stf/src/lib.rs
+++ b/crates/proof-impl/evm-ee-stf/src/lib.rs
@@ -7,6 +7,7 @@ pub mod utils;
 
 pub use primitives::{EvmBlockStfInput, EvmBlockStfOutput};
 use rsp_client_executor::io::EthClientExecutorInput;
+use strata_bridge_params::BridgeParams;
 use utils::generate_exec_update;
 use zkaleido::{ZkVmEnvBorsh, ZkVmEnvSerde};
 
@@ -17,13 +18,15 @@ use crate::executor::process_block;
 pub fn process_block_transaction_outer(zkvm: &(impl ZkVmEnvBorsh + ZkVmEnvSerde)) {
     let num_blocks: u32 = zkvm.read_serde();
     assert!(num_blocks > 0, "At least one block is required.");
+    let bridge_params: BridgeParams = zkvm.read_serde();
 
     let mut exec_updates = Vec::with_capacity(num_blocks as usize);
     let mut current_blockhash = None;
 
     for _ in 0..num_blocks {
         let input: EthClientExecutorInput = zkvm.read_serde();
-        let output = process_block(input).expect("Failed to process block transaction");
+        let output =
+            process_block(input, bridge_params).expect("Failed to process block transaction");
 
         if let Some(expected_hash) = current_blockhash {
             assert_eq!(output.prev_blockhash, expected_hash, "Block hash mismatch");
@@ -43,7 +46,7 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
 
-    use super::{process_block, EvmBlockStfInput, EvmBlockStfOutput};
+    use super::{process_block, BridgeParams, EvmBlockStfInput, EvmBlockStfOutput};
 
     #[derive(Serialize, Deserialize)]
     struct TestData {
@@ -76,7 +79,8 @@ mod tests {
         let test_data = get_mock_data();
 
         let input = test_data.witness;
-        let op = process_block(input).expect("Failed to process block transaction");
+        let op = process_block(input, BridgeParams::default())
+            .expect("Failed to process block transaction");
         assert_eq!(op, test_data.params);
     }
 }

--- a/crates/proof-impl/evm-ee-stf/src/lib.rs
+++ b/crates/proof-impl/evm-ee-stf/src/lib.rs
@@ -5,7 +5,7 @@ pub mod primitives;
 pub mod program;
 pub mod utils;
 
-pub use primitives::{EvmBlockStfInput, EvmBlockStfOutput};
+pub use primitives::{EvmBlockStfInput, EvmBlockStfOutput, EvmEeProofOutput};
 use rsp_client_executor::io::EthClientExecutorInput;
 use strata_bridge_params::BridgeParams;
 use utils::generate_exec_update;
@@ -36,7 +36,7 @@ pub fn process_block_transaction_outer(zkvm: &(impl ZkVmEnvBorsh + ZkVmEnvSerde)
         exec_updates.push(generate_exec_update(&output));
     }
 
-    zkvm.commit_borsh(&exec_updates);
+    zkvm.commit_borsh(&EvmEeProofOutput::new(bridge_params, exec_updates));
 }
 
 #[cfg(test)]

--- a/crates/proof-impl/evm-ee-stf/src/primitives.rs
+++ b/crates/proof-impl/evm-ee-stf/src/primitives.rs
@@ -4,6 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use revm_primitives::alloy_primitives::FixedBytes;
 use rsp_client_executor::io::EthClientExecutorInput;
 use serde::{Deserialize, Serialize};
+use strata_bridge_params::BridgeParams;
 use strata_state::exec_update::ExecUpdate;
 
 /// Information relating to how to update the execution layer.
@@ -34,7 +35,20 @@ pub type EvmEeProofOutput = Vec<ExecSegment>;
 pub type EvmBlockStfInput = EthClientExecutorInput;
 
 /// Public Parameters that proof asserts
-pub type EvmEeProofInput = Vec<EthClientExecutorInput>;
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EvmEeProofInput {
+    pub bridge_params: BridgeParams,
+    pub block_inputs: Vec<EvmBlockStfInput>,
+}
+
+impl EvmEeProofInput {
+    pub fn new(bridge_params: BridgeParams, block_inputs: Vec<EvmBlockStfInput>) -> Self {
+        Self {
+            bridge_params,
+            block_inputs,
+        }
+    }
+}
 
 /// Result of the block execution
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/proof-impl/evm-ee-stf/src/primitives.rs
+++ b/crates/proof-impl/evm-ee-stf/src/primitives.rs
@@ -28,11 +28,45 @@ impl ExecSegment {
     }
 }
 
+/// Policy-relevant [`BridgeParams`] fields committed by the EVM EE STF proof public statement.
+///
+/// This statement must mirror every bridge parameter field that affects execution policy.
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct BridgeParamsStatement {
+    denomination: u64,
+    max_withdrawal_amount: Option<u64>,
+    max_withdrawal_descriptor_len: u32,
+}
+
+impl BridgeParamsStatement {
+    pub fn from_bridge_params(bridge_params: BridgeParams) -> Self {
+        Self {
+            denomination: bridge_params.denomination(),
+            max_withdrawal_amount: bridge_params.max_withdrawal_amount(),
+            max_withdrawal_descriptor_len: bridge_params.max_withdrawal_descriptor_len(),
+        }
+    }
+
+    pub fn denomination(&self) -> u64 {
+        self.denomination
+    }
+
+    pub fn max_withdrawal_amount(&self) -> Option<u64> {
+        self.max_withdrawal_amount
+    }
+
+    pub fn max_withdrawal_descriptor_len(&self) -> u32 {
+        self.max_withdrawal_descriptor_len
+    }
+}
+
 /// Public statement proven by the EVM EE STF proof.
 #[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct EvmEeProofOutput {
     /// Bridge parameters used while executing the proved blocks.
-    bridge_params: BridgeParams,
+    bridge_params: BridgeParamsStatement,
     /// Execution updates derived from the proved blocks.
     segments: Vec<ExecSegment>,
 }
@@ -40,13 +74,13 @@ pub struct EvmEeProofOutput {
 impl EvmEeProofOutput {
     pub fn new(bridge_params: BridgeParams, segments: Vec<ExecSegment>) -> Self {
         Self {
-            bridge_params,
+            bridge_params: BridgeParamsStatement::from_bridge_params(bridge_params),
             segments,
         }
     }
 
     /// Bridge parameters committed as part of the public proof statement.
-    pub fn bridge_params(&self) -> &BridgeParams {
+    pub fn bridge_params(&self) -> &BridgeParamsStatement {
         &self.bridge_params
     }
 

--- a/crates/proof-impl/evm-ee-stf/src/primitives.rs
+++ b/crates/proof-impl/evm-ee-stf/src/primitives.rs
@@ -28,8 +28,33 @@ impl ExecSegment {
     }
 }
 
-/// Public Parameters that proof asserts
-pub type EvmEeProofOutput = Vec<ExecSegment>;
+/// Public statement proven by the EVM EE STF proof.
+#[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct EvmEeProofOutput {
+    /// Bridge parameters used while executing the proved blocks.
+    bridge_params: BridgeParams,
+    /// Execution updates derived from the proved blocks.
+    segments: Vec<ExecSegment>,
+}
+
+impl EvmEeProofOutput {
+    pub fn new(bridge_params: BridgeParams, segments: Vec<ExecSegment>) -> Self {
+        Self {
+            bridge_params,
+            segments,
+        }
+    }
+
+    /// Bridge parameters committed as part of the public proof statement.
+    pub fn bridge_params(&self) -> &BridgeParams {
+        &self.bridge_params
+    }
+
+    /// Execution segments committed as part of the public proof statement.
+    pub fn segments(&self) -> &[ExecSegment] {
+        &self.segments
+    }
+}
 
 /// Input to the block execution
 pub type EvmBlockStfInput = EthClientExecutorInput;

--- a/crates/proof-impl/evm-ee-stf/src/program.rs
+++ b/crates/proof-impl/evm-ee-stf/src/program.rs
@@ -26,9 +26,10 @@ impl ZkVmProgram for EvmEeProgram {
         B: zkaleido::ZkVmInputBuilder<'a>,
     {
         let mut input_builder = B::new();
-        input_builder.write_serde(&el_inputs.len())?;
+        input_builder.write_serde(&el_inputs.block_inputs.len())?;
+        input_builder.write_serde(&el_inputs.bridge_params)?;
 
-        for el_block_input in el_inputs {
+        for el_block_input in &el_inputs.block_inputs {
             input_builder.write_serde(el_block_input)?;
         }
 

--- a/crates/proof-impl/evm-ee-stf/src/program.rs
+++ b/crates/proof-impl/evm-ee-stf/src/program.rs
@@ -59,3 +59,44 @@ impl EvmEeProgram {
         <Self as ZkVmProgram>::process_output::<NativeHost>(summary.public_values())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::read_to_string, path::PathBuf};
+
+    use rsp_client_executor::io::EthClientExecutorInput;
+    use strata_bridge_params::BridgeParams;
+
+    use super::*;
+    use crate::primitives::EvmEeProofInput;
+
+    fn get_mock_input() -> EthClientExecutorInput {
+        let json_content = read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../test-utils/data/evm_ee/witness_params.json"),
+        )
+        .expect("Failed to read the blob data file");
+
+        #[derive(serde::Deserialize)]
+        struct TestData {
+            witness: EthClientExecutorInput,
+        }
+
+        serde_json::from_str::<TestData>(&json_content)
+            .expect("Valid json")
+            .witness
+    }
+
+    #[test]
+    fn public_output_commits_bridge_params() {
+        let bridge_params =
+            BridgeParams::new_with_descriptor_limit(100_000_000, Some(1_000_000_000), 100)
+                .expect("valid bridge params");
+        let input = EvmEeProofInput::new(bridge_params, vec![get_mock_input()]);
+
+        let output = EvmEeProgram::execute(&input).expect("native execution succeeds");
+
+        assert_eq!(output.bridge_params(), &bridge_params);
+        assert_eq!(output.segments().len(), 1);
+    }
+}

--- a/crates/proof-impl/evm-ee-stf/src/program.rs
+++ b/crates/proof-impl/evm-ee-stf/src/program.rs
@@ -96,7 +96,18 @@ mod tests {
 
         let output = EvmEeProgram::execute(&input).expect("native execution succeeds");
 
-        assert_eq!(output.bridge_params(), &bridge_params);
+        assert_eq!(
+            output.bridge_params().denomination(),
+            bridge_params.denomination()
+        );
+        assert_eq!(
+            output.bridge_params().max_withdrawal_amount(),
+            bridge_params.max_withdrawal_amount()
+        );
+        assert_eq!(
+            output.bridge_params().max_withdrawal_descriptor_len(),
+            bridge_params.max_withdrawal_descriptor_len()
+        );
         assert_eq!(output.segments().len(), 1);
     }
 }

--- a/crates/reth/evm/Cargo.toml
+++ b/crates/reth/evm/Cargo.toml
@@ -20,6 +20,7 @@ reth-evm.workspace = true
 reth-primitives.workspace = true
 revm.workspace = true
 revm-primitives.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 secp256k1.workspace = true

--- a/crates/reth/evm/src/evm.rs
+++ b/crates/reth/evm/src/evm.rs
@@ -11,7 +11,7 @@ use revm::{
     Context, Inspector, MainBuilder, MainContext,
 };
 use revm_primitives::{hardfork::SpecId, U256};
-use strata_bridge_params::BridgeParams;
+use strata_bridge_params::{BridgeParams, DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN};
 
 use crate::{
     apis::AlpenAlloyEvm,
@@ -28,6 +28,8 @@ use crate::{
 pub struct AlpenEvmFactory {
     denomination_wei: U256,
     max_withdrawal_wei: Option<U256>,
+    max_withdrawal_descriptor_len: u32,
+    bridge_params: BridgeParams,
 }
 
 impl Default for AlpenEvmFactory {
@@ -35,6 +37,8 @@ impl Default for AlpenEvmFactory {
         Self {
             denomination_wei: u256_from(WEI_PER_BTC),
             max_withdrawal_wei: Some(u256_from(WEI_PER_BTC * 10)),
+            max_withdrawal_descriptor_len: DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
+            bridge_params: BridgeParams::default(),
         }
     }
 }
@@ -44,7 +48,17 @@ impl AlpenEvmFactory {
         Self {
             denomination_wei,
             max_withdrawal_wei,
+            max_withdrawal_descriptor_len: DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
+            bridge_params: BridgeParams::default(),
         }
+    }
+
+    pub fn max_withdrawal_descriptor_len(&self) -> u32 {
+        self.max_withdrawal_descriptor_len
+    }
+
+    pub fn bridge_params(&self) -> &BridgeParams {
+        &self.bridge_params
     }
 
     /// Creates an [`AlpenEvmFactory`] from [`BridgeParams`] (sats-denominated),
@@ -54,7 +68,12 @@ impl AlpenEvmFactory {
         let max_wei = bp
             .max_withdrawal_amount()
             .map(|m| U256::from(m) * WEI_PER_SAT);
-        Self::new(denom_wei, max_wei)
+        Self {
+            denomination_wei: denom_wei,
+            max_withdrawal_wei: max_wei,
+            max_withdrawal_descriptor_len: bp.max_withdrawal_descriptor_len(),
+            bridge_params: *bp,
+        }
     }
 }
 
@@ -73,6 +92,7 @@ impl EvmFactory for AlpenEvmFactory {
             input.cfg_env.spec,
             self.denomination_wei,
             self.max_withdrawal_wei,
+            self.max_withdrawal_descriptor_len,
         );
 
         let evm = Context::mainnet()

--- a/crates/reth/evm/src/evm.rs
+++ b/crates/reth/evm/src/evm.rs
@@ -11,70 +11,52 @@ use revm::{
     Context, Inspector, MainBuilder, MainContext,
 };
 use revm_primitives::{hardfork::SpecId, U256};
-use strata_bridge_params::{BridgeParams, DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN};
+use strata_bridge_params::BridgeParams;
 
-use crate::{
-    apis::AlpenAlloyEvm,
-    precompiles::factory,
-    utils::{u256_from, WEI_PER_BTC, WEI_PER_SAT},
-};
+use crate::{apis::AlpenAlloyEvm, precompiles::factory, utils::wei_to_sats};
 
 /// Custom EVM configuration.
 ///
-/// Carries withdrawal denomination and optional cap (in wei) for bridge
-/// precompile validation. Use [`AlpenEvmFactory::new`] to construct, or
-/// [`Default`] for the standard 1 BTC denomination / 10 BTC cap.
-#[derive(Debug, Clone)]
+/// Carries bridge withdrawal policy for precompile validation.
+#[derive(Debug, Clone, Default)]
 pub struct AlpenEvmFactory {
-    denomination_wei: U256,
-    max_withdrawal_wei: Option<U256>,
-    max_withdrawal_descriptor_len: u32,
     bridge_params: BridgeParams,
-}
-
-impl Default for AlpenEvmFactory {
-    fn default() -> Self {
-        Self {
-            denomination_wei: u256_from(WEI_PER_BTC),
-            max_withdrawal_wei: Some(u256_from(WEI_PER_BTC * 10)),
-            max_withdrawal_descriptor_len: DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
-            bridge_params: BridgeParams::default(),
-        }
-    }
 }
 
 impl AlpenEvmFactory {
     pub fn new(denomination_wei: U256, max_withdrawal_wei: Option<U256>) -> Self {
+        let denomination = wei_to_sats_exact(denomination_wei, "denomination_wei");
+        let max_withdrawal_amount =
+            max_withdrawal_wei.map(|max| wei_to_sats_exact(max, "max_withdrawal_wei"));
+
         Self {
-            denomination_wei,
-            max_withdrawal_wei,
-            max_withdrawal_descriptor_len: DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN,
-            bridge_params: BridgeParams::default(),
+            bridge_params: BridgeParams::new(denomination, max_withdrawal_amount)
+                .expect("withdrawal policy constructed from wei must be valid"),
         }
     }
 
     pub fn max_withdrawal_descriptor_len(&self) -> u32 {
-        self.max_withdrawal_descriptor_len
+        self.bridge_params.max_withdrawal_descriptor_len()
     }
 
     pub fn bridge_params(&self) -> &BridgeParams {
         &self.bridge_params
     }
 
-    /// Creates an [`AlpenEvmFactory`] from [`BridgeParams`] (sats-denominated),
-    /// converting to wei.
+    /// Creates an [`AlpenEvmFactory`] from [`BridgeParams`].
     pub fn from_bridge_params(bp: &BridgeParams) -> Self {
-        let denom_wei = U256::from(bp.denomination()) * WEI_PER_SAT;
-        let max_wei = bp
-            .max_withdrawal_amount()
-            .map(|m| U256::from(m) * WEI_PER_SAT);
-        Self {
-            denomination_wei: denom_wei,
-            max_withdrawal_wei: max_wei,
-            max_withdrawal_descriptor_len: bp.max_withdrawal_descriptor_len(),
-            bridge_params: *bp,
-        }
+        Self { bridge_params: *bp }
     }
+}
+
+fn wei_to_sats_exact(wei: U256, field: &str) -> u64 {
+    let (sats, remainder) = wei_to_sats(wei);
+    assert!(
+        remainder.is_zero(),
+        "{field} must be an exact number of satoshis"
+    );
+    sats.try_into()
+        .expect("withdrawal policy amount must fit in u64 satoshis")
 }
 
 impl EvmFactory for AlpenEvmFactory {
@@ -88,12 +70,7 @@ impl EvmFactory for AlpenEvmFactory {
     type Precompiles = PrecompilesMap;
 
     fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
-        let precompiles = factory::create_precompiles_map(
-            input.cfg_env.spec,
-            self.denomination_wei,
-            self.max_withdrawal_wei,
-            self.max_withdrawal_descriptor_len,
-        );
+        let precompiles = factory::create_precompiles_map(input.cfg_env.spec, self.bridge_params);
 
         let evm = Context::mainnet()
             .with_db(db)

--- a/crates/reth/evm/src/lib.rs
+++ b/crates/reth/evm/src/lib.rs
@@ -5,7 +5,7 @@ mod utils;
 
 pub use utils::{
     accumulate_logs_bloom, address_to_subject, extract_withdrawal_intents, subject_to_address,
-    subject_to_address_unchecked,
+    subject_to_address_unchecked, WithdrawalIntentExtractionError,
 };
 
 pub mod apis;

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -24,6 +24,7 @@ pub(crate) fn bridge_context_call(
     mut input: PrecompileInput<'_>,
     denomination_wei: U256,
     max_withdrawal_wei: Option<U256>,
+    max_withdrawal_descriptor_len: u32,
 ) -> PrecompileResult {
     if !input.is_direct_call() {
         return Err(PrecompileError::other(
@@ -42,8 +43,8 @@ pub(crate) fn bridge_context_call(
         )
     })?;
 
-    // Validate that this is a valid BOSD
-    validate_bosd(&calldata.bosd)?;
+    // Validate that this is a valid BOSD.
+    validate_bosd(&calldata.bosd, max_withdrawal_descriptor_len)?;
 
     let withdrawal_amount = input.value;
 
@@ -118,8 +119,16 @@ fn validate_withdrawal_amount(
     Ok(())
 }
 
-/// Validates that input is a valid BOSD [`Descriptor`].
-fn validate_bosd(data: &[u8]) -> Result<(), PrecompileError> {
+/// Validates that input is a valid BOSD [`Descriptor`] within the configured limit.
+fn validate_bosd(data: &[u8], max_withdrawal_descriptor_len: u32) -> Result<(), PrecompileError> {
+    if data.len() > max_withdrawal_descriptor_len as usize {
+        return Err(PrecompileError::other(format!(
+            "Invalid BOSD: descriptor length {} exceeds maximum {}",
+            data.len(),
+            max_withdrawal_descriptor_len
+        )));
+    }
+
     Descriptor::from_bytes(data)
         .map_err(|_| PrecompileError::other("Invalid BOSD: expected a valid BOSD descriptor"))?;
     Ok(())
@@ -147,6 +156,7 @@ mod tests {
         buf[0] = 0x03; // P2WPKH type tag
         buf
     };
+    const MAX_DESCRIPTOR_LEN: u32 = 81;
 
     #[test]
     fn test_decode_calldata_empty() {
@@ -371,5 +381,28 @@ mod tests {
             None
         )
         .is_ok());
+    }
+
+    #[test]
+    fn test_validate_bosd_accepts_descriptor_at_limit() {
+        let mut bosd = vec![0u8; MAX_DESCRIPTOR_LEN as usize];
+        bosd[0] = 0x00;
+
+        assert!(validate_bosd(&bosd, MAX_DESCRIPTOR_LEN).is_ok());
+    }
+
+    #[test]
+    fn test_validate_bosd_rejects_oversized_descriptor() {
+        let mut bosd = vec![0u8; MAX_DESCRIPTOR_LEN as usize + 1];
+        bosd[0] = 0x00;
+
+        assert!(validate_bosd(&bosd, MAX_DESCRIPTOR_LEN).is_err());
+    }
+
+    #[test]
+    fn test_validate_bosd_rejects_malformed_descriptor() {
+        let bosd = [0x03, 0x01, 0x02, 0x03];
+
+        assert!(validate_bosd(&bosd, MAX_DESCRIPTOR_LEN).is_err());
     }
 }

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -2,6 +2,7 @@ use alpen_reth_primitives::{WithdrawalCalldata, WithdrawalIntentEvent};
 use reth_evm::precompiles::PrecompileInput;
 use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 use revm_primitives::{Bytes, Log, LogData, U256};
+use strata_bridge_params::BridgeParams;
 use strata_primitives::bitcoin_bosd::Descriptor;
 
 use crate::{constants::BRIDGEOUT_PRECOMPILE_ADDRESS, utils::wei_to_sats};
@@ -22,9 +23,7 @@ const BRIDGEOUT_CALLDATA_BYTE_GAS: u64 = 16;
 /// - Any other value: operator index
 pub(crate) fn bridge_context_call(
     mut input: PrecompileInput<'_>,
-    denomination_wei: U256,
-    max_withdrawal_wei: Option<U256>,
-    max_withdrawal_descriptor_len: u32,
+    bridge_params: BridgeParams,
 ) -> PrecompileResult {
     if !input.is_direct_call() {
         return Err(PrecompileError::other(
@@ -44,18 +43,11 @@ pub(crate) fn bridge_context_call(
     })?;
 
     // Validate that this is a valid BOSD.
-    validate_bosd(&calldata.bosd, max_withdrawal_descriptor_len)?;
+    validate_bosd(&calldata.bosd, &bridge_params)?;
 
-    let withdrawal_amount = input.value;
-
-    // Verify that the transaction value is a positive exact multiple of the withdrawal denomination
-    validate_withdrawal_amount(withdrawal_amount, denomination_wei, max_withdrawal_wei)?;
-
-    // Convert wei to satoshis
-    let (sats, _) = wei_to_sats(withdrawal_amount);
-
-    // Try converting sats (U256) into u64 amount
-    let amount = sats_to_withdrawal_amount(sats)?;
+    // Verify that the transaction value is a positive exact multiple of the withdrawal
+    // denomination.
+    let amount = validate_withdrawal_amount(input.value, &bridge_params)?;
 
     // Log the bridge withdrawal intent
     let evt = WithdrawalIntentEvent {
@@ -97,35 +89,38 @@ fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
         .ok_or_else(|| PrecompileError::Fatal("Bridgeout gas cost overflow".into()))
 }
 
-/// Validates that the withdrawal amount is a positive exact multiple of the denomination
-/// and within the optional cap.
+/// Validates that the withdrawal amount is a positive exact multiple of the denomination and cap.
 fn validate_withdrawal_amount(
-    amount: U256,
-    denomination_wei: U256,
-    max_withdrawal_wei: Option<U256>,
-) -> Result<(), PrecompileError> {
-    if amount.is_zero() || !(amount % denomination_wei).is_zero() {
+    amount_wei: U256,
+    bridge_params: &BridgeParams,
+) -> Result<u64, PrecompileError> {
+    let (amount_sats, remainder_wei) = wei_to_sats(amount_wei);
+    if !remainder_wei.is_zero() {
         return Err(PrecompileError::other(format!(
-            "Invalid withdrawal value: must be a positive exact multiple of {denomination_wei} wei",
+            "Invalid withdrawal value {amount_wei}: must be an exact number of satoshis",
         )));
     }
-    if let Some(max) = max_withdrawal_wei {
-        if amount > max {
-            return Err(PrecompileError::other(format!(
-                "Withdrawal value {amount} exceeds maximum allowed {max} wei",
-            )));
-        }
+
+    let amount_sats = sats_to_withdrawal_amount(amount_sats)?;
+
+    if !bridge_params.validate_withdrawal_amount(amount_sats) {
+        return Err(PrecompileError::other(format!(
+            "Invalid withdrawal value: {amount_sats} sats must be a positive exact multiple of {} sats and within {:?} sats",
+            bridge_params.denomination(),
+            bridge_params.max_withdrawal_amount()
+        )));
     }
-    Ok(())
+
+    Ok(amount_sats)
 }
 
 /// Validates that input is a valid BOSD [`Descriptor`] within the configured limit.
-fn validate_bosd(data: &[u8], max_withdrawal_descriptor_len: u32) -> Result<(), PrecompileError> {
-    if data.len() > max_withdrawal_descriptor_len as usize {
+fn validate_bosd(data: &[u8], bridge_params: &BridgeParams) -> Result<(), PrecompileError> {
+    if !bridge_params.validate_withdrawal_descriptor_len(data.len()) {
         return Err(PrecompileError::other(format!(
             "Invalid BOSD: descriptor length {} exceeds maximum {}",
             data.len(),
-            max_withdrawal_descriptor_len
+            bridge_params.max_withdrawal_descriptor_len()
         )));
     }
 
@@ -254,8 +249,12 @@ mod tests {
 
     // --- withdrawal amount validation tests ---
 
-    fn max_withdrawal() -> Option<U256> {
-        Some(FIXED_WITHDRAWAL_WEI * U256::from(10))
+    fn bridge_params() -> BridgeParams {
+        BridgeParams::default()
+    }
+
+    fn bridge_params_without_cap() -> BridgeParams {
+        BridgeParams::new(100_000_000, None).unwrap()
     }
 
     fn valid_bridgeout_calldata() -> Vec<u8> {
@@ -280,7 +279,7 @@ mod tests {
             internals: EvmInternals::new(&mut journal, &block_env),
         };
 
-        let error = bridge_context_call(input, FIXED_WITHDRAWAL_WEI, max_withdrawal()).unwrap_err();
+        let error = bridge_context_call(input, bridge_params()).unwrap_err();
 
         assert_eq!(
             error,
@@ -303,84 +302,75 @@ mod tests {
             internals: EvmInternals::new(&mut journal, &block_env),
         };
 
-        assert!(bridge_context_call(input, FIXED_WITHDRAWAL_WEI, max_withdrawal()).is_ok());
+        assert!(bridge_context_call(input, bridge_params()).is_ok());
     }
 
     #[test]
     fn test_validate_withdrawal_exact_denomination() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI,
-            FIXED_WITHDRAWAL_WEI,
-            max_withdrawal()
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_validate_withdrawal_exact_multiple() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI * U256::from(3),
-            FIXED_WITHDRAWAL_WEI,
-            max_withdrawal()
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_validate_withdrawal_zero_rejected() {
-        assert!(
-            validate_withdrawal_amount(U256::ZERO, FIXED_WITHDRAWAL_WEI, max_withdrawal()).is_err()
+        assert_eq!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI, &bridge_params()).unwrap(),
+            100_000_000
         );
     }
 
     #[test]
+    fn test_validate_withdrawal_exact_multiple() {
+        assert_eq!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI * U256::from(3), &bridge_params())
+                .unwrap(),
+            300_000_000
+        );
+    }
+
+    #[test]
+    fn test_validate_withdrawal_zero_rejected() {
+        assert!(validate_withdrawal_amount(U256::ZERO, &bridge_params()).is_err());
+    }
+
+    #[test]
     fn test_validate_withdrawal_non_multiple_rejected() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI + U256::from(1),
-            FIXED_WITHDRAWAL_WEI,
-            max_withdrawal()
-        )
-        .is_err());
+        assert!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI + U256::from(1), &bridge_params())
+                .is_err()
+        );
     }
 
     #[test]
     fn test_validate_withdrawal_below_denomination_rejected() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI - U256::from(1),
-            FIXED_WITHDRAWAL_WEI,
-            max_withdrawal()
-        )
-        .is_err());
+        assert!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI - U256::from(1), &bridge_params())
+                .is_err()
+        );
     }
 
     #[test]
     fn test_validate_withdrawal_exceeds_cap() {
         assert!(validate_withdrawal_amount(
             FIXED_WITHDRAWAL_WEI * U256::from(11),
-            FIXED_WITHDRAWAL_WEI,
-            max_withdrawal()
+            &bridge_params()
         )
         .is_err());
     }
 
     #[test]
     fn test_validate_withdrawal_at_cap() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI * U256::from(10),
-            FIXED_WITHDRAWAL_WEI,
-            max_withdrawal()
-        )
-        .is_ok());
+        assert_eq!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI * U256::from(10), &bridge_params())
+                .unwrap(),
+            1_000_000_000
+        );
     }
 
     #[test]
     fn test_validate_withdrawal_no_cap() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI * U256::from(100),
-            FIXED_WITHDRAWAL_WEI,
-            None
-        )
-        .is_ok());
+        assert_eq!(
+            validate_withdrawal_amount(
+                FIXED_WITHDRAWAL_WEI * U256::from(100),
+                &bridge_params_without_cap()
+            )
+            .unwrap(),
+            10_000_000_000
+        );
     }
 
     #[test]
@@ -388,7 +378,7 @@ mod tests {
         let mut bosd = vec![0u8; MAX_DESCRIPTOR_LEN as usize];
         bosd[0] = 0x00;
 
-        assert!(validate_bosd(&bosd, MAX_DESCRIPTOR_LEN).is_ok());
+        assert!(validate_bosd(&bosd, &bridge_params()).is_ok());
     }
 
     #[test]
@@ -396,13 +386,13 @@ mod tests {
         let mut bosd = vec![0u8; MAX_DESCRIPTOR_LEN as usize + 1];
         bosd[0] = 0x00;
 
-        assert!(validate_bosd(&bosd, MAX_DESCRIPTOR_LEN).is_err());
+        assert!(validate_bosd(&bosd, &bridge_params()).is_err());
     }
 
     #[test]
     fn test_validate_bosd_rejects_malformed_descriptor() {
         let bosd = [0x03, 0x01, 0x02, 0x03];
 
-        assert!(validate_bosd(&bosd, MAX_DESCRIPTOR_LEN).is_err());
+        assert!(validate_bosd(&bosd, &bridge_params()).is_err());
     }
 }

--- a/crates/reth/evm/src/precompiles/factory.rs
+++ b/crates/reth/evm/src/precompiles/factory.rs
@@ -12,6 +12,7 @@ pub fn create_precompiles_map(
     spec: SpecId,
     denomination_wei: U256,
     max_withdrawal_wei: Option<U256>,
+    max_withdrawal_descriptor_len: u32,
 ) -> PrecompilesMap {
     let mut precompiles = PrecompilesMap::from_static(AlpenEvmPrecompiles::new(spec).precompiles());
 
@@ -20,7 +21,14 @@ pub fn create_precompiles_map(
     precompiles.apply_precompile(&BRIDGEOUT_PRECOMPILE_ADDRESS, |_| {
         Some(DynPrecompile::new_stateful(
             PrecompileId::custom(BRIDGEOUT_PRECOMPILE_ID),
-            move |input| bridge_context_call(input, denomination_wei, max_withdrawal_wei),
+            move |input| {
+                bridge_context_call(
+                    input,
+                    denomination_wei,
+                    max_withdrawal_wei,
+                    max_withdrawal_descriptor_len,
+                )
+            },
         ))
     });
 

--- a/crates/reth/evm/src/precompiles/factory.rs
+++ b/crates/reth/evm/src/precompiles/factory.rs
@@ -1,6 +1,7 @@
 use reth_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use revm::precompile::PrecompileId;
-use revm_primitives::{hardfork::SpecId, U256};
+use revm_primitives::hardfork::SpecId;
+use strata_bridge_params::BridgeParams;
 
 use crate::{
     constants::{BRIDGEOUT_PRECOMPILE_ADDRESS, BRIDGEOUT_PRECOMPILE_ID},
@@ -8,12 +9,7 @@ use crate::{
 };
 
 /// Creates a precompiles map with Alpen-specific precompiles, including the bridge precompile.
-pub fn create_precompiles_map(
-    spec: SpecId,
-    denomination_wei: U256,
-    max_withdrawal_wei: Option<U256>,
-    max_withdrawal_descriptor_len: u32,
-) -> PrecompilesMap {
+pub fn create_precompiles_map(spec: SpecId, bridge_params: BridgeParams) -> PrecompilesMap {
     let mut precompiles = PrecompilesMap::from_static(AlpenEvmPrecompiles::new(spec).precompiles());
 
     // Add bridge precompile using DynPrecompile for compatibility.
@@ -21,14 +17,7 @@ pub fn create_precompiles_map(
     precompiles.apply_precompile(&BRIDGEOUT_PRECOMPILE_ADDRESS, |_| {
         Some(DynPrecompile::new_stateful(
             PrecompileId::custom(BRIDGEOUT_PRECOMPILE_ID),
-            move |input| {
-                bridge_context_call(
-                    input,
-                    denomination_wei,
-                    max_withdrawal_wei,
-                    max_withdrawal_descriptor_len,
-                )
-            },
+            move |input| bridge_context_call(input, bridge_params),
         ))
     });
 

--- a/crates/reth/evm/src/utils.rs
+++ b/crates/reth/evm/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, mem::size_of};
+use std::mem::size_of;
 
 use alloy_consensus::TxReceipt;
 use alloy_sol_types::SolEvent;
@@ -9,6 +9,7 @@ use strata_bridge_params::BridgeParams;
 use strata_identifiers::{SubjectId, SubjectIdBytes, SUBJ_ID_LEN};
 use strata_ol_bridge_types::OperatorSelection;
 use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32};
+use thiserror::Error;
 
 use crate::constants::BRIDGEOUT_PRECOMPILE_ADDRESS;
 
@@ -29,34 +30,15 @@ pub(crate) fn wei_to_sats(wei: U256) -> (U256, U256) {
 }
 
 /// Error returned when a bridge-out log cannot be decoded into a valid withdrawal intent.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum WithdrawalIntentExtractionError {
+    #[error("failed to decode withdrawal intent event for tx {txid:?}")]
     EventDecode { txid: Buf32 },
+    #[error("withdrawal descriptor length {len} exceeds maximum {max} for tx {txid:?}")]
     InvalidDescriptorLength { txid: Buf32, len: usize, max: u32 },
+    #[error("failed to decode withdrawal descriptor for tx {txid:?}")]
     DescriptorDecode { txid: Buf32 },
 }
-
-impl fmt::Display for WithdrawalIntentExtractionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EventDecode { txid } => {
-                write!(
-                    f,
-                    "failed to decode withdrawal intent event for tx {txid:?}"
-                )
-            }
-            Self::InvalidDescriptorLength { txid, len, max } => write!(
-                f,
-                "withdrawal descriptor length {len} exceeds maximum {max} for tx {txid:?}"
-            ),
-            Self::DescriptorDecode { txid } => {
-                write!(f, "failed to decode withdrawal descriptor for tx {txid:?}")
-            }
-        }
-    }
-}
-
-impl Error for WithdrawalIntentExtractionError {}
 
 /// Extracts withdrawal intents from bridge-out events in transaction receipts.
 /// Returns an error if a log emitted by the bridge-out precompile is malformed.

--- a/crates/reth/evm/src/utils.rs
+++ b/crates/reth/evm/src/utils.rs
@@ -18,6 +18,7 @@ pub(crate) const fn u256_from(val: u128) -> U256 {
 }
 
 /// Number of wei per rollup BTC (1e18).
+#[cfg(test)]
 pub(crate) const WEI_PER_BTC: u128 = 1_000_000_000_000_000_000u128;
 
 /// Number of wei per satoshi (1e10).

--- a/crates/reth/evm/src/utils.rs
+++ b/crates/reth/evm/src/utils.rs
@@ -1,13 +1,14 @@
-use std::mem::size_of;
+use std::{error::Error, fmt, mem::size_of};
 
 use alloy_consensus::TxReceipt;
 use alloy_sol_types::SolEvent;
 use alpen_reth_primitives::{WithdrawalIntent, WithdrawalIntentEvent};
 use reth_primitives::{Receipt, TransactionSigned};
-use revm_primitives::{alloy_primitives::Bloom, Address, U256};
+use revm_primitives::{alloy_primitives::Bloom, Address, Log, U256};
+use strata_bridge_params::BridgeParams;
 use strata_identifiers::{SubjectId, SubjectIdBytes, SUBJ_ID_LEN};
 use strata_ol_bridge_types::OperatorSelection;
-use strata_primitives::bitcoin_bosd::Descriptor;
+use strata_primitives::{bitcoin_bosd::Descriptor, buf::Buf32};
 
 use crate::constants::BRIDGEOUT_PRECOMPILE_ADDRESS;
 
@@ -27,45 +28,96 @@ pub(crate) fn wei_to_sats(wei: U256) -> (U256, U256) {
     wei.div_rem(WEI_PER_SAT)
 }
 
+/// Error returned when a bridge-out log cannot be decoded into a valid withdrawal intent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WithdrawalIntentExtractionError {
+    EventDecode { txid: Buf32 },
+    InvalidDescriptorLength { txid: Buf32, len: usize, max: u32 },
+    DescriptorDecode { txid: Buf32 },
+}
+
+impl fmt::Display for WithdrawalIntentExtractionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EventDecode { txid } => {
+                write!(
+                    f,
+                    "failed to decode withdrawal intent event for tx {txid:?}"
+                )
+            }
+            Self::InvalidDescriptorLength { txid, len, max } => write!(
+                f,
+                "withdrawal descriptor length {len} exceeds maximum {max} for tx {txid:?}"
+            ),
+            Self::DescriptorDecode { txid } => {
+                write!(f, "failed to decode withdrawal descriptor for tx {txid:?}")
+            }
+        }
+    }
+}
+
+impl Error for WithdrawalIntentExtractionError {}
+
 /// Extracts withdrawal intents from bridge-out events in transaction receipts.
-/// Returns an iterator of [`WithdrawalIntent`]s.
-///
-/// # Note
-///
-/// A [`Descriptor`], if invalid does not create a [`WithdrawalIntent`].
+/// Returns an error if a log emitted by the bridge-out precompile is malformed.
 ///
 /// # Panics
 ///
 /// Panics if the number of transactions does not match the number of receipts.
-pub fn extract_withdrawal_intents<'a>(
-    transactions: &'a [TransactionSigned],
-    receipts: &'a [Receipt],
-) -> impl Iterator<Item = WithdrawalIntent> + 'a {
+pub fn extract_withdrawal_intents(
+    transactions: &[TransactionSigned],
+    receipts: &[Receipt],
+    bridge_params: &BridgeParams,
+) -> Result<Vec<WithdrawalIntent>, WithdrawalIntentExtractionError> {
     assert_eq!(
         transactions.len(),
         receipts.len(),
         "transactions and receipts must have the same length"
     );
 
-    transactions
-        .iter()
-        .zip(receipts.iter())
-        .flat_map(|(_tx, receipt)| {
-            receipt.logs.iter().filter_map(move |log| {
-                if log.address != BRIDGEOUT_PRECOMPILE_ADDRESS {
-                    return None;
-                }
+    let mut intents = Vec::new();
 
-                let event = WithdrawalIntentEvent::decode_log(log).ok()?;
-                let destination = Descriptor::from_bytes(&event.destination).ok()?;
+    for (tx, receipt) in transactions.iter().zip(receipts.iter()) {
+        let txid = Buf32((*tx.hash()).into());
+        for log in &receipt.logs {
+            if let Some(intent) = extract_withdrawal_intent_from_log(txid, log, bridge_params)? {
+                intents.push(intent);
+            }
+        }
+    }
 
-                Some(WithdrawalIntent {
-                    amt: event.amount,
-                    destination,
-                    selected_operator: OperatorSelection::from_raw(event.selectedOperator),
-                })
-            })
-        })
+    Ok(intents)
+}
+
+fn extract_withdrawal_intent_from_log(
+    txid: Buf32,
+    log: &Log,
+    bridge_params: &BridgeParams,
+) -> Result<Option<WithdrawalIntent>, WithdrawalIntentExtractionError> {
+    if log.address != BRIDGEOUT_PRECOMPILE_ADDRESS {
+        return Ok(None);
+    }
+
+    let event = WithdrawalIntentEvent::decode_log(log)
+        .map_err(|_| WithdrawalIntentExtractionError::EventDecode { txid })?;
+
+    let descriptor_len = event.destination.len();
+    if !bridge_params.validate_withdrawal_descriptor_len(descriptor_len) {
+        return Err(WithdrawalIntentExtractionError::InvalidDescriptorLength {
+            txid,
+            len: descriptor_len,
+            max: bridge_params.max_withdrawal_descriptor_len(),
+        });
+    }
+
+    let destination = Descriptor::from_bytes(&event.destination)
+        .map_err(|_| WithdrawalIntentExtractionError::DescriptorDecode { txid })?;
+
+    Ok(Some(WithdrawalIntent {
+        amt: event.amount,
+        destination,
+        selected_operator: OperatorSelection::from_raw(event.selectedOperator),
+    }))
 }
 
 /// Accumulates logs bloom from all receipts in the execution output.
@@ -131,7 +183,10 @@ pub fn address_to_subject(address: Address) -> SubjectId {
 
 #[cfg(test)]
 mod tests {
+    use alpen_reth_primitives::WithdrawalIntentEvent;
     use proptest::prelude::*;
+    use revm_primitives::{Bytes, LogData};
+    use strata_bridge_params::DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN;
 
     use super::*;
 
@@ -169,5 +224,92 @@ mod tests {
         let subject = address_to_subject(address);
         let recovered = subject_to_address(&subject).expect("should convert");
         assert_eq!(address, recovered);
+    }
+
+    fn test_txid() -> Buf32 {
+        Buf32([7u8; 32])
+    }
+
+    fn bridgeout_log(destination: Vec<u8>) -> Log {
+        let event = WithdrawalIntentEvent {
+            amount: 100,
+            destination: Bytes::from(destination),
+            selectedOperator: u32::MAX,
+        };
+        Log {
+            address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            data: LogData::from(&event),
+        }
+    }
+
+    #[test]
+    fn test_extract_withdrawal_intent_from_valid_bridgeout_log() {
+        let mut bosd = vec![0u8; DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN as usize];
+        bosd[0] = 0x00;
+        let log = bridgeout_log(bosd);
+
+        let intent =
+            extract_withdrawal_intent_from_log(test_txid(), &log, &BridgeParams::default())
+                .unwrap()
+                .expect("bridgeout log should produce intent");
+
+        assert_eq!(intent.amt, 100);
+        assert_eq!(intent.selected_operator, OperatorSelection::any());
+    }
+
+    #[test]
+    fn test_extract_withdrawal_intent_ignores_other_addresses() {
+        let mut log = bridgeout_log(vec![0x03; 21]);
+        log.address = Address::ZERO;
+
+        assert!(
+            extract_withdrawal_intent_from_log(test_txid(), &log, &BridgeParams::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_extract_withdrawal_intent_fails_on_bad_event_log() {
+        let log = Log {
+            address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            data: LogData::empty(),
+        };
+
+        let err = extract_withdrawal_intent_from_log(test_txid(), &log, &BridgeParams::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WithdrawalIntentExtractionError::EventDecode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_extract_withdrawal_intent_fails_on_oversized_descriptor() {
+        let mut bosd = vec![0u8; DEFAULT_MAX_WITHDRAWAL_DESCRIPTOR_LEN as usize + 1];
+        bosd[0] = 0x00;
+        let log = bridgeout_log(bosd);
+
+        let err = extract_withdrawal_intent_from_log(test_txid(), &log, &BridgeParams::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WithdrawalIntentExtractionError::InvalidDescriptorLength { .. }
+        ));
+    }
+
+    #[test]
+    fn test_extract_withdrawal_intent_fails_on_malformed_descriptor() {
+        let log = bridgeout_log(vec![0x03, 0x01, 0x02, 0x03]);
+
+        let err = extract_withdrawal_intent_from_log(test_txid(), &log, &BridgeParams::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WithdrawalIntentExtractionError::DescriptorDecode { .. }
+        ));
     }
 }

--- a/crates/reth/node/src/payload_builder.rs
+++ b/crates/reth/node/src/payload_builder.rs
@@ -341,7 +341,8 @@ where
     let receipts: Vec<Receipt> = execution_result.receipts;
     let txns: Vec<TransactionSigned> = block.body().transactions().cloned().collect();
     let withdrawal_intents: Vec<WithdrawalIntent> =
-        extract_withdrawal_intents(&txns, &receipts).collect();
+        extract_withdrawal_intents(&txns, &receipts, evm_config.evm_factory().bridge_params())
+            .map_err(PayloadBuilderError::other)?;
 
     let strata_payload =
         AlpenBuiltPayload::new(eth_payload, withdrawal_intents).with_block_witness(block_witness);


### PR DESCRIPTION
## Description

Restricts withdrawal BOSD descriptors to a configurable maximum length, defaulting to 81 bytes including the type tag, and makes bridge-out withdrawal decoding fail closed. This makes possible to have 80-byte `OP_RETURN` withdrawal destinations.

This validates withdrawal descriptors at the EVM precompile boundary, when extracting bridge-out logs, and when OL processes bridge-gateway withdrawal messages. Malformed or oversized bridge-out logs now invalidate payload/execution processing instead of being silently dropped.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Commits are split by review area:

1. `BridgeParams` descriptor limit API/defaults.
2. Reth precompile and fail-closed withdrawal extraction.
3. OL bridge-gateway descriptor validation.
4. CLI/node config surfaces.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This PR was implemented with AI assistance.

## Related Issues

STR-3238