### PR TITLE
backport: fix(reth): capture contract bytecode missing from block witness (#2024)

### DIFF
--- a/crates/reth/node/src/block_witness.rs
+++ b/crates/reth/node/src/block_witness.rs
@@ -12,7 +12,10 @@
 //! sparse state at assembly time (see `EvmPartialState::from_witness_parts`), so
 //! the trie reconstruction is a chunk-level concern.
 
+use std::collections::BTreeMap;
+
 use alloy_consensus::Header;
+use alloy_primitives::{keccak256, Bytes, B256};
 use reth_provider::{HeaderProvider, StateProofProvider};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord, Database};
 use reth_trie::TrieInput;
@@ -100,7 +103,7 @@ where
         .map(|node| node.to_vec())
         .collect();
 
-    let codes = codes.into_iter().map(|code| code.to_vec()).collect();
+    let codes = collect_accessed_codes(executed_state, codes)?;
 
     // BLOCKHASH ancestor headers: the contiguous range from the lowest block
     // referenced (or just the parent) up to the parent.
@@ -120,4 +123,211 @@ where
         raw_block_rlp: block_rlp,
         raw_parent_header_rlp,
     })
+}
+
+/// Collects every bytecode the block accessed, deduped by code hash, to store
+/// in the block witness.
+///
+/// The witness is the only source of bytecode when the block is later
+/// re-executed for proving, so it must carry every code the block touched.
+/// reth's [`ExecutionWitnessRecord`] is not enough on its own: it reports only
+/// code that passed through its in-memory bytecode stores (`cache.contracts` +
+/// `bundle_state.contracts`), so a contract whose code reached the EVM solely
+/// via its account's `info.code` — a warm load that never issued a by-hash
+/// fetch — is silently left out.
+///
+/// This starts from reth's `record_codes` and adds the code of every accessed
+/// account that carries one, so the result is complete regardless of how each
+/// contract's code was loaded.
+fn collect_accessed_codes<DB>(
+    executed_state: &State<DB>,
+    record_codes: Vec<Bytes>,
+) -> eyre::Result<Vec<Vec<u8>>>
+where
+    DB: Database,
+{
+    let mut codes_by_hash: BTreeMap<B256, Bytes> = record_codes
+        .into_iter()
+        .map(|code| (keccak256(&code), code))
+        .collect();
+
+    for account in executed_state.cache.accounts.values() {
+        let Some(plain) = &account.account else {
+            continue;
+        };
+        if plain.info.is_empty_code_hash() {
+            continue;
+        }
+        let Some(code) = &plain.info.code else {
+            continue;
+        };
+
+        // The guest content-addresses code by `keccak256(bytes)`, so code stored
+        // under a hash that disagrees with its bytes would be unreachable there.
+        // Surface the inconsistency as a build failure now, not a guest panic.
+        let actual_hash = code.hash_slow();
+        if actual_hash != plain.info.code_hash {
+            eyre::bail!(
+                "accessed account bytecode hash mismatch: expected_code_hash={}, actual_hash={actual_hash}",
+                plain.info.code_hash,
+            );
+        }
+
+        codes_by_hash
+            .entry(plain.info.code_hash)
+            .or_insert_with(|| code.original_bytes());
+    }
+
+    Ok(codes_by_hash
+        .into_values()
+        .map(|code| code.to_vec())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use reth_revm::db::{states::cache_account::CacheAccount, EmptyDB, State};
+    use revm::state::{AccountInfo, Bytecode};
+
+    use super::*;
+
+    /// A contract whose code is attached to its account `info.code` but never
+    /// entered `cache.contracts` (the in-memory bytecode store
+    /// `record_executed_state` reads) must still be captured: otherwise the guest
+    /// panics in `WitnessDB::code_by_hash_ref` when that bytecode is missing.
+    #[test]
+    fn collects_code_attached_to_account_info_not_in_dedup_map() {
+        // A pre-existing contract whose code only lives on the loaded account.
+        let raw = Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xf3]); // PUSH1 0 PUSH1 0 RETURN
+        let code = Bytecode::new_raw(raw);
+        let code_hash = code.hash_slow();
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: Some(code),
+        };
+        state.cache.accounts.insert(
+            Address::repeat_byte(0x42),
+            CacheAccount::new_loaded(info, Default::default()),
+        );
+
+        // `record_executed_state` produced no codes (dedup map was empty), the
+        // exact condition that dropped the bytecode before the fix.
+        let codes = collect_accessed_codes(&state, Vec::new()).unwrap();
+
+        assert!(
+            codes.iter().any(|c| keccak256(c) == code_hash),
+            "accessed contract code must be captured even when only on info.code"
+        );
+    }
+
+    /// An empty-code (EOA) account must not contribute a bytecode entry.
+    #[test]
+    fn skips_accounts_without_code() {
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        let info = AccountInfo {
+            balance: U256::from(5u64),
+            nonce: 0,
+            ..Default::default()
+        };
+        state.cache.accounts.insert(
+            Address::repeat_byte(0x7),
+            CacheAccount::new_loaded(info, Default::default()),
+        );
+
+        assert!(collect_accessed_codes(&state, Vec::new())
+            .unwrap()
+            .is_empty());
+    }
+
+    /// Locks the exact bug shape: reth's raw `ExecutionWitnessRecord` can miss
+    /// code attached to an accessed account, but Alpen's block witness producer
+    /// must include it before persisting the record.
+    #[test]
+    fn regression_supplements_codes_missing_from_reth_record() {
+        let raw = Bytes::from_static(&[0x60, 0x2a, 0x60, 0x00, 0x52]);
+        let code = Bytecode::new_raw(raw);
+        let code_hash = code.hash_slow();
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: Some(code),
+        };
+        state.cache.accounts.insert(
+            Address::repeat_byte(0x24),
+            CacheAccount::new_loaded(info, Default::default()),
+        );
+
+        let mut record = ExecutionWitnessRecord::default();
+        record.record_executed_state(&state);
+        assert!(
+            !record.codes.iter().any(|code| keccak256(code) == code_hash),
+            "raw reth record should reproduce the missing-code condition"
+        );
+
+        let codes = collect_accessed_codes(&state, record.codes).unwrap();
+        assert!(
+            codes.iter().any(|code| keccak256(code) == code_hash),
+            "block witness codes must include every accessed account info.code"
+        );
+    }
+
+    /// Account-attached bytecode must be content-addressed by the account's
+    /// code hash. Otherwise the guest would still miss it after rehashing.
+    #[test]
+    fn rejects_account_info_code_with_mismatched_hash() {
+        let raw = Bytes::from_static(&[0x60, 0x00, 0x56]);
+        let code = Bytecode::new_raw(raw);
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash: B256::repeat_byte(0x11),
+            code: Some(code),
+        };
+        state.cache.accounts.insert(
+            Address::repeat_byte(0x55),
+            CacheAccount::new_loaded(info, Default::default()),
+        );
+
+        let err = collect_accessed_codes(&state, Vec::new()).unwrap_err();
+        assert!(
+            err.to_string().contains("bytecode hash mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A code supplied by both reth's record and an accessed account's
+    /// `info.code` is captured exactly once; supplementing is idempotent.
+    #[test]
+    fn dedupes_code_present_in_both_record_and_account_info() {
+        let raw = Bytes::from_static(&[0x60, 0x01, 0x60, 0x02, 0x01]); // PUSH1 1 PUSH1 2 ADD
+        let code = Bytecode::new_raw(raw.clone());
+        let code_hash = code.hash_slow();
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: Some(code),
+        };
+        state.cache.accounts.insert(
+            Address::repeat_byte(0x33),
+            CacheAccount::new_loaded(info, Default::default()),
+        );
+
+        // The same bytecode arrives via reth's record_codes and the account.
+        let codes = collect_accessed_codes(&state, vec![raw]).unwrap();
+
+        assert_eq!(codes.len(), 1, "duplicate code must collapse to one entry");
+        assert_eq!(keccak256(&codes[0]), code_hash);
+    }
 }


### PR DESCRIPTION
## Description

Backport of #2024 to `releases/0.3.0`.

Fix inline EE block-witness bytecode capture so chunk proofs include bytecode that is attached to accessed account state but absent from Reth's `ExecutionWitnessRecord.codes`.

`ExecutionWitnessRecord::record_executed_state` collects bytecodes from `cache.contracts` and `bundle_state.contracts`, but it can miss bytecode already attached to an accessed account as `account.info.code`. The chunk prover later builds `EvmPartialState.bytecodes` only from `BlockWitnessRecord.codes`, so guest replay can fail in `WitnessDB::code_by_hash_ref` with `Bytecode must be present in witness`.

Clean cherry-pick of `72541458` (squash-merge of #2024) onto `releases/0.3.0`; touches only `crates/reth/node/src/block_witness.rs`. `cargo check -p alpen-reth-node` passes.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Backports #2024