### PR TITLE
frontport: refactor(alpen-ee): cleanup block assembly input message handling (#2014)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,6 @@ dependencies = [
  "strata-msg-fmt",
  "strata-ol-bridge-types",
  "strata-ol-msg-types",
- "strata-snark-acct-runtime",
  "tracing",
 ]
 

--- a/crates/alpen-ee/block-assembly/Cargo.toml
+++ b/crates/alpen-ee/block-assembly/Cargo.toml
@@ -17,7 +17,6 @@ strata-ee-chain-types.workspace = true
 strata-msg-fmt.workspace = true
 strata-ol-bridge-types.workspace = true
 strata-ol-msg-types.workspace = true
-strata-snark-acct-runtime.workspace = true
 
 alloy-primitives.workspace = true
 bitcoin-bosd.workspace = true

--- a/crates/alpen-ee/block-assembly/src/block.rs
+++ b/crates/alpen-ee/block-assembly/src/block.rs
@@ -58,7 +58,7 @@ pub async fn build_next_exec_block<E: PayloadBuilderEngine>(
     } = inputs;
 
     // 1. apply new inbox messages to account state
-    let parsed_inputs = apply_input_messages(&mut account_state, inbox_messages)
+    apply_input_messages(&mut account_state, inbox_messages)
         .context("build_next_exec_block: failed to apply input messages")?;
 
     // 2. build exec block payload
@@ -75,11 +75,18 @@ pub async fn build_next_exec_block<E: PayloadBuilderEngine>(
     // 3. update account state based on built payload and consumed inputs
     account_state.set_last_exec_blkid(*update_extra_data.new_tip_blkid());
     account_state.set_last_exec_state_root(*update_extra_data.new_tip_state_root());
+    // Extract pending input entries that got executed in the current block.
+    let processed_inputs: Vec<_> = account_state
+        .pending_inputs()
+        .iter()
+        .take(*update_extra_data.processed_inputs() as usize)
+        .cloned()
+        .collect();
     account_state.remove_pending_inputs(*update_extra_data.processed_inputs() as usize);
     account_state.remove_pending_fincls(*update_extra_data.processed_fincls() as usize);
 
     // 4. build exec package
-    let package = build_block_package(bridge_gateway_account_id, parsed_inputs, &payload);
+    let package = build_block_package(bridge_gateway_account_id, processed_inputs, &payload);
 
     Ok(BlockAssemblyOutputs {
         package,

--- a/crates/alpen-ee/block-assembly/src/block.rs
+++ b/crates/alpen-ee/block-assembly/src/block.rs
@@ -75,15 +75,10 @@ pub async fn build_next_exec_block<E: PayloadBuilderEngine>(
     // 3. update account state based on built payload and consumed inputs
     account_state.set_last_exec_blkid(*update_extra_data.new_tip_blkid());
     account_state.set_last_exec_state_root(*update_extra_data.new_tip_state_root());
-    // Extract pending input entries that got executed in the current block.
-    let processed_inputs: Vec<_> = account_state
-        .pending_inputs()
-        .iter()
-        .take(*update_extra_data.processed_inputs() as usize)
-        .cloned()
-        .collect();
-    account_state.remove_pending_inputs(*update_extra_data.processed_inputs() as usize);
-    account_state.remove_pending_fincls(*update_extra_data.processed_fincls() as usize);
+    // Drain pending input entries that got executed in the current block.
+    let processed_inputs =
+        account_state.remove_pending_inputs(*update_extra_data.processed_inputs() as usize);
+    let _ = account_state.remove_pending_fincls(*update_extra_data.processed_fincls() as usize);
 
     // 4. build exec package
     let package = build_block_package(bridge_gateway_account_id, processed_inputs, &payload);

--- a/crates/alpen-ee/block-assembly/src/package.rs
+++ b/crates/alpen-ee/block-assembly/src/package.rs
@@ -2,46 +2,27 @@ use alpen_ee_common::EnginePayload;
 use bitcoin_bosd::Descriptor;
 use strata_acct_types::{AccountId, BitcoinAmount, Hash, MsgPayload};
 use strata_codec::encode_to_vec;
-use strata_ee_acct_types::DecodedEeMessageData;
+use strata_ee_acct_types::PendingInputEntry;
 use strata_ee_chain_types::{
     ExecBlockCommitment, ExecBlockPackage, ExecInputs, ExecOutputs, OutputMessage,
-    SubjectDepositData,
 };
 use strata_msg_fmt::{Msg as MsgTrait, OwnedMsg};
 use strata_ol_bridge_types::OperatorSelection;
 use strata_ol_msg_types::{WithdrawalMsgData, DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID};
-use strata_snark_acct_runtime::InputMessage;
 use tracing::{info, warn};
 
-/// Builds [`ExecInputs`] from parsed input messages.
-///
-/// Only `Deposit` messages are processed; other message types are logged and ignored.
-// TODO(STR-2583) convert this to do it based on extracting pending inputs from the
-// current EE account inner state
-pub(crate) fn build_block_inputs(
-    parsed_inputs: Vec<InputMessage<DecodedEeMessageData>>,
-) -> ExecInputs {
+/// Builds [`ExecInputs`] from pending input entries that were executed in the current block.
+pub(crate) fn build_block_inputs(pending_inputs: Vec<PendingInputEntry>) -> ExecInputs {
     let mut inputs = ExecInputs::new_empty();
-    for msg in parsed_inputs {
-        let value = msg.meta().value();
-        match msg.message() {
-            Some(DecodedEeMessageData::Deposit(deposit_msg_data)) => {
-                let dest_subject = *deposit_msg_data.dest_subject();
+    for pending_input in pending_inputs {
+        match pending_input {
+            PendingInputEntry::Deposit(subj_deposit_data) => {
                 info!(
-                    ?dest_subject,
-                    amount_sat = value.to_sat(),
+                    dest_subject = ?subj_deposit_data.dest,
+                    amount_sat = subj_deposit_data.value.to_sat(),
                     "accepted deposit message as EE input",
                 );
-                inputs.add_subject_deposit(SubjectDepositData::new(dest_subject, value));
-            }
-            Some(DecodedEeMessageData::SubjTransfer(_)) => {
-                // no need to warn on this
-            }
-            Some(DecodedEeMessageData::Commit(_)) => {
-                // no need to warn on this
-            }
-            None => {
-                // Unknown message, skip
+                inputs.add_subject_deposit(subj_deposit_data);
             }
         }
     }
@@ -85,7 +66,7 @@ pub(crate) fn build_block_outputs<TPayload: EnginePayload>(
 /// Builds the block package based on execution inputs and results.
 pub(crate) fn build_block_package<TPayload: EnginePayload>(
     bridge_gateway_account_id: AccountId,
-    parsed_inputs: Vec<InputMessage<DecodedEeMessageData>>,
+    pending_inputs: Vec<PendingInputEntry>,
     payload: &TPayload,
 ) -> ExecBlockPackage {
     // 1. build block commitment
@@ -95,7 +76,7 @@ pub(crate) fn build_block_package<TPayload: EnginePayload>(
     let commitment = ExecBlockCommitment::new(exec_blkid, raw_block_encoded_hash);
 
     // 2. build block inputs
-    let inputs = build_block_inputs(parsed_inputs);
+    let inputs = build_block_inputs(pending_inputs);
 
     // 3. build block outputs
     let outputs = build_block_outputs(bridge_gateway_account_id, payload);
@@ -124,63 +105,46 @@ fn create_withdrawal_init_message_payload(
 #[cfg(test)]
 mod tests {
     use strata_acct_types::SubjectId;
-    use strata_codec::VarVec;
-    use strata_ee_acct_types::{CommitMsgData, DepositMsgData, SubjTransferMsgData};
-    use strata_snark_acct_runtime::MsgMeta;
+    use strata_ee_chain_types::SubjectDepositData;
 
     use super::*;
 
-    fn make_deposit_msg(dest_bytes: [u8; 32], sats: u64) -> InputMessage<DecodedEeMessageData> {
-        InputMessage::from_msg(
-            MsgMeta::new(AccountId::zero(), 0, BitcoinAmount::from_sat(sats)),
-            DecodedEeMessageData::Deposit(DepositMsgData::new(SubjectId::new(dest_bytes))),
-        )
-    }
-
-    fn make_subj_transfer_msg(sats: u64) -> InputMessage<DecodedEeMessageData> {
-        InputMessage::from_msg(
-            MsgMeta::new(AccountId::zero(), 0, BitcoinAmount::from_sat(sats)),
-            DecodedEeMessageData::SubjTransfer(SubjTransferMsgData::new(
-                SubjectId::new([0xaa; 32]),
-                SubjectId::new([0xbb; 32]),
-                VarVec::new(),
-            )),
-        )
-    }
-
-    fn make_commit_msg() -> InputMessage<DecodedEeMessageData> {
-        InputMessage::from_msg(
-            MsgMeta::new(AccountId::zero(), 0, BitcoinAmount::from_sat(0)),
-            DecodedEeMessageData::Commit(CommitMsgData::new([0xcc; 32])),
-        )
+    fn make_deposit(dest_bytes: [u8; 32], sats: u64) -> PendingInputEntry {
+        PendingInputEntry::Deposit(SubjectDepositData::new(
+            SubjectId::new(dest_bytes),
+            BitcoinAmount::from_sat(sats),
+        ))
     }
 
     #[test]
-    fn build_block_inputs_filters_non_deposit_messages() {
-        // Mix of deposit, transfer, and commit messages
+    fn build_block_inputs_converts_pending_deposits() {
         let inputs = vec![
-            make_deposit_msg([0x01; 32], 1000),
-            make_subj_transfer_msg(500), // Should be ignored
-            make_deposit_msg([0x02; 32], 2000),
-            make_commit_msg(), // Should be ignored
-            make_deposit_msg([0x03; 32], 3000),
+            make_deposit([0x01; 32], 1000),
+            make_deposit([0x02; 32], 2000),
+            make_deposit([0x03; 32], 3000),
         ];
 
         let block_inputs = build_block_inputs(inputs);
 
-        // Only deposits should be included
         assert_eq!(block_inputs.total_inputs(), 3);
         let deposits = block_inputs.subject_deposits();
         assert_eq!(deposits[0].dest(), SubjectId::new([0x01; 32]));
         assert_eq!(deposits[0].value(), BitcoinAmount::from_sat(1000));
         assert_eq!(deposits[1].dest(), SubjectId::new([0x02; 32]));
+        assert_eq!(deposits[1].value(), BitcoinAmount::from_sat(2000));
         assert_eq!(deposits[2].dest(), SubjectId::new([0x03; 32]));
+        assert_eq!(deposits[2].value(), BitcoinAmount::from_sat(3000));
     }
 
     #[test]
-    fn build_block_inputs_preserves_deposit_value_from_msg_meta() {
-        // The value comes from msg.value() (the meta), not from the deposit message itself
-        let inputs = vec![make_deposit_msg([0xaa; 32], 12345)];
+    fn build_block_inputs_empty() {
+        let block_inputs = build_block_inputs(Vec::new());
+        assert_eq!(block_inputs.total_inputs(), 0);
+    }
+
+    #[test]
+    fn build_block_inputs_preserves_deposit_value() {
+        let inputs = vec![make_deposit([0xaa; 32], 12345)];
 
         let block_inputs = build_block_inputs(inputs);
 

--- a/crates/ee-acct-runtime/src/block_assembly.rs
+++ b/crates/ee-acct-runtime/src/block_assembly.rs
@@ -1,29 +1,18 @@
 //! Helpers for working with ee account during block assembly.
 
 use strata_acct_types::MessageEntry;
-use strata_ee_acct_types::{DecodedEeMessageData, EeAccountState, EnvError, EnvResult};
+use strata_ee_acct_types::{EeAccountState, EnvError, EnvResult};
 use strata_snark_acct_runtime::InputMessage;
 
 use crate::ee_program::process_input_message;
 
 /// Applies state changes from a list of messages.
-///
-/// Returns all parsed messages, including unknown/unparsable ones (which will
-/// have `message() == None`). Value is always tracked regardless of whether the
-/// message was successfully decoded.
-pub fn apply_input_messages(
-    astate: &mut EeAccountState,
-    msgs: &[MessageEntry],
-) -> EnvResult<Vec<InputMessage<DecodedEeMessageData>>> {
-    let mut parsed_messages = Vec::with_capacity(msgs.len());
-
+pub fn apply_input_messages(astate: &mut EeAccountState, msgs: &[MessageEntry]) -> EnvResult<()> {
     for entry in msgs.iter() {
         let input_msg = InputMessage::from_msg_entry(entry);
 
         process_input_message(astate, &input_msg).map_err(|_| EnvError::InvalidBlock)?;
-
-        parsed_messages.push(input_msg);
     }
 
-    Ok(parsed_messages)
+    Ok(())
 }

--- a/crates/ee-acct-types/src/state.rs
+++ b/crates/ee-acct-types/src/state.rs
@@ -71,16 +71,16 @@ impl EeAccountState {
     }
 
     /// Removing some number of pending inputs.
-    pub fn remove_pending_inputs(&mut self, n: usize) -> bool {
+    pub fn remove_pending_inputs(&mut self, n: usize) -> Vec<PendingInputEntry> {
         if self.pending_inputs.len() < n {
-            false
+            vec![]
         } else {
             let mut vec: Vec<_> = self.pending_inputs.clone().into();
-            vec.drain(..n);
+            let drained = vec.drain(..n).collect();
             self.pending_inputs = vec
                 .try_into()
                 .expect("pending inputs should not exceed capacity");
-            true
+            drained
         }
     }
 
@@ -93,16 +93,17 @@ impl EeAccountState {
     }
 
     /// Removing some number of pending forced inclusions.
-    pub fn remove_pending_fincls(&mut self, n: usize) -> bool {
+    pub fn remove_pending_fincls(&mut self, n: usize) -> Vec<PendingFinclEntry> {
         if self.pending_fincls.len() < n {
-            false
+            vec![]
         } else {
             let mut vec: Vec<_> = self.pending_fincls.clone().into();
-            vec.drain(..n);
+            let drained = vec.drain(..n).collect();
             self.pending_fincls = vec
                 .try_into()
                 .expect("pending fincls should not exceed capacity");
-            true
+
+            drained
         }
     }
 }


### PR DESCRIPTION
Cc @sapinb 

Frontport #2012 and #2014 to the `main` branch

* refactor(alpen-ee): cleanup block assembly input message handling

- return drained inputs from account_state.remove_pending_inputs()
- remove processed message collection in apply_input_messages

* lint: remove unused import

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
