### PR TITLE
feat(dbtool): add EE batch rollback recovery command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15613,10 +15613,14 @@ dependencies = [
 name = "strata-dbtool"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "alloy-eips",
  "alpen-ee-common",
  "alpen-ee-database",
+ "alpen-reth-node",
  "argh",
  "hex",
+ "reth-node-api",
+ "reth-primitives-traits",
  "serde",
  "serde_json",
  "sled",
@@ -15633,6 +15637,7 @@ dependencies = [
  "strata-ol-chain-types",
  "strata-paas",
  "strata-primitives",
+ "tokio",
  "tracing-subscriber 0.3.23",
  "typed-sled",
  "zkaleido",

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -14,9 +14,8 @@ use std::{fmt, sync::Arc};
 
 use alloy_primitives::B256;
 use alpen_ee_common::{
-    build_ledger_refs_from_da, encode_batch_task_key, BatchId, BatchStatus, BatchStorage,
-    ChunkStorage, ExecBlockStorage, L1DaBlockRef, Storage, BATCH_TASK_KEY_TAG,
-    RANGE_TASK_KEY_BYTES,
+    build_ledger_refs_from_da, decode_batch_task_key, encode_batch_task_key, BatchId, BatchStatus,
+    BatchStorage, ChunkStorage, ExecBlockStorage, L1DaBlockRef, ProverTaskKeyDecodeError, Storage,
 };
 use alpen_ee_da_runtime::builders::{build_da_witness, DaDedupResolver, DaWitnessBuildError};
 use alpen_ee_database::EeNodeStorage;
@@ -62,32 +61,11 @@ impl From<BatchTask> for Vec<u8> {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum BatchTaskDecodeError {
-    #[error("invalid BatchTask byte length: expected {RANGE_TASK_KEY_BYTES}, got {0}")]
-    InvalidLength(usize),
-    #[error("invalid BatchTask tag byte: expected 0x{BATCH_TASK_KEY_TAG:02x}, got 0x{0:02x}")]
-    InvalidTag(u8),
-}
-
 impl TryFrom<Vec<u8>> for BatchTask {
-    type Error = BatchTaskDecodeError;
+    type Error = ProverTaskKeyDecodeError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        if bytes.len() != RANGE_TASK_KEY_BYTES {
-            return Err(BatchTaskDecodeError::InvalidLength(bytes.len()));
-        }
-        if bytes[0] != BATCH_TASK_KEY_TAG {
-            return Err(BatchTaskDecodeError::InvalidTag(bytes[0]));
-        }
-        let mut prev = [0u8; 32];
-        let mut last = [0u8; 32];
-        prev.copy_from_slice(&bytes[1..33]);
-        last.copy_from_slice(&bytes[33..]);
-        Ok(BatchTask(BatchId::from_parts(
-            Hash::from(prev),
-            Hash::from(last),
-        )))
+        decode_batch_task_key(&bytes).map(BatchTask)
     }
 }
 

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -14,8 +14,9 @@ use std::{fmt, sync::Arc};
 
 use alloy_primitives::B256;
 use alpen_ee_common::{
-    build_ledger_refs_from_da, BatchId, BatchStatus, BatchStorage, ChunkStorage, ExecBlockStorage,
-    L1DaBlockRef, Storage,
+    build_ledger_refs_from_da, encode_batch_task_key, BatchId, BatchStatus, BatchStorage,
+    ChunkStorage, ExecBlockStorage, L1DaBlockRef, Storage, BATCH_TASK_KEY_TAG,
+    RANGE_TASK_KEY_BYTES,
 };
 use alpen_ee_da_runtime::builders::{build_da_witness, DaDedupResolver, DaWitnessBuildError};
 use alpen_ee_database::EeNodeStorage;
@@ -55,31 +56,17 @@ impl fmt::Display for BatchTask {
     }
 }
 
-/// Single-byte kind tag for [`BatchTask`] encoding; see the matching
-/// `CHUNK_TASK_TAG` on `ChunkTask` for why the shared prover-task tree
-/// needs a discriminator.
-pub(crate) const BATCH_TASK_TAG: u8 = b'a';
-
-/// Tag byte + the underlying `BatchId`'s bytes.
-const BATCH_TASK_BYTES: usize = 1 + size_of::<BatchId>();
-
 impl From<BatchTask> for Vec<u8> {
     fn from(task: BatchTask) -> Self {
-        let mut buf = Vec::with_capacity(BATCH_TASK_BYTES);
-        buf.push(BATCH_TASK_TAG);
-        let prev: [u8; 32] = task.0.prev_block().into();
-        let last: [u8; 32] = task.0.last_block().into();
-        buf.extend_from_slice(&prev);
-        buf.extend_from_slice(&last);
-        buf
+        encode_batch_task_key(task.0)
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum BatchTaskDecodeError {
-    #[error("invalid BatchTask byte length: expected {BATCH_TASK_BYTES}, got {0}")]
+    #[error("invalid BatchTask byte length: expected {RANGE_TASK_KEY_BYTES}, got {0}")]
     InvalidLength(usize),
-    #[error("invalid BatchTask tag byte: expected 0x{BATCH_TASK_TAG:02x}, got 0x{0:02x}")]
+    #[error("invalid BatchTask tag byte: expected 0x{BATCH_TASK_KEY_TAG:02x}, got 0x{0:02x}")]
     InvalidTag(u8),
 }
 
@@ -87,10 +74,10 @@ impl TryFrom<Vec<u8>> for BatchTask {
     type Error = BatchTaskDecodeError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        if bytes.len() != BATCH_TASK_BYTES {
+        if bytes.len() != RANGE_TASK_KEY_BYTES {
             return Err(BatchTaskDecodeError::InvalidLength(bytes.len()));
         }
-        if bytes[0] != BATCH_TASK_TAG {
+        if bytes[0] != BATCH_TASK_KEY_TAG {
             return Err(BatchTaskDecodeError::InvalidTag(bytes[0]));
         }
         let mut prev = [0u8; 32];

--- a/bin/alpen-client/src/prover/spec_chunk.rs
+++ b/bin/alpen-client/src/prover/spec_chunk.rs
@@ -9,8 +9,8 @@
 use std::{fmt, sync::Arc};
 
 use alpen_ee_common::{
-    encode_chunk_task_key, BlockWitnessStore, ChunkId, ChunkStorage, ExecBlockStorage,
-    CHUNK_TASK_KEY_TAG, RANGE_TASK_KEY_BYTES,
+    decode_chunk_task_key, encode_chunk_task_key, BlockWitnessStore, ChunkId, ChunkStorage,
+    ExecBlockStorage, ProverTaskKeyDecodeError,
 };
 use alpen_ee_database::EeNodeStorage;
 use alpen_reth_node::BlockWitnessRecord;
@@ -55,32 +55,11 @@ impl From<ChunkTask> for Vec<u8> {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ChunkTaskDecodeError {
-    #[error("invalid ChunkTask byte length: expected {RANGE_TASK_KEY_BYTES}, got {0}")]
-    InvalidLength(usize),
-    #[error("invalid ChunkTask tag byte: expected 0x{CHUNK_TASK_KEY_TAG:02x}, got 0x{0:02x}")]
-    InvalidTag(u8),
-}
-
 impl TryFrom<Vec<u8>> for ChunkTask {
-    type Error = ChunkTaskDecodeError;
+    type Error = ProverTaskKeyDecodeError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        if bytes.len() != RANGE_TASK_KEY_BYTES {
-            return Err(ChunkTaskDecodeError::InvalidLength(bytes.len()));
-        }
-        if bytes[0] != CHUNK_TASK_KEY_TAG {
-            return Err(ChunkTaskDecodeError::InvalidTag(bytes[0]));
-        }
-        let mut prev = [0u8; 32];
-        let mut last = [0u8; 32];
-        prev.copy_from_slice(&bytes[1..33]);
-        last.copy_from_slice(&bytes[33..]);
-        Ok(ChunkTask(ChunkId::from_parts(
-            Hash::from(prev),
-            Hash::from(last),
-        )))
+        decode_chunk_task_key(&bytes).map(ChunkTask)
     }
 }
 

--- a/bin/alpen-client/src/prover/spec_chunk.rs
+++ b/bin/alpen-client/src/prover/spec_chunk.rs
@@ -8,7 +8,10 @@
 
 use std::{fmt, sync::Arc};
 
-use alpen_ee_common::{BlockWitnessStore, ChunkId, ChunkStorage, ExecBlockStorage};
+use alpen_ee_common::{
+    encode_chunk_task_key, BlockWitnessStore, ChunkId, ChunkStorage, ExecBlockStorage,
+    CHUNK_TASK_KEY_TAG, RANGE_TASK_KEY_BYTES,
+};
 use alpen_ee_database::EeNodeStorage;
 use alpen_reth_node::BlockWitnessRecord;
 use async_trait::async_trait;
@@ -46,33 +49,17 @@ impl fmt::Display for ChunkTask {
     }
 }
 
-/// Single-byte kind tag for [`ChunkTask`] encoding.
-///
-/// The chunk + acct provers share one sled prover-task tree; this tag
-/// disambiguates chunk keys from batch keys so single-chunk batches
-/// (same `(prev, last)` pair) can't collide.
-pub(crate) const CHUNK_TASK_TAG: u8 = b'c';
-
-/// Tag byte + the underlying `ChunkId`'s bytes.
-const CHUNK_TASK_BYTES: usize = 1 + size_of::<ChunkId>();
-
 impl From<ChunkTask> for Vec<u8> {
     fn from(task: ChunkTask) -> Self {
-        let mut buf = Vec::with_capacity(CHUNK_TASK_BYTES);
-        buf.push(CHUNK_TASK_TAG);
-        let prev: [u8; 32] = task.0.prev_block().into();
-        let last: [u8; 32] = task.0.last_block().into();
-        buf.extend_from_slice(&prev);
-        buf.extend_from_slice(&last);
-        buf
+        encode_chunk_task_key(task.0)
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ChunkTaskDecodeError {
-    #[error("invalid ChunkTask byte length: expected {CHUNK_TASK_BYTES}, got {0}")]
+    #[error("invalid ChunkTask byte length: expected {RANGE_TASK_KEY_BYTES}, got {0}")]
     InvalidLength(usize),
-    #[error("invalid ChunkTask tag byte: expected 0x{CHUNK_TASK_TAG:02x}, got 0x{0:02x}")]
+    #[error("invalid ChunkTask tag byte: expected 0x{CHUNK_TASK_KEY_TAG:02x}, got 0x{0:02x}")]
     InvalidTag(u8),
 }
 
@@ -80,10 +67,10 @@ impl TryFrom<Vec<u8>> for ChunkTask {
     type Error = ChunkTaskDecodeError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        if bytes.len() != CHUNK_TASK_BYTES {
+        if bytes.len() != RANGE_TASK_KEY_BYTES {
             return Err(ChunkTaskDecodeError::InvalidLength(bytes.len()));
         }
-        if bytes[0] != CHUNK_TASK_TAG {
+        if bytes[0] != CHUNK_TASK_KEY_TAG {
             return Err(ChunkTaskDecodeError::InvalidTag(bytes[0]));
         }
         let mut prev = [0u8; 32];

--- a/bin/alpen-client/src/prover/storage.rs
+++ b/bin/alpen-client/src/prover/storage.rs
@@ -3,7 +3,7 @@
 //! Three managers, all wrapping the shared [`EeProverDbSled`]:
 //!
 //! - [`EeProverTaskDbManager`] — impls `paas::TaskStore`. Shared across chunk + acct provers via
-//!   the kind-tagged task-key encoding (see `CHUNK_TASK_TAG` / `BATCH_TASK_TAG`).
+//!   the kind-tagged task-key encoding (see `CHUNK_TASK_KEY_TAG` / `BATCH_TASK_KEY_TAG`).
 //! - [`EeChunkReceiptStore`] — impls `paas::ReceiptStore`. The chunk prover writes here; the acct
 //!   `fetch_input` reads from here.
 //! - [`EeBatchProofDbManager`] — typed API keyed by [`BatchId`]; the outer (acct) prover writes

--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -11,8 +11,8 @@ name = "strata-datatool"
 path = "src/main.rs"
 
 [dependencies]
-alpen-ee-config.workspace = true
 alpen-chainspec.workspace = true
+alpen-ee-config.workspace = true
 strata-asm-params.workspace = true
 strata-asm-proto-bridge-v1-types.workspace = true
 strata-btc-types.workspace = true

--- a/bin/strata-dbtool/Cargo.toml
+++ b/bin/strata-dbtool/Cargo.toml
@@ -11,10 +11,10 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-argh.workspace = true
 alloy-eips.workspace = true
-hex.workspace = true
 alpen-reth-node.workspace = true
+argh.workspace = true
+hex.workspace = true
 reth-node-api.workspace = true
 reth-primitives-traits.workspace = true
 serde.workspace = true

--- a/bin/strata-dbtool/Cargo.toml
+++ b/bin/strata-dbtool/Cargo.toml
@@ -12,10 +12,15 @@ workspace = true
 
 [dependencies]
 argh.workspace = true
+alloy-eips.workspace = true
 hex.workspace = true
+alpen-reth-node.workspace = true
+reth-node-api.workspace = true
+reth-primitives-traits.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sled.workspace = true
+tokio.workspace = true
 tracing-subscriber.workspace = true
 typed-sled.workspace = true
 zkaleido.workspace = true

--- a/bin/strata-dbtool/README.md
+++ b/bin/strata-dbtool/README.md
@@ -568,6 +568,51 @@ strata-dbtool ee-get-acct-proof <prev_block>:<last_block> [OPTIONS]
 strata-dbtool ee-delete-acct-proof <prev_block>:<last_block> --force
 ```
 
+### `ee-revert-batches`
+Revert EE batch metadata from `--from-batch-idx` onward, delete the
+corresponding unfinalized exec-block suffix, and clean exact affected
+chunk/acct prover rows. Without `--force`, prints the full change set as
+a dry run.
+
+```bash
+strata-dbtool -d <alpen-client-datadir> ee-revert-batches --from-batch-idx <n> [--tx-export <path>] [--force]
+```
+
+**Notes:**
+- `--tx-export <path>` writes affected block transaction indexes, hashes,
+  and raw 2718 bytes for manual rebroadcast. The file is written during
+  dry-run too.
+- The locally accepted frontier is derived from the EE sled, not from a live
+  OL query. The command reads `best_ee_account_state()`, takes its
+  `last_exec_blkid`, then scans stored EE batches until it finds the batch
+  whose `last_block()` matches that execution block. The matching batch index
+  is reported as `local_accepted_frontier.accepted_batch_idx`; the account
+  state's `ol_epoch()` is reported as `local_accepted_frontier.best_epoch`.
+  This is the last OL-accepted EE state observed by this EE node and may lag
+  canonical OL if the snapshot is stale.
+- If the rollback crosses the locally observed OL-accepted EE frontier,
+  the command also rolls back EE account-state rows to the kept batch tip.
+  If it cannot find a stored account-state epoch for that kept tip, the
+  command blocks instead of leaving `best_ee_account_state` dangling.
+- The report includes `affected_block_summary.reverted_batch` for blocks that
+  belong to reverted sealed batches and `affected_block_summary.unbatched_suffix`
+  for extra unbatched blocks built on top of the last reverted batch tip.
+- Forced rollback is not one cross-tree transaction. The command rolls back
+  EE account state when needed, deletes affected exec blocks and prover rows,
+  then reverts batch metadata last. If a pre-final mutation fails, keep the node
+  stopped and rerun the same command; earlier deletes are idempotent and the
+  batch metadata is still available to reconstruct the plan. Export txs before
+  forcing if manual rebroadcast data is needed after a partial retry.
+- Old block-witness rows, chunk rows, and DA/broadcast rows are left in
+  place; the report calls out these orphaned artifacts explicitly.
+
+To inspect the rollback frontier during dry-run:
+
+```bash
+strata-dbtool -d <alpen-client-datadir> ee-revert-batches --from-batch-idx <n> -o json \
+  | jq '.local_accepted_frontier'
+```
+
 ## Output Formats
 
 ### Porcelain Format (Default)

--- a/bin/strata-dbtool/src/cli.rs
+++ b/bin/strata-dbtool/src/cli.rs
@@ -19,6 +19,7 @@ use crate::cmd::{
     ee_receipts::{
         EeDeleteAcctProofArgs, EeDeleteChunkReceiptArgs, EeGetAcctProofArgs, EeGetChunkReceiptArgs,
     },
+    ee_revert::EeRevertBatchesArgs,
     l1::{GetL1BlockArgs, GetL1SummaryArgs},
     ol::{DeleteOLBlockArgs, GetOLBlockArgs, GetOLBlocksAtSlotArgs, GetOLSummaryArgs},
     ol_state::{GetOLStateArgs, RevertOLStateArgs},
@@ -88,6 +89,7 @@ pub(crate) enum Command {
     EeDeleteChunkReceipt(EeDeleteChunkReceiptArgs),
     EeGetAcctProof(EeGetAcctProofArgs),
     EeDeleteAcctProof(EeDeleteAcctProofArgs),
+    EeRevertBatches(EeRevertBatchesArgs),
 }
 
 /// Output format

--- a/bin/strata-dbtool/src/cmd/ee_revert.rs
+++ b/bin/strata-dbtool/src/cmd/ee_revert.rs
@@ -9,7 +9,7 @@ use std::{
 
 use alloy_eips::eip2718::Encodable2718 as _;
 use alpen_ee_common::{
-    encode_batch_task_key, encode_chunk_task_key, BatchId, BatchStatus, BatchStorage, Chunk,
+    encode_batch_task_key, encode_chunk_task_key, Batch, BatchId, BatchStatus, BatchStorage, Chunk,
     ChunkId, ChunkStatus, ChunkStorage, EnginePayload, ExecBlockPayload, ExecBlockStorage,
     OLBlockOrEpoch, Storage, StorageError,
 };
@@ -254,17 +254,7 @@ async fn build_plan(
             Box::new(first_batch.idx()),
         )
     })?;
-    let first_reverted_record = storage
-        .get_exec_block(first_reverted_hash)
-        .await
-        .internal_error("Failed to read first reverted EE exec block")?
-        .ok_or_else(|| {
-            DisplayedError::UserError(
-                "First reverted batch block is missing from EE exec-block storage".to_string(),
-                Box::new(hash_hex(first_reverted_hash)),
-            )
-        })?;
-    let first_reverted_block_height = first_reverted_record.blocknum();
+    let first_reverted_block_height = first_batch_blocknum(&first_batch)?;
 
     let (kept_batch, _) = storage
         .get_batch_by_idx(args.from_batch_idx - 1)
@@ -471,6 +461,8 @@ async fn build_plan(
     let mut reverted_batch_blocks_sorted =
         reverted_batch_blocks.iter().copied().collect::<Vec<_>>();
     reverted_batch_blocks_sorted.sort_by_key(|hash| hash_hex(*hash));
+    let mut missing_affected_block_count = 0usize;
+    let mut first_missing_affected_block = None;
     for block_hash in reverted_batch_blocks_sorted {
         if !seen_delete_hashes.contains(&block_hash) {
             if storage
@@ -487,12 +479,17 @@ async fn build_plan(
                     )
                 });
             } else {
-                warnings.push(format!(
-                    "affected batch block {} was not found in the unfinalized suffix to delete",
-                    hash_hex(block_hash)
-                ));
+                missing_affected_block_count += 1;
+                first_missing_affected_block.get_or_insert(block_hash);
             }
         }
+    }
+    if missing_affected_block_count > 0 {
+        warnings.push(format!(
+            "{} affected batch block(s) were not found in the unfinalized suffix to delete; this is expected when retrying after a partial rollback that already deleted exec blocks. first_missing={}",
+            missing_affected_block_count,
+            hash_hex(first_missing_affected_block.expect("missing count is non-zero")),
+        ));
     }
 
     affected_blocks.sort_by(|a, b| {
@@ -550,6 +547,33 @@ async fn build_plan(
         chunk_artifacts,
         batch_artifacts,
     })
+}
+
+fn first_batch_blocknum(batch: &Batch) -> Result<u64, DisplayedError> {
+    let block_count = batch.blocks_iter().count();
+    if block_count == 0 {
+        return Err(DisplayedError::InternalError(
+            "Non-genesis batch unexpectedly has no blocks".to_string(),
+            Box::new(batch.idx()),
+        ));
+    }
+
+    let block_count = u64::try_from(block_count).map_err(|err| {
+        DisplayedError::InternalError(
+            "Batch block count does not fit into u64".to_string(),
+            Box::new(err),
+        )
+    })?;
+    batch
+        .last_blocknum()
+        .checked_add(1)
+        .and_then(|exclusive_end| exclusive_end.checked_sub(block_count))
+        .ok_or_else(|| {
+            DisplayedError::InternalError(
+                "Batch block count is inconsistent with last block height".to_string(),
+                Box::new(batch.idx()),
+            )
+        })
 }
 
 fn build_account_state_rollback_plan(
@@ -861,6 +885,27 @@ mod tests {
             target_exec_block_hash: required.then(|| hash_hex(test_hash(9))),
             performed: false,
         }
+    }
+
+    #[test]
+    fn first_batch_blocknum_uses_batch_metadata() {
+        let batch = Batch::new(
+            7,
+            test_hash(1),
+            test_hash(4),
+            16,
+            vec![test_hash(2), test_hash(3)],
+        )
+        .unwrap();
+
+        assert_eq!(first_batch_blocknum(&batch).unwrap(), 14);
+    }
+
+    #[test]
+    fn first_batch_blocknum_handles_single_block_batch() {
+        let batch = Batch::new(7, test_hash(1), test_hash(2), 16, Vec::new()).unwrap();
+
+        assert_eq!(first_batch_blocknum(&batch).unwrap(), 16);
     }
 
     #[test]

--- a/bin/strata-dbtool/src/cmd/ee_revert.rs
+++ b/bin/strata-dbtool/src/cmd/ee_revert.rs
@@ -50,9 +50,12 @@ const FRONTIER_CAVEAT: &str =
 /// accepted EE frontier, the command also rolls back EE account-state rows to
 /// the kept batch tip or blocks if that target state is unavailable.
 ///
-/// Forced execution is intentionally not one cross-tree transaction. Batch
-/// metadata is reverted last so a failed pre-final mutation can be retried
-/// while the command can still reconstruct the affected batch/chunk plan.
+/// Forced execution is intentionally not one cross-tree transaction. If needed,
+/// EE account-state rollback runs first and is not reversible by this command;
+/// retry-safety comes from recomputing the accepted frontier from the rolled
+/// back best EE account state on the next run. Batch metadata is still reverted
+/// last so a later failure can be retried with the affected batch/chunk plan
+/// intact.
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "ee-revert-batches")]
 pub(crate) struct EeRevertBatchesArgs {
@@ -135,8 +138,10 @@ pub(crate) async fn ee_revert_batches(
     }
 
     // This command mutates multiple sled trees and the prover DB without one
-    // outer transaction. Keep batch metadata as the final mutation so a
-    // pre-final failure can be retried with the same `--from-batch-idx`.
+    // outer transaction. Account-state rollback runs first; if a later step
+    // fails, the next run recomputes the accepted frontier from the rolled-back
+    // best EE account state. Keep batch metadata as the final mutation so the
+    // affected batch/chunk plan remains reconstructable on retry.
     if let Some(account_state_rollback) = &plan.account_state_rollback {
         storage
             .rollback_ee_account_state(account_state_rollback.target_epoch)
@@ -254,7 +259,6 @@ async fn build_plan(
             Box::new(first_batch.idx()),
         )
     })?;
-    let first_reverted_block_height = first_batch_blocknum(&first_batch)?;
 
     let (kept_batch, _) = storage
         .get_batch_by_idx(args.from_batch_idx - 1)
@@ -266,6 +270,7 @@ async fn build_plan(
                 Box::new(args.from_batch_idx - 1),
             )
         })?;
+    let first_reverted_block_height = first_batch_blocknum(&kept_batch, &first_batch)?;
 
     let mut affected_batches = Vec::new();
     let mut affected_chunks = Vec::new();
@@ -549,12 +554,23 @@ async fn build_plan(
     })
 }
 
-fn first_batch_blocknum(batch: &Batch) -> Result<u64, DisplayedError> {
-    let block_count = batch.blocks_iter().count();
+fn first_batch_blocknum(kept_batch: &Batch, first_batch: &Batch) -> Result<u64, DisplayedError> {
+    if first_batch.prev_block() != kept_batch.last_block() {
+        return Err(DisplayedError::InternalError(
+            "First reverted batch does not extend kept batch".to_string(),
+            Box::new((
+                first_batch.idx(),
+                hash_hex(first_batch.prev_block()),
+                hash_hex(kept_batch.last_block()),
+            )),
+        ));
+    }
+
+    let block_count = first_batch.blocks_iter().count();
     if block_count == 0 {
         return Err(DisplayedError::InternalError(
             "Non-genesis batch unexpectedly has no blocks".to_string(),
-            Box::new(batch.idx()),
+            Box::new(first_batch.idx()),
         ));
     }
 
@@ -564,16 +580,33 @@ fn first_batch_blocknum(batch: &Batch) -> Result<u64, DisplayedError> {
             Box::new(err),
         )
     })?;
-    batch
+    let height_span = first_batch
         .last_blocknum()
-        .checked_add(1)
-        .and_then(|exclusive_end| exclusive_end.checked_sub(block_count))
+        .checked_sub(kept_batch.last_blocknum())
         .ok_or_else(|| {
             DisplayedError::InternalError(
-                "Batch block count is inconsistent with last block height".to_string(),
-                Box::new(batch.idx()),
+                "First reverted batch last block height is before kept batch tip".to_string(),
+                Box::new((kept_batch.idx(), first_batch.idx())),
             )
-        })
+        })?;
+    if height_span != block_count {
+        return Err(DisplayedError::InternalError(
+            "First reverted batch block count is inconsistent with kept batch height".to_string(),
+            Box::new((
+                first_batch.idx(),
+                kept_batch.last_blocknum(),
+                first_batch.last_blocknum(),
+                block_count,
+            )),
+        ));
+    }
+
+    kept_batch.last_blocknum().checked_add(1).ok_or_else(|| {
+        DisplayedError::InternalError(
+            "Kept batch height overflow while deriving first reverted block height".to_string(),
+            Box::new(kept_batch.idx()),
+        )
+    })
 }
 
 fn build_account_state_rollback_plan(
@@ -889,7 +922,8 @@ mod tests {
 
     #[test]
     fn first_batch_blocknum_uses_batch_metadata() {
-        let batch = Batch::new(
+        let kept_batch = Batch::new(6, test_hash(9), test_hash(1), 13, Vec::new()).unwrap();
+        let first_batch = Batch::new(
             7,
             test_hash(1),
             test_hash(4),
@@ -898,14 +932,33 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(first_batch_blocknum(&batch).unwrap(), 14);
+        assert_eq!(first_batch_blocknum(&kept_batch, &first_batch).unwrap(), 14);
     }
 
     #[test]
     fn first_batch_blocknum_handles_single_block_batch() {
-        let batch = Batch::new(7, test_hash(1), test_hash(2), 16, Vec::new()).unwrap();
+        let kept_batch = Batch::new(6, test_hash(9), test_hash(1), 15, Vec::new()).unwrap();
+        let first_batch = Batch::new(7, test_hash(1), test_hash(2), 16, Vec::new()).unwrap();
 
-        assert_eq!(first_batch_blocknum(&batch).unwrap(), 16);
+        assert_eq!(first_batch_blocknum(&kept_batch, &first_batch).unwrap(), 16);
+    }
+
+    #[test]
+    fn first_batch_blocknum_blocks_inconsistent_height_span() {
+        let kept_batch = Batch::new(6, test_hash(9), test_hash(1), 13, Vec::new()).unwrap();
+        let first_batch = Batch::new(
+            7,
+            test_hash(1),
+            test_hash(4),
+            17,
+            vec![test_hash(2), test_hash(3)],
+        )
+        .unwrap();
+
+        let err = first_batch_blocknum(&kept_batch, &first_batch)
+            .expect_err("non-contiguous batch metadata should be rejected");
+
+        assert!(format!("{err:?}").contains("block count is inconsistent"));
     }
 
     #[test]
@@ -930,6 +983,29 @@ mod tests {
         let plan = build_account_state_rollback_plan(&rollback_info(false, None), test_hash(3))
             .expect("not crossing accepted frontier should not block");
 
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn account_state_rollback_plan_is_not_required_on_retry_after_tracker_rollback() {
+        let from_batch_idx = 354;
+        let kept_batch_idx = from_batch_idx - 1;
+        let accepted_frontier = build_accepted_frontier_info(
+            Some(134),
+            Some(test_hash(1)),
+            Some(kept_batch_idx),
+            from_batch_idx,
+        );
+        let rollback_info = AccountStateRollbackInfo {
+            required: accepted_frontier.crosses_accepted_frontier,
+            target_epoch: None,
+            target_exec_block_hash: None,
+            performed: false,
+        };
+        let plan = build_account_state_rollback_plan(&rollback_info, test_hash(1))
+            .expect("retry after account-state rollback should not require another rollback");
+
+        assert!(!accepted_frontier.crosses_accepted_frontier);
         assert!(plan.is_none());
     }
 

--- a/bin/strata-dbtool/src/cmd/ee_revert.rs
+++ b/bin/strata-dbtool/src/cmd/ee_revert.rs
@@ -1,0 +1,908 @@
+//! EE rollback maintenance commands.
+
+use std::{
+    cmp::Reverse,
+    collections::{HashMap, HashSet},
+    fs,
+    path::PathBuf,
+};
+
+use alloy_eips::eip2718::Encodable2718 as _;
+use alpen_ee_common::{
+    encode_batch_task_key, encode_chunk_task_key, BatchId, BatchStatus, BatchStorage, Chunk,
+    ChunkId, ChunkStatus, ChunkStorage, EnginePayload, ExecBlockPayload, ExecBlockStorage,
+    OLBlockOrEpoch, Storage, StorageError,
+};
+use alpen_ee_database::{EeNodeStorage, EeProverDbSled};
+use alpen_reth_node::AlpenBuiltPayload;
+use argh::FromArgs;
+use reth_node_api::BuiltPayload as _;
+use reth_primitives_traits::SignedTransaction as _;
+use strata_acct_types::Hash;
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
+use strata_db_types::prover_task::ProverTaskDatabase;
+
+use crate::{
+    cli::OutputFormat,
+    cmd::prover_task_common::print_force_hint,
+    output::{
+        ee_revert::{
+            AcceptedFrontierInfo, AccountStateRollbackInfo, AffectedBatchInfo, AffectedBlockInfo,
+            AffectedBlockSummary, AffectedChunkInfo, BlockRangeSummary, BlockTransactionInfo,
+            EeRevertBatchesReport, MutationInfo, ProverArtifactInfo,
+        },
+        output,
+        prover_task::StatusInfo,
+    },
+};
+
+const FRONTIER_SOURCE: &str = "local_ee_sled_best_ee_account_state";
+const FRONTIER_CAVEAT: &str =
+    "This is the last accepted EE account state observed by this EE node; it may lag canonical OL.";
+
+/// Revert EE batches from the provided batch index.
+///
+/// The command removes batch metadata for `idx >= --from-batch-idx`, deletes
+/// all unfinalized exec blocks at or above the first reverted block height,
+/// and cleans exact prover rows derivable from the affected batch/chunk ids.
+/// Dry-run unless `--force` is passed. `--tx-export` writes raw affected
+/// transactions even during dry-run. If the rollback crosses the local
+/// accepted EE frontier, the command also rolls back EE account-state rows to
+/// the kept batch tip or blocks if that target state is unavailable.
+///
+/// Forced execution is intentionally not one cross-tree transaction. Batch
+/// metadata is reverted last so a failed pre-final mutation can be retried
+/// while the command can still reconstruct the affected batch/chunk plan.
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "ee-revert-batches")]
+pub(crate) struct EeRevertBatchesArgs {
+    /// first batch index to revert; batch 0 (genesis) cannot be reverted
+    #[argh(option)]
+    pub(crate) from_batch_idx: u64,
+
+    /// write affected block transactions to this JSON file for manual rebroadcast
+    #[argh(option)]
+    pub(crate) tx_export: Option<PathBuf>,
+
+    /// force execution (without this flag, only a dry run is performed)
+    #[argh(switch, short = 'f')]
+    pub(crate) force: bool,
+
+    /// output format: "porcelain" (default) or "json"
+    #[argh(option, short = 'o', default = "OutputFormat::Porcelain")]
+    pub(crate) output_format: OutputFormat,
+}
+
+struct RevertPlan {
+    report: EeRevertBatchesReport,
+    account_state_rollback: Option<AccountStateRollbackPlan>,
+    block_deletions: Vec<BlockDeletionPlan>,
+    chunk_artifacts: Vec<ChunkArtifactPlan>,
+    batch_artifacts: Vec<BatchArtifactPlan>,
+}
+
+#[derive(Debug)]
+struct AccountStateRollbackPlan {
+    target_epoch: u32,
+}
+
+struct BlockDeletionPlan {
+    report_index: usize,
+    hash: Hash,
+    blocknum: u64,
+}
+
+struct ChunkArtifactPlan {
+    report_index: usize,
+    task_key: Vec<u8>,
+}
+
+struct BatchArtifactPlan {
+    report_index: usize,
+    batch_id: BatchId,
+    task_key: Vec<u8>,
+}
+
+/// Revert EE batches and the corresponding unfinalized exec-block suffix.
+pub(crate) async fn ee_revert_batches(
+    storage: &EeNodeStorage,
+    prover_db: &EeProverDbSled,
+    args: EeRevertBatchesArgs,
+) -> Result<(), DisplayedError> {
+    let mut plan = build_plan(storage, prover_db, &args).await?;
+
+    if let Some(export_path) = &args.tx_export {
+        write_tx_export(export_path, &plan.report.affected_blocks)?;
+        plan.report.mutation.tx_export_written = true;
+    }
+
+    if plan.report.blocked {
+        let reason = plan.report.block_reason.clone();
+        output(&plan.report, args.output_format)?;
+        if args.force {
+            return Err(DisplayedError::UserError(
+                "EE batch rollback is blocked".to_string(),
+                Box::new(reason),
+            ));
+        }
+        return Ok(());
+    }
+
+    if !args.force {
+        output(&plan.report, args.output_format)?;
+        print_force_hint();
+        return Ok(());
+    }
+
+    // This command mutates multiple sled trees and the prover DB without one
+    // outer transaction. Keep batch metadata as the final mutation so a
+    // pre-final failure can be retried with the same `--from-batch-idx`.
+    if let Some(account_state_rollback) = &plan.account_state_rollback {
+        storage
+            .rollback_ee_account_state(account_state_rollback.target_epoch)
+            .await
+            .internal_error("Failed to roll back EE account-state tracker")?;
+        plan.report.account_state_rollback.performed = true;
+    }
+
+    plan.block_deletions
+        .sort_by_cached_key(|deletion| (Reverse(deletion.blocknum), hash_hex(deletion.hash)));
+    for deletion in &plan.block_deletions {
+        storage
+            .delete_exec_block(deletion.hash)
+            .await
+            .internal_error("Failed to delete EE exec block")?;
+        plan.report.affected_blocks[deletion.report_index].deleted = true;
+        plan.report.mutation.exec_blocks_deleted += 1;
+    }
+
+    for artifact in &plan.chunk_artifacts {
+        if prover_db
+            .delete_task(artifact.task_key.clone())
+            .internal_error("Failed to delete EE chunk prover task")?
+        {
+            plan.report.affected_chunks[artifact.report_index]
+                .task
+                .deleted = true;
+            plan.report.mutation.chunk_tasks_deleted += 1;
+        }
+
+        if prover_db
+            .delete_chunk_receipt(&artifact.task_key)
+            .internal_error("Failed to delete EE chunk receipt")?
+        {
+            plan.report.affected_chunks[artifact.report_index].receipt_deleted = true;
+            plan.report.mutation.chunk_receipts_deleted += 1;
+        }
+    }
+
+    for artifact in &plan.batch_artifacts {
+        if prover_db
+            .delete_task(artifact.task_key.clone())
+            .internal_error("Failed to delete EE acct prover task")?
+        {
+            plan.report.affected_batches[artifact.report_index]
+                .acct_task
+                .deleted = true;
+            plan.report.mutation.acct_tasks_deleted += 1;
+        }
+
+        if prover_db
+            .delete_acct_proof(artifact.batch_id)
+            .internal_error("Failed to delete EE acct proof")?
+        {
+            plan.report.affected_batches[artifact.report_index].acct_proof_deleted = true;
+            plan.report.mutation.acct_proofs_deleted += 1;
+        }
+    }
+
+    let revert_to_batch_idx = args.from_batch_idx - 1;
+    storage
+        .revert_batches(revert_to_batch_idx)
+        .await
+        .internal_error("Failed to revert EE batch metadata")?;
+    plan.report.mutation.batch_rows_reverted = plan.report.affected_batches.len();
+
+    plan.report.dry_run = false;
+    plan.report.mutation.force = true;
+    output(&plan.report, args.output_format)
+}
+
+async fn build_plan(
+    storage: &EeNodeStorage,
+    prover_db: &EeProverDbSled,
+    args: &EeRevertBatchesArgs,
+) -> Result<RevertPlan, DisplayedError> {
+    if args.from_batch_idx == 0 {
+        return Err(DisplayedError::UserError(
+            "Cannot revert genesis batch; --from-batch-idx must be greater than 0".to_string(),
+            Box::new(args.from_batch_idx),
+        ));
+    }
+
+    let (latest_batch, _) = storage
+        .get_latest_batch()
+        .await
+        .internal_error("Failed to read latest EE batch")?
+        .ok_or_else(|| {
+            DisplayedError::UserError("No EE batches found".to_string(), Box::new(()))
+        })?;
+    let latest_batch_idx = latest_batch.idx();
+    if args.from_batch_idx > latest_batch_idx {
+        return Err(DisplayedError::UserError(
+            format!(
+                "--from-batch-idx {} is after latest EE batch {latest_batch_idx}",
+                args.from_batch_idx
+            ),
+            Box::new(args.from_batch_idx),
+        ));
+    }
+
+    let (first_batch, _) = storage
+        .get_batch_by_idx(args.from_batch_idx)
+        .await
+        .internal_error("Failed to read first reverted EE batch")?
+        .ok_or_else(|| {
+            DisplayedError::UserError(
+                "EE batch not found for --from-batch-idx".to_string(),
+                Box::new(args.from_batch_idx),
+            )
+        })?;
+    let first_reverted_hash = first_batch.blocks_iter().next().ok_or_else(|| {
+        DisplayedError::InternalError(
+            "Non-genesis batch unexpectedly has no blocks".to_string(),
+            Box::new(first_batch.idx()),
+        )
+    })?;
+    let first_reverted_record = storage
+        .get_exec_block(first_reverted_hash)
+        .await
+        .internal_error("Failed to read first reverted EE exec block")?
+        .ok_or_else(|| {
+            DisplayedError::UserError(
+                "First reverted batch block is missing from EE exec-block storage".to_string(),
+                Box::new(hash_hex(first_reverted_hash)),
+            )
+        })?;
+    let first_reverted_block_height = first_reverted_record.blocknum();
+
+    let (kept_batch, _) = storage
+        .get_batch_by_idx(args.from_batch_idx - 1)
+        .await
+        .internal_error("Failed to read kept EE batch before rollback range")?
+        .ok_or_else(|| {
+            DisplayedError::UserError(
+                "Kept EE batch before rollback range is missing".to_string(),
+                Box::new(args.from_batch_idx - 1),
+            )
+        })?;
+
+    let mut affected_batches = Vec::new();
+    let mut affected_chunks = Vec::new();
+    let mut chunk_artifacts = Vec::new();
+    let mut batch_artifacts = Vec::new();
+    let mut block_to_batch = HashMap::new();
+    let mut reverted_batch_blocks = HashSet::new();
+
+    for batch_idx in args.from_batch_idx..=latest_batch_idx {
+        let (batch, status) = storage
+            .get_batch_by_idx(batch_idx)
+            .await
+            .internal_error("Failed to read affected EE batch")?
+            .ok_or_else(|| {
+                DisplayedError::UserError(
+                    "Missing EE batch inside rollback range".to_string(),
+                    Box::new(batch_idx),
+                )
+            })?;
+        for block_hash in batch.blocks_iter() {
+            reverted_batch_blocks.insert(block_hash);
+            block_to_batch.insert(block_hash, batch.idx());
+        }
+
+        let batch_id = batch.id();
+        let chunk_ids = storage
+            .get_batch_chunks(batch_id)
+            .await
+            .internal_error("Failed to read EE batch chunk associations")?
+            .unwrap_or_default();
+
+        let acct_task_key = encode_batch_task_key(batch_id);
+        let acct_task_record = prover_db
+            .get_task(acct_task_key.clone())
+            .internal_error("Failed to read EE acct prover task")?;
+        let acct_proof_exists = prover_db
+            .has_acct_proof(batch_id)
+            .internal_error("Failed to read EE acct proof")?;
+        let report_index = affected_batches.len();
+        affected_batches.push(AffectedBatchInfo {
+            idx: batch.idx(),
+            id: batch_id.to_string(),
+            status: batch_status_name(&status).to_string(),
+            update_seq_no: batch.update_seq_no(),
+            prev_block: hash_hex(batch.prev_block()),
+            last_block: hash_hex(batch.last_block()),
+            last_blocknum: batch.last_blocknum(),
+            block_count: batch.blocks_iter().count(),
+            chunk_count: chunk_ids.len(),
+            acct_task: ProverArtifactInfo {
+                key_hex: hex::encode(&acct_task_key),
+                existed: acct_task_record.is_some(),
+                deleted: false,
+                status: acct_task_record
+                    .as_ref()
+                    .map(|record| StatusInfo::from(record.status())),
+            },
+            acct_proof_exists,
+            acct_proof_deleted: false,
+        });
+        batch_artifacts.push(BatchArtifactPlan {
+            report_index,
+            batch_id,
+            task_key: acct_task_key,
+        });
+
+        for chunk_id in chunk_ids {
+            let chunk_record = storage
+                .get_chunk_by_id(chunk_id)
+                .await
+                .internal_error("Failed to read affected EE chunk")?;
+            let task_key = encode_chunk_task_key(chunk_id);
+            let task_record = prover_db
+                .get_task(task_key.clone())
+                .internal_error("Failed to read EE chunk prover task")?;
+            let receipt_exists = prover_db
+                .get_chunk_receipt(&task_key)
+                .internal_error("Failed to read EE chunk receipt")?
+                .is_some();
+            let report_index = affected_chunks.len();
+            affected_chunks.push(build_affected_chunk_info(
+                batch.idx(),
+                chunk_id,
+                chunk_record,
+                &task_key,
+                task_record.as_ref(),
+                receipt_exists,
+            ));
+            chunk_artifacts.push(ChunkArtifactPlan {
+                report_index,
+                task_key,
+            });
+        }
+    }
+
+    let local_accepted_frontier =
+        accepted_frontier_info(storage, latest_batch_idx, args.from_batch_idx).await?;
+    let account_state_rollback =
+        account_state_rollback_info(storage, &local_accepted_frontier, kept_batch.last_block())
+            .await?;
+
+    let mut warnings = Vec::new();
+    if local_accepted_frontier.crosses_accepted_frontier {
+        warnings.push(
+            "Rollback crosses the locally observed OL-accepted EE batch frontier; EE account-state tracker will be rolled back too. OL rollback may also be required."
+                .to_string(),
+        );
+    }
+
+    let finalized_height = storage
+        .get_finalized_height(first_reverted_hash)
+        .await
+        .internal_error("Failed to check finalized status for first reverted EE block")?;
+    let mut blocked = false;
+    let mut block_reason = None;
+    if let Some(height) = finalized_height {
+        blocked = true;
+        block_reason = Some(format!(
+            "first reverted block {} is finalized at height {height}",
+            hash_hex(first_reverted_hash)
+        ));
+    }
+    let account_state_rollback_plan =
+        match build_account_state_rollback_plan(&account_state_rollback, kept_batch.last_block()) {
+            Ok(plan) => plan,
+            Err(reason) => {
+                blocked = true;
+                block_reason.get_or_insert(reason);
+                None
+            }
+        };
+
+    let unfinalized_blocks = storage
+        .get_unfinalized_blocks()
+        .await
+        .internal_error("Failed to list unfinalized EE blocks")?;
+    let mut affected_blocks = Vec::new();
+    let mut block_deletions = Vec::new();
+    let mut seen_delete_hashes = HashSet::new();
+
+    for block_hash in unfinalized_blocks {
+        let Some(block_record) = storage
+            .get_exec_block(block_hash)
+            .await
+            .internal_error("Failed to read unfinalized EE exec block")?
+        else {
+            warnings.push(format!(
+                "unfinalized block index pointed at missing block {}",
+                hash_hex(block_hash)
+            ));
+            continue;
+        };
+
+        if block_record.blocknum() < first_reverted_block_height {
+            continue;
+        }
+
+        let payload = storage
+            .get_block_payload(block_hash)
+            .await
+            .internal_error("Failed to read EE block payload")?;
+        let transactions = match payload {
+            Some(payload) => block_transactions(&payload, args.tx_export.is_some())?,
+            None => {
+                warnings.push(format!(
+                    "missing payload for affected EE block {}",
+                    hash_hex(block_hash)
+                ));
+                Vec::new()
+            }
+        };
+
+        let report_index = affected_blocks.len();
+        affected_blocks.push(AffectedBlockInfo {
+            blocknum: block_record.blocknum(),
+            hash: hash_hex(block_hash),
+            parent_hash: hash_hex(block_record.parent_blockhash()),
+            batch_idx: block_to_batch.get(&block_hash).copied(),
+            in_reverted_batch: reverted_batch_blocks.contains(&block_hash),
+            delete_planned: true,
+            deleted: false,
+            tx_count: transactions.len(),
+            transactions,
+        });
+        seen_delete_hashes.insert(block_hash);
+        block_deletions.push(BlockDeletionPlan {
+            report_index,
+            hash: block_hash,
+            blocknum: block_record.blocknum(),
+        });
+    }
+
+    let mut reverted_batch_blocks_sorted =
+        reverted_batch_blocks.iter().copied().collect::<Vec<_>>();
+    reverted_batch_blocks_sorted.sort_by_key(|hash| hash_hex(*hash));
+    for block_hash in reverted_batch_blocks_sorted {
+        if !seen_delete_hashes.contains(&block_hash) {
+            if storage
+                .get_finalized_height(block_hash)
+                .await
+                .internal_error("Failed to check finalized status for affected EE block")?
+                .is_some()
+            {
+                blocked = true;
+                block_reason.get_or_insert_with(|| {
+                    format!(
+                        "affected batch block {} is finalized and cannot be deleted",
+                        hash_hex(block_hash)
+                    )
+                });
+            } else {
+                warnings.push(format!(
+                    "affected batch block {} was not found in the unfinalized suffix to delete",
+                    hash_hex(block_hash)
+                ));
+            }
+        }
+    }
+
+    affected_blocks.sort_by(|a, b| {
+        a.blocknum
+            .cmp(&b.blocknum)
+            .then_with(|| a.hash.cmp(&b.hash))
+    });
+    let report_index_by_hash = affected_blocks
+        .iter()
+        .enumerate()
+        .map(|(idx, block)| (block.hash.clone(), idx))
+        .collect::<HashMap<_, _>>();
+    for deletion in &mut block_deletions {
+        if let Some(idx) = report_index_by_hash.get(&hash_hex(deletion.hash)) {
+            deletion.report_index = *idx;
+        }
+    }
+    let affected_block_summary = affected_block_summary(&affected_blocks);
+
+    let orphan_notes = vec![
+        "Old block witness rows are keyed by old block hash and are left in place; rebuilt blocks get new hashes and fresh witnesses.".to_string(),
+        "Chunk rows may remain orphaned after batch metadata is removed; alpen-client startup cleanup handles chunks that no longer belong to a batch.".to_string(),
+        "DA/broadcast rows are not removed by this command.".to_string(),
+    ];
+
+    Ok(RevertPlan {
+        report: EeRevertBatchesReport {
+            dry_run: true,
+            from_batch_idx: args.from_batch_idx,
+            revert_to_batch_idx: args.from_batch_idx - 1,
+            latest_batch_idx_before: latest_batch_idx,
+            first_reverted_block_height,
+            first_reverted_block_hash: hash_hex(first_reverted_hash),
+            local_accepted_frontier,
+            account_state_rollback,
+            warnings,
+            blocked,
+            block_reason,
+            affected_block_summary,
+            affected_batches,
+            affected_chunks,
+            affected_blocks,
+            orphan_notes,
+            tx_export_path: args
+                .tx_export
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            mutation: MutationInfo {
+                force: args.force,
+                ..MutationInfo::default()
+            },
+        },
+        account_state_rollback: account_state_rollback_plan,
+        block_deletions,
+        chunk_artifacts,
+        batch_artifacts,
+    })
+}
+
+fn build_account_state_rollback_plan(
+    account_state_rollback: &AccountStateRollbackInfo,
+    kept_batch_tip: Hash,
+) -> Result<Option<AccountStateRollbackPlan>, String> {
+    if !account_state_rollback.required {
+        return Ok(None);
+    }
+
+    account_state_rollback
+        .target_epoch
+        .map(|target_epoch| Some(AccountStateRollbackPlan { target_epoch }))
+        .ok_or_else(|| {
+            format!(
+                "rollback crosses locally accepted frontier, but no EE account-state epoch points at kept batch tip {}",
+                hash_hex(kept_batch_tip)
+            )
+        })
+}
+
+fn affected_block_summary(affected_blocks: &[AffectedBlockInfo]) -> AffectedBlockSummary {
+    AffectedBlockSummary {
+        total_count: affected_blocks.len(),
+        reverted_batch: block_range_summary(
+            affected_blocks
+                .iter()
+                .filter(|block| block.in_reverted_batch),
+        ),
+        unbatched_suffix: block_range_summary(
+            affected_blocks
+                .iter()
+                .filter(|block| !block.in_reverted_batch),
+        ),
+    }
+}
+
+fn block_range_summary<'a>(
+    blocks: impl Iterator<Item = &'a AffectedBlockInfo>,
+) -> BlockRangeSummary {
+    let mut count = 0;
+    let mut first_blocknum = None;
+    let mut last_blocknum = None;
+
+    for block in blocks {
+        count += 1;
+        first_blocknum.get_or_insert(block.blocknum);
+        last_blocknum = Some(block.blocknum);
+    }
+
+    BlockRangeSummary {
+        count,
+        first_blocknum,
+        last_blocknum,
+    }
+}
+
+async fn accepted_frontier_info(
+    storage: &EeNodeStorage,
+    latest_batch_idx: u64,
+    from_batch_idx: u64,
+) -> Result<AcceptedFrontierInfo, DisplayedError> {
+    let accepted_tip = storage
+        .best_ee_account_state()
+        .await
+        .internal_error("Failed to read best EE account state")?
+        .map(|state| (state.ol_epoch(), state.last_exec_blkid()));
+    let best_epoch = accepted_tip.map(|(epoch, _)| epoch);
+    let accepted_tip = accepted_tip.map(|(_, tip)| tip);
+
+    let mut accepted_batch_idx = None;
+    if let Some(accepted_tip) = accepted_tip {
+        // Offline maintenance path: there is no reverse index from EE exec
+        // block hash to batch idx, so scan stored batches and stop at the
+        // first match.
+        for batch_idx in 0..=latest_batch_idx {
+            let Some((batch, _)) = storage
+                .get_batch_by_idx(batch_idx)
+                .await
+                .internal_error("Failed to scan EE batches for accepted frontier")?
+            else {
+                continue;
+            };
+            if batch.last_block() == accepted_tip {
+                accepted_batch_idx = Some(batch.idx());
+                break;
+            }
+        }
+    }
+
+    Ok(build_accepted_frontier_info(
+        best_epoch,
+        accepted_tip,
+        accepted_batch_idx,
+        from_batch_idx,
+    ))
+}
+
+fn build_accepted_frontier_info(
+    best_epoch: Option<u32>,
+    accepted_tip: Option<Hash>,
+    accepted_batch_idx: Option<u64>,
+    from_batch_idx: u64,
+) -> AcceptedFrontierInfo {
+    AcceptedFrontierInfo {
+        source: FRONTIER_SOURCE,
+        last_exec_block_hash: accepted_tip.map(hash_hex),
+        best_epoch,
+        accepted_batch_idx,
+        crosses_accepted_frontier: accepted_batch_idx.is_some_and(|idx| from_batch_idx <= idx),
+        caveat: FRONTIER_CAVEAT,
+    }
+}
+
+async fn account_state_rollback_info(
+    storage: &EeNodeStorage,
+    accepted_frontier: &AcceptedFrontierInfo,
+    target_exec_block: Hash,
+) -> Result<AccountStateRollbackInfo, DisplayedError> {
+    let required = accepted_frontier.crosses_accepted_frontier;
+    let mut info = AccountStateRollbackInfo {
+        required,
+        target_epoch: None,
+        target_exec_block_hash: required.then(|| hash_hex(target_exec_block)),
+        performed: false,
+    };
+
+    if !required {
+        return Ok(info);
+    }
+
+    let Some(best_epoch) = accepted_frontier.best_epoch else {
+        return Ok(info);
+    };
+
+    // There is no reverse index from EE exec block hash to account-state
+    // epoch. Walk backward from the observed best epoch and stop at the first
+    // state that points at the kept batch tip.
+    for epoch in (0..=best_epoch).rev() {
+        let state = match storage.ee_account_state(OLBlockOrEpoch::Epoch(epoch)).await {
+            Ok(Some(state)) => state,
+            Ok(None) | Err(StorageError::StateNotFound(_)) => continue,
+            Err(e) => {
+                return Err(DisplayedError::InternalError(
+                    "Failed to scan EE account-state rollback target".to_string(),
+                    Box::new(e),
+                ));
+            }
+        };
+
+        if state.last_exec_blkid() == target_exec_block {
+            info.target_epoch = Some(epoch);
+            break;
+        }
+    }
+
+    Ok(info)
+}
+
+fn build_affected_chunk_info(
+    batch_idx: u64,
+    chunk_id: ChunkId,
+    chunk_record: Option<(Chunk, ChunkStatus)>,
+    task_key: &[u8],
+    task_record: Option<&strata_paas::TaskRecordData>,
+    receipt_exists: bool,
+) -> AffectedChunkInfo {
+    let (idx, status, last_blocknum, block_count) = match chunk_record {
+        Some((chunk, status)) => (
+            Some(chunk.idx()),
+            Some(chunk_status_name(&status).to_string()),
+            Some(chunk.last_blocknum()),
+            Some(chunk.blocks_iter().count()),
+        ),
+        None => (None, None, None, None),
+    };
+
+    AffectedChunkInfo {
+        batch_idx,
+        idx,
+        id: chunk_id_string(chunk_id),
+        status,
+        prev_block: hash_hex(chunk_id.prev_block()),
+        last_block: hash_hex(chunk_id.last_block()),
+        last_blocknum,
+        block_count,
+        task: ProverArtifactInfo {
+            key_hex: hex::encode(task_key),
+            existed: task_record.is_some(),
+            deleted: false,
+            status: task_record.map(|record| StatusInfo::from(record.status())),
+        },
+        receipt_exists,
+        receipt_deleted: false,
+    }
+}
+
+fn block_transactions(
+    payload: &ExecBlockPayload,
+    include_raw: bool,
+) -> Result<Vec<BlockTransactionInfo>, DisplayedError> {
+    let payload = AlpenBuiltPayload::from_bytes(payload.as_bytes())
+        .internal_error("Failed to decode EE exec block payload")?;
+    Ok(payload
+        .block()
+        .body()
+        .transactions()
+        .enumerate()
+        .map(|(index, tx)| BlockTransactionInfo {
+            index,
+            hash: format!("{:x}", tx.recalculate_hash()),
+            raw_tx_hex: include_raw.then(|| hex::encode(tx.encoded_2718())),
+        })
+        .collect())
+}
+
+fn write_tx_export(
+    path: &PathBuf,
+    affected_blocks: &[AffectedBlockInfo],
+) -> Result<(), DisplayedError> {
+    #[derive(serde::Serialize)]
+    struct TxExportBlock<'a> {
+        blocknum: u64,
+        hash: &'a str,
+        parent_hash: &'a str,
+        batch_idx: Option<u64>,
+        transactions: Vec<TxExportTransaction<'a>>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct TxExportTransaction<'a> {
+        index: usize,
+        hash: &'a str,
+        raw_tx_hex: &'a str,
+    }
+
+    let blocks_with_txs = affected_blocks
+        .iter()
+        .filter(|block| block.tx_count > 0)
+        .map(|block| TxExportBlock {
+            blocknum: block.blocknum,
+            hash: &block.hash,
+            parent_hash: &block.parent_hash,
+            batch_idx: block.batch_idx,
+            transactions: block
+                .transactions
+                .iter()
+                .map(|tx| TxExportTransaction {
+                    index: tx.index,
+                    hash: &tx.hash,
+                    raw_tx_hex: tx.raw_tx_hex.as_deref().unwrap_or_default(),
+                })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    let encoded = serde_json::to_vec_pretty(&blocks_with_txs)
+        .internal_error("Failed to serialize EE rollback transaction export")?;
+    fs::write(path, encoded).map_err(|e| {
+        DisplayedError::UserError(
+            format!("Failed to write transaction export to {}", path.display()),
+            Box::new(e),
+        )
+    })
+}
+
+fn hash_hex(hash: Hash) -> String {
+    format!("{hash:x}")
+}
+
+fn chunk_id_string(chunk_id: ChunkId) -> String {
+    format!(
+        "{}:{}",
+        hash_hex(chunk_id.prev_block()),
+        hash_hex(chunk_id.last_block())
+    )
+}
+
+fn batch_status_name(status: &BatchStatus) -> &'static str {
+    match status {
+        BatchStatus::Genesis => "genesis",
+        BatchStatus::Sealed => "sealed",
+        BatchStatus::DaPending { .. } => "da_pending",
+        BatchStatus::DaComplete { .. } => "da_complete",
+        BatchStatus::ProofPending { .. } => "proof_pending",
+        BatchStatus::ProofReady { .. } => "proof_ready",
+    }
+}
+
+fn chunk_status_name(status: &ChunkStatus) -> &'static str {
+    match status {
+        ChunkStatus::ProvingNotStarted => "proving_not_started",
+        ChunkStatus::ProofPending(_) => "proof_pending",
+        ChunkStatus::ProofReady(_) => "proof_ready",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_hash(byte: u8) -> Hash {
+        Hash::from([byte; 32])
+    }
+
+    fn rollback_info(required: bool, target_epoch: Option<u32>) -> AccountStateRollbackInfo {
+        AccountStateRollbackInfo {
+            required,
+            target_epoch,
+            target_exec_block_hash: required.then(|| hash_hex(test_hash(9))),
+            performed: false,
+        }
+    }
+
+    #[test]
+    fn accepted_frontier_crosses_when_reverting_accepted_batch() {
+        let info = build_accepted_frontier_info(Some(134), Some(test_hash(1)), Some(353), 353);
+
+        assert_eq!(info.accepted_batch_idx, Some(353));
+        assert_eq!(info.best_epoch, Some(134));
+        assert!(info.crosses_accepted_frontier);
+    }
+
+    #[test]
+    fn accepted_frontier_does_not_cross_when_reverting_after_accepted_batch() {
+        let info = build_accepted_frontier_info(Some(134), Some(test_hash(1)), Some(353), 354);
+
+        assert_eq!(info.accepted_batch_idx, Some(353));
+        assert!(!info.crosses_accepted_frontier);
+    }
+
+    #[test]
+    fn account_state_rollback_plan_is_not_required_after_frontier() {
+        let plan = build_account_state_rollback_plan(&rollback_info(false, None), test_hash(3))
+            .expect("not crossing accepted frontier should not block");
+
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn account_state_rollback_plan_uses_found_target_epoch() {
+        let plan = build_account_state_rollback_plan(&rollback_info(true, Some(42)), test_hash(3))
+            .expect("found target epoch should allow rollback")
+            .expect("crossing accepted frontier should build rollback plan");
+
+        assert_eq!(plan.target_epoch, 42);
+    }
+
+    #[test]
+    fn account_state_rollback_plan_blocks_without_target_epoch() {
+        let err = build_account_state_rollback_plan(&rollback_info(true, None), test_hash(3))
+            .expect_err("crossing accepted frontier without target epoch should block");
+
+        assert!(err.contains("rollback crosses locally accepted frontier"));
+        assert!(err.contains(&hash_hex(test_hash(3))));
+    }
+}

--- a/bin/strata-dbtool/src/cmd/mod.rs
+++ b/bin/strata-dbtool/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod checkpoint_proof;
 pub(crate) mod client_state;
 pub(crate) mod ee_prover_task;
 pub(crate) mod ee_receipts;
+pub(crate) mod ee_revert;
 pub(crate) mod l1;
 pub(crate) mod ol;
 pub(crate) mod ol_state;

--- a/bin/strata-dbtool/src/db.rs
+++ b/bin/strata-dbtool/src/db.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, sync::Arc};
 
-use alpen_ee_database::EeProverDbSled;
+use alpen_ee_database::{init_db_storage, EeDatabases, EeProverDbSled};
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_db_store_sled::{open_sled_database, SledBackend, SledDbConfig, SLED_NAME};
 use typed_sled::SledDb;
@@ -44,4 +44,14 @@ pub(crate) fn open_ee_database(datadir: &Path) -> Result<Arc<EeProverDbSled>, Di
         .map(Arc::new)?;
 
     Ok(prover_db)
+}
+
+/// Opens the full EE sled store at `<datadir>/sled`.
+///
+/// Use this for commands that need node-chain state in addition to the prover
+/// trees. The narrower [`open_ee_database`] helper stays in place for
+/// receipt/task-only commands so those commands do not construct unrelated DB
+/// wrappers.
+pub(crate) fn open_full_ee_database(datadir: &Path) -> Result<EeDatabases, DisplayedError> {
+    init_db_storage(datadir, 5).internal_error("Could not open full EE database")
 }

--- a/bin/strata-dbtool/src/main.rs
+++ b/bin/strata-dbtool/src/main.rs
@@ -1,5 +1,5 @@
 //! Binary entry‑point for the offline Alpen database tool.
-//! Parses CLI arguments with **Clap** and delegates to the `alpen_dbtool` lib.
+//! Parses CLI arguments with **argh** and delegates to command modules.
 
 mod cli;
 mod cmd;
@@ -7,11 +7,13 @@ mod db;
 mod output;
 mod utils;
 
-use std::{path::Path, process::exit};
+use std::{future::Future, path::Path, process::exit, sync::Arc};
 
-use alpen_ee_database::EeProverDbSled;
+use alpen_ee_database::{EeNodeStorage, EeProverDbSled};
+use strata_cli_common::errors::{DisplayableError, DisplayedError};
 use strata_db_store_sled::SledBackend;
 use strata_db_types::backend::DatabaseBackend;
+use tokio::runtime::Builder;
 use tracing_subscriber::fmt::init;
 
 use crate::{
@@ -29,6 +31,7 @@ use crate::{
         ee_receipts::{
             ee_delete_acct_proof, ee_delete_chunk_receipt, ee_get_acct_proof, ee_get_chunk_receipt,
         },
+        ee_revert::ee_revert_batches,
         l1::{get_l1_block, get_l1_summary},
         ol::{delete_ol_block, get_ol_block, get_ol_blocks_at_slot, get_ol_summary},
         ol_state::{get_ol_state, revert_ol_state},
@@ -40,7 +43,7 @@ use crate::{
         syncinfo::get_syncinfo,
         writer::{get_writer_payload, get_writer_summary},
     },
-    db::{open_database, open_ee_database},
+    db::{open_database, open_ee_database, open_full_ee_database},
 };
 
 fn main() {
@@ -134,6 +137,11 @@ fn main() {
         Command::EeDeleteAcctProof(args) => {
             with_ee_db(&datadir, |db| ee_delete_acct_proof(db, args))
         }
+        Command::EeRevertBatches(args) => {
+            with_full_ee_db(&datadir, |storage, prover_db| async move {
+                ee_revert_batches(&storage, prover_db.as_ref(), args).await
+            })
+        }
     };
 
     if let Err(e) = result {
@@ -164,4 +172,27 @@ where
         exit(1);
     });
     f(db.as_ref())
+}
+
+/// Opens the full EE sled at `datadir` and runs `f` against it.
+fn with_full_ee_db<F, Fut>(datadir: &Path, f: F) -> Result<(), DisplayedError>
+where
+    F: FnOnce(EeNodeStorage, Arc<EeProverDbSled>) -> Fut,
+    Fut: Future<Output = Result<(), DisplayedError>>,
+{
+    let rt = Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .internal_error("Could not initialize dbtool Tokio runtime")
+        .unwrap_or_else(|e: DisplayedError| {
+            eprintln!("{e}");
+            exit(1);
+        });
+    let db = open_full_ee_database(datadir).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        exit(1);
+    });
+    let storage = db.node_storage(rt.handle().clone());
+    let prover_db = db.prover_db();
+    rt.block_on(f(storage, prover_db))
 }

--- a/bin/strata-dbtool/src/output/ee_revert.rs
+++ b/bin/strata-dbtool/src/output/ee_revert.rs
@@ -1,0 +1,421 @@
+//! Output types for EE rollback maintenance commands.
+
+use serde::Serialize;
+
+use super::{
+    helpers::{porcelain_bool, porcelain_field},
+    prover_task::StatusInfo,
+    traits::Formattable,
+};
+
+#[derive(Serialize)]
+pub(crate) struct EeRevertBatchesReport {
+    pub(crate) dry_run: bool,
+    pub(crate) from_batch_idx: u64,
+    pub(crate) revert_to_batch_idx: u64,
+    pub(crate) latest_batch_idx_before: u64,
+    pub(crate) first_reverted_block_height: u64,
+    pub(crate) first_reverted_block_hash: String,
+    pub(crate) local_accepted_frontier: AcceptedFrontierInfo,
+    pub(crate) account_state_rollback: AccountStateRollbackInfo,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) blocked: bool,
+    pub(crate) block_reason: Option<String>,
+    pub(crate) affected_block_summary: AffectedBlockSummary,
+    pub(crate) affected_batches: Vec<AffectedBatchInfo>,
+    pub(crate) affected_chunks: Vec<AffectedChunkInfo>,
+    pub(crate) affected_blocks: Vec<AffectedBlockInfo>,
+    pub(crate) orphan_notes: Vec<String>,
+    pub(crate) tx_export_path: Option<String>,
+    pub(crate) mutation: MutationInfo,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AffectedBlockSummary {
+    pub(crate) total_count: usize,
+    pub(crate) reverted_batch: BlockRangeSummary,
+    pub(crate) unbatched_suffix: BlockRangeSummary,
+}
+
+#[derive(Serialize)]
+pub(crate) struct BlockRangeSummary {
+    pub(crate) count: usize,
+    pub(crate) first_blocknum: Option<u64>,
+    pub(crate) last_blocknum: Option<u64>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AcceptedFrontierInfo {
+    pub(crate) source: &'static str,
+    pub(crate) last_exec_block_hash: Option<String>,
+    pub(crate) best_epoch: Option<u32>,
+    pub(crate) accepted_batch_idx: Option<u64>,
+    pub(crate) crosses_accepted_frontier: bool,
+    pub(crate) caveat: &'static str,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AccountStateRollbackInfo {
+    pub(crate) required: bool,
+    pub(crate) target_epoch: Option<u32>,
+    pub(crate) target_exec_block_hash: Option<String>,
+    pub(crate) performed: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AffectedBatchInfo {
+    pub(crate) idx: u64,
+    pub(crate) id: String,
+    pub(crate) status: String,
+    pub(crate) update_seq_no: Option<u64>,
+    pub(crate) prev_block: String,
+    pub(crate) last_block: String,
+    pub(crate) last_blocknum: u64,
+    pub(crate) block_count: usize,
+    pub(crate) chunk_count: usize,
+    pub(crate) acct_task: ProverArtifactInfo,
+    pub(crate) acct_proof_exists: bool,
+    pub(crate) acct_proof_deleted: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AffectedChunkInfo {
+    pub(crate) batch_idx: u64,
+    pub(crate) idx: Option<u64>,
+    pub(crate) id: String,
+    pub(crate) status: Option<String>,
+    pub(crate) prev_block: String,
+    pub(crate) last_block: String,
+    pub(crate) last_blocknum: Option<u64>,
+    pub(crate) block_count: Option<usize>,
+    pub(crate) task: ProverArtifactInfo,
+    pub(crate) receipt_exists: bool,
+    pub(crate) receipt_deleted: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ProverArtifactInfo {
+    pub(crate) key_hex: String,
+    pub(crate) existed: bool,
+    pub(crate) deleted: bool,
+    pub(crate) status: Option<StatusInfo>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AffectedBlockInfo {
+    pub(crate) blocknum: u64,
+    pub(crate) hash: String,
+    pub(crate) parent_hash: String,
+    pub(crate) batch_idx: Option<u64>,
+    pub(crate) in_reverted_batch: bool,
+    pub(crate) delete_planned: bool,
+    pub(crate) deleted: bool,
+    pub(crate) tx_count: usize,
+    pub(crate) transactions: Vec<BlockTransactionInfo>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct BlockTransactionInfo {
+    pub(crate) index: usize,
+    pub(crate) hash: String,
+    #[serde(skip_serializing)]
+    pub(crate) raw_tx_hex: Option<String>,
+}
+
+#[derive(Serialize, Default)]
+pub(crate) struct MutationInfo {
+    pub(crate) force: bool,
+    pub(crate) tx_export_written: bool,
+    pub(crate) batch_rows_reverted: usize,
+    pub(crate) exec_blocks_deleted: usize,
+    pub(crate) chunk_tasks_deleted: usize,
+    pub(crate) chunk_receipts_deleted: usize,
+    pub(crate) acct_tasks_deleted: usize,
+    pub(crate) acct_proofs_deleted: usize,
+}
+
+impl Formattable for EeRevertBatchesReport {
+    fn format_porcelain(&self) -> String {
+        let mut out = vec![
+            porcelain_field("dry_run", porcelain_bool(self.dry_run)),
+            porcelain_field("from_batch_idx", self.from_batch_idx),
+            porcelain_field("revert_to_batch_idx", self.revert_to_batch_idx),
+            porcelain_field("latest_batch_idx_before", self.latest_batch_idx_before),
+            porcelain_field(
+                "first_reverted_block_height",
+                self.first_reverted_block_height,
+            ),
+            porcelain_field("first_reverted_block_hash", &self.first_reverted_block_hash),
+            porcelain_field("blocked", porcelain_bool(self.blocked)),
+        ];
+
+        if let Some(reason) = &self.block_reason {
+            out.push(porcelain_field("block_reason", reason));
+        }
+
+        out.push(porcelain_field(
+            "local_accepted_frontier.source",
+            self.local_accepted_frontier.source,
+        ));
+        if let Some(hash) = &self.local_accepted_frontier.last_exec_block_hash {
+            out.push(porcelain_field(
+                "local_accepted_frontier.last_exec_block_hash",
+                hash,
+            ));
+        }
+        if let Some(idx) = self.local_accepted_frontier.accepted_batch_idx {
+            out.push(porcelain_field(
+                "local_accepted_frontier.accepted_batch_idx",
+                idx,
+            ));
+        }
+        if let Some(epoch) = self.local_accepted_frontier.best_epoch {
+            out.push(porcelain_field("local_accepted_frontier.best_epoch", epoch));
+        }
+        out.push(porcelain_field(
+            "local_accepted_frontier.crosses_accepted_frontier",
+            porcelain_bool(self.local_accepted_frontier.crosses_accepted_frontier),
+        ));
+        out.push(porcelain_field(
+            "local_accepted_frontier.caveat",
+            self.local_accepted_frontier.caveat,
+        ));
+        out.push(porcelain_field(
+            "account_state_rollback.required",
+            porcelain_bool(self.account_state_rollback.required),
+        ));
+        if let Some(epoch) = self.account_state_rollback.target_epoch {
+            out.push(porcelain_field(
+                "account_state_rollback.target_epoch",
+                epoch,
+            ));
+        }
+        if let Some(hash) = &self.account_state_rollback.target_exec_block_hash {
+            out.push(porcelain_field(
+                "account_state_rollback.target_exec_block_hash",
+                hash,
+            ));
+        }
+        out.push(porcelain_field(
+            "account_state_rollback.performed",
+            porcelain_bool(self.account_state_rollback.performed),
+        ));
+
+        for (i, warning) in self.warnings.iter().enumerate() {
+            out.push(porcelain_field(&format!("warnings[{i}]"), warning));
+        }
+
+        out.extend(self.affected_block_summary.format_porcelain());
+
+        for (i, batch) in self.affected_batches.iter().enumerate() {
+            out.extend(batch.format_porcelain(i));
+        }
+
+        for (i, chunk) in self.affected_chunks.iter().enumerate() {
+            out.extend(chunk.format_porcelain(i));
+        }
+
+        for (i, block) in self.affected_blocks.iter().enumerate() {
+            out.extend(block.format_porcelain(i));
+        }
+
+        for (i, note) in self.orphan_notes.iter().enumerate() {
+            out.push(porcelain_field(&format!("orphan_notes[{i}]"), note));
+        }
+
+        if let Some(path) = &self.tx_export_path {
+            out.push(porcelain_field("tx_export_path", path));
+        }
+
+        out.extend(self.mutation.format_porcelain());
+        out.join("\n")
+    }
+}
+
+impl AffectedBlockSummary {
+    fn format_porcelain(&self) -> Vec<String> {
+        let mut out = vec![porcelain_field(
+            "affected_block_summary.total_count",
+            self.total_count,
+        )];
+        out.extend(
+            self.reverted_batch
+                .format_porcelain("affected_block_summary.reverted_batch"),
+        );
+        out.extend(
+            self.unbatched_suffix
+                .format_porcelain("affected_block_summary.unbatched_suffix"),
+        );
+        out
+    }
+}
+
+impl BlockRangeSummary {
+    fn format_porcelain(&self, prefix: &str) -> Vec<String> {
+        let mut out = vec![porcelain_field(&format!("{prefix}.count"), self.count)];
+        if let Some(blocknum) = self.first_blocknum {
+            out.push(porcelain_field(
+                &format!("{prefix}.first_blocknum"),
+                blocknum,
+            ));
+        }
+        if let Some(blocknum) = self.last_blocknum {
+            out.push(porcelain_field(
+                &format!("{prefix}.last_blocknum"),
+                blocknum,
+            ));
+        }
+        out
+    }
+}
+
+impl AffectedBatchInfo {
+    fn format_porcelain(&self, i: usize) -> Vec<String> {
+        let prefix = format!("affected_batches[{i}]");
+        let mut out = vec![
+            porcelain_field(&format!("{prefix}.idx"), self.idx),
+            porcelain_field(&format!("{prefix}.id"), &self.id),
+            porcelain_field(&format!("{prefix}.status"), &self.status),
+            porcelain_field(&format!("{prefix}.prev_block"), &self.prev_block),
+            porcelain_field(&format!("{prefix}.last_block"), &self.last_block),
+            porcelain_field(&format!("{prefix}.last_blocknum"), self.last_blocknum),
+            porcelain_field(&format!("{prefix}.block_count"), self.block_count),
+            porcelain_field(&format!("{prefix}.chunk_count"), self.chunk_count),
+            porcelain_field(
+                &format!("{prefix}.acct_proof_exists"),
+                porcelain_bool(self.acct_proof_exists),
+            ),
+            porcelain_field(
+                &format!("{prefix}.acct_proof_deleted"),
+                porcelain_bool(self.acct_proof_deleted),
+            ),
+        ];
+        if let Some(seq_no) = self.update_seq_no {
+            out.push(porcelain_field(&format!("{prefix}.update_seq_no"), seq_no));
+        }
+        out.extend(
+            self.acct_task
+                .format_porcelain(&format!("{prefix}.acct_task")),
+        );
+        out
+    }
+}
+
+impl AffectedChunkInfo {
+    fn format_porcelain(&self, i: usize) -> Vec<String> {
+        let prefix = format!("affected_chunks[{i}]");
+        let mut out = vec![
+            porcelain_field(&format!("{prefix}.batch_idx"), self.batch_idx),
+            porcelain_field(&format!("{prefix}.id"), &self.id),
+            porcelain_field(&format!("{prefix}.prev_block"), &self.prev_block),
+            porcelain_field(&format!("{prefix}.last_block"), &self.last_block),
+            porcelain_field(
+                &format!("{prefix}.receipt_exists"),
+                porcelain_bool(self.receipt_exists),
+            ),
+            porcelain_field(
+                &format!("{prefix}.receipt_deleted"),
+                porcelain_bool(self.receipt_deleted),
+            ),
+        ];
+        if let Some(idx) = self.idx {
+            out.push(porcelain_field(&format!("{prefix}.idx"), idx));
+        }
+        if let Some(status) = &self.status {
+            out.push(porcelain_field(&format!("{prefix}.status"), status));
+        }
+        if let Some(last_blocknum) = self.last_blocknum {
+            out.push(porcelain_field(
+                &format!("{prefix}.last_blocknum"),
+                last_blocknum,
+            ));
+        }
+        if let Some(block_count) = self.block_count {
+            out.push(porcelain_field(
+                &format!("{prefix}.block_count"),
+                block_count,
+            ));
+        }
+        out.extend(self.task.format_porcelain(&format!("{prefix}.task")));
+        out
+    }
+}
+
+impl ProverArtifactInfo {
+    fn format_porcelain(&self, prefix: &str) -> Vec<String> {
+        let mut out = vec![
+            porcelain_field(&format!("{prefix}.key_hex"), &self.key_hex),
+            porcelain_field(&format!("{prefix}.existed"), porcelain_bool(self.existed)),
+            porcelain_field(&format!("{prefix}.deleted"), porcelain_bool(self.deleted)),
+        ];
+        if let Some(status) = &self.status {
+            out.push(porcelain_field(&format!("{prefix}.status"), status.name));
+            if let Some(retry_count) = status.retry_count {
+                out.push(porcelain_field(
+                    &format!("{prefix}.status.retry_count"),
+                    retry_count,
+                ));
+            }
+            if let Some(error) = &status.error {
+                out.push(porcelain_field(&format!("{prefix}.status.error"), error));
+            }
+        }
+        out
+    }
+}
+
+impl AffectedBlockInfo {
+    fn format_porcelain(&self, i: usize) -> Vec<String> {
+        let prefix = format!("affected_blocks[{i}]");
+        let mut out = vec![
+            porcelain_field(&format!("{prefix}.blocknum"), self.blocknum),
+            porcelain_field(&format!("{prefix}.hash"), &self.hash),
+            porcelain_field(&format!("{prefix}.parent_hash"), &self.parent_hash),
+            porcelain_field(
+                &format!("{prefix}.in_reverted_batch"),
+                porcelain_bool(self.in_reverted_batch),
+            ),
+            porcelain_field(
+                &format!("{prefix}.delete_planned"),
+                porcelain_bool(self.delete_planned),
+            ),
+            porcelain_field(&format!("{prefix}.deleted"), porcelain_bool(self.deleted)),
+            porcelain_field(&format!("{prefix}.tx_count"), self.tx_count),
+        ];
+        if let Some(batch_idx) = self.batch_idx {
+            out.push(porcelain_field(&format!("{prefix}.batch_idx"), batch_idx));
+        }
+        for (j, tx) in self.transactions.iter().enumerate() {
+            out.push(porcelain_field(
+                &format!("{prefix}.transactions[{j}].index"),
+                tx.index,
+            ));
+            out.push(porcelain_field(
+                &format!("{prefix}.transactions[{j}].hash"),
+                &tx.hash,
+            ));
+        }
+        out
+    }
+}
+
+impl MutationInfo {
+    fn format_porcelain(&self) -> Vec<String> {
+        vec![
+            porcelain_field("mutation.force", porcelain_bool(self.force)),
+            porcelain_field(
+                "mutation.tx_export_written",
+                porcelain_bool(self.tx_export_written),
+            ),
+            porcelain_field("mutation.batch_rows_reverted", self.batch_rows_reverted),
+            porcelain_field("mutation.exec_blocks_deleted", self.exec_blocks_deleted),
+            porcelain_field("mutation.chunk_tasks_deleted", self.chunk_tasks_deleted),
+            porcelain_field(
+                "mutation.chunk_receipts_deleted",
+                self.chunk_receipts_deleted,
+            ),
+            porcelain_field("mutation.acct_tasks_deleted", self.acct_tasks_deleted),
+            porcelain_field("mutation.acct_proofs_deleted", self.acct_proofs_deleted),
+        ]
+    }
+}

--- a/bin/strata-dbtool/src/output/mod.rs
+++ b/bin/strata-dbtool/src/output/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod checkpoint;
 pub(crate) mod checkpoint_proof;
 pub(crate) mod client_state;
 pub(crate) mod ee_receipts;
+pub(crate) mod ee_revert;
 pub(crate) mod helpers;
 pub(crate) mod l1;
 pub(crate) mod ol;

--- a/crates/alpen-ee/common/src/lib.rs
+++ b/crates/alpen-ee/common/src/lib.rs
@@ -51,7 +51,8 @@ pub use types::{
     payload_builder::{DepositInfo, PayloadBuildAttributes},
     prover::{Proof, ProofId},
     prover_task_key::{
-        encode_batch_task_key, encode_chunk_task_key, BATCH_TASK_KEY_TAG, CHUNK_TASK_KEY_TAG,
+        decode_batch_task_key, decode_chunk_task_key, encode_batch_task_key, encode_chunk_task_key,
+        ProverTaskKeyDecodeError, ProverTaskKeyKind, BATCH_TASK_KEY_TAG, CHUNK_TASK_KEY_TAG,
         RANGE_TASK_KEY_BYTES,
     },
 };

--- a/crates/alpen-ee/common/src/lib.rs
+++ b/crates/alpen-ee/common/src/lib.rs
@@ -50,6 +50,10 @@ pub use types::{
     ol_chain_status::{OLChainStatus, OLFinalizedStatus},
     payload_builder::{DepositInfo, PayloadBuildAttributes},
     prover::{Proof, ProofId},
+    prover_task_key::{
+        encode_batch_task_key, encode_chunk_task_key, BATCH_TASK_KEY_TAG, CHUNK_TASK_KEY_TAG,
+        RANGE_TASK_KEY_BYTES,
+    },
 };
 pub use utils::{
     clock::{Clock, SystemClock},

--- a/crates/alpen-ee/common/src/types/mod.rs
+++ b/crates/alpen-ee/common/src/types/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod ol_account_epoch_summary;
 pub(crate) mod ol_chain_status;
 pub(crate) mod payload_builder;
 pub(crate) mod prover;
+pub(crate) mod prover_task_key;

--- a/crates/alpen-ee/common/src/types/prover_task_key.rs
+++ b/crates/alpen-ee/common/src/types/prover_task_key.rs
@@ -1,0 +1,73 @@
+//! Shared EE prover task-key encoding.
+
+use strata_acct_types::Hash;
+
+use super::{batch::BatchId, chunk::ChunkId};
+
+/// EE chunk-prover task-key tag.
+pub const CHUNK_TASK_KEY_TAG: u8 = b'c';
+
+/// EE acct-prover task-key tag.
+pub const BATCH_TASK_KEY_TAG: u8 = b'a';
+
+/// Tag byte plus the `(prev_block, last_block)` range.
+pub const RANGE_TASK_KEY_BYTES: usize = 1 + 32 + 32;
+
+/// Encodes an EE chunk-prover task key.
+pub fn encode_chunk_task_key(chunk_id: ChunkId) -> Vec<u8> {
+    tagged_range_key(
+        CHUNK_TASK_KEY_TAG,
+        chunk_id.prev_block(),
+        chunk_id.last_block(),
+    )
+}
+
+/// Encodes an EE acct-prover task key.
+pub fn encode_batch_task_key(batch_id: BatchId) -> Vec<u8> {
+    tagged_range_key(
+        BATCH_TASK_KEY_TAG,
+        batch_id.prev_block(),
+        batch_id.last_block(),
+    )
+}
+
+fn tagged_range_key(tag: u8, prev_block: Hash, last_block: Hash) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(RANGE_TASK_KEY_BYTES);
+    buf.push(tag);
+    let prev: [u8; 32] = prev_block.into();
+    let last: [u8; 32] = last_block.into();
+    buf.extend_from_slice(&prev);
+    buf.extend_from_slice(&last);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_identifiers::Buf32;
+
+    use super::*;
+
+    fn test_hash(byte: u8) -> Hash {
+        let mut bytes = [0u8; 32];
+        bytes[31] = byte;
+        Buf32(bytes)
+    }
+
+    #[test]
+    fn chunk_and_batch_keys_are_tagged_ranges() {
+        let prev = test_hash(1);
+        let last = test_hash(2);
+
+        let chunk_key = encode_chunk_task_key(ChunkId::from_parts(prev, last));
+        assert_eq!(chunk_key.len(), RANGE_TASK_KEY_BYTES);
+        assert_eq!(chunk_key[0], CHUNK_TASK_KEY_TAG);
+        assert_eq!(&chunk_key[1..33], <[u8; 32]>::from(prev).as_slice());
+        assert_eq!(&chunk_key[33..], <[u8; 32]>::from(last).as_slice());
+
+        let acct_key = encode_batch_task_key(BatchId::from_parts(prev, last));
+        assert_eq!(acct_key.len(), RANGE_TASK_KEY_BYTES);
+        assert_eq!(acct_key[0], BATCH_TASK_KEY_TAG);
+        assert_eq!(&acct_key[1..33], <[u8; 32]>::from(prev).as_slice());
+        assert_eq!(&acct_key[33..], <[u8; 32]>::from(last).as_slice());
+    }
+}

--- a/crates/alpen-ee/common/src/types/prover_task_key.rs
+++ b/crates/alpen-ee/common/src/types/prover_task_key.rs
@@ -1,5 +1,7 @@
 //! Shared EE prover task-key encoding.
 
+use std::fmt;
+
 use strata_acct_types::Hash;
 
 use super::{batch::BatchId, chunk::ChunkId};
@@ -31,6 +33,63 @@ pub fn encode_batch_task_key(batch_id: BatchId) -> Vec<u8> {
     )
 }
 
+/// Decodes an EE chunk-prover task key.
+pub fn decode_chunk_task_key(bytes: &[u8]) -> Result<ChunkId, ProverTaskKeyDecodeError> {
+    let (prev_block, last_block) =
+        decode_tagged_range_key(ProverTaskKeyKind::Chunk, CHUNK_TASK_KEY_TAG, bytes)?;
+    Ok(ChunkId::from_parts(prev_block, last_block))
+}
+
+/// Decodes an EE acct-prover task key.
+pub fn decode_batch_task_key(bytes: &[u8]) -> Result<BatchId, ProverTaskKeyDecodeError> {
+    let (prev_block, last_block) =
+        decode_tagged_range_key(ProverTaskKeyKind::Batch, BATCH_TASK_KEY_TAG, bytes)?;
+    Ok(BatchId::from_parts(prev_block, last_block))
+}
+
+/// EE prover task-key kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProverTaskKeyKind {
+    /// Chunk proof task key.
+    Chunk,
+    /// Account proof task key.
+    Batch,
+}
+
+impl fmt::Display for ProverTaskKeyKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Chunk => f.write_str("ChunkTask"),
+            Self::Batch => f.write_str("BatchTask"),
+        }
+    }
+}
+
+/// Error returned when decoding an EE prover task key.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ProverTaskKeyDecodeError {
+    /// The key length did not match the fixed tagged range-key size.
+    #[error("invalid {kind} byte length: expected {expected}, got {actual}")]
+    InvalidLength {
+        /// Task-key kind being decoded.
+        kind: ProverTaskKeyKind,
+        /// Expected byte length.
+        expected: usize,
+        /// Actual byte length.
+        actual: usize,
+    },
+    /// The tag byte did not match the expected task type.
+    #[error("invalid {kind} tag byte: expected 0x{expected:02x}, got 0x{actual:02x}")]
+    InvalidTag {
+        /// Task-key kind being decoded.
+        kind: ProverTaskKeyKind,
+        /// Expected tag byte.
+        expected: u8,
+        /// Actual tag byte.
+        actual: u8,
+    },
+}
+
 fn tagged_range_key(tag: u8, prev_block: Hash, last_block: Hash) -> Vec<u8> {
     let mut buf = Vec::with_capacity(RANGE_TASK_KEY_BYTES);
     buf.push(tag);
@@ -39,6 +98,34 @@ fn tagged_range_key(tag: u8, prev_block: Hash, last_block: Hash) -> Vec<u8> {
     buf.extend_from_slice(&prev);
     buf.extend_from_slice(&last);
     buf
+}
+
+fn decode_tagged_range_key(
+    kind: ProverTaskKeyKind,
+    expected_tag: u8,
+    bytes: &[u8],
+) -> Result<(Hash, Hash), ProverTaskKeyDecodeError> {
+    if bytes.len() != RANGE_TASK_KEY_BYTES {
+        return Err(ProverTaskKeyDecodeError::InvalidLength {
+            kind,
+            expected: RANGE_TASK_KEY_BYTES,
+            actual: bytes.len(),
+        });
+    }
+    if bytes[0] != expected_tag {
+        return Err(ProverTaskKeyDecodeError::InvalidTag {
+            kind,
+            expected: expected_tag,
+            actual: bytes[0],
+        });
+    }
+
+    let mut prev = [0u8; 32];
+    let mut last = [0u8; 32];
+    prev.copy_from_slice(&bytes[1..33]);
+    last.copy_from_slice(&bytes[33..]);
+
+    Ok((Hash::from(prev), Hash::from(last)))
 }
 
 #[cfg(test)]
@@ -69,5 +156,38 @@ mod tests {
         assert_eq!(acct_key[0], BATCH_TASK_KEY_TAG);
         assert_eq!(&acct_key[1..33], <[u8; 32]>::from(prev).as_slice());
         assert_eq!(&acct_key[33..], <[u8; 32]>::from(last).as_slice());
+    }
+
+    #[test]
+    fn task_keys_roundtrip_through_shared_decoder() {
+        let prev = test_hash(1);
+        let last = test_hash(2);
+
+        let chunk_id = ChunkId::from_parts(prev, last);
+        let batch_id = BatchId::from_parts(prev, last);
+
+        assert_eq!(
+            decode_chunk_task_key(&encode_chunk_task_key(chunk_id)).unwrap(),
+            chunk_id
+        );
+        assert_eq!(
+            decode_batch_task_key(&encode_batch_task_key(batch_id)).unwrap(),
+            batch_id
+        );
+    }
+
+    #[test]
+    fn task_key_decoder_rejects_wrong_tag() {
+        let batch_id = BatchId::from_parts(test_hash(1), test_hash(2));
+        let err = decode_chunk_task_key(&encode_batch_task_key(batch_id)).unwrap_err();
+
+        assert_eq!(
+            err,
+            ProverTaskKeyDecodeError::InvalidTag {
+                kind: ProverTaskKeyKind::Chunk,
+                expected: CHUNK_TASK_KEY_TAG,
+                actual: BATCH_TASK_KEY_TAG,
+            }
+        );
     }
 }


### PR DESCRIPTION
Add `ee-revert-batches` for offline EE recovery after stale block-witness generation. The command dry-runs by default, reports affected batches, chunks, exec blocks, prover rows, txs, and accepted-frontier state, and requires --force for mutation.

On force, it removes the unaccepted batch suffix, deletes the related exec-block suffix and prover task/proof/receipt rows, and can export raw txs for manual rebroadcast.

Also share chunk/acct prover task key encoding with alpen-client so dbtool uses the same keys as the runtime.



### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
