### PR TITLE
Str 3849 - Fix checkpoint sync node startup attempting to build canonical block index

### DIFF
--- a/bin/strata/src/css.rs
+++ b/bin/strata/src/css.rs
@@ -75,6 +75,13 @@ impl CheckpointSyncCtx for StrataCheckpointSyncContext {
             .await
     }
 
+    /// Resolves the canonical checkpoint observed for `ep`.
+    ///
+    /// The index may hold several candidates, but only after a reorg: ASM accepts
+    /// one checkpoint per epoch per chain. Keeping the one whose L1 block is still
+    /// canonical leaves exactly the survivor on the current chain. Two survivors
+    /// would be two checkpoints for one epoch on-chain, which can't happen, so it
+    /// errors with [`CheckpointSyncError::AmbiguousObservation`].
     async fn get_observed_checkpoint_for_epoch(
         &self,
         ep: Epoch,
@@ -83,14 +90,16 @@ impl CheckpointSyncCtx for StrataCheckpointSyncContext {
         let l1 = self.storage.l1();
 
         let mut canonical: Option<EpochCommitment> = None;
-        // refs_from is ascending by epoch; entries at `ep` are contiguous.
-        for (commitment, l1_ref) in ol_checkpoint.get_checkpoint_l1_refs_from_async(ep).await? {
-            if commitment.epoch() < ep {
+        for commitment in ol_checkpoint
+            .get_observed_checkpoint_commitments_for_epoch_async(ep)
+            .await?
+        {
+            let Some(l1_ref) = ol_checkpoint
+                .get_checkpoint_l1_ref_async(commitment)
+                .await?
+            else {
                 continue;
-            }
-            if commitment.epoch() > ep {
-                break;
-            }
+            };
 
             // Drop observations recorded on an orphaned L1 block, matching CSM's
             // read-time filtering; a reorg can leave stale observations behind.

--- a/bin/strata/src/css.rs
+++ b/bin/strata/src/css.rs
@@ -112,6 +112,13 @@ impl CheckpointSyncCtx for StrataCheckpointSyncContext {
         Ok(canonical)
     }
 
+    async fn get_genesis_epoch_commitment(&self) -> DbResult<Option<EpochCommitment>> {
+        self.storage
+            .ol_checkpoint()
+            .get_canonical_epoch_commitment_at_async(0)
+            .await
+    }
+
     async fn get_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<Option<EpochSummary>> {
         self.storage
             .ol_checkpoint()

--- a/bin/strata/src/css.rs
+++ b/bin/strata/src/css.rs
@@ -65,13 +65,6 @@ impl CheckpointSyncCtx for StrataCheckpointSyncContext {
         Ok(self.csm_monitor.get_current())
     }
 
-    async fn get_canonical_epoch_commitment(&self, ep: Epoch) -> DbResult<Option<EpochCommitment>> {
-        self.storage
-            .ol_checkpoint()
-            .get_canonical_epoch_commitment_at_async(ep)
-            .await
-    }
-
     async fn get_checkpoint_l1_ref(
         &self,
         epoch: EpochCommitment,
@@ -80,6 +73,43 @@ impl CheckpointSyncCtx for StrataCheckpointSyncContext {
             .ol_checkpoint()
             .get_checkpoint_l1_ref_async(epoch)
             .await
+    }
+
+    async fn get_observed_checkpoint_for_epoch(
+        &self,
+        ep: Epoch,
+    ) -> CheckpointSyncResult<Option<EpochCommitment>> {
+        let ol_checkpoint = self.storage.ol_checkpoint();
+        let l1 = self.storage.l1();
+
+        let mut canonical: Option<EpochCommitment> = None;
+        // refs_from is ascending by epoch; entries at `ep` are contiguous.
+        for (commitment, l1_ref) in ol_checkpoint.get_checkpoint_l1_refs_from_async(ep).await? {
+            if commitment.epoch() < ep {
+                continue;
+            }
+            if commitment.epoch() > ep {
+                break;
+            }
+
+            // Drop observations recorded on an orphaned L1 block, matching CSM's
+            // read-time filtering; a reorg can leave stale observations behind.
+            let l1_block = l1_ref.l1_commitment;
+            if l1
+                .get_canonical_blockid_at_height_async(l1_block.height())
+                .await?
+                != Some(*l1_block.blkid())
+            {
+                continue;
+            }
+
+            if canonical.is_some() {
+                return Err(CheckpointSyncError::AmbiguousObservation(ep));
+            }
+            canonical = Some(commitment);
+        }
+
+        Ok(canonical)
     }
 
     async fn get_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<Option<EpochSummary>> {

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -127,6 +127,35 @@ fn get_ol_genesis_block(storage: &NodeStorage) -> Result<Option<OLBlockCommitmen
     Ok(genesis_commitment)
 }
 
+/// Ensures the genesis canonical entry exists and matches `genesis_commitment`.
+///
+/// Runs on every node before the canonical tip checks. Genesis init seeds this
+/// entry, but that happens later in service startup, so a legacy or
+/// checkpoint-sync DB holding OL genesis block data may still lack the canonical
+/// index here; this repairs it so the canonical tip resolves to genesis.
+fn ensure_genesis_canonical_entry(
+    storage: &NodeStorage,
+    genesis_commitment: OLBlockCommitment,
+) -> Result<()> {
+    let canonical_genesis = storage
+        .ol_block()
+        .get_canonical_block_at_blocking(0)
+        .context("startup: failed to query canonical OL genesis block")?;
+    if let Some(canonical_genesis) = canonical_genesis {
+        if canonical_genesis != genesis_commitment {
+            bail!(
+                "startup: canonical OL genesis block mismatch: expected {genesis_commitment}, got {canonical_genesis}"
+            );
+        }
+        return Ok(());
+    }
+
+    storage
+        .ol_block()
+        .replace_canonical_suffix_from_blocking(0, vec![*genesis_commitment.blkid()])
+        .context("startup: failed to seed genesis canonical OL block entry")
+}
+
 /// Ensures the canonical block index is initialized for legacy DBs.
 ///
 /// This backfills DBs created before the canonical OL block index existed. FCM
@@ -137,18 +166,6 @@ fn ensure_canonical_block_index(
     genesis_commitment: OLBlockCommitment,
     finalized_epoch: Option<EpochCommitment>,
 ) -> Result<()> {
-    let canonical_genesis = storage
-        .ol_block()
-        .get_canonical_block_at_blocking(0)
-        .context("startup: failed to query canonical OL genesis block")?;
-    if let Some(canonical_genesis) = canonical_genesis
-        && canonical_genesis != genesis_commitment
-    {
-        bail!(
-            "startup: canonical OL genesis block mismatch: expected {genesis_commitment}, got {canonical_genesis}"
-        );
-    }
-
     let finalized_commitment = finalized_epoch
         .filter(|epoch| !epoch.is_null())
         .map_or(genesis_commitment, |epoch| epoch.to_block_commitment());
@@ -412,16 +429,26 @@ pub(crate) fn run_startup_checks(ctx: &NodeContext) -> Result<()> {
         }
     }
 
-    if let Some(genesis_commitment) = genesis_commitment {
-        ensure_canonical_block_index(ctx.storage().as_ref(), genesis_commitment, finalized_epoch)?;
-        verify_genesis_ol_state(ctx.storage().as_ref(), genesis_commitment)?;
-        verify_genesis_epoch_summary(ctx.storage().as_ref(), genesis_commitment)?;
+    let is_sequencer = ctx.config().client.is_sequencer;
 
-        let tip_commitment = resolve_tip_ol_block(ctx.storage().as_ref())?;
-        let tip_block = verify_tip_ol_block(ctx.storage().as_ref(), tip_commitment)?;
-        verify_tip_parent(ctx.storage().as_ref(), &tip_block, tip_commitment)?;
-        verify_tip_ol_state(ctx.storage().as_ref(), tip_commitment)?;
-        verify_previous_epoch_summary_for_tip(ctx.storage().as_ref(), &tip_block)?;
+    if let Some(genesis_commitment) = genesis_commitment {
+        let storage = ctx.storage().as_ref();
+        verify_genesis_ol_state(storage, genesis_commitment)?;
+        verify_genesis_epoch_summary(storage, genesis_commitment)?;
+        ensure_genesis_canonical_entry(storage, genesis_commitment)?;
+
+        // Only the sequencer backfills the full canonical OL block index. FCM is
+        // the sole writer that advances it past genesis and does not run on
+        // checkpoint-sync nodes, which store no OL blocks past genesis.
+        if is_sequencer {
+            ensure_canonical_block_index(storage, genesis_commitment, finalized_epoch)?;
+        }
+
+        let tip_commitment = resolve_tip_ol_block(storage)?;
+        let tip_block = verify_tip_ol_block(storage, tip_commitment)?;
+        verify_tip_parent(storage, &tip_block, tip_commitment)?;
+        verify_tip_ol_state(storage, tip_commitment)?;
+        verify_previous_epoch_summary_for_tip(storage, &tip_block)?;
     }
 
     info!("startup: startup checks passed");
@@ -713,6 +740,87 @@ mod tests {
                 .get_canonical_tip_blocking()
                 .expect("test: get canonical tip after backfill"),
             Some(genesis_commitment)
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_sync_seeds_genesis_canonical_entry() {
+        let (storage, genesis_commitment) = setup_storage_with_genesis();
+        storage
+            .ol_block()
+            .replace_canonical_suffix_from_blocking(0, Vec::new())
+            .expect("test: clear canonical index");
+        storage
+            .ol_block()
+            .get_canonical_tip_blocking()
+            .expect_err("test: missing canonical index has no tip");
+
+        ensure_genesis_canonical_entry(&storage, genesis_commitment)
+            .expect("test: seed genesis canonical entry");
+
+        let tip_commitment = resolve_tip_ol_block(&storage).expect("test: resolve tip");
+        assert_eq!(tip_commitment, genesis_commitment);
+
+        let tip_block = verify_tip_ol_block(&storage, tip_commitment).expect("test: tip block");
+        verify_tip_parent(&storage, &tip_block, tip_commitment).expect("test: tip parent");
+        verify_tip_ol_state(&storage, tip_commitment).expect("test: tip state");
+        verify_previous_epoch_summary_for_tip(&storage, &tip_block)
+            .expect("test: previous epoch summary");
+    }
+
+    #[test]
+    fn test_ensure_genesis_canonical_entry_is_idempotent() {
+        let (storage, genesis_commitment) = setup_storage_with_genesis();
+        // Genesis init already seeded the entry; a second call must be a no-op.
+        ensure_genesis_canonical_entry(&storage, genesis_commitment).expect("test: idempotent");
+        assert_eq!(
+            storage
+                .ol_block()
+                .get_canonical_tip_blocking()
+                .expect("test: canonical tip"),
+            Some(genesis_commitment)
+        );
+    }
+
+    #[test]
+    fn test_ensure_genesis_canonical_entry_mismatch_errors() {
+        let (storage, genesis_commitment) = setup_storage_with_genesis();
+        let wrong_genesis = OLBlockCommitment::new(0, OLBlockId::from(Buf32::from([9u8; 32])));
+
+        let result = ensure_genesis_canonical_entry(&storage, wrong_genesis);
+
+        let err = result.expect_err("test: mismatch must error");
+        assert!(
+            err.to_string()
+                .contains("canonical OL genesis block mismatch"),
+            "unexpected error: {err:#}"
+        );
+        // The stored genesis entry must be left untouched.
+        assert_eq!(
+            storage
+                .ol_block()
+                .get_canonical_block_at_blocking(0)
+                .expect("test: query canonical genesis"),
+            Some(genesis_commitment)
+        );
+    }
+
+    #[test]
+    fn test_sequencer_missing_finalized_block_errors() {
+        let (storage, genesis_commitment) = setup_storage_with_genesis();
+        storage
+            .ol_block()
+            .replace_canonical_suffix_from_blocking(0, Vec::new())
+            .expect("test: clear canonical index");
+
+        let finalized_epoch = EpochCommitment::new(1, 1, OLBlockId::from(Buf32::from([7u8; 32])));
+        let result =
+            ensure_canonical_block_index(&storage, genesis_commitment, Some(finalized_epoch));
+
+        let err = result.expect_err("test: sequencer must error on missing finalized block");
+        assert!(
+            format!("{err:#}").contains("missing finalized OL block"),
+            "unexpected error: {err:#}"
         );
     }
 

--- a/crates/consensus-logic/src/checkpoint_sync/context.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/context.rs
@@ -32,17 +32,21 @@ pub trait CheckpointSyncCtx: Send + Sync + 'static {
         &self,
     ) -> impl Future<Output = CheckpointSyncResult<CsmWorkerStatus>> + Send;
 
-    /// Gets the canonical epoch commitment for a given epoch number.
-    fn get_canonical_epoch_commitment(
-        &self,
-        ep: Epoch,
-    ) -> impl Future<Output = DbResult<Option<EpochCommitment>>> + Send;
-
     /// Gets the L1 reference of a checkpoint for the given epoch, if present.
     fn get_checkpoint_l1_ref(
         &self,
         epoch: EpochCommitment,
     ) -> impl Future<Output = DbResult<Option<CheckpointL1Ref>>> + Send;
+
+    /// Resolves the checkpoint observed on the canonical L1 chain for epoch `ep`.
+    ///
+    /// Reads the L1 observations CSM records before an epoch is applied, so it
+    /// resolves predecessors during cold catch-up when no epoch summary exists
+    /// yet. Errs if more than one canonical observation survives for the epoch.
+    fn get_observed_checkpoint_for_epoch(
+        &self,
+        ep: Epoch,
+    ) -> impl Future<Output = CheckpointSyncResult<Option<EpochCommitment>>> + Send;
 
     /// Gets the epoch summary for the given epoch, if present.
     fn get_epoch_summary(

--- a/crates/consensus-logic/src/checkpoint_sync/context.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/context.rs
@@ -48,6 +48,16 @@ pub trait CheckpointSyncCtx: Send + Sync + 'static {
         ep: Epoch,
     ) -> impl Future<Output = CheckpointSyncResult<Option<EpochCommitment>>> + Send;
 
+    /// Resolves the genesis (epoch 0) commitment from the applied/summary source.
+    ///
+    /// Genesis is the always-applied base of the chain and has no L1 checkpoint
+    /// observation, so the backward scan terminates here rather than looking
+    /// genesis up via [`Self::get_observed_checkpoint_for_epoch`]. This is for
+    /// genesis resolution only, not for walking unapplied predecessors.
+    fn get_genesis_epoch_commitment(
+        &self,
+    ) -> impl Future<Output = DbResult<Option<EpochCommitment>>> + Send;
+
     /// Gets the epoch summary for the given epoch, if present.
     fn get_epoch_summary(
         &self,

--- a/crates/consensus-logic/src/checkpoint_sync/errors.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/errors.rs
@@ -30,6 +30,11 @@ pub enum CheckpointSyncError {
     #[error("predecessor epoch {0} not found in db while scanning finalized chain")]
     MissingPredecessor(Epoch),
 
+    /// More than one checkpoint observation for an epoch survives the canonical-L1
+    /// filter, so the canonical one is ambiguous.
+    #[error("multiple canonical checkpoint observations for epoch {0}")]
+    AmbiguousObservation(Epoch),
+
     /// A finalized epoch has no epoch summary when one was expected.
     #[error("epoch summary missing for {0}")]
     MissingEpochSummary(EpochCommitment),

--- a/crates/consensus-logic/src/checkpoint_sync/state.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/state.rs
@@ -259,11 +259,20 @@ pub(crate) async fn scan_unapplied_epochs(
             info!(scanned = unapplied.len(), %cur_finalized, "scan in progress");
         }
 
-        // Resolve the predecessor from L1 observations, not the summary-derived
-        // canonical index: during cold catch-up the predecessor is observed but
-        // not yet applied, so its summary (and thus its canonical-index entry)
-        // does not exist yet.
+        // Genesis (epoch 0) is the always-applied base and has no L1 observation,
+        // so resolve it from the applied/summary source and stop.
         let prev_epoch_num = cur_finalized.epoch().saturating_sub(1);
+        if prev_epoch_num == 0 {
+            let genesis = ctx
+                .get_genesis_epoch_commitment()
+                .await?
+                .ok_or(CheckpointSyncError::MissingPredecessor(0))?;
+            break Some(genesis);
+        }
+
+        // Resolve unapplied predecessors from L1 observations, not the
+        // summary-derived canonical index: during cold catch-up the predecessor
+        // is observed but not yet applied, so its summary does not exist yet.
         cur_finalized = ctx
             .get_observed_checkpoint_for_epoch(prev_epoch_num)
             .await?

--- a/crates/consensus-logic/src/checkpoint_sync/state.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/state.rs
@@ -259,9 +259,13 @@ pub(crate) async fn scan_unapplied_epochs(
             info!(scanned = unapplied.len(), %cur_finalized, "scan in progress");
         }
 
+        // Resolve the predecessor from L1 observations, not the summary-derived
+        // canonical index: during cold catch-up the predecessor is observed but
+        // not yet applied, so its summary (and thus its canonical-index entry)
+        // does not exist yet.
         let prev_epoch_num = cur_finalized.epoch().saturating_sub(1);
         cur_finalized = ctx
-            .get_canonical_epoch_commitment(prev_epoch_num)
+            .get_observed_checkpoint_for_epoch(prev_epoch_num)
             .await?
             .ok_or(CheckpointSyncError::MissingPredecessor(prev_epoch_num))?;
     };

--- a/crates/consensus-logic/src/checkpoint_sync/tests.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/tests.rs
@@ -142,6 +142,16 @@ impl MockCtx {
         self.l1_refs.insert(ec, l1_ref);
         self
     }
+
+    /// Seeds genesis (epoch 0) faithfully: applied (summary + canonical entry) but
+    /// with no L1 observation, since epoch 0 produces no checkpoint tip update.
+    fn add_genesis(mut self, ec: EpochCommitment) -> Self {
+        assert_eq!(ec.epoch(), 0, "genesis must be epoch 0");
+        self.epoch_commitments.insert(0, ec);
+        let summary = make_epoch_summary(0, ec, EpochCommitment::null(), 0);
+        self.epoch_summaries.get_mut().unwrap().insert(ec, summary);
+        self
+    }
 }
 
 impl CheckpointSyncCtx for MockCtx {
@@ -177,6 +187,10 @@ impl CheckpointSyncCtx for MockCtx {
             return Err(CheckpointSyncError::AmbiguousObservation(ep));
         }
         Ok(result)
+    }
+
+    async fn get_genesis_epoch_commitment(&self) -> DbResult<Option<EpochCommitment>> {
+        Ok(self.epoch_commitments.get(&0).copied())
     }
 
     async fn get_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<Option<EpochSummary>> {
@@ -225,7 +239,7 @@ async fn scan_walks_to_genesis_when_nothing_applied() {
     let epoch3 = make_epoch(3, 30, 0x03);
 
     let ctx = MockCtx::new(3, 200)
-        .add_epoch(epoch0, make_l1_ref(100), None)
+        .add_genesis(epoch0)
         .add_epoch(epoch1, make_l1_ref(110), None)
         .add_epoch(epoch2, make_l1_ref(120), None)
         .add_epoch(epoch3, make_l1_ref(130), None);
@@ -275,7 +289,7 @@ async fn scan_all_already_applied() {
     let summary2 = make_epoch_summary(2, epoch2, epoch1, 120);
 
     let ctx = MockCtx::new(3, 200)
-        .add_epoch(epoch0, make_l1_ref(100), None)
+        .add_genesis(epoch0)
         .add_epoch(epoch1, make_l1_ref(110), Some(summary1))
         .add_epoch(epoch2, make_l1_ref(120), Some(summary2));
 
@@ -292,11 +306,10 @@ async fn scan_collects_unapplied_newest_first_stops_at_applied() {
     let epoch2 = make_epoch(2, 20, 0x02);
     let epoch3 = make_epoch(3, 30, 0x03);
 
-    let summary0 = make_epoch_summary(0, epoch0, EpochCommitment::null(), 100);
     let summary1 = make_epoch_summary(1, epoch1, epoch0, 110);
 
     let ctx = MockCtx::new(3, 200)
-        .add_epoch(epoch0, make_l1_ref(100), Some(summary0))
+        .add_genesis(epoch0)
         .add_epoch(epoch1, make_l1_ref(110), Some(summary1)) // applied upto here
         .add_epoch(epoch2, make_l1_ref(120), None)
         .add_epoch(epoch3, make_l1_ref(130), None);
@@ -314,7 +327,7 @@ async fn scan_single_unapplied_epoch_above_genesis() {
     let epoch1 = make_epoch(1, 10, 0x01);
 
     let ctx = MockCtx::new(3, 200)
-        .add_epoch(epoch0, make_l1_ref(100), None)
+        .add_genesis(epoch0)
         .add_epoch(epoch1, make_l1_ref(110), None);
 
     let (last_applied, unapplied) = scan_unapplied_epochs(&ctx, epoch1, 200, 3).await.unwrap();
@@ -378,11 +391,10 @@ async fn find_and_apply_multi_epoch_catch_up() {
     let epoch2 = make_epoch(2, 20, 0x02);
     let epoch3 = make_epoch(3, 30, 0x03);
 
-    let summary0 = make_epoch_summary(0, epoch0, EpochCommitment::null(), 100);
     let summary1 = make_epoch_summary(1, epoch1, epoch0, 110);
 
     let ctx = MockCtx::new(3, 200)
-        .add_epoch(epoch0, make_l1_ref(100), Some(summary0))
+        .add_genesis(epoch0)
         .add_epoch(epoch1, make_l1_ref(110), Some(summary1))
         .add_epoch(epoch2, make_l1_ref(120), None)
         .add_epoch(epoch3, make_l1_ref(130), None);
@@ -430,12 +442,11 @@ async fn handle_errors_on_chain_hole_leaves_state_unadvanced() {
     let epoch1 = make_epoch(1, 10, 0x01);
     let epoch3 = make_epoch(3, 30, 0x03);
 
-    let summary0 = make_epoch_summary(0, epoch0, EpochCommitment::null(), 100);
     let summary1 = make_epoch_summary(1, epoch1, epoch0, 110);
 
     let ctx = Arc::new(
         MockCtx::new(3, 200)
-            .add_epoch(epoch0, make_l1_ref(100), Some(summary0))
+            .add_genesis(epoch0)
             .add_epoch(epoch1, make_l1_ref(110), Some(summary1))
             .add_epoch(epoch3, make_l1_ref(130), None)
             .with_csm_finalized(Some(epoch3)),
@@ -463,11 +474,10 @@ async fn rerun_after_partial_drain_applies_nothing() {
     let epoch2 = make_epoch(2, 20, 0x02);
     let epoch3 = make_epoch(3, 30, 0x03);
 
-    let summary0 = make_epoch_summary(0, epoch0, EpochCommitment::null(), 100);
     let summary1 = make_epoch_summary(1, epoch1, epoch0, 110);
 
     let ctx = MockCtx::new(3, 200)
-        .add_epoch(epoch0, make_l1_ref(100), Some(summary0))
+        .add_genesis(epoch0)
         .add_epoch(epoch1, make_l1_ref(110), Some(summary1))
         .add_epoch(epoch2, make_l1_ref(120), None)
         .add_epoch(epoch3, make_l1_ref(130), None);

--- a/crates/consensus-logic/src/checkpoint_sync/tests.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/tests.rs
@@ -77,7 +77,8 @@ struct MockCtx {
     l1_tip_height: L1Height,
     /// CSM status returned by `fetch_csm_status`.
     csm_status: CsmWorkerStatus,
-    /// Epoch number -> commitment lookup (canonical chain).
+    /// Epoch number -> commitment, used by mock `apply_checkpoint` to build the
+    /// previous-epoch link in synthesized summaries.
     epoch_commitments: HashMap<Epoch, EpochCommitment>,
     /// L1 reference for each finalized epoch's checkpoint tx.
     l1_refs: HashMap<EpochCommitment, CheckpointL1Ref>,
@@ -133,6 +134,14 @@ impl MockCtx {
         }
         self
     }
+
+    /// Seeds an L1-observed checkpoint without a canonical epoch->commitment entry
+    /// or summary, mirroring CSM's pre-apply state: the checkpoint is observed on
+    /// L1 but the node has not yet reconstructed (applied) the epoch.
+    fn add_observed_epoch(mut self, ec: EpochCommitment, l1_ref: CheckpointL1Ref) -> Self {
+        self.l1_refs.insert(ec, l1_ref);
+        self
+    }
 }
 
 impl CheckpointSyncCtx for MockCtx {
@@ -148,15 +157,26 @@ impl CheckpointSyncCtx for MockCtx {
         Ok(self.csm_status.clone())
     }
 
-    async fn get_canonical_epoch_commitment(&self, ep: Epoch) -> DbResult<Option<EpochCommitment>> {
-        Ok(self.epoch_commitments.get(&ep).copied())
-    }
-
     async fn get_checkpoint_l1_ref(
         &self,
         epoch: EpochCommitment,
     ) -> DbResult<Option<CheckpointL1Ref>> {
         Ok(self.l1_refs.get(&epoch).cloned())
+    }
+
+    async fn get_observed_checkpoint_for_epoch(
+        &self,
+        ep: Epoch,
+    ) -> CheckpointSyncResult<Option<EpochCommitment>> {
+        // Resolve from observed L1 refs by epoch number, mirroring the production
+        // range scan. The mock seeds only canonical observations, so at most one
+        // matches per epoch.
+        let mut found = self.l1_refs.keys().filter(|c| c.epoch() == ep);
+        let result = found.next().copied();
+        if found.next().is_some() {
+            return Err(CheckpointSyncError::AmbiguousObservation(ep));
+        }
+        Ok(result)
     }
 
     async fn get_epoch_summary(&self, epoch: EpochCommitment) -> DbResult<Option<EpochSummary>> {
@@ -215,6 +235,34 @@ async fn scan_walks_to_genesis_when_nothing_applied() {
     // Genesis is the stopping point; epochs 1..=3 are all unapplied, newest-first.
     assert_eq!(last_applied, Some(epoch0));
     assert_eq!(unapplied, vec![epoch3, epoch2, epoch1]);
+}
+
+// Observed checkpoints without summaries must still provide the predecessor chain
+// during cold catch-up.
+#[tokio::test]
+async fn scan_cold_catchup_uses_observed_predecessors() {
+    let epoch131 = make_epoch(131, 1310, 0x83);
+    let epoch132 = make_epoch(132, 1320, 0x84);
+    let epoch133 = make_epoch(133, 1330, 0x85);
+    let epoch134 = make_epoch(134, 1340, 0x86);
+
+    // epoch131 is applied (summary present) and is the stopping point. 132/133/134
+    // are only L1-observed, so the summary-derived canonical index has no entry for
+    // them; the walk must resolve their predecessors from the observations.
+    let summary131 = make_epoch_summary(131, epoch131, make_epoch(130, 1300, 0x82), 1310);
+    let ctx = MockCtx::new(3, 2000)
+        .add_epoch(epoch131, make_l1_ref(1310), Some(summary131))
+        .add_observed_epoch(epoch132, make_l1_ref(1320))
+        .add_observed_epoch(epoch133, make_l1_ref(1330))
+        .add_observed_epoch(epoch134, make_l1_ref(1340))
+        .with_csm_finalized(Some(epoch134));
+
+    let (last_applied, unapplied) = scan_unapplied_epochs(&ctx, epoch134, 2000, 3)
+        .await
+        .unwrap();
+
+    assert_eq!(last_applied, Some(epoch131));
+    assert_eq!(unapplied, vec![epoch134, epoch133, epoch132]);
 }
 
 #[tokio::test]
@@ -308,9 +356,10 @@ async fn scan_errors_on_missing_l1_ref() {
 
 #[tokio::test]
 async fn scan_errors_when_prev_epoch_missing_from_chain() {
-    // epoch2 exists but epoch1 does not — broken invariant for a finalized chain.
+    // epoch2 is observed, but epoch1 has neither an observation nor a canonical
+    // mapping — a genuinely broken finalized chain, distinct from cold catch-up.
     let epoch2 = make_epoch(2, 20, 0x02);
-    let ctx = MockCtx::new(3, 200).add_epoch(epoch2, make_l1_ref(120), None);
+    let ctx = MockCtx::new(3, 200).add_observed_epoch(epoch2, make_l1_ref(120));
 
     let err = scan_unapplied_epochs(&ctx, epoch2, 200, 3)
         .await

--- a/crates/db/store-sled/src/ol_checkpoint/db.rs
+++ b/crates/db/store-sled/src/ol_checkpoint/db.rs
@@ -18,6 +18,7 @@ define_sled_database!(
         l1_observed_payload_tree: OLCheckpointL1ObservedPayloadSchema,
         unsigned_tree: UnsignedCheckpointIndexSchema,
         epoch_summary_tree: OLEpochSummarySchema,
+        l1_ref_epoch_index_tree: OLCheckpointEpochIndexSchema,
     }
 );
 
@@ -373,10 +374,18 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
         epoch: EpochCommitment,
         l1_ref: CheckpointL1Ref,
     ) -> DbResult<()> {
-        self.config.with_retry((&self.l1_ref_tree,), |(lot,)| {
-            lot.insert(&epoch, &l1_ref)?;
-            Ok(())
-        })?;
+        self.config.with_retry(
+            (&self.l1_ref_tree, &self.l1_ref_epoch_index_tree),
+            |(lot, idx)| {
+                lot.insert(&epoch, &l1_ref)?;
+                let mut candidates = idx.get(&epoch.epoch())?.unwrap_or_default();
+                if !candidates.contains(&epoch) {
+                    candidates.push(epoch);
+                    idx.insert(&epoch.epoch(), &candidates)?;
+                }
+                Ok(())
+            },
+        )?;
         Ok(())
     }
 
@@ -414,14 +423,57 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
         Ok(refs)
     }
 
+    fn get_observed_checkpoint_commitments_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>> {
+        if let Some(candidates) = self.l1_ref_epoch_index_tree.get(&epoch)? {
+            return Ok(candidates);
+        }
+
+        // Read-repair: a legacy entry written before the index existed. Rebuild
+        // it from the L1-ref table and persist so later reads hit the index. The
+        // scan is non-transactional; the persist unions the scanned candidates
+        // with any entry created concurrently so neither set is lost.
+        let scanned: Vec<EpochCommitment> = self
+            .get_checkpoint_l1_refs_from(epoch)?
+            .into_iter()
+            .filter(|(commitment, _)| commitment.epoch() == epoch)
+            .map(|(commitment, _)| commitment)
+            .collect();
+
+        self.config
+            .with_retry((&self.l1_ref_epoch_index_tree,), |(idx,)| {
+                let mut merged = idx.get(&epoch)?.unwrap_or_default();
+                for commitment in &scanned {
+                    if !merged.contains(commitment) {
+                        merged.push(*commitment);
+                    }
+                }
+                idx.insert(&epoch, &merged)?;
+                Ok(merged)
+            })
+    }
+
     fn del_checkpoint_l1_ref(&self, epoch: EpochCommitment) -> DbResult<bool> {
-        self.config.with_retry((&self.l1_ref_tree,), |(lot,)| {
-            if !lot.contains_key(&epoch)? {
-                return Ok(false);
-            }
-            lot.remove(&epoch)?;
-            Ok(true)
-        })
+        self.config.with_retry(
+            (&self.l1_ref_tree, &self.l1_ref_epoch_index_tree),
+            |(lot, idx)| {
+                if !lot.contains_key(&epoch)? {
+                    return Ok(false);
+                }
+                lot.remove(&epoch)?;
+                if let Some(mut candidates) = idx.get(&epoch.epoch())? {
+                    candidates.retain(|c| c != &epoch);
+                    if candidates.is_empty() {
+                        idx.remove(&epoch.epoch())?;
+                    } else {
+                        idx.insert(&epoch.epoch(), &candidates)?;
+                    }
+                }
+                Ok(true)
+            },
+        )
     }
 
     fn del_checkpoint_l1_refs_from_epoch(
@@ -440,16 +492,20 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
             return Ok(Vec::new());
         }
 
-        let deleted_epochs = self.config.with_retry((&self.l1_ref_tree,), |(lot,)| {
-            let mut deleted_epochs = Vec::new();
-            for epoch_comm in &keys {
-                if lot.contains_key(epoch_comm)? {
-                    lot.remove(epoch_comm)?;
-                    deleted_epochs.push(*epoch_comm);
+        let deleted_epochs = self.config.with_retry(
+            (&self.l1_ref_tree, &self.l1_ref_epoch_index_tree),
+            |(lot, idx)| {
+                let mut deleted_epochs = Vec::new();
+                for epoch_comm in &keys {
+                    if lot.contains_key(epoch_comm)? {
+                        lot.remove(epoch_comm)?;
+                        idx.remove(&epoch_comm.epoch())?;
+                        deleted_epochs.push(*epoch_comm);
+                    }
                 }
-            }
-            Ok(deleted_epochs)
-        })?;
+                Ok(deleted_epochs)
+            },
+        )?;
         Ok(deleted_epochs)
     }
 
@@ -473,10 +529,19 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
         }
 
         self.config.with_retry(
-            (&self.l1_observed_payload_tree, &self.l1_ref_tree),
-            |(opt, lot)| {
+            (
+                &self.l1_observed_payload_tree,
+                &self.l1_ref_tree,
+                &self.l1_ref_epoch_index_tree,
+            ),
+            |(opt, lot, idx)| {
                 opt.insert(&commitment, &payload)?;
                 lot.insert(&commitment, &l1_ref)?;
+                let mut candidates = idx.get(&commitment.epoch())?.unwrap_or_default();
+                if !candidates.contains(&commitment) {
+                    candidates.push(commitment);
+                    idx.insert(&commitment.epoch(), &candidates)?;
+                }
                 Ok(())
             },
         )?;
@@ -536,10 +601,100 @@ impl OLCheckpointDatabase for OLCheckpointDBSled {
 #[cfg(feature = "test_utils")]
 #[cfg(test)]
 mod tests {
+    use strata_csm_types::CheckpointL1Ref;
     use strata_db_tests::ol_checkpoint_db_tests;
+    use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId, OLBlockId, RBuf32};
 
     use super::*;
     use crate::sled_db_test_setup;
 
     sled_db_test_setup!(OLCheckpointDBSled, ol_checkpoint_db_tests);
+
+    fn temp_db() -> OLCheckpointDBSled {
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let sled_db = typed_sled::SledDb::new(db).unwrap();
+        OLCheckpointDBSled::new(sled_db.into(), crate::SledDbConfig::test()).unwrap()
+    }
+
+    fn l1_ref(height: u32) -> CheckpointL1Ref {
+        let blkid = L1BlockId::from(Buf32::from([height as u8; 32]));
+        CheckpointL1Ref::new(
+            L1BlockCommitment::new(height, blkid),
+            RBuf32::from([height as u8; 32]),
+            RBuf32::from([(height + 1) as u8; 32]),
+        )
+    }
+
+    fn commitment(epoch: u32, tag: u8) -> EpochCommitment {
+        EpochCommitment::new(
+            Epoch::from(epoch),
+            u64::from(epoch),
+            OLBlockId::from(Buf32::from([tag; 32])),
+        )
+    }
+
+    /// Legacy rows written directly to the L1-ref tree (before the index
+    /// existed) are read-repaired on first lookup and then served from the
+    /// index. Seeds via a direct tree insert because the public writers now
+    /// maintain the index, so only a raw insert reproduces a legacy row.
+    #[test]
+    fn observed_commitments_read_repair_from_legacy_rows() {
+        let db = temp_db();
+        let a = commitment(9, 1);
+        let b = commitment(9, 2);
+        db.l1_ref_tree.insert(&a, &l1_ref(900)).unwrap();
+        db.l1_ref_tree.insert(&b, &l1_ref(901)).unwrap();
+        assert!(
+            db.l1_ref_epoch_index_tree
+                .get(&Epoch::from(9u32))
+                .unwrap()
+                .is_none(),
+            "index must be absent before repair"
+        );
+
+        // First lookup repairs from the scan and persists the candidate set.
+        let mut repaired = db
+            .get_observed_checkpoint_commitments_for_epoch(Epoch::from(9u32))
+            .unwrap();
+        repaired.sort_by_key(|c| *c.last_blkid());
+        let mut expected = vec![a, b];
+        expected.sort_by_key(|c| *c.last_blkid());
+        assert_eq!(repaired, expected);
+
+        let mut persisted = db
+            .l1_ref_epoch_index_tree
+            .get(&Epoch::from(9u32))
+            .unwrap()
+            .expect("index persisted after repair");
+        persisted.sort_by_key(|c| *c.last_blkid());
+        assert_eq!(persisted, expected);
+    }
+
+    /// Confirms the per-epoch lookup serves from the index without rescanning the
+    /// L1-ref table on every call: once the index is populated, the result no
+    /// longer depends on the underlying l1_refs, so a cold-start catch-up that
+    /// resolves many predecessors does not repeat the full scan per epoch.
+    #[test]
+    fn observed_commitments_served_from_index_without_rescan() {
+        let db = temp_db();
+        let c = commitment(7, 1);
+        db.put_checkpoint_l1_ref(c, l1_ref(700)).unwrap();
+
+        // The public writer populated the index, so this lookup is index-served.
+        assert_eq!(
+            db.get_observed_checkpoint_commitments_for_epoch(Epoch::from(7u32))
+                .unwrap(),
+            vec![c]
+        );
+
+        // Drop the l1_ref tree entry but leave the index intact. A rescan would
+        // now return empty; serving from the index still returns the candidate.
+        db.l1_ref_tree.remove(&c).unwrap();
+        assert_eq!(
+            db.get_observed_checkpoint_commitments_for_epoch(Epoch::from(7u32))
+                .unwrap(),
+            vec![c],
+            "second lookup must hit the index, not rescan the l1_ref table"
+        );
+    }
 }

--- a/crates/db/store-sled/src/ol_checkpoint/schemas.rs
+++ b/crates/db/store-sled/src/ol_checkpoint/schemas.rs
@@ -36,3 +36,11 @@ define_table_with_integer_key!(
     /// Table mapping epoch indexes to the list of summaries in that index.
     (OLEpochSummarySchema) u64 => Vec<EpochSummary>
 );
+
+define_table_with_integer_key!(
+    /// Observed checkpoint commitments per epoch number.
+    ///
+    /// Observed candidate set: reorged observations remain until explicit
+    /// pruning, so canonicity is resolved at read time.
+    (OLCheckpointEpochIndexSchema) Epoch => Vec<EpochCommitment>
+);

--- a/crates/db/tests/src/ol_checkpoint_tests.rs
+++ b/crates/db/tests/src/ol_checkpoint_tests.rs
@@ -490,6 +490,101 @@ pub fn test_del_checkpoint_l1_refs_from_epoch(db: &impl OLCheckpointDatabase) {
     }
 }
 
+fn commitment_at(epoch: u32, tag: u8) -> EpochCommitment {
+    let blkid = OLBlockId::from(Buf32::from([tag; 32]));
+    EpochCommitment::new(Epoch::from(epoch), u64::from(epoch), blkid)
+}
+
+pub fn test_observed_checkpoint_commitments_index_populated_on_write(
+    db: &impl OLCheckpointDatabase,
+) {
+    let payload = payload_for_epoch(21);
+    let key = checkpoint_epoch_commitment(&payload);
+    db.put_checkpoint_l1_observation(key, payload, l1_ref_entry(300))
+        .expect("put observation");
+
+    let candidates = db
+        .get_observed_checkpoint_commitments_for_epoch(Epoch::from(21u32))
+        .expect("get observed commitments");
+    assert_eq!(candidates, vec![key]);
+}
+
+pub fn test_observed_checkpoint_commitments_index_maintained_on_put_l1_ref(
+    db: &impl OLCheckpointDatabase,
+) {
+    // The low-level l1_ref setter must keep the epoch index coherent so a later
+    // read sees rows it added. Two commitments share an epoch number.
+    let ep = 22;
+    let a = commitment_at(ep, 1);
+    let b = commitment_at(ep, 2);
+    db.put_checkpoint_l1_ref(a, l1_ref_entry(310))
+        .expect("put l1 ref a");
+    db.put_checkpoint_l1_ref(b, l1_ref_entry(311))
+        .expect("put l1 ref b");
+
+    let mut candidates = db
+        .get_observed_checkpoint_commitments_for_epoch(Epoch::from(ep))
+        .expect("observed commitments");
+    candidates.sort_by_key(|c| *c.last_blkid());
+    let mut expected = vec![a, b];
+    expected.sort_by_key(|c| *c.last_blkid());
+    assert_eq!(candidates, expected);
+
+    // Repair persisted the set: deleting the underlying l1 ref now also prunes
+    // the index, so a subsequent read reflects the deletion.
+    db.del_checkpoint_l1_ref(a).expect("delete l1 ref a");
+    let candidates = db
+        .get_observed_checkpoint_commitments_for_epoch(Epoch::from(22u32))
+        .expect("observed commitments after delete");
+    assert_eq!(candidates, vec![b]);
+
+    // A put after the index was read-repaired to empty must still surface: read
+    // an unseen epoch (persists []), then put, then the new row is visible.
+    let later = 23;
+    assert!(db
+        .get_observed_checkpoint_commitments_for_epoch(Epoch::from(later))
+        .expect("empty epoch read")
+        .is_empty());
+    let c = commitment_at(later, 1);
+    db.put_checkpoint_l1_ref(c, l1_ref_entry(312))
+        .expect("put l1 ref after empty read");
+    assert_eq!(
+        db.get_observed_checkpoint_commitments_for_epoch(Epoch::from(later))
+            .expect("observed after late put"),
+        vec![c]
+    );
+}
+
+pub fn test_observed_checkpoint_commitments_index_pruned_on_del_from_epoch(
+    db: &impl OLCheckpointDatabase,
+) {
+    for epoch in 0u32..3 {
+        let payload = payload_for_epoch(epoch);
+        let key = checkpoint_epoch_commitment(&payload);
+        db.put_checkpoint_l1_observation(key, payload, l1_ref_entry(320 + epoch))
+            .expect("put observation");
+    }
+    // A second candidate at epoch 1 so the delete must clear a k>1 index entry.
+    db.put_checkpoint_l1_ref(commitment_at(1, 9), l1_ref_entry(329))
+        .expect("put second epoch-1 candidate");
+
+    db.del_checkpoint_l1_refs_from_epoch(Epoch::from(1u32))
+        .expect("delete from epoch");
+
+    assert!(
+        db.get_observed_checkpoint_commitments_for_epoch(Epoch::from(0u32))
+            .expect("epoch 0 retained")
+            .len()
+            == 1
+    );
+    for epoch in 1u32..3 {
+        assert!(db
+            .get_observed_checkpoint_commitments_for_epoch(Epoch::from(epoch))
+            .expect("deleted epoch empty")
+            .is_empty());
+    }
+}
+
 pub fn test_get_next_unsigned_checkpoint_epoch_all_signed_returns_none(
     db: &impl OLCheckpointDatabase,
 ) {
@@ -1007,6 +1102,24 @@ macro_rules! ol_checkpoint_db_tests {
         fn test_del_checkpoint_l1_refs_from_epoch() {
             let db = $setup_expr;
             $crate::ol_checkpoint_tests::test_del_checkpoint_l1_refs_from_epoch(&db);
+        }
+
+        #[test]
+        fn test_observed_checkpoint_commitments_index_populated_on_write() {
+            let db = $setup_expr;
+            $crate::ol_checkpoint_tests::test_observed_checkpoint_commitments_index_populated_on_write(&db);
+        }
+
+        #[test]
+        fn test_observed_checkpoint_commitments_index_maintained_on_put_l1_ref() {
+            let db = $setup_expr;
+            $crate::ol_checkpoint_tests::test_observed_checkpoint_commitments_index_maintained_on_put_l1_ref(&db);
+        }
+
+        #[test]
+        fn test_observed_checkpoint_commitments_index_pruned_on_del_from_epoch() {
+            let db = $setup_expr;
+            $crate::ol_checkpoint_tests::test_observed_checkpoint_commitments_index_pruned_on_del_from_epoch(&db);
         }
 
         #[test]

--- a/crates/db/types/src/ol_checkpoint.rs
+++ b/crates/db/types/src/ol_checkpoint.rs
@@ -133,6 +133,15 @@ pub trait OLCheckpointDatabase: Send + Sync + 'static {
         start_epoch: Epoch,
     ) -> DbResult<Vec<(EpochCommitment, CheckpointL1Ref)>>;
 
+    /// Get the observed checkpoint commitments for `epoch`.
+    ///
+    /// The returned candidates are observed, not canonical: an L1 reorg can
+    /// leave more than one, so callers resolve canonicity at read time.
+    fn get_observed_checkpoint_commitments_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>>;
+
     /// Delete an OL checkpoint L1 ref by epoch commitment.
     ///
     /// Returns true if it existed and was deleted.

--- a/crates/storage/src/managers/ol_checkpoint.rs
+++ b/crates/storage/src/managers/ol_checkpoint.rs
@@ -357,6 +357,17 @@ impl OLCheckpointManager {
         self.ops.get_checkpoint_l1_refs_from_blocking(start_epoch)
     }
 
+    /// Gets all observed `(epoch commitment, L1 ref)` pairs at or above
+    /// `start_epoch`, ordered by ascending epoch.
+    pub async fn get_checkpoint_l1_refs_from_async(
+        &self,
+        start_epoch: Epoch,
+    ) -> DbResult<Vec<(EpochCommitment, CheckpointL1Ref)>> {
+        self.ops
+            .get_checkpoint_l1_refs_from_async(start_epoch)
+            .await
+    }
+
     /// Deletes an OL checkpoint L1 ref by epoch commitment.
     pub async fn del_checkpoint_l1_ref_async(&self, epoch: EpochCommitment) -> DbResult<bool> {
         self.ops.del_checkpoint_l1_ref_async(epoch).await

--- a/crates/storage/src/managers/ol_checkpoint.rs
+++ b/crates/storage/src/managers/ol_checkpoint.rs
@@ -357,14 +357,16 @@ impl OLCheckpointManager {
         self.ops.get_checkpoint_l1_refs_from_blocking(start_epoch)
     }
 
-    /// Gets all observed `(epoch commitment, L1 ref)` pairs at or above
-    /// `start_epoch`, ordered by ascending epoch.
-    pub async fn get_checkpoint_l1_refs_from_async(
+    /// Gets the observed checkpoint commitments for `epoch`.
+    ///
+    /// Candidates are observed, not canonical; callers resolve canonicity at
+    /// read time since an L1 reorg can leave more than one.
+    pub async fn get_observed_checkpoint_commitments_for_epoch_async(
         &self,
-        start_epoch: Epoch,
-    ) -> DbResult<Vec<(EpochCommitment, CheckpointL1Ref)>> {
+        epoch: Epoch,
+    ) -> DbResult<Vec<EpochCommitment>> {
         self.ops
-            .get_checkpoint_l1_refs_from_async(start_epoch)
+            .get_observed_checkpoint_commitments_for_epoch_async(epoch)
             .await
     }
 

--- a/functional-tests/tests/strata/test_checkpoint_sync_node_restart.py
+++ b/functional-tests/tests/strata/test_checkpoint_sync_node_restart.py
@@ -1,0 +1,72 @@
+"""A checkpoint-sync OL node restarts cleanly after syncing a post-genesis epoch.
+
+A checkpoint-sync node stores no OL blocks except genesis: it persists OL state
+and epoch summaries when applying checkpoints, and the finalized epoch lives in
+client state. Once it has synced a post-genesis checkpoint, its persisted client
+state declares a finalized epoch whose OL block is not in the store.
+
+This test lets the sequencer post checkpoints to L1, waits for the
+checkpoint-sync node to itself finalize a post-genesis epoch (so it has persisted
+non-genesis client state), then restarts that node reusing its datadir. The
+second startup must not require the finalized OL block to be present in the
+store.
+"""
+
+import logging
+
+import flexitest
+
+from common.base_test import BaseTest
+from common.config.constants import ServiceType
+from common.rpc_types.strata import ChainSyncStatus
+from common.services.bitcoin import BitcoinService
+from common.services.strata import StrataService
+from common.wait import wait_until_with_value
+
+logger = logging.getLogger(__name__)
+
+
+def mine_and_get_status(strata: StrataService, btc_rpc) -> ChainSyncStatus:
+    """Mines L1 blocks so OL checkpoints confirm, then returns the node's status."""
+    btc_rpc.proxy.generatetoaddress(2, btc_rpc.proxy.getnewaddress())
+    return strata.get_sync_status()
+
+
+@flexitest.register
+class TestCheckpointSyncNodeRestart(BaseTest):
+    """Restarts a checkpoint-sync node after it syncs a post-genesis epoch."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env("el_ol_checkpoint_sync")
+
+    def main(self, ctx):
+        checkpoint_node: StrataService = self.get_service(ServiceType.StrataCheckpointNode)
+        bitcoin: BitcoinService = self.get_service(ServiceType.Bitcoin)
+        btc_rpc = bitcoin.create_rpc()
+
+        checkpoint_node.wait_for_rpc_ready(timeout=20)
+
+        # First get checkpoint node to sync upto first chekpoint.
+        pre_restart_status = wait_until_with_value(
+            lambda: mine_and_get_status(checkpoint_node, btc_rpc),
+            lambda st: st["finalized"]["epoch"] >= 1,
+            error_with="checkpoint-sync node did not finalize a post-genesis epoch",
+            timeout=120,
+        )
+        finalized_epoch = pre_restart_status["finalized"]["epoch"]
+        logger.info(f"checkpoint-sync node finalized epoch {finalized_epoch}; restarting")
+
+        # Now restart.
+        checkpoint_node.stop()
+        checkpoint_node.start()
+        checkpoint_node.wait_for_rpc_ready(timeout=30)
+
+        post_restart_status = checkpoint_node.get_sync_status()
+        tip_slot = post_restart_status["tip"]["slot"]
+        logger.info(f"checkpoint-sync node restarted; canonical tip at slot {tip_slot}")
+        wait_until_with_value(
+            lambda: mine_and_get_status(checkpoint_node, btc_rpc),
+            lambda st: st["finalized"]["epoch"] >= 2,
+            error_with="checkpoint-sync node did not finalize a post-genesis epoch",
+            timeout=120,
+        )

--- a/functional-tests/tests/strata/test_checkpoint_sync_node_restart.py
+++ b/functional-tests/tests/strata/test_checkpoint_sync_node_restart.py
@@ -1,15 +1,10 @@
 """A checkpoint-sync OL node restarts cleanly after syncing a post-genesis epoch.
 
-A checkpoint-sync node stores no OL blocks except genesis: it persists OL state
-and epoch summaries when applying checkpoints, and the finalized epoch lives in
-client state. Once it has synced a post-genesis checkpoint, its persisted client
-state declares a finalized epoch whose OL block is not in the store.
-
-This test lets the sequencer post checkpoints to L1, waits for the
-checkpoint-sync node to itself finalize a post-genesis epoch (so it has persisted
-non-genesis client state), then restarts that node reusing its datadir. The
-second startup must not require the finalized OL block to be present in the
-store.
+A checkpoint-sync node stores no OL blocks except genesis. This test lets the
+sequencer post checkpoints to L1, waits for the checkpoint-sync node to itself
+finalize a post-genesis epoch (so it has persisted non-genesis client state),
+then restarts that node reusing its datadir. The second startup must not require
+the finalized OL block to be present in the store.
 """
 
 import logging
@@ -46,7 +41,7 @@ class TestCheckpointSyncNodeRestart(BaseTest):
 
         checkpoint_node.wait_for_rpc_ready(timeout=20)
 
-        # First get checkpoint node to sync upto first chekpoint.
+        # First get checkpoint node to sync up to first checkpoint.
         pre_restart_status = wait_until_with_value(
             lambda: mine_and_get_status(checkpoint_node, btc_rpc),
             lambda st: st["finalized"]["epoch"] >= 1,
@@ -64,9 +59,11 @@ class TestCheckpointSyncNodeRestart(BaseTest):
         post_restart_status = checkpoint_node.get_sync_status()
         tip_slot = post_restart_status["tip"]["slot"]
         logger.info(f"checkpoint-sync node restarted; canonical tip at slot {tip_slot}")
+
+        # Require a strictly new finalization after restart.
         wait_until_with_value(
             lambda: mine_and_get_status(checkpoint_node, btc_rpc),
-            lambda st: st["finalized"]["epoch"] >= 2,
-            error_with="checkpoint-sync node did not finalize a post-genesis epoch",
+            lambda st: st["finalized"]["epoch"] > finalized_epoch,
+            error_with="checkpoint-sync node did not finalize a new epoch after restart",
             timeout=120,
         )


### PR DESCRIPTION
## Description

**AI usage**: This PR was created with the assistance from claude and codex with instructions from author.

- This replicates the checkpoint sync node startup failure with a new functional test(see first commit) and then applies the fix. On doing so, tests a checkpoint sync node restart as well.
- Basically, the startup was incorrectly attempting to index canonical blocks for a checkpoint sync node and was failing. This PR fixes that behavior by making the indexing node specific.
- When I tried this out with current staging deployment another issue was revealed where there is a chicken-and-egg problem while scanning checkpoints backwards from current finalized checkpoint in CSS. This was resolved as well.
- Adds an index of `epoch -> Vec<EpochCommitment>` that keeps track of epoch commitments per epoch. CSS resolves the correct commitment by checking if the corresponding L1 reference is canonical or not. This is sufficient because ASM ensures one checkpoint per epoch.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
