### PR TITLE
feat(chainspec): add safe factory to testnet3 genesis

### DIFF
--- a/crates/reth/chainspec/src/res/testnet3-chain.json
+++ b/crates/reth/chainspec/src/res/testnet3-chain.json
@@ -6,6 +6,13 @@
     "difficulty": "0x0",
     "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x5400000000000000000000000000000000000011",
+    "alloc": {
+        "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7": {
+            "balance": "0x0",
+            "nonce": "0x1",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
+        }
+    },
     "number": "0x0",
     "gasUsed": "0x0",
     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
## Description

Adds the Safe singleton factory account to the Testnet III Reth genesis `alloc` so the factory is present from genesis for the production Testnet III deployment.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The Safe factory allocation uses the address, nonce, balance, and runtime bytecode shared in the Slack coordination thread.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- Slack thread: https://alpen-labs.slack.com/archives/C0AUP27EFQD/p1782130067558289

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This PR was prepared with assistance from Codex.

Validation:

- `jq . crates/reth/chainspec/src/res/testnet3-chain.json`
- `cargo test -p alpen-chainspec`

## Related Issues

N/A
