### PR TITLE
fix(storage): reconcile checkpoint artifacts against canonical ASM state

### DIFF
--- a/bin/strata/src/checkpoint_auth.rs
+++ b/bin/strata/src/checkpoint_auth.rs
@@ -13,16 +13,16 @@ use strata_storage::NodeStorage;
 /// Errors produced while resolving checkpoint envelope authentication.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CheckpointAuthError {
-    /// The latest ASM state could not be loaded from storage.
-    #[error("failed to fetch latest ASM state")]
-    FetchLatestAsmState(#[source] DbError),
+    /// The canonical ASM state could not be loaded from storage.
+    #[error("failed to fetch canonical ASM state")]
+    FetchCanonicalAsmState(#[source] DbError),
 
-    /// No ASM state exists yet.
-    #[error("latest ASM state is not available")]
-    MissingLatestAsmState,
+    /// No canonical ASM state exists yet.
+    #[error("canonical ASM state is not available")]
+    MissingCanonicalAsmState,
 
     /// The checkpoint subprotocol section is missing from ASM state.
-    #[error("latest ASM state is missing checkpoint subprotocol state")]
+    #[error("canonical ASM state is missing checkpoint subprotocol state")]
     MissingCheckpointState,
 
     /// The checkpoint subprotocol section could not be decoded.
@@ -50,7 +50,7 @@ pub(crate) enum CheckpointAuthError {
     Sp1Groth16,
 }
 
-/// Resolves the active checkpoint sequencer key from the latest ASM state.
+/// Resolves the active checkpoint sequencer key from the canonical ASM state.
 #[derive(Clone)]
 pub(crate) struct CheckpointSequencerKeyProvider {
     storage: Arc<NodeStorage>,
@@ -71,10 +71,9 @@ impl CheckpointSequencerKeyProvider {
     fn resolve_signing_mode(&self) -> Result<EnvelopeSigningMode, CheckpointAuthError> {
         let (_, asm_state) = self
             .storage
-            .asm()
-            .fetch_most_recent_state_blocking()
-            .map_err(CheckpointAuthError::FetchLatestAsmState)?
-            .ok_or(CheckpointAuthError::MissingLatestAsmState)?;
+            .fetch_canonical_asm_state_blocking()
+            .map_err(CheckpointAuthError::FetchCanonicalAsmState)?
+            .ok_or(CheckpointAuthError::MissingCanonicalAsmState)?;
 
         let checkpoint_section = asm_state
             .state()

--- a/bin/strata/src/checkpoint_reconcile.rs
+++ b/bin/strata/src/checkpoint_reconcile.rs
@@ -110,11 +110,10 @@ where
 fn first_unaccepted_checkpoint_epoch(nodectx: &NodeContext) -> Result<Option<Epoch>> {
     let Some((asm_l1, asm_state)) = nodectx
         .storage()
-        .asm()
-        .fetch_most_recent_state_blocking()
-        .context("fetch latest ASM state")?
+        .fetch_canonical_asm_state_blocking()
+        .context("fetch canonical ASM state")?
     else {
-        debug!("latest ASM state is not available; skipping checkpoint artifact reconciliation");
+        debug!("canonical ASM state is not available; skipping checkpoint artifact reconciliation");
         return Ok(None);
     };
 

--- a/crates/db/tests/src/asm_tests.rs
+++ b/crates/db/tests/src/asm_tests.rs
@@ -20,6 +20,11 @@ pub fn test_get_asm(db: &impl AsmDatabase) {
     assert_eq!(update, state);
 }
 
+/// Minimal [`AsmState`] for tests that only need a persistable value.
+pub fn make_test_asm_state() -> AsmState {
+    AsmState::new(make_anchor_state(), vec![])
+}
+
 fn make_anchor_state() -> AnchorState {
     let anchor = L1Anchor {
         block: L1BlockCommitment::default(),

--- a/crates/ol/block-assembly/Cargo.toml
+++ b/crates/ol/block-assembly/Cargo.toml
@@ -82,3 +82,4 @@ strata-ol-chain-types = { workspace = true, features = ["test-utils"] }
 strata-ol-msg-types.workspace = true
 strata-predicate.workspace = true
 strata-state.workspace = true
+strata-storage = { workspace = true, features = ["test-utils"] }

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -1009,7 +1009,7 @@ mod tests {
     use strata_acct_types::*;
     use strata_asm_manifest_types::AsmLogEntry;
     use strata_asm_proto_checkpoint_types::MAX_OL_LOGS_PER_CHECKPOINT;
-    use strata_identifiers::{Buf32, L1BlockId, L1Height, OLBlockId};
+    use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId, L1Height, OLBlockId};
     use strata_ol_chain_types::{MAX_LOGS_PER_BLOCK, MAX_SEALING_MANIFEST_COUNT, OLLog};
     use strata_ol_state_support_types::MemoryStateBaseLayer;
 
@@ -1873,8 +1873,10 @@ mod tests {
             .extend_canonical_chain_async(&missing_manifest_blkid, first_height_past_cap)
             .await
             .expect("insert missing-manifest canonical entry past cap");
-        // ASM tip still points at the original height's blkid; the fetch path only reads its
-        // height.
+        put_test_asm_state(
+            env.storage().as_ref(),
+            L1BlockCommitment::new(first_height_past_cap, missing_manifest_blkid),
+        );
 
         let output = env
             .construct_empty_block()
@@ -2022,6 +2024,10 @@ mod tests {
             .extend_canonical_chain_async(&missing_manifest_blkid, 2)
             .await
             .expect("insert missing-manifest canonical entry at height 2");
+        put_test_asm_state(
+            env.storage().as_ref(),
+            L1BlockCommitment::new(2, missing_manifest_blkid),
+        );
 
         let err = env
             .generate_block_template()

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -193,8 +193,8 @@ where
 
         let asm_tip_height = match self
             .storage
-            .asm()
-            .fetch_most_recent_state_blocking()
+            .fetch_canonical_asm_state_async()
+            .await
             .map_err(BlockAssemblyError::Db)?
         {
             Some((commitment, _)) => commitment.height(),

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -782,7 +782,13 @@ async fn setup_asm_state_with_l1_manifests_list(
             .expect("Failed to extend L1 canonical chain");
     }
 
-    // Create minimal ASM state for testing
+    put_test_asm_state(storage, l1_commitment);
+
+    l1_commitment
+}
+
+/// Stores a minimal ASM state for tests that only need an accepted L1 commitment.
+pub(crate) fn put_test_asm_state(storage: &NodeStorage, l1_commitment: L1BlockCommitment) {
     let pow_state = HeaderVerificationState::init(L1Anchor {
         block: l1_commitment,
         next_target: 0,
@@ -805,8 +811,6 @@ async fn setup_asm_state_with_l1_manifests_list(
         .asm()
         .put_state_blocking(l1_commitment, asm_state)
         .expect("Failed to store ASM state");
-
-    l1_commitment
 }
 
 /// Default balance for test accounts (100 billion sats).

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -70,7 +70,11 @@ pub use ops::l1tx_broadcast::BroadcastDbOps;
 use strata_db_store_sled::SledBackend;
 use strata_db_types::backend::DatabaseBackend;
 pub use strata_db_types::MmrId;
+use strata_db_types::DbResult;
+use strata_primitives::L1BlockCommitment;
+use strata_state::asm_state::AsmState;
 use tokio::runtime::Handle;
+use tracing::warn;
 
 /// A consolidation of database managers.
 // TODO(STR-3679): move this to its own module
@@ -179,6 +183,51 @@ impl NodeStorage {
     pub fn l1_writer(&self) -> &Arc<L1WriterManager> {
         &self.l1_writer_manager
     }
+
+    /// Returns the latest persisted ASM state on the canonical L1 chain, or
+    /// [`None`] if there is none. May lag the L1 canonical tip when ASM is behind.
+    ///
+    /// [`AsmStateManager::fetch_most_recent_state_blocking`] can return an orphan
+    /// from an abandoned reorg branch (those rows are never pruned); this resolves
+    /// down the canonical chain instead. See STR-3832.
+    pub fn fetch_canonical_asm_state_blocking(
+        &self,
+    ) -> DbResult<Option<(L1BlockCommitment, AsmState)>> {
+        let Some((recent_block, recent_state)) =
+            self.asm_state_manager.fetch_most_recent_state_blocking()?
+        else {
+            return Ok(None);
+        };
+
+        if self
+            .l1_block_manager
+            .get_canonical_blockid_at_height(recent_block.height())?
+            == Some(*recent_block.blkid())
+        {
+            return Ok(Some((recent_block, recent_state)));
+        }
+
+        // Most-recent is an orphan. Resolve down from the canonical tip to the
+        // highest block with a persisted ASM state.
+        let Some((tip_height, _)) = self.l1_block_manager.get_canonical_chain_tip()? else {
+            return Ok(None);
+        };
+        for height in (0..=tip_height).rev() {
+            let Some(blockid) = self
+                .l1_block_manager
+                .get_canonical_blockid_at_height(height)?
+            else {
+                continue;
+            };
+            let block = L1BlockCommitment::new(height, blockid);
+            if let Some(state) = self.asm_state_manager.get_state_blocking(block)? {
+                return Ok(Some((block, state)));
+            }
+        }
+
+        warn!(%recent_block, tip_height, "ASM has states but none on the canonical chain");
+        Ok(None)
+    }
 }
 
 /// Given a raw database, creates storage managers and returns a [`NodeStorage`]
@@ -253,4 +302,115 @@ pub fn test_runtime_handle() -> Handle {
     RT.get_or_init(|| Runtime::new().expect("test: build runtime"))
         .handle()
         .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_db_tests::asm_tests::make_test_asm_state;
+    use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId};
+
+    use super::*;
+
+    fn setup() -> NodeStorage {
+        let db = get_test_sled_backend();
+        create_node_storage(db, test_runtime_handle()).expect("test: create node storage")
+    }
+
+    fn blkid(n: u8) -> L1BlockId {
+        L1BlockId::from(Buf32::from([n; 32]))
+    }
+
+    fn extend_canonical(storage: &NodeStorage, up_to: u32) {
+        for height in 1..=up_to {
+            storage
+                .l1()
+                .extend_canonical_chain(&blkid(height as u8), height)
+                .expect("test: extend canonical chain");
+        }
+    }
+
+    // Orphan above the canonical tip: resolving to it would under-delete.
+    #[test]
+    fn canonical_resolution_prefers_canonical_over_higher_orphan() {
+        let storage = setup();
+        extend_canonical(&storage, 10);
+
+        let canonical = L1BlockCommitment::new(10, blkid(10));
+        // Height 12 is not on the canonical chain (canonical only reaches 10).
+        let orphan = L1BlockCommitment::new(12, blkid(99));
+        storage
+            .asm()
+            .put_state_blocking(canonical, make_test_asm_state())
+            .unwrap();
+        storage
+            .asm()
+            .put_state_blocking(orphan, make_test_asm_state())
+            .unwrap();
+
+        // Precondition: most-recent (highest-keyed) is the orphan.
+        let (recent, _) = storage
+            .asm()
+            .fetch_most_recent_state_blocking()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recent, orphan, "setup: most-recent should be the orphan");
+
+        let (resolved, _) = storage
+            .fetch_canonical_asm_state_blocking()
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, canonical);
+        assert_ne!(resolved, orphan);
+    }
+
+    // Same-height orphan sibling sorting above canonical: would over-delete.
+    #[test]
+    fn canonical_resolution_prefers_canonical_sibling_at_same_height() {
+        let storage = setup();
+        extend_canonical(&storage, 10);
+
+        let canonical = L1BlockCommitment::new(10, blkid(10));
+        let orphan = L1BlockCommitment::new(10, blkid(200));
+        storage
+            .asm()
+            .put_state_blocking(canonical, make_test_asm_state())
+            .unwrap();
+        storage
+            .asm()
+            .put_state_blocking(orphan, make_test_asm_state())
+            .unwrap();
+
+        let (recent, _) = storage
+            .asm()
+            .fetch_most_recent_state_blocking()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            recent, orphan,
+            "setup: most-recent should be the higher-id orphan sibling"
+        );
+
+        let (resolved, _) = storage
+            .fetch_canonical_asm_state_blocking()
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, canonical);
+    }
+
+    // No canonical chain tracked: resolve to nothing so the caller skips.
+    #[test]
+    fn canonical_resolution_none_without_canonical_state() {
+        let storage = setup();
+        let orphan = L1BlockCommitment::new(5, blkid(99));
+        storage
+            .asm()
+            .put_state_blocking(orphan, make_test_asm_state())
+            .unwrap();
+
+        assert!(storage
+            .fetch_canonical_asm_state_blocking()
+            .unwrap()
+            .is_none());
+    }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -69,8 +69,8 @@ pub use managers::writer::L1WriterManager;
 pub use ops::l1tx_broadcast::BroadcastDbOps;
 use strata_db_store_sled::SledBackend;
 use strata_db_types::backend::DatabaseBackend;
-pub use strata_db_types::MmrId;
 use strata_db_types::DbResult;
+pub use strata_db_types::MmrId;
 use strata_primitives::L1BlockCommitment;
 use strata_state::asm_state::AsmState;
 use tokio::runtime::Handle;
@@ -201,7 +201,7 @@ impl NodeStorage {
 
         if self
             .l1_block_manager
-            .get_canonical_blockid_at_height(recent_block.height())?
+            .get_canonical_blockid_at_height_uncached(recent_block.height())?
             == Some(*recent_block.blkid())
         {
             return Ok(Some((recent_block, recent_state)));
@@ -212,15 +212,64 @@ impl NodeStorage {
         let Some((tip_height, _)) = self.l1_block_manager.get_canonical_chain_tip()? else {
             return Ok(None);
         };
-        for height in (0..=tip_height).rev() {
+        let search_tip = tip_height.min(recent_block.height());
+        for height in (0..=search_tip).rev() {
             let Some(blockid) = self
                 .l1_block_manager
-                .get_canonical_blockid_at_height(height)?
+                .get_canonical_blockid_at_height_uncached(height)?
             else {
                 continue;
             };
             let block = L1BlockCommitment::new(height, blockid);
             if let Some(state) = self.asm_state_manager.get_state_blocking(block)? {
+                return Ok(Some((block, state)));
+            }
+        }
+
+        warn!(%recent_block, tip_height, "ASM has states but none on the canonical chain");
+        Ok(None)
+    }
+
+    /// Returns the latest persisted ASM state on the canonical L1 chain, or
+    /// [`None`] if there is none. May lag the L1 canonical tip when ASM is behind.
+    pub async fn fetch_canonical_asm_state_async(
+        &self,
+    ) -> DbResult<Option<(L1BlockCommitment, AsmState)>> {
+        let Some((recent_block, recent_state)) = self
+            .asm_state_manager
+            .fetch_most_recent_state_async()
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        if self
+            .l1_block_manager
+            .get_canonical_blockid_at_height_async(recent_block.height())
+            .await?
+            == Some(*recent_block.blkid())
+        {
+            return Ok(Some((recent_block, recent_state)));
+        }
+
+        let Some((tip_height, _)) = self
+            .l1_block_manager
+            .get_canonical_chain_tip_async()
+            .await?
+        else {
+            return Ok(None);
+        };
+        let search_tip = tip_height.min(recent_block.height());
+        for height in (0..=search_tip).rev() {
+            let Some(blockid) = self
+                .l1_block_manager
+                .get_canonical_blockid_at_height_async(height)
+                .await?
+            else {
+                continue;
+            };
+            let block = L1BlockCommitment::new(height, blockid);
+            if let Some(state) = self.asm_state_manager.get_state_async(block).await? {
                 return Ok(Some((block, state)));
             }
         }
@@ -425,6 +474,31 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(resolved, canonical);
+    }
+
+    // ASM has persisted states, but none belong to the canonical chain.
+    #[test]
+    fn canonical_resolution_none_when_all_asm_states_are_orphans() {
+        let storage = setup();
+        extend_canonical(&storage, 10);
+
+        let orphan = L1BlockCommitment::new(12, blkid(99));
+        storage
+            .asm()
+            .put_state_blocking(orphan, make_test_asm_state())
+            .unwrap();
+
+        let (recent, _) = storage
+            .asm()
+            .fetch_most_recent_state_blocking()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recent, orphan, "setup: most-recent should be the orphan");
+
+        assert!(storage
+            .fetch_canonical_asm_state_blocking()
+            .unwrap()
+            .is_none());
     }
 
     // No canonical chain tracked: resolve to nothing so the caller skips.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -330,6 +330,35 @@ mod tests {
         }
     }
 
+    #[test]
+    fn canonical_resolution_none_without_asm_state() {
+        let storage = setup();
+        extend_canonical(&storage, 10);
+
+        assert!(storage
+            .fetch_canonical_asm_state_blocking()
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn canonical_resolution_returns_recent_canonical_state() {
+        let storage = setup();
+        extend_canonical(&storage, 10);
+
+        let canonical = L1BlockCommitment::new(10, blkid(10));
+        storage
+            .asm()
+            .put_state_blocking(canonical, make_test_asm_state())
+            .unwrap();
+
+        let (resolved, _) = storage
+            .fetch_canonical_asm_state_blocking()
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved, canonical);
+    }
+
     // Orphan above the canonical tip: resolving to it would under-delete.
     #[test]
     fn canonical_resolution_prefers_canonical_over_higher_orphan() {

--- a/crates/storage/src/managers/asm.rs
+++ b/crates/storage/src/managers/asm.rs
@@ -44,6 +44,11 @@ impl AsmStateManager {
         self.ops.get_asm_state_blocking(block)
     }
 
+    /// Returns [`AsmState`] that corresponds to passed block.
+    pub async fn get_state_async(&self, block: L1BlockCommitment) -> DbResult<Option<AsmState>> {
+        self.ops.get_asm_state_async(block).await
+    }
+
     /// Puts [`AsmState`] for the given block.
     pub fn put_state_blocking(
         &self,

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -265,6 +265,13 @@ impl L1BlockManager {
         })
     }
 
+    pub(crate) fn get_canonical_blockid_at_height_uncached(
+        &self,
+        height: L1Height,
+    ) -> DbResult<Option<L1BlockId>> {
+        self.ops.get_canonical_blockid_at_height_blocking(height)
+    }
+
     // Get [`L1BlockId`] at `height` in tracked canonical chain.
     pub async fn get_canonical_blockid_at_height_async(
         &self,


### PR DESCRIPTION
Fixes STR-3832.

Startup checkpoint reconciler read `asm().fetch_most_recent_state_blocking()` (highest-keyed, can be an orphan after an L1 reorg) to pick the first-unaccepted epoch → under-/over-deletes checkpoint artifacts.

Adds `NodeStorage::fetch_canonical_asm_state_blocking` (resolves down the canonical chain) and points the reconciler at it. Storage tests cover orphan-higher, same-height sibling, and no-canonical-chain.

Follow-up: reconciler-level deletion test (needs checkpoint-subprotocol section fixtures).