### PR TITLE
fix(reth): reject delegated bridgeout precompile calls

### DIFF
--- a/crates/alpen-ee/rpc/api/Cargo.toml
+++ b/crates/alpen-ee/rpc/api/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
-alpen-ee-rpc-types = { workspace = true, features = ["jsonschema"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
+alpen-ee-rpc-types = { workspace = true, features = ["jsonschema"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 schemars.workspace = true
 strata-open-rpc.workspace = true

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -25,6 +25,12 @@ pub(crate) fn bridge_context_call(
     denomination_wei: U256,
     max_withdrawal_wei: Option<U256>,
 ) -> PrecompileResult {
+    if !input.is_direct_call() {
+        return Err(PrecompileError::other(
+            "bridgeout precompile must be invoked via CALL",
+        ));
+    }
+
     let gas_cost = bridgeout_gas_cost(input.data.len())?;
     if gas_cost > input.gas {
         return Err(PrecompileError::OutOfGas);
@@ -118,6 +124,12 @@ fn validate_bosd(data: &[u8]) -> Result<(), PrecompileError> {
 
 #[cfg(test)]
 mod tests {
+    use reth_evm::EvmInternals;
+    use revm::{
+        context::{BlockEnv, Journal, JournalEntry, JournalTr},
+        database::EmptyDB,
+        primitives::address,
+    };
     use strata_ol_bridge_types::OperatorSelection;
 
     use super::*;
@@ -224,6 +236,54 @@ mod tests {
 
     fn max_withdrawal() -> Option<U256> {
         Some(FIXED_WITHDRAWAL_WEI * U256::from(10))
+    }
+
+    fn valid_bridgeout_calldata() -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&u32::MAX.to_be_bytes());
+        data.extend_from_slice(VALID_P2WPKH_BOSD);
+        data
+    }
+
+    #[test]
+    fn test_bridgeout_rejects_delegatecall_apparent_value() {
+        let calldata = valid_bridgeout_calldata();
+        let mut journal: Journal<EmptyDB, JournalEntry> = Journal::new(EmptyDB::new());
+        let block_env = BlockEnv::default();
+        let input = PrecompileInput {
+            data: &calldata,
+            gas: u64::MAX,
+            caller: address!("1111111111111111111111111111111111111111"),
+            value: FIXED_WITHDRAWAL_WEI,
+            target_address: address!("2222222222222222222222222222222222222222"),
+            bytecode_address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            internals: EvmInternals::new(&mut journal, &block_env),
+        };
+
+        let error = bridge_context_call(input, FIXED_WITHDRAWAL_WEI, max_withdrawal()).unwrap_err();
+
+        assert_eq!(
+            error,
+            PrecompileError::Other("bridgeout precompile must be invoked via CALL".into())
+        );
+    }
+
+    #[test]
+    fn test_bridgeout_accepts_direct_call_value() {
+        let calldata = valid_bridgeout_calldata();
+        let mut journal: Journal<EmptyDB, JournalEntry> = Journal::new(EmptyDB::new());
+        let block_env = BlockEnv::default();
+        let input = PrecompileInput {
+            data: &calldata,
+            gas: u64::MAX,
+            caller: address!("1111111111111111111111111111111111111111"),
+            value: FIXED_WITHDRAWAL_WEI,
+            target_address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            bytecode_address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            internals: EvmInternals::new(&mut journal, &block_env),
+        };
+
+        assert!(bridge_context_call(input, FIXED_WITHDRAWAL_WEI, max_withdrawal()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Reject bridgeout precompile invocations that are not direct calls before trusting `PrecompileInput.value`. This prevents `DELEGATECALL`/`CALLCODE` apparent values from emitting withdrawal intents without value being transferred to the bridgeout precompile.

Adds regression coverage for non-direct invocation rejection and confirms direct calls still succeed. Also includes the `taplo fmt` dependency ordering change present on the branch.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The fix intentionally keeps the security change scoped to the direct-call invariant from STR-3309. Additional hardening ideas around exact balance subtraction and OL-side invariants are not bundled here.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://alpenlabs.atlassian.net/browse/STR-3309

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI Assistance Notice: This PR was prepared with assistance from OpenAI Codex.

## Related Issues

- STR-3309