### PR TITLE
(btcio/writer): Ensure previous intent is bundled before bundling cur…

### DIFF
--- a/crates/btcio/src/writer/bundler/builder.rs
+++ b/crates/btcio/src/writer/bundler/builder.rs
@@ -2,14 +2,13 @@
 
 use std::{sync::Arc, time::Duration};
 
-use strata_db_types::l1_writer::IntentEntry;
 use strata_service::{ServiceBuilder, ServiceMonitor, TickingInput, TokioMpscInput};
 use strata_storage::ops::writer::EnvelopeDataOps;
 use strata_tasks::TaskExecutor;
 use tokio::sync::mpsc;
 
 use super::{
-    logic::get_initial_unbundled_entries,
+    logic::{get_initial_unbundled_entries, PendingIntent},
     service::{BundlerService, BundlerState, BundlerStatus},
 };
 
@@ -17,14 +16,14 @@ use super::{
 pub struct BundlerBuilder {
     ops: Arc<EnvelopeDataOps>,
     bundle_interval: Duration,
-    intent_rx: mpsc::Receiver<IntentEntry>,
+    intent_rx: mpsc::Receiver<PendingIntent>,
 }
 
 impl BundlerBuilder {
     pub fn new(
         ops: Arc<EnvelopeDataOps>,
         bundle_interval: Duration,
-        intent_rx: mpsc::Receiver<IntentEntry>,
+        intent_rx: mpsc::Receiver<PendingIntent>,
     ) -> Self {
         Self {
             ops,

--- a/crates/btcio/src/writer/bundler/logic.rs
+++ b/crates/btcio/src/writer/bundler/logic.rs
@@ -40,7 +40,9 @@ async fn is_predecessor_bundled(ops: &EnvelopeDataOps, idx: u64) -> anyhow::Resu
 
     let prev_idx = idx - 1;
     let Some(prev_entry) = ops.get_intent_by_idx_async(prev_idx).await? else {
-        bail!("missing predecessor intent entry at idx {prev_idx} before bundling idx {idx}");
+        bail!(
+            "inconsistent L1 writer DB: missing predecessor intent idx {prev_idx} before bundling idx {idx}"
+        );
     };
 
     match prev_entry.status {
@@ -51,7 +53,7 @@ async fn is_predecessor_bundled(ops: &EnvelopeDataOps, idx: u64) -> anyhow::Resu
 
 async fn bundle_unbundled_intent(ops: &EnvelopeDataOps, intent_idx: u64) -> anyhow::Result<()> {
     let Some(entry) = ops.get_intent_by_idx_async(intent_idx).await? else {
-        bail!("missing pending intent entry at idx {intent_idx}");
+        bail!("inconsistent L1 writer DB: pending intent idx {intent_idx} is missing");
     };
 
     // Check it is actually unbundled, omit if bundled.
@@ -162,6 +164,27 @@ mod tests {
                 .expect("test: scan unbundled")
                 .is_empty(),
             "restart recovery should not strand an earlier unbundled intent"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_predecessor_is_fatal_writer_db_inconsistency() {
+        let ops = get_envelope_ops();
+        let (first_idx, first_entry) = put_unbundled_intent(&ops, 1);
+        let (second_idx, _) = put_unbundled_intent(&ops, 2);
+
+        ops.del_intent_entry_blocking(*first_entry.intent.commitment())
+            .expect("test: delete predecessor intent");
+
+        let err = process_unbundled_entries(ops.as_ref(), vec![second_idx])
+            .await
+            .expect_err("missing predecessor should be fatal");
+
+        assert_eq!(first_idx, 0);
+        assert!(
+            err.to_string()
+                .contains("inconsistent L1 writer DB: missing predecessor intent idx 0"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/btcio/src/writer/bundler/logic.rs
+++ b/crates/btcio/src/writer/bundler/logic.rs
@@ -1,50 +1,89 @@
-use strata_db_types::{
-    l1_writer::{BundledPayloadEntry, IntentEntry, IntentStatus},
-    DbResult,
-};
+use std::collections::BTreeSet;
+
+use anyhow::bail;
+use strata_db_types::l1_writer::{BundledPayloadEntry, IntentStatus};
 use strata_storage::ops::writer::EnvelopeDataOps;
 use tracing::*;
 
-/// Processes and bundles a list of unbundled intents into payload entries. Returns a vector of
-/// entries which are unbundled for some reason.
+pub type PendingIntent = u64;
+
+/// Processes and bundles a list of pending intents into payload entries. Returns a vector of
+/// entries which remain unbundled for some reason.
 /// The reason could be the entries is too small in size to be included in an envelope and thus
 /// makes sense to include once a bunch of entries are collected.
-/// NOTE: The current logic is simply 1-1 mapping between intents and payloads, in future it can
-/// be sophisticated.
+///
+/// Ensures previous intents are bundled before bundling a new one.
 pub(crate) async fn process_unbundled_entries(
     ops: &EnvelopeDataOps,
-    unbundled: Vec<IntentEntry>,
-) -> DbResult<Vec<IntentEntry>> {
-    for entry in unbundled {
-        // Check it is actually unbundled, omit if bundled
-        if entry.status != IntentStatus::Unbundled {
+    unbundled: Vec<PendingIntent>,
+) -> anyhow::Result<Vec<PendingIntent>> {
+    let mut pending: BTreeSet<u64> = unbundled.into_iter().collect();
+
+    while let Some(&intent_idx) = pending.first() {
+        if !is_predecessor_bundled(ops, intent_idx).await? {
+            pending.insert(intent_idx - 1); // intent_idx - 1 is safe here as 0 is already checked
             continue;
         }
-        // NOTE: In future, the logic to create payload will be different. We need to group
-        // intents and create payload entries accordingly
-        let payload_entry = BundledPayloadEntry::new_unsigned(entry.payload().clone());
 
-        let intent_commitment = *entry.intent.commitment();
-        let idx = ops
-            .bundle_intent_payload_async(intent_commitment, entry, payload_entry)
-            .await?;
-        info!(
-            component = "btcio_writer_bundler",
-            %intent_commitment,
-            payload_idx = idx,
-            "bundled L1 intent into payload entry"
-        );
+        bundle_unbundled_intent(ops, intent_idx).await?;
+        pending.remove(&intent_idx);
     }
     // Return empty Vec because each entry is being bundled right now. This might be different in
     // future.
     Ok(vec![])
 }
 
-/// Retrieves unbundled intents since the beginning in ascending order along with the latest
-/// entry idx. This traverses backwards from latest index and breaks once it founds a bundled entry.
+async fn is_predecessor_bundled(ops: &EnvelopeDataOps, idx: u64) -> anyhow::Result<bool> {
+    if idx == 0 {
+        return Ok(true);
+    }
+
+    let prev_idx = idx - 1;
+    let Some(prev_entry) = ops.get_intent_by_idx_async(prev_idx).await? else {
+        bail!("missing predecessor intent entry at idx {prev_idx} before bundling idx {idx}");
+    };
+
+    match prev_entry.status {
+        IntentStatus::Bundled(_) => Ok(true),
+        IntentStatus::Unbundled => Ok(false),
+    }
+}
+
+async fn bundle_unbundled_intent(ops: &EnvelopeDataOps, intent_idx: u64) -> anyhow::Result<()> {
+    let Some(entry) = ops.get_intent_by_idx_async(intent_idx).await? else {
+        bail!("missing pending intent entry at idx {intent_idx}");
+    };
+
+    // Check it is actually unbundled, omit if bundled.
+    if entry.status != IntentStatus::Unbundled {
+        return Ok(());
+    }
+
+    // NOTE: In future, the logic to create payload will be different. We need to group
+    // intents and create payload entries accordingly
+    let payload_entry = BundledPayloadEntry::new_unsigned(entry.payload().clone());
+
+    let intent_commitment = *entry.intent.commitment();
+    let payload_idx = ops
+        .bundle_intent_payload_async(intent_commitment, entry, payload_entry)
+        .await?;
+    info!(
+        %intent_commitment,
+        intent_idx,
+        payload_idx,
+        "bundled L1 intent into payload entry"
+    );
+
+    Ok(())
+}
+
+/// Retrieves unbundled intents since the beginning in ascending order with their intent indexes.
+/// This traverses backwards from latest index and breaks once it finds a bundled entry. The
+/// processing of unbundled entries [`process_unbundled_entries`] ensures that the entries are
+/// bundled *in order*.
 pub(crate) fn get_initial_unbundled_entries(
     ops: &EnvelopeDataOps,
-) -> anyhow::Result<Vec<IntentEntry>> {
+) -> anyhow::Result<Vec<PendingIntent>> {
     let mut curr_idx = ops.get_next_intent_idx_blocking()?;
     let mut unbundled = Vec::new();
 
@@ -52,7 +91,7 @@ pub(crate) fn get_initial_unbundled_entries(
         curr_idx -= 1;
         if let Some(intent) = ops.get_intent_by_idx_blocking(curr_idx)? {
             match intent.status {
-                IntentStatus::Unbundled => unbundled.push(intent),
+                IntentStatus::Unbundled => unbundled.push(curr_idx),
                 IntentStatus::Bundled(_) => {
                     // Bundled intent found, no more to scan
                     break;
@@ -68,4 +107,81 @@ pub(crate) fn get_initial_unbundled_entries(
     unbundled.reverse();
 
     Ok(unbundled)
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_csm_types::{L1Payload, PayloadDest, PayloadIntent};
+    use strata_db_types::l1_writer::{BundledPayloadEntry, IntentEntry, IntentStatus};
+    use strata_l1_txfmt::TagData;
+    use strata_primitives::buf::Buf32;
+
+    use super::*;
+    use crate::writer::test_utils::get_envelope_ops;
+
+    fn test_intent(seed: u8) -> PayloadIntent {
+        let tag = TagData::new(1, seed, vec![]).expect("test tag is valid");
+        let payload = L1Payload::new(vec![vec![seed; 8]], tag).expect("test payload is valid");
+        PayloadIntent::new(PayloadDest::L1, Buf32::from([seed; 32]), payload)
+    }
+
+    fn put_unbundled_intent(ops: &EnvelopeDataOps, seed: u8) -> (u64, IntentEntry) {
+        let intent = test_intent(seed);
+        let id = *intent.commitment();
+        let entry = IntentEntry::new_unbundled(intent);
+        let idx = ops
+            .put_intent_entry_blocking(id, entry.clone())
+            .expect("test: put intent");
+        (idx, entry)
+    }
+
+    #[tokio::test]
+    async fn processes_missing_unbundled_predecessor_before_later_pending_intent() {
+        let ops = get_envelope_ops();
+        let (first_idx, first_entry) = put_unbundled_intent(&ops, 1);
+        let (second_idx, _) = put_unbundled_intent(&ops, 2);
+
+        process_unbundled_entries(ops.as_ref(), vec![second_idx])
+            .await
+            .expect("test: process pending intent");
+
+        let stored_first = ops
+            .get_intent_by_idx_blocking(first_idx)
+            .expect("test: get first intent")
+            .expect("test: first intent exists");
+        let stored_second = ops
+            .get_intent_by_idx_blocking(second_idx)
+            .expect("test: get second intent")
+            .expect("test: second intent exists");
+
+        assert_eq!(stored_first.intent, first_entry.intent);
+        assert_eq!(stored_first.status, IntentStatus::Bundled(0));
+        assert_eq!(stored_second.status, IntentStatus::Bundled(1));
+        assert!(
+            get_initial_unbundled_entries(ops.as_ref())
+                .expect("test: scan unbundled")
+                .is_empty(),
+            "restart recovery should not strand an earlier unbundled intent"
+        );
+    }
+
+    #[test]
+    fn startup_scan_returns_indexed_unbundled_tail_in_order() {
+        let ops = get_envelope_ops();
+        let (first_idx, first_entry) = put_unbundled_intent(&ops, 1);
+        let first_payload = BundledPayloadEntry::new_unsigned(first_entry.payload().clone());
+        ops.bundle_intent_payload_blocking(
+            *first_entry.intent.commitment(),
+            first_entry,
+            first_payload,
+        )
+        .expect("test: bundle first intent");
+        let (second_idx, _) = put_unbundled_intent(&ops, 2);
+        let (third_idx, _) = put_unbundled_intent(&ops, 3);
+
+        let unbundled = get_initial_unbundled_entries(ops.as_ref()).expect("test: scan unbundled");
+
+        assert_eq!(first_idx, 0);
+        assert_eq!(unbundled, vec![second_idx, third_idx]);
+    }
 }

--- a/crates/btcio/src/writer/bundler/mod.rs
+++ b/crates/btcio/src/writer/bundler/mod.rs
@@ -3,3 +3,4 @@ mod logic;
 mod service;
 
 pub use builder::BundlerBuilder;
+pub use logic::PendingIntent;

--- a/crates/btcio/src/writer/bundler/service.rs
+++ b/crates/btcio/src/writer/bundler/service.rs
@@ -6,11 +6,10 @@
 use std::{mem, sync::Arc};
 
 use serde::Serialize;
-use strata_db_types::l1_writer::IntentEntry;
 use strata_service::{AsyncService, Response, Service, ServiceState, TickMsg};
 use strata_storage::ops::writer::EnvelopeDataOps;
 
-use super::logic::process_unbundled_entries;
+use super::logic::{process_unbundled_entries, PendingIntent};
 
 #[derive(Clone, Debug, Serialize)]
 pub struct BundlerStatus {
@@ -19,7 +18,7 @@ pub struct BundlerStatus {
 
 pub(crate) struct BundlerState {
     pub(crate) ops: Arc<EnvelopeDataOps>,
-    pub(crate) unbundled: Vec<IntentEntry>,
+    pub(crate) unbundled: Vec<PendingIntent>,
 }
 
 impl ServiceState for BundlerState {
@@ -32,7 +31,7 @@ pub(crate) struct BundlerService;
 
 impl Service for BundlerService {
     type State = BundlerState;
-    type Msg = TickMsg<IntentEntry>;
+    type Msg = TickMsg<PendingIntent>;
     type Status = BundlerStatus;
 
     fn get_status(state: &Self::State) -> Self::Status {

--- a/crates/btcio/src/writer/handle.rs
+++ b/crates/btcio/src/writer/handle.rs
@@ -7,6 +7,8 @@ use strata_storage::ops::writer::EnvelopeDataOps;
 use tokio::sync::mpsc::Sender;
 use tracing::*;
 
+use super::bundler::PendingIntent;
+
 /// A handle to the Envelope task.
 #[expect(
     missing_debug_implementations,
@@ -14,11 +16,11 @@ use tracing::*;
 )]
 pub struct EnvelopeHandle {
     ops: Arc<EnvelopeDataOps>,
-    intent_tx: Sender<IntentEntry>,
+    intent_tx: Sender<PendingIntent>,
 }
 
 impl EnvelopeHandle {
-    pub fn new(ops: Arc<EnvelopeDataOps>, intent_tx: Sender<IntentEntry>) -> Self {
+    pub fn new(ops: Arc<EnvelopeDataOps>, intent_tx: Sender<PendingIntent>) -> Self {
         Self { ops, intent_tx }
     }
 
@@ -43,10 +45,10 @@ impl EnvelopeHandle {
 
         // Create and store IntentEntry
         let entry = IntentEntry::new_unbundled(intent);
-        let _idx = self.ops.put_intent_entry_blocking(id, entry.clone())?;
+        let idx = self.ops.put_intent_entry_blocking(id, entry.clone())?;
 
         // Send to bundler
-        if let Err(e) = self.intent_tx.blocking_send(entry) {
+        if let Err(e) = self.intent_tx.blocking_send(idx) {
             warn!(%e, %id, "could not send intent entry to bundler");
         }
         Ok(())
@@ -86,7 +88,7 @@ impl EnvelopeHandle {
         let intent_idx = self.ops.put_intent_entry_async(id, entry.clone()).await?;
 
         // Send to bundler
-        if let Err(e) = self.intent_tx.send(entry).await {
+        if let Err(e) = self.intent_tx.send(intent_idx).await {
             warn!(%e, %id, "could not send intent entry to bundler");
         }
 

--- a/crates/btcio/src/writer/mod.rs
+++ b/crates/btcio/src/writer/mod.rs
@@ -10,7 +10,7 @@ mod watcher;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-pub use bundler::BundlerBuilder;
+pub use bundler::{BundlerBuilder, PendingIntent};
 pub use chunked_envelope::{create_chunked_envelope_task, ChunkedEnvelopeHandle};
 pub use context::{EnvelopeSigningMode, EnvelopeSigningModeProvider, WriterContext};
 pub use handle::EnvelopeHandle;


### PR DESCRIPTION
## Description
**AI usage:** Codex was used for writing tests, the production code is mostly by the author.
Fixes [STR-3170](https://alpenlabs.atlassian.net/browse/STR-3170)

There was a small issue with bundling payload intents in `btcio`. The startup recovery logic assumes that `IntentEntry`s are bundled in index order when they are converted into `BundledPayloadEntry`s. The happy path mostly preserved this, but intents are delivered to the bundler through an mpsc channel, so under contention a later persisted intent can reach the bundler before an earlier one.

This PR keeps the existing startup recovery behavior, but makes the bundling path explicitly enforce ordered intent
processing. The bundler now passes intent indices through the channel, reloads the authoritative intent from storage, and ensures any unbundled predecessor is processed first before bundling a later intent.

Other options considered were introducing a separate pending-intents table where entries are atomically removed once bundled, or tracking a high-watermark for the last bundled intent. Those approaches add more state to maintain and more room for consistency bugs. Enforcing ordered bundling in the existing bundler module is a smaller fix and matches the current architecture, since startup recovery and intent processing already live together and there is no other path that performs bundling.


<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues


[STR-3170]: https://alpenlabs.atlassian.net/browse/STR-3170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ