### PR TITLE
Str 3857 checkpoint sync rpc fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15215,6 +15215,7 @@ dependencies = [
  "strata-ol-state-support-types",
  "strata-ol-state-types",
  "strata-ol-stf",
+ "strata-predicate",
  "strata-primitives",
  "strata-service",
  "strata-snark-acct-types",

--- a/bin/strata-dbtool/Cargo.toml
+++ b/bin/strata-dbtool/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-alpen-reth-node.workspace = true
 alpen-ee-common.workspace = true
 alpen-ee-database.workspace = true
+alpen-reth-node.workspace = true
 ssz.workspace = true
 strata-acct-types.workspace = true
 strata-asm-logs.workspace = true

--- a/bin/strata/src/rpc/errors.rs
+++ b/bin/strata/src/rpc/errors.rs
@@ -36,6 +36,12 @@ pub(crate) fn invalid_params_error(msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(INVALID_PARAMS_CODE, msg.into(), None::<()>)
 }
 
+/// Creates an RPC error for data this node role does not serve (e.g. OL block
+/// bodies on a checkpoint-sync node).
+pub(crate) fn not_available_on_node_error(msg: impl Into<String>) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(NOT_AVAILABLE_ON_NODE_CODE, msg.into(), None::<()>)
+}
+
 /// Maps mempool errors to RPC errors with appropriate error codes.
 pub(crate) fn map_mempool_error_to_rpc(err: OLMempoolError) -> ErrorObjectOwned {
     match &err {

--- a/bin/strata/src/rpc/mod.rs
+++ b/bin/strata/src/rpc/mod.rs
@@ -210,11 +210,11 @@ fn build_public_rpc_module(deps: &RpcDeps) -> Result<RpcModule<()>> {
 }
 
 /// Maps a node role to the OL block-data access the RPC server should serve.
-fn ol_block_data_access(node_role: NodeRole) -> OlBlockDataAccess {
+fn ol_block_data_access(node_role: NodeRole) -> OLBlockDataAccess {
     if node_role.serves_fullnode_rpc() {
-        OlBlockDataAccess::Available
+        OLBlockDataAccess::Available
     } else {
-        OlBlockDataAccess::Unavailable
+        OLBlockDataAccess::Unavailable
     }
 }
 

--- a/bin/strata/src/rpc/mod.rs
+++ b/bin/strata/src/rpc/mod.rs
@@ -209,6 +209,15 @@ fn build_public_rpc_module(deps: &RpcDeps) -> Result<RpcModule<()>> {
     Ok(module)
 }
 
+/// Maps a node role to the OL block-data access the RPC server should serve.
+fn ol_block_data_access(node_role: NodeRole) -> OlBlockDataAccess {
+    if node_role.serves_fullnode_rpc() {
+        OlBlockDataAccess::Available
+    } else {
+        OlBlockDataAccess::Unavailable
+    }
+}
+
 fn register_client_rpc(module: &mut RpcModule<()>, deps: &RpcDeps) -> Result<()> {
     let client_provider = NodeRpcProvider::new(
         deps.storage.clone(),
@@ -219,6 +228,7 @@ fn register_client_rpc(module: &mut RpcModule<()>, deps: &RpcDeps) -> Result<()>
         client_provider,
         deps.genesis_l1_height,
         deps.max_headers_range,
+        ol_block_data_access(deps.node_role),
     );
     let ol_module = OLClientRpcServer::into_rpc(ol_rpc_server);
     module
@@ -236,6 +246,7 @@ fn register_fullnode_rpc(module: &mut RpcModule<()>, deps: &RpcDeps) -> Result<(
         fullnode_provider,
         deps.genesis_l1_height,
         deps.max_headers_range,
+        ol_block_data_access(deps.node_role),
     );
     let ol_fullnode_module = OLFullNodeRpcServer::into_rpc(ol_fullnode_listener);
     module
@@ -303,6 +314,7 @@ fn build_submit_rpc_module(deps: &RpcDeps) -> Result<RpcModule<OLRpcServer<NodeR
         submit_provider,
         deps.genesis_l1_height,
         deps.max_headers_range,
+        ol_block_data_access(deps.node_role),
     );
 
     Ok(<OLRpcServer<NodeRpcProvider> as OLSubmitRpcServer>::into_rpc(submit_listener))

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -32,8 +32,28 @@ use strata_snark_acct_types::{ProofState, UpdateInputData, UpdateStateData};
 use tracing::{error, info};
 
 use crate::rpc::errors::{
-    db_error, internal_error, invalid_params_error, map_mempool_error_to_rpc, not_found_error,
+    db_error, internal_error, invalid_params_error, map_mempool_error_to_rpc,
+    not_available_on_node_error, not_found_error,
 };
+
+/// Whether this node serves OL block body/data over RPC.
+///
+/// Checkpoint-sync nodes are DA-reconstructed and store no block bodies, so
+/// block-scoped lookups must report a capability error rather than empty or
+/// "block not found" results.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum OlBlockDataAccess {
+    /// Full block data is available.
+    Available,
+    /// Block data is not stored (checkpoint-sync node).
+    Unavailable,
+}
+
+impl OlBlockDataAccess {
+    fn is_available(self) -> bool {
+        matches!(self, Self::Available)
+    }
+}
 
 /// One canonical-chain block in the range walked by `get_blocks_summaries`.
 struct ChainBlock {
@@ -48,6 +68,7 @@ pub(crate) struct OLRpcServer<P: OLRpcProvider> {
     genesis_l1_height: L1Height,
     // Maximum number of headers/block-data that can be queried
     max_headers_range: usize,
+    block_data_access: OlBlockDataAccess,
 }
 
 /// Convenient wrapper for account records.
@@ -105,11 +126,17 @@ fn local_inbox_message_range(
 
 impl<P: OLRpcProvider> OLRpcServer<P> {
     /// Creates a new [`OLRpcServer`].
-    pub(crate) fn new(provider: P, genesis_l1_height: L1Height, max_headers_range: usize) -> Self {
+    pub(crate) fn new(
+        provider: P,
+        genesis_l1_height: L1Height,
+        max_headers_range: usize,
+        block_data_access: OlBlockDataAccess,
+    ) -> Self {
         Self {
             provider,
             genesis_l1_height,
             max_headers_range,
+            block_data_access,
         }
     }
 
@@ -703,7 +730,18 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         else {
             return Ok(None);
         };
-        let l2_start = self.get_first_l2_block_in_epoch(&epoch_summary).await?;
+        // Deriving the first L2 block of a non-genesis epoch needs block bodies,
+        // which checkpoint-sync nodes do not store. Report a capability error
+        // instead of failing later with a misleading "block not found".
+        let l2_start = if epoch == 0 {
+            *epoch_summary.terminal()
+        } else if self.block_data_access.is_available() {
+            self.get_first_l2_block_in_epoch(&epoch_summary).await?
+        } else {
+            return Err(not_available_on_node_error(
+                "OL block bodies are not available on this node",
+            ));
+        };
         let l2_range = (l2_start, *epoch_summary.terminal());
 
         let cur_l1 = *epoch_summary.new_l1();
@@ -852,6 +890,16 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                 "Block range too big. Allowed range is {}",
                 self.max_headers_range
             )));
+        }
+
+        // Without block bodies the canonical walk silently yields no blocks past
+        // genesis, which would return an empty list that reads as "present but
+        // empty". Report the missing capability instead. Genesis (slot 0) is
+        // still served because its block is always available.
+        if !self.block_data_access.is_available() && end_slot > 0 {
+            return Err(not_available_on_node_error(
+                "OL block bodies are not available on this node",
+            ));
         }
 
         let chain_blocks = self.collect_canonical_chain(start_slot, end_slot).await?;

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -42,14 +42,14 @@ use crate::rpc::errors::{
 /// block-scoped lookups must report a capability error rather than empty or
 /// "block not found" results.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum OlBlockDataAccess {
+pub(crate) enum OLBlockDataAccess {
     /// Full block data is available.
     Available,
     /// Block data is not stored (checkpoint-sync node).
     Unavailable,
 }
 
-impl OlBlockDataAccess {
+impl OLBlockDataAccess {
     fn is_available(self) -> bool {
         matches!(self, Self::Available)
     }
@@ -68,7 +68,8 @@ pub(crate) struct OLRpcServer<P: OLRpcProvider> {
     genesis_l1_height: L1Height,
     // Maximum number of headers/block-data that can be queried
     max_headers_range: usize,
-    block_data_access: OlBlockDataAccess,
+    // Indicates whether or not the server has access to block data.
+    block_data_access: OLBlockDataAccess,
 }
 
 /// Convenient wrapper for account records.
@@ -130,7 +131,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
         provider: P,
         genesis_l1_height: L1Height,
         max_headers_range: usize,
-        block_data_access: OlBlockDataAccess,
+        block_data_access: OLBlockDataAccess,
     ) -> Self {
         Self {
             provider,
@@ -731,18 +732,16 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             return Ok(None);
         };
         // Deriving the first L2 block of a non-genesis epoch needs block bodies,
-        // which checkpoint-sync nodes do not store. Report a capability error
-        // instead of failing later with a misleading "block not found".
+        // which checkpoint-sync nodes lack; `l2_start` is `None` there. The
+        // terminal (`l2_end`) is always available from the summary.
+        let l2_end = *epoch_summary.terminal();
         let l2_start = if epoch == 0 {
-            *epoch_summary.terminal()
+            Some(l2_end)
         } else if self.block_data_access.is_available() {
-            self.get_first_l2_block_in_epoch(&epoch_summary).await?
+            Some(self.get_first_l2_block_in_epoch(&epoch_summary).await?)
         } else {
-            return Err(not_available_on_node_error(
-                "OL block bodies are not available on this node",
-            ));
+            None
         };
-        let l2_range = (l2_start, *epoch_summary.terminal());
 
         let cur_l1 = *epoch_summary.new_l1();
         let l1_start = if epoch == 0 {
@@ -837,7 +836,8 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         Ok(Some(RpcCheckpointInfo {
             idx: epoch as u64,
             l1_range,
-            l2_range,
+            l2_start,
+            l2_end,
             confirmation_status,
         }))
     }

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -2825,6 +2825,60 @@ async fn epoch_summary_multi_record_slices_messages_per_update() {
 }
 
 #[tokio::test]
+async fn epoch_summary_checkpoint_sync_populates_terminal_root_only() {
+    // Checkpoint-sync records carry no block attribution. The terminal update's
+    // meta carries the post-epoch root; earlier updates have no meta at all.
+    // The RPC must surface the terminal root and null for the earlier one.
+    let epoch: Epoch = 2;
+    let account_id = test_account_id(7);
+    let epoch_commitment = test_epoch_commitment(epoch, 40, 0x62);
+    let prev_epoch_commitment = test_epoch_commitment(epoch - 1, 30, 0x61);
+
+    // The mock snark state's inner root is Hash::zero(); the terminal update's
+    // recovered root equals that post-epoch root.
+    let final_root = Hash::zero();
+    let records = vec![
+        update_record_with_prev(None, 10, 2, 2, Some(vec![0xA0])),
+        update_record_with_prev(
+            Some(AccountUpdateMeta::new(None, final_root)),
+            11,
+            2,
+            2,
+            Some(vec![0xA1]),
+        ),
+    ];
+
+    let provider = MockProvider::new()
+        .with_epoch_commitment(epoch, epoch_commitment)
+        .with_epoch_commitment(epoch - 1, prev_epoch_commitment)
+        .with_snark_state_at_terminal(epoch_commitment, account_id, 11, 2)
+        .with_snark_state_at_terminal(prev_epoch_commitment, account_id, 9, 2)
+        .with_account_update_records(account_id, epoch, records)
+        .with_inbox_fetch_fn(inbox_fetch_expect_success(account_id, 2, 2, vec![]));
+    let rpc = make_rpc(provider);
+
+    let summary = rpc
+        .get_acct_epoch_summary(account_id, epoch)
+        .await
+        .expect("epoch summary");
+    let updates = summary.update_inputs();
+    assert_eq!(updates.len(), 2);
+    assert!(
+        updates[0].new_state_root.is_none(),
+        "earlier update root null"
+    );
+    assert_eq!(
+        updates[1]
+            .new_state_root
+            .as_ref()
+            .expect("terminal root present")
+            .0,
+        summary.final_state_root().0,
+        "terminal update surfaces post-epoch root"
+    );
+}
+
+#[tokio::test]
 async fn epoch_summary_epoch_zero_has_no_messages() {
     let epoch = 0;
     let account_id = test_account_id(12);

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -36,9 +36,10 @@ use strata_snark_acct_types::{ProofState, Seqno, UpdateInputData, UpdateStateDat
 use strata_status::OLSyncStatus;
 use tokio::runtime::Builder;
 
-use super::OLRpcServer;
+use super::{OLRpcServer, OlBlockDataAccess};
 use crate::rpc::errors::{
-    INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, MEMPOOL_CAPACITY_ERROR_CODE, map_mempool_error_to_rpc,
+    INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, MEMPOOL_CAPACITY_ERROR_CODE,
+    NOT_AVAILABLE_ON_NODE_CODE, map_mempool_error_to_rpc,
 };
 
 // -- Mock provider --
@@ -647,7 +648,22 @@ const TEST_MAX_HEADERS_RANGE: usize = 5000;
 const DEFAULT_NEXT_INBOX_MSG_IDX: u64 = 0;
 
 fn make_rpc(provider: MockProvider) -> OLRpcServer<MockProvider> {
-    OLRpcServer::new(provider, TEST_GENESIS_L1_HEIGHT, TEST_MAX_HEADERS_RANGE)
+    OLRpcServer::new(
+        provider,
+        TEST_GENESIS_L1_HEIGHT,
+        TEST_MAX_HEADERS_RANGE,
+        OlBlockDataAccess::Available,
+    )
+}
+
+/// Server for a checkpoint-sync node: no OL block bodies stored.
+fn make_rpc_checkpoint_sync(provider: MockProvider) -> OLRpcServer<MockProvider> {
+    OLRpcServer::new(
+        provider,
+        TEST_GENESIS_L1_HEIGHT,
+        TEST_MAX_HEADERS_RANGE,
+        OlBlockDataAccess::Unavailable,
+    )
 }
 
 fn make_gam_rpc_tx(target: AccountId, payload: Vec<u8>) -> RpcOLTransaction {
@@ -1339,6 +1355,79 @@ async fn checkpoint_info_epoch_0_l1_did_not_advance() {
 }
 
 #[tokio::test]
+async fn checkpoint_info_non_genesis_errors_on_checkpoint_sync() {
+    // Checkpoint-sync nodes lack block bodies, so the first-L2-block walk for a
+    // non-genesis epoch must report a capability error rather than the
+    // misleading "block not found".
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
+    let terminal = L2BlockCommitment::new(20, fixed_ol_block_id(0x20));
+    let prev_summary = EpochSummary::new(
+        1,
+        prev_terminal,
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
+        L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
+        fixed_buf32(0x40),
+    );
+    let cur_summary = EpochSummary::new(
+        2,
+        terminal,
+        prev_terminal,
+        L1BlockCommitment::new(510, fixed_l1_block_id(0x31)),
+        fixed_buf32(0x41),
+    );
+    let prev_commitment = prev_summary.get_epoch_commitment();
+    let cur_commitment = cur_summary.get_epoch_commitment();
+
+    // No block bodies registered: this is what a checkpoint-sync node has.
+    let provider = MockProvider::new()
+        .with_epoch_commitment(1, prev_commitment)
+        .with_epoch_commitment(2, cur_commitment)
+        .with_epoch_summary(prev_summary)
+        .with_epoch_summary(cur_summary);
+
+    let rpc = make_rpc_checkpoint_sync(provider);
+
+    let err = rpc
+        .get_checkpoint_info(2)
+        .await
+        .expect_err("checkpoint-sync must not serve non-genesis checkpoint info");
+    assert_eq!(err.code(), NOT_AVAILABLE_ON_NODE_CODE);
+    assert!(err.message().contains("block bodies"));
+}
+
+#[tokio::test]
+async fn checkpoint_info_epoch_0_ok_on_checkpoint_sync() {
+    // Epoch 0's L2 start is the genesis terminal itself, derivable from the
+    // summary without a block body, so checkpoint-sync still serves it.
+    let genesis_blkid = fixed_ol_block_id(0x01);
+    let terminal = L2BlockCommitment::new(0, genesis_blkid);
+    let genesis_l1 = L1BlockCommitment::new(TEST_GENESIS_L1_HEIGHT, fixed_l1_block_id(0x55));
+    let summary = EpochSummary::new(
+        0,
+        terminal,
+        OLBlockCommitment::null(),
+        genesis_l1,
+        fixed_buf32(0x99),
+    );
+    let commitment = summary.get_epoch_commitment();
+
+    let provider = MockProvider::new()
+        .with_epoch_commitment(0, commitment)
+        .with_epoch_summary(summary);
+
+    let rpc = make_rpc_checkpoint_sync(provider);
+
+    let info = rpc
+        .get_checkpoint_info(0)
+        .await
+        .expect("checkpoint info should not error")
+        .expect("epoch 0 checkpoint should exist");
+    assert_eq!(info.idx, 0);
+    assert_eq!(info.l2_range.0, terminal);
+    assert_eq!(info.l2_range.1, terminal);
+}
+
+#[tokio::test]
 async fn checkpoint_info_errors_when_l1_tip_is_below_observed_height() {
     let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
     let observed_height = 505;
@@ -1528,6 +1617,42 @@ async fn blocks_summaries_start_gt_end_returns_invalid_params() {
     let result = rpc.get_blocks_summaries(test_account_id(1), 10, 5).await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), INVALID_PARAMS_CODE);
+}
+
+#[tokio::test]
+async fn blocks_summaries_non_genesis_errors_on_checkpoint_sync() {
+    // Beyond genesis a checkpoint-sync node has no canonical blocks, so an empty
+    // result would falsely read as "present but empty". Expect a capability
+    // error instead.
+    let provider = MockProvider::new();
+    let rpc = make_rpc_checkpoint_sync(provider);
+
+    let err = rpc
+        .get_blocks_summaries(test_account_id(1), 1, 3)
+        .await
+        .expect_err("checkpoint-sync must not serve non-genesis block summaries");
+    assert_eq!(err.code(), NOT_AVAILABLE_ON_NODE_CODE);
+    assert!(err.message().contains("block bodies"));
+}
+
+#[tokio::test]
+async fn blocks_summaries_genesis_ok_on_checkpoint_sync() {
+    // Genesis (slot 0) is always available, so the [0, 0] range still works on a
+    // checkpoint-sync node.
+    let account_id = test_account_id(1);
+    let genesis_block = make_block(0, 0, null_blkid());
+    let provider = MockProvider::new().with_block_and_state(
+        &genesis_block,
+        ol_state_with_snark_account(account_id, 0, 0, DEFAULT_NEXT_INBOX_MSG_IDX),
+    );
+    let rpc = make_rpc_checkpoint_sync(provider);
+
+    let summaries = rpc
+        .get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect("genesis summary should be served");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].block_commitment().slot(), 0);
 }
 
 #[tokio::test]

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -36,7 +36,7 @@ use strata_snark_acct_types::{ProofState, Seqno, UpdateInputData, UpdateStateDat
 use strata_status::OLSyncStatus;
 use tokio::runtime::Builder;
 
-use super::{OLRpcServer, OlBlockDataAccess};
+use super::{OLBlockDataAccess, OLRpcServer};
 use crate::rpc::errors::{
     INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, MEMPOOL_CAPACITY_ERROR_CODE,
     NOT_AVAILABLE_ON_NODE_CODE, map_mempool_error_to_rpc,
@@ -652,7 +652,7 @@ fn make_rpc(provider: MockProvider) -> OLRpcServer<MockProvider> {
         provider,
         TEST_GENESIS_L1_HEIGHT,
         TEST_MAX_HEADERS_RANGE,
-        OlBlockDataAccess::Available,
+        OLBlockDataAccess::Available,
     )
 }
 
@@ -662,7 +662,7 @@ fn make_rpc_checkpoint_sync(provider: MockProvider) -> OLRpcServer<MockProvider>
         provider,
         TEST_GENESIS_L1_HEIGHT,
         TEST_MAX_HEADERS_RANGE,
-        OlBlockDataAccess::Unavailable,
+        OLBlockDataAccess::Unavailable,
     )
 }
 
@@ -988,8 +988,8 @@ async fn checkpoint_info_with_l1_advance() {
         .expect("checkpoint should exist");
 
     assert_eq!(info.idx, 2);
-    assert_eq!(info.l2_range.0.slot(), 11);
-    assert_eq!(info.l2_range.1, terminal);
+    assert_eq!(info.l2_start.expect("full node has l2 start").slot(), 11);
+    assert_eq!(info.l2_end, terminal);
     assert_eq!(info.l1_range.0.height(), 501);
     assert_eq!(info.l1_range.1.height(), 510);
 }
@@ -1298,8 +1298,8 @@ async fn checkpoint_info_epoch_0_with_l1_advance() {
     assert_eq!(info.l1_range.0.height(), TEST_GENESIS_L1_HEIGHT + 1);
     assert_eq!(*info.l1_range.0.blkid(), l1_start_blkid);
     assert_eq!(info.l1_range.1, advanced_l1);
-    assert_eq!(info.l2_range.0, terminal);
-    assert_eq!(info.l2_range.1, terminal);
+    assert_eq!(info.l2_start.expect("full node has l2 start"), terminal);
+    assert_eq!(info.l2_end, terminal);
     match info.confirmation_status {
         RpcCheckpointConfStatus::Finalized { l1_reference } => {
             assert_eq!(l1_reference.l1_block, advanced_l1);
@@ -1341,8 +1341,8 @@ async fn checkpoint_info_epoch_0_l1_did_not_advance() {
     assert_eq!(info.idx, 0);
     assert_eq!(info.l1_range.0, genesis_l1);
     assert_eq!(info.l1_range.1, genesis_l1);
-    assert_eq!(info.l2_range.0, terminal);
-    assert_eq!(info.l2_range.1, terminal);
+    assert_eq!(info.l2_start.expect("full node has l2 start"), terminal);
+    assert_eq!(info.l2_end, terminal);
     assert!(info.l1_range.0.height() <= info.l1_range.1.height());
     match info.confirmation_status {
         RpcCheckpointConfStatus::Finalized { l1_reference } => {
@@ -1355,10 +1355,10 @@ async fn checkpoint_info_epoch_0_l1_did_not_advance() {
 }
 
 #[tokio::test]
-async fn checkpoint_info_non_genesis_errors_on_checkpoint_sync() {
-    // Checkpoint-sync nodes lack block bodies, so the first-L2-block walk for a
-    // non-genesis epoch must report a capability error rather than the
-    // misleading "block not found".
+async fn checkpoint_info_non_genesis_omits_l2_start_on_checkpoint_sync() {
+    // Checkpoint-sync nodes lack block bodies, so the first L2 block of a
+    // non-genesis epoch is unavailable: `l2_start` is `None`. The rest of the
+    // checkpoint info (terminal, L1 range, status) is still served.
     let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
     let terminal = L2BlockCommitment::new(20, fixed_ol_block_id(0x20));
     let prev_summary = EpochSummary::new(
@@ -1378,21 +1378,50 @@ async fn checkpoint_info_non_genesis_errors_on_checkpoint_sync() {
     let prev_commitment = prev_summary.get_epoch_commitment();
     let cur_commitment = cur_summary.get_epoch_commitment();
 
+    let l1_ref = CheckpointL1Ref::new(
+        L1BlockCommitment::new(505, fixed_l1_block_id(0x50)),
+        RBuf32::from(fixed_buf32(0xAA).0),
+        RBuf32::from(fixed_buf32(0xBB).0),
+    );
+
     // No block bodies registered: this is what a checkpoint-sync node has.
     let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            OLBlockCommitment::new(120, fixed_ol_block_id(0x77)),
+            3,
+            false,
+            prev_commitment,
+            cur_commitment,
+            prev_commitment,
+        ))
+        .with_l1_tip_height(510)
         .with_epoch_commitment(1, prev_commitment)
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
-        .with_epoch_summary(cur_summary);
+        .with_epoch_summary(cur_summary)
+        .with_manifest(
+            AsmManifest::new(
+                501,
+                L1BlockId::from(Buf32::from([0x61; 32])),
+                WtxidsRoot::default(),
+                vec![],
+            )
+            .expect("test manifest should be valid"),
+        )
+        .with_checkpoint_l1_ref(cur_commitment, l1_ref);
 
     let rpc = make_rpc_checkpoint_sync(provider);
 
-    let err = rpc
+    let info = rpc
         .get_checkpoint_info(2)
         .await
-        .expect_err("checkpoint-sync must not serve non-genesis checkpoint info");
-    assert_eq!(err.code(), NOT_AVAILABLE_ON_NODE_CODE);
-    assert!(err.message().contains("block bodies"));
+        .expect("checkpoint info")
+        .expect("checkpoint should exist");
+    assert_eq!(info.idx, 2);
+    assert_eq!(info.l2_start, None, "checkpoint-sync omits the L2 start");
+    assert_eq!(info.l2_end, terminal);
+    assert_eq!(info.l1_range.0.height(), 501);
+    assert_eq!(info.l1_range.1.height(), 510);
 }
 
 #[tokio::test]
@@ -1423,8 +1452,12 @@ async fn checkpoint_info_epoch_0_ok_on_checkpoint_sync() {
         .expect("checkpoint info should not error")
         .expect("epoch 0 checkpoint should exist");
     assert_eq!(info.idx, 0);
-    assert_eq!(info.l2_range.0, terminal);
-    assert_eq!(info.l2_range.1, terminal);
+    assert_eq!(
+        info.l2_start
+            .expect("epoch 0 start is the genesis terminal"),
+        terminal
+    );
+    assert_eq!(info.l2_end, terminal);
 }
 
 #[tokio::test]

--- a/crates/chain-worker/Cargo.toml
+++ b/crates/chain-worker/Cargo.toml
@@ -42,6 +42,7 @@ tracing.workspace = true
 strata-db-store-sled.workspace = true
 strata-ol-state-types = { workspace = true, features = ["test-utils"] }
 strata-ol-stf = { workspace = true, features = ["test-utils"] }
+strata-predicate.workspace = true
 strata-snark-acct-types.workspace = true
 strata-storage = { workspace = true, features = ["test-utils"] }
 sled.workspace = true

--- a/crates/chain-worker/src/context.rs
+++ b/crates/chain-worker/src/context.rs
@@ -485,8 +485,14 @@ pub(crate) fn build_checkpoint_indexing_writes(
                 found: log.new_msg_idx(),
             });
         }
+        // Checkpoint-sync has no per-block attribution, but the terminal update
+        // of an epoch carries a recoverable post-epoch root; earlier updates
+        // have `None`.
+        let update_meta = update
+            .state()
+            .map(|root| AccountUpdateMeta::new(None, root));
         let record = AccountUpdateRecord::new(
-            None,
+            update_meta,
             *update.seqno().inner(),
             update.prev_next_read_idx(),
             update.next_read_idx(),
@@ -714,6 +720,66 @@ mod tests {
                 found: 0
             }
         ));
+    }
+
+    /// Builds an output with snark updates and one matching log per update.
+    fn checkpoint_output_with_snark_updates(
+        updates: impl IntoIterator<Item = (AccountId, AccountSerial, SnarkAcctStateUpdate)>,
+    ) -> OLBlockExecutionOutput {
+        let mut indexer_writes = IndexerWrites::new();
+        let mut logs = Vec::new();
+        for (_account_id, serial, update) in updates {
+            let log_data =
+                SnarkAccountUpdateLogData::new(update.next_read_idx(), vec![0xaa]).unwrap();
+            logs.push(OLLog::new(serial, log_data.encode_log().unwrap()));
+            indexer_writes.push_snark_acct_update(update);
+        }
+        OLBlockExecutionOutput::new(Buf32::zero(), WriteBatch::default(), indexer_writes, logs)
+    }
+
+    /// Regression: a checkpoint-sync update that carries a terminal post-epoch
+    /// root must surface that root in the index record. Today
+    /// `build_checkpoint_indexing_writes` drops it (`update_meta: None`),
+    /// which is what makes RPC `new_state_root` come back null.
+    #[test]
+    fn build_checkpoint_indexing_writes_keeps_terminal_root() {
+        let account_id = AccountId::from([7u8; 32]);
+        let serial = AccountSerial::from(7u32);
+        let root = Hash::from([9u8; 32]);
+
+        let update = SnarkAcctStateUpdate::new(account_id, Some(root), 0, 3, Seqno::from(5));
+        let output = checkpoint_output_with_snark_updates([(account_id, serial, update)]);
+
+        let writes = build_checkpoint_indexing_writes(&output).unwrap();
+        let records = writes
+            .account_updates()
+            .get(&account_id)
+            .expect("account update should be present");
+        assert_eq!(records.len(), 1);
+
+        let meta = records[0]
+            .update_meta()
+            .expect("terminal update must carry root metadata");
+        assert_eq!(meta.new_state_root(), root);
+        assert!(
+            meta.block_commitment().is_none(),
+            "checkpoint-sync rows have no block attribution"
+        );
+    }
+
+    /// Updates with no root (earlier updates in a multi-update epoch) stay
+    /// `update_meta: None` — the intermediate roots are genuinely unavailable.
+    #[test]
+    fn build_checkpoint_indexing_writes_leaves_non_terminal_root_absent() {
+        let account_id = AccountId::from([8u8; 32]);
+        let serial = AccountSerial::from(8u32);
+
+        let earlier = SnarkAcctStateUpdate::new(account_id, None, 0, 2, Seqno::from(1));
+        let output = checkpoint_output_with_snark_updates([(account_id, serial, earlier)]);
+
+        let writes = build_checkpoint_indexing_writes(&output).unwrap();
+        let records = writes.account_updates().get(&account_id).unwrap();
+        assert!(records[0].update_meta().is_none());
     }
 
     fn output_with_l1_block_records(

--- a/crates/chain-worker/src/context.rs
+++ b/crates/chain-worker/src/context.rs
@@ -454,9 +454,7 @@ fn debug_assert_contiguous_update_ranges(
 
 /// Builds an [`IndexingWrites`] payload for a DA-reconstructed epoch.
 ///
-/// Like [`build_indexing_writes`] but with no per-block attribution and no
-/// per-update state root: update records carry `update_meta: None`. The
-/// post-epoch root lives on the epoch summary.
+/// Like [`build_indexing_writes`] but with no per-block attribution.
 pub(crate) fn build_checkpoint_indexing_writes(
     output: &OLBlockExecutionOutput,
 ) -> WorkerResult<IndexingWrites> {

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -17,7 +17,7 @@ use strata_asm_proto_checkpoint_types::{CheckpointSidecar, CheckpointTip};
 use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::errors::DbError;
-use strata_identifiers::{AccountId, Buf32, Epoch, Hash, OLBlockCommitment};
+use strata_identifiers::{AccountId, Buf32, Epoch, OLBlockCommitment};
 use strata_ledger_types::{
     IAccountState, ISnarkAccountState, IStateAccessor, StateError, StateResult,
 };
@@ -44,22 +44,21 @@ use crate::{
     traits::ChainWorkerContext,
 };
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct SnarkAccountCursor {
     seqno: Seqno,
     next_inbox_msg_idx: u64,
 }
 
-impl SnarkAccountCursor {
-    pub(crate) fn new_empty() -> Self {
-        Self {
-            seqno: Seqno::zero(),
-            next_inbox_msg_idx: 0,
-        }
-    }
-}
-
 type SnarkAccountCursors = HashMap<AccountSerial, SnarkAccountCursor>;
+
+#[derive(Clone)]
+struct ReconstructedSnarkData {
+    /// Snark acct updates as they appear in OL logs.
+    updates: Vec<SnarkAcctStateUpdate>,
+    /// New cursors(next inbox id and seq no) for each account in logs.
+    acct_cursors: SnarkAccountCursors,
+}
 
 /// Mutable state for the chain worker.
 ///
@@ -523,9 +522,10 @@ pub(crate) fn apply_checkpoint_epoch(
 
     // Replace the DA-collapsed snark records (one per account) with per-update
     // records derived from the epoch's `ol_logs`.
-    let (rebuilt_snark_updates, derived_cursors) =
-        rebuild_snark_records_from_logs(&indexer_state, &ol_logs, &pre_cursors)?;
-    let derived_seqnos: HashMap<AccountSerial, Seqno> = derived_cursors
+    let recons_data =
+        reconstruct_snark_acct_update_records(&indexer_state, &ol_logs, &pre_cursors)?;
+    let derived_seqnos: HashMap<AccountSerial, Seqno> = recons_data
+        .acct_cursors
         .iter()
         .map(|(&serial, cursor)| (serial, cursor.seqno))
         .collect();
@@ -544,7 +544,7 @@ pub(crate) fn apply_checkpoint_epoch(
 
     verify_snark_seqno_invariant(&new_state, &derived_seqnos)?;
 
-    indexer_writes.set_snark_acct_state_updates(rebuilt_snark_updates);
+    indexer_writes.set_snark_acct_state_updates(recons_data.updates);
     let final_state_root =
         new_state
             .compute_state_root()
@@ -708,7 +708,8 @@ fn verify_snark_seqno_invariant<S: IStateAccessor>(
             .find_account_id_by_serial(serial)
             .map_err(acct_read_err("post-state serial lookup"))?
             .ok_or(WorkerError::UnknownAccountSerial(serial))?;
-        let post = snark_acct_seq_no(state, account_id)
+        let post = get_snark_acct(state, account_id)
+            .map(|s| s.seqno())
             .map_err(acct_read_err("post-state as_snark_account"))?;
         if post != derived {
             error!(
@@ -743,38 +744,48 @@ fn collect_pre_snark_account_cursors<S: IStateAccessor>(
         if pre_cursors.contains_key(&serial) {
             continue;
         }
-        let cursor = match base_state
-            .find_account_id_by_serial(serial)
-            .map_err(acct_read_err("pre-state serial lookup"))?
-        {
-            None => SnarkAccountCursor::new_empty(),
-            Some(account_id) => match snark_acct(base_state, account_id) {
-                Ok(snacct) => SnarkAccountCursor {
-                    seqno: snacct.seqno(),
-                    next_inbox_msg_idx: snacct.next_inbox_msg_idx(),
-                },
-                Err(StateError::MissingAccount(_)) => SnarkAccountCursor::new_empty(),
-                Err(source) => {
-                    return Err(acct_read_err("pre-state account read")(source));
-                }
-            },
-        };
+        let cursor = get_snark_acct_cursor(base_state, serial)?;
         pre_cursors.insert(serial, cursor);
     }
     Ok(pre_cursors)
 }
 
-/// Rebuilds per-update snark index records from the epoch's OL logs.
-fn rebuild_snark_records_from_logs<S: IStateAccessor>(
+/// Gets account state and constructs `SnarkAccountCursor` from the state defaulting to zero valued
+/// cursors.
+fn get_snark_acct_cursor<S: IStateAccessor>(
+    base_state: &S,
+    serial: AccountSerial,
+) -> WorkerResult<SnarkAccountCursor> {
+    let cursor = match base_state
+        .find_account_id_by_serial(serial)
+        .map_err(acct_read_err("pre-state serial lookup"))?
+    {
+        None => SnarkAccountCursor::default(),
+        Some(account_id) => match get_snark_acct(base_state, account_id) {
+            Ok(snacct) => SnarkAccountCursor {
+                seqno: snacct.seqno(),
+                next_inbox_msg_idx: snacct.next_inbox_msg_idx(),
+            },
+            Err(StateError::MissingAccount(_)) => SnarkAccountCursor::default(),
+            Err(source) => {
+                return Err(acct_read_err("pre-state account read")(source));
+            }
+        },
+    };
+    Ok(cursor)
+}
+
+/// Reconstructs per-update snark index records from the epoch's OL logs.
+fn reconstruct_snark_acct_update_records<S: IStateAccessor>(
     state: &S,
     ol_logs: &[OLLog],
     pre_cursors: &SnarkAccountCursors,
-) -> WorkerResult<(Vec<SnarkAcctStateUpdate>, SnarkAccountCursors)> {
-    let mut next_cursor: SnarkAccountCursors = HashMap::new();
-    let mut records = Vec::with_capacity(ol_logs.len());
+) -> WorkerResult<ReconstructedSnarkData> {
+    let mut acct_cursors: SnarkAccountCursors = HashMap::new();
+    let mut updates = Vec::with_capacity(ol_logs.len());
     // Index of each account's last update, so we can stamp the recoverable
     // post-epoch root onto it after the walk.
-    let mut last_record_idx: HashMap<AccountId, usize> = HashMap::new();
+    let mut acct_last_record_idx: HashMap<AccountId, usize> = HashMap::new();
 
     for log in ol_logs {
         let serial = log.account_serial();
@@ -793,11 +804,11 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
             .map_err(acct_read_err("post-state serial lookup"))?
             .ok_or(WorkerError::UnknownAccountSerial(serial))?;
 
-        let cur = next_cursor.entry(serial).or_insert_with(|| {
+        let cur = acct_cursors.entry(serial).or_insert_with(|| {
             pre_cursors
                 .get(&serial)
                 .copied()
-                .unwrap_or(SnarkAccountCursor::new_empty())
+                .unwrap_or(SnarkAccountCursor::default())
         });
         let prev_next_read_idx = cur.next_inbox_msg_idx;
         cur.seqno = cur.seqno.incr();
@@ -806,8 +817,8 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
 
         // Intermediate per-update roots are not in checkpoint logs; the terminal
         // update is patched below with the recoverable post-epoch root.
-        last_record_idx.insert(account_id, records.len());
-        records.push(SnarkAcctStateUpdate::new(
+        acct_last_record_idx.insert(account_id, updates.len());
+        updates.push(SnarkAcctStateUpdate::new(
             account_id,
             None,
             prev_next_read_idx,
@@ -818,17 +829,21 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
 
     // The post-DA state holds each account's final inner state root, which is
     // the terminal update's post-state root. Earlier updates stay `None`.
-    for (account_id, idx) in last_record_idx {
-        let root = snark_acct_inner_state_root(state, account_id)
+    for (account_id, idx) in acct_last_record_idx {
+        let root = get_snark_acct(state, account_id)
+            .map(|s| s.inner_state_root())
             .map_err(acct_read_err("post epoch snark state root"))?;
-        records[idx].set_state(Some(root));
+        updates[idx].set_state(Some(root));
     }
 
-    Ok((records, next_cursor))
+    Ok(ReconstructedSnarkData {
+        updates,
+        acct_cursors,
+    })
 }
 
 /// Gets corresponding snark account for given account id.
-fn snark_acct<S: IStateAccessor>(
+fn get_snark_acct<S: IStateAccessor>(
     state: &S,
     account_id: AccountId,
 ) -> StateResult<&<S::AccountState as IAccountState>::SnarkAccountState> {
@@ -837,19 +852,6 @@ fn snark_acct<S: IStateAccessor>(
     };
 
     acct.as_snark_account()
-}
-
-/// Reads an account's final inner state root from state.
-fn snark_acct_inner_state_root<S: IStateAccessor>(
-    state: &S,
-    account_id: AccountId,
-) -> StateResult<Hash> {
-    snark_acct(state, account_id).map(|s| s.inner_state_root())
-}
-
-/// Gets an account's sequencer number.
-fn snark_acct_seq_no<S: IStateAccessor>(state: &S, account_id: AccountId) -> StateResult<Seqno> {
-    snark_acct(state, account_id).map(|s| s.seqno())
 }
 
 /// Builds a [`WorkerError::AccountStateRead`] closure tagged with `stage`.
@@ -949,6 +951,7 @@ fn build_epoch_summary(
 
 #[cfg(test)]
 mod tests {
+    use strata_acct_types::Hash;
     use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId, L1Height, OLBlockId};
     use strata_ol_chain_types::{BlockFlags, OLBlockHeader};
     use strata_ol_state_support_types::IndexerWrites;
@@ -1049,8 +1052,9 @@ mod tests {
         };
         let logs = vec![log(1), log(2)];
 
-        let (records, _) =
-            rebuild_snark_records_from_logs(&state, &logs, &HashMap::new()).expect("rebuild");
+        let ReconstructedSnarkData {
+            updates: records, ..
+        } = reconstruct_snark_acct_update_records(&state, &logs, &HashMap::new()).expect("rebuild");
 
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].state(), None, "earlier update root unavailable");

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -18,7 +18,9 @@ use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::errors::DbError;
 use strata_identifiers::{AccountId, Buf32, Epoch, Hash, OLBlockCommitment};
-use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
+use strata_ledger_types::{
+    IAccountState, ISnarkAccountState, IStateAccessor, StateError, StateResult,
+};
 use strata_msg_fmt::{Msg, MsgRef};
 use strata_ol_chain_types::{
     BlockFlags, MAX_SEALING_MANIFEST_COUNT, OLBlock, OLBlockHeader, OLLog, OLLogType,
@@ -46,6 +48,15 @@ use crate::{
 struct SnarkAccountCursor {
     seqno: Seqno,
     next_inbox_msg_idx: u64,
+}
+
+impl SnarkAccountCursor {
+    pub(crate) fn new_empty() -> Self {
+        Self {
+            seqno: Seqno::zero(),
+            next_inbox_msg_idx: 0,
+        }
+    }
 }
 
 type SnarkAccountCursors = HashMap<AccountSerial, SnarkAccountCursor>;
@@ -695,29 +706,10 @@ fn verify_snark_seqno_invariant<S: IStateAccessor>(
     for (&serial, &derived) in derived_seqnos {
         let account_id = state
             .find_account_id_by_serial(serial)
-            .map_err(|source| WorkerError::AccountStateRead {
-                stage: "post-state serial lookup",
-                source,
-            })?
+            .map_err(acct_read_err("post-state serial lookup"))?
             .ok_or(WorkerError::UnknownAccountSerial(serial))?;
-        let acct = state
-            .get_account_state(account_id)
-            .map_err(|source| WorkerError::AccountStateRead {
-                stage: "post-state account read",
-                source,
-            })?
-            .ok_or_else(|| {
-                WorkerError::Unexpected(format!(
-                    "post-state account {account_id} missing after batch apply"
-                ))
-            })?;
-        let post = acct
-            .as_snark_account()
-            .map(|s| s.seqno())
-            .map_err(|source| WorkerError::AccountStateRead {
-                stage: "post-state as_snark_account",
-                source,
-            })?;
+        let post = snark_acct_seq_no(state, account_id)
+            .map_err(acct_read_err("post-state as_snark_account"))?;
         if post != derived {
             error!(
                 ?serial, %account_id, ?derived, ?post,
@@ -753,34 +745,18 @@ fn collect_pre_snark_account_cursors<S: IStateAccessor>(
         }
         let cursor = match base_state
             .find_account_id_by_serial(serial)
-            .map_err(|source| WorkerError::AccountStateRead {
-                stage: "pre-state serial lookup",
-                source,
-            })? {
-            Some(id) => match base_state.get_account_state(id).map_err(|source| {
-                WorkerError::AccountStateRead {
-                    stage: "pre-state account read",
-                    source,
-                }
-            })? {
-                Some(state) => state
-                    .as_snark_account()
-                    .map(|s| SnarkAccountCursor {
-                        seqno: s.seqno(),
-                        next_inbox_msg_idx: s.next_inbox_msg_idx(),
-                    })
-                    .map_err(|source| WorkerError::AccountStateRead {
-                        stage: "pre-state as_snark_account",
-                        source,
-                    })?,
-                None => SnarkAccountCursor {
-                    seqno: Seqno::zero(),
-                    next_inbox_msg_idx: 0,
+            .map_err(acct_read_err("pre-state serial lookup"))?
+        {
+            None => SnarkAccountCursor::new_empty(),
+            Some(account_id) => match snark_acct(base_state, account_id) {
+                Ok(snacct) => SnarkAccountCursor {
+                    seqno: snacct.seqno(),
+                    next_inbox_msg_idx: snacct.next_inbox_msg_idx(),
                 },
-            },
-            None => SnarkAccountCursor {
-                seqno: Seqno::zero(),
-                next_inbox_msg_idx: 0,
+                Err(StateError::MissingAccount(_)) => SnarkAccountCursor::new_empty(),
+                Err(source) => {
+                    return Err(acct_read_err("pre-state account read")(source));
+                }
             },
         };
         pre_cursors.insert(serial, cursor);
@@ -798,7 +774,7 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
     let mut records = Vec::with_capacity(ol_logs.len());
     // Index of each account's last update, so we can stamp the recoverable
     // post-epoch root onto it after the walk.
-    let mut terminal_idx: HashMap<AccountId, usize> = HashMap::new();
+    let mut last_record_idx: HashMap<AccountId, usize> = HashMap::new();
 
     for log in ol_logs {
         let serial = log.account_serial();
@@ -814,20 +790,14 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
 
         let account_id = state
             .find_account_id_by_serial(serial)
-            .map_err(|source| WorkerError::AccountStateRead {
-                stage: "post-state serial lookup",
-                source,
-            })?
+            .map_err(acct_read_err("post-state serial lookup"))?
             .ok_or(WorkerError::UnknownAccountSerial(serial))?;
 
         let cur = next_cursor.entry(serial).or_insert_with(|| {
             pre_cursors
                 .get(&serial)
                 .copied()
-                .unwrap_or(SnarkAccountCursor {
-                    seqno: Seqno::zero(),
-                    next_inbox_msg_idx: 0,
-                })
+                .unwrap_or(SnarkAccountCursor::new_empty())
         });
         let prev_next_read_idx = cur.next_inbox_msg_idx;
         cur.seqno = cur.seqno.incr();
@@ -836,7 +806,7 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
 
         // Intermediate per-update roots are not in checkpoint logs; the terminal
         // update is patched below with the recoverable post-epoch root.
-        terminal_idx.insert(account_id, records.len());
+        last_record_idx.insert(account_id, records.len());
         records.push(SnarkAcctStateUpdate::new(
             account_id,
             None,
@@ -848,41 +818,43 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
 
     // The post-DA state holds each account's final inner state root, which is
     // the terminal update's post-state root. Earlier updates stay `None`.
-    for (account_id, idx) in terminal_idx {
-        let root = post_epoch_inner_state_root(state, account_id)?;
-        let prev = &records[idx];
-        records[idx] = SnarkAcctStateUpdate::new(
-            account_id,
-            Some(root),
-            prev.prev_next_read_idx(),
-            prev.next_read_idx(),
-            prev.seqno(),
-        );
+    for (account_id, idx) in last_record_idx {
+        let root = snark_acct_inner_state_root(state, account_id)
+            .map_err(acct_read_err("post epoch snark state root"))?;
+        records[idx].set_state(Some(root));
     }
 
     Ok((records, next_cursor))
 }
 
-/// Reads an account's final inner state root from the post-DA state.
-fn post_epoch_inner_state_root<S: IStateAccessor>(
+/// Gets corresponding snark account for given account id.
+fn snark_acct<S: IStateAccessor>(
     state: &S,
     account_id: AccountId,
-) -> WorkerResult<Hash> {
-    let acct = state
-        .get_account_state(account_id)
-        .map_err(|source| WorkerError::AccountStateRead {
-            stage: "post-state account read",
-            source,
-        })?
-        .ok_or_else(|| {
-            WorkerError::Unexpected(format!("post-state account {account_id} missing"))
-        })?;
+) -> StateResult<&<S::AccountState as IAccountState>::SnarkAccountState> {
+    let Some(acct) = state.get_account_state(account_id)? else {
+        return Err(StateError::MissingAccount(account_id));
+    };
+
     acct.as_snark_account()
-        .map(|s| s.inner_state_root())
-        .map_err(|source| WorkerError::AccountStateRead {
-            stage: "post-state as_snark_account",
-            source,
-        })
+}
+
+/// Reads an account's final inner state root from state.
+fn snark_acct_inner_state_root<S: IStateAccessor>(
+    state: &S,
+    account_id: AccountId,
+) -> StateResult<Hash> {
+    snark_acct(state, account_id).map(|s| s.inner_state_root())
+}
+
+/// Gets an account's sequencer number.
+fn snark_acct_seq_no<S: IStateAccessor>(state: &S, account_id: AccountId) -> StateResult<Seqno> {
+    snark_acct(state, account_id).map(|s| s.seqno())
+}
+
+/// Builds a [`WorkerError::AccountStateRead`] closure tagged with `stage`.
+fn acct_read_err(stage: &'static str) -> impl FnOnce(StateError) -> WorkerError {
+    move |source| WorkerError::AccountStateRead { stage, source }
 }
 
 /// The values produced by reconstructing one epoch from its checkpoint,

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -785,7 +785,7 @@ fn reconstruct_snark_acct_update_records<S: IStateAccessor>(
     let mut updates = Vec::with_capacity(ol_logs.len());
     // Index of each account's last update, so we can stamp the recoverable
     // post-epoch root onto it after the walk.
-    let mut acct_last_record_idx: HashMap<AccountId, usize> = HashMap::new();
+    let mut last_record_idxs: HashMap<AccountId, usize> = HashMap::new();
 
     for log in ol_logs {
         let serial = log.account_serial();
@@ -817,7 +817,7 @@ fn reconstruct_snark_acct_update_records<S: IStateAccessor>(
 
         // Intermediate per-update roots are not in checkpoint logs; the terminal
         // update is patched below with the recoverable post-epoch root.
-        acct_last_record_idx.insert(account_id, updates.len());
+        last_record_idxs.insert(account_id, updates.len());
         updates.push(SnarkAcctStateUpdate::new(
             account_id,
             None,
@@ -829,7 +829,7 @@ fn reconstruct_snark_acct_update_records<S: IStateAccessor>(
 
     // The post-DA state holds each account's final inner state root, which is
     // the terminal update's post-state root. Earlier updates stay `None`.
-    for (account_id, idx) in acct_last_record_idx {
+    for (account_id, idx) in last_record_idxs {
         let root = get_snark_acct(state, account_id)
             .map(|s| s.inner_state_root())
             .map_err(acct_read_err("post epoch snark state root"))?;

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -17,7 +17,7 @@ use strata_asm_proto_checkpoint_types::{CheckpointSidecar, CheckpointTip};
 use strata_bridge_params::BridgeParams;
 use strata_checkpoint_types::EpochSummary;
 use strata_db_types::errors::DbError;
-use strata_identifiers::{Buf32, Epoch, OLBlockCommitment};
+use strata_identifiers::{AccountId, Buf32, Epoch, Hash, OLBlockCommitment};
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_msg_fmt::{Msg, MsgRef};
 use strata_ol_chain_types::{
@@ -796,6 +796,9 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
 ) -> WorkerResult<(Vec<SnarkAcctStateUpdate>, SnarkAccountCursors)> {
     let mut next_cursor: SnarkAccountCursors = HashMap::new();
     let mut records = Vec::with_capacity(ol_logs.len());
+    // Index of each account's last update, so we can stamp the recoverable
+    // post-epoch root onto it after the walk.
+    let mut terminal_idx: HashMap<AccountId, usize> = HashMap::new();
 
     for log in ol_logs {
         let serial = log.account_serial();
@@ -831,7 +834,9 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
         cur.next_inbox_msg_idx = log_data.new_msg_idx;
         let seqno = cur.seqno;
 
-        // No per-update inner state root is available from checkpoint logs.
+        // Intermediate per-update roots are not in checkpoint logs; the terminal
+        // update is patched below with the recoverable post-epoch root.
+        terminal_idx.insert(account_id, records.len());
         records.push(SnarkAcctStateUpdate::new(
             account_id,
             None,
@@ -841,7 +846,43 @@ fn rebuild_snark_records_from_logs<S: IStateAccessor>(
         ));
     }
 
+    // The post-DA state holds each account's final inner state root, which is
+    // the terminal update's post-state root. Earlier updates stay `None`.
+    for (account_id, idx) in terminal_idx {
+        let root = post_epoch_inner_state_root(state, account_id)?;
+        let prev = &records[idx];
+        records[idx] = SnarkAcctStateUpdate::new(
+            account_id,
+            Some(root),
+            prev.prev_next_read_idx(),
+            prev.next_read_idx(),
+            prev.seqno(),
+        );
+    }
+
     Ok((records, next_cursor))
+}
+
+/// Reads an account's final inner state root from the post-DA state.
+fn post_epoch_inner_state_root<S: IStateAccessor>(
+    state: &S,
+    account_id: AccountId,
+) -> WorkerResult<Hash> {
+    let acct = state
+        .get_account_state(account_id)
+        .map_err(|source| WorkerError::AccountStateRead {
+            stage: "post-state account read",
+            source,
+        })?
+        .ok_or_else(|| {
+            WorkerError::Unexpected(format!("post-state account {account_id} missing"))
+        })?;
+    acct.as_snark_account()
+        .map(|s| s.inner_state_root())
+        .map_err(|source| WorkerError::AccountStateRead {
+            stage: "post-state as_snark_account",
+            source,
+        })
 }
 
 /// The values produced by reconstructing one epoch from its checkpoint,
@@ -1000,5 +1041,51 @@ mod tests {
         assert_eq!(summary.epoch(), 5);
         assert_eq!(summary.final_state(), &state_root);
         assert_eq!(summary.prev_terminal(), &OLBlockCommitment::null());
+    }
+
+    /// Checkpoint reconstruction can only recover the terminal per-account root
+    /// (= post-epoch state root). Earlier updates in a multi-update epoch stay
+    /// `None`; the terminal update is stamped with the account's final root.
+    #[test]
+    fn rebuild_snark_records_stamps_terminal_root_only() {
+        use strata_acct_types::BitcoinAmount;
+        use strata_ledger_types::{IStateAccessorMut, NewAccountData, NewAccountTypeState};
+        use strata_ol_state_support_types::MemoryStateBaseLayer;
+        use strata_predicate::PredicateKey;
+
+        let account_id = AccountId::from([7u8; 32]);
+        let final_root = Hash::from([9u8; 32]);
+
+        let mut state = MemoryStateBaseLayer::new(create_test_genesis_state());
+        let serial = state
+            .create_new_account(
+                account_id,
+                NewAccountData::new(
+                    BitcoinAmount::zero(),
+                    NewAccountTypeState::Snark {
+                        update_vk: PredicateKey::always_accept(),
+                        initial_state_root: final_root,
+                    },
+                ),
+            )
+            .expect("create snark account");
+
+        // Two updates to the same account in one epoch (cursors advance 0->1->2).
+        let log = |new_idx: u64| {
+            let data = SnarkAccountUpdateLogData::new(new_idx, vec![0xaa]).unwrap();
+            OLLog::new(serial, data.encode_log().unwrap())
+        };
+        let logs = vec![log(1), log(2)];
+
+        let (records, _) =
+            rebuild_snark_records_from_logs(&state, &logs, &HashMap::new()).expect("rebuild");
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].state(), None, "earlier update root unavailable");
+        assert_eq!(
+            records[1].state(),
+            Some(final_root),
+            "terminal update carries post-epoch root"
+        );
     }
 }

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -156,9 +156,10 @@ pub struct RpcUpdateInputData {
     pub seq_no: u64,
     /// Inbox cursor after this update.
     pub next_inbox_msg_idx: u64,
-    /// Inner state root after this update. `None` on checkpoint-sync nodes,
-    /// which do not store per-update roots (only the post-epoch root on the
-    /// epoch summary). The epoch's `final_state_root` is still populated.
+    /// Inner state root after this update. On checkpoint-sync nodes only the
+    /// terminal update of an epoch carries a root (the recoverable post-epoch
+    /// root); earlier updates are `None`, since intermediate roots are not in
+    /// the checkpoint DA. The epoch's `final_state_root` is always populated.
     pub new_state_root: Option<HexBytes32>,
     /// Extra data posted with this update.
     pub extra_data: HexBytes,

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -156,8 +156,9 @@ pub struct RpcUpdateInputData {
     pub seq_no: u64,
     /// Inbox cursor after this update.
     pub next_inbox_msg_idx: u64,
-    /// Inner state root after this update. `None` for checkpoint-sync
-    /// sources on intermediate updates.
+    /// Inner state root after this update. `None` on checkpoint-sync nodes,
+    /// which do not store per-update roots (only the post-epoch root on the
+    /// epoch summary). The epoch's `final_state_root` is still populated.
     pub new_state_root: Option<HexBytes32>,
     /// Extra data posted with this update.
     pub extra_data: HexBytes,

--- a/crates/ol/rpc/types/src/checkpoint.rs
+++ b/crates/ol/rpc/types/src/checkpoint.rs
@@ -51,8 +51,11 @@ pub struct RpcCheckpointInfo {
     pub idx: u64,
     /// L1 block range (inclusive) covered by the checkpoint.
     pub l1_range: (L1BlockCommitment, L1BlockCommitment),
-    /// L2 block range (inclusive) covered by the checkpoint.
-    pub l2_range: (L2BlockCommitment, L2BlockCommitment),
+    /// First L2 block of the checkpoint. `None` on checkpoint-sync nodes for
+    /// non-genesis epochs, where deriving it needs block bodies the node lacks.
+    pub l2_start: Option<L2BlockCommitment>,
+    /// Last L2 block (terminal) of the checkpoint.
+    pub l2_end: L2BlockCommitment,
     /// Confirmation/finality status.
     pub confirmation_status: RpcCheckpointConfStatus,
 }

--- a/crates/ol/rpc/types/src/jsonschema.rs
+++ b/crates/ol/rpc/types/src/jsonschema.rs
@@ -85,7 +85,8 @@ impl schemars::JsonSchema for RpcCheckpointInfo {
             "required": [
                 "idx",
                 "l1_range",
-                "l2_range",
+                "l2_start",
+                "l2_end",
                 "confirmation_status"
             ],
             "properties": {
@@ -96,11 +97,11 @@ impl schemars::JsonSchema for RpcCheckpointInfo {
                     "maxItems": 2,
                     "items": { "type": "object" }
                 },
-                "l2_range": {
-                    "type": "array",
-                    "minItems": 2,
-                    "maxItems": 2,
-                    "items": { "type": "object" }
+                "l2_start": {
+                    "type": ["object", "null"]
+                },
+                "l2_end": {
+                    "type": "object"
                 },
                 "confirmation_status": {
                     "type": "object"

--- a/crates/ol/state-support-types/src/index_types.rs
+++ b/crates/ol/state-support-types/src/index_types.rs
@@ -64,8 +64,10 @@ pub struct SnarkAcctStateUpdate {
 
     /// The new inner state root, if known.
     ///
-    /// Present on block-sync updates; `None` for checkpoint-sync updates
-    /// rebuilt from logs, which carry no per-update intermediate root.
+    /// Present on block-sync updates. On checkpoint-sync only the terminal
+    /// per-account update of an epoch carries a root (the recoverable
+    /// post-epoch root); earlier updates are `None`, since intermediate roots
+    /// are not in the checkpoint logs.
     state: Option<Hash>,
 
     /// The inbox cursor before this update.
@@ -100,7 +102,8 @@ impl SnarkAcctStateUpdate {
         self.account_id
     }
 
-    /// Returns the new inner state root, or `None` for checkpoint-sync updates.
+    /// Returns the new inner state root. `None` for non-terminal checkpoint-sync
+    /// updates (intermediate roots are unavailable).
     pub fn state(&self) -> Option<Hash> {
         self.state
     }

--- a/crates/ol/state-support-types/src/index_types.rs
+++ b/crates/ol/state-support-types/src/index_types.rs
@@ -122,6 +122,11 @@ impl SnarkAcctStateUpdate {
     pub fn seqno(&self) -> Seqno {
         self.seqno
     }
+
+    /// Sets the inner state root.
+    pub fn set_state(&mut self, state: Option<Hash>) {
+        self.state = state;
+    }
 }
 
 // ============================================================================

--- a/crates/snark-acct-types/src/state.rs
+++ b/crates/snark-acct-types/src/state.rs
@@ -10,7 +10,7 @@ use crate::ssz_generated::ssz::state::*;
 type RawSeqno = u64;
 
 /// Account sequence number type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct Seqno(RawSeqno);
 


### PR DESCRIPTION
## Description
**AI Usage:** This PR was created with the assistance of claude and codex.

This PR fixes some of the issues surfaced in checkpoint sync node testing. The main change is the introduction of `OLBlockDataAccess: Available | Unavailable` enum to `OLRpcServer`. The rpc methods then use it to return appropriate response.

**Chain worker** now explicitly stores the new state root for an snark account for the terminal block in checkpoint sync path. This fixes the second issue in [the ticket](https://alpenlabs.atlassian.net/browse/STR-3857). 

**[Breaking Change(only one rpc method)]:** The `RpcCheckpointInfo` now splits `l2_range` into `l2_start: Option<OLBlockCommitment>` and `l2_end: OLBlockCommitment`. This is to make the method compatible with checkpoint sync node which cannot serve the start of the OL range(can only serve terminal block info). An alternative would be to have first value optional in the `l2_range` but although it keeps the response unchanged, it is a bit uglier. This fixes the first issue in [the ticket](https://alpenlabs.atlassian.net/browse/STR-3857).

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
