### PR TITLE
STR 3835 Checkpoint reconstruction skips L1BlockRefs MMR index writes

### DIFF
--- a/crates/chain-worker-new/src/context.rs
+++ b/crates/chain-worker-new/src/context.rs
@@ -180,16 +180,14 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
             .apply_block_indexing_blocking(epoch, commitment, writes)
         {
             Ok(()) => {
-                index_inbox_mmr_writes(&self.mmr_index_mgr, output)?;
-                index_l1_block_ref_mmr_writes(&self.mmr_index_mgr, output)?;
+                index_mmr_writes(&self.mmr_index_mgr, output)?;
             }
             Err(DbError::BlockIndexingConflict {
                 attempted,
                 last_applied,
                 ..
             }) if attempted == commitment && last_applied == commitment => {
-                index_inbox_mmr_writes(&self.mmr_index_mgr, output)?;
-                index_l1_block_ref_mmr_writes(&self.mmr_index_mgr, output)?;
+                index_mmr_writes(&self.mmr_index_mgr, output)?;
                 debug!(%commitment, "block indexing already applied; treating as retry");
             }
             Err(e) => return Err(e.into()),
@@ -343,7 +341,7 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
         let writes = build_checkpoint_indexing_writes(output)?;
         self.ol_state_indexing_mgr
             .apply_epoch_indexing_blocking(*epoch, writes)?;
-        index_inbox_mmr_writes(&self.mmr_index_mgr, output)?;
+        index_mmr_writes(&self.mmr_index_mgr, output)?;
         Ok(())
     }
 }
@@ -517,6 +515,16 @@ pub(crate) fn build_checkpoint_indexing_writes(
         account_updates,
         account_inbox_writes,
     ))
+}
+
+/// Mirrors all MMR writes from an accepted OL execution output into the proof index.
+pub(crate) fn index_mmr_writes(
+    mmr_index_mgr: &MmrIndexManager,
+    output: &OLBlockExecutionOutput,
+) -> WorkerResult<()> {
+    index_inbox_mmr_writes(mmr_index_mgr, output)?;
+    index_l1_block_ref_mmr_writes(mmr_index_mgr, output)?;
+    Ok(())
 }
 
 /// Applies snark inbox writes to the MMR proof index.
@@ -719,6 +727,21 @@ mod tests {
         OLBlockExecutionOutput::new(Buf32::zero(), WriteBatch::default(), indexer_writes, vec![])
     }
 
+    fn output_with_mmr_writes(
+        inbox_writes: impl IntoIterator<Item = (AccountId, MessageEntry, u64)>,
+        l1_writes: impl IntoIterator<Item = L1BlockRecordWrite>,
+    ) -> OLBlockExecutionOutput {
+        let mut indexer_writes = IndexerWrites::new();
+        for (account_id, entry, index) in inbox_writes {
+            indexer_writes.push_inbox_message(InboxMessageWrite::new(account_id, entry, index));
+        }
+        for write in l1_writes {
+            indexer_writes.push_l1_block_record(write);
+        }
+
+        OLBlockExecutionOutput::new(Buf32::zero(), WriteBatch::default(), indexer_writes, vec![])
+    }
+
     fn l1_block_record_write(height: u32, seed: u8) -> L1BlockRecordWrite {
         let record = L1BlockRecord::new([seed; 32], [seed.wrapping_add(1); 32]);
         L1BlockRecordWrite { height, record }
@@ -756,6 +779,70 @@ mod tests {
             Some(expected_hash)
         );
         assert_eq!(handle.get_blocking(index).unwrap(), expected_preimage);
+    }
+
+    #[test]
+    fn index_mmr_writes_stores_inbox_and_l1_block_refs() {
+        let mmr_index_mgr = setup_mmr_index_manager();
+        let account_id = AccountId::from([1u8; 32]);
+        let entry = message_entry(10, 100);
+        let l1_write = l1_block_record_write(1, 20);
+        let output = output_with_mmr_writes([(account_id, entry.clone(), 0)], [l1_write.clone()]);
+
+        prefill_l1_block_refs_mmr_blocking(&mmr_index_mgr, 0).unwrap();
+        index_mmr_writes(&mmr_index_mgr, &output).unwrap();
+
+        assert_eq!(
+            mmr_index_mgr
+                .get_handle(MmrId::SnarkMsgInbox(account_id))
+                .get_num_leaves_blocking()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            mmr_index_mgr
+                .get_handle(MmrId::L1BlockRefs)
+                .get_num_leaves_blocking()
+                .unwrap(),
+            2
+        );
+        assert_mmr_entry(&mmr_index_mgr, account_id, 0, &entry);
+        assert_l1_block_ref_entry(&mmr_index_mgr, 1, &l1_write);
+    }
+
+    #[test]
+    fn index_mmr_writes_is_idempotent() {
+        let mmr_index_mgr = setup_mmr_index_manager();
+        let account_id = AccountId::from([2u8; 32]);
+        let entry = message_entry(11, 200);
+        let first_l1 = l1_block_record_write(1, 30);
+        let second_l1 = l1_block_record_write(2, 40);
+        let output = output_with_mmr_writes(
+            [(account_id, entry.clone(), 0)],
+            [first_l1.clone(), second_l1.clone()],
+        );
+
+        prefill_l1_block_refs_mmr_blocking(&mmr_index_mgr, 0).unwrap();
+        index_mmr_writes(&mmr_index_mgr, &output).unwrap();
+        index_mmr_writes(&mmr_index_mgr, &output).unwrap();
+
+        assert_eq!(
+            mmr_index_mgr
+                .get_handle(MmrId::SnarkMsgInbox(account_id))
+                .get_num_leaves_blocking()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            mmr_index_mgr
+                .get_handle(MmrId::L1BlockRefs)
+                .get_num_leaves_blocking()
+                .unwrap(),
+            3
+        );
+        assert_mmr_entry(&mmr_index_mgr, account_id, 0, &entry);
+        assert_l1_block_ref_entry(&mmr_index_mgr, 1, &first_l1);
+        assert_l1_block_ref_entry(&mmr_index_mgr, 2, &second_l1);
     }
 
     #[test]

--- a/crates/chain-worker-new/src/tests/apply_checkpoint.rs
+++ b/crates/chain-worker-new/src/tests/apply_checkpoint.rs
@@ -563,6 +563,7 @@ fn group_snark_by_account(writes: &IndexerWrites) -> HashMap<AccountId, Vec<Snar
 mod db_idempotency {
     use std::{collections::BTreeSet, sync::Arc};
 
+    use ssz::Encode;
     use strata_db_store_sled::{
         MmrIndexDb, SledDbConfig, ol_checkpoint::db::OLCheckpointDBSled,
         ol_state::db::OLStateDBSled, ol_state_index::db::OLStateIndexingDBSled,
@@ -571,9 +572,9 @@ mod db_idempotency {
         errors::DbError,
         ol_state_index::{AccountUpdateRecord, InboxMessageRecord},
     };
-    use strata_identifiers::AccountId;
+    use strata_identifiers::{AccountId, Hash};
     use strata_ledger_types::IStateAccessor;
-    use strata_ol_state_support_types::MemoryStateBaseLayer;
+    use strata_ol_state_support_types::{L1BlockRecordWrite, MemoryStateBaseLayer};
     use strata_storage::{
         MmrId, MmrIndexManager, OLCheckpointManager, OLStateIndexingManager, OLStateManager,
     };
@@ -581,10 +582,34 @@ mod db_idempotency {
 
     use super::{EpochCommitment, build_epoch, mock_for};
     use crate::{
-        context::{build_checkpoint_indexing_writes, index_inbox_mmr_writes},
+        context::{
+            build_checkpoint_indexing_writes, index_mmr_writes, prefill_l1_block_refs_mmr_blocking,
+        },
         state::{AppliedEpochArtifacts, apply_checkpoint_epoch},
         tests::fixture::EpochShape,
     };
+
+    #[derive(Debug, PartialEq)]
+    struct DbSnapshot {
+        toplevel_state_root: Option<strata_identifiers::Buf32>,
+        summary: Option<strata_checkpoint_types::EpochSummary>,
+        canonical_epoch_commitment: Option<EpochCommitment>,
+        per_account: Vec<(
+            AccountId,
+            Vec<AccountUpdateRecord>,
+            Vec<InboxMessageRecord>,
+            u64,
+        )>,
+        l1_block_refs_leaf_count: u64,
+        l1_block_refs: Vec<L1BlockRefMirrorEntry>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct L1BlockRefMirrorEntry {
+        height: u32,
+        leaf_hash: Option<Hash>,
+        preimage: Vec<u8>,
+    }
 
     /// Sled-backed wiring for the four managers `apply_checkpoint`'s writes
     /// touch. Each is opened on its own temporary sled, matching how
@@ -597,8 +622,12 @@ mod db_idempotency {
     }
 
     impl WriteHarness {
-        fn new() -> Self {
+        fn new(genesis_l1_height: u64) -> Self {
             let handle = strata_storage::test_runtime_handle();
+            let mmr_index = Arc::new(MmrIndexManager::new(handle.clone(), make_mmr_index_db()));
+            prefill_l1_block_refs_mmr_blocking(&mmr_index, genesis_l1_height)
+                .expect("prefill L1 block refs MMR");
+
             Self {
                 ol_state: Arc::new(OLStateManager::new(handle.clone(), make_ol_state_db())),
                 ol_indexing: Arc::new(OLStateIndexingManager::new(
@@ -609,7 +638,7 @@ mod db_idempotency {
                     handle.clone(),
                     make_ol_checkpoint_db(),
                 )),
-                mmr_index: Arc::new(MmrIndexManager::new(handle, make_mmr_index_db())),
+                mmr_index,
             }
         }
 
@@ -625,7 +654,7 @@ mod db_idempotency {
             let indexing_writes = build_checkpoint_indexing_writes(&artifacts.output)?;
             self.ol_indexing
                 .apply_epoch_indexing_blocking(epoch, indexing_writes)?;
-            index_inbox_mmr_writes(&self.mmr_index, &artifacts.output)?;
+            index_mmr_writes(&self.mmr_index, &artifacts.output)?;
 
             let commitment = artifacts.summary.get_epoch_commitment();
             self.ol_indexing
@@ -661,6 +690,7 @@ mod db_idempotency {
             epoch: EpochCommitment,
             terminal: super::OLBlockCommitment,
             accounts: &[AccountId],
+            l1_block_records: &[L1BlockRecordWrite],
         ) -> DbSnapshot {
             let toplevel_state_root = self
                 .ol_state
@@ -697,26 +727,38 @@ mod db_idempotency {
                     .expect("get_num_leaves");
                 per_account.push((acct, updates, inbox, mmr_leaves));
             }
+
+            let l1_block_refs_handle = self.mmr_index.get_handle(MmrId::L1BlockRefs);
+            let l1_block_refs_leaf_count = l1_block_refs_handle
+                .get_num_leaves_blocking()
+                .expect("get L1 block refs leaf count");
+            let l1_block_refs = l1_block_records
+                .iter()
+                .map(|write| {
+                    let idx = u64::from(write.height);
+                    let leaf_hash = l1_block_refs_handle
+                        .get_leaf_blocking(idx)
+                        .expect("get L1 block ref leaf hash");
+                    let preimage = l1_block_refs_handle
+                        .get_blocking(idx)
+                        .expect("get L1 block ref preimage");
+                    L1BlockRefMirrorEntry {
+                        height: write.height,
+                        leaf_hash,
+                        preimage,
+                    }
+                })
+                .collect();
+
             DbSnapshot {
                 toplevel_state_root,
                 summary,
                 canonical_epoch_commitment: canonical,
                 per_account,
+                l1_block_refs_leaf_count,
+                l1_block_refs,
             }
         }
-    }
-
-    #[derive(Debug, PartialEq)]
-    struct DbSnapshot {
-        toplevel_state_root: Option<strata_identifiers::Buf32>,
-        summary: Option<strata_checkpoint_types::EpochSummary>,
-        canonical_epoch_commitment: Option<EpochCommitment>,
-        per_account: Vec<(
-            AccountId,
-            Vec<AccountUpdateRecord>,
-            Vec<InboxMessageRecord>,
-            u64,
-        )>,
     }
 
     fn make_temp_sled() -> Arc<SledDb> {
@@ -787,16 +829,46 @@ mod db_idempotency {
             "fixture must touch at least one account for the snapshot to be meaningful"
         );
 
-        let harness = WriteHarness::new();
+        let l1_block_records = artifacts.output.indexer_writes().l1_block_records();
+        assert!(
+            !l1_block_records.is_empty(),
+            "fixture must emit L1 block records for the snapshot to be meaningful"
+        );
+
+        let genesis_l1_height = u64::from(built.prev_summary.new_l1().height());
+        let expected_l1_leaf_count = l1_block_records
+            .iter()
+            .map(|write| u64::from(write.height) + 1)
+            .max()
+            .unwrap_or(genesis_l1_height + 1);
+
+        let harness = WriteHarness::new(genesis_l1_height);
         harness
             .run_three_writes(epoch, &artifacts)
             .expect("first apply");
-        let first = harness.snapshot(epoch, artifacts.terminal, &touched_accounts);
+        let first = harness.snapshot(
+            epoch,
+            artifacts.terminal,
+            &touched_accounts,
+            l1_block_records,
+        );
+
+        assert_eq!(first.l1_block_refs_leaf_count, expected_l1_leaf_count);
+        for (actual, expected) in first.l1_block_refs.iter().zip(l1_block_records) {
+            assert_eq!(actual.height, expected.height);
+            assert_eq!(actual.leaf_hash, Some(expected.record.leaf_hash().into()));
+            assert_eq!(actual.preimage, expected.record.as_ssz_bytes());
+        }
 
         harness
             .run_three_writes(epoch, &artifacts)
             .expect("second apply (idempotency check)");
-        let second = harness.snapshot(epoch, artifacts.terminal, &touched_accounts);
+        let second = harness.snapshot(
+            epoch,
+            artifacts.terminal,
+            &touched_accounts,
+            l1_block_records,
+        );
 
         assert_eq!(
             first, second,


### PR DESCRIPTION
## Description

- Write `L1BlockRefs` leaves to the MMR index DB during checkpoint sync.
- Route block sync and checkpoint sync through a shared `index_mmr_writes` helper so inbox and L1 block-ref MMR writes stay aligned.
- Extend checkpoint idempotency coverage to assert the `L1BlockRefs` MMR index entries are written and stable across retries.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3835](https://alpenlabs.atlassian.net/browse/STR-3835)


[STR-3835]: https://alpenlabs.atlassian.net/browse/STR-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ