### PR TITLE
fix(reth): return recoverable bridgeout amount error

### DIFF
--- a/crates/alpen-ee/rpc/api/Cargo.toml
+++ b/crates/alpen-ee/rpc/api/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
-alpen-ee-rpc-types = { workspace = true, features = ["jsonschema"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
+alpen-ee-rpc-types = { workspace = true, features = ["jsonschema"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 schemars.workspace = true
 strata-open-rpc.workspace = true

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -48,9 +48,7 @@ pub(crate) fn bridge_context_call(
     let (sats, _) = wei_to_sats(withdrawal_amount);
 
     // Try converting sats (U256) into u64 amount
-    let amount: u64 = sats.try_into().map_err(|_| {
-        PrecompileError::Fatal("Withdrawal amount exceeds maximum allowed value".into())
-    })?;
+    let amount = sats_to_withdrawal_amount(sats)?;
 
     // Log the bridge withdrawal intent
     let evt = WithdrawalIntentEvent {
@@ -75,6 +73,11 @@ pub(crate) fn bridge_context_call(
         })?;
 
     Ok(PrecompileOutput::new(gas_cost, Bytes::new()))
+}
+
+fn sats_to_withdrawal_amount(sats: U256) -> Result<u64, PrecompileError> {
+    sats.try_into()
+        .map_err(|_| PrecompileError::other("Withdrawal amount exceeds maximum allowed value"))
 }
 
 fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
@@ -218,6 +221,13 @@ mod tests {
     #[test]
     fn test_bridgeout_gas_cost_rejects_overflow() {
         assert!(bridgeout_gas_cost(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn test_sats_to_withdrawal_amount_rejects_overflow_as_recoverable_error() {
+        let err = sats_to_withdrawal_amount(U256::from(u64::MAX) + U256::from(1)).unwrap_err();
+
+        assert!(matches!(err, PrecompileError::Other(_)));
     }
 
     // --- withdrawal amount validation tests ---


### PR DESCRIPTION
## Description

Converts bridgeout withdrawal amount overflow from a fatal precompile error into a recoverable precompile error. Invalid user-supplied amounts now reject the transaction through normal precompile failure handling instead of surfacing as a top-level fatal execution error.

Adds unit coverage for the overflow conversion path.

Also includes a Taplo-only manifest ordering change in `crates/alpen-ee/rpc/api/Cargo.toml`, which was required for `just pr-lite` to pass.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

STR-3569 also mentions the `set_balance(...)` fatal site. This PR intentionally leaves it as `Fatal` because, in the current local `alloy-evm 0.23.3` API, `EvmInternals::set_balance` can fail only through `EvmInternalsError::Database`, which is an infrastructure/database-load failure rather than deterministic user input.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

https://alpenlabs.atlassian.net/browse/STR-3569

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This PR was prepared with assistance from OpenAI Codex.

## Related Issues

https://alpenlabs.atlassian.net/browse/STR-3569
