### PR TITLE
STR-3855 return unused gas on bridge pegout failure

### DIFF
--- a/crates/reth/evm/src/precompiles/IBridgeOut.sol
+++ b/crates/reth/evm/src/precompiles/IBridgeOut.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @title IBridgeOut
+/// @notice Canonical declarations for the bridge-out precompile's custom errors.
+///         The precompile lives at `BRIDGEOUT_PRECOMPILE_ADDRESS` and is implemented
+///         natively (see `bridge.rs`); this interface exists so that on-chain callers
+///         and off-chain tooling can decode its revert data.
+///
+/// @dev On a rejected withdrawal the precompile REVERTS (refunding unspent gas) with
+///      ABI-encoded custom-error data: `bytes4(keccak256(signature)) ++ abi.encode(args)`.
+///      Selectors (kept in sync with `bridge.rs` by an in-crate keccak256 test):
+///        IncorrectCallType()            0x7a5e63dc
+///        MalformedCalldata()            0x59170bf0
+///        MalformedCalldataBosd()        0xc8e45892
+///        OversizeBosd(uint256)          0x2725ac73
+///        NonIntegerAmount()             0xf7738c57
+///        IncorrectAmount(uint256)       0x88967d2f
+///        OversizeWithdrawal(uint256)    0xb0701377
+interface IBridgeOut {
+    /// @notice The precompile was not reached via a direct CALL
+    ///         (e.g. invoked through DELEGATECALL/CALLCODE/STATICCALL).
+    error IncorrectCallType();
+
+    /// @notice Calldata was too short to contain the 4-byte operator selector
+    ///         followed by at least one BOSD byte.
+    error MalformedCalldata();
+
+    /// @notice The BOSD bytes are not a valid descriptor.
+    error MalformedCalldataBosd();
+
+    /// @notice The BOSD descriptor length exceeds the configured maximum.
+    /// @param max The maximum allowed descriptor length, in bytes.
+    error OversizeBosd(uint256 max);
+
+    /// @notice The withdrawal value is not a whole number of satoshis.
+    error NonIntegerAmount();
+
+    /// @notice The withdrawal value is zero or not a positive multiple of the denomination.
+    /// @param denomination The withdrawal denomination, in satoshis.
+    error IncorrectAmount(uint256 denomination);
+
+    /// @notice The withdrawal value exceeds the maximum permitted withdrawal.
+    /// @param max The maximum permitted withdrawal, in satoshis.
+    error OversizeWithdrawal(uint256 max);
+}

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -14,42 +14,78 @@ const BRIDGEOUT_BASE_GAS: u64 = 10_000;
 /// Raw EVM gas charged per calldata byte handled by the bridge-out precompile.
 const BRIDGEOUT_CALLDATA_BYTE_GAS: u64 = 16;
 
-/// Solidity `Error(string)` selector: `bytes4(keccak256("Error(string)"))`.
-const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
-
-/// Appends `value` as a 32-byte big-endian ABI word.
-fn push_abi_word(out: &mut Vec<u8>, value: u64) {
-    let mut word = [0u8; 32];
-    word[24..].copy_from_slice(&value.to_be_bytes());
-    out.extend_from_slice(&word);
-}
-
-/// ABI-encodes a human-readable reason as Solidity `Error(string)` revert data so
-/// standard tooling (ethers/web3/foundry) decodes it as `revert("...")`.
-fn abi_encode_error_string(reason: &str) -> Bytes {
-    let reason_bytes = reason.as_bytes();
-    let len = reason_bytes.len();
-    let padded_len = len.div_ceil(32) * 32;
-
-    let mut out = Vec::with_capacity(4 + 64 + padded_len);
-    out.extend_from_slice(&ERROR_STRING_SELECTOR);
-    push_abi_word(&mut out, 32); // offset to the string data (always 0x20)
-    push_abi_word(&mut out, len as u64); // string length
-    out.extend_from_slice(reason_bytes); // string bytes
-    out.resize(4 + 64 + padded_len, 0); // right-pad to a 32-byte boundary
-    Bytes::from(out)
-}
-
-/// Builds a gas-refunding revert carrying an ABI-encoded `Error(string)` reason.
+/// Machine-readable failure reasons returned by the bridge-out precompile.
 ///
-/// Unlike returning `Err(PrecompileError::other(..))` — which is an exceptional halt
-/// that burns all gas forwarded to the call — a revert refunds the unspent gas
-/// (only `gas_used` is charged) and surfaces `reason` as the call's return data.
-fn revert_with_reason(gas_used: u64, reason: &str) -> PrecompileResult {
-    Ok(PrecompileOutput::new_reverted(
-        gas_used,
-        abi_encode_error_string(reason),
-    ))
+/// Each variant is encoded as a Solidity ABI custom error: the 4-byte selector
+/// `bytes4(keccak256(signature))` followed by ABI-encoded parameters. The canonical
+/// definitions consumers decode against live in `IBridgeOut.sol` (next to this file).
+/// The selector bytes below are asserted against `keccak256` of the signatures in
+/// `test_custom_error_selectors_match_signatures`, so they cannot silently drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BridgeOutError {
+    /// `IncorrectCallType()` — precompile was not reached via a direct CALL.
+    IncorrectCallType,
+    /// `MalformedCalldata()` — calldata too short to hold operator selector + BOSD.
+    MalformedCalldata,
+    /// `MalformedCalldataBosd()` — BOSD bytes are not a valid descriptor.
+    MalformedCalldataBosd,
+    /// `OversizeBosd(uint256 max)` — BOSD descriptor length exceeds `max` bytes.
+    OversizeBosd { max: U256 },
+    /// `NonIntegerAmount()` — value is not a whole number of satoshis.
+    NonIntegerAmount,
+    /// `IncorrectAmount(uint256 denomination)` — value is zero or not a multiple of
+    /// `denomination` sats.
+    IncorrectAmount { denomination: U256 },
+    /// `OversizeWithdrawal(uint256 max)` — value exceeds the `max` withdrawal (sats).
+    OversizeWithdrawal { max: U256 },
+}
+
+impl BridgeOutError {
+    /// The Solidity custom-error selector, `bytes4(keccak256(signature))`.
+    const fn selector(self) -> [u8; 4] {
+        match self {
+            Self::IncorrectCallType => [0x7a, 0x5e, 0x63, 0xdc],
+            Self::MalformedCalldata => [0x59, 0x17, 0x0b, 0xf0],
+            Self::MalformedCalldataBosd => [0xc8, 0xe4, 0x58, 0x92],
+            Self::OversizeBosd { .. } => [0x27, 0x25, 0xac, 0x73],
+            Self::NonIntegerAmount => [0xf7, 0x73, 0x8c, 0x57],
+            Self::IncorrectAmount { .. } => [0x88, 0x96, 0x7d, 0x2f],
+            Self::OversizeWithdrawal { .. } => [0xb0, 0x70, 0x13, 0x77],
+        }
+    }
+
+    /// The single `uint256` parameter, if the error carries one.
+    const fn param(self) -> Option<U256> {
+        match self {
+            Self::OversizeBosd { max } => Some(max),
+            Self::IncorrectAmount { denomination } => Some(denomination),
+            Self::OversizeWithdrawal { max } => Some(max),
+            Self::IncorrectCallType
+            | Self::MalformedCalldata
+            | Self::MalformedCalldataBosd
+            | Self::NonIntegerAmount => None,
+        }
+    }
+
+    /// ABI-encodes the error as `selector ++ abi.encode(params)`.
+    fn abi_encode(self) -> Bytes {
+        let mut out = Vec::with_capacity(4 + 32);
+        out.extend_from_slice(&self.selector());
+        if let Some(value) = self.param() {
+            // A `uint256` parameter is its 32-byte big-endian representation.
+            out.extend_from_slice(&value.to_be_bytes::<32>());
+        }
+        Bytes::from(out)
+    }
+}
+
+/// Builds a gas-refunding revert carrying an ABI-encoded custom error.
+///
+/// Unlike returning `Err(PrecompileError::other(..))` — an exceptional halt that burns
+/// all gas forwarded to the call — a revert refunds the unspent gas (only `gas_used` is
+/// charged) and surfaces the typed error as the call's return data.
+fn revert_with_error(gas_used: u64, error: BridgeOutError) -> PrecompileResult {
+    Ok(PrecompileOutput::new_reverted(gas_used, error.abi_encode()))
 }
 
 /// Custom precompile to burn rollup native token and add bridge out intent of equal amount.
@@ -71,28 +107,25 @@ pub(crate) fn bridge_context_call(
     }
 
     // From here on, user-facing validation failures revert (refunding unspent gas and
-    // returning a reason) rather than halting and burning all forwarded gas.
+    // returning a typed error) rather than halting and burning all forwarded gas.
     if !input.is_direct_call() {
-        return revert_with_reason(gas_cost, "bridgeout precompile must be invoked via CALL");
+        return revert_with_error(gas_cost, BridgeOutError::IncorrectCallType);
     }
 
     let Some(calldata) = WithdrawalCalldata::decode(input.data) else {
-        return revert_with_reason(
-            gas_cost,
-            "Calldata too short: expected at least 5 bytes (4 operator + 1 BOSD)",
-        );
+        return revert_with_error(gas_cost, BridgeOutError::MalformedCalldata);
     };
 
-    // Validate that this is a valid BOSD.
-    if let Err(reason) = validate_bosd(&calldata.bosd, &bridge_params) {
-        return revert_with_reason(gas_cost, &reason);
+    // Validate that this is a valid BOSD within the configured length limit.
+    if let Err(error) = validate_bosd(&calldata.bosd, &bridge_params) {
+        return revert_with_error(gas_cost, error);
     }
 
     // Verify that the transaction value is a positive exact multiple of the withdrawal
-    // denomination.
+    // denomination and within the cap.
     let amount = match validate_withdrawal_amount(input.value, &bridge_params) {
         Ok(amount) => amount,
-        Err(reason) => return revert_with_reason(gas_cost, &reason),
+        Err(error) => return revert_with_error(gas_cost, error),
     };
 
     // Log the bridge withdrawal intent
@@ -120,11 +153,6 @@ pub(crate) fn bridge_context_call(
     Ok(PrecompileOutput::new(gas_cost, Bytes::new()))
 }
 
-fn sats_to_withdrawal_amount(sats: U256) -> Result<u64, String> {
-    sats.try_into()
-        .map_err(|_| "Withdrawal amount exceeds maximum allowed value".to_string())
-}
-
 fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
     let calldata_len = u64::try_from(calldata_len)
         .map_err(|_| PrecompileError::Fatal("Bridgeout calldata length exceeds u64".into()))?;
@@ -135,43 +163,51 @@ fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
         .ok_or_else(|| PrecompileError::Fatal("Bridgeout gas cost overflow".into()))
 }
 
-/// Validates that the withdrawal amount is a positive exact multiple of the denomination and cap.
+/// Validates that the withdrawal amount is a positive exact multiple of the denomination
+/// and within the cap, returning the amount in satoshis.
 fn validate_withdrawal_amount(
     amount_wei: U256,
     bridge_params: &BridgeParams,
-) -> Result<u64, String> {
+) -> Result<u64, BridgeOutError> {
     let (amount_sats, remainder_wei) = wei_to_sats(amount_wei);
     if !remainder_wei.is_zero() {
-        return Err(format!(
-            "Invalid withdrawal value {amount_wei}: must be an exact number of satoshis",
-        ));
+        return Err(BridgeOutError::NonIntegerAmount);
     }
 
-    let amount_sats = sats_to_withdrawal_amount(amount_sats)?;
+    // A value that overflows u64 satoshis cannot be within any cap.
+    let amount_sats: u64 =
+        amount_sats
+            .try_into()
+            .map_err(|_| BridgeOutError::OversizeWithdrawal {
+                max: U256::from(bridge_params.max_withdrawal_amount().unwrap_or(u64::MAX)),
+            })?;
 
+    // `BridgeParams` is the source of truth for validity; when it rejects the amount we
+    // attribute the specific reason so the caller gets a precise, typed error.
     if !bridge_params.validate_withdrawal_amount(amount_sats) {
-        return Err(format!(
-            "Invalid withdrawal value: {amount_sats} sats must be a positive exact multiple of {} sats and within {:?} sats",
-            bridge_params.denomination(),
-            bridge_params.max_withdrawal_amount()
-        ));
+        let denomination = bridge_params.denomination();
+        if amount_sats == 0 || !amount_sats.is_multiple_of(denomination) {
+            return Err(BridgeOutError::IncorrectAmount {
+                denomination: U256::from(denomination),
+            });
+        }
+        return Err(BridgeOutError::OversizeWithdrawal {
+            max: U256::from(bridge_params.max_withdrawal_amount().unwrap_or(u64::MAX)),
+        });
     }
 
     Ok(amount_sats)
 }
 
 /// Validates that input is a valid BOSD [`Descriptor`] within the configured limit.
-fn validate_bosd(data: &[u8], bridge_params: &BridgeParams) -> Result<(), String> {
+fn validate_bosd(data: &[u8], bridge_params: &BridgeParams) -> Result<(), BridgeOutError> {
     if !bridge_params.validate_withdrawal_descriptor_len(data.len()) {
-        return Err(format!(
-            "Invalid BOSD: descriptor length {} exceeds maximum {}",
-            data.len(),
-            bridge_params.max_withdrawal_descriptor_len()
-        ));
+        return Err(BridgeOutError::OversizeBosd {
+            max: U256::from(bridge_params.max_withdrawal_descriptor_len()),
+        });
     }
 
-    Descriptor::from_bytes(data)
-        .map_err(|_| "Invalid BOSD: expected a valid BOSD descriptor".to_string())?;
+    Descriptor::from_bytes(data).map_err(|_| BridgeOutError::MalformedCalldataBosd)?;
     Ok(())
 }
 
@@ -199,12 +235,78 @@ mod tests {
     };
     const MAX_DESCRIPTOR_LEN: u32 = 81;
 
-    /// Decodes Solidity `Error(string)` revert data back into its message.
-    fn decode_error_string(data: &[u8]) -> String {
-        assert_eq!(&data[0..4], &ERROR_STRING_SELECTOR, "wrong revert selector");
-        // Layout: selector[4] | offset word[32] | length word[32] | data[..]
-        let len = u64::from_be_bytes(data[60..68].try_into().unwrap()) as usize;
-        String::from_utf8(data[68..68 + len].to_vec()).unwrap()
+    /// Returns the 4-byte selector at the head of ABI-encoded revert data.
+    fn selector_of(data: &[u8]) -> [u8; 4] {
+        data[0..4].try_into().unwrap()
+    }
+
+    /// Decodes the single trailing `uint256` parameter (low 64 bits).
+    fn uint_param(data: &[u8]) -> u64 {
+        // selector[0..4] | uint256 word[4..36]; low 8 bytes at [28..36].
+        u64::from_be_bytes(data[28..36].try_into().unwrap())
+    }
+
+    #[test]
+    fn test_custom_error_selectors_match_signatures() {
+        use revm_primitives::keccak256;
+
+        let cases: [(BridgeOutError, &str); 7] = [
+            (BridgeOutError::IncorrectCallType, "IncorrectCallType()"),
+            (BridgeOutError::MalformedCalldata, "MalformedCalldata()"),
+            (
+                BridgeOutError::MalformedCalldataBosd,
+                "MalformedCalldataBosd()",
+            ),
+            (
+                BridgeOutError::OversizeBosd { max: U256::ZERO },
+                "OversizeBosd(uint256)",
+            ),
+            (BridgeOutError::NonIntegerAmount, "NonIntegerAmount()"),
+            (
+                BridgeOutError::IncorrectAmount {
+                    denomination: U256::ZERO,
+                },
+                "IncorrectAmount(uint256)",
+            ),
+            (
+                BridgeOutError::OversizeWithdrawal { max: U256::ZERO },
+                "OversizeWithdrawal(uint256)",
+            ),
+        ];
+
+        for (err, sig) in cases {
+            assert_eq!(
+                err.selector(),
+                keccak256(sig.as_bytes())[..4],
+                "selector drift for {sig}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_custom_error_abi_encoding_layout() {
+        // No-param error: selector only.
+        let encoded = BridgeOutError::IncorrectCallType.abi_encode();
+        assert_eq!(encoded.len(), 4);
+        assert_eq!(
+            selector_of(&encoded),
+            BridgeOutError::IncorrectCallType.selector()
+        );
+
+        // Parametrized error: selector + one uint256 word.
+        let encoded = BridgeOutError::IncorrectAmount {
+            denomination: U256::from(100_000_000u64),
+        }
+        .abi_encode();
+        assert_eq!(encoded.len(), 36);
+        assert_eq!(
+            selector_of(&encoded),
+            BridgeOutError::IncorrectAmount {
+                denomination: U256::ZERO
+            }
+            .selector()
+        );
+        assert_eq!(uint_param(&encoded), 100_000_000);
     }
 
     #[test]
@@ -294,24 +396,6 @@ mod tests {
         assert!(bridgeout_gas_cost(usize::MAX).is_err());
     }
 
-    #[test]
-    fn test_sats_to_withdrawal_amount_rejects_overflow_as_recoverable_error() {
-        let err = sats_to_withdrawal_amount(U256::from(u64::MAX) + U256::from(1)).unwrap_err();
-
-        assert!(err.contains("exceeds maximum allowed value"));
-    }
-
-    #[test]
-    fn test_abi_encode_error_string_roundtrips() {
-        let msg = "Withdrawal value 11 exceeds maximum allowed 10 wei";
-        let encoded = abi_encode_error_string(msg);
-
-        // Selector + two head words + content padded to a 32-byte boundary.
-        assert_eq!(&encoded[0..4], &ERROR_STRING_SELECTOR);
-        assert_eq!(encoded.len(), 4 + 64 + msg.len().div_ceil(32) * 32);
-        assert_eq!(decode_error_string(&encoded), msg);
-    }
-
     // --- withdrawal amount validation tests ---
 
     fn bridge_params() -> BridgeParams {
@@ -346,9 +430,12 @@ mod tests {
 
         let output = bridge_context_call(input, bridge_params()).unwrap();
 
-        // Misuse reverts (refunding gas) rather than halting and burning all gas.
+        // Misuse reverts (refunding gas) with a typed error rather than halting.
         assert!(output.reverted);
-        assert!(decode_error_string(&output.bytes).contains("must be invoked via CALL"));
+        assert_eq!(
+            selector_of(&output.bytes),
+            BridgeOutError::IncorrectCallType.selector()
+        );
     }
 
     #[test]
@@ -370,7 +457,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bridgeout_over_cap_reverts_with_reason() {
+    fn test_bridgeout_over_cap_reverts_with_typed_error() {
         let calldata = valid_bridgeout_calldata();
         let mut journal: Journal<EmptyDB, JournalEntry> = Journal::new(EmptyDB::new());
         let block_env = BlockEnv::default();
@@ -392,7 +479,12 @@ mod tests {
             output.gas_used,
             bridgeout_gas_cost(valid_bridgeout_calldata().len()).unwrap()
         );
-        assert!(decode_error_string(&output.bytes).contains("exact multiple"));
+        assert_eq!(
+            selector_of(&output.bytes),
+            BridgeOutError::OversizeWithdrawal { max: U256::ZERO }.selector()
+        );
+        // The error carries the configured cap (10 BTC in sats).
+        assert_eq!(uint_param(&output.bytes), 1_000_000_000);
     }
 
     #[test]
@@ -414,32 +506,47 @@ mod tests {
 
     #[test]
     fn test_validate_withdrawal_zero_rejected() {
-        assert!(validate_withdrawal_amount(U256::ZERO, &bridge_params()).is_err());
-    }
-
-    #[test]
-    fn test_validate_withdrawal_non_multiple_rejected() {
-        assert!(
-            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI + U256::from(1), &bridge_params())
-                .is_err()
+        assert_eq!(
+            validate_withdrawal_amount(U256::ZERO, &bridge_params()).unwrap_err(),
+            BridgeOutError::IncorrectAmount {
+                denomination: U256::from(100_000_000u64)
+            }
         );
     }
 
     #[test]
-    fn test_validate_withdrawal_below_denomination_rejected() {
-        assert!(
-            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI - U256::from(1), &bridge_params())
-                .is_err()
+    fn test_validate_withdrawal_non_multiple_rejected() {
+        assert_eq!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI + U256::from(1), &bridge_params())
+                .unwrap_err(),
+            BridgeOutError::NonIntegerAmount
+        );
+    }
+
+    #[test]
+    fn test_validate_withdrawal_sub_denomination_multiple_rejected() {
+        // 1.5 BTC: a whole number of sats, but not a multiple of the 1 BTC denomination.
+        assert_eq!(
+            validate_withdrawal_amount(
+                FIXED_WITHDRAWAL_WEI + FIXED_WITHDRAWAL_WEI / U256::from(2),
+                &bridge_params()
+            )
+            .unwrap_err(),
+            BridgeOutError::IncorrectAmount {
+                denomination: U256::from(100_000_000u64)
+            }
         );
     }
 
     #[test]
     fn test_validate_withdrawal_exceeds_cap() {
-        assert!(validate_withdrawal_amount(
-            FIXED_WITHDRAWAL_WEI * U256::from(11),
-            &bridge_params()
-        )
-        .is_err());
+        assert_eq!(
+            validate_withdrawal_amount(FIXED_WITHDRAWAL_WEI * U256::from(11), &bridge_params())
+                .unwrap_err(),
+            BridgeOutError::OversizeWithdrawal {
+                max: U256::from(1_000_000_000u64)
+            }
+        );
     }
 
     #[test]
@@ -476,13 +583,21 @@ mod tests {
         let mut bosd = vec![0u8; MAX_DESCRIPTOR_LEN as usize + 1];
         bosd[0] = 0x00;
 
-        assert!(validate_bosd(&bosd, &bridge_params()).is_err());
+        assert_eq!(
+            validate_bosd(&bosd, &bridge_params()).unwrap_err(),
+            BridgeOutError::OversizeBosd {
+                max: U256::from(MAX_DESCRIPTOR_LEN)
+            }
+        );
     }
 
     #[test]
     fn test_validate_bosd_rejects_malformed_descriptor() {
         let bosd = [0x03, 0x01, 0x02, 0x03];
 
-        assert!(validate_bosd(&bosd, &bridge_params()).is_err());
+        assert_eq!(
+            validate_bosd(&bosd, &bridge_params()).unwrap_err(),
+            BridgeOutError::MalformedCalldataBosd
+        );
     }
 }

--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -14,6 +14,44 @@ const BRIDGEOUT_BASE_GAS: u64 = 10_000;
 /// Raw EVM gas charged per calldata byte handled by the bridge-out precompile.
 const BRIDGEOUT_CALLDATA_BYTE_GAS: u64 = 16;
 
+/// Solidity `Error(string)` selector: `bytes4(keccak256("Error(string)"))`.
+const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
+
+/// Appends `value` as a 32-byte big-endian ABI word.
+fn push_abi_word(out: &mut Vec<u8>, value: u64) {
+    let mut word = [0u8; 32];
+    word[24..].copy_from_slice(&value.to_be_bytes());
+    out.extend_from_slice(&word);
+}
+
+/// ABI-encodes a human-readable reason as Solidity `Error(string)` revert data so
+/// standard tooling (ethers/web3/foundry) decodes it as `revert("...")`.
+fn abi_encode_error_string(reason: &str) -> Bytes {
+    let reason_bytes = reason.as_bytes();
+    let len = reason_bytes.len();
+    let padded_len = len.div_ceil(32) * 32;
+
+    let mut out = Vec::with_capacity(4 + 64 + padded_len);
+    out.extend_from_slice(&ERROR_STRING_SELECTOR);
+    push_abi_word(&mut out, 32); // offset to the string data (always 0x20)
+    push_abi_word(&mut out, len as u64); // string length
+    out.extend_from_slice(reason_bytes); // string bytes
+    out.resize(4 + 64 + padded_len, 0); // right-pad to a 32-byte boundary
+    Bytes::from(out)
+}
+
+/// Builds a gas-refunding revert carrying an ABI-encoded `Error(string)` reason.
+///
+/// Unlike returning `Err(PrecompileError::other(..))` — which is an exceptional halt
+/// that burns all gas forwarded to the call — a revert refunds the unspent gas
+/// (only `gas_used` is charged) and surfaces `reason` as the call's return data.
+fn revert_with_reason(gas_used: u64, reason: &str) -> PrecompileResult {
+    Ok(PrecompileOutput::new_reverted(
+        gas_used,
+        abi_encode_error_string(reason),
+    ))
+}
+
 /// Custom precompile to burn rollup native token and add bridge out intent of equal amount.
 /// Bridge out intent is created during block payload generation.
 /// This precompile validates transaction and burns the bridge out amount.
@@ -25,29 +63,37 @@ pub(crate) fn bridge_context_call(
     mut input: PrecompileInput<'_>,
     bridge_params: BridgeParams,
 ) -> PrecompileResult {
-    if !input.is_direct_call() {
-        return Err(PrecompileError::other(
-            "bridgeout precompile must be invoked via CALL",
-        ));
-    }
-
+    // Compute the gas this call should be charged. A genuine "not enough gas to even
+    // run" condition is the one case that stays a hard out-of-gas halt.
     let gas_cost = bridgeout_gas_cost(input.data.len())?;
     if gas_cost > input.gas {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let calldata = WithdrawalCalldata::decode(input.data).ok_or_else(|| {
-        PrecompileError::other(
+    // From here on, user-facing validation failures revert (refunding unspent gas and
+    // returning a reason) rather than halting and burning all forwarded gas.
+    if !input.is_direct_call() {
+        return revert_with_reason(gas_cost, "bridgeout precompile must be invoked via CALL");
+    }
+
+    let Some(calldata) = WithdrawalCalldata::decode(input.data) else {
+        return revert_with_reason(
+            gas_cost,
             "Calldata too short: expected at least 5 bytes (4 operator + 1 BOSD)",
-        )
-    })?;
+        );
+    };
 
     // Validate that this is a valid BOSD.
-    validate_bosd(&calldata.bosd, &bridge_params)?;
+    if let Err(reason) = validate_bosd(&calldata.bosd, &bridge_params) {
+        return revert_with_reason(gas_cost, &reason);
+    }
 
     // Verify that the transaction value is a positive exact multiple of the withdrawal
     // denomination.
-    let amount = validate_withdrawal_amount(input.value, &bridge_params)?;
+    let amount = match validate_withdrawal_amount(input.value, &bridge_params) {
+        Ok(amount) => amount,
+        Err(reason) => return revert_with_reason(gas_cost, &reason),
+    };
 
     // Log the bridge withdrawal intent
     let evt = WithdrawalIntentEvent {
@@ -74,9 +120,9 @@ pub(crate) fn bridge_context_call(
     Ok(PrecompileOutput::new(gas_cost, Bytes::new()))
 }
 
-fn sats_to_withdrawal_amount(sats: U256) -> Result<u64, PrecompileError> {
+fn sats_to_withdrawal_amount(sats: U256) -> Result<u64, String> {
     sats.try_into()
-        .map_err(|_| PrecompileError::other("Withdrawal amount exceeds maximum allowed value"))
+        .map_err(|_| "Withdrawal amount exceeds maximum allowed value".to_string())
 }
 
 fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
@@ -93,39 +139,39 @@ fn bridgeout_gas_cost(calldata_len: usize) -> Result<u64, PrecompileError> {
 fn validate_withdrawal_amount(
     amount_wei: U256,
     bridge_params: &BridgeParams,
-) -> Result<u64, PrecompileError> {
+) -> Result<u64, String> {
     let (amount_sats, remainder_wei) = wei_to_sats(amount_wei);
     if !remainder_wei.is_zero() {
-        return Err(PrecompileError::other(format!(
+        return Err(format!(
             "Invalid withdrawal value {amount_wei}: must be an exact number of satoshis",
-        )));
+        ));
     }
 
     let amount_sats = sats_to_withdrawal_amount(amount_sats)?;
 
     if !bridge_params.validate_withdrawal_amount(amount_sats) {
-        return Err(PrecompileError::other(format!(
+        return Err(format!(
             "Invalid withdrawal value: {amount_sats} sats must be a positive exact multiple of {} sats and within {:?} sats",
             bridge_params.denomination(),
             bridge_params.max_withdrawal_amount()
-        )));
+        ));
     }
 
     Ok(amount_sats)
 }
 
 /// Validates that input is a valid BOSD [`Descriptor`] within the configured limit.
-fn validate_bosd(data: &[u8], bridge_params: &BridgeParams) -> Result<(), PrecompileError> {
+fn validate_bosd(data: &[u8], bridge_params: &BridgeParams) -> Result<(), String> {
     if !bridge_params.validate_withdrawal_descriptor_len(data.len()) {
-        return Err(PrecompileError::other(format!(
+        return Err(format!(
             "Invalid BOSD: descriptor length {} exceeds maximum {}",
             data.len(),
             bridge_params.max_withdrawal_descriptor_len()
-        )));
+        ));
     }
 
     Descriptor::from_bytes(data)
-        .map_err(|_| PrecompileError::other("Invalid BOSD: expected a valid BOSD descriptor"))?;
+        .map_err(|_| "Invalid BOSD: expected a valid BOSD descriptor".to_string())?;
     Ok(())
 }
 
@@ -152,6 +198,14 @@ mod tests {
         buf
     };
     const MAX_DESCRIPTOR_LEN: u32 = 81;
+
+    /// Decodes Solidity `Error(string)` revert data back into its message.
+    fn decode_error_string(data: &[u8]) -> String {
+        assert_eq!(&data[0..4], &ERROR_STRING_SELECTOR, "wrong revert selector");
+        // Layout: selector[4] | offset word[32] | length word[32] | data[..]
+        let len = u64::from_be_bytes(data[60..68].try_into().unwrap()) as usize;
+        String::from_utf8(data[68..68 + len].to_vec()).unwrap()
+    }
 
     #[test]
     fn test_decode_calldata_empty() {
@@ -244,7 +298,18 @@ mod tests {
     fn test_sats_to_withdrawal_amount_rejects_overflow_as_recoverable_error() {
         let err = sats_to_withdrawal_amount(U256::from(u64::MAX) + U256::from(1)).unwrap_err();
 
-        assert!(matches!(err, PrecompileError::Other(_)));
+        assert!(err.contains("exceeds maximum allowed value"));
+    }
+
+    #[test]
+    fn test_abi_encode_error_string_roundtrips() {
+        let msg = "Withdrawal value 11 exceeds maximum allowed 10 wei";
+        let encoded = abi_encode_error_string(msg);
+
+        // Selector + two head words + content padded to a 32-byte boundary.
+        assert_eq!(&encoded[0..4], &ERROR_STRING_SELECTOR);
+        assert_eq!(encoded.len(), 4 + 64 + msg.len().div_ceil(32) * 32);
+        assert_eq!(decode_error_string(&encoded), msg);
     }
 
     // --- withdrawal amount validation tests ---
@@ -279,12 +344,11 @@ mod tests {
             internals: EvmInternals::new(&mut journal, &block_env),
         };
 
-        let error = bridge_context_call(input, bridge_params()).unwrap_err();
+        let output = bridge_context_call(input, bridge_params()).unwrap();
 
-        assert_eq!(
-            error,
-            PrecompileError::Other("bridgeout precompile must be invoked via CALL".into())
-        );
+        // Misuse reverts (refunding gas) rather than halting and burning all gas.
+        assert!(output.reverted);
+        assert!(decode_error_string(&output.bytes).contains("must be invoked via CALL"));
     }
 
     #[test]
@@ -303,6 +367,32 @@ mod tests {
         };
 
         assert!(bridge_context_call(input, bridge_params()).is_ok());
+    }
+
+    #[test]
+    fn test_bridgeout_over_cap_reverts_with_reason() {
+        let calldata = valid_bridgeout_calldata();
+        let mut journal: Journal<EmptyDB, JournalEntry> = Journal::new(EmptyDB::new());
+        let block_env = BlockEnv::default();
+        let input = PrecompileInput {
+            data: &calldata,
+            gas: u64::MAX,
+            caller: address!("1111111111111111111111111111111111111111"),
+            value: FIXED_WITHDRAWAL_WEI * U256::from(11),
+            target_address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            bytecode_address: BRIDGEOUT_PRECOMPILE_ADDRESS,
+            internals: EvmInternals::new(&mut journal, &block_env),
+        };
+
+        let output = bridge_context_call(input, bridge_params()).unwrap();
+
+        assert!(output.reverted);
+        // Only the computed gas cost is charged; the caller keeps the remainder.
+        assert_eq!(
+            output.gas_used,
+            bridgeout_gas_cost(valid_bridgeout_calldata().len()).unwrap()
+        );
+        assert!(decode_error_string(&output.bytes).contains("exact multiple"));
     }
 
     #[test]

--- a/functional-tests/tests/alpen_client/precompiles/test_bridgeout_cap.py
+++ b/functional-tests/tests/alpen_client/precompiles/test_bridgeout_cap.py
@@ -17,6 +17,7 @@ from common.base_test import BaseTest
 from common.config.constants import DEV_CHAIN_ID, DEV_PRIVATE_KEY, ServiceType
 from common.evm import DEV_ACCOUNT_ADDRESS
 from common.precompile import PRECOMPILE_BRIDGEOUT_ADDRESS, wait_for_receipt
+from common.rpc import RpcError
 from common.services import AlpenClientService
 from envconfigs.alpen_client import AlpenClientEnv
 
@@ -26,11 +27,19 @@ SATS_TO_WEI = 10**10
 DENOMINATION_SATS = 100_000_000  # 1 BTC
 MAX_WITHDRAWAL_SATS = 1_000_000_000  # 10 BTC
 
+# Gas limit forwarded with each bridgeout tx. A rejected withdrawal should REVERT and
+# refund the unspent gas, so a failing tx must consume far less than this. If failures
+# instead halted (the old behavior), gasUsed would pin to ~GAS_LIMIT.
+GAS_LIMIT = 200_000
+
 # Bridgeout calldata: [4 bytes: selected_operator (u32 big-endian)][BOSD bytes]
 # 0xFFFFFFFF = no operator preference
 # 0x03 + 20 bytes = valid P2WPKH BOSD descriptor
 NO_OP_HEX = "ffffffff"
 VALID_P2WPKH_BOSD_HEX = "03" + "14" * 20
+
+# Solidity Error(string) selector, bytes4(keccak256("Error(string)")).
+ERROR_STRING_SELECTOR = "08c379a0"
 
 
 def build_bridgeout_tx(rpc, amount_sats: int, nonce: int) -> dict:
@@ -39,12 +48,61 @@ def build_bridgeout_tx(rpc, amount_sats: int, nonce: int) -> dict:
     return {
         "nonce": nonce,
         "gasPrice": gas_price,
-        "gas": 200_000,
+        "gas": GAS_LIMIT,
         "to": to_checksum_address(PRECOMPILE_BRIDGEOUT_ADDRESS),
         "value": amount_sats * SATS_TO_WEI,
         "data": bytes.fromhex(NO_OP_HEX + VALID_P2WPKH_BOSD_HEX),
         "chainId": DEV_CHAIN_ID,
     }
+
+
+def gas_used(receipt: dict) -> int:
+    """Return the receipt's gasUsed as an int (handles hex or int encodings)."""
+    used = receipt["gasUsed"]
+    return int(used, 16) if isinstance(used, str) else used
+
+
+def get_revert_reason(rpc, amount_sats: int) -> str | None:
+    """Simulate a bridgeout via eth_call and return the revert error text, if any.
+
+    Returns the RPC error string on revert (which carries the decoded Error(string)
+    reason and/or the 0x08c379a0 revert payload), or None if the call did not revert.
+    """
+    try:
+        rpc.eth_call(
+            {
+                "from": DEV_ACCOUNT_ADDRESS,
+                "to": to_checksum_address(PRECOMPILE_BRIDGEOUT_ADDRESS),
+                "value": hex(amount_sats * SATS_TO_WEI),
+                "data": "0x" + NO_OP_HEX + VALID_P2WPKH_BOSD_HEX,
+            },
+            "latest",
+        )
+        return None
+    except RpcError as e:
+        return str(e)
+
+
+def assert_reverted(rpc, receipt: dict, amount_sats: int, expect_reason: str):
+    """Assert a failing bridgeout reverted with gas refunded and the expected reason."""
+    status = receipt["status"]
+    status = int(status, 16) if isinstance(status, str) else status
+    assert status == 0, f"expected failure status, got {status}"
+
+    # A revert refunds unspent gas; a gas-burning halt would consume ~GAS_LIMIT.
+    used = gas_used(receipt)
+    assert used < GAS_LIMIT // 2, (
+        f"expected gas to be refunded on revert, but gasUsed={used} (limit {GAS_LIMIT}) "
+        f"— this looks like an all-gas-consuming halt, not a revert"
+    )
+
+    # The reason should be recoverable from an eth_call simulation.
+    reason = get_revert_reason(rpc, amount_sats)
+    assert reason is not None, "eth_call did not revert"
+    reason_l = reason.lower()
+    assert expect_reason.lower() in reason_l or ERROR_STRING_SELECTOR in reason_l, (
+        f"revert reason {reason!r} missing expected text {expect_reason!r} / selector"
+    )
 
 
 @flexitest.register
@@ -60,7 +118,7 @@ class TestBridgeoutWithdrawalCap(BaseTest):
 
         nonce = int(rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
 
-        # --- Test 1: Over-cap (11 BTC) should revert ---
+        # --- Test 1: Over-cap (11 BTC) should revert with gas refunded ---
         over_cap_sats = 11 * DENOMINATION_SATS
         logger.info(f"Test 1: bridgeout {over_cap_sats} sats (over cap, expect revert)")
 
@@ -69,13 +127,13 @@ class TestBridgeoutWithdrawalCap(BaseTest):
         tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
         receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
 
-        assert receipt["status"] in (0, "0x0"), (
-            f"Over-cap bridgeout should revert, got status {receipt['status']}"
+        assert_reverted(rpc, receipt, over_cap_sats, expect_reason="exact multiple")
+        logger.info(
+            f"  Over-cap bridgeout reverted as expected, gasUsed={gas_used(receipt)} (refunded)"
         )
-        logger.info("  Over-cap bridgeout reverted as expected")
         nonce += 1
 
-        # --- Test 2: Non-multiple of denomination (0.5 BTC) should revert ---
+        # --- Test 2: Non-multiple of denomination (0.5 BTC) should revert with gas refunded ---
         non_multiple_sats = 50_000_000  # 0.5 BTC
         logger.info(f"Test 2: bridgeout {non_multiple_sats} sats (non-multiple, expect revert)")
 
@@ -84,15 +142,15 @@ class TestBridgeoutWithdrawalCap(BaseTest):
         tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
         receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
 
-        assert receipt["status"] in (0, "0x0"), (
-            f"Non-multiple bridgeout should revert, got status {receipt['status']}"
+        assert_reverted(rpc, receipt, non_multiple_sats, expect_reason="positive exact multiple")
+        logger.info(
+            f"  Non-multiple bridgeout reverted as expected, gasUsed={gas_used(receipt)} (refunded)"
         )
-        logger.info("  Non-multiple bridgeout reverted as expected")
         nonce += 1
 
         # --- Test 3: At-cap (10 BTC) should succeed ---
         at_cap_sats = MAX_WITHDRAWAL_SATS
-        logger.info(f"Test 2: bridgeout {at_cap_sats} sats (at cap, expect success)")
+        logger.info(f"Test 3: bridgeout {at_cap_sats} sats (at cap, expect success)")
 
         tx = build_bridgeout_tx(rpc, at_cap_sats, nonce)
         signed = Account.sign_transaction(tx, DEV_PRIVATE_KEY)

--- a/functional-tests/tests/alpen_client/precompiles/test_bridgeout_cap.py
+++ b/functional-tests/tests/alpen_client/precompiles/test_bridgeout_cap.py
@@ -1,8 +1,11 @@
 """Verify the bridgeout precompile enforces the withdrawal cap.
 
-Sends two transactions to the bridgeout precompile:
-  1. Over-cap amount (11 BTC) -> expects revert
-  2. At-cap amount (10 BTC) -> expects success
+Sends transactions to the bridgeout precompile and checks that rejected withdrawals
+REVERT (refunding gas) with the expected ABI custom-error selector, while a valid
+at-cap withdrawal succeeds.
+Test 1: Over-cap amount (11 BTC) -> expects revert
+Test 2: Non-integer multiple of the denomination -> expects revert
+Test 3: At-cap amount (10 BTC) -> expects success
 
 Uses the dev account which has a large pre-funded balance.
 """
@@ -38,8 +41,10 @@ GAS_LIMIT = 200_000
 NO_OP_HEX = "ffffffff"
 VALID_P2WPKH_BOSD_HEX = "03" + "14" * 20
 
-# Solidity Error(string) selector, bytes4(keccak256("Error(string)")).
-ERROR_STRING_SELECTOR = "08c379a0"
+# Bridge-out custom-error selectors, bytes4(keccak256(signature)). Kept in sync with
+# bridge.rs (which has a keccak256 drift test) and IBridgeOut.sol.
+SELECTOR_INCORRECT_AMOUNT = "88967d2f"  # IncorrectAmount(uint256)
+SELECTOR_OVERSIZE_WITHDRAWAL = "b0701377"  # OversizeWithdrawal(uint256)
 
 
 def build_bridgeout_tx(rpc, amount_sats: int, nonce: int) -> dict:
@@ -62,11 +67,13 @@ def gas_used(receipt: dict) -> int:
     return int(used, 16) if isinstance(used, str) else used
 
 
-def get_revert_reason(rpc, amount_sats: int) -> str | None:
-    """Simulate a bridgeout via eth_call and return the revert error text, if any.
+def get_revert_data(rpc, amount_sats: int) -> str | None:
+    """Simulate a bridgeout via eth_call and return the revert payload hex, if any.
 
-    Returns the RPC error string on revert (which carries the decoded Error(string)
-    reason and/or the 0x08c379a0 revert payload), or None if the call did not revert.
+    On revert the node returns the raw revert bytes in the JSON-RPC error `data`
+    field, i.e. `bytes4(selector) ++ abi.encode(args)`. The custom-error selector
+    lives there, NOT in the human message. Returns that hex string, or None if the
+    call did not revert (or carried no data).
     """
     try:
         rpc.eth_call(
@@ -80,28 +87,35 @@ def get_revert_reason(rpc, amount_sats: int) -> str | None:
         )
         return None
     except RpcError as e:
-        return str(e)
+        data = e.data
+        # Some nodes nest the payload, e.g. {"data": "0x..."}.
+        if isinstance(data, dict):
+            data = data.get("data") or data.get("message")
+        return data if isinstance(data, str) else None
 
 
-def assert_reverted(rpc, receipt: dict, amount_sats: int, expect_reason: str):
-    """Assert a failing bridgeout reverted with gas refunded and the expected reason."""
+def assert_reverted(rpc, receipt: dict, amount_sats: int, expect_selector: str):
+    """Assert a failing bridgeout reverted with gas refunded and the expected custom error."""
     status = receipt["status"]
     status = int(status, 16) if isinstance(status, str) else status
     assert status == 0, f"expected failure status, got {status}"
 
     # A revert refunds unspent gas; a gas-burning halt would consume ~GAS_LIMIT.
+    # Note: for all practical purposes this is a binary check: either we consume the fixed amount of
+    # gas, roughly 30k gas units, or we consume the entire gas. So the following assert suffices. If
+    # it fails, something is wrong.
     used = gas_used(receipt)
     assert used < GAS_LIMIT // 2, (
         f"expected gas to be refunded on revert, but gasUsed={used} (limit {GAS_LIMIT}) "
         f"— this looks like an all-gas-consuming halt, not a revert"
     )
 
-    # The reason should be recoverable from an eth_call simulation.
-    reason = get_revert_reason(rpc, amount_sats)
-    assert reason is not None, "eth_call did not revert"
-    reason_l = reason.lower()
-    assert expect_reason.lower() in reason_l or ERROR_STRING_SELECTOR in reason_l, (
-        f"revert reason {reason!r} missing expected text {expect_reason!r} / selector"
+    # The custom-error selector should be recoverable from an eth_call simulation, whose
+    # revert payload is `bytes4(selector) ++ abi.encode(args)`.
+    revert_data = get_revert_data(rpc, amount_sats)
+    assert revert_data is not None, "eth_call did not revert with data"
+    assert expect_selector.lower() in revert_data.lower(), (
+        f"revert payload {revert_data!r} missing expected selector 0x{expect_selector}"
     )
 
 
@@ -127,7 +141,7 @@ class TestBridgeoutWithdrawalCap(BaseTest):
         tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
         receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
 
-        assert_reverted(rpc, receipt, over_cap_sats, expect_reason="exact multiple")
+        assert_reverted(rpc, receipt, over_cap_sats, expect_selector=SELECTOR_OVERSIZE_WITHDRAWAL)
         logger.info(
             f"  Over-cap bridgeout reverted as expected, gasUsed={gas_used(receipt)} (refunded)"
         )
@@ -142,7 +156,7 @@ class TestBridgeoutWithdrawalCap(BaseTest):
         tx_hash = rpc.eth_sendRawTransaction("0x" + signed.raw_transaction.hex())
         receipt = wait_for_receipt(rpc, tx_hash, timeout=30)
 
-        assert_reverted(rpc, receipt, non_multiple_sats, expect_reason="positive exact multiple")
+        assert_reverted(rpc, receipt, non_multiple_sats, expect_selector=SELECTOR_INCORRECT_AMOUNT)
         logger.info(
             f"  Non-multiple bridgeout reverted as expected, gasUsed={gas_used(receipt)} (refunded)"
         )


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
The reported issue (str-3855) is that on failure on the bridge precompile contract the entire tx gas is consumed -- this is an incorrect behaviour, since as a precompile, gas consumption should be fixed (though dependent on the calldata length).
The crux of the issue is that in the previous implementation, when the contract throws an error it does not make sure to "revert" the call and "refund" the user for the additional gas (beyond the precompile setting). This is being handled in this PR.

The entire code was written by Claude, Opus 4.8 model. I verified it.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
[str-3855](https://alpenlabs.atlassian.net/browse/STR-3855)