### PR TITLE
Str 2105: Correct implementation of `get_canonical_block_at_slot`

### DIFF
--- a/bin/strata-dbtool/src/cmd/ol.rs
+++ b/bin/strata-dbtool/src/cmd/ol.rs
@@ -1,7 +1,7 @@
 use argh::FromArgs;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_db_types::traits::{BlockStatus, DatabaseBackend, OLBlockDatabase};
-use strata_identifiers::{Epoch, OLBlockId, Slot};
+use strata_identifiers::{Epoch, OLBlockCommitment, OLBlockId, Slot};
 use strata_ol_chain_types_new::OLBlock;
 use strata_primitives::l1::L1BlockId;
 
@@ -131,7 +131,7 @@ pub(crate) fn get_ol_summary(
     db: &impl DatabaseBackend,
     args: GetOLSummaryArgs,
 ) -> Result<(), DisplayedError> {
-    // Get the tip block (highest slot) from OL block database.
+    // Get the canonical tip block from OL block database.
     let tip_block_id = get_chain_tip_ol_block_id(db)?;
     let tip_block_data = get_ol_block_data(db, tip_block_id)?.ok_or_else(|| {
         DisplayedError::InternalError(
@@ -234,12 +234,29 @@ pub(crate) fn delete_ol_block(
         ));
     }
 
+    let canonical_block = db
+        .ol_block_db()
+        .get_canonical_block(slot)
+        .internal_error(format!("Failed to get canonical block at slot {slot}"))?;
+    if canonical_block == Some(block_id) {
+        return Err(DisplayedError::UserError(
+            "Refusing to delete canonical OL block".to_string(),
+            Box::new(block_id),
+        ));
+    }
+
     // A stored child means this block is (or was) extended by some chain;
     // deleting it would leave that child without a parent in the database.
+    let Some(next_slot) = slot.checked_add(1) else {
+        return Err(DisplayedError::UserError(
+            "Refusing to delete max-slot OL block".to_string(),
+            Box::new(block_id),
+        ));
+    };
     let blocks_at_next_slot = db
         .ol_block_db()
-        .get_blocks_at_height(slot + 1)
-        .internal_error(format!("Failed to get blocks at slot {}", slot + 1))?;
+        .get_blocks_at_height(next_slot)
+        .internal_error(format!("Failed to get blocks at slot {next_slot}"))?;
     for child_id in blocks_at_next_slot {
         let Some(child) = get_ol_block_data(db, child_id)? else {
             continue;
@@ -281,26 +298,33 @@ pub(crate) fn delete_ol_block(
 }
 
 fn get_chain_tip_ol_block_id(db: &impl DatabaseBackend) -> Result<OLBlockId, DisplayedError> {
+    Ok(*get_canonical_ol_tip(db)?.blkid())
+}
+
+pub(crate) fn get_canonical_ol_tip(
+    db: &impl DatabaseBackend,
+) -> Result<OLBlockCommitment, DisplayedError> {
     let tip_slot = db
         .ol_block_db()
         .get_tip_slot()
         .internal_error("Failed to get OL tip slot")?;
-
-    get_canonical_ol_block_at_slot(db, tip_slot)
+    let tip_blkid = get_canonical_ol_block_at_slot(db, tip_slot)?;
+    Ok(OLBlockCommitment::new(tip_slot, tip_blkid))
 }
 
 pub(crate) fn get_canonical_ol_block_at_slot(
     db: &impl DatabaseBackend,
     slot: Slot,
 ) -> Result<OLBlockId, DisplayedError> {
-    let blocks = db
-        .ol_block_db()
-        .get_blocks_at_height(slot)
-        .internal_error("Failed to fetch OL blocks at slot")?;
-
-    blocks.first().copied().ok_or_else(|| {
-        DisplayedError::InternalError("No OL blocks found at slot".to_string(), Box::new(slot))
-    })
+    db.ol_block_db()
+        .get_canonical_block(slot)
+        .internal_error("Failed to fetch canonical OL block at slot")?
+        .ok_or_else(|| {
+            DisplayedError::InternalError(
+                "No canonical OL block found at slot".to_string(),
+                Box::new(slot),
+            )
+        })
 }
 
 pub(crate) fn get_ol_block_slot_and_epoch(

--- a/bin/strata-dbtool/src/cmd/ol_state.rs
+++ b/bin/strata-dbtool/src/cmd/ol_state.rs
@@ -153,7 +153,6 @@ pub(crate) fn revert_ol_state(
         );
         return Ok(());
     }
-
     let finalized_epoch = get_latest_finalized_checkpoint_epoch(db, args.l1_reorg_safe_depth)?
         .unwrap_or_else(EpochCommitment::null);
     let finalized_slot = finalized_epoch.last_slot();
@@ -243,6 +242,9 @@ pub(crate) fn revert_ol_state(
                 .rollback_block_high_watermark(target_commitment)
                 .internal_error("Failed to roll back OL block high-watermark")?;
         }
+        db.ol_block_db()
+            .replace_canonical_suffix_from(target_slot, vec![target_block_id])
+            .internal_error("Failed to rewrite canonical OL block index")?;
     }
 
     let mut checkpoints_to_delete = Vec::new();
@@ -291,6 +293,7 @@ pub(crate) fn revert_ol_state(
     if let Some(high_watermark) = high_watermark_to_rollback {
         println!("Block high-watermark rollback: {high_watermark} -> {target_commitment}");
     }
+    println!("Canonical block index rewrite from slot: {target_slot}");
     println!("Checkpoints to delete: {}", checkpoints_to_delete.len());
     println!(
         "Epoch summaries to delete: {}",

--- a/bin/strata-dbtool/src/cmd/syncinfo.rs
+++ b/bin/strata-dbtool/src/cmd/syncinfo.rs
@@ -10,7 +10,7 @@ use super::{
         get_latest_finalized_checkpoint_epoch,
     },
     l1::get_l1_chain_tip,
-    ol::get_canonical_ol_block_at_slot,
+    ol::get_canonical_ol_tip,
 };
 use crate::{
     cli::OutputFormat,
@@ -38,12 +38,10 @@ pub(crate) fn get_syncinfo(
     // Get L1 tip
     let (l1_tip_height, l1_tip_block_id) = get_l1_chain_tip(db)?;
 
-    // Get OL tip slot and select canonical tip block using first block at that slot.
-    let ol_tip_height = db
-        .ol_block_db()
-        .get_tip_slot()
-        .internal_error("Failed to get OL tip slot")?;
-    let ol_tip_block_id = get_canonical_ol_block_at_slot(db, ol_tip_height)?;
+    // Get the canonical OL tip slot and block.
+    let ol_tip_commitment = get_canonical_ol_tip(db)?;
+    let ol_tip_height = ol_tip_commitment.slot();
+    let ol_tip_block_id = *ol_tip_commitment.blkid();
 
     // Get OL tip block status from OL block db.
     let ol_tip_block_status = db
@@ -63,7 +61,6 @@ pub(crate) fn get_syncinfo(
         })?;
 
     // Use the same chosen canonical tip commitment for OL state reads.
-    let ol_tip_commitment = OLBlockCommitment::new(ol_tip_height, ol_tip_block_id);
     let top_level_state = db
         .ol_state_db()
         .get_toplevel_ol_state(ol_tip_commitment)

--- a/bin/strata/src/fcm.rs
+++ b/bin/strata/src/fcm.rs
@@ -147,14 +147,14 @@ impl FcmStorage for StrataFcmContext {
             .await
     }
 
-    async fn update_canonical_blocks_above(
+    async fn replace_canonical_blocks_from(
         &self,
-        pivot_slot: Slot,
+        start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         self.storage
             .ol_block()
-            .update_canonical_blocks_above_async(pivot_slot, blocks)
+            .replace_canonical_blocks_from_async(start_slot, blocks)
             .await
     }
 

--- a/bin/strata/src/fcm.rs
+++ b/bin/strata/src/fcm.rs
@@ -147,14 +147,14 @@ impl FcmStorage for StrataFcmContext {
             .await
     }
 
-    async fn replace_canonical_blocks_from(
+    async fn replace_canonical_suffix_from(
         &self,
         start_slot: Slot,
-        blocks: Vec<(Slot, OLBlockId)>,
+        block_ids: Vec<OLBlockId>,
     ) -> DbResult<()> {
         self.storage
             .ol_block()
-            .replace_canonical_blocks_from_async(start_slot, blocks)
+            .replace_canonical_suffix_from_async(start_slot, block_ids)
             .await
     }
 

--- a/bin/strata/src/fcm.rs
+++ b/bin/strata/src/fcm.rs
@@ -147,6 +147,17 @@ impl FcmStorage for StrataFcmContext {
             .await
     }
 
+    async fn replace_canonical_suffix(
+        &self,
+        pivot_slot: Slot,
+        blocks: Vec<(Slot, OLBlockId)>,
+    ) -> DbResult<()> {
+        self.storage
+            .ol_block()
+            .replace_canonical_suffix_async(pivot_slot, blocks)
+            .await
+    }
+
     async fn get_canonical_epoch_commitment_at(
         &self,
         epoch: Epoch,

--- a/bin/strata/src/fcm.rs
+++ b/bin/strata/src/fcm.rs
@@ -147,14 +147,14 @@ impl FcmStorage for StrataFcmContext {
             .await
     }
 
-    async fn replace_canonical_suffix(
+    async fn update_canonical_blocks_above(
         &self,
         pivot_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         self.storage
             .ol_block()
-            .replace_canonical_suffix_async(pivot_slot, blocks)
+            .update_canonical_blocks_above_async(pivot_slot, blocks)
             .await
     }
 

--- a/bin/strata/src/genesis.rs
+++ b/bin/strata/src/genesis.rs
@@ -63,7 +63,7 @@ pub(crate) fn init_ol_genesis(
     // Update the canonical block index for first block.
     storage
         .ol_block()
-        .update_canonical_blocks_above_blocking(0, vec![(0, genesis_blkid)])?;
+        .replace_canonical_blocks_from_blocking(0, vec![(0, genesis_blkid)])?;
 
     info!(%genesis_blkid, slot = 0, "OL genesis initialization complete");
     Ok(commitment)

--- a/bin/strata/src/genesis.rs
+++ b/bin/strata/src/genesis.rs
@@ -60,10 +60,7 @@ pub(crate) fn init_ol_genesis(
         .ol_checkpoint()
         .insert_epoch_summary_blocking(epoch_summary)?;
 
-    // Record the genesis block as canonical at slot 0 LAST. `ensure_ol_genesis`
-    // treats canonical slot 0 as the "genesis exists" marker, so it must not be
-    // durable until the genesis state and epoch summary above are written — else a
-    // crash in between would make restart skip genesis with missing data.
+    // Update the canonical block index for first block.
     storage
         .ol_block()
         .update_canonical_blocks_above_blocking(0, vec![(0, genesis_blkid)])?;

--- a/bin/strata/src/genesis.rs
+++ b/bin/strata/src/genesis.rs
@@ -66,7 +66,7 @@ pub(crate) fn init_ol_genesis(
     // crash in between would make restart skip genesis with missing data.
     storage
         .ol_block()
-        .replace_canonical_suffix_blocking(0, vec![(0, genesis_blkid)])?;
+        .update_canonical_blocks_above_blocking(0, vec![(0, genesis_blkid)])?;
 
     info!(%genesis_blkid, slot = 0, "OL genesis initialization complete");
     Ok(commitment)

--- a/bin/strata/src/genesis.rs
+++ b/bin/strata/src/genesis.rs
@@ -60,6 +60,14 @@ pub(crate) fn init_ol_genesis(
         .ol_checkpoint()
         .insert_epoch_summary_blocking(epoch_summary)?;
 
+    // Record the genesis block as canonical at slot 0 LAST. `ensure_ol_genesis`
+    // treats canonical slot 0 as the "genesis exists" marker, so it must not be
+    // durable until the genesis state and epoch summary above are written — else a
+    // crash in between would make restart skip genesis with missing data.
+    storage
+        .ol_block()
+        .replace_canonical_suffix_blocking(0, vec![(0, genesis_blkid)])?;
+
     info!(%genesis_blkid, slot = 0, "OL genesis initialization complete");
     Ok(commitment)
 }

--- a/bin/strata/src/genesis.rs
+++ b/bin/strata/src/genesis.rs
@@ -63,7 +63,7 @@ pub(crate) fn init_ol_genesis(
     // Update the canonical block index for first block.
     storage
         .ol_block()
-        .replace_canonical_blocks_from_blocking(0, vec![(0, genesis_blkid)])?;
+        .replace_canonical_suffix_from_blocking(0, vec![genesis_blkid])?;
 
     info!(%genesis_blkid, slot = 0, "OL genesis initialization complete");
     Ok(commitment)

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -344,7 +344,7 @@ fn verify_tip_ol_state(storage: &NodeStorage, tip_commitment: OLBlockCommitment)
         .is_some();
 
     if !has_tip_state {
-        bail!("startup: missing OL state for tip block");
+        bail!("startup: missing OL state for tip block {}", tip_commitment);
     }
 
     Ok(())

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -645,7 +645,7 @@ mod tests {
         // Update the canonical index.
         storage
             .ol_block()
-            .update_canonical_blocks_above_blocking(1, vec![(1, block_1_blkid)])
+            .replace_canonical_blocks_from_blocking(1, vec![(1, block_1_blkid)])
             .expect("test: canonical entry for slot 1");
 
         // Validate checks with tip at block 1.
@@ -704,7 +704,7 @@ mod tests {
         // Update the canonical index.
         storage
             .ol_block()
-            .update_canonical_blocks_above_blocking(2, vec![(2, block_2_blkid)])
+            .replace_canonical_blocks_from_blocking(2, vec![(2, block_2_blkid)])
             .expect("test: canonical entry for slot 2");
 
         // Validate checks with tip at block 2.

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -642,6 +642,11 @@ mod tests {
             .ol_state()
             .put_toplevel_ol_state_blocking(block_1_commitment, (*genesis_state).clone())
             .expect("test: insert block 1 state");
+        // Update the canonical index.
+        storage
+            .ol_block()
+            .update_canonical_blocks_above_blocking(1, vec![(1, block_1_blkid)])
+            .expect("test: canonical entry for slot 1");
 
         // Validate checks with tip at block 1.
         let result_after_block_1 = (|| {
@@ -696,6 +701,11 @@ mod tests {
             .ol_state()
             .put_toplevel_ol_state_blocking(block_2_commitment, (*genesis_state).clone())
             .expect("test: insert block 2 state");
+        // Update the canonical index.
+        storage
+            .ol_block()
+            .update_canonical_blocks_above_blocking(2, vec![(2, block_2_blkid)])
+            .expect("test: canonical entry for slot 2");
 
         // Validate checks with tip at block 2.
         let result_after_block_2 = (|| {

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -126,6 +126,36 @@ fn get_ol_genesis_block(storage: &NodeStorage) -> Result<Option<OLBlockCommitmen
     Ok(genesis_commitment)
 }
 
+/// Ensures the canonical block index has the genesis entry.
+///
+/// This backfills DBs created before the canonical OL block index existed. FCM
+/// reconciles the unfinalized suffix after startup once slot 0 gives it a
+/// stable canonical base.
+fn ensure_canonical_genesis_block(
+    storage: &NodeStorage,
+    genesis_commitment: OLBlockCommitment,
+) -> Result<()> {
+    let canonical_genesis = storage
+        .ol_block()
+        .get_canonical_block_at_blocking(0)
+        .context("startup: failed to query canonical OL genesis block")?;
+    if canonical_genesis == Some(genesis_commitment) {
+        return Ok(());
+    }
+    if let Some(canonical_genesis) = canonical_genesis {
+        bail!(
+            "startup: canonical OL genesis block mismatch: expected {genesis_commitment}, got {canonical_genesis}"
+        );
+    }
+
+    storage
+        .ol_block()
+        .replace_canonical_suffix_from_blocking(0, vec![*genesis_commitment.blkid()])
+        .context("startup: failed to backfill canonical OL genesis block")?;
+
+    Ok(())
+}
+
 /// Verifies that OL state exists for the resolved genesis block commitment.
 fn verify_genesis_ol_state(
     storage: &NodeStorage,
@@ -298,6 +328,7 @@ pub(crate) fn run_startup_checks(ctx: &NodeContext) -> Result<()> {
     }
 
     if let Some(genesis_commitment) = genesis_commitment {
+        ensure_canonical_genesis_block(ctx.storage().as_ref(), genesis_commitment)?;
         verify_genesis_ol_state(ctx.storage().as_ref(), genesis_commitment)?;
         verify_genesis_epoch_summary(ctx.storage().as_ref(), genesis_commitment)?;
 
@@ -553,6 +584,31 @@ mod tests {
             .expect("test: genesis epoch summary should exist");
 
         assert_eq!(commitment, genesis_commitment);
+    }
+
+    #[test]
+    fn test_missing_canonical_genesis_index_is_backfilled() {
+        let (storage, genesis_commitment) = setup_storage_with_genesis();
+        storage
+            .ol_block()
+            .replace_canonical_suffix_from_blocking(0, Vec::new())
+            .expect("test: clear canonical index");
+
+        storage
+            .ol_block()
+            .get_canonical_tip_blocking()
+            .expect_err("test: missing canonical index has no tip");
+
+        ensure_canonical_genesis_block(&storage, genesis_commitment)
+            .expect("test: backfill canonical genesis");
+
+        assert_eq!(
+            storage
+                .ol_block()
+                .get_canonical_tip_blocking()
+                .expect("test: get canonical tip after backfill"),
+            Some(genesis_commitment)
+        );
     }
 
     #[test]

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -645,7 +645,7 @@ mod tests {
         // Update the canonical index.
         storage
             .ol_block()
-            .replace_canonical_blocks_from_blocking(1, vec![(1, block_1_blkid)])
+            .replace_canonical_suffix_from_blocking(1, vec![block_1_blkid])
             .expect("test: canonical entry for slot 1");
 
         // Validate checks with tip at block 1.
@@ -704,7 +704,7 @@ mod tests {
         // Update the canonical index.
         storage
             .ol_block()
-            .replace_canonical_blocks_from_blocking(2, vec![(2, block_2_blkid)])
+            .replace_canonical_suffix_from_blocking(2, vec![block_2_blkid])
             .expect("test: canonical entry for slot 2");
 
         // Validate checks with tip at block 2.

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -5,7 +5,8 @@ use bitcoind_async_client::{
     Client, corepc_types::model::GetBlockchainInfo, error::ClientError, traits::Reader,
 };
 use strata_btc_types::BlockHashExt;
-use strata_identifiers::{EpochCommitment, OLBlockCommitment};
+use strata_db_types::traits::BlockStatus;
+use strata_identifiers::{EpochCommitment, OLBlockCommitment, OLBlockId};
 use strata_node_context::NodeContext;
 use strata_ol_chain_types_new::OLBlock;
 use strata_primitives::L1BlockCommitment;
@@ -126,34 +127,115 @@ fn get_ol_genesis_block(storage: &NodeStorage) -> Result<Option<OLBlockCommitmen
     Ok(genesis_commitment)
 }
 
-/// Ensures the canonical block index has the genesis entry.
+/// Ensures the canonical block index is initialized for legacy DBs.
 ///
 /// This backfills DBs created before the canonical OL block index existed. FCM
-/// reconciles the unfinalized suffix after startup once slot 0 gives it a
-/// stable canonical base.
-fn ensure_canonical_genesis_block(
+/// reconciles the unfinalized suffix after startup once the finalized base is
+/// present in the canonical index.
+fn ensure_canonical_block_index(
     storage: &NodeStorage,
     genesis_commitment: OLBlockCommitment,
+    finalized_epoch: Option<EpochCommitment>,
 ) -> Result<()> {
     let canonical_genesis = storage
         .ol_block()
         .get_canonical_block_at_blocking(0)
         .context("startup: failed to query canonical OL genesis block")?;
-    if canonical_genesis == Some(genesis_commitment) {
-        return Ok(());
-    }
-    if let Some(canonical_genesis) = canonical_genesis {
+    if let Some(canonical_genesis) = canonical_genesis
+        && canonical_genesis != genesis_commitment
+    {
         bail!(
             "startup: canonical OL genesis block mismatch: expected {genesis_commitment}, got {canonical_genesis}"
         );
     }
 
+    let finalized_commitment = finalized_epoch
+        .filter(|epoch| !epoch.is_null())
+        .map_or(genesis_commitment, |epoch| epoch.to_block_commitment());
+    let canonical_finalized = storage
+        .ol_block()
+        .get_canonical_block_at_blocking(finalized_commitment.slot())
+        .with_context(|| {
+            format!("startup: failed to query canonical finalized OL block {finalized_commitment}")
+        })?;
+    if canonical_finalized == Some(finalized_commitment)
+        && let Ok(Some(canonical_tip)) = storage.ol_block().get_canonical_tip_blocking()
+        && canonical_tip.slot() >= finalized_commitment.slot()
+    {
+        return Ok(());
+    }
+
+    // Keep this as a single suffix replacement so restart never observes a partially migrated
+    // finalized prefix. For scale: 10 million slots is about 305 MiB for Vec<OLBlockId> (32 bytes
+    // each) plus about 381 MiB for the temporary Vec<(Slot, OLBlockId)> built by the DB layer. A
+    // legacy DB has an empty canonical tree, so the suffix-removal side is effectively free. If
+    // this ever needs batching, the migration must stay resumable and must not let FCM start until
+    // canonical_at(finalized_slot) equals the declared finalized block.
+    let finalized_chain =
+        collect_finalized_canonical_chain(storage, genesis_commitment, finalized_commitment)
+            .context("startup: failed to collect finalized OL canonical blocks")?;
+
     storage
         .ol_block()
-        .replace_canonical_suffix_from_blocking(0, vec![*genesis_commitment.blkid()])
-        .context("startup: failed to backfill canonical OL genesis block")?;
+        .replace_canonical_suffix_from_blocking(0, finalized_chain)
+        .context("startup: failed to backfill canonical OL block index")?;
 
     Ok(())
+}
+
+fn collect_finalized_canonical_chain(
+    storage: &NodeStorage,
+    genesis_commitment: OLBlockCommitment,
+    finalized_commitment: OLBlockCommitment,
+) -> Result<Vec<OLBlockId>> {
+    let mut reversed_chain = Vec::new();
+    let mut current = finalized_commitment;
+
+    loop {
+        let blkid = *current.blkid();
+        let block = storage
+            .ol_block()
+            .get_block_data_blocking(blkid)
+            .with_context(|| format!("startup: failed to query finalized OL block {current}"))?
+            .ok_or_else(|| anyhow!("startup: missing finalized OL block {current}"))?;
+
+        if block.header().slot() != current.slot() {
+            bail!(
+                "startup: finalized OL block slot mismatch: commitment {current}, block slot {}",
+                block.header().slot()
+            );
+        }
+
+        let status = storage
+            .ol_block()
+            .get_block_status_blocking(blkid)
+            .with_context(|| {
+                format!("startup: failed to query finalized OL block status {current}")
+            })?;
+        if status != Some(BlockStatus::Valid) {
+            bail!("startup: finalized OL block {current} is not valid");
+        }
+
+        reversed_chain.push(blkid);
+
+        if current.slot() == 0 {
+            if current != genesis_commitment {
+                bail!(
+                    "startup: finalized OL chain terminates at non-genesis block: expected {genesis_commitment}, got {current}"
+                );
+            }
+            if !block.header().parent_blkid().is_null() {
+                bail!("startup: genesis OL block must have null parent commitment");
+            }
+            break;
+        }
+
+        let parent_slot = current.slot() - 1;
+        current = OLBlockCommitment::new(parent_slot, *block.header().parent_blkid());
+    }
+
+    reversed_chain.reverse();
+    Ok(reversed_chain)
 }
 
 /// Verifies that OL state exists for the resolved genesis block commitment.
@@ -307,12 +389,15 @@ pub(crate) fn run_startup_checks(ctx: &NodeContext) -> Result<()> {
         warn!(%reason, "startup: deferring Bitcoin RPC network check");
     }
 
-    let has_client_state = ctx
+    let latest_client_state = ctx
         .storage()
         .client_state()
         .fetch_most_recent_state()
-        .context("startup: failed to fetch most recent client state")?
-        .is_some();
+        .context("startup: failed to fetch most recent client state")?;
+    let has_client_state = latest_client_state.is_some();
+    let finalized_epoch = latest_client_state
+        .as_ref()
+        .and_then(|(_, state)| state.get_declared_final_epoch());
     let genesis_commitment = get_ol_genesis_block(ctx.storage().as_ref())?;
     let has_ol_genesis = genesis_commitment.is_some();
     validate_persisted_state_presence(has_client_state, has_ol_genesis)?;
@@ -328,7 +413,7 @@ pub(crate) fn run_startup_checks(ctx: &NodeContext) -> Result<()> {
     }
 
     if let Some(genesis_commitment) = genesis_commitment {
-        ensure_canonical_genesis_block(ctx.storage().as_ref(), genesis_commitment)?;
+        ensure_canonical_block_index(ctx.storage().as_ref(), genesis_commitment, finalized_epoch)?;
         verify_genesis_ol_state(ctx.storage().as_ref(), genesis_commitment)?;
         verify_genesis_epoch_summary(ctx.storage().as_ref(), genesis_commitment)?;
 
@@ -587,8 +672,8 @@ mod tests {
     }
 
     #[test]
-    fn test_missing_canonical_genesis_index_is_backfilled() {
-        let (storage, genesis_commitment) = setup_storage_with_genesis();
+    fn test_missing_canonical_index_is_backfilled_through_finalized_epoch() {
+        let (storage, genesis_commitment, tip_commitment) = setup_storage_with_non_genesis_tip();
         storage
             .ol_block()
             .replace_canonical_suffix_from_blocking(0, Vec::new())
@@ -599,8 +684,29 @@ mod tests {
             .get_canonical_tip_blocking()
             .expect_err("test: missing canonical index has no tip");
 
-        ensure_canonical_genesis_block(&storage, genesis_commitment)
-            .expect("test: backfill canonical genesis");
+        let finalized_epoch = EpochCommitment::new(1, 1, *tip_commitment.blkid());
+        ensure_canonical_block_index(&storage, genesis_commitment, Some(finalized_epoch))
+            .expect("test: backfill canonical index");
+
+        assert_eq!(
+            storage
+                .ol_block()
+                .get_canonical_tip_blocking()
+                .expect("test: get canonical tip after backfill"),
+            Some(tip_commitment)
+        );
+    }
+
+    #[test]
+    fn test_missing_canonical_index_without_finalized_epoch_backfills_genesis_only() {
+        let (storage, genesis_commitment, _) = setup_storage_with_non_genesis_tip();
+        storage
+            .ol_block()
+            .replace_canonical_suffix_from_blocking(0, Vec::new())
+            .expect("test: clear canonical index");
+
+        ensure_canonical_block_index(&storage, genesis_commitment, None)
+            .expect("test: backfill canonical index");
 
         assert_eq!(
             storage

--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -140,29 +140,11 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
     }
 
     fn fetch_chain_tip(&self) -> WorkerResult<Option<OLBlockCommitment>> {
-        // Get the highest slot with a block
-        let tip_slot = self.ol_block_mgr.get_tip_slot_blocking()?;
-
-        // Slot 0 with no blocks means no chain yet
-        if tip_slot == 0 {
-            let blocks = self.fetch_blocks_at_slot(0)?;
-            if blocks.is_empty() {
-                return Ok(None);
-            }
+        match self.ol_block_mgr.get_canonical_tip_blocking() {
+            Ok(tip) => Ok(tip),
+            Err(DbError::NotBootstrapped) => Ok(None),
+            Err(err) => Err(err.into()),
         }
-
-        // Get blocks at the tip slot
-        let block_ids = self.fetch_blocks_at_slot(tip_slot)?;
-
-        // Return the first block at the tip slot
-        // If there are multiple (forks), we just pick one - the caller can
-        // use fork choice logic if needed
-        let blkid = match block_ids.first() {
-            Some(id) => *id,
-            None => return Ok(None),
-        };
-
-        Ok(Some(OLBlockCommitment::new(tip_slot, blkid)))
     }
 
     fn fetch_ol_state(&self, commitment: OLBlockCommitment) -> WorkerResult<Option<OLState>> {

--- a/crates/chain-worker-new/src/traits.rs
+++ b/crates/chain-worker-new/src/traits.rs
@@ -31,9 +31,7 @@ pub trait ChainWorkerContext: Send + Sync + 'static {
 
     /// Fetches the current chain tip from the database.
     ///
-    /// Returns the highest slot block that has been stored. If there are multiple
-    /// blocks at the tip slot (forks), returns one of them.
-    /// Returns `None` if no blocks have been stored yet.
+    /// Returns the canonical OL tip, or `None` if no canonical block has been stored yet.
     fn fetch_chain_tip(&self) -> WorkerResult<Option<OLBlockCommitment>>;
 
     // =========================================================================

--- a/crates/consensus-logic/src/errors.rs
+++ b/crates/consensus-logic/src/errors.rs
@@ -1,5 +1,5 @@
 use strata_db_types::errors::DbError;
-use strata_identifiers::Epoch;
+use strata_identifiers::{Epoch, Slot};
 use strata_predicate::PredicateError;
 use strata_primitives::{
     l1::{L1BlockCommitment, L1BlockId},
@@ -64,6 +64,47 @@ pub enum Error {
     /// FCM finished applying a tip update but did not land on the expected block ID.
     #[error("OL apply tip mismatch (expected {0}, got {1})")]
     OLApplyTipMismatch(OLBlockCommitment, OLBlockCommitment),
+
+    /// FCM could not select a chain tip during startup.
+    #[error("FCM has no chain tips")]
+    FcmNoChainTips,
+
+    /// FCM computed a non-empty canonical suffix above the maximum slot.
+    #[error("FCM canonical suffix above max slot {0} is non-empty")]
+    FcmCanonicalSuffixAboveMaxSlot(Slot),
+
+    /// FCM reconstructed a chain that does not land on the finalized tip.
+    #[error(
+        "FCM reconstructed chain tip {tip} does not trace back to finalized tip {finalized_tip}"
+    )]
+    FcmCanonicalChainNotFinalized {
+        tip: OLBlockId,
+        finalized_tip: OLBlockId,
+    },
+
+    /// FCM reached the finalized slot, but the canonical index points elsewhere.
+    #[error(
+        "FCM canonical block at finalized slot {finalized_slot} is {canonical:?}, expected finalized tip {finalized_tip}"
+    )]
+    FcmCanonicalFinalizedMismatch {
+        finalized_slot: Slot,
+        canonical: Option<OLBlockCommitment>,
+        finalized_tip: OLBlockId,
+    },
+
+    /// FCM reconstructed a block ID that is missing from the in-memory tracker.
+    #[error("FCM reconstructed block {0} missing from tracker")]
+    FcmCanonicalTrackerMissingBlock(OLBlockId),
+
+    /// FCM found a corrupt parent link while walking the reconstructed chain.
+    #[error(
+        "FCM non-decreasing slot {parent_slot} >= {child_slot} walking parents from tip {tip}; corrupt parent link"
+    )]
+    FcmCanonicalParentSlotNotDescending {
+        parent_slot: Slot,
+        child_slot: Slot,
+        tip: OLBlockCommitment,
+    },
 
     #[error("csm dropped")]
     CsmDropped,

--- a/crates/consensus-logic/src/fcm/context.rs
+++ b/crates/consensus-logic/src/fcm/context.rs
@@ -62,11 +62,11 @@ pub trait FcmStorage: UnfinalizedOLBlockSource {
 
     async fn get_canonical_block_at(&self, slot: Slot) -> DbResult<Option<OLBlockCommitment>>;
 
-    /// Replaces canonical blocks from `start_slot` with `blocks`.
-    async fn replace_canonical_blocks_from(
+    /// Replaces the canonical suffix from `start_slot` with `block_ids`.
+    async fn replace_canonical_suffix_from(
         &self,
         start_slot: Slot,
-        blocks: Vec<(Slot, OLBlockId)>,
+        block_ids: Vec<OLBlockId>,
     ) -> DbResult<()>;
 
     async fn get_canonical_epoch_commitment_at(

--- a/crates/consensus-logic/src/fcm/context.rs
+++ b/crates/consensus-logic/src/fcm/context.rs
@@ -62,10 +62,10 @@ pub trait FcmStorage: UnfinalizedOLBlockSource {
 
     async fn get_canonical_block_at(&self, slot: Slot) -> DbResult<Option<OLBlockCommitment>>;
 
-    /// Updates the canonical blocks above `pivot_slot` with `blocks`.
-    async fn update_canonical_blocks_above(
+    /// Replaces canonical blocks from `start_slot` with `blocks`.
+    async fn replace_canonical_blocks_from(
         &self,
-        pivot_slot: Slot,
+        start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()>;
 

--- a/crates/consensus-logic/src/fcm/context.rs
+++ b/crates/consensus-logic/src/fcm/context.rs
@@ -62,6 +62,18 @@ pub trait FcmStorage: UnfinalizedOLBlockSource {
 
     async fn get_canonical_block_at(&self, slot: Slot) -> DbResult<Option<OLBlockCommitment>>;
 
+    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`.
+    ///
+    /// Single write path for canonical-tip changes: truncates every canonical entry above
+    /// `pivot_slot`, then writes `blocks`, atomically. An extend passes an empty truncation; a
+    /// reorg truncates the abandoned branch and writes the new one; a revert passes an empty
+    /// `blocks`.
+    async fn replace_canonical_suffix(
+        &self,
+        pivot_slot: Slot,
+        blocks: Vec<(Slot, OLBlockId)>,
+    ) -> DbResult<()>;
+
     async fn get_canonical_epoch_commitment_at(
         &self,
         epoch: Epoch,

--- a/crates/consensus-logic/src/fcm/context.rs
+++ b/crates/consensus-logic/src/fcm/context.rs
@@ -62,13 +62,8 @@ pub trait FcmStorage: UnfinalizedOLBlockSource {
 
     async fn get_canonical_block_at(&self, slot: Slot) -> DbResult<Option<OLBlockCommitment>>;
 
-    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`.
-    ///
-    /// Single write path for canonical-tip changes: truncates every canonical entry above
-    /// `pivot_slot`, then writes `blocks`, atomically. An extend passes an empty truncation; a
-    /// reorg truncates the abandoned branch and writes the new one; a revert passes an empty
-    /// `blocks`.
-    async fn replace_canonical_suffix(
+    /// Updates the canonical blocks above `pivot_slot` with `blocks`.
+    async fn update_canonical_blocks_above(
         &self,
         pivot_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -632,7 +632,7 @@ async fn apply_tip_update<C: FcmContext>(
             let pivot_slot = fcm_state.cur_best_block().slot();
             fcm_state.update_tip_block(blk_cmmt, ol_state).await?;
 
-            record_canonical_suffix(fcm_state, pivot_slot, vec![(slot, blkid)]).await?;
+            record_canonical_suffix(fcm_state, pivot_slot, vec![blkid]).await?;
 
             Ok(())
         }
@@ -651,7 +651,7 @@ async fn apply_tip_update<C: FcmContext>(
             let mut applied = Vec::with_capacity(intermediate.len());
             for blkid in intermediate {
                 advance_fcm_to_block(blkid, fcm_state).await?;
-                applied.push((fcm_state.get_block_slot(blkid).await?, blkid));
+                applied.push(blkid);
             }
 
             let final_tip = fcm_state.cur_best_block();
@@ -691,7 +691,7 @@ async fn apply_tip_update<C: FcmContext>(
             let mut applied = Vec::new();
             for blkid in reorg.apply_iter().copied() {
                 advance_fcm_to_block(blkid, fcm_state).await?;
-                applied.push((fcm_state.get_block_slot(blkid).await?, blkid));
+                applied.push(blkid);
             }
 
             let final_tip = fcm_state.cur_best_block();
@@ -731,18 +731,18 @@ async fn apply_tip_update<C: FcmContext>(
 async fn record_canonical_suffix<C: FcmContext>(
     fcm_state: &FcmServiceState<C>,
     pivot_slot: Slot,
-    blocks: Vec<(Slot, OLBlockId)>,
+    block_ids: Vec<OLBlockId>,
 ) -> anyhow::Result<()> {
     let Some(start_slot) = pivot_slot.checked_add(1) else {
         // Truncating above the maximum slot is a no-op; only a non-empty suffix is impossible.
-        if blocks.is_empty() {
+        if block_ids.is_empty() {
             return Ok(());
         }
         return Err(Error::FcmCanonicalSuffixAboveMaxSlot(pivot_slot).into());
     };
     fcm_state
         .ctx()
-        .replace_canonical_blocks_from(start_slot, blocks)
+        .replace_canonical_suffix_from(start_slot, block_ids)
         .await?;
     Ok(())
 }
@@ -1072,14 +1072,27 @@ mod tests {
                 .copied())
         }
 
-        async fn replace_canonical_blocks_from(
+        async fn replace_canonical_suffix_from(
             &self,
             start_slot: Slot,
-            blocks: Vec<(Slot, OLBlockId)>,
+            block_ids: Vec<OLBlockId>,
         ) -> DbResult<()> {
             let mut inner = self.inner.lock().unwrap();
             inner.canonical_blocks.retain(|slot, _| *slot < start_slot);
-            for (slot, id) in blocks {
+            let block_count = block_ids.len();
+            for (offset, id) in block_ids.into_iter().enumerate() {
+                let offset = u64::try_from(offset).map_err(|_| {
+                    strata_db_types::DbError::OLCanonicalSuffixOverflow {
+                        start_slot,
+                        block_count,
+                    }
+                })?;
+                let slot = start_slot.checked_add(offset).ok_or({
+                    strata_db_types::DbError::OLCanonicalSuffixOverflow {
+                        start_slot,
+                        block_count,
+                    }
+                })?;
                 inner
                     .canonical_blocks
                     .insert(slot, OLBlockCommitment::new(slot, id));
@@ -1183,13 +1196,13 @@ mod tests {
             self.storage.get_canonical_block_at(slot).await
         }
 
-        async fn replace_canonical_blocks_from(
+        async fn replace_canonical_suffix_from(
             &self,
             start_slot: Slot,
-            blocks: Vec<(Slot, OLBlockId)>,
+            block_ids: Vec<OLBlockId>,
         ) -> DbResult<()> {
             self.storage
-                .replace_canonical_blocks_from(start_slot, blocks)
+                .replace_canonical_suffix_from(start_slot, block_ids)
                 .await
         }
 
@@ -1697,7 +1710,7 @@ mod tests {
         fixture
             .ctx
             .storage()
-            .replace_canonical_blocks_from(1, vec![(1, fork.a1.blkid()), (2, fork.a2.blkid())])
+            .replace_canonical_suffix_from(1, vec![fork.a1.blkid(), fork.a2.blkid()])
             .await?;
 
         process_fc_message(
@@ -1742,13 +1755,9 @@ mod tests {
 
         let storage = fixture.ctx.storage();
         storage
-            .replace_canonical_blocks_from(
+            .replace_canonical_suffix_from(
                 1,
-                vec![
-                    (1, chain.x1.blkid()),
-                    (2, chain.x2.blkid()),
-                    (3, chain.x3.blkid()),
-                ],
+                vec![chain.x1.blkid(), chain.x2.blkid(), chain.x3.blkid()],
             )
             .await?;
 
@@ -1778,13 +1787,9 @@ mod tests {
         // Simulate a crash that left the index pointing past the recovered tip (x1): slots 2 and 3
         // still hold blocks no longer canonical.
         storage
-            .replace_canonical_blocks_from(
+            .replace_canonical_suffix_from(
                 1,
-                vec![
-                    (1, chain.x1.blkid()),
-                    (2, chain.x2.blkid()),
-                    (3, chain.x3.blkid()),
-                ],
+                vec![chain.x1.blkid(), chain.x2.blkid(), chain.x3.blkid()],
             )
             .await?;
 
@@ -1996,7 +2001,7 @@ mod tests {
         // canonical write.
         assert_eq!(storage.get_canonical_block_at(1).await.unwrap(), None);
         storage
-            .replace_canonical_blocks_from(1, vec![(1, blkid)])
+            .replace_canonical_suffix_from(1, vec![blkid])
             .await
             .unwrap();
         assert_eq!(

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -5,6 +5,7 @@ use metrics::{counter, histogram};
 use serde::Serialize;
 use strata_csm_types::CheckpointState;
 use strata_db_types::traits::BlockStatus;
+use strata_identifiers::Slot;
 use strata_ol_chain_types_new::{
     sequencer_predicate_requires_signature, verify_sequencer_predicate_signature, OLBlock,
 };
@@ -618,15 +619,20 @@ async fn apply_tip_update<C: FcmContext>(
         TipUpdate::ExtendTip(_cur, _new) => {
             // TODO(STR-3673): what's the relation between _new and bundle
             // Update the tip block in the FCM state.
-            let blk_cmmt =
-                OLBlockCommitment::new(bundle.header().slot(), bundle.header().compute_blkid());
+            let slot = bundle.header().slot();
+            let blkid = bundle.header().compute_blkid();
+            let blk_cmmt = OLBlockCommitment::new(slot, blkid);
             let ol_state = fcm_state
                 .ctx()
                 .get_toplevel_ol_state(blk_cmmt)
                 .await?
                 .ok_or(Error::MissingOLState(blk_cmmt))?;
 
+            // Capture the old tip slot before the update; it is the truncation pivot.
+            let pivot_slot = fcm_state.cur_best_block().slot();
             fcm_state.update_tip_block(blk_cmmt, ol_state).await?;
+
+            record_canonical_suffix(fcm_state, pivot_slot, vec![(slot, blkid)]).await?;
 
             Ok(())
         }
@@ -641,8 +647,11 @@ async fn apply_tip_update<C: FcmContext>(
             // blocks we're applying.
             intermediate.push(new);
 
+            let pivot_slot = fcm_state.cur_best_block().slot();
+            let mut applied = Vec::with_capacity(intermediate.len());
             for blkid in intermediate {
                 advance_fcm_to_block(blkid, fcm_state).await?;
+                applied.push((fcm_state.get_block_slot(blkid).await?, blkid));
             }
 
             let final_tip = fcm_state.cur_best_block();
@@ -651,6 +660,8 @@ async fn apply_tip_update<C: FcmContext>(
             if final_tip != expected_tip {
                 return Err(Error::OLApplyTipMismatch(expected_tip, final_tip).into());
             }
+
+            record_canonical_suffix(fcm_state, pivot_slot, applied).await?;
 
             Ok(())
         }
@@ -677,8 +688,10 @@ async fn apply_tip_update<C: FcmContext>(
                 return Err(Error::InvalidOLReorgEmptyDownPivot(cur_best, pivot_block).into());
             }
 
+            let mut applied = Vec::new();
             for blkid in reorg.apply_iter().copied() {
                 advance_fcm_to_block(blkid, fcm_state).await?;
+                applied.push((fcm_state.get_block_slot(blkid).await?, blkid));
             }
 
             let final_tip = fcm_state.cur_best_block();
@@ -692,8 +705,11 @@ async fn apply_tip_update<C: FcmContext>(
                 return Err(Error::OLApplyTipMismatch(expected_tip, final_tip).into());
             }
 
-            // TODO(STR-3673): any cleanup?
+            // Truncate the abandoned branch above the pivot and write the new one.
+            record_canonical_suffix(fcm_state, pivot_slot, applied).await?;
 
+            // TODO(STR-3673): canonical-index cleanup is handled above; revisit
+            // whether any other post-reorg cleanup is still needed here.
             counter!("strata_fcm_reorgs_total").increment(1);
             histogram!("strata_fcm_reorg_depth").record(reorg_depth as f64);
 
@@ -704,9 +720,26 @@ async fn apply_tip_update<C: FcmContext>(
             let slot = fcm_state.get_block_slot(new).await?;
             let block = OLBlockCommitment::new(slot, new);
             revert_ol_state_to_block(&block, fcm_state).await?;
+
+            // Revert to a lower tip; truncate everything above it, write nothing.
+            record_canonical_suffix(fcm_state, slot, Vec::new()).await?;
+
             Ok(())
         }
     }
+}
+
+/// Single canonical write path for fork-choice tip moves.
+async fn record_canonical_suffix<C: FcmContext>(
+    fcm_state: &FcmServiceState<C>,
+    pivot_slot: Slot,
+    blocks: Vec<(Slot, OLBlockId)>,
+) -> anyhow::Result<()> {
+    fcm_state
+        .ctx()
+        .replace_canonical_suffix(pivot_slot, blocks)
+        .await?;
+    Ok(())
 }
 
 /// Advances the in-memory OL state to an already-executed block.
@@ -850,7 +883,8 @@ mod tests {
             if !blocks_at_slot.contains(&blkid) {
                 blocks_at_slot.push(blkid);
             }
-            inner.canonical_blocks.entry(slot).or_insert(commitment);
+            // The canonical index is written only via `replace_canonical_suffix`,
+            // mirroring the real DB where plain block puts do not touch it.
             if let Some(state) = state {
                 inner.states.insert(commitment, Arc::new(state));
             }
@@ -876,6 +910,17 @@ mod tests {
                 .unwrap()
                 .canonical_epochs
                 .insert(epoch.epoch(), epoch);
+        }
+
+        /// Seeds the canonical slot-0 entry, mirroring what real genesis does.
+        /// Plain block puts do not touch the canonical index, so tests that boot
+        /// FCM must seed slot 0 explicitly or the startup loop never resolves.
+        fn seed_canonical_genesis(&self, genesis_blkid: OLBlockId) {
+            self.inner
+                .lock()
+                .unwrap()
+                .canonical_blocks
+                .insert(0, OLBlockCommitment::new(0, genesis_blkid));
         }
 
         fn set_block_high_watermark(&self, block: OLBlockCommitment) {
@@ -1024,6 +1069,21 @@ mod tests {
                 .copied())
         }
 
+        async fn replace_canonical_suffix(
+            &self,
+            pivot_slot: Slot,
+            blocks: Vec<(Slot, OLBlockId)>,
+        ) -> DbResult<()> {
+            let mut inner = self.inner.lock().unwrap();
+            inner.canonical_blocks.retain(|slot, _| *slot <= pivot_slot);
+            for (slot, id) in blocks {
+                inner
+                    .canonical_blocks
+                    .insert(slot, OLBlockCommitment::new(slot, id));
+            }
+            Ok(())
+        }
+
         async fn get_canonical_epoch_commitment_at(
             &self,
             epoch: Epoch,
@@ -1120,6 +1180,16 @@ mod tests {
             self.storage.get_canonical_block_at(slot).await
         }
 
+        async fn replace_canonical_suffix(
+            &self,
+            pivot_slot: Slot,
+            blocks: Vec<(Slot, OLBlockId)>,
+        ) -> DbResult<()> {
+            self.storage
+                .replace_canonical_suffix(pivot_slot, blocks)
+                .await
+        }
+
         async fn get_canonical_epoch_commitment_at(
             &self,
             epoch: Epoch,
@@ -1174,6 +1244,7 @@ mod tests {
                 seed_executed_block(ctx.storage(), block, BlockStatus::Valid);
             }
             ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+            ctx.storage().seed_canonical_genesis(genesis.blkid());
 
             Self { ctx: Arc::new(ctx) }
         }
@@ -1421,6 +1492,7 @@ mod tests {
         );
         seed_executed_block(ctx.storage(), &genesis, BlockStatus::Valid);
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis.blkid());
 
         let tracker = empty_tracker(&genesis);
         let inner = FcmInnerState::new(
@@ -1607,6 +1679,57 @@ mod tests {
         Ok(())
     }
 
+    /// A reorg from branch A to branch B must rewrite the canonical index to the
+    /// new branch and drop the abandoned branch's entries, including any slot the
+    /// shorter branch no longer reaches.
+    #[tokio::test]
+    async fn reorg_rewrites_canonical_index_and_drops_abandoned_branch() -> anyhow::Result<()> {
+        let fork = TestFork::new();
+        let fixture = fork.fixture();
+        seed_executed_block(fixture.ctx.storage(), &fork.b3, BlockStatus::Valid);
+        let tracker = fork.tracker_without_b3();
+        let mut fcm_state = fixture.fcm_state_at(tracker, &fork.a2);
+
+        // Seed the canonical index as if branch A were the live chain.
+        fixture
+            .ctx
+            .storage()
+            .replace_canonical_suffix(0, vec![(1, fork.a1.blkid()), (2, fork.a2.blkid())])
+            .await?;
+
+        process_fc_message(
+            &ForkChoiceMessage::NewBlock(fork.b3.blkid()),
+            &mut fcm_state,
+        )
+        .await?;
+
+        let storage = fixture.ctx.storage();
+        // Branch B is now canonical at every slot.
+        assert_eq!(
+            storage.get_canonical_block_at(1).await?,
+            Some(fork.b1.commitment())
+        );
+        assert_eq!(
+            storage.get_canonical_block_at(2).await?,
+            Some(fork.b2.commitment())
+        );
+        assert_eq!(
+            storage.get_canonical_block_at(3).await?,
+            Some(fork.b3.commitment())
+        );
+        // Branch A's blocks no longer win their slots.
+        assert_ne!(
+            storage.get_canonical_block_at(1).await?,
+            Some(fork.a1.commitment())
+        );
+        assert_ne!(
+            storage.get_canonical_block_at(2).await?,
+            Some(fork.a2.commitment())
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn long_extend_applies_intermediate_blocks_to_new_tip() -> anyhow::Result<()> {
         let chain = LinearChain::new();
@@ -1765,6 +1888,7 @@ mod tests {
                 .put_toplevel_ol_state(commitment, make_genesis_state().state().clone());
         }
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis_blkid);
 
         let mut fcm_state =
             init_fcm_service_state(PredicateKey::always_accept(), ctx.clone()).await?;
@@ -1798,6 +1922,13 @@ mod tests {
 
         assert_eq!(storage.get_ol_block(blkid).await.unwrap(), Some(block));
         assert_eq!(storage.get_blocks_at_height(1).await.unwrap(), vec![blkid]);
+        // A plain put does not make a block canonical; that requires an explicit
+        // canonical write.
+        assert_eq!(storage.get_canonical_block_at(1).await.unwrap(), None);
+        storage
+            .replace_canonical_suffix(0, vec![(1, blkid)])
+            .await
+            .unwrap();
         assert_eq!(
             storage.get_canonical_block_at(1).await.unwrap(),
             Some(commitment)
@@ -1885,6 +2016,7 @@ mod tests {
         ctx.storage()
             .put_toplevel_ol_state(block_commitment, make_genesis_state().state().clone());
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis_blkid);
 
         let mut fcm_state = init_fcm_service_state(PredicateKey::always_accept(), ctx.clone())
             .await
@@ -1940,6 +2072,7 @@ mod tests {
             .await?;
         ctx.storage().set_block_high_watermark(block_commitment);
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis_blkid);
 
         let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
         assert_eq!(fcm_state.take_startup_replay_candidates(), vec![blkid]);
@@ -1988,6 +2121,7 @@ mod tests {
         ctx.storage().put_ol_block(block);
         ctx.storage().set_block_high_watermark(block_commitment);
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis_blkid);
 
         let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
 
@@ -2051,6 +2185,7 @@ mod tests {
         ctx.storage().put_ol_block(fork);
         ctx.storage().set_block_high_watermark(canonical_commitment);
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis_blkid);
 
         let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
 
@@ -2111,6 +2246,7 @@ mod tests {
         ctx.storage().put_ol_block(fork);
         ctx.storage().set_block_high_watermark(canonical_commitment);
         ctx.storage().put_canonical_epoch_commitment(genesis_epoch);
+        ctx.storage().seed_canonical_genesis(genesis_blkid);
 
         let mut fcm_state = init_fcm_service_state(schnorr_predicate(&pk), ctx.clone()).await?;
 

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -735,9 +735,17 @@ async fn record_canonical_suffix<C: FcmContext>(
     pivot_slot: Slot,
     blocks: Vec<(Slot, OLBlockId)>,
 ) -> anyhow::Result<()> {
+    if blocks.is_empty() {
+        return Ok(());
+    }
+    let Some(start_slot) = pivot_slot.checked_add(1) else {
+        return Err(anyhow!(
+            "fcm: canonical suffix above max slot {pivot_slot} is non-empty"
+        ));
+    };
     fcm_state
         .ctx()
-        .update_canonical_blocks_above(pivot_slot, blocks)
+        .replace_canonical_blocks_from(start_slot, blocks)
         .await?;
     Ok(())
 }
@@ -1067,13 +1075,13 @@ mod tests {
                 .copied())
         }
 
-        async fn update_canonical_blocks_above(
+        async fn replace_canonical_blocks_from(
             &self,
-            pivot_slot: Slot,
+            start_slot: Slot,
             blocks: Vec<(Slot, OLBlockId)>,
         ) -> DbResult<()> {
             let mut inner = self.inner.lock().unwrap();
-            inner.canonical_blocks.retain(|slot, _| *slot <= pivot_slot);
+            inner.canonical_blocks.retain(|slot, _| *slot < start_slot);
             for (slot, id) in blocks {
                 inner
                     .canonical_blocks
@@ -1178,13 +1186,13 @@ mod tests {
             self.storage.get_canonical_block_at(slot).await
         }
 
-        async fn update_canonical_blocks_above(
+        async fn replace_canonical_blocks_from(
             &self,
-            pivot_slot: Slot,
+            start_slot: Slot,
             blocks: Vec<(Slot, OLBlockId)>,
         ) -> DbResult<()> {
             self.storage
-                .update_canonical_blocks_above(pivot_slot, blocks)
+                .replace_canonical_blocks_from(start_slot, blocks)
                 .await
         }
 
@@ -1692,7 +1700,7 @@ mod tests {
         fixture
             .ctx
             .storage()
-            .update_canonical_blocks_above(0, vec![(1, fork.a1.blkid()), (2, fork.a2.blkid())])
+            .replace_canonical_blocks_from(1, vec![(1, fork.a1.blkid()), (2, fork.a2.blkid())])
             .await?;
 
         process_fc_message(
@@ -1924,7 +1932,7 @@ mod tests {
         // canonical write.
         assert_eq!(storage.get_canonical_block_at(1).await.unwrap(), None);
         storage
-            .update_canonical_blocks_above(0, vec![(1, blkid)])
+            .replace_canonical_blocks_from(1, vec![(1, blkid)])
             .await
             .unwrap();
         assert_eq!(

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -708,8 +708,6 @@ async fn apply_tip_update<C: FcmContext>(
             // Truncate the abandoned branch above the pivot and write the new one.
             record_canonical_suffix(fcm_state, pivot_slot, applied).await?;
 
-            // TODO(STR-3673): canonical-index cleanup is handled above; revisit
-            // whether any other post-reorg cleanup is still needed here.
             counter!("strata_fcm_reorgs_total").increment(1);
             histogram!("strata_fcm_reorg_depth").record(reorg_depth as f64);
 
@@ -735,13 +733,12 @@ async fn record_canonical_suffix<C: FcmContext>(
     pivot_slot: Slot,
     blocks: Vec<(Slot, OLBlockId)>,
 ) -> anyhow::Result<()> {
-    if blocks.is_empty() {
-        return Ok(());
-    }
     let Some(start_slot) = pivot_slot.checked_add(1) else {
-        return Err(anyhow!(
-            "fcm: canonical suffix above max slot {pivot_slot} is non-empty"
-        ));
+        // Truncating above the maximum slot is a no-op; only a non-empty suffix is impossible.
+        if blocks.is_empty() {
+            return Ok(());
+        }
+        return Err(Error::FcmCanonicalSuffixAboveMaxSlot(pivot_slot).into());
     };
     fcm_state
         .ctx()
@@ -833,7 +830,7 @@ mod tests {
     use crate::{
         fcm::{
             context::{ChainController, CsmStatusReader},
-            state::FcmInnerState,
+            state::{reconcile_canonical_blocks_index, FcmInnerState},
         },
         tip_update::TipUpdate,
         unfinalized_tracker::{UnfinalizedBlockTracker, UnfinalizedOLBlockSource},
@@ -1732,6 +1729,73 @@ mod tests {
             storage.get_canonical_block_at(2).await?,
             Some(fork.a2.commitment())
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn revert_truncates_canonical_index_above_new_tip() -> anyhow::Result<()> {
+        let chain = LinearChain::new();
+        let fixture = chain.fixture_without_x4();
+        let tracker = chain.tracker_through_x3();
+        let mut fcm_state = fixture.fcm_state_at(tracker, &chain.x3);
+
+        let storage = fixture.ctx.storage();
+        storage
+            .replace_canonical_blocks_from(
+                1,
+                vec![
+                    (1, chain.x1.blkid()),
+                    (2, chain.x2.blkid()),
+                    (3, chain.x3.blkid()),
+                ],
+            )
+            .await?;
+
+        let update = expected_tip_update(&chain.x3, &chain.x1, fcm_state.chain_tracker())?;
+        assert!(matches!(update, TipUpdate::Revert(..)));
+
+        apply_tip_update(update, &mut fcm_state, &chain.x1.block).await?;
+
+        assert_eq!(fcm_state.cur_best_block(), chain.x1.commitment());
+        assert_eq!(
+            storage.get_canonical_block_at(1).await?,
+            Some(chain.x1.commitment())
+        );
+        assert_eq!(storage.get_canonical_block_at(2).await?, None);
+        assert_eq!(storage.get_canonical_block_at(3).await?, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reconcile_truncates_stale_canonical_entries_on_restart() -> anyhow::Result<()> {
+        let chain = LinearChain::new();
+        let fixture = chain.fixture_without_x4();
+        let tracker = tracker_with_blocks(&chain.genesis, &[&chain.x1]);
+
+        let storage = fixture.ctx.storage();
+        // Simulate a crash that left the index pointing past the recovered tip (x1): slots 2 and 3
+        // still hold blocks no longer canonical.
+        storage
+            .replace_canonical_blocks_from(
+                1,
+                vec![
+                    (1, chain.x1.blkid()),
+                    (2, chain.x2.blkid()),
+                    (3, chain.x3.blkid()),
+                ],
+            )
+            .await?;
+
+        reconcile_canonical_blocks_index(&tracker, chain.x1.commitment(), storage).await?;
+
+        assert_eq!(
+            storage.get_canonical_block_at(1).await?,
+            Some(chain.x1.commitment())
+        );
+        assert_eq!(storage.get_canonical_block_at(2).await?, None);
+        assert_eq!(storage.get_canonical_block_at(3).await?, None);
 
         Ok(())
     }

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -737,7 +737,7 @@ async fn record_canonical_suffix<C: FcmContext>(
 ) -> anyhow::Result<()> {
     fcm_state
         .ctx()
-        .replace_canonical_suffix(pivot_slot, blocks)
+        .update_canonical_blocks_above(pivot_slot, blocks)
         .await?;
     Ok(())
 }
@@ -883,8 +883,6 @@ mod tests {
             if !blocks_at_slot.contains(&blkid) {
                 blocks_at_slot.push(blkid);
             }
-            // The canonical index is written only via `replace_canonical_suffix`,
-            // mirroring the real DB where plain block puts do not touch it.
             if let Some(state) = state {
                 inner.states.insert(commitment, Arc::new(state));
             }
@@ -1069,7 +1067,7 @@ mod tests {
                 .copied())
         }
 
-        async fn replace_canonical_suffix(
+        async fn update_canonical_blocks_above(
             &self,
             pivot_slot: Slot,
             blocks: Vec<(Slot, OLBlockId)>,
@@ -1180,13 +1178,13 @@ mod tests {
             self.storage.get_canonical_block_at(slot).await
         }
 
-        async fn replace_canonical_suffix(
+        async fn update_canonical_blocks_above(
             &self,
             pivot_slot: Slot,
             blocks: Vec<(Slot, OLBlockId)>,
         ) -> DbResult<()> {
             self.storage
-                .replace_canonical_suffix(pivot_slot, blocks)
+                .update_canonical_blocks_above(pivot_slot, blocks)
                 .await
         }
 
@@ -1694,7 +1692,7 @@ mod tests {
         fixture
             .ctx
             .storage()
-            .replace_canonical_suffix(0, vec![(1, fork.a1.blkid()), (2, fork.a2.blkid())])
+            .update_canonical_blocks_above(0, vec![(1, fork.a1.blkid()), (2, fork.a2.blkid())])
             .await?;
 
         process_fc_message(
@@ -1926,7 +1924,7 @@ mod tests {
         // canonical write.
         assert_eq!(storage.get_canonical_block_at(1).await.unwrap(), None);
         storage
-            .replace_canonical_suffix(0, vec![(1, blkid)])
+            .update_canonical_blocks_above(0, vec![(1, blkid)])
             .await
             .unwrap();
         assert_eq!(

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -1806,6 +1806,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn startup_preserves_canonical_tip_on_equal_slot_forks() -> anyhow::Result<()> {
+        let fork = TestFork::new();
+        let fixture = fork.fixture();
+        let (canonical_1, canonical_2, other_2) = if fork.a2.blkid() > fork.b2.blkid() {
+            (&fork.a1, &fork.a2, &fork.b2)
+        } else {
+            (&fork.b1, &fork.b2, &fork.a2)
+        };
+        assert!(canonical_2.blkid() > other_2.blkid());
+
+        fixture
+            .ctx
+            .storage()
+            .replace_canonical_suffix_from(1, vec![canonical_1.blkid(), canonical_2.blkid()])
+            .await?;
+
+        let fcm_state = init_fcm_service_state(PredicateKey::always_accept(), fixture.ctx).await?;
+
+        assert_eq!(fcm_state.cur_best_block(), canonical_2.commitment());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn long_extend_applies_intermediate_blocks_to_new_tip() -> anyhow::Result<()> {
         let chain = LinearChain::new();
         let fixture = chain.fixture_without_x4();

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -15,7 +15,7 @@ use crate::{
     unfinalized_tracker::UnfinalizedBlockTracker,
 };
 
-type CanonicalSuffix = Vec<(Slot, OLBlockId)>;
+type CanonicalSuffix = Vec<OLBlockId>;
 
 /// Runtime container for the FCM service.
 ///
@@ -360,7 +360,7 @@ pub(crate) async fn reconcile_canonical_blocks_index(
         return Err(Error::FcmCanonicalSuffixAboveMaxSlot(pivot_slot));
     };
     storage
-        .replace_canonical_blocks_from(start_slot, canon_blocks)
+        .replace_canonical_suffix_from(start_slot, canon_blocks)
         .await?;
     Ok(())
 }
@@ -402,7 +402,7 @@ async fn canonical_blocks_from_tip(
             });
         }
 
-        suffix.push((slot, blkid));
+        suffix.push(blkid);
     }
 
     unreachable!("validated parent chain always includes the finalized tip")

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -353,16 +353,24 @@ async fn reconcile_canonical_blocks_index(
     tip: OLBlockCommitment,
     storage: &(impl FcmStorage + ?Sized),
 ) -> anyhow::Result<()> {
-    let (pivot_slot, suffix) = canonical_suffix_from_tip(unfin, tip, storage).await?;
+    let (pivot_slot, canon_blocks) = canonical_blocks_from_tip(unfin, tip, storage).await?;
+    if canon_blocks.is_empty() {
+        return Ok(());
+    }
+    let Some(start_slot) = pivot_slot.checked_add(1) else {
+        return Err(anyhow!(
+            "fcm: canonical suffix above max slot {pivot_slot} is non-empty"
+        ));
+    };
     storage
-        .update_canonical_blocks_above(pivot_slot, suffix)
+        .replace_canonical_blocks_from(start_slot, canon_blocks)
         .await?;
     Ok(())
 }
 
 /// Walks from `tip` toward the finalized tip until it reaches the first block
 /// already recorded as canonical.
-async fn canonical_suffix_from_tip(
+async fn canonical_blocks_from_tip(
     unfin: &UnfinalizedBlockTracker,
     tip: OLBlockCommitment,
     storage: &(impl FcmStorage + ?Sized),

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -295,7 +295,7 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
         .load_unfinalized_ol_blocks_async(fcm_ctx.as_ref())
         .await?;
 
-    let cur_tip_block = determine_start_tip(&chain_tracker)?;
+    let cur_tip_block = determine_start_tip(&chain_tracker, fcm_ctx.as_ref()).await?;
     debug!(?chain_tracker, "init chain tracker");
 
     // Update the canonical blocks index just in case this might have drifted during the restarts.
@@ -327,16 +327,31 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
     ))
 }
 
-/// Determines the starting chain tip by choosing the highest-slot tip, using
-/// the lowest ordered block ID as the tie-breaker.
-fn determine_start_tip(unfin: &UnfinalizedBlockTracker) -> Result<OLBlockCommitment, Error> {
+/// Determines the starting chain tip by choosing the highest-slot tip.
+///
+/// If multiple tips share the highest slot, the previously persisted canonical
+/// block wins. If no highest-slot tip matches the persisted canonical index,
+/// the lowest ordered block ID wins as a deterministic fallback.
+async fn determine_start_tip(
+    unfin: &UnfinalizedBlockTracker,
+    storage: &(impl FcmStorage + ?Sized),
+) -> Result<OLBlockCommitment, Error> {
     // Unfinalized block tracker only loads blocks which are valid and exist in db so no need to
     // check for db existence at this point.
+    let Some(max_slot) = unfin.chain_tip_blocks_iter().map(|tip| tip.slot()).max() else {
+        return Err(Error::FcmNoChainTips);
+    };
+
+    let canonical_at_max_slot = storage.get_canonical_block_at(max_slot).await?;
+
     unfin
         .chain_tip_blocks_iter()
+        .filter(|tip| tip.slot() == max_slot)
         .max_by(|a, b| {
-            a.slot()
-                .cmp(&b.slot())
+            let a_is_canonical = Some(*a.blkid()) == canonical_at_max_slot.map(|c| *c.blkid());
+            let b_is_canonical = Some(*b.blkid()) == canonical_at_max_slot.map(|c| *c.blkid());
+            a_is_canonical
+                .cmp(&b_is_canonical)
                 .then_with(|| b.blkid().cmp(a.blkid()))
         })
         .ok_or(Error::FcmNoChainTips)

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -1,7 +1,8 @@
-use std::{collections::VecDeque, mem, sync::Arc, time};
+use std::{collections::VecDeque, iter, mem, sync::Arc, time};
 
 use anyhow::anyhow;
 use metrics::{counter, gauge};
+use strata_identifiers::Slot;
 use strata_ol_state_types::OLState;
 use strata_predicate::PredicateKey;
 use strata_primitives::{EpochCommitment, OLBlockCommitment, OLBlockId};
@@ -14,6 +15,8 @@ use crate::{
     fcm::context::{FcmContext, FcmStorage},
     unfinalized_tracker::UnfinalizedBlockTracker,
 };
+
+type CanonicalSuffix = Vec<(Slot, OLBlockId)>;
 
 /// Runtime container for the FCM service.
 ///
@@ -294,14 +297,11 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
         .load_unfinalized_ol_blocks_async(fcm_ctx.as_ref())
         .await?;
 
-    let cur_tip_block = determine_start_tip(&chain_tracker, fcm_ctx.as_ref()).await?;
+    let cur_tip_block = determine_start_tip(&chain_tracker)?;
     debug!(?chain_tracker, "init chain tracker");
 
-    // Force the canonical index to match the reconstructed chain before any
-    // consumer reads it. A crash can leave the index ahead of, behind, or forked
-    // from fork choice; this repairs all of those by rewriting the unfinalized
-    // suffix from the reconstructed tip.
-    reconcile_canonical_index(&chain_tracker, cur_tip_block, fcm_ctx.as_ref()).await?;
+    // Update the canonical blocks index just in case this might have drifted during the restarts.
+    reconcile_canonical_blocks_index(&chain_tracker, cur_tip_block, fcm_ctx.as_ref()).await?;
 
     // Load in that block's ol_state.
     let tip_blkid = cur_tip_block;
@@ -329,96 +329,116 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
     ))
 }
 
-/// Determines the starting chain tip.  For now, this is just the block with the
-/// highest index, choosing the lowest ordered blockid in the case of ties.
-async fn determine_start_tip(
-    unfin: &UnfinalizedBlockTracker,
-    storage: &(impl FcmStorage + ?Sized),
-) -> anyhow::Result<OLBlockCommitment> {
-    let mut iter = unfin.chain_tips_iter();
-
-    let mut best = iter.next().expect("fcm: no chain tips");
-    let mut best_slot = storage
-        .get_ol_block(*best)
-        .await?
-        .ok_or(Error::MissingOLBlock(*best))?
-        .header()
-        .slot();
-
-    // Iterate through the remaining elements and choose.
-    for blkid in iter {
-        let blkid_slot = storage
-            .get_ol_block(*blkid)
-            .await?
-            .ok_or(Error::MissingOLBlock(*blkid))?
-            .header()
-            .slot();
-
-        if blkid_slot == best_slot && blkid < best {
-            best = blkid;
-        } else if blkid_slot > best_slot {
-            best = blkid;
-            best_slot = blkid_slot;
-        }
-    }
-
-    Ok(OLBlockCommitment::new(best_slot, *best))
+/// Determines the starting chain tip by choosing the highest-slot tip, using
+/// the lowest ordered block ID as the tie-breaker.
+fn determine_start_tip(unfin: &UnfinalizedBlockTracker) -> anyhow::Result<OLBlockCommitment> {
+    // Unfinalized block tracker only loads blocks which are valid and exist in db so no need to
+    // check for db existence at this point.
+    unfin
+        .chain_tip_blocks_iter()
+        .max_by(|a, b| {
+            a.slot()
+                .cmp(&b.slot())
+                .then_with(|| b.blkid().cmp(a.blkid()))
+        })
+        .ok_or_else(|| anyhow!("fcm: no chain tips"))
 }
 
 /// Rewrites the canonical index to match the reconstructed chain.
 ///
 /// Only the unfinalized suffix is rewritten; slots at or below the finalized tip are left untouched
 /// since finalized history never forks.
-async fn reconcile_canonical_index(
+async fn reconcile_canonical_blocks_index(
     unfin: &UnfinalizedBlockTracker,
     tip: OLBlockCommitment,
     storage: &(impl FcmStorage + ?Sized),
 ) -> anyhow::Result<()> {
-    let finalized_slot = unfin.finalized_epoch().last_slot();
+    let (pivot_slot, suffix) = canonical_suffix_from_tip(unfin, tip, storage).await?;
+    storage
+        .update_canonical_blocks_above(pivot_slot, suffix)
+        .await?;
+    Ok(())
+}
 
-    // Slots strictly decrease child->parent (enforced by `attach_block`), so a
-    // non-decrease means a corrupt parent link; erroring out also bounds the walk.
-    let mut chain = Vec::new();
-    let mut cursor = *tip.blkid();
-    let mut prev_slot: Option<u64> = None;
-    while let Some(parent) = unfin.get_parent(&cursor) {
-        let slot = unfin
-            .get_slot(&cursor)
-            .ok_or_else(|| anyhow!("fcm: reconstructed block {cursor} missing from tracker"))?;
-        if let Some(prev) = prev_slot {
-            if slot >= prev {
-                return Err(anyhow!(
-                    "fcm: non-decreasing slot {slot} >= {prev} walking parents from tip {}; corrupt parent link",
-                    tip.blkid()
-                ));
-            }
-        }
-        prev_slot = Some(slot);
-        chain.push((slot, cursor));
-        cursor = *parent;
-    }
-
-    // The walk must land on the finalized tip; otherwise the chain doesn't trace
-    // back to finalized history — corruption, not recoverable.
+/// Walks from `tip` toward the finalized tip until it reaches the first block
+/// already recorded as canonical.
+async fn canonical_suffix_from_tip(
+    unfin: &UnfinalizedBlockTracker,
+    tip: OLBlockCommitment,
+    storage: &(impl FcmStorage + ?Sized),
+) -> anyhow::Result<(Slot, CanonicalSuffix)> {
+    let parent_chain = construct_validated_parent_chain(unfin, tip)?;
     let finalized_tip = *unfin.finalized_tip();
-    if cursor != finalized_tip {
+
+    if parent_chain.last() != Some(&finalized_tip) {
         return Err(anyhow!(
             "fcm: reconstructed chain tip {} does not trace back to finalized tip {finalized_tip}",
             tip.blkid()
         ));
     }
 
-    // The finalized slot is left untouched, so verify it is already canonical.
-    let canonical_finalized = storage.get_canonical_block_at(finalized_slot).await?;
-    if canonical_finalized.map(|c| *c.blkid()) != Some(finalized_tip) {
-        return Err(anyhow!(
-            "fcm: canonical block at finalized slot {finalized_slot} is {canonical_finalized:?}, expected finalized tip {finalized_tip}"
-        ));
+    let mut suffix = Vec::new();
+
+    for blkid in parent_chain {
+        let slot = tracker_slot(unfin, blkid)?;
+
+        let canonical = storage.get_canonical_block_at(slot).await?;
+        if canonical.map(|c| *c.blkid()) == Some(blkid) {
+            suffix.reverse();
+            return Ok((slot, suffix));
+        }
+
+        if blkid == finalized_tip {
+            let finalized_slot = unfin.finalized_epoch().last_slot();
+            return Err(anyhow!(
+                "fcm: canonical block at finalized slot {finalized_slot} is {canonical:?}, expected finalized tip {finalized_tip}"
+            ));
+        }
+
+        suffix.push((slot, blkid));
     }
 
-    chain.reverse();
-    storage
-        .update_canonical_blocks_above(finalized_slot, chain)
-        .await?;
+    unreachable!("validated parent chain always includes the finalized tip")
+}
+
+fn construct_validated_parent_chain(
+    unfin: &UnfinalizedBlockTracker,
+    tip: OLBlockCommitment,
+) -> anyhow::Result<Vec<OLBlockId>> {
+    let mut chain = Vec::new();
+    let mut child_slot: Option<Slot> = None;
+    let parent_chain =
+        iter::successors(Some(*tip.blkid()), |blkid| unfin.get_parent(blkid).copied());
+
+    for blkid in parent_chain {
+        let slot = tracker_slot(unfin, blkid)?;
+        ensure_parent_slot_descends(slot, child_slot, tip)?;
+        child_slot = Some(slot);
+        chain.push(blkid);
+    }
+
+    Ok(chain)
+}
+
+fn tracker_slot(unfin: &UnfinalizedBlockTracker, blkid: OLBlockId) -> anyhow::Result<Slot> {
+    unfin
+        .get_slot(&blkid)
+        .ok_or_else(|| anyhow!("fcm: reconstructed block {blkid} missing from tracker"))
+}
+
+fn ensure_parent_slot_descends(
+    parent_slot: Slot,
+    child_slot: Option<Slot>,
+    tip: OLBlockCommitment,
+) -> anyhow::Result<()> {
+    if let Some(child_slot) = child_slot {
+        if parent_slot >= child_slot {
+            return Err(anyhow!(
+                "fcm: non-decreasing slot {parent_slot} >= {child_slot} walking parents from tip {}; corrupt parent link",
+                tip.blkid()
+            ));
+        }
+    }
+
     Ok(())
 }

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use metrics::{counter, gauge};
 use strata_ol_state_types::OLState;
 use strata_predicate::PredicateKey;
-use strata_primitives::{EpochCommitment, L2BlockCommitment, OLBlockCommitment, OLBlockId};
+use strata_primitives::{EpochCommitment, OLBlockCommitment, OLBlockId};
 use strata_service::ServiceState;
 use tokio::time::sleep;
 use tracing::{debug, warn};
@@ -243,7 +243,7 @@ impl<C: FcmContext> ServiceState for FcmServiceState<C> {
 #[derive(Debug)]
 pub(crate) struct FcmInnerState {
     chain_tracker: UnfinalizedBlockTracker,
-    cur_best_block: L2BlockCommitment,
+    cur_best_block: OLBlockCommitment,
     cur_olstate: Arc<OLState>,
     startup_replay_candidates: Vec<OLBlockId>,
     epochs_pending_finalization: VecDeque<EpochCommitment>,
@@ -252,7 +252,7 @@ pub(crate) struct FcmInnerState {
 impl FcmInnerState {
     pub(crate) fn new(
         chain_tracker: UnfinalizedBlockTracker,
-        cur_best_block: L2BlockCommitment,
+        cur_best_block: OLBlockCommitment,
         cur_olstate: Arc<OLState>,
         startup_replay_candidates: Vec<OLBlockId>,
     ) -> Self {
@@ -334,7 +334,7 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
 async fn determine_start_tip(
     unfin: &UnfinalizedBlockTracker,
     storage: &(impl FcmStorage + ?Sized),
-) -> anyhow::Result<L2BlockCommitment> {
+) -> anyhow::Result<OLBlockCommitment> {
     let mut iter = unfin.chain_tips_iter();
 
     let mut best = iter.next().expect("fcm: no chain tips");
@@ -362,7 +362,7 @@ async fn determine_start_tip(
         }
     }
 
-    Ok(L2BlockCommitment::new(best_slot, *best))
+    Ok(OLBlockCommitment::new(best_slot, *best))
 }
 
 /// Rewrites the canonical index to match the reconstructed chain.
@@ -371,7 +371,7 @@ async fn determine_start_tip(
 /// since finalized history never forks.
 async fn reconcile_canonical_index(
     unfin: &UnfinalizedBlockTracker,
-    tip: L2BlockCommitment,
+    tip: OLBlockCommitment,
     storage: &(impl FcmStorage + ?Sized),
 ) -> anyhow::Result<()> {
     let finalized_slot = unfin.finalized_epoch().last_slot();
@@ -418,7 +418,7 @@ async fn reconcile_canonical_index(
 
     chain.reverse();
     storage
-        .replace_canonical_suffix(finalized_slot, chain)
+        .update_canonical_blocks_above(finalized_slot, chain)
         .await?;
     Ok(())
 }

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -1,6 +1,5 @@
 use std::{collections::VecDeque, iter, mem, sync::Arc, time};
 
-use anyhow::anyhow;
 use metrics::{counter, gauge};
 use strata_identifiers::Slot;
 use strata_ol_state_types::OLState;
@@ -163,7 +162,7 @@ impl<C: FcmContext> FcmServiceState<C> {
         self.chain_tracker_mut().update_finalized_epoch(&epoch)?;
 
         // Clear out old pending entries.
-        self.clear_pending_epochs(epoch)?;
+        self.clear_pending_epochs(epoch);
 
         counter!("strata_fcm_epochs_finalized_total").increment(1);
         gauge!("strata_fcm_finalized_epoch").set(epoch.epoch() as f64);
@@ -172,7 +171,7 @@ impl<C: FcmContext> FcmServiceState<C> {
         Ok(())
     }
 
-    fn clear_pending_epochs(&mut self, epoch: EpochCommitment) -> anyhow::Result<()> {
+    fn clear_pending_epochs(&mut self, epoch: EpochCommitment) {
         let epoch_pending_fin = &mut self.inner_state.epochs_pending_finalization;
         while epoch_pending_fin
             .front()
@@ -180,10 +179,9 @@ impl<C: FcmContext> FcmServiceState<C> {
         {
             epoch_pending_fin
                 .pop_front()
-                .ok_or(anyhow!("pop on empty epoch_pending dequeue"))?;
+                .expect("front checked before popping pending finalized epoch");
         }
         self.record_pending_epochs();
-        Ok(())
     }
 
     fn record_pending_epochs(&self) {
@@ -331,7 +329,7 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
 
 /// Determines the starting chain tip by choosing the highest-slot tip, using
 /// the lowest ordered block ID as the tie-breaker.
-fn determine_start_tip(unfin: &UnfinalizedBlockTracker) -> anyhow::Result<OLBlockCommitment> {
+fn determine_start_tip(unfin: &UnfinalizedBlockTracker) -> Result<OLBlockCommitment, Error> {
     // Unfinalized block tracker only loads blocks which are valid and exist in db so no need to
     // check for db existence at this point.
     unfin
@@ -341,26 +339,25 @@ fn determine_start_tip(unfin: &UnfinalizedBlockTracker) -> anyhow::Result<OLBloc
                 .cmp(&b.slot())
                 .then_with(|| b.blkid().cmp(a.blkid()))
         })
-        .ok_or_else(|| anyhow!("fcm: no chain tips"))
+        .ok_or(Error::FcmNoChainTips)
 }
 
 /// Rewrites the canonical index to match the reconstructed chain.
 ///
 /// Only the unfinalized suffix is rewritten; slots at or below the finalized tip are left untouched
 /// since finalized history never forks.
-async fn reconcile_canonical_blocks_index(
+pub(crate) async fn reconcile_canonical_blocks_index(
     unfin: &UnfinalizedBlockTracker,
     tip: OLBlockCommitment,
     storage: &(impl FcmStorage + ?Sized),
-) -> anyhow::Result<()> {
+) -> Result<(), Error> {
     let (pivot_slot, canon_blocks) = canonical_blocks_from_tip(unfin, tip, storage).await?;
-    if canon_blocks.is_empty() {
-        return Ok(());
-    }
     let Some(start_slot) = pivot_slot.checked_add(1) else {
-        return Err(anyhow!(
-            "fcm: canonical suffix above max slot {pivot_slot} is non-empty"
-        ));
+        // An empty suffix at the max slot means nothing above the tip to truncate.
+        if canon_blocks.is_empty() {
+            return Ok(());
+        }
+        return Err(Error::FcmCanonicalSuffixAboveMaxSlot(pivot_slot));
     };
     storage
         .replace_canonical_blocks_from(start_slot, canon_blocks)
@@ -374,15 +371,15 @@ async fn canonical_blocks_from_tip(
     unfin: &UnfinalizedBlockTracker,
     tip: OLBlockCommitment,
     storage: &(impl FcmStorage + ?Sized),
-) -> anyhow::Result<(Slot, CanonicalSuffix)> {
+) -> Result<(Slot, CanonicalSuffix), Error> {
     let parent_chain = construct_validated_parent_chain(unfin, tip)?;
     let finalized_tip = *unfin.finalized_tip();
 
     if parent_chain.last() != Some(&finalized_tip) {
-        return Err(anyhow!(
-            "fcm: reconstructed chain tip {} does not trace back to finalized tip {finalized_tip}",
-            tip.blkid()
-        ));
+        return Err(Error::FcmCanonicalChainNotFinalized {
+            tip: *tip.blkid(),
+            finalized_tip,
+        });
     }
 
     let mut suffix = Vec::new();
@@ -398,9 +395,11 @@ async fn canonical_blocks_from_tip(
 
         if blkid == finalized_tip {
             let finalized_slot = unfin.finalized_epoch().last_slot();
-            return Err(anyhow!(
-                "fcm: canonical block at finalized slot {finalized_slot} is {canonical:?}, expected finalized tip {finalized_tip}"
-            ));
+            return Err(Error::FcmCanonicalFinalizedMismatch {
+                finalized_slot,
+                canonical,
+                finalized_tip,
+            });
         }
 
         suffix.push((slot, blkid));
@@ -412,7 +411,7 @@ async fn canonical_blocks_from_tip(
 fn construct_validated_parent_chain(
     unfin: &UnfinalizedBlockTracker,
     tip: OLBlockCommitment,
-) -> anyhow::Result<Vec<OLBlockId>> {
+) -> Result<Vec<OLBlockId>, Error> {
     let mut chain = Vec::new();
     let mut child_slot: Option<Slot> = None;
     let parent_chain =
@@ -428,23 +427,24 @@ fn construct_validated_parent_chain(
     Ok(chain)
 }
 
-fn tracker_slot(unfin: &UnfinalizedBlockTracker, blkid: OLBlockId) -> anyhow::Result<Slot> {
+fn tracker_slot(unfin: &UnfinalizedBlockTracker, blkid: OLBlockId) -> Result<Slot, Error> {
     unfin
         .get_slot(&blkid)
-        .ok_or_else(|| anyhow!("fcm: reconstructed block {blkid} missing from tracker"))
+        .ok_or(Error::FcmCanonicalTrackerMissingBlock(blkid))
 }
 
 fn ensure_parent_slot_descends(
     parent_slot: Slot,
     child_slot: Option<Slot>,
     tip: OLBlockCommitment,
-) -> anyhow::Result<()> {
+) -> Result<(), Error> {
     if let Some(child_slot) = child_slot {
         if parent_slot >= child_slot {
-            return Err(anyhow!(
-                "fcm: non-decreasing slot {parent_slot} >= {child_slot} walking parents from tip {}; corrupt parent link",
-                tip.blkid()
-            ));
+            return Err(Error::FcmCanonicalParentSlotNotDescending {
+                parent_slot,
+                child_slot,
+                tip,
+            });
         }
     }
 

--- a/crates/consensus-logic/src/fcm/state.rs
+++ b/crates/consensus-logic/src/fcm/state.rs
@@ -297,6 +297,12 @@ pub(crate) async fn init_fcm_service_state<C: FcmContext>(
     let cur_tip_block = determine_start_tip(&chain_tracker, fcm_ctx.as_ref()).await?;
     debug!(?chain_tracker, "init chain tracker");
 
+    // Force the canonical index to match the reconstructed chain before any
+    // consumer reads it. A crash can leave the index ahead of, behind, or forked
+    // from fork choice; this repairs all of those by rewriting the unfinalized
+    // suffix from the reconstructed tip.
+    reconcile_canonical_index(&chain_tracker, cur_tip_block, fcm_ctx.as_ref()).await?;
+
     // Load in that block's ol_state.
     let tip_blkid = cur_tip_block;
     let ol_state = fcm_ctx
@@ -357,4 +363,62 @@ async fn determine_start_tip(
     }
 
     Ok(L2BlockCommitment::new(best_slot, *best))
+}
+
+/// Rewrites the canonical index to match the reconstructed chain.
+///
+/// Only the unfinalized suffix is rewritten; slots at or below the finalized tip are left untouched
+/// since finalized history never forks.
+async fn reconcile_canonical_index(
+    unfin: &UnfinalizedBlockTracker,
+    tip: L2BlockCommitment,
+    storage: &(impl FcmStorage + ?Sized),
+) -> anyhow::Result<()> {
+    let finalized_slot = unfin.finalized_epoch().last_slot();
+
+    // Slots strictly decrease child->parent (enforced by `attach_block`), so a
+    // non-decrease means a corrupt parent link; erroring out also bounds the walk.
+    let mut chain = Vec::new();
+    let mut cursor = *tip.blkid();
+    let mut prev_slot: Option<u64> = None;
+    while let Some(parent) = unfin.get_parent(&cursor) {
+        let slot = unfin
+            .get_slot(&cursor)
+            .ok_or_else(|| anyhow!("fcm: reconstructed block {cursor} missing from tracker"))?;
+        if let Some(prev) = prev_slot {
+            if slot >= prev {
+                return Err(anyhow!(
+                    "fcm: non-decreasing slot {slot} >= {prev} walking parents from tip {}; corrupt parent link",
+                    tip.blkid()
+                ));
+            }
+        }
+        prev_slot = Some(slot);
+        chain.push((slot, cursor));
+        cursor = *parent;
+    }
+
+    // The walk must land on the finalized tip; otherwise the chain doesn't trace
+    // back to finalized history — corruption, not recoverable.
+    let finalized_tip = *unfin.finalized_tip();
+    if cursor != finalized_tip {
+        return Err(anyhow!(
+            "fcm: reconstructed chain tip {} does not trace back to finalized tip {finalized_tip}",
+            tip.blkid()
+        ));
+    }
+
+    // The finalized slot is left untouched, so verify it is already canonical.
+    let canonical_finalized = storage.get_canonical_block_at(finalized_slot).await?;
+    if canonical_finalized.map(|c| *c.blkid()) != Some(finalized_tip) {
+        return Err(anyhow!(
+            "fcm: canonical block at finalized slot {finalized_slot} is {canonical_finalized:?}, expected finalized tip {finalized_tip}"
+        ));
+    }
+
+    chain.reverse();
+    storage
+        .replace_canonical_suffix(finalized_slot, chain)
+        .await?;
+    Ok(())
 }

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -237,7 +237,7 @@ impl OLBlockDatabase for OLBlockDBSled {
     fn replace_canonical_suffix(
         &self,
         pivot_slot: Slot,
-        blocks: &[(Slot, OLBlockId)],
+        blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         // Enumerate canonical entries strictly above the pivot to drop. Read
         // outside the transaction; keys are big-endian so the range is ordered.
@@ -255,7 +255,7 @@ impl OLBlockDatabase for OLBlockDBSled {
                 for slot in &slots_to_drop {
                     ct.remove(slot)?;
                 }
-                for (slot, id) in blocks {
+                for (slot, id) in &blocks {
                     ct.insert(slot, id)?;
                 }
                 Ok(())

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -9,6 +9,7 @@ use typed_sled::error::Error as TSledError;
 
 use super::schemas::{
     OLBlockHeightSchema, OLBlockHighWatermarkSchema, OLBlockSchema, OLBlockStatusSchema,
+    OLCanonicalBlockSchema,
 };
 use crate::{
     define_sled_database,
@@ -23,6 +24,7 @@ define_sled_database!(
         blk_status_tree: OLBlockStatusSchema,
         blk_height_tree: OLBlockHeightSchema,
         blk_high_watermark_tree: OLBlockHighWatermarkSchema,
+        blk_canonical_tree: OLCanonicalBlockSchema,
     }
 );
 
@@ -226,6 +228,39 @@ impl OLBlockDatabase for OLBlockDBSled {
 
             slot -= 1;
         }
+    }
+
+    fn get_canonical_block(&self, slot: Slot) -> DbResult<Option<OLBlockId>> {
+        Ok(self.blk_canonical_tree.get(&slot)?)
+    }
+
+    fn replace_canonical_suffix(
+        &self,
+        pivot_slot: Slot,
+        blocks: &[(Slot, OLBlockId)],
+    ) -> DbResult<()> {
+        // Enumerate canonical entries strictly above the pivot to drop. Read
+        // outside the transaction; keys are big-endian so the range is ordered.
+        // At Slot::MAX there is nothing above the pivot, so the range is empty.
+        let mut slots_to_drop = Vec::new();
+        if let Some(start_slot) = pivot_slot.checked_add(1) {
+            for item in self.blk_canonical_tree.range(start_slot..)? {
+                let (slot, _) = item?;
+                slots_to_drop.push(slot);
+            }
+        }
+
+        self.config
+            .with_retry((&self.blk_canonical_tree,), |(ct,)| {
+                for slot in &slots_to_drop {
+                    ct.remove(slot)?;
+                }
+                for (slot, id) in blocks {
+                    ct.insert(slot, id)?;
+                }
+                Ok(())
+            })
+            .map_err(to_db_error)
     }
 }
 

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -234,14 +234,12 @@ impl OLBlockDatabase for OLBlockDBSled {
         Ok(self.blk_canonical_tree.get(&slot)?)
     }
 
-    fn replace_canonical_suffix(
+    fn update_canonical_blocks_above(
         &self,
         pivot_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
-        // Enumerate canonical entries strictly above the pivot to drop. Read
-        // outside the transaction; keys are big-endian so the range is ordered.
-        // At Slot::MAX there is nothing above the pivot, so the range is empty.
+        // First collect all slots to remove above the pivot.
         let mut slots_to_drop = Vec::new();
         if let Some(start_slot) = pivot_slot.checked_add(1) {
             for item in self.blk_canonical_tree.range(start_slot..)? {
@@ -250,6 +248,7 @@ impl OLBlockDatabase for OLBlockDBSled {
             }
         }
 
+        // Now actually remove and insert new canonical blocks inside a transaction.
         self.config
             .with_retry((&self.blk_canonical_tree,), |(ct,)| {
                 for slot in &slots_to_drop {

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -234,18 +234,16 @@ impl OLBlockDatabase for OLBlockDBSled {
         Ok(self.blk_canonical_tree.get(&slot)?)
     }
 
-    fn update_canonical_blocks_above(
+    fn replace_canonical_blocks_from(
         &self,
-        pivot_slot: Slot,
+        start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
-        // First collect all slots to remove above the pivot.
+        // First collect all slots to remove from the suffix.
         let mut slots_to_drop = Vec::new();
-        if let Some(start_slot) = pivot_slot.checked_add(1) {
-            for item in self.blk_canonical_tree.range(start_slot..)? {
-                let (slot, _) = item?;
-                slots_to_drop.push(slot);
-            }
+        for item in self.blk_canonical_tree.range(start_slot..)? {
+            let (slot, _) = item?;
+            slots_to_drop.push(slot);
         }
 
         // Now actually remove and insert new canonical blocks inside a transaction.

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -166,17 +166,34 @@ impl OLBlockDatabase for OLBlockDBSled {
             None => return Ok(false),
         };
         let slot = block.header().slot();
+        let mut canonical_slots_to_drop = Vec::new();
+        if self.blk_canonical_tree.get(&slot)? == Some(id) {
+            for item in self.blk_canonical_tree.range(slot..)? {
+                let (canonical_slot, _) = item?;
+                canonical_slots_to_drop.push(canonical_slot);
+            }
+        }
 
         self.config
             .with_retry(
-                (&self.blk_tree, &self.blk_status_tree, &self.blk_height_tree),
-                |(bt, bst, bht)| {
+                (
+                    &self.blk_tree,
+                    &self.blk_status_tree,
+                    &self.blk_height_tree,
+                    &self.blk_canonical_tree,
+                ),
+                |(bt, bst, bht, ct)| {
                     let mut blocks_at_slot = bht.get(&slot)?.unwrap_or(Vec::new());
                     blocks_at_slot.retain(|&bid| bid != id);
 
                     bt.remove(&id)?;
                     bst.remove(&id)?;
                     bht.insert(&slot, &blocks_at_slot)?;
+                    if ct.get(&slot)? == Some(id) {
+                        for canonical_slot in &canonical_slots_to_drop {
+                            ct.remove(canonical_slot)?;
+                        }
+                    }
                     Ok(true)
                 },
             )
@@ -201,33 +218,10 @@ impl OLBlockDatabase for OLBlockDBSled {
     }
 
     fn get_tip_slot(&self) -> DbResult<Slot> {
-        let bht = &self.blk_height_tree;
-        let mut slot = bht.last()?.map(first).ok_or(DbError::NotBootstrapped)?;
-
-        loop {
-            let blocks = self.get_blocks_at_height(slot)?;
-            // Check if any valid blocks exist at this slot.
-            // Multiple blocks at the same slot can be marked Valid during forks.
-            let has_valid = blocks
-                .into_iter()
-                .filter_map(|blkid| match self.get_block_status(blkid) {
-                    Ok(Some(BlockStatus::Valid)) => Some(Ok(())),
-                    Ok(_) => None,
-                    Err(e) => Some(Err(e)),
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            // Return the highest slot that has at least one valid block.
-            if !has_valid.is_empty() {
-                return Ok(slot);
-            }
-
-            if slot == 0 {
-                return Err(DbError::NotBootstrapped);
-            }
-
-            slot -= 1;
-        }
+        self.blk_canonical_tree
+            .last()?
+            .map(first)
+            .ok_or(DbError::NotBootstrapped)
     }
 
     fn get_canonical_block(&self, slot: Slot) -> DbResult<Option<OLBlockId>> {
@@ -257,8 +251,7 @@ impl OLBlockDatabase for OLBlockDBSled {
         }
 
         // Collect the suffix slots before the transaction: sled's transactional tree has no range
-        // scan. Safe under the single-writer contract (fork choice is the sole writer), so no
-        // concurrent insert can land in the range between this read and the commit below.
+        // scan.
         let mut slots_to_drop = Vec::new();
         for item in self.blk_canonical_tree.range(start_slot..)? {
             let (slot, _) = item?;

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -239,7 +239,9 @@ impl OLBlockDatabase for OLBlockDBSled {
         start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
-        // First collect all slots to remove from the suffix.
+        // Collect the suffix slots before the transaction: sled's transactional tree has no range
+        // scan. Safe under the single-writer contract (fork choice is the sole writer), so no
+        // concurrent insert can land in the range between this read and the commit below.
         let mut slots_to_drop = Vec::new();
         for item in self.blk_canonical_tree.range(start_slot..)? {
             let (slot, _) = item?;

--- a/crates/db/store-sled/src/ol/db.rs
+++ b/crates/db/store-sled/src/ol/db.rs
@@ -234,11 +234,28 @@ impl OLBlockDatabase for OLBlockDBSled {
         Ok(self.blk_canonical_tree.get(&slot)?)
     }
 
-    fn replace_canonical_blocks_from(
+    fn replace_canonical_suffix_from(
         &self,
         start_slot: Slot,
-        blocks: Vec<(Slot, OLBlockId)>,
+        block_ids: Vec<OLBlockId>,
     ) -> DbResult<()> {
+        let block_count = block_ids.len();
+        let mut blocks = Vec::with_capacity(block_count);
+        for (offset, block_id) in block_ids.into_iter().enumerate() {
+            let offset = u64::try_from(offset).map_err(|_| DbError::OLCanonicalSuffixOverflow {
+                start_slot,
+                block_count,
+            })?;
+            let slot =
+                start_slot
+                    .checked_add(offset)
+                    .ok_or(DbError::OLCanonicalSuffixOverflow {
+                        start_slot,
+                        block_count,
+                    })?;
+            blocks.push((slot, block_id));
+        }
+
         // Collect the suffix slots before the transaction: sled's transactional tree has no range
         // scan. Safe under the single-writer contract (fork choice is the sole writer), so no
         // concurrent insert can land in the range between this read and the commit below.

--- a/crates/db/store-sled/src/ol/schemas.rs
+++ b/crates/db/store-sled/src/ol/schemas.rs
@@ -37,6 +37,12 @@ define_table_with_integer_key!(
     (OLBlockHeightSchema) u64 => Vec<OLBlockId>
 );
 
+define_table_with_integer_key!(
+    /// A table mapping each slot to its canonical OL block id, as selected by
+    /// fork choice. Maps slot to OLBlockId.
+    (OLCanonicalBlockSchema) u64 => OLBlockId
+);
+
 define_table_without_codec!(
     /// Stores the latest OL block committed through the high-watermark path.
     (OLBlockHighWatermarkSchema) u8 => OLBlockCommitment

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -66,13 +66,13 @@ pub fn test_get_canonical_block_empty(db: &impl OLBlockDatabase) {
     assert!(result.is_none());
 }
 
-pub fn test_replace_canonical_suffix_extend(db: &impl OLBlockDatabase) {
+pub fn test_update_canonical_blocks_above_extend(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then extend by appending slot 5 with an empty truncation.
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, seed.clone())
+    db.update_canonical_blocks_above(0, seed.clone())
         .expect("test: seed canonical");
 
-    db.replace_canonical_suffix(4, vec![(5, canonical_id(50))])
+    db.update_canonical_blocks_above(4, vec![(5, canonical_id(50))])
         .expect("test: extend canonical");
 
     for (slot, id) in &seed {
@@ -81,14 +81,14 @@ pub fn test_replace_canonical_suffix_extend(db: &impl OLBlockDatabase) {
     assert_eq!(db.get_canonical_block(5).unwrap(), Some(canonical_id(50)));
 }
 
-pub fn test_replace_canonical_suffix_reorg_shorter(db: &impl OLBlockDatabase) {
+pub fn test_update_canonical_blocks_above_reorg_shorter(db: &impl OLBlockDatabase) {
     // Seed slots 0..=9, then reorg at pivot 5 onto a shorter branch (slots 6,7).
     let seed: Vec<(u64, OLBlockId)> = (0..=9).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, seed)
+    db.update_canonical_blocks_above(0, seed)
         .expect("test: seed canonical");
 
     let branch = vec![(6u64, canonical_id(0x60)), (7u64, canonical_id(0x70))];
-    db.replace_canonical_suffix(5, branch)
+    db.update_canonical_blocks_above(5, branch)
         .expect("test: reorg canonical");
 
     // Slots 0..=5 untouched.
@@ -106,13 +106,13 @@ pub fn test_replace_canonical_suffix_reorg_shorter(db: &impl OLBlockDatabase) {
     assert_eq!(db.get_canonical_block(9).unwrap(), None);
 }
 
-pub fn test_replace_canonical_suffix_revert_empty_branch(db: &impl OLBlockDatabase) {
+pub fn test_update_canonical_blocks_above_revert_empty_branch(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then revert to slot 2 with an empty branch.
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, seed)
+    db.update_canonical_blocks_above(0, seed)
         .expect("test: seed canonical");
 
-    db.replace_canonical_suffix(2, Vec::new())
+    db.update_canonical_blocks_above(2, Vec::new())
         .expect("test: revert canonical");
 
     for s in 0..=2u64 {
@@ -125,13 +125,13 @@ pub fn test_replace_canonical_suffix_revert_empty_branch(db: &impl OLBlockDataba
     assert_eq!(db.get_canonical_block(4).unwrap(), None);
 }
 
-pub fn test_replace_canonical_suffix_pivot_max(db: &impl OLBlockDatabase) {
+pub fn test_update_canonical_blocks_above_pivot_max(db: &impl OLBlockDatabase) {
     // pivot == u64::MAX: there is no slot above it, so nothing is truncated and
     // the existing entry survives. Guards against `pivot + 1` overflow.
-    db.replace_canonical_suffix(u64::MAX, vec![(u64::MAX, canonical_id(0xaa))])
+    db.update_canonical_blocks_above(u64::MAX, vec![(u64::MAX, canonical_id(0xaa))])
         .expect("test: seed canonical at max slot");
 
-    db.replace_canonical_suffix(u64::MAX, Vec::new())
+    db.update_canonical_blocks_above(u64::MAX, Vec::new())
         .expect("test: replace suffix at max pivot");
 
     assert_eq!(
@@ -140,12 +140,12 @@ pub fn test_replace_canonical_suffix_pivot_max(db: &impl OLBlockDatabase) {
     );
 }
 
-pub fn test_replace_canonical_suffix_idempotent(db: &impl OLBlockDatabase) {
+pub fn test_update_canonical_blocks_above_idempotent(db: &impl OLBlockDatabase) {
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, seed.clone())
+    db.update_canonical_blocks_above(0, seed.clone())
         .expect("test: seed canonical");
     // Re-applying the same suffix is a no-op.
-    db.replace_canonical_suffix(0, seed.clone())
+    db.update_canonical_blocks_above(0, seed.clone())
         .expect("test: re-apply canonical");
 
     for (slot, id) in &seed {
@@ -581,33 +581,33 @@ macro_rules! ol_block_db_tests {
         }
 
         #[test]
-        fn test_replace_canonical_suffix_extend() {
+        fn test_update_canonical_blocks_above_extend() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_suffix_extend(&db);
+            $crate::ol_block_tests::test_update_canonical_blocks_above_extend(&db);
         }
 
         #[test]
-        fn test_replace_canonical_suffix_reorg_shorter() {
+        fn test_update_canonical_blocks_above_reorg_shorter() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_suffix_reorg_shorter(&db);
+            $crate::ol_block_tests::test_update_canonical_blocks_above_reorg_shorter(&db);
         }
 
         #[test]
-        fn test_replace_canonical_suffix_revert_empty_branch() {
+        fn test_update_canonical_blocks_above_revert_empty_branch() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_suffix_revert_empty_branch(&db);
+            $crate::ol_block_tests::test_update_canonical_blocks_above_revert_empty_branch(&db);
         }
 
         #[test]
-        fn test_replace_canonical_suffix_pivot_max() {
+        fn test_update_canonical_blocks_above_pivot_max() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_suffix_pivot_max(&db);
+            $crate::ol_block_tests::test_update_canonical_blocks_above_pivot_max(&db);
         }
 
         #[test]
-        fn test_replace_canonical_suffix_idempotent() {
+        fn test_update_canonical_blocks_above_idempotent() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_suffix_idempotent(&db);
+            $crate::ol_block_tests::test_update_canonical_blocks_above_idempotent(&db);
         }
 
         proptest::proptest! {

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -55,6 +55,98 @@ pub fn test_get_empty_block_high_watermark(db: &impl OLBlockDatabase) {
     assert!(high_watermark.is_none());
 }
 
+fn canonical_id(byte: u8) -> OLBlockId {
+    OLBlockId::from(Buf32::from([byte; 32]))
+}
+
+pub fn test_get_canonical_block_empty(db: &impl OLBlockDatabase) {
+    let result = db
+        .get_canonical_block(7)
+        .expect("test: get canonical at empty slot");
+    assert!(result.is_none());
+}
+
+pub fn test_replace_canonical_suffix_extend(db: &impl OLBlockDatabase) {
+    // Seed slots 0..=4, then extend by appending slot 5 with an empty truncation.
+    let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
+    db.replace_canonical_suffix(0, &seed)
+        .expect("test: seed canonical");
+
+    db.replace_canonical_suffix(4, &[(5, canonical_id(50))])
+        .expect("test: extend canonical");
+
+    for (slot, id) in &seed {
+        assert_eq!(db.get_canonical_block(*slot).unwrap(), Some(*id));
+    }
+    assert_eq!(db.get_canonical_block(5).unwrap(), Some(canonical_id(50)));
+}
+
+pub fn test_replace_canonical_suffix_reorg_shorter(db: &impl OLBlockDatabase) {
+    // Seed slots 0..=9, then reorg at pivot 5 onto a shorter branch (slots 6,7).
+    let seed: Vec<(u64, OLBlockId)> = (0..=9).map(|s| (s, canonical_id(s as u8))).collect();
+    db.replace_canonical_suffix(0, &seed)
+        .expect("test: seed canonical");
+
+    let branch = [(6u64, canonical_id(0x60)), (7u64, canonical_id(0x70))];
+    db.replace_canonical_suffix(5, &branch)
+        .expect("test: reorg canonical");
+
+    // Slots 0..=5 untouched.
+    for s in 0..=5u64 {
+        assert_eq!(db.get_canonical_block(s).unwrap(), Some(canonical_id(s as u8)));
+    }
+    // Slots 6,7 rewritten to the new branch.
+    assert_eq!(db.get_canonical_block(6).unwrap(), Some(canonical_id(0x60)));
+    assert_eq!(db.get_canonical_block(7).unwrap(), Some(canonical_id(0x70)));
+    // Slots 8,9 from the abandoned branch are gone.
+    assert_eq!(db.get_canonical_block(8).unwrap(), None);
+    assert_eq!(db.get_canonical_block(9).unwrap(), None);
+}
+
+pub fn test_replace_canonical_suffix_revert_empty_branch(db: &impl OLBlockDatabase) {
+    // Seed slots 0..=4, then revert to slot 2 with an empty branch.
+    let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
+    db.replace_canonical_suffix(0, &seed)
+        .expect("test: seed canonical");
+
+    db.replace_canonical_suffix(2, &[])
+        .expect("test: revert canonical");
+
+    for s in 0..=2u64 {
+        assert_eq!(db.get_canonical_block(s).unwrap(), Some(canonical_id(s as u8)));
+    }
+    assert_eq!(db.get_canonical_block(3).unwrap(), None);
+    assert_eq!(db.get_canonical_block(4).unwrap(), None);
+}
+
+pub fn test_replace_canonical_suffix_pivot_max(db: &impl OLBlockDatabase) {
+    // pivot == u64::MAX: there is no slot above it, so nothing is truncated and
+    // the existing entry survives. Guards against `pivot + 1` overflow.
+    db.replace_canonical_suffix(u64::MAX, &[(u64::MAX, canonical_id(0xaa))])
+        .expect("test: seed canonical at max slot");
+
+    db.replace_canonical_suffix(u64::MAX, &[])
+        .expect("test: replace suffix at max pivot");
+
+    assert_eq!(
+        db.get_canonical_block(u64::MAX).unwrap(),
+        Some(canonical_id(0xaa))
+    );
+}
+
+pub fn test_replace_canonical_suffix_idempotent(db: &impl OLBlockDatabase) {
+    let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
+    db.replace_canonical_suffix(0, &seed)
+        .expect("test: seed canonical");
+    // Re-applying the same suffix is a no-op.
+    db.replace_canonical_suffix(0, &seed)
+        .expect("test: re-apply canonical");
+
+    for (slot, id) in &seed {
+        assert_eq!(db.get_canonical_block(*slot).unwrap(), Some(*id));
+    }
+}
+
 // Proptest-based tests for random block data
 pub fn proptest_put_and_get_random_block(db: &impl OLBlockDatabase, block: OLBlock) {
     let block_id = block.header().compute_blkid();
@@ -474,6 +566,42 @@ macro_rules! ol_block_db_tests {
         fn test_get_empty_block_high_watermark() {
             let db = $setup_expr;
             $crate::ol_block_tests::test_get_empty_block_high_watermark(&db);
+        }
+
+        #[test]
+        fn test_get_canonical_block_empty() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_get_canonical_block_empty(&db);
+        }
+
+        #[test]
+        fn test_replace_canonical_suffix_extend() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_replace_canonical_suffix_extend(&db);
+        }
+
+        #[test]
+        fn test_replace_canonical_suffix_reorg_shorter() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_replace_canonical_suffix_reorg_shorter(&db);
+        }
+
+        #[test]
+        fn test_replace_canonical_suffix_revert_empty_branch() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_replace_canonical_suffix_revert_empty_branch(&db);
+        }
+
+        #[test]
+        fn test_replace_canonical_suffix_pivot_max() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_replace_canonical_suffix_pivot_max(&db);
+        }
+
+        #[test]
+        fn test_replace_canonical_suffix_idempotent() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_replace_canonical_suffix_idempotent(&db);
         }
 
         proptest::proptest! {

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -69,10 +69,10 @@ pub fn test_get_canonical_block_empty(db: &impl OLBlockDatabase) {
 pub fn test_replace_canonical_suffix_extend(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then extend by appending slot 5 with an empty truncation.
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, &seed)
+    db.replace_canonical_suffix(0, seed.clone())
         .expect("test: seed canonical");
 
-    db.replace_canonical_suffix(4, &[(5, canonical_id(50))])
+    db.replace_canonical_suffix(4, vec![(5, canonical_id(50))])
         .expect("test: extend canonical");
 
     for (slot, id) in &seed {
@@ -84,16 +84,19 @@ pub fn test_replace_canonical_suffix_extend(db: &impl OLBlockDatabase) {
 pub fn test_replace_canonical_suffix_reorg_shorter(db: &impl OLBlockDatabase) {
     // Seed slots 0..=9, then reorg at pivot 5 onto a shorter branch (slots 6,7).
     let seed: Vec<(u64, OLBlockId)> = (0..=9).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, &seed)
+    db.replace_canonical_suffix(0, seed)
         .expect("test: seed canonical");
 
-    let branch = [(6u64, canonical_id(0x60)), (7u64, canonical_id(0x70))];
-    db.replace_canonical_suffix(5, &branch)
+    let branch = vec![(6u64, canonical_id(0x60)), (7u64, canonical_id(0x70))];
+    db.replace_canonical_suffix(5, branch)
         .expect("test: reorg canonical");
 
     // Slots 0..=5 untouched.
     for s in 0..=5u64 {
-        assert_eq!(db.get_canonical_block(s).unwrap(), Some(canonical_id(s as u8)));
+        assert_eq!(
+            db.get_canonical_block(s).unwrap(),
+            Some(canonical_id(s as u8))
+        );
     }
     // Slots 6,7 rewritten to the new branch.
     assert_eq!(db.get_canonical_block(6).unwrap(), Some(canonical_id(0x60)));
@@ -106,14 +109,17 @@ pub fn test_replace_canonical_suffix_reorg_shorter(db: &impl OLBlockDatabase) {
 pub fn test_replace_canonical_suffix_revert_empty_branch(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then revert to slot 2 with an empty branch.
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, &seed)
+    db.replace_canonical_suffix(0, seed)
         .expect("test: seed canonical");
 
-    db.replace_canonical_suffix(2, &[])
+    db.replace_canonical_suffix(2, Vec::new())
         .expect("test: revert canonical");
 
     for s in 0..=2u64 {
-        assert_eq!(db.get_canonical_block(s).unwrap(), Some(canonical_id(s as u8)));
+        assert_eq!(
+            db.get_canonical_block(s).unwrap(),
+            Some(canonical_id(s as u8))
+        );
     }
     assert_eq!(db.get_canonical_block(3).unwrap(), None);
     assert_eq!(db.get_canonical_block(4).unwrap(), None);
@@ -122,10 +128,10 @@ pub fn test_replace_canonical_suffix_revert_empty_branch(db: &impl OLBlockDataba
 pub fn test_replace_canonical_suffix_pivot_max(db: &impl OLBlockDatabase) {
     // pivot == u64::MAX: there is no slot above it, so nothing is truncated and
     // the existing entry survives. Guards against `pivot + 1` overflow.
-    db.replace_canonical_suffix(u64::MAX, &[(u64::MAX, canonical_id(0xaa))])
+    db.replace_canonical_suffix(u64::MAX, vec![(u64::MAX, canonical_id(0xaa))])
         .expect("test: seed canonical at max slot");
 
-    db.replace_canonical_suffix(u64::MAX, &[])
+    db.replace_canonical_suffix(u64::MAX, Vec::new())
         .expect("test: replace suffix at max pivot");
 
     assert_eq!(
@@ -136,10 +142,10 @@ pub fn test_replace_canonical_suffix_pivot_max(db: &impl OLBlockDatabase) {
 
 pub fn test_replace_canonical_suffix_idempotent(db: &impl OLBlockDatabase) {
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_suffix(0, &seed)
+    db.replace_canonical_suffix(0, seed.clone())
         .expect("test: seed canonical");
     // Re-applying the same suffix is a no-op.
-    db.replace_canonical_suffix(0, &seed)
+    db.replace_canonical_suffix(0, seed.clone())
         .expect("test: re-apply canonical");
 
     for (slot, id) in &seed {

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -64,6 +64,10 @@ pub fn test_get_canonical_block_empty(db: &impl OLBlockDatabase) {
         .get_canonical_block(7)
         .expect("test: get canonical at empty slot");
     assert!(result.is_none());
+    let err = db
+        .get_tip_slot()
+        .expect_err("test: empty canonical index has no tip slot");
+    assert!(matches!(err, DbError::NotBootstrapped));
 }
 
 pub fn test_replace_canonical_suffix_from_extend(db: &impl OLBlockDatabase) {
@@ -123,6 +127,7 @@ pub fn test_replace_canonical_suffix_from_revert_empty_branch(db: &impl OLBlockD
     }
     assert_eq!(db.get_canonical_block(3).unwrap(), None);
     assert_eq!(db.get_canonical_block(4).unwrap(), None);
+    assert_eq!(db.get_tip_slot().unwrap(), 2);
 }
 
 pub fn test_replace_canonical_suffix_from_max(db: &impl OLBlockDatabase) {
@@ -162,6 +167,101 @@ pub fn test_replace_canonical_suffix_from_idempotent(db: &impl OLBlockDatabase) 
     for (slot, id) in seed.iter().enumerate() {
         assert_eq!(db.get_canonical_block(slot as u64).unwrap(), Some(*id));
     }
+    assert_eq!(db.get_tip_slot().unwrap(), 4);
+}
+
+pub fn test_delete_canonical_block_clears_canonical_index(
+    db: &impl OLBlockDatabase,
+    mut block: OLBlock,
+) {
+    block.signed_header.header.slot = 11;
+    let block_id = block.header().compute_blkid();
+
+    db.put_block_data(block).expect("test: put block");
+    db.replace_canonical_suffix_from(11, vec![block_id])
+        .expect("test: seed canonical");
+
+    assert_eq!(db.get_tip_slot().expect("test: get tip slot"), 11);
+
+    db.del_block_data(block_id).expect("test: delete block");
+
+    assert_eq!(
+        db.get_canonical_block(11)
+            .expect("test: get deleted canonical slot"),
+        None
+    );
+    let err = db
+        .get_tip_slot()
+        .expect_err("test: deleted canonical tip leaves no tip slot");
+    assert!(matches!(err, DbError::NotBootstrapped));
+}
+
+pub fn test_delete_canonical_block_truncates_canonical_suffix(
+    db: &impl OLBlockDatabase,
+    mut block1: OLBlock,
+    mut block2: OLBlock,
+    mut block3: OLBlock,
+) {
+    block1.signed_header.header.slot = 10;
+    block2.signed_header.header.slot = 11;
+    block3.signed_header.header.slot = 12;
+    let block1_id = block1.header().compute_blkid();
+    let block2_id = block2.header().compute_blkid();
+    let block3_id = block3.header().compute_blkid();
+
+    db.put_block_data(block1).expect("test: put block 1");
+    db.put_block_data(block2).expect("test: put block 2");
+    db.put_block_data(block3).expect("test: put block 3");
+    db.replace_canonical_suffix_from(10, vec![block1_id, block2_id, block3_id])
+        .expect("test: seed canonical suffix");
+
+    db.del_block_data(block2_id)
+        .expect("test: delete middle canonical block");
+
+    assert_eq!(
+        db.get_canonical_block(10)
+            .expect("test: get canonical slot 10"),
+        Some(block1_id)
+    );
+    assert_eq!(
+        db.get_canonical_block(11)
+            .expect("test: get canonical slot 11"),
+        None
+    );
+    assert_eq!(
+        db.get_canonical_block(12)
+            .expect("test: get canonical slot 12"),
+        None
+    );
+    assert_eq!(db.get_tip_slot().expect("test: get truncated tip slot"), 10);
+}
+
+pub fn test_delete_noncanonical_block_preserves_canonical_index(
+    db: &impl OLBlockDatabase,
+    mut canonical: OLBlock,
+    mut noncanonical: OLBlock,
+) {
+    canonical.signed_header.header.slot = 7;
+    noncanonical.signed_header.header.slot = 7;
+    let canonical_id = canonical.header().compute_blkid();
+    let noncanonical_id = noncanonical.header().compute_blkid();
+    if canonical_id == noncanonical_id {
+        return;
+    }
+
+    db.put_block_data(canonical).expect("test: put canonical");
+    db.put_block_data(noncanonical)
+        .expect("test: put noncanonical");
+    db.replace_canonical_suffix_from(7, vec![canonical_id])
+        .expect("test: seed canonical");
+
+    db.del_block_data(noncanonical_id)
+        .expect("test: delete noncanonical block");
+
+    assert_eq!(
+        db.get_canonical_block(7).expect("test: get canonical slot"),
+        Some(canonical_id)
+    );
 }
 
 // Proptest-based tests for random block data
@@ -531,19 +631,24 @@ pub fn proptest_get_tip_slot(db: &impl OLBlockDatabase, mut block1: OLBlock, mut
     block1.signed_header.header.slot = 5u64;
     block2.signed_header.header.slot = 10u64;
 
+    let block_id1 = block1.header().compute_blkid();
     let block_id2 = block2.header().compute_blkid();
 
     // Put blocks
     db.put_block_data(block1).expect("test: put block 1");
     db.put_block_data(block2).expect("test: put block 2");
 
-    // Set block2 as valid (higher slot)
+    // Set block2 as valid, but keep the canonical index at block1.
+    db.set_block_status(block_id1, BlockStatus::Valid)
+        .expect("test: set block 1 status");
     db.set_block_status(block_id2, BlockStatus::Valid)
         .expect("test: set block 2 status");
+    db.replace_canonical_suffix_from(5, vec![block_id1])
+        .expect("test: seed canonical index");
 
-    // Get tip slot - should be 10 (highest valid slot)
+    // Get tip slot - should be 5 (highest canonical slot), not the higher valid fork.
     let tip_slot = db.get_tip_slot().expect("test: get tip slot");
-    assert_eq!(tip_slot, 10u64);
+    assert_eq!(tip_slot, 5u64);
 }
 
 #[macro_export]
@@ -628,6 +733,35 @@ macro_rules! ol_block_db_tests {
         }
 
         proptest::proptest! {
+            #[test]
+            fn test_delete_canonical_block_clears_canonical_index(block in ol_test_utils::ol_block_strategy()) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::test_delete_canonical_block_clears_canonical_index(&db, block);
+            }
+
+            #[test]
+            fn test_delete_canonical_block_truncates_canonical_suffix(
+                block1 in ol_test_utils::ol_block_strategy(),
+                block2 in ol_test_utils::ol_block_strategy(),
+                block3 in ol_test_utils::ol_block_strategy(),
+            ) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::test_delete_canonical_block_truncates_canonical_suffix(
+                    &db, block1, block2, block3,
+                );
+            }
+
+            #[test]
+            fn test_delete_noncanonical_block_preserves_canonical_index(
+                canonical in ol_test_utils::ol_block_strategy(),
+                noncanonical in ol_test_utils::ol_block_strategy(),
+            ) {
+                let db = $setup_expr;
+                $crate::ol_block_tests::test_delete_noncanonical_block_preserves_canonical_index(
+                    &db, canonical, noncanonical,
+                );
+            }
+
             #[test]
             fn proptest_put_and_get_random_block(block in ol_test_utils::ol_block_strategy()) {
                 let db = $setup_expr;

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -66,13 +66,13 @@ pub fn test_get_canonical_block_empty(db: &impl OLBlockDatabase) {
     assert!(result.is_none());
 }
 
-pub fn test_update_canonical_blocks_above_extend(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_blocks_from_extend(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then extend by appending slot 5 with an empty truncation.
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.update_canonical_blocks_above(0, seed.clone())
+    db.replace_canonical_blocks_from(0, seed.clone())
         .expect("test: seed canonical");
 
-    db.update_canonical_blocks_above(4, vec![(5, canonical_id(50))])
+    db.replace_canonical_blocks_from(5, vec![(5, canonical_id(50))])
         .expect("test: extend canonical");
 
     for (slot, id) in &seed {
@@ -81,14 +81,14 @@ pub fn test_update_canonical_blocks_above_extend(db: &impl OLBlockDatabase) {
     assert_eq!(db.get_canonical_block(5).unwrap(), Some(canonical_id(50)));
 }
 
-pub fn test_update_canonical_blocks_above_reorg_shorter(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_blocks_from_reorg_shorter(db: &impl OLBlockDatabase) {
     // Seed slots 0..=9, then reorg at pivot 5 onto a shorter branch (slots 6,7).
     let seed: Vec<(u64, OLBlockId)> = (0..=9).map(|s| (s, canonical_id(s as u8))).collect();
-    db.update_canonical_blocks_above(0, seed)
+    db.replace_canonical_blocks_from(0, seed)
         .expect("test: seed canonical");
 
     let branch = vec![(6u64, canonical_id(0x60)), (7u64, canonical_id(0x70))];
-    db.update_canonical_blocks_above(5, branch)
+    db.replace_canonical_blocks_from(6, branch)
         .expect("test: reorg canonical");
 
     // Slots 0..=5 untouched.
@@ -106,13 +106,13 @@ pub fn test_update_canonical_blocks_above_reorg_shorter(db: &impl OLBlockDatabas
     assert_eq!(db.get_canonical_block(9).unwrap(), None);
 }
 
-pub fn test_update_canonical_blocks_above_revert_empty_branch(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_blocks_from_revert_empty_branch(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then revert to slot 2 with an empty branch.
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.update_canonical_blocks_above(0, seed)
+    db.replace_canonical_blocks_from(0, seed)
         .expect("test: seed canonical");
 
-    db.update_canonical_blocks_above(2, Vec::new())
+    db.replace_canonical_blocks_from(3, Vec::new())
         .expect("test: revert canonical");
 
     for s in 0..=2u64 {
@@ -125,27 +125,25 @@ pub fn test_update_canonical_blocks_above_revert_empty_branch(db: &impl OLBlockD
     assert_eq!(db.get_canonical_block(4).unwrap(), None);
 }
 
-pub fn test_update_canonical_blocks_above_pivot_max(db: &impl OLBlockDatabase) {
-    // pivot == u64::MAX: there is no slot above it, so nothing is truncated and
-    // the existing entry survives. Guards against `pivot + 1` overflow.
-    db.update_canonical_blocks_above(u64::MAX, vec![(u64::MAX, canonical_id(0xaa))])
+pub fn test_replace_canonical_blocks_from_max(db: &impl OLBlockDatabase) {
+    db.replace_canonical_blocks_from(u64::MAX, vec![(u64::MAX, canonical_id(0xaa))])
         .expect("test: seed canonical at max slot");
 
-    db.update_canonical_blocks_above(u64::MAX, Vec::new())
-        .expect("test: replace suffix at max pivot");
+    db.replace_canonical_blocks_from(u64::MAX, vec![(u64::MAX, canonical_id(0xbb))])
+        .expect("test: replace suffix from max slot");
 
     assert_eq!(
         db.get_canonical_block(u64::MAX).unwrap(),
-        Some(canonical_id(0xaa))
+        Some(canonical_id(0xbb))
     );
 }
 
-pub fn test_update_canonical_blocks_above_idempotent(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_blocks_from_idempotent(db: &impl OLBlockDatabase) {
     let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.update_canonical_blocks_above(0, seed.clone())
+    db.replace_canonical_blocks_from(0, seed.clone())
         .expect("test: seed canonical");
     // Re-applying the same suffix is a no-op.
-    db.update_canonical_blocks_above(0, seed.clone())
+    db.replace_canonical_blocks_from(0, seed.clone())
         .expect("test: re-apply canonical");
 
     for (slot, id) in &seed {
@@ -581,33 +579,33 @@ macro_rules! ol_block_db_tests {
         }
 
         #[test]
-        fn test_update_canonical_blocks_above_extend() {
+        fn test_replace_canonical_blocks_from_extend() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_update_canonical_blocks_above_extend(&db);
+            $crate::ol_block_tests::test_replace_canonical_blocks_from_extend(&db);
         }
 
         #[test]
-        fn test_update_canonical_blocks_above_reorg_shorter() {
+        fn test_replace_canonical_blocks_from_reorg_shorter() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_update_canonical_blocks_above_reorg_shorter(&db);
+            $crate::ol_block_tests::test_replace_canonical_blocks_from_reorg_shorter(&db);
         }
 
         #[test]
-        fn test_update_canonical_blocks_above_revert_empty_branch() {
+        fn test_replace_canonical_blocks_from_revert_empty_branch() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_update_canonical_blocks_above_revert_empty_branch(&db);
+            $crate::ol_block_tests::test_replace_canonical_blocks_from_revert_empty_branch(&db);
         }
 
         #[test]
-        fn test_update_canonical_blocks_above_pivot_max() {
+        fn test_replace_canonical_blocks_from_max() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_update_canonical_blocks_above_pivot_max(&db);
+            $crate::ol_block_tests::test_replace_canonical_blocks_from_max(&db);
         }
 
         #[test]
-        fn test_update_canonical_blocks_above_idempotent() {
+        fn test_replace_canonical_blocks_from_idempotent() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_update_canonical_blocks_above_idempotent(&db);
+            $crate::ol_block_tests::test_replace_canonical_blocks_from_idempotent(&db);
         }
 
         proptest::proptest! {

--- a/crates/db/tests/src/ol_block_tests.rs
+++ b/crates/db/tests/src/ol_block_tests.rs
@@ -66,29 +66,29 @@ pub fn test_get_canonical_block_empty(db: &impl OLBlockDatabase) {
     assert!(result.is_none());
 }
 
-pub fn test_replace_canonical_blocks_from_extend(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_suffix_from_extend(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then extend by appending slot 5 with an empty truncation.
-    let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_blocks_from(0, seed.clone())
+    let seed: Vec<OLBlockId> = (0..=4).map(|s| canonical_id(s as u8)).collect();
+    db.replace_canonical_suffix_from(0, seed.clone())
         .expect("test: seed canonical");
 
-    db.replace_canonical_blocks_from(5, vec![(5, canonical_id(50))])
+    db.replace_canonical_suffix_from(5, vec![canonical_id(50)])
         .expect("test: extend canonical");
 
-    for (slot, id) in &seed {
-        assert_eq!(db.get_canonical_block(*slot).unwrap(), Some(*id));
+    for (slot, id) in seed.iter().enumerate() {
+        assert_eq!(db.get_canonical_block(slot as u64).unwrap(), Some(*id));
     }
     assert_eq!(db.get_canonical_block(5).unwrap(), Some(canonical_id(50)));
 }
 
-pub fn test_replace_canonical_blocks_from_reorg_shorter(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_suffix_from_reorg_shorter(db: &impl OLBlockDatabase) {
     // Seed slots 0..=9, then reorg at pivot 5 onto a shorter branch (slots 6,7).
-    let seed: Vec<(u64, OLBlockId)> = (0..=9).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_blocks_from(0, seed)
+    let seed: Vec<OLBlockId> = (0..=9).map(|s| canonical_id(s as u8)).collect();
+    db.replace_canonical_suffix_from(0, seed)
         .expect("test: seed canonical");
 
-    let branch = vec![(6u64, canonical_id(0x60)), (7u64, canonical_id(0x70))];
-    db.replace_canonical_blocks_from(6, branch)
+    let branch = vec![canonical_id(0x60), canonical_id(0x70)];
+    db.replace_canonical_suffix_from(6, branch)
         .expect("test: reorg canonical");
 
     // Slots 0..=5 untouched.
@@ -106,13 +106,13 @@ pub fn test_replace_canonical_blocks_from_reorg_shorter(db: &impl OLBlockDatabas
     assert_eq!(db.get_canonical_block(9).unwrap(), None);
 }
 
-pub fn test_replace_canonical_blocks_from_revert_empty_branch(db: &impl OLBlockDatabase) {
+pub fn test_replace_canonical_suffix_from_revert_empty_branch(db: &impl OLBlockDatabase) {
     // Seed slots 0..=4, then revert to slot 2 with an empty branch.
-    let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_blocks_from(0, seed)
+    let seed: Vec<OLBlockId> = (0..=4).map(|s| canonical_id(s as u8)).collect();
+    db.replace_canonical_suffix_from(0, seed)
         .expect("test: seed canonical");
 
-    db.replace_canonical_blocks_from(3, Vec::new())
+    db.replace_canonical_suffix_from(3, Vec::new())
         .expect("test: revert canonical");
 
     for s in 0..=2u64 {
@@ -125,11 +125,11 @@ pub fn test_replace_canonical_blocks_from_revert_empty_branch(db: &impl OLBlockD
     assert_eq!(db.get_canonical_block(4).unwrap(), None);
 }
 
-pub fn test_replace_canonical_blocks_from_max(db: &impl OLBlockDatabase) {
-    db.replace_canonical_blocks_from(u64::MAX, vec![(u64::MAX, canonical_id(0xaa))])
+pub fn test_replace_canonical_suffix_from_max(db: &impl OLBlockDatabase) {
+    db.replace_canonical_suffix_from(u64::MAX, vec![canonical_id(0xaa)])
         .expect("test: seed canonical at max slot");
 
-    db.replace_canonical_blocks_from(u64::MAX, vec![(u64::MAX, canonical_id(0xbb))])
+    db.replace_canonical_suffix_from(u64::MAX, vec![canonical_id(0xbb)])
         .expect("test: replace suffix from max slot");
 
     assert_eq!(
@@ -138,16 +138,29 @@ pub fn test_replace_canonical_blocks_from_max(db: &impl OLBlockDatabase) {
     );
 }
 
-pub fn test_replace_canonical_blocks_from_idempotent(db: &impl OLBlockDatabase) {
-    let seed: Vec<(u64, OLBlockId)> = (0..=4).map(|s| (s, canonical_id(s as u8))).collect();
-    db.replace_canonical_blocks_from(0, seed.clone())
+pub fn test_replace_canonical_suffix_from_overflow(db: &impl OLBlockDatabase) {
+    let err = db
+        .replace_canonical_suffix_from(u64::MAX, vec![canonical_id(0xaa), canonical_id(0xbb)])
+        .expect_err("test: overflowing canonical suffix must fail");
+    assert!(matches!(
+        err,
+        DbError::OLCanonicalSuffixOverflow {
+            start_slot: u64::MAX,
+            block_count: 2,
+        }
+    ));
+}
+
+pub fn test_replace_canonical_suffix_from_idempotent(db: &impl OLBlockDatabase) {
+    let seed: Vec<OLBlockId> = (0..=4).map(|s| canonical_id(s as u8)).collect();
+    db.replace_canonical_suffix_from(0, seed.clone())
         .expect("test: seed canonical");
     // Re-applying the same suffix is a no-op.
-    db.replace_canonical_blocks_from(0, seed.clone())
+    db.replace_canonical_suffix_from(0, seed.clone())
         .expect("test: re-apply canonical");
 
-    for (slot, id) in &seed {
-        assert_eq!(db.get_canonical_block(*slot).unwrap(), Some(*id));
+    for (slot, id) in seed.iter().enumerate() {
+        assert_eq!(db.get_canonical_block(slot as u64).unwrap(), Some(*id));
     }
 }
 
@@ -579,33 +592,39 @@ macro_rules! ol_block_db_tests {
         }
 
         #[test]
-        fn test_replace_canonical_blocks_from_extend() {
+        fn test_replace_canonical_suffix_from_extend() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_blocks_from_extend(&db);
+            $crate::ol_block_tests::test_replace_canonical_suffix_from_extend(&db);
         }
 
         #[test]
-        fn test_replace_canonical_blocks_from_reorg_shorter() {
+        fn test_replace_canonical_suffix_from_reorg_shorter() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_blocks_from_reorg_shorter(&db);
+            $crate::ol_block_tests::test_replace_canonical_suffix_from_reorg_shorter(&db);
         }
 
         #[test]
-        fn test_replace_canonical_blocks_from_revert_empty_branch() {
+        fn test_replace_canonical_suffix_from_revert_empty_branch() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_blocks_from_revert_empty_branch(&db);
+            $crate::ol_block_tests::test_replace_canonical_suffix_from_revert_empty_branch(&db);
         }
 
         #[test]
-        fn test_replace_canonical_blocks_from_max() {
+        fn test_replace_canonical_suffix_from_max() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_blocks_from_max(&db);
+            $crate::ol_block_tests::test_replace_canonical_suffix_from_max(&db);
         }
 
         #[test]
-        fn test_replace_canonical_blocks_from_idempotent() {
+        fn test_replace_canonical_suffix_from_overflow() {
             let db = $setup_expr;
-            $crate::ol_block_tests::test_replace_canonical_blocks_from_idempotent(&db);
+            $crate::ol_block_tests::test_replace_canonical_suffix_from_overflow(&db);
+        }
+
+        #[test]
+        fn test_replace_canonical_suffix_from_idempotent() {
+            let db = $setup_expr;
+            $crate::ol_block_tests::test_replace_canonical_suffix_from_idempotent(&db);
         }
 
         proptest::proptest! {

--- a/crates/db/types/src/errors.rs
+++ b/crates/db/types/src/errors.rs
@@ -1,4 +1,4 @@
-use strata_identifiers::{AccountId, Epoch, Hash, OLBlockCommitment};
+use strata_identifiers::{AccountId, Epoch, Hash, OLBlockCommitment, Slot};
 use strata_primitives::{epoch::EpochCommitment, l1::L1BlockId, l2::L2BlockId, L1Height};
 use strata_storage_common::exec::OpsError;
 use thiserror::Error;
@@ -101,6 +101,14 @@ pub enum DbError {
 
     #[error("invalid argument")]
     InvalidArgument,
+
+    #[error(
+        "OL canonical suffix from slot {start_slot} with {block_count} blocks overflows slot range"
+    )]
+    OLCanonicalSuffixOverflow {
+        start_slot: Slot,
+        block_count: usize,
+    },
 
     #[error("resource busy")]
     Busy,

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -654,6 +654,21 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Returns the highest slot that has a valid OL block, or an error at genesis or when no valid
     /// block exists.
     fn get_tip_slot(&self) -> DbResult<Slot>;
+
+    /// Gets the canonical OL block id at a slot, as recorded by fork choice.
+    ///
+    /// Returns `None` for slots above the current canonical tip or never written.
+    fn get_canonical_block(&self, slot: Slot) -> DbResult<Option<OLBlockId>>;
+
+    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`.
+    ///
+    /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
+    /// writes each `(slot, id)` in `blocks`.
+    fn replace_canonical_suffix(
+        &self,
+        pivot_slot: Slot,
+        blocks: &[(Slot, OLBlockId)],
+    ) -> DbResult<()>;
 }
 
 /// Database for OL state indexing data.

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -664,6 +664,10 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     ///
     /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
     /// then writes each `(slot, id)` in `blocks`.
+    ///
+    /// Single-writer contract: fork choice is the sole writer of the canonical index. Callers must
+    /// not invoke this concurrently with another canonical write; the atomicity guarantee covers
+    /// the remove-then-insert against readers, not against a competing writer.
     fn replace_canonical_blocks_from(
         &self,
         start_slot: Slot,

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -660,18 +660,18 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Returns `None` for slots above the current canonical tip or never written.
     fn get_canonical_block(&self, slot: Slot) -> DbResult<Option<OLBlockId>>;
 
-    /// Replaces canonical blocks from `start_slot`.
+    /// Replaces the canonical suffix from `start_slot`.
     ///
     /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
-    /// then writes each `(slot, id)` in `blocks`.
+    /// then writes each block ID into a contiguous suffix starting at `start_slot`.
     ///
     /// Single-writer contract: fork choice is the sole writer of the canonical index. Callers must
     /// not invoke this concurrently with another canonical write; the atomicity guarantee covers
     /// the remove-then-insert against readers, not against a competing writer.
-    fn replace_canonical_blocks_from(
+    fn replace_canonical_suffix_from(
         &self,
         start_slot: Slot,
-        blocks: Vec<(Slot, OLBlockId)>,
+        block_ids: Vec<OLBlockId>,
     ) -> DbResult<()>;
 }
 

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -664,9 +664,9 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
     /// then writes each block ID into a contiguous suffix starting at `start_slot`.
     ///
-    /// Single-writer contract: fork choice is the sole writer of the canonical index. Callers must
-    /// not invoke this concurrently with another canonical write; the atomicity guarantee covers
-    /// the remove-then-insert against readers, not against a competing writer.
+    /// Single-writer contract: callers must not invoke this concurrently with another canonical
+    /// write; the atomicity guarantee covers the remove-then-insert against readers, not against a
+    /// competing writer.
     fn replace_canonical_suffix_from(
         &self,
         start_slot: Slot,

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -651,8 +651,7 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Gets the validity status of a block.
     fn get_block_status(&self, id: OLBlockId) -> DbResult<Option<BlockStatus>>;
 
-    /// Returns the highest slot that has a valid OL block, or an error at genesis or when no valid
-    /// block exists.
+    /// Returns the highest slot recorded in the canonical OL block index.
     fn get_tip_slot(&self) -> DbResult<Slot>;
 
     /// Gets the canonical OL block id at a slot, as recorded by fork choice.

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -667,7 +667,7 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     fn replace_canonical_suffix(
         &self,
         pivot_slot: Slot,
-        blocks: &[(Slot, OLBlockId)],
+        blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()>;
 }
 

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -660,11 +660,11 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Returns `None` for slots above the current canonical tip or never written.
     fn get_canonical_block(&self, slot: Slot) -> DbResult<Option<OLBlockId>>;
 
-    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`.
+    /// Updates canonical blocks above `pivot_slot`.
     ///
     /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
     /// writes each `(slot, id)` in `blocks`.
-    fn replace_canonical_suffix(
+    fn update_canonical_blocks_above(
         &self,
         pivot_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,

--- a/crates/db/types/src/traits.rs
+++ b/crates/db/types/src/traits.rs
@@ -660,13 +660,13 @@ pub trait OLBlockDatabase: Send + Sync + 'static {
     /// Returns `None` for slots above the current canonical tip or never written.
     fn get_canonical_block(&self, slot: Slot) -> DbResult<Option<OLBlockId>>;
 
-    /// Updates canonical blocks above `pivot_slot`.
+    /// Replaces canonical blocks from `start_slot`.
     ///
-    /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
-    /// writes each `(slot, id)` in `blocks`.
-    fn update_canonical_blocks_above(
+    /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
+    /// then writes each `(slot, id)` in `blocks`.
+    fn replace_canonical_blocks_from(
         &self,
-        pivot_slot: Slot,
+        start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()>;
 }

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1389,6 +1389,16 @@ impl TestStorageFixtureBuilder {
                 .await
                 .expect("Failed to store parent block");
 
+            fixture
+                .storage()
+                .ol_block()
+                .update_canonical_blocks_above_async(
+                    parent_header.slot().saturating_sub(1),
+                    vec![(parent_header.slot(), *commitment.blkid())],
+                )
+                .await
+                .expect("Failed to store parent block in canonical index");
+
             commitment
         } else {
             // No parent slot - return null commitment for genesis testing

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1392,8 +1392,8 @@ impl TestStorageFixtureBuilder {
             fixture
                 .storage()
                 .ol_block()
-                .update_canonical_blocks_above_async(
-                    parent_header.slot().saturating_sub(1),
+                .replace_canonical_blocks_from_async(
+                    parent_header.slot(),
                     vec![(parent_header.slot(), *commitment.blkid())],
                 )
                 .await

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -1392,9 +1392,9 @@ impl TestStorageFixtureBuilder {
             fixture
                 .storage()
                 .ol_block()
-                .replace_canonical_blocks_from_async(
+                .replace_canonical_suffix_from_async(
                     parent_header.slot(),
-                    vec![(parent_header.slot(), *commitment.blkid())],
+                    vec![*commitment.blkid()],
                 )
                 .await
                 .expect("Failed to store parent block in canonical index");

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -222,32 +222,60 @@ impl OLBlockManager {
         self.get_canonical_block_at_async(tip).await
     }
 
-    /// Gets the canonical block commitment at given height.
+    /// Gets the canonical block commitment at given slot. Blocking.
+    ///
+    /// Reads the canonical index recorded by fork choice. Returns `None` for slots above the
+    /// canonical tip or not yet written.
     pub fn get_canonical_block_at_blocking(
         &self,
-        tip: Slot,
+        slot: Slot,
     ) -> DbResult<Option<OLBlockCommitment>> {
-        let blocks = self.get_blocks_at_height_blocking(tip)?;
-        // TODO(STR-2105): determine how to get the canonical block. for now it is just the first
-        // one
-        Ok(blocks
-            .first()
-            .cloned()
-            .map(|id| OLBlockCommitment::new(tip, id)))
+        Ok(self
+            .ops
+            .get_canonical_block_blocking(slot)?
+            .map(|id| OLBlockCommitment::new(slot, id)))
     }
 
-    /// Gets the canonical block commitment at given height.
+    /// Gets the canonical block commitment at given slot. Async.
+    ///
+    /// Reads the canonical index recorded by fork choice. Returns `None` for slots above the
+    /// canonical tip or not yet written.
     pub async fn get_canonical_block_at_async(
         &self,
-        tip: Slot,
+        slot: Slot,
     ) -> DbResult<Option<OLBlockCommitment>> {
-        let blocks = self.get_blocks_at_height_async(tip).await?;
-        // TODO(STR-2105): determine how to get the canonical block. for now, it is just the first
-        // one
-        Ok(blocks
-            .first()
-            .cloned()
-            .map(|id| OLBlockCommitment::new(tip, id)))
+        Ok(self
+            .ops
+            .get_canonical_block_async(slot)
+            .await?
+            .map(|id| OLBlockCommitment::new(slot, id)))
+    }
+
+    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`. Async.
+    ///
+    /// Truncates every canonical entry above `pivot_slot`, then writes `blocks`, in one
+    /// transaction.
+    pub async fn replace_canonical_suffix_async(
+        &self,
+        pivot_slot: Slot,
+        blocks: Vec<(Slot, OLBlockId)>,
+    ) -> DbResult<()> {
+        self.ops
+            .replace_canonical_suffix_async(pivot_slot, blocks)
+            .await
+    }
+
+    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`. Blocking.
+    ///
+    /// Truncates every canonical entry above `pivot_slot`, then writes `blocks`, in one
+    /// transaction.
+    pub fn replace_canonical_suffix_blocking(
+        &self,
+        pivot_slot: Slot,
+        blocks: Vec<(Slot, OLBlockId)>,
+    ) -> DbResult<()> {
+        self.ops
+            .replace_canonical_suffix_blocking(pivot_slot, blocks)
     }
 }
 
@@ -372,6 +400,47 @@ mod tests {
                 assert_eq!(block_ids.len(), 2);
                 assert!(block_ids.contains(&block_id1));
                 assert!(block_ids.contains(&block_id2));
+            });
+        }
+
+        #[test]
+        fn proptest_canonical_at_returns_indexed_block_not_first(
+            mut stale in ol_test_utils::ol_block_strategy(),
+            mut canonical in ol_test_utils::ol_block_strategy(),
+        ) {
+            let slot = 7u64;
+            stale.signed_header.header.slot = slot;
+            canonical.signed_header.header.slot = slot;
+            let stale_id = stale.header().compute_blkid();
+            let canonical_id = canonical.header().compute_blkid();
+            prop_assume!(stale_id != canonical_id);
+
+            let rt = Runtime::new().unwrap();
+            rt.block_on(async {
+                let manager = setup_manager();
+
+                // Stale block lands in the height index first, so `.first()` returns it.
+                manager.put_block_data_async(stale).await.expect("put stale");
+                manager.put_block_data_async(canonical).await.expect("put canonical");
+                let at_height = manager
+                    .get_blocks_at_height_async(slot)
+                    .await
+                    .expect("get blocks at height");
+                assert_eq!(at_height.first(), Some(&stale_id));
+
+                // Fork choice records the canonical (second) block at the slot.
+                manager
+                    .replace_canonical_suffix_async(slot - 1, vec![(slot, canonical_id)])
+                    .await
+                    .expect("seed canonical");
+
+                let got = manager
+                    .get_canonical_block_at_async(slot)
+                    .await
+                    .expect("get canonical")
+                    .expect("canonical present");
+                assert_eq!(got.blkid(), &canonical_id);
+                assert_ne!(got.blkid(), &stale_id);
             });
         }
 

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -251,31 +251,31 @@ impl OLBlockManager {
             .map(|id| OLBlockCommitment::new(slot, id)))
     }
 
-    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`. Async.
+    /// Updates canonical blocks above `pivot_slot`.
     ///
-    /// Truncates every canonical entry above `pivot_slot`, then writes `blocks`, in one
-    /// transaction.
-    pub async fn replace_canonical_suffix_async(
+    /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
+    /// writes each `(slot, id)` in `blocks`.
+    pub async fn update_canonical_blocks_above_async(
         &self,
         pivot_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         self.ops
-            .replace_canonical_suffix_async(pivot_slot, blocks)
+            .update_canonical_blocks_above_async(pivot_slot, blocks)
             .await
     }
 
-    /// Replaces the canonical index suffix above `pivot_slot` with `blocks`. Blocking.
+    /// Updates canonical blocks above `pivot_slot`.
     ///
-    /// Truncates every canonical entry above `pivot_slot`, then writes `blocks`, in one
-    /// transaction.
-    pub fn replace_canonical_suffix_blocking(
+    /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
+    /// writes each `(slot, id)` in `blocks`.
+    pub fn update_canonical_blocks_above_blocking(
         &self,
         pivot_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         self.ops
-            .replace_canonical_suffix_blocking(pivot_slot, blocks)
+            .update_canonical_blocks_above_blocking(pivot_slot, blocks)
     }
 }
 
@@ -430,7 +430,7 @@ mod tests {
 
                 // Fork choice records the canonical (second) block at the slot.
                 manager
-                    .replace_canonical_suffix_async(slot - 1, vec![(slot, canonical_id)])
+                    .update_canonical_blocks_above_async(slot - 1, vec![(slot, canonical_id)])
                     .await
                     .expect("seed canonical");
 

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -251,31 +251,31 @@ impl OLBlockManager {
             .map(|id| OLBlockCommitment::new(slot, id)))
     }
 
-    /// Updates canonical blocks above `pivot_slot`.
+    /// Replaces canonical blocks from `start_slot`.
     ///
-    /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
-    /// writes each `(slot, id)` in `blocks`.
-    pub async fn update_canonical_blocks_above_async(
+    /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
+    /// then writes each `(slot, id)` in `blocks`.
+    pub async fn replace_canonical_blocks_from_async(
         &self,
-        pivot_slot: Slot,
+        start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         self.ops
-            .update_canonical_blocks_above_async(pivot_slot, blocks)
+            .replace_canonical_blocks_from_async(start_slot, blocks)
             .await
     }
 
-    /// Updates canonical blocks above `pivot_slot`.
+    /// Replaces canonical blocks from `start_slot`.
     ///
-    /// Atomically removes every canonical entry for slots strictly greater than `pivot_slot`, then
-    /// writes each `(slot, id)` in `blocks`.
-    pub fn update_canonical_blocks_above_blocking(
+    /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
+    /// then writes each `(slot, id)` in `blocks`.
+    pub fn replace_canonical_blocks_from_blocking(
         &self,
-        pivot_slot: Slot,
+        start_slot: Slot,
         blocks: Vec<(Slot, OLBlockId)>,
     ) -> DbResult<()> {
         self.ops
-            .update_canonical_blocks_above_blocking(pivot_slot, blocks)
+            .replace_canonical_blocks_from_blocking(start_slot, blocks)
     }
 }
 
@@ -430,7 +430,7 @@ mod tests {
 
                 // Fork choice records the canonical (second) block at the slot.
                 manager
-                    .update_canonical_blocks_above_async(slot - 1, vec![(slot, canonical_id)])
+                    .replace_canonical_blocks_from_async(slot, vec![(slot, canonical_id)])
                     .await
                     .expect("seed canonical");
 

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -479,18 +479,24 @@ mod tests {
                 block1.signed_header.header.slot = 5u64;
                 block2.signed_header.header.slot = 10u64;
 
+                let block_id1 = block1.header().compute_blkid();
                 let block_id2 = block2.header().compute_blkid();
 
                 // Put blocks
                 manager.put_block_data_async(block1).await.expect("put block 1");
                 manager.put_block_data_async(block2).await.expect("put block 2");
 
-                // Set block2 as valid (higher slot)
+                // Set block2 as valid, but keep the canonical index at block1.
+                manager.set_block_status_async(block_id1, BlockStatus::Valid).await.expect("set status");
                 manager.set_block_status_async(block_id2, BlockStatus::Valid).await.expect("set status");
+                manager
+                    .replace_canonical_suffix_from_async(5, vec![block_id1])
+                    .await
+                    .expect("seed canonical index");
 
-                // Get tip slot - should be 10 (highest valid slot)
+                // Get tip slot - should be 5 (highest canonical slot), not the higher valid fork.
                 let tip_slot = manager.get_tip_slot_async().await.expect("get tip slot");
-                assert_eq!(tip_slot, 10u64);
+                assert_eq!(tip_slot, 5u64);
             });
         }
 
@@ -502,18 +508,23 @@ mod tests {
             block1.signed_header.header.slot = 5u64;
             block2.signed_header.header.slot = 10u64;
 
+            let block_id1 = block1.header().compute_blkid();
             let block_id2 = block2.header().compute_blkid();
 
             // Put blocks
             manager.put_block_data_blocking(block1).expect("put block 1");
             manager.put_block_data_blocking(block2).expect("put block 2");
 
-            // Set block2 as valid (higher slot)
+            // Set block2 as valid, but keep the canonical index at block1.
+            manager.set_block_status_blocking(block_id1, BlockStatus::Valid).expect("set status");
             manager.set_block_status_blocking(block_id2, BlockStatus::Valid).expect("set status");
+            manager
+                .replace_canonical_suffix_from_blocking(5, vec![block_id1])
+                .expect("seed canonical index");
 
-            // Get tip slot - should be 10 (highest valid slot)
+            // Get tip slot - should be 5 (highest canonical slot), not the higher valid fork.
             let tip_slot = manager.get_tip_slot_blocking().expect("get tip slot");
-            assert_eq!(tip_slot, 10u64);
+            assert_eq!(tip_slot, 5u64);
         }
     }
 

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -176,12 +176,12 @@ impl OLBlockManager {
         self.ops.get_blocks_at_height_blocking(slot)
     }
 
-    /// Gets the tip slot (highest slot with valid block). Async.
+    /// Gets the canonical tip slot. Async.
     pub async fn get_tip_slot_async(&self) -> DbResult<Slot> {
         self.ops.get_tip_slot_async().await
     }
 
-    /// Gets the tip slot (highest slot with valid block). Blocking.
+    /// Gets the canonical tip slot. Blocking.
     pub fn get_tip_slot_blocking(&self) -> DbResult<Slot> {
         self.ops.get_tip_slot_blocking()
     }

--- a/crates/storage/src/managers/ol.rs
+++ b/crates/storage/src/managers/ol.rs
@@ -251,31 +251,31 @@ impl OLBlockManager {
             .map(|id| OLBlockCommitment::new(slot, id)))
     }
 
-    /// Replaces canonical blocks from `start_slot`.
+    /// Replaces the canonical suffix from `start_slot`.
     ///
     /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
-    /// then writes each `(slot, id)` in `blocks`.
-    pub async fn replace_canonical_blocks_from_async(
+    /// then writes each block ID into a contiguous suffix starting at `start_slot`.
+    pub async fn replace_canonical_suffix_from_async(
         &self,
         start_slot: Slot,
-        blocks: Vec<(Slot, OLBlockId)>,
+        block_ids: Vec<OLBlockId>,
     ) -> DbResult<()> {
         self.ops
-            .replace_canonical_blocks_from_async(start_slot, blocks)
+            .replace_canonical_suffix_from_async(start_slot, block_ids)
             .await
     }
 
-    /// Replaces canonical blocks from `start_slot`.
+    /// Replaces the canonical suffix from `start_slot`.
     ///
     /// Atomically removes every canonical entry for slots greater than or equal to `start_slot`,
-    /// then writes each `(slot, id)` in `blocks`.
-    pub fn replace_canonical_blocks_from_blocking(
+    /// then writes each block ID into a contiguous suffix starting at `start_slot`.
+    pub fn replace_canonical_suffix_from_blocking(
         &self,
         start_slot: Slot,
-        blocks: Vec<(Slot, OLBlockId)>,
+        block_ids: Vec<OLBlockId>,
     ) -> DbResult<()> {
         self.ops
-            .replace_canonical_blocks_from_blocking(start_slot, blocks)
+            .replace_canonical_suffix_from_blocking(start_slot, block_ids)
     }
 }
 
@@ -430,7 +430,7 @@ mod tests {
 
                 // Fork choice records the canonical (second) block at the slot.
                 manager
-                    .replace_canonical_blocks_from_async(slot, vec![(slot, canonical_id)])
+                    .replace_canonical_suffix_from_async(slot, vec![canonical_id])
                     .await
                     .expect("seed canonical");
 

--- a/crates/storage/src/ops/ol.rs
+++ b/crates/storage/src/ops/ol.rs
@@ -16,6 +16,8 @@ inst_ops_simple! {
         rollback_block_high_watermark(target: OLBlockCommitment) => bool;
         del_block_data(id: OLBlockId) => bool;
         get_blocks_at_height(slot: u64) => Vec<OLBlockId>;
+        get_canonical_block(slot: Slot) => Option<OLBlockId>;
+        replace_canonical_suffix(pivot_slot: Slot, blocks: Vec<(Slot, OLBlockId)>) => ();
         get_tip_slot() => Slot;
         get_block_status(id: OLBlockId) => Option<BlockStatus>;
         set_block_status(id: OLBlockId, status: BlockStatus) => bool;

--- a/crates/storage/src/ops/ol.rs
+++ b/crates/storage/src/ops/ol.rs
@@ -17,7 +17,7 @@ inst_ops_simple! {
         del_block_data(id: OLBlockId) => bool;
         get_blocks_at_height(slot: u64) => Vec<OLBlockId>;
         get_canonical_block(slot: Slot) => Option<OLBlockId>;
-        update_canonical_blocks_above(pivot_slot: Slot, blocks: Vec<(Slot, OLBlockId)>) => ();
+        replace_canonical_blocks_from(start_slot: Slot, blocks: Vec<(Slot, OLBlockId)>) => ();
         get_tip_slot() => Slot;
         get_block_status(id: OLBlockId) => Option<BlockStatus>;
         set_block_status(id: OLBlockId, status: BlockStatus) => bool;

--- a/crates/storage/src/ops/ol.rs
+++ b/crates/storage/src/ops/ol.rs
@@ -17,7 +17,7 @@ inst_ops_simple! {
         del_block_data(id: OLBlockId) => bool;
         get_blocks_at_height(slot: u64) => Vec<OLBlockId>;
         get_canonical_block(slot: Slot) => Option<OLBlockId>;
-        replace_canonical_suffix(pivot_slot: Slot, blocks: Vec<(Slot, OLBlockId)>) => ();
+        update_canonical_blocks_above(pivot_slot: Slot, blocks: Vec<(Slot, OLBlockId)>) => ();
         get_tip_slot() => Slot;
         get_block_status(id: OLBlockId) => Option<BlockStatus>;
         set_block_status(id: OLBlockId, status: BlockStatus) => bool;

--- a/crates/storage/src/ops/ol.rs
+++ b/crates/storage/src/ops/ol.rs
@@ -17,7 +17,7 @@ inst_ops_simple! {
         del_block_data(id: OLBlockId) => bool;
         get_blocks_at_height(slot: u64) => Vec<OLBlockId>;
         get_canonical_block(slot: Slot) => Option<OLBlockId>;
-        replace_canonical_blocks_from(start_slot: Slot, blocks: Vec<(Slot, OLBlockId)>) => ();
+        replace_canonical_suffix_from(start_slot: Slot, block_ids: Vec<OLBlockId>) => ();
         get_tip_slot() => Slot;
         get_block_status(id: OLBlockId) => Option<BlockStatus>;
         set_block_status(id: OLBlockId, status: BlockStatus) => bool;


### PR DESCRIPTION
## Description
**AI Usage**: Claude and codex were used with close supervision of the author.

This PR does the following:
- Adds an index tree to track canonical blocks.
- The tree is only updated by fcm because it keeps track of the tip and reorgs.
- Adds `replace_canonical_suffix_from(slot, blockids)` method to OL blocks database, which first clears the existing canonical entries beyond the `slot` and inserts the blockids as canonical entries.
- Fixes ripple effects on chain worker and dbtool.
- Also adds startup migration in case when the existing database does not contain canonical index tree.

At first I was reluctant to add another indexing tree because that's another maintenance so I considered a heuristic approach where, in order to find canonical block at slot `n`, we would find the closest finalized epoch with terminal block ` >= n` and traverse back from that epoch terminal upto slot `n`. This works correctly for finalized slots, but is not unviersally correct i.e. it does not work for unfinalized slots. So I reverted back to a separate index, which is the most correct way, although needs careful handling of the index.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
