### PR TITLE
genparams: template-driven bridge denomination (staging-v2 → 2 BTC)

### DIFF
--- a/.github/params/generate-params.sh
+++ b/.github/params/generate-params.sh
@@ -73,15 +73,36 @@ run_datatool "${CHAIN_CONFIG_ABS}:/app/chain.json:ro" -- \
     -o /out/ol-params-raw.json
 echo "  ol-params-raw.json generated"
 
+# Align the raw ol-params bridge denomination with the deployment template BEFORE
+# gen-asm-params computes genesis_ol_blkid. The OL genesis STF hashes bridge_params
+# (denomination + cap) into the genesis block, so genesis_ol_blkid is
+# denomination-dependent (crates/ol/genesis: execute_and_complete_block consumes
+# params.bridge_params()). gen-ol-params has no denomination flag and emits the
+# datatool default; without this patch a template denomination != that default
+# would make the node's runtime genesis diverge from the asm-params
+# genesis_ol_blkid and bootstrap would fail. Patch the raw (used for
+# genesis_ol_blkid) and pass the same value to --deposit-sats (Bridge.denomination)
+# so ol-params, genesis_ol_blkid, and asm Bridge.denomination all agree.
+# Aligned copy goes to a new file (not an in-place patch): the raw is written by
+# datatool as root in docker and is not writable by the host runner user.
+DEPOSIT_SATS=$(python3 "${SCRIPT_DIR}/params-helper.py" align-denomination \
+    --raw "${WORK_DIR}/ol-params-raw.json" \
+    --template "${TEMPLATE_DIR}/ol-params.json" \
+    --out "${WORK_DIR}/ol-params-aligned.json")
+echo "  ol-params bridge denomination aligned to template: ${DEPOSIT_SATS} sats"
+
 # The ASM checkpoint sequencer_predicate is static (from the template); the raw
 # generation only needs operators + safe-harbour, so no -s/sequencer key here.
+# Use the denomination-aligned ol-params so genesis_ol_blkid matches the deployed
+# ol-params (which carries the template denomination).
 run_datatool -- \
     gen-asm-params \
     -B /out/op-pks.txt \
     --checkpoint-predicate sp1-groth16 \
-    --ol-params /out/ol-params-raw.json \
+    --ol-params /out/ol-params-aligned.json \
     --genesis-l1-height "${GENESIS_L1_HEIGHT}" \
     --safe-harbour-address "${SAFE_HARBOUR}" \
+    --deposit-sats "${DEPOSIT_SATS}" \
     -o /out/asm-params-raw.json
 echo "  asm-params-raw.json generated"
 

--- a/.github/params/params-helper.py
+++ b/.github/params/params-helper.py
@@ -114,6 +114,49 @@ def extract_safe_harbour(template_dir: Path) -> str:
     raise ValueError("safe_harbour_address not found in asm-params template")
 
 
+def align_denomination(raw_path: Path, template_path: Path, out_path: Path) -> int:
+    """Write a copy of the datatool raw ol-params with bridge_params (denomination
+    + cap) taken from the template, to out_path.
+
+    The OL genesis STF hashes bridge_params into the genesis block, so the
+    genesis_ol_blkid that gen-asm-params derives from the raw is
+    denomination-dependent. gen-ol-params has no denomination flag (it emits the
+    datatool default), so without this the deployed ol-params denomination (from
+    the template) could differ from the value baked into genesis_ol_blkid and the
+    node would fail to bootstrap. Feeding this aligned copy to
+    gen-asm-params --ol-params keeps genesis_ol_blkid, the deployed ol-params, and
+    asm Bridge.denomination (via --deposit-sats) in agreement.
+
+    Writes to a new out_path rather than patching raw_path in place: the raw is
+    produced by datatool running as root in docker, so it is not writable by the
+    host runner user. Prints the denomination (sats) on stdout for the caller; all
+    diagnostics go to stderr so stdout stays a single clean integer.
+    """
+    tpl_bridge = load_json(template_path)["bridge_params"]
+    denom = int(tpl_bridge["denomination"])
+    maxw = tpl_bridge.get("max_withdrawal_amount")
+
+    # Mirror BridgeParams::new invariants (crates/bridge-params) to fail early
+    # instead of letting datatool reject the aligned ol-params mid-run.
+    if denom <= 0:
+        print("ERROR: template bridge denomination must be non-zero", file=sys.stderr)
+        sys.exit(1)
+    if maxw is not None and (maxw < denom or maxw % denom != 0):
+        print(
+            f"ERROR: max_withdrawal_amount {maxw} must be >= and a multiple of "
+            f"denomination {denom}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    raw = load_json(raw_path)
+    raw["bridge_params"] = {"denomination": denom, "max_withdrawal_amount": maxw}
+    write_json(out_path, raw)
+    print(f"  aligned ol-params bridge_params <- denomination={denom}, max_withdrawal_amount={maxw}", file=sys.stderr)
+    print(denom)
+    return denom
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -127,7 +170,19 @@ def main():
     keys_p.add_argument("--template-dir", required=True, help="Directory with pre-committed templates")
     keys_p.add_argument("--output-dir", required=True, help="Directory to write key files")
 
+    align_p = sub.add_parser(
+        "align-denomination",
+        help="Patch raw ol-params bridge denomination from template; print denomination (sats)",
+    )
+    align_p.add_argument("--raw", required=True, help="Path to datatool raw ol-params.json (read-only)")
+    align_p.add_argument("--template", required=True, help="Path to template ol-params.json (denomination source)")
+    align_p.add_argument("--out", required=True, help="Path to write the aligned ol-params.json")
+
     args = parser.parse_args()
+
+    if args.command == "align-denomination":
+        align_denomination(Path(args.raw), Path(args.template), Path(args.out))
+        return
 
     if args.command == "extract-keys":
         template_dir = Path(args.template_dir)

--- a/.github/params/templates/staging-v2/asm-params.json
+++ b/.github/params/templates/staging-v2/asm-params.json
@@ -67,7 +67,7 @@
           "027098a1e38159f586536fabcb5537cdbb1454b1464c5c4a1bfd48de6c794d28c4",
           "0288610184701307eef5dbb81ce1d974bc6940d21601a9656b565dab485321a03f"
         ],
-        "denomination": 100000000,
+        "denomination": 200000000,
         "assignment_duration": 64,
         "operator_fee": 150000,
         "recovery_delay": 6,

--- a/.github/params/templates/staging-v2/ol-params.json
+++ b/.github/params/templates/staging-v2/ol-params.json
@@ -16,7 +16,7 @@
   },
   "last_l1_block": "__LAST_L1_BLOCK__",
   "bridge_params": {
-    "denomination": 100000000,
+    "denomination": 200000000,
     "max_withdrawal_amount": 1000000000
   }
 }


### PR DESCRIPTION
## Description

Makes the bridge denomination in generated params **template-driven**, and sets **staging-v2 to 2 BTC** per the cross-team Params doc (datatool defaults to 1 BTC).

Root cause this fixes: the OL genesis STF hashes `bridge_params` into the genesis block (`crates/ol/genesis`: `execute_and_complete_block(..., *params.bridge_params())`), so `genesis_ol_blkid` is **denomination-dependent**. But `gen-ol-params` emits the datatool *default* denomination and has no override flag, while the deployed `ol-params` takes its denomination from the committed template. Any template denomination differing from the datatool default therefore silently desyncs the node's runtime genesis from the `genesis_ol_blkid` baked into `asm-params` → bootstrap failure. This is a latent footgun today, and it blocks deploying a non-default denomination.

Changes:
- `generate-params.sh`: after `gen-ol-params`, patch the raw `ol-params` `bridge_params` to the template value (via the new `params-helper.py align-denomination`) **before** `gen-asm-params` computes `genesis_ol_blkid`, and pass the same value to `gen-asm-params --deposit-sats`. Result: deployed `ol-params`, `genesis_ol_blkid`, and `asm Bridge.denomination` agree by construction.
- `params-helper.py`: new `align-denomination` subcommand (mirrors the `BridgeParams::new` invariants; prints the denomination to stdout, diagnostics to stderr).
- `templates/staging-v2/ol-params.json`: `denomination` 1 BTC → **2 BTC** (`max_withdrawal_amount` 10 BTC stays a valid multiple). Separate commit.

Run via `ci-genparams` with `checkout_ref` pointed at this branch (datatool image stays `e637830`).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)

## Notes to Reviewers

`prod` templates are untouched — only `staging-v2`. The tooling change is a no-op for any environment whose template denomination already equals the datatool default; it only changes behavior when they differ (which previously produced a broken genesis).

Is this PR addressing any specification, design doc or external reference document?

- [x] Yes

Notion 🪨 Params doc (staging-v2 bridge denomination = 2 BTC).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance: drafted with Claude Code, reviewed by me.