### PR TITLE
feat(rpc): add checkpoint epoch to block status response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
  "jsonrpsee",
  "reth-node-builder",
  "reth-provider",
+ "strata-identifiers",
  "tokio",
 ]
 
@@ -1413,6 +1414,8 @@ version = "0.3.0-alpha.1"
 dependencies = [
  "schemars 1.2.1",
  "serde",
+ "serde_json",
+ "strata-identifiers",
 ]
 
 [[package]]

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -443,8 +443,12 @@ fn main() {
                 let storage = storage.clone();
                 move |ctx| {
                     let provider = ctx.provider().clone();
-                    let ee_rpc_server =
-                        EeRpcServer::new(provider, consensus_watcher, storage.clone());
+                    let ee_rpc_server = EeRpcServer::new(
+                        provider,
+                        consensus_watcher,
+                        storage.clone(),
+                        storage.clone(),
+                    );
                     ctx.modules.merge_configured(ee_rpc_server.into_rpc())?;
                     Ok(())
                 }

--- a/crates/alpen-ee/rpc/server/Cargo.toml
+++ b/crates/alpen-ee/rpc/server/Cargo.toml
@@ -15,4 +15,5 @@ async-trait.workspace = true
 jsonrpsee = { workspace = true, features = ["server"] }
 reth-node-builder.workspace = true
 reth-provider.workspace = true
+strata-identifiers.workspace = true
 tokio.workspace = true

--- a/crates/alpen-ee/rpc/server/src/block_status.rs
+++ b/crates/alpen-ee/rpc/server/src/block_status.rs
@@ -1,9 +1,9 @@
 //! Alpen EE RPC handler implementation.
 
-use std::{fmt, sync::Arc};
+use std::{fmt, future::Future, sync::Arc};
 
 use alloy_primitives::B256;
-use alpen_ee_common::{ChunkStatus, ChunkStorage, ConsensusHeads};
+use alpen_ee_common::{ChunkStatus, ChunkStorage, ConsensusHeads, OLBlockOrEpoch, Storage};
 use alpen_ee_rpc_api::{
     AlpenEeRpcServer, BlockStatus, BlockStatusResponse, ChunkProofCoverageResponse,
 };
@@ -14,6 +14,7 @@ use reth_provider::{
     providers::{BlockchainProvider, ProviderNodeTypes},
     BlockHashReader, BlockNumReader, ProviderResult,
 };
+use strata_identifiers::Epoch;
 use tokio::sync::watch;
 
 use crate::errors::{block_not_found_error, internal_error, invalid_params_error};
@@ -23,7 +24,7 @@ use crate::errors::{block_not_found_error, internal_error, invalid_params_error}
 /// Returns `Ok(Some(n))` only when `block_hash` is the canonical hash at
 /// height `n`. A hash that is known to the provider but belongs to an
 /// orphaned / non-canonical branch returns `Ok(None)`.
-fn canonical_block_number<N: NodeTypesWithDB + ProviderNodeTypes>(
+fn fetch_canonical_block_number<N: NodeTypesWithDB + ProviderNodeTypes>(
     provider: &BlockchainProvider<N>,
     block_hash: B256,
 ) -> ProviderResult<Option<u64>> {
@@ -44,11 +45,76 @@ fn hash_to_b256(hash: &[u8]) -> B256 {
     B256::from_slice(hash)
 }
 
+/// Canonical EE block number of the last block included in `epoch`'s checkpoint.
+///
+/// Returns an error when the epoch's account state is missing (e.g. pruned) or
+/// when its last included block is not canonical on this node.
+async fn fetch_epoch_last_alpen_block_number<N: NodeTypesWithDB + ProviderNodeTypes>(
+    storage: &Arc<dyn Storage>,
+    provider: &BlockchainProvider<N>,
+    epoch: Epoch,
+) -> RpcResult<u64> {
+    let state = storage
+        .ee_account_state(OLBlockOrEpoch::Epoch(epoch))
+        .await
+        .map_err(|e| internal_error(e.to_string()))?
+        .ok_or_else(|| internal_error(format!("missing EE account state for epoch {epoch}")))?;
+
+    let last_blkid = state.last_exec_blkid();
+    let last_hash = hash_to_b256(last_blkid.as_slice());
+    match fetch_canonical_block_number(provider, last_hash) {
+        Ok(Some(n)) => Ok(n),
+        Ok(None) => Err(internal_error(format!(
+            "last block of epoch {epoch} is not canonical"
+        ))),
+        Err(e) => Err(internal_error(e.to_string())),
+    }
+}
+
+/// Binary search for the smallest epoch in `[0, frontier_epoch]` whose last
+/// included EE block height is at or beyond `target_num`.
+///
+/// `epoch_last_num` maps an epoch to the canonical EE block height of the last
+/// block included in that epoch's checkpoint. The mapping is assumed
+/// monotonically non-decreasing, which holds because each successive checkpoint
+/// extends the canonical EE chain. The frontier epoch must cover `target_num`;
+/// otherwise there is no containing epoch in the search range.
+async fn search_containing_epoch<F, Fut>(
+    frontier_epoch: Epoch,
+    target_num: u64,
+    epoch_last_num: F,
+) -> RpcResult<Epoch>
+where
+    F: Fn(Epoch) -> Fut,
+    Fut: Future<Output = RpcResult<u64>>,
+{
+    let frontier_last_num = epoch_last_num(frontier_epoch).await?;
+    if frontier_last_num < target_num {
+        return Err(internal_error(format!(
+            "frontier epoch {frontier_epoch} only covers through block {frontier_last_num}, \
+             below target block {target_num}"
+        )));
+    }
+
+    let mut lo: Epoch = 0;
+    let mut hi: Epoch = frontier_epoch;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if epoch_last_num(mid).await? >= target_num {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    Ok(lo)
+}
+
 /// RPC handler for [`AlpenEeRpcServer`].
 pub struct EeRpcServer<N: NodeTypesWithDB + ProviderNodeTypes> {
     provider: BlockchainProvider<N>,
     consensus_rx: watch::Receiver<ConsensusHeads>,
     chunk_storage: Arc<dyn ChunkStorage>,
+    account_storage: Arc<dyn Storage>,
 }
 
 impl<N: NodeTypesWithDB + ProviderNodeTypes> fmt::Debug for EeRpcServer<N> {
@@ -62,12 +128,35 @@ impl<N: NodeTypesWithDB + ProviderNodeTypes> EeRpcServer<N> {
         provider: BlockchainProvider<N>,
         consensus_rx: watch::Receiver<ConsensusHeads>,
         chunk_storage: Arc<dyn ChunkStorage>,
+        account_storage: Arc<dyn Storage>,
     ) -> Self {
         Self {
             provider,
             consensus_rx,
             chunk_storage,
+            account_storage,
         }
+    }
+
+    /// Resolves the OL checkpoint epoch that contains the canonical EE block at
+    /// `target_num`, searching epochs in `[0, frontier_epoch]`.
+    ///
+    /// The OL tracker records, for each epoch, the last EE block included in that
+    /// epoch's checkpoint. That last-block height is monotonically non-decreasing
+    /// in the epoch number, so a binary search finds the smallest epoch whose last
+    /// included block is at or beyond `target_num` — i.e. the epoch that contains
+    /// the block. `frontier_epoch` is the confirmed or finalized frontier already
+    /// verified to cover `target_num`, so its last included block is at or beyond
+    /// `target_num` and the search is well defined.
+    async fn containing_epoch(&self, target_num: u64, frontier_epoch: Epoch) -> RpcResult<Epoch> {
+        let storage = self.account_storage.clone();
+        let provider = self.provider.clone();
+        search_containing_epoch(frontier_epoch, target_num, move |epoch| {
+            let storage = storage.clone();
+            let provider = provider.clone();
+            async move { fetch_epoch_last_alpen_block_number(&storage, &provider, epoch).await }
+        })
+        .await
     }
 }
 
@@ -80,16 +169,18 @@ where
         // Resolve target to a canonical block number. `block_number` alone
         // does not distinguish canonical blocks from orphaned ones stored in
         // the DB, so round-trip through `block_hash(number)` to verify.
-        let target_num = match canonical_block_number(&self.provider, block_hash) {
+        let target_num = match fetch_canonical_block_number(&self.provider, block_hash) {
             Ok(Some(n)) => n,
             Ok(None) => return Err(block_not_found_error()),
             Err(e) => return Err(internal_error(e.to_string())),
         };
 
-        // Preserve genesis semantics: block 0 is always considered finalized.
+        // Preserve genesis semantics: block 0 is always considered finalized
+        // and belongs to the genesis epoch.
         if target_num == 0 {
             return Ok(BlockStatusResponse {
                 status: BlockStatus::Finalized,
+                checkpoint_epoch: Some(0),
             });
         }
 
@@ -100,10 +191,14 @@ where
         // tracking a fork that Reth hasn't reorged to).
         let finalized_b256 = hash_to_b256(heads.finalized().as_slice());
         if !finalized_b256.is_zero() {
-            match canonical_block_number(&self.provider, finalized_b256) {
+            match fetch_canonical_block_number(&self.provider, finalized_b256) {
                 Ok(Some(fin_num)) if target_num <= fin_num => {
+                    let epoch = self
+                        .containing_epoch(target_num, heads.finalized_epoch())
+                        .await?;
                     return Ok(BlockStatusResponse {
                         status: BlockStatus::Finalized,
+                        checkpoint_epoch: Some(epoch),
                     });
                 }
                 Ok(_) => {}
@@ -114,10 +209,14 @@ where
         // Confirmed check.
         let confirmed_b256 = hash_to_b256(heads.confirmed().as_slice());
         if !confirmed_b256.is_zero() {
-            match canonical_block_number(&self.provider, confirmed_b256) {
+            match fetch_canonical_block_number(&self.provider, confirmed_b256) {
                 Ok(Some(conf_num)) if target_num <= conf_num => {
+                    let epoch = self
+                        .containing_epoch(target_num, heads.confirmed_epoch())
+                        .await?;
                     return Ok(BlockStatusResponse {
                         status: BlockStatus::Confirmed,
+                        checkpoint_epoch: Some(epoch),
                     });
                 }
                 Ok(_) => {}
@@ -127,6 +226,7 @@ where
 
         Ok(BlockStatusResponse {
             status: BlockStatus::Pending,
+            checkpoint_epoch: None,
         })
     }
 
@@ -168,7 +268,7 @@ where
                 continue;
             };
 
-            let prev_block_num = match canonical_block_number(
+            let prev_block_num = match fetch_canonical_block_number(
                 &self.provider,
                 hash_to_b256(chunk.prev_block().as_slice()),
             ) {
@@ -176,7 +276,7 @@ where
                 Ok(None) => continue,
                 Err(e) => return Err(internal_error(e.to_string())),
             };
-            let last_block_num = match canonical_block_number(
+            let last_block_num = match fetch_canonical_block_number(
                 &self.provider,
                 hash_to_b256(chunk.last_block().as_slice()),
             ) {
@@ -214,5 +314,70 @@ where
             covered: false,
             first_uncovered_block: Some(first_uncovered_block),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Runs the epoch binary search against a synthetic, monotonically
+    /// non-decreasing `epoch -> last included block height` mapping.
+    async fn search(heights: &[u64], target_num: u64) -> Epoch {
+        let frontier_epoch = (heights.len() - 1) as Epoch;
+        search_containing_epoch(frontier_epoch, target_num, |epoch| {
+            let height = heights[epoch as usize];
+            async move { Ok(height) }
+        })
+        .await
+        .expect("search should succeed")
+    }
+
+    #[tokio::test]
+    async fn finds_smallest_covering_epoch() {
+        // epoch:                0   1   2    3
+        // last block height:    5  10  10   20
+        // Epoch 2 includes no new blocks (height unchanged from epoch 1).
+        let heights = [5u64, 10, 10, 20];
+
+        // Blocks 1..=5 were first included in epoch 0.
+        assert_eq!(search(&heights, 1).await, 0);
+        assert_eq!(search(&heights, 5).await, 0);
+
+        // Blocks 6..=10 were first included in epoch 1, not the later empty epoch 2.
+        assert_eq!(search(&heights, 6).await, 1);
+        assert_eq!(search(&heights, 10).await, 1);
+
+        // Blocks 11..=20 were included in epoch 3.
+        assert_eq!(search(&heights, 11).await, 3);
+        assert_eq!(search(&heights, 20).await, 3);
+    }
+
+    #[tokio::test]
+    async fn single_epoch_frontier() {
+        let heights = [7u64];
+        assert_eq!(search(&heights, 1).await, 0);
+        assert_eq!(search(&heights, 7).await, 0);
+    }
+
+    #[tokio::test]
+    async fn propagates_lookup_error() {
+        let result = search_containing_epoch(3, 10, |_epoch| async move {
+            Err(internal_error("boom".to_string()))
+        })
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn errors_when_frontier_does_not_cover_target() {
+        let heights = [3u64, 5, 7];
+        let result = search_containing_epoch(2, 10, |epoch| {
+            let height = heights[epoch as usize];
+            async move { Ok(height) }
+        })
+        .await;
+
+        assert!(result.is_err());
     }
 }

--- a/crates/alpen-ee/rpc/types/Cargo.toml
+++ b/crates/alpen-ee/rpc/types/Cargo.toml
@@ -9,6 +9,10 @@ workspace = true
 [dependencies]
 schemars = { workspace = true, optional = true }
 serde.workspace = true
+strata-identifiers.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
 
 [features]
 jsonschema = ["dep:schemars"]

--- a/crates/alpen-ee/rpc/types/src/lib.rs
+++ b/crates/alpen-ee/rpc/types/src/lib.rs
@@ -1,8 +1,16 @@
 //! Alpen EE RPC type definitions.
 
 use serde::{Deserialize, Serialize};
+use strata_identifiers::Epoch;
 
 /// L1 finalization status of an EE block.
+///
+/// The `status` discriminant serializes as a lowercase string.
+///
+/// JSON representation:
+/// - `{"status": "pending"}`
+/// - `{"status": "confirmed"}`
+/// - `{"status": "finalized"}`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "lowercase")]
@@ -26,6 +34,14 @@ pub enum BlockStatus {
 pub struct BlockStatusResponse {
     /// L1 finalization status.
     pub status: BlockStatus,
+
+    /// OL checkpoint epoch that contains this block.
+    ///
+    /// Pending blocks are not covered by any checkpoint and carry no epoch. Confirmed and
+    /// finalized blocks carry the per-block containing checkpoint epoch, not the node's frontier
+    /// epoch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_epoch: Option<Epoch>,
 }
 
 /// Response for `alpen_getChunkProofCoverage`.
@@ -43,4 +59,61 @@ pub struct ChunkProofCoverageResponse {
 
     /// First requested block not yet covered by a proof-ready chunk.
     pub first_uncovered_block: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_status_response_json_shape() {
+        let pending = BlockStatusResponse {
+            status: BlockStatus::Pending,
+            checkpoint_epoch: None,
+        };
+        assert_eq!(
+            serde_json::to_value(pending).unwrap(),
+            serde_json::json!({ "status": "pending" }),
+        );
+
+        let confirmed = BlockStatusResponse {
+            status: BlockStatus::Confirmed,
+            checkpoint_epoch: Some(5),
+        };
+        assert_eq!(
+            serde_json::to_value(confirmed).unwrap(),
+            serde_json::json!({ "status": "confirmed", "checkpoint_epoch": 5 }),
+        );
+
+        let finalized = BlockStatusResponse {
+            status: BlockStatus::Finalized,
+            checkpoint_epoch: Some(0),
+        };
+        assert_eq!(
+            serde_json::to_value(finalized).unwrap(),
+            serde_json::json!({ "status": "finalized", "checkpoint_epoch": 0 }),
+        );
+    }
+
+    #[test]
+    fn block_status_response_round_trips() {
+        for response in [
+            BlockStatusResponse {
+                status: BlockStatus::Pending,
+                checkpoint_epoch: None,
+            },
+            BlockStatusResponse {
+                status: BlockStatus::Confirmed,
+                checkpoint_epoch: Some(7),
+            },
+            BlockStatusResponse {
+                status: BlockStatus::Finalized,
+                checkpoint_epoch: Some(42),
+            },
+        ] {
+            let encoded = serde_json::to_string(&response).unwrap();
+            let decoded: BlockStatusResponse = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(response, decoded);
+        }
+    }
 }

--- a/functional-tests/common/services/alpen_client.py
+++ b/functional-tests/common/services/alpen_client.py
@@ -117,14 +117,10 @@ class AlpenClientService(RpcService):
             number = hex(number)
         return rpc.eth_getBlockByNumber(number, False)
 
-    def get_block_status(self, block_hash: str) -> str:
-        """Get the L1 finalization status of an EE block.
-
-        Returns one of: "pending", "confirmed", "finalized".
-        """
+    def get_block_status(self, block_hash: str) -> dict:
+        """Get the raw L1 finalization status response of an EE block."""
         rpc = self.create_rpc()
-        result = rpc.alpen_getBlockStatus(block_hash)
-        return result["status"]
+        return rpc.alpen_getBlockStatus(block_hash)
 
     def get_peers(self) -> list[dict]:
         """Get connected peers via admin_peers."""

--- a/functional-tests/tests/alpen_client/test_ee_block_status.py
+++ b/functional-tests/tests/alpen_client/test_ee_block_status.py
@@ -27,19 +27,52 @@ class TestEeBlockStatus(BaseTest):
     def __init__(self, ctx: flexitest.InitContext):
         ctx.set_env("el_ol")
 
-    def assert_statuses_consistent(self, alpen_seq, alpen_rpc, up_to_block: int) -> dict:
-        """Assert statuses are monotonically non-increasing for non-genesis blocks.
+    def assert_epoch_matches_status(self, response: dict) -> None:
+        """Assert the checkpoint epoch presence and shape match the returned status.
 
-        Collects statuses for blocks 0..N, then checks ordering only within block 1..N.
+        Pending blocks carry no ``checkpoint_epoch`` key; confirmed and finalized
+        blocks carry an integer ``checkpoint_epoch`` for the OL checkpoint that
+        contains the block.
+        """
+        status = response["status"]
+        checkpoint_epoch = response.get("checkpoint_epoch")
+        if status == "pending":
+            assert checkpoint_epoch is None, (
+                f"Pending block should not have a checkpoint_epoch, got {checkpoint_epoch!r}"
+            )
+        else:
+            assert isinstance(checkpoint_epoch, int), (
+                f"{status} block should have integer checkpoint_epoch, got {checkpoint_epoch!r}"
+            )
+
+    def assert_statuses_consistent(self, alpen_seq, alpen_rpc, up_to_block: int) -> dict:
+        """Assert status and checkpoint-epoch ordering across blocks 0..N.
+
+        Statuses must be monotonically non-increasing for non-genesis blocks, and
+        the per-block containing checkpoint epoch must be monotonically
+        non-decreasing with block number (a lower block cannot be checkpointed in a
+        later epoch than a higher block). Genesis is checkpointed in epoch 0.
+
         Returns a dict mapping block number to status string.
         """
         statuses = {}
+        epochs = {}
         for i in range(up_to_block + 1):
             block = alpen_rpc.eth_getBlockByNumber(hex(i), False)
             assert block is not None, f"Failed to get block {i}"
-            status = alpen_seq.get_block_status(block["hash"])
+            response = alpen_seq.get_block_status(block["hash"])
+            self.assert_epoch_matches_status(response)
+            status = response["status"]
             statuses[i] = status
-            logger.info(f"  Block {i}: {status}")
+            epochs[i] = response.get("checkpoint_epoch")
+            logger.info(
+                "  Block %s: status=%s checkpoint_epoch=%s",
+                i,
+                status,
+                epochs[i],
+            )
+
+        assert epochs[0] == 0, f"Genesis should be checkpointed in epoch 0, got {epochs[0]!r}"
 
         for i in range(2, up_to_block + 1):
             prev = self.STATUS_ORDER.index(statuses[i - 1])
@@ -49,25 +82,33 @@ class TestEeBlockStatus(BaseTest):
                 f"than block {i} ({statuses[i]})"
             )
 
+        # Containing epoch is non-decreasing with block number for checkpointed blocks.
+        for i in range(1, up_to_block + 1):
+            if epochs[i] is None or epochs[i - 1] is None:
+                continue
+            assert epochs[i - 1] <= epochs[i], (
+                f"Block {i - 1} epoch ({epochs[i - 1]}) should be <= block {i} epoch ({epochs[i]})"
+            )
+
         return statuses
 
     def wait_for_fullnode_match(
         self,
         alpen_fullnode: AlpenClientService,
         block_hash: str,
-        expected_status: str,
+        expected_response: dict,
         timeout: int = FULLNODE_SYNC_TIMEOUT,
     ) -> None:
-        """Poll the fullnode until its status for ``block_hash`` matches ``expected_status``.
+        """Poll the fullnode until its status response for ``block_hash`` matches.
 
         Absorbs the OLTracker polling lag between sequencer and fullnode
         without making the test flaky.
         """
         wait_until(
-            lambda: alpen_fullnode.get_block_status(block_hash) == expected_status,
+            lambda: alpen_fullnode.get_block_status(block_hash) == expected_response,
             error_with=(
-                f"Fullnode status for {block_hash} did not converge to "
-                f"{expected_status!r} within {timeout}s "
+                f"Fullnode status response for {block_hash} did not converge to "
+                f"{expected_response!r} within {timeout}s "
                 f"(last={alpen_fullnode.get_block_status(block_hash)!r})"
             ),
             timeout=timeout,
@@ -84,9 +125,10 @@ class TestEeBlockStatus(BaseTest):
         for i in range(up_to_block + 1):
             block = alpen_rpc.eth_getBlockByNumber(hex(i), False)
             assert block is not None, f"Failed to get block {i}"
-            seq_status = alpen_seq.get_block_status(block["hash"])
-            self.wait_for_fullnode_match(alpen_fullnode, block["hash"], seq_status)
-            logger.info(f"  Block {i}: fullnode converged to {seq_status}")
+            seq_response = alpen_seq.get_block_status(block["hash"])
+            self.assert_epoch_matches_status(seq_response)
+            self.wait_for_fullnode_match(alpen_fullnode, block["hash"], seq_response)
+            logger.info("  Block %s: fullnode converged to %s", i, seq_response)
 
     def main(self, ctx):
         alpen_seq: AlpenClientService = self.get_service(ServiceType.AlpenSequencer)
@@ -138,17 +180,24 @@ class TestEeBlockStatus(BaseTest):
             )
             assert e.code == -32602, f"Expected invalid params (-32602), got {e.code}"
 
-        initial_status = alpen_seq.get_block_status(target_hash)
-        logger.info(f"Block {self.TARGET_BLOCK_NUMBER} initial status: {initial_status}")
+        initial_response = alpen_seq.get_block_status(target_hash)
+        self.assert_epoch_matches_status(initial_response)
+        initial_status = initial_response["status"]
+        logger.info(
+            "Block %s initial status response: %s",
+            self.TARGET_BLOCK_NUMBER,
+            initial_response,
+        )
 
-        # Fullnode should converge to the same status for the target block.
-        self.wait_for_fullnode_match(alpen_fullnode, target_hash, initial_status)
+        # Fullnode should converge to the same status response for the target block.
+        self.wait_for_fullnode_match(alpen_fullnode, target_hash, initial_response)
 
-        # Block 0 should be finalized.
+        # Block 0 should be finalized at genesis epoch 0.
         block_0 = alpen_rpc.eth_getBlockByNumber("0x0", False)
-        status_0 = alpen_seq.get_block_status(block_0["hash"])
-        logger.info(f"Block 0 status: {status_0}")
-        assert status_0 == "finalized", f"Expected finalized, got {status_0}"
+        response_0 = alpen_seq.get_block_status(block_0["hash"])
+        logger.info("Block 0 status response: %s", response_0)
+        assert response_0["status"] == "finalized", f"Expected finalized, got {response_0}"
+        assert response_0["checkpoint_epoch"] == 0, f"Expected checkpoint_epoch 0, got {response_0}"
 
         if initial_status == "finalized":
             logger.info("Initial status consistency check:")
@@ -168,7 +217,7 @@ class TestEeBlockStatus(BaseTest):
 
         # Mine until target block is confirmed.
         status = bitcoin.mine_until(
-            check=lambda: alpen_seq.get_block_status(target_hash),
+            check=lambda: alpen_seq.get_block_status(target_hash)["status"],
             predicate=lambda s: s in ("confirmed", "finalized"),
             error_with=(f"Block {self.TARGET_BLOCK_NUMBER} did not reach confirmed status"),
         )
@@ -191,7 +240,7 @@ class TestEeBlockStatus(BaseTest):
 
         # Mine until target block is finalized.
         status = bitcoin.mine_until(
-            check=lambda: alpen_seq.get_block_status(target_hash),
+            check=lambda: alpen_seq.get_block_status(target_hash)["status"],
             predicate=lambda s: s == "finalized",
             error_with=(f"Block {self.TARGET_BLOCK_NUMBER} did not reach finalized status"),
         )


### PR DESCRIPTION
## Description

Adds the checkpoint epoch to `alpen_getBlockStatus` responses.

For confirmed and finalized blocks, the RPC now returns the OL checkpoint epoch that contains the requested canonical Alpen block. The server follows the Slack suggestion from STR-3796: it uses the OL tracker's per-epoch last-included EE block state and Reth's canonical block-number lookup, then binary-searches the confirmed or finalized frontier to find the smallest epoch that covers the target block.

Pending blocks are not covered by a checkpoint and return only `status: \"pending\"`. Confirmed and finalized blocks return a flattened response shape such as `status: \"confirmed\", epoch: 5`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The returned `epoch` is a per-block containing checkpoint epoch, not the node's confirmed or finalized frontier epoch.

The implementation covers:
- canonical block validation before status lookup
- genesis as finalized in epoch 0
- binary search over checkpoint epochs using stored EE account state
- confirmed/finalized statuses carrying `epoch`
- pending status carrying no `epoch`
- fullnode responses converging to sequencer responses for both `status` and `epoch`

AI assistance was used for this PR.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- Slack discussion: https://alpen-labs.slack.com/archives/C07EYBQS9GB/p1781536409828939

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3796