### PR TITLE
feat: gossip fee model constants over Alpen RLPx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "alpen-ee-rpc-types",
  "jsonrpsee",
  "schemars 1.2.1",
+ "strata-config",
  "strata-open-rpc",
 ]
 
@@ -1551,6 +1552,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "serde",
+ "strata-config",
  "strata-identifiers",
  "strata-primitives",
  "tokio",
@@ -15329,6 +15331,7 @@ version = "0.3.0-alpha.1"
 dependencies = [
  "bitcoin",
  "proptest",
+ "schemars 1.2.1",
  "serde",
  "toml 0.5.11",
  "zeroize",

--- a/bin/alpen-client/Cargo.toml
+++ b/bin/alpen-client/Cargo.toml
@@ -19,7 +19,6 @@ sequencer = [
   "dep:bitcoind-async-client",
   "dep:reth-payload-builder",
   "dep:strata-btcio",
-  "dep:strata-config",
 ]
 # SP1 remote proving for the EE chunk + acct provers. Required for
 # production; native-only test builds can drop this feature.
@@ -59,7 +58,7 @@ strata-bridge-params.workspace = true
 strata-btcio = { workspace = true, optional = true }
 strata-codec.workspace = true
 strata-common = { workspace = true, features = ["async"] }
-strata-config = { workspace = true, optional = true }
+strata-config.workspace = true
 strata-db-types.workspace = true
 strata-ee-acct-runtime.workspace = true
 strata-ee-acct-types.workspace = true

--- a/bin/alpen-client/src/gossip.rs
+++ b/bin/alpen-client/src/gossip.rs
@@ -10,6 +10,7 @@ use reth_network_api::PeerId;
 use reth_primitives::Header;
 use reth_provider::CanonStateNotification;
 use strata_acct_types::Hash;
+use strata_config::StaticFeeModelConfig;
 use strata_primitives::buf::Buf32;
 use tokio::{
     select,
@@ -37,6 +38,7 @@ fn handle_gossip_event(
     connections: &mut HashMap<PeerId, mpsc::UnboundedSender<AlpenGossipCommand>>,
     highest_seq_no: &mut u64,
     preconf_tx: &watch::Sender<BlockNumHash>,
+    fee_config_tx: &watch::Sender<Option<StaticFeeModelConfig>>,
     config: &GossipConfig,
 ) -> bool {
     match event {
@@ -69,8 +71,33 @@ fn handle_gossip_event(
             connections,
             highest_seq_no,
             preconf_tx,
+            fee_config_tx,
             config,
         ),
+    }
+}
+
+/// Updates the local fee config when gossip provides a different value.
+fn update_fee_config(
+    fee_config_tx: &watch::Sender<Option<StaticFeeModelConfig>>,
+    fee_config: StaticFeeModelConfig,
+) {
+    let previous_fee_config = *fee_config_tx.borrow();
+    if previous_fee_config != Some(fee_config) {
+        if fee_config_tx.send(Some(fee_config)).is_err() {
+            warn!(
+                target: "alpen-gossip",
+                "Failed to update fee config from gossip (no receivers)"
+            );
+        } else {
+            debug!(
+                target: "alpen-gossip",
+                prover_fee_per_gas_wei = fee_config.prover_fee_per_gas_wei(),
+                da_overhead_multiplier_bps = fee_config.da_overhead_multiplier_bps(),
+                ol_overhead_wei = fee_config.ol_overhead_wei(),
+                "Updated fee config from gossip"
+            );
+        }
     }
 }
 
@@ -81,6 +108,7 @@ fn handle_gossip_package(
     connections: &HashMap<PeerId, mpsc::UnboundedSender<AlpenGossipCommand>>,
     highest_seq_no: &mut u64,
     preconf_tx: &watch::Sender<BlockNumHash>,
+    fee_config_tx: &watch::Sender<Option<StaticFeeModelConfig>>,
     config: &GossipConfig,
 ) -> bool {
     // Validate signature before processing
@@ -110,18 +138,30 @@ fn handle_gossip_package(
     // we only need to check if this seq_no is greater than the highest we've seen.
     // This prevents duplicate messages and replay of stale blocks.
     if seq_no <= *highest_seq_no {
+        if !config.sequencer_enabled
+            && seq_no == *highest_seq_no
+            && fee_config_tx.borrow().is_none()
+        {
+            // The package is signature-verified and the empty view cannot regress, so initialize it
+            // at the current head to keep the fee RPC available after a restart.
+            update_fee_config(fee_config_tx, package.message().fee_config());
+        }
         debug!(
             target: "alpen-gossip",
             %peer_id,
             seq_no,
             highest_seq_no = *highest_seq_no,
-            "Package already seen or stale, skipping"
+            "Package already seen or stale, skipping further processing"
         );
         return true; // Continue loop
     }
 
     // Update the highest sequence number seen
     *highest_seq_no = seq_no;
+
+    if !config.sequencer_enabled {
+        update_fee_config(fee_config_tx, package.message().fee_config());
+    }
 
     let block_hash = package.message().header().hash_slow();
 
@@ -170,6 +210,8 @@ fn handle_gossip_package(
 fn handle_state_event(
     res: Result<CanonStateNotification, broadcast::error::RecvError>,
     connections: &HashMap<PeerId, mpsc::UnboundedSender<AlpenGossipCommand>>,
+    highest_seq_no: &mut u64,
+    fee_config_rx: &watch::Receiver<Option<StaticFeeModelConfig>>,
     config: &GossipConfig,
 ) -> bool {
     match res {
@@ -177,7 +219,13 @@ fn handle_state_event(
             if let CanonStateNotification::Commit { new } = event {
                 // Extract the last header from the new chain segment
                 if let Some(tip) = new.headers().last().map(|h| h.header().clone()) {
-                    broadcast_new_block(&tip, connections, config);
+                    handle_canonical_commit(
+                        &tip,
+                        connections,
+                        highest_seq_no,
+                        fee_config_rx,
+                        config,
+                    );
                 }
             }
             true // Continue loop
@@ -196,10 +244,23 @@ fn handle_state_event(
     }
 }
 
+/// Handles a newly canonical block.
+fn handle_canonical_commit(
+    tip: &Header,
+    connections: &HashMap<PeerId, mpsc::UnboundedSender<AlpenGossipCommand>>,
+    highest_seq_no: &mut u64,
+    fee_config_rx: &watch::Receiver<Option<StaticFeeModelConfig>>,
+    config: &GossipConfig,
+) {
+    *highest_seq_no = (*highest_seq_no).max(tip.number);
+    broadcast_new_block(tip, connections, fee_config_rx, config);
+}
+
 /// Broadcasts a new canonical block to all connected peers.
 fn broadcast_new_block(
     tip: &Header,
     connections: &HashMap<PeerId, mpsc::UnboundedSender<AlpenGossipCommand>>,
+    fee_config_rx: &watch::Receiver<Option<StaticFeeModelConfig>>,
     config: &GossipConfig,
 ) {
     if !config.sequencer_enabled {
@@ -224,12 +285,21 @@ fn broadcast_new_block(
             return;
         };
 
+        let Some(fee_config) = *fee_config_rx.borrow() else {
+            error!(
+                target: "alpen-gossip",
+                "Sequencer mode enabled but no fee config is available; skipping broadcast"
+            );
+            return;
+        };
+
         let msg = AlpenGossipMessage::new(
             tip.clone(),
             // NOTE: we use the block number as the sequence number
             //       because it's the block number from the header, which naturally
             //       provides monotonic, unique sequence numbers for gossip messages.
             tip.number,
+            fee_config,
         );
         let pkg = msg.into_package(config.sequencer_pubkey, sequencer_privkey);
 
@@ -255,18 +325,24 @@ fn broadcast_new_block(
 /// - Connection tracking (establish/close)
 /// - Receiving gossip messages and forwarding block hashes to engine control
 /// - Broadcasting new canonical blocks to connected peers
+///
+/// Seeding the replay guard from the canonical head rejects replayed packages for blocks the node
+/// already has, closing the stale-fee-config window after a restart.
 pub(crate) async fn create_gossip_task(
     mut gossip_rx: mpsc::UnboundedReceiver<AlpenGossipEvent>,
     mut state_events: broadcast::Receiver<CanonStateNotification>,
     preconf_tx: watch::Sender<BlockNumHash>,
+    fee_config_tx: watch::Sender<Option<StaticFeeModelConfig>>,
+    fee_config_rx: watch::Receiver<Option<StaticFeeModelConfig>>,
+    initial_highest_seq_no: u64,
     config: GossipConfig,
 ) {
     let mut connections: HashMap<PeerId, mpsc::UnboundedSender<AlpenGossipCommand>> =
         HashMap::new();
-    // Track the highest sequence number (block number) seen from the sequencer.
-    // This prevents duplicate and stale message processing since blocks are produced
-    // monotonically.
-    let mut highest_seq_no: u64 = 0;
+    // Seed the highest sequence number (block number) from the canonical head. This rejects
+    // replayed packages for blocks the node already has and closes the stale-fee-config window
+    // after a restart.
+    let mut highest_seq_no = initial_highest_seq_no;
 
     loop {
         select! {
@@ -276,15 +352,323 @@ pub(crate) async fn create_gossip_task(
                     &mut connections,
                     &mut highest_seq_no,
                     &preconf_tx,
+                    &fee_config_tx,
                     &config,
                 );
             },
             res = state_events.recv() => {
-                if !handle_state_event(res, &connections, &config) {
+                if !handle_state_event(
+                    res,
+                    &connections,
+                    &mut highest_seq_no,
+                    &fee_config_rx,
+                    &config,
+                ) {
                     break;
                 }
             },
             else => { break; }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_reth_node::AlpenGossipMessage;
+
+    use super::*;
+
+    fn test_peer_id() -> PeerId {
+        PeerId::repeat_byte(1)
+    }
+
+    fn sequencer_keys() -> (Buf32, Buf32) {
+        let private_key = "0x0101010101010101010101010101010101010101010101010101010101010101"
+            .parse::<Buf32>()
+            .expect("private key should parse");
+        let public_key = "0x1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+            .parse::<Buf32>()
+            .expect("public key should parse");
+        (private_key, public_key)
+    }
+
+    fn signed_package(
+        seq_no: u64,
+        fee_config: StaticFeeModelConfig,
+        public_key: Buf32,
+        private_key: Buf32,
+    ) -> AlpenGossipPackage {
+        let header = Header {
+            number: seq_no,
+            ..Header::default()
+        };
+        AlpenGossipMessage::new(header, seq_no, fee_config).into_package(public_key, private_key)
+    }
+
+    fn blocknumhash_sender() -> watch::Sender<BlockNumHash> {
+        let hash = Hash::from([0u8; 32]);
+        let (tx, _) = watch::channel(BlockNumHash::new(hash, 0));
+        tx
+    }
+
+    #[test]
+    fn test_valid_gossip_updates_fee_config() {
+        let (private_key, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let updated_fee_config = StaticFeeModelConfig::new(25, 12_500, 42);
+        let (fee_config_tx, fee_config_rx) = watch::channel(None);
+        let package = signed_package(1, updated_fee_config, public_key, private_key);
+        let mut highest_seq_no = 0;
+
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &HashMap::new(),
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), Some(updated_fee_config));
+        assert_eq!(highest_seq_no, 1);
+    }
+
+    #[test]
+    fn test_sequencer_ignores_gossiped_fee_config() {
+        let (private_key, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: true,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let local_config = StaticFeeModelConfig::new(10, 10_000, 20);
+        let gossiped_config = StaticFeeModelConfig::new(25, 12_500, 42);
+        let (fee_config_tx, fee_config_rx) = watch::channel(Some(local_config));
+        let package = signed_package(1, gossiped_config, public_key, private_key);
+        let mut highest_seq_no = 0;
+
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &HashMap::new(),
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), Some(local_config));
+        assert_eq!(highest_seq_no, 1);
+    }
+
+    #[test]
+    fn test_unexpected_public_key_does_not_update_fee_config() {
+        let (private_key, public_key) = sequencer_keys();
+        let unexpected_public_key =
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+                .parse::<Buf32>()
+                .expect("public key should parse");
+        let config = GossipConfig {
+            sequencer_pubkey: unexpected_public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let (fee_config_tx, fee_config_rx) = watch::channel(None);
+        let package = signed_package(
+            1,
+            StaticFeeModelConfig::new(25, 12_500, 42),
+            public_key,
+            private_key,
+        );
+        let mut highest_seq_no = 0;
+
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &HashMap::new(),
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), None);
+        assert_eq!(highest_seq_no, 0);
+    }
+
+    #[test]
+    fn test_same_height_package_initializes_empty_fee_config() {
+        let (private_key, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let gossiped_fee_config = StaticFeeModelConfig::new(25, 12_500, 42);
+        let (fee_config_tx, fee_config_rx) = watch::channel(None);
+        let package = signed_package(5, gossiped_fee_config, public_key, private_key);
+        let mut highest_seq_no = 5;
+
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &HashMap::new(),
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), Some(gossiped_fee_config));
+        assert_eq!(highest_seq_no, 5);
+    }
+
+    #[test]
+    fn test_same_height_package_does_not_overwrite_existing_fee_config() {
+        let (private_key, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let local_fee_config = StaticFeeModelConfig::new(10, 10_000, 20);
+        let gossiped_fee_config = StaticFeeModelConfig::new(25, 12_500, 42);
+        let (fee_config_tx, fee_config_rx) = watch::channel(Some(local_fee_config));
+        let package = signed_package(5, gossiped_fee_config, public_key, private_key);
+        let mut highest_seq_no = 5;
+
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &HashMap::new(),
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), Some(local_fee_config));
+        assert_eq!(highest_seq_no, 5);
+    }
+
+    #[test]
+    fn test_older_package_does_not_initialize_empty_fee_config() {
+        let (private_key, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let gossiped_fee_config = StaticFeeModelConfig::new(25, 12_500, 42);
+        let (fee_config_tx, fee_config_rx) = watch::channel(None);
+        let package = signed_package(4, gossiped_fee_config, public_key, private_key);
+        let mut highest_seq_no = 5;
+
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &HashMap::new(),
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), None);
+        assert_eq!(highest_seq_no, 5);
+    }
+
+    #[test]
+    fn test_canonical_commit_advances_replay_guard() {
+        let (_, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let (_, fee_config_rx) = watch::channel(None);
+        let connections = HashMap::new();
+        let mut highest_seq_no = 3;
+        let tip = Header {
+            number: 5,
+            ..Header::default()
+        };
+
+        handle_canonical_commit(
+            &tip,
+            &connections,
+            &mut highest_seq_no,
+            &fee_config_rx,
+            &config,
+        );
+
+        assert_eq!(highest_seq_no, 5);
+
+        let lower_tip = Header {
+            number: 4,
+            ..Header::default()
+        };
+        handle_canonical_commit(
+            &lower_tip,
+            &connections,
+            &mut highest_seq_no,
+            &fee_config_rx,
+            &config,
+        );
+
+        assert_eq!(highest_seq_no, 5);
+    }
+
+    #[test]
+    fn test_replayed_package_after_commit_is_rejected() {
+        let (private_key, public_key) = sequencer_keys();
+        let config = GossipConfig {
+            sequencer_pubkey: public_key,
+            sequencer_enabled: false,
+            #[cfg(feature = "sequencer")]
+            sequencer_privkey: None,
+        };
+        let prior_fee_config = StaticFeeModelConfig::new(10, 10_000, 20);
+        let replayed_fee_config = StaticFeeModelConfig::new(25, 12_500, 42);
+        let (fee_config_tx, fee_config_rx) = watch::channel(Some(prior_fee_config));
+        let connections = HashMap::new();
+        let mut highest_seq_no = 3;
+        let tip = Header {
+            number: 5,
+            ..Header::default()
+        };
+
+        handle_canonical_commit(
+            &tip,
+            &connections,
+            &mut highest_seq_no,
+            &fee_config_rx,
+            &config,
+        );
+        let package = signed_package(4, replayed_fee_config, public_key, private_key);
+        handle_gossip_package(
+            test_peer_id(),
+            package,
+            &connections,
+            &mut highest_seq_no,
+            &blocknumhash_sender(),
+            &fee_config_tx,
+            &config,
+        );
+
+        assert_eq!(*fee_config_rx.borrow(), Some(prior_fee_config));
+        assert_eq!(highest_seq_no, 5);
     }
 }

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -50,7 +50,7 @@ use alpen_ee_exec_chain::{init_exec_chain_state_from_storage, ExecChainState};
 use alpen_ee_genesis::ensure_finalized_exec_chain_genesis;
 use alpen_ee_genesis::{ensure_batch_genesis, ensure_genesis_ee_account_state};
 use alpen_ee_ol_tracker::init_ol_tracker_state;
-use alpen_ee_rpc_server::{AlpenEeRpcServer, EeRpcServer, StaticFeeModelConfig};
+use alpen_ee_rpc_server::{AlpenEeRpcServer, EeRpcContext, EeRpcServer, StaticFeeModelConfig};
 #[cfg(feature = "sequencer")]
 use alpen_ee_sequencer::{
     block_builder_task, build_ol_chain_tracker, init_batch_builder_state, init_lifecycle_state,
@@ -480,15 +480,9 @@ fn main() {
                 let storage = storage.clone();
                 move |ctx| {
                     let provider = ctx.provider().clone();
-                    let fee_config_rx = fee_config_rx.clone();
-                    let fee_model_config = Arc::new(move || *fee_config_rx.borrow());
-                    let ee_rpc_server = EeRpcServer::new(
-                        provider,
-                        consensus_watcher,
-                        storage.clone(),
-                        storage.clone(),
-                        fee_model_config,
-                    );
+                    let rpc_context =
+                        EeRpcContext::new(storage.clone(), storage.clone(), fee_config_rx.clone());
+                    let ee_rpc_server = EeRpcServer::new(provider, consensus_watcher, rpc_context);
                     ctx.modules.merge_configured(ee_rpc_server.into_rpc())?;
                     Ok(())
                 }

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -50,7 +50,7 @@ use alpen_ee_exec_chain::{init_exec_chain_state_from_storage, ExecChainState};
 use alpen_ee_genesis::ensure_finalized_exec_chain_genesis;
 use alpen_ee_genesis::{ensure_batch_genesis, ensure_genesis_ee_account_state};
 use alpen_ee_ol_tracker::init_ol_tracker_state;
-use alpen_ee_rpc_server::{AlpenEeRpcServer, EeRpcServer};
+use alpen_ee_rpc_server::{AlpenEeRpcServer, EeRpcServer, StaticFeeModelConfig};
 #[cfg(feature = "sequencer")]
 use alpen_ee_sequencer::{
     block_builder_task, build_ol_chain_tracker, init_batch_builder_state, init_lifecycle_state,
@@ -80,7 +80,7 @@ use reth_cli_runner::{tokio_runtime, CliRunner};
 use reth_cli_util::sigsegv_handler;
 use reth_network::{protocol::IntoRlpxSubProtocol, NetworkProtocols};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
-use reth_provider::CanonStateSubscriptions;
+use reth_provider::{BlockNumReader, CanonStateSubscriptions};
 #[cfg(feature = "sequencer")]
 use strata_btcio::{
     broadcaster::BroadcasterBuilder, writer::chunked_envelope::create_chunked_envelope_task,
@@ -97,11 +97,13 @@ use strata_l1_txfmt::MagicBytes;
 use strata_logging::{init_logging_from_config, LoggingInitConfig};
 use strata_predicate::PredicateKey;
 use strata_primitives::{buf::Buf32, L1Height};
+#[cfg(not(feature = "sp1"))]
+use strata_zkvm_hosts as _;
 use tokio::{
     runtime::Handle,
     sync::{mpsc, watch},
 };
-use tracing::{error, info, info_span, Instrument};
+use tracing::{error, info, info_span, warn, Instrument};
 
 #[cfg(feature = "sequencer")]
 mod sequencer_imports {
@@ -153,6 +155,9 @@ const ALPEN_EE_BLOCK_TIME_MS_ENV_VAR: &str = "ALPEN_EE_BLOCK_TIME_MS";
 
 const DEFAULT_HEALTH_CHECK_HOST: &str = "0.0.0.0";
 const DEFAULT_HEALTH_CHECK_PORT: u16 = 8080;
+const DEFAULT_PROVER_FEE_PER_GAS_WEI: u64 = 15;
+const DEFAULT_DA_OVERHEAD_MULTIPLIER_BPS: u32 = 10_000;
+const DEFAULT_OL_OVERHEAD_WEI: u64 = 0;
 
 /// Default end-to-end deadline applied to the SP1 prover network for the EE
 /// chunk + acct provers when `--sp1-proof-deadline-secs` is not set. Chosen
@@ -402,6 +407,8 @@ fn main() {
             // This channel sends block hash and number received from peers to the engine control
             // task
             let (preconf_tx, preconf_rx) = watch::channel(initial_preconf_head);
+            let initial_fee_config = ext.sequencer.then(|| fee_config_from_ext(&ext));
+            let (fee_config_tx, fee_config_rx) = watch::channel(initial_fee_config);
 
             let ol_tracker = services::ol_tracker::start_ol_tracker_service(
                 ol_tracker_state,
@@ -469,14 +476,18 @@ fn main() {
 
             node_builder = node_builder.extend_rpc_modules({
                 let consensus_watcher = consensus_watcher.clone();
+                let fee_config_rx = fee_config_rx.clone();
                 let storage = storage.clone();
                 move |ctx| {
                     let provider = ctx.provider().clone();
+                    let fee_config_rx = fee_config_rx.clone();
+                    let fee_model_config = Arc::new(move || *fee_config_rx.borrow());
                     let ee_rpc_server = EeRpcServer::new(
                         provider,
                         consensus_watcher,
                         storage.clone(),
                         storage.clone(),
+                        fee_model_config,
                     );
                     ctx.modules.merge_configured(ee_rpc_server.into_rpc())?;
                     Ok(())
@@ -518,9 +529,29 @@ fn main() {
             // Subscribe to canonical state notifications for broadcasting new blocks
             let state_events = node.provider.subscribe_to_canonical_state();
 
+            let initial_highest_seq_no = match node.provider.best_block_number() {
+                Ok(block_number) => block_number,
+                Err(err) => {
+                    warn!(
+                        target: "alpen-gossip",
+                        component = "alpen",
+                        ?err,
+                        "failed to read canonical head for gossip replay guard; falling back to zero"
+                    );
+                    0
+                }
+            };
+
             // Create gossip task for broadcasting new blocks
-            let gossip_task =
-                create_gossip_task(gossip_rx, state_events, preconf_tx.clone(), gossip_config);
+            let gossip_task = create_gossip_task(
+                gossip_rx,
+                state_events,
+                preconf_tx.clone(),
+                fee_config_tx,
+                fee_config_rx.clone(),
+                initial_highest_seq_no,
+                gossip_config,
+            );
 
             // Spawn critical tasks
             node.task_executor.spawn_critical(
@@ -1082,6 +1113,18 @@ pub struct AdditionalConfig {
     #[arg(long, required = true, value_parser = parse_buf32)]
     pub sequencer_pubkey: Buf32,
 
+    /// Static proving fee charged per unit of raw EVM gas.
+    #[arg(long, default_value_t = DEFAULT_PROVER_FEE_PER_GAS_WEI)]
+    pub prover_fee_per_gas_wei: u64,
+
+    /// Basis-points multiplier applied to estimated DA cost.
+    #[arg(long, default_value_t = DEFAULT_DA_OVERHEAD_MULTIPLIER_BPS)]
+    pub da_overhead_multiplier_bps: u32,
+
+    /// Small additive fee charged for OL and infrastructure overhead.
+    #[arg(long, default_value_t = DEFAULT_OL_OVERHEAD_WEI)]
+    pub ol_overhead_wei: u64,
+
     // --- DA Configuration ---
     /// Magic bytes (hex-encoded, 4 bytes) for tagging EE DA envelope transactions.
     /// Example: `ALPN`.
@@ -1327,6 +1370,16 @@ fn parse_buf32(s: &str) -> eyre::Result<Buf32> {
 fn parse_magic_bytes(s: &str) -> eyre::Result<MagicBytes> {
     s.parse::<MagicBytes>()
         .map_err(|e| eyre::eyre!("Failed to parse magic bytes: {e}"))
+}
+
+fn fee_config_from_ext(ext: &AdditionalConfig) -> StaticFeeModelConfig {
+    // TODO(STR-2161): source these constants from the canonical SequencerFeeModelConfig once
+    // quote() drives charging, so gossip/RPC match the values the sequencer actually charges.
+    StaticFeeModelConfig::new(
+        ext.prover_fee_per_gas_wei,
+        ext.da_overhead_multiplier_bps,
+        ext.ol_overhead_wei,
+    )
 }
 
 #[cfg(feature = "sequencer")]

--- a/crates/alpen-ee/rpc/api/Cargo.toml
+++ b/crates/alpen-ee/rpc/api/Cargo.toml
@@ -11,6 +11,7 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 alpen-ee-rpc-types = { workspace = true, features = ["jsonschema"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 schemars.workspace = true
+strata-config = { workspace = true, features = ["jsonschema"] }
 strata-open-rpc.workspace = true
 
 [features]

--- a/crates/alpen-ee/rpc/api/src/lib.rs
+++ b/crates/alpen-ee/rpc/api/src/lib.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use alloy_primitives::B256;
 pub use alpen_ee_rpc_types::{BlockStatus, BlockStatusResponse, ChunkProofCoverageResponse};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+pub use strata_config::StaticFeeModelConfig;
 
 /// RPC methods exposed by Alpen EE nodes.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "alpen"))]
@@ -21,6 +22,10 @@ pub trait AlpenEeRpc {
         start_block: u64,
         end_block: u64,
     ) -> RpcResult<ChunkProofCoverageResponse>;
+
+    /// Returns the current static v1 fee-model constants known by this node.
+    #[method(name = "getFeeModelConfig")]
+    async fn get_fee_model_config(&self) -> RpcResult<StaticFeeModelConfig>;
 }
 
 struct RpcB256;
@@ -83,6 +88,22 @@ impl AlpenEeRpcOpenRpc {
             inputs,
             result,
             "Reports whether proof-ready chunks cover the requested EE block interval.",
+            Some("Alpen EE".to_string()),
+            false,
+        );
+
+        let result = Some(builder.create_content_descriptor::<StaticFeeModelConfig>(
+            "StaticFeeModelConfig",
+            None,
+            None,
+            true,
+        ));
+        builder.add_method(
+            "alpen",
+            "getFeeModelConfig",
+            Vec::new(),
+            result,
+            "Returns the current static v1 fee-model constants known by this node.",
             Some("Alpen EE".to_string()),
             false,
         );

--- a/crates/alpen-ee/rpc/server/src/block_status.rs
+++ b/crates/alpen-ee/rpc/server/src/block_status.rs
@@ -53,7 +53,7 @@ fn hash_to_b256(hash: &[u8]) -> B256 {
 /// Returns an error when the epoch's account state is missing (e.g. pruned) or
 /// when its last included block is not canonical on this node.
 async fn fetch_epoch_last_alpen_block_number<N: NodeTypesWithDB + ProviderNodeTypes>(
-    storage: &Arc<dyn Storage>,
+    storage: &dyn Storage,
     provider: &BlockchainProvider<N>,
     epoch: Epoch,
 ) -> RpcResult<u64> {
@@ -112,13 +112,50 @@ where
     Ok(lo)
 }
 
+/// Shared dependencies used by Alpen EE RPC methods.
+pub struct EeRpcContext {
+    chunk_storage: Arc<dyn ChunkStorage>,
+    account_storage: Arc<dyn Storage>,
+    fee_model_config: watch::Receiver<Option<StaticFeeModelConfig>>,
+}
+
+impl fmt::Debug for EeRpcContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EeRpcContext").finish_non_exhaustive()
+    }
+}
+
+impl EeRpcContext {
+    pub fn new(
+        chunk_storage: Arc<dyn ChunkStorage>,
+        account_storage: Arc<dyn Storage>,
+        fee_model_config: watch::Receiver<Option<StaticFeeModelConfig>>,
+    ) -> Self {
+        Self {
+            chunk_storage,
+            account_storage,
+            fee_model_config,
+        }
+    }
+
+    pub fn chunk_storage(&self) -> &dyn ChunkStorage {
+        self.chunk_storage.as_ref()
+    }
+
+    pub fn account_storage(&self) -> &dyn Storage {
+        self.account_storage.as_ref()
+    }
+
+    pub fn get_fee_model_config(&self) -> Option<StaticFeeModelConfig> {
+        *self.fee_model_config.borrow()
+    }
+}
+
 /// RPC handler for [`AlpenEeRpcServer`].
 pub struct EeRpcServer<N: NodeTypesWithDB + ProviderNodeTypes> {
     provider: BlockchainProvider<N>,
     consensus_rx: watch::Receiver<ConsensusHeads>,
-    chunk_storage: Arc<dyn ChunkStorage>,
-    account_storage: Arc<dyn Storage>,
-    fee_model_config: Arc<dyn Fn() -> Option<StaticFeeModelConfig> + Send + Sync>,
+    context: EeRpcContext,
 }
 
 impl<N: NodeTypesWithDB + ProviderNodeTypes> fmt::Debug for EeRpcServer<N> {
@@ -131,16 +168,12 @@ impl<N: NodeTypesWithDB + ProviderNodeTypes> EeRpcServer<N> {
     pub fn new(
         provider: BlockchainProvider<N>,
         consensus_rx: watch::Receiver<ConsensusHeads>,
-        chunk_storage: Arc<dyn ChunkStorage>,
-        account_storage: Arc<dyn Storage>,
-        fee_model_config: Arc<dyn Fn() -> Option<StaticFeeModelConfig> + Send + Sync>,
+        context: EeRpcContext,
     ) -> Self {
         Self {
             provider,
             consensus_rx,
-            chunk_storage,
-            account_storage,
-            fee_model_config,
+            context,
         }
     }
 
@@ -155,12 +188,10 @@ impl<N: NodeTypesWithDB + ProviderNodeTypes> EeRpcServer<N> {
     /// verified to cover `target_num`, so its last included block is at or beyond
     /// `target_num` and the search is well defined.
     async fn containing_epoch(&self, target_num: u64, frontier_epoch: Epoch) -> RpcResult<Epoch> {
-        let storage = self.account_storage.clone();
-        let provider = self.provider.clone();
-        search_containing_epoch(frontier_epoch, target_num, move |epoch| {
-            let storage = storage.clone();
-            let provider = provider.clone();
-            async move { fetch_epoch_last_alpen_block_number(&storage, &provider, epoch).await }
+        let storage = self.context.account_storage();
+        let provider = &self.provider;
+        search_containing_epoch(frontier_epoch, target_num, |epoch| {
+            fetch_epoch_last_alpen_block_number(storage, provider, epoch)
         })
         .await
     }
@@ -248,7 +279,8 @@ where
         }
 
         let latest_chunk = self
-            .chunk_storage
+            .context
+            .chunk_storage()
             .get_latest_chunk()
             .await
             .map_err(|e| internal_error(e.to_string()))?;
@@ -266,7 +298,8 @@ where
 
         for chunk_idx in 0..=latest_chunk.idx() {
             let Some((chunk, status)) = self
-                .chunk_storage
+                .context
+                .chunk_storage()
                 .get_chunk_by_idx(chunk_idx)
                 .await
                 .map_err(|e| internal_error(e.to_string()))?
@@ -323,7 +356,9 @@ where
     }
 
     async fn get_fee_model_config(&self) -> RpcResult<StaticFeeModelConfig> {
-        (self.fee_model_config)().ok_or_else(fee_model_config_unavailable_error)
+        self.context
+            .get_fee_model_config()
+            .ok_or_else(fee_model_config_unavailable_error)
     }
 }
 

--- a/crates/alpen-ee/rpc/server/src/block_status.rs
+++ b/crates/alpen-ee/rpc/server/src/block_status.rs
@@ -6,6 +6,7 @@ use alloy_primitives::B256;
 use alpen_ee_common::{ChunkStatus, ChunkStorage, ConsensusHeads, OLBlockOrEpoch, Storage};
 use alpen_ee_rpc_api::{
     AlpenEeRpcServer, BlockStatus, BlockStatusResponse, ChunkProofCoverageResponse,
+    StaticFeeModelConfig,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -17,7 +18,9 @@ use reth_provider::{
 use strata_identifiers::Epoch;
 use tokio::sync::watch;
 
-use crate::errors::{block_not_found_error, internal_error, invalid_params_error};
+use crate::errors::{
+    block_not_found_error, fee_model_config_unavailable_error, internal_error, invalid_params_error,
+};
 
 /// Resolve `block_hash` to its canonical block number on `provider`.
 ///
@@ -115,6 +118,7 @@ pub struct EeRpcServer<N: NodeTypesWithDB + ProviderNodeTypes> {
     consensus_rx: watch::Receiver<ConsensusHeads>,
     chunk_storage: Arc<dyn ChunkStorage>,
     account_storage: Arc<dyn Storage>,
+    fee_model_config: Arc<dyn Fn() -> Option<StaticFeeModelConfig> + Send + Sync>,
 }
 
 impl<N: NodeTypesWithDB + ProviderNodeTypes> fmt::Debug for EeRpcServer<N> {
@@ -129,12 +133,14 @@ impl<N: NodeTypesWithDB + ProviderNodeTypes> EeRpcServer<N> {
         consensus_rx: watch::Receiver<ConsensusHeads>,
         chunk_storage: Arc<dyn ChunkStorage>,
         account_storage: Arc<dyn Storage>,
+        fee_model_config: Arc<dyn Fn() -> Option<StaticFeeModelConfig> + Send + Sync>,
     ) -> Self {
         Self {
             provider,
             consensus_rx,
             chunk_storage,
             account_storage,
+            fee_model_config,
         }
     }
 
@@ -314,6 +320,10 @@ where
             covered: false,
             first_uncovered_block: Some(first_uncovered_block),
         })
+    }
+
+    async fn get_fee_model_config(&self) -> RpcResult<StaticFeeModelConfig> {
+        (self.fee_model_config)().ok_or_else(fee_model_config_unavailable_error)
     }
 }
 

--- a/crates/alpen-ee/rpc/server/src/errors.rs
+++ b/crates/alpen-ee/rpc/server/src/errors.rs
@@ -17,3 +17,12 @@ pub(crate) fn block_not_found_error() -> ErrorObjectOwned {
 pub(crate) fn invalid_params_error(msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(INVALID_PARAMS_CODE, msg.into(), None::<()>)
 }
+
+/// Creates an RPC error for unavailable fee-model config.
+pub(crate) fn fee_model_config_unavailable_error() -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        INTERNAL_ERROR_CODE,
+        "fee model config unavailable; waiting for sequencer gossip",
+        None::<()>,
+    )
+}

--- a/crates/alpen-ee/rpc/server/src/lib.rs
+++ b/crates/alpen-ee/rpc/server/src/lib.rs
@@ -3,5 +3,5 @@
 mod block_status;
 mod errors;
 
-pub use alpen_ee_rpc_api::AlpenEeRpcServer;
+pub use alpen_ee_rpc_api::{AlpenEeRpcServer, StaticFeeModelConfig};
 pub use block_status::EeRpcServer;

--- a/crates/alpen-ee/rpc/server/src/lib.rs
+++ b/crates/alpen-ee/rpc/server/src/lib.rs
@@ -4,4 +4,4 @@ mod block_status;
 mod errors;
 
 pub use alpen_ee_rpc_api::{AlpenEeRpcServer, StaticFeeModelConfig};
-pub use block_status::EeRpcServer;
+pub use block_status::{EeRpcContext, EeRpcServer};

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,9 +8,13 @@ workspace = true
 
 [dependencies]
 bitcoin.workspace = true
+schemars = { workspace = true, optional = true }
 serde.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
 toml.workspace = true
+
+[features]
+jsonschema = ["dep:schemars"]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -241,17 +241,59 @@ fn default_l1_fee_rate_source() -> L1FeeRateSourceConfig {
     L1FeeRateSourceConfig::BtcioWriter
 }
 
+/// Static v1 fee-model constants.
+///
+/// Gossip encodes these fields manually in `encode_fee_config` / `decode_fee_config` and signs the
+/// encoded bytes, so changes to this field set must update the gossip wire format as well.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct StaticFeeModelConfig {
+    /// Static proving fee charged per unit of raw EVM gas.
+    pub prover_fee_per_gas_wei: u64,
+
+    /// Basis-points multiplier applied to the estimated DA fee.
+    pub da_overhead_multiplier_bps: u32,
+
+    /// Small additive fee charged for OL and infrastructure overhead.
+    pub ol_overhead_wei: u64,
+}
+
+impl StaticFeeModelConfig {
+    /// Creates static v1 fee-model constants.
+    pub const fn new(
+        prover_fee_per_gas_wei: u64,
+        da_overhead_multiplier_bps: u32,
+        ol_overhead_wei: u64,
+    ) -> Self {
+        Self {
+            prover_fee_per_gas_wei,
+            da_overhead_multiplier_bps,
+            ol_overhead_wei,
+        }
+    }
+
+    /// Returns the proving fee charged per unit of raw EVM gas.
+    pub const fn prover_fee_per_gas_wei(&self) -> u64 {
+        self.prover_fee_per_gas_wei
+    }
+
+    /// Returns the basis-points multiplier applied to the estimated DA fee.
+    pub const fn da_overhead_multiplier_bps(&self) -> u32 {
+        self.da_overhead_multiplier_bps
+    }
+
+    /// Returns the additive OL and infrastructure overhead fee.
+    pub const fn ol_overhead_wei(&self) -> u64 {
+        self.ol_overhead_wei
+    }
+}
+
 /// Configuration for the v1 L2 fee model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SequencerFeeModelConfig {
-    /// Static proving fee charged per unit of raw EVM gas.
-    pub(crate) prover_fee_per_gas_wei: u64,
-
-    /// Basis-points multiplier applied to the estimated DA fee.
-    pub(crate) da_overhead_multiplier_bps: u32,
-
-    /// Small additive fee charged for OL and infrastructure overhead.
-    pub(crate) ol_overhead_wei: u64,
+    /// Static fee-model constants shared with gossip and RPC.
+    #[serde(flatten)]
+    pub(crate) static_config: StaticFeeModelConfig,
 
     /// Source used to resolve the current L1 fee rate.
     #[serde(default = "default_l1_fee_rate_source")]
@@ -267,26 +309,33 @@ impl SequencerFeeModelConfig {
         l1_fee_rate_source: L1FeeRateSourceConfig,
     ) -> Self {
         Self {
-            prover_fee_per_gas_wei,
-            da_overhead_multiplier_bps,
-            ol_overhead_wei,
+            static_config: StaticFeeModelConfig::new(
+                prover_fee_per_gas_wei,
+                da_overhead_multiplier_bps,
+                ol_overhead_wei,
+            ),
             l1_fee_rate_source,
         }
     }
 
+    /// Returns the static fee-model constants.
+    pub fn static_config(&self) -> StaticFeeModelConfig {
+        self.static_config
+    }
+
     /// Returns the proving fee charged per unit of raw EVM gas.
     pub fn prover_fee_per_gas_wei(&self) -> u64 {
-        self.prover_fee_per_gas_wei
+        self.static_config.prover_fee_per_gas_wei()
     }
 
     /// Returns the basis-points multiplier applied to the estimated DA fee.
     pub fn da_overhead_multiplier_bps(&self) -> u32 {
-        self.da_overhead_multiplier_bps
+        self.static_config.da_overhead_multiplier_bps()
     }
 
     /// Returns the additive OL and infrastructure overhead fee.
     pub fn ol_overhead_wei(&self) -> u64 {
-        self.ol_overhead_wei
+        self.static_config.ol_overhead_wei()
     }
 
     /// Returns the source used to resolve the current L1 fee rate.

--- a/crates/reth/node/Cargo.toml
+++ b/crates/reth/node/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 alpen-reth-evm.workspace = true
 alpen-reth-primitives.workspace = true
 alpen-reth-rpc.workspace = true
+strata-config.workspace = true
 strata-primitives.workspace = true
 
 alloy-consensus.workspace = true

--- a/crates/reth/node/src/gossip/package.rs
+++ b/crates/reth/node/src/gossip/package.rs
@@ -20,6 +20,12 @@ use strata_primitives::{
 /// Size of the sequence number in bytes.
 const SEQ_NO_SIZE: usize = mem::size_of::<u64>();
 
+/// Size of the [`u32`] in bytes.
+const U32_SIZE: usize = mem::size_of::<u32>();
+
+/// Size of the fee config in bytes.
+const FEE_CONFIG_SIZE: usize = SEQ_NO_SIZE + U32_SIZE + SEQ_NO_SIZE;
+
 /// Message ID for gossip packages
 /// This is prepended to each Message
 const GOSSIP_PACKAGE_MSG_ID: u8 = 0x00;
@@ -32,6 +38,9 @@ pub struct AlpenGossipMessage {
 
     /// Sequence number.
     seq_no: u64,
+
+    /// Current static fee-model constants.
+    fee_config: StaticFeeModelConfig,
 }
 
 /// Alpen Gossip Package that contains the message and the signature.
@@ -49,8 +58,12 @@ pub struct AlpenGossipPackage {
 
 impl AlpenGossipMessage {
     /// Creates a new [`AlpenGossipMessage`].
-    pub fn new(header: Header, seq_no: u64) -> Self {
-        Self { header, seq_no }
+    pub fn new(header: Header, seq_no: u64, fee_config: StaticFeeModelConfig) -> Self {
+        Self {
+            header,
+            seq_no,
+            fee_config,
+        }
     }
 
     /// Gets the header of the [`AlpenGossipMessage`].
@@ -61,6 +74,11 @@ impl AlpenGossipMessage {
     /// Gets the sequence number of the [`AlpenGossipMessage`].
     pub fn seq_no(&self) -> u64 {
         self.seq_no
+    }
+
+    /// Gets the fee-model constants of the [`AlpenGossipMessage`].
+    pub fn fee_config(&self) -> StaticFeeModelConfig {
+        self.fee_config
     }
 
     /// Gets the hash of the [`AlpenGossipMessage`].
@@ -84,6 +102,7 @@ impl AlpenGossipMessage {
         let mut buf = BytesMut::new();
         self.header.encode(&mut buf);
         buf.put_u64(self.seq_no);
+        encode_fee_config(&self.fee_config, &mut buf);
         buf
     }
 
@@ -104,9 +123,34 @@ impl AlpenGossipMessage {
 
         // Decode the sequence number
         let seq_no = buf.get_u64();
+        let fee_config = decode_fee_config(buf)?;
 
-        Ok(Self { header, seq_no })
+        Ok(Self {
+            header,
+            seq_no,
+            fee_config,
+        })
     }
+}
+
+fn encode_fee_config(fee_config: &StaticFeeModelConfig, buf: &mut BytesMut) {
+    buf.put_u64(fee_config.prover_fee_per_gas_wei());
+    buf.put_u32(fee_config.da_overhead_multiplier_bps());
+    buf.put_u64(fee_config.ol_overhead_wei());
+}
+
+fn decode_fee_config(buf: &mut &[u8]) -> Result<StaticFeeModelConfig> {
+    ensure!(
+        buf.remaining() >= FEE_CONFIG_SIZE,
+        "buffer too short for fee config: need {FEE_CONFIG_SIZE} bytes, have {}",
+        buf.remaining()
+    );
+
+    Ok(StaticFeeModelConfig::new(
+        buf.get_u64(),
+        buf.get_u32(),
+        buf.get_u64(),
+    ))
 }
 
 impl AlpenGossipPackage {
@@ -216,13 +260,30 @@ mod tests {
         Just(Header::default())
     }
 
+    fn fee_config_strategy() -> impl Strategy<Value = StaticFeeModelConfig> {
+        (any::<u64>(), any::<u32>(), any::<u64>()).prop_map(
+            |(prover_fee_per_gas_wei, da_overhead_multiplier_bps, ol_overhead_wei)| {
+                StaticFeeModelConfig::new(
+                    prover_fee_per_gas_wei,
+                    da_overhead_multiplier_bps,
+                    ol_overhead_wei,
+                )
+            },
+        )
+    }
+
+    fn test_fee_config() -> StaticFeeModelConfig {
+        StaticFeeModelConfig::new(15, 10_000, 0)
+    }
+
     proptest! {
         #[test]
         fn test_message_encode_decode_roundtrip(
             header in header_strategy(),
-            seq_no in any::<u64>()
+            seq_no in any::<u64>(),
+            fee_config in fee_config_strategy()
         ) {
-            let original = AlpenGossipMessage::new(header, seq_no);
+            let original = AlpenGossipMessage::new(header, seq_no, fee_config);
             let encoded = original.encode();
             let decoded = AlpenGossipMessage::try_decode(&mut &encoded[..])
                 .expect("decode should succeed");
@@ -232,9 +293,10 @@ mod tests {
         #[test]
         fn test_message_encode_deterministic(
             header in header_strategy(),
-            seq_no in any::<u64>()
+            seq_no in any::<u64>(),
+            fee_config in fee_config_strategy()
         ) {
-            let msg = AlpenGossipMessage::new(header, seq_no);
+            let msg = AlpenGossipMessage::new(header, seq_no, fee_config);
             let encoded1 = msg.encode();
             let encoded2 = msg.encode();
             prop_assert_eq!(encoded1, encoded2, "encoding should be deterministic");
@@ -243,22 +305,25 @@ mod tests {
         #[test]
         fn test_message_getters(
             header in header_strategy(),
-            seq_no in any::<u64>()
+            seq_no in any::<u64>(),
+            fee_config in fee_config_strategy()
         ) {
-            let msg = AlpenGossipMessage::new(header.clone(), seq_no);
+            let msg = AlpenGossipMessage::new(header.clone(), seq_no, fee_config);
             prop_assert_eq!(msg.header(), &header);
             prop_assert_eq!(msg.seq_no(), seq_no);
+            prop_assert_eq!(msg.fee_config(), fee_config);
         }
 
         #[test]
         fn test_message_different_seq_no_different_encoding(
             header in header_strategy(),
             seq_no1 in any::<u64>(),
-            seq_no2 in any::<u64>()
+            seq_no2 in any::<u64>(),
+            fee_config in fee_config_strategy()
         ) {
             prop_assume!(seq_no1 != seq_no2);
-            let msg1 = AlpenGossipMessage::new(header.clone(), seq_no1);
-            let msg2 = AlpenGossipMessage::new(header, seq_no2);
+            let msg1 = AlpenGossipMessage::new(header.clone(), seq_no1, fee_config);
+            let msg2 = AlpenGossipMessage::new(header, seq_no2, fee_config);
             prop_assert_ne!(msg1.encode(), msg2.encode());
         }
     }
@@ -305,15 +370,29 @@ mod tests {
             .contains("buffer too short for sequence number"));
     }
 
+    #[test]
+    fn test_message_try_decode_truncated_fee_config() {
+        let mut encoded = AlpenGossipMessage::new(Header::default(), 1, test_fee_config()).encode();
+        encoded.truncate(encoded.len() - 1);
+
+        let result = AlpenGossipMessage::try_decode(&mut &encoded[..]);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("buffer too short for fee config"));
+    }
+
     proptest! {
         #[test]
         fn test_package_encode_decode_roundtrip(
             header in header_strategy(),
             seq_no in any::<u64>(),
+            fee_config in fee_config_strategy(),
             public_key in buf32_strategy(),
             signature in buf64_strategy()
         ) {
-            let message = AlpenGossipMessage::new(header, seq_no);
+            let message = AlpenGossipMessage::new(header, seq_no, fee_config);
             let original = AlpenGossipPackage::new(message, public_key, signature);
             let encoded = original.encode();
             let decoded = AlpenGossipPackage::try_decode(&mut &encoded[..])
@@ -325,10 +404,11 @@ mod tests {
         fn test_package_getters(
             header in header_strategy(),
             seq_no in any::<u64>(),
+            fee_config in fee_config_strategy(),
             public_key in buf32_strategy(),
             signature in buf64_strategy()
         ) {
-            let message = AlpenGossipMessage::new(header, seq_no);
+            let message = AlpenGossipMessage::new(header, seq_no, fee_config);
             let pkg = AlpenGossipPackage::new(message.clone(), public_key, signature);
             prop_assert_eq!(pkg.message(), &message);
             prop_assert_eq!(pkg.public_key(), &public_key);
@@ -339,14 +419,39 @@ mod tests {
         fn test_package_encode_deterministic(
             header in header_strategy(),
             seq_no in any::<u64>(),
+            fee_config in fee_config_strategy(),
             public_key in buf32_strategy(),
             signature in buf64_strategy()
         ) {
-            let message = AlpenGossipMessage::new(header, seq_no);
+            let message = AlpenGossipMessage::new(header, seq_no, fee_config);
             let pkg = AlpenGossipPackage::new(message, public_key, signature);
             let encoded1 = pkg.encode();
             let encoded2 = pkg.encode();
             prop_assert_eq!(encoded1, encoded2, "encoding should be deterministic");
         }
+    }
+
+    #[test]
+    fn test_signature_covers_fee_config() {
+        let public_key = "0x1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+            .parse::<Buf32>()
+            .expect("public key should parse");
+        let private_key = "0x0101010101010101010101010101010101010101010101010101010101010101"
+            .parse::<Buf32>()
+            .expect("private key should parse");
+
+        let package = AlpenGossipMessage::new(Header::default(), 1, test_fee_config())
+            .into_package(public_key, private_key);
+        assert!(package.validate_signature());
+
+        let altered_message = AlpenGossipMessage::new(
+            package.message().header().clone(),
+            package.message().seq_no(),
+            StaticFeeModelConfig::new(16, 10_000, 0),
+        );
+        let altered_package =
+            AlpenGossipPackage::new(altered_message, *package.public_key(), *package.signature());
+
+        assert!(!altered_package.validate_signature());
     }
 }

--- a/crates/reth/node/src/gossip/package.rs
+++ b/crates/reth/node/src/gossip/package.rs
@@ -11,6 +11,7 @@ use alloy_primitives::{
 use alloy_rlp::{Decodable, Encodable};
 use eyre::{ensure, eyre, Result};
 use reth_primitives::Header;
+use strata_config::StaticFeeModelConfig;
 use strata_primitives::{
     buf::Buf64,
     crypto::{sign_schnorr_sig, verify_schnorr_sig},

--- a/crates/rpc/open-rpc-spec/src/lib.rs
+++ b/crates/rpc/open-rpc-spec/src/lib.rs
@@ -64,6 +64,7 @@ mod tests {
             "strata_submitTransaction",
             "alpen_getBlockStatus",
             "alpen_getChunkProofCoverage",
+            "alpen_getFeeModelConfig",
         ] {
             assert!(
                 method_names.contains(&expected_method),

--- a/functional-tests/common/config/__init__.py
+++ b/functional-tests/common/config/__init__.py
@@ -9,6 +9,7 @@ from common.config.config import (
     ClientConfig,
     EeDaConfig,
     EpochSealingConfig,
+    FeeModelConfig,
     LoggingConfig,
     ProverConfig,
     ReaderConfig,
@@ -50,6 +51,7 @@ __all__ = [
     "ProverConfig",
     "SequencerConfig",
     "SequencerRuntimeConfig",
+    "FeeModelConfig",
     "EeDaConfig",
     "EpochSealingConfig",
     # constants.py

--- a/functional-tests/common/services/alpen_client.py
+++ b/functional-tests/common/services/alpen_client.py
@@ -122,6 +122,11 @@ class AlpenClientService(RpcService):
         rpc = self.create_rpc()
         return rpc.alpen_getBlockStatus(block_hash)
 
+    def get_fee_model_config(self) -> dict:
+        """Get this node's current static v1 fee-model constants."""
+        rpc = self.create_rpc()
+        return rpc.alpen_getFeeModelConfig()
+
     def get_peers(self) -> list[dict]:
         """Get connected peers via admin_peers."""
         rpc = self.create_rpc()

--- a/functional-tests/envconfigs/alpen_client.py
+++ b/functional-tests/envconfigs/alpen_client.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import flexitest
 
-from common.config import EeDaConfig, ServiceType
+from common.config import EeDaConfig, FeeModelConfig, ServiceType
 from common.services.bitcoin import BitcoinService
 from factories.alpen_client import AlpenClientFactory, generate_sequencer_keypair
 from factories.bitcoin import BitcoinFactory
@@ -41,6 +41,7 @@ class AlpenClientEnvParams:
     batch_sealing_block_count: int = 10
     dev_track_latest_epoch: bool = False
     beneficiary_address: str | None = None
+    fee_model: FeeModelConfig | None = None
 
 
 class AlpenClientEnv(flexitest.EnvConfig):
@@ -72,6 +73,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
         l1_reorg_safe_depth: int = 1,
         batch_sealing_block_count: int = 5,
         beneficiary_address: str | None = None,
+        fee_model: FeeModelConfig | None = None,
     ):
         self.env_params = AlpenClientEnvParams(
             fullnode_count=fullnode_count,
@@ -83,6 +85,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
             l1_reorg_safe_depth=l1_reorg_safe_depth,
             batch_sealing_block_count=batch_sealing_block_count,
             beneficiary_address=beneficiary_address,
+            fee_model=fee_model,
         )
         if pure_discovery and not enable_discovery:
             raise ValueError("pure_discovery requires enable_discovery=True")
@@ -166,6 +169,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
             batch_sealing_block_count=envparams.batch_sealing_block_count,
             dev_track_latest_epoch=envparams.dev_track_latest_epoch,
             beneficiary_address=envparams.beneficiary_address,
+            fee_model=envparams.fee_model,
         )
         sequencer.wait_for_ready(timeout=60)
         seq_enode = sequencer.get_enode()

--- a/functional-tests/factories/alpen_client.py
+++ b/functional-tests/factories/alpen_client.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import flexitest
 
-from common.config import EeDaConfig
+from common.config import EeDaConfig, FeeModelConfig
 from common.config.constants import DEFAULT_EE_BLOCK_TIME_MS
 from common.datatool import generate_ee_params
 from common.services import AlpenClientProps, AlpenClientService
@@ -74,6 +74,7 @@ class AlpenClientFactory(flexitest.Factory):
         bridge_denomination: int = 100_000_000,
         max_withdrawal_amount: int | None = 1_000_000_000,
         beneficiary_address: str | None = None,
+        fee_model: FeeModelConfig | None = None,
         **kwargs,
     ) -> AlpenClientService:
         """
@@ -172,6 +173,18 @@ class AlpenClientFactory(flexitest.Factory):
 
         if beneficiary_address is not None:
             cmd.extend(["--beneficiary-address", beneficiary_address])
+
+        if fee_model is not None:
+            cmd.extend(
+                [
+                    "--prover-fee-per-gas-wei",
+                    str(fee_model.prover_fee_per_gas_wei),
+                    "--da-overhead-multiplier-bps",
+                    str(fee_model.da_overhead_multiplier_bps),
+                    "--ol-overhead-wei",
+                    str(fee_model.ol_overhead_wei),
+                ]
+            )
 
         # DA pipeline configuration
         if da_config is not None:

--- a/functional-tests/tests/alpen_client/test_fee_model_gossip.py
+++ b/functional-tests/tests/alpen_client/test_fee_model_gossip.py
@@ -1,0 +1,58 @@
+"""Test fee-model constant propagation over Alpen gossip."""
+
+import logging
+
+import flexitest
+
+from common.base_test import AlpenClientTest
+from common.config import FeeModelConfig
+from common.config.constants import ServiceType
+from common.wait import wait_until
+from envconfigs.alpen_client import AlpenClientEnv
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_FEE_CONFIG = {
+    "prover_fee_per_gas_wei": 25,
+    "da_overhead_multiplier_bps": 12_500,
+    "ol_overhead_wei": 42,
+}
+
+
+@flexitest.register
+class TestFeeModelGossip(AlpenClientTest):
+    """Sequencer gossips static fee constants to a fullnode."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(
+            AlpenClientEnv(
+                enable_l1_da=True,
+                fee_model=FeeModelConfig(
+                    prover_fee_per_gas_wei=EXPECTED_FEE_CONFIG["prover_fee_per_gas_wei"],
+                    da_overhead_multiplier_bps=EXPECTED_FEE_CONFIG["da_overhead_multiplier_bps"],
+                    ol_overhead_wei=EXPECTED_FEE_CONFIG["ol_overhead_wei"],
+                ),
+            )
+        )
+
+    def main(self, ctx):
+        sequencer = self.get_service(ServiceType.AlpenSequencer)
+        fullnode = self.get_service(ServiceType.AlpenFullNode)
+
+        sequencer.wait_for_peers(1, timeout=60)
+        fullnode.wait_for_peers(1, timeout=60)
+
+        sequencer_config = sequencer.get_fee_model_config()
+        assert sequencer_config == EXPECTED_FEE_CONFIG, sequencer_config
+
+        target_block = sequencer.wait_for_additional_blocks(1)
+        fullnode.wait_for_block(target_block, timeout=60)
+
+        wait_until(
+            lambda: fullnode.get_fee_model_config() == EXPECTED_FEE_CONFIG,
+            error_with="fullnode did not apply gossiped fee-model config",
+            timeout=60,
+        )
+
+        logger.info("Fee config propagated to fullnode: %s", EXPECTED_FEE_CONFIG)
+        return True


### PR DESCRIPTION
## Description

Extends the Alpen RLPx gossip message to carry the static v1 fee-model constants signed by the sequencer:

- `prover_fee_per_gas_wei`
- `da_overhead_multiplier_bps`
- `ol_overhead_wei`

Fullnodes validate signed sequencer gossip before updating an in-memory fee-model view, and the current view is exposed through `alpen_getFeeModelConfig`.

Fresh fullnodes now treat the fee model as unknown until valid sequencer gossip arrives, so RPC consumers do not mistake local defaults for network values.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The gossiped/RPC constants currently come from standalone `alpen-client` CLI flags. A TODO tracks unifying this source with the canonical `SequencerFeeModelConfig` when STR-2161 fee quoting/charging becomes authoritative.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- Alpen L2 Fee Model: https://app.notion.com/p/Alpen-L2-Fee-Model-333901ba000f80d899b7c628cf0469d9

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This PR was implemented with assistance from OpenAI Codex.

## Related Issues

STR-3072.