### PR TITLE
fix(strata): Decouple BTCIO startup from CSM state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15356,6 +15356,7 @@ dependencies = [
  "strata-common",
  "strata-csm-types",
  "strata-csm-worker",
+ "strata-db-store-sled",
  "strata-db-types",
  "strata-identifiers",
  "strata-l1-txfmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15351,6 +15351,7 @@ dependencies = [
  "strata-asm-spec-debug",
  "strata-asm-worker",
  "strata-btc-types",
+ "strata-btc-verification",
  "strata-chain-worker",
  "strata-checkpoint-types",
  "strata-common",

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -7,7 +7,10 @@ use strata_btcio::reader::query::{ReaderValidation, bitcoin_data_reader_task};
 use strata_chain_worker::{ChainWorkerHandle, start_chain_worker_service_from_ctx};
 use strata_consensus_logic::{
     AsmBlockSubmitter, SyncServiceHandle,
-    sync_manager::{spawn_asm_worker_with_ctx, spawn_csm_listener_with_ctx},
+    sync_manager::{
+        reconcile_l1_storage_and_submit_to_asm, spawn_asm_worker_with_ctx,
+        spawn_csm_listener_with_ctx,
+    },
 };
 use strata_csm_worker::CsmWorkerStatus;
 use strata_node_context::NodeContext;
@@ -255,8 +258,24 @@ pub(crate) fn start_strata_services(
     // Start Asm worker
     let asm_handle = Arc::new(spawn_asm_worker_with_ctx(&nodectx)?);
 
+    let startup_asm_block =
+        nodectx
+            .task_manager()
+            .handle()
+            .block_on(reconcile_l1_storage_and_submit_to_asm(
+                nodectx.storage().clone(),
+                nodectx.bitcoin_client().clone(),
+                asm_handle.as_ref(),
+                nodectx.asm_params().anchor.block.height(),
+                nodectx.config().btcio.l1_reorg_safe_depth,
+            ))?;
+
     // Start Csm worker
-    let csm_monitor = Arc::new(spawn_csm_listener_with_ctx(&nodectx, asm_handle.monitor())?);
+    let csm_monitor = Arc::new(spawn_csm_listener_with_ctx(
+        &nodectx,
+        asm_handle.monitor(),
+        startup_asm_block,
+    )?);
 
     // btcio reader task must start before genesis init because genesis requires ASM to
     // have the genesis manifest which will be available only after btcio reader provides

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -42,8 +42,12 @@ fn is_retryable_startup_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause
             .downcast_ref::<ClientError>()
-            .is_some_and(ClientError::is_retriable)
+            .is_some_and(|err| err.is_retriable() || is_bitcoind_warmup_error(err))
     })
+}
+
+fn is_bitcoind_warmup_error(err: &ClientError) -> bool {
+    matches!(err, ClientError::Server(-28, _))
 }
 
 pub(crate) async fn run_bitcoin_connectivity_and_network_checks(
@@ -543,6 +547,16 @@ mod tests {
         }
     }
 
+    fn mock_client_warming_up() -> MockBitcoinClient {
+        MockBitcoinClient {
+            blockchain_info_result: Some(MockResult::ClientError(ClientError::Server(
+                -28,
+                "Loading block index...".into(),
+            ))),
+            block_hash_result: None,
+        }
+    }
+
     fn mock_client_with_block_hash(hash: BlockHash) -> MockBitcoinClient {
         MockBitcoinClient {
             blockchain_info_result: None,
@@ -559,6 +573,16 @@ mod tests {
         }
     }
 
+    fn mock_client_block_hash_warming_up() -> MockBitcoinClient {
+        MockBitcoinClient {
+            blockchain_info_result: None,
+            block_hash_result: Some(MockResult::ClientError(ClientError::Server(
+                -28,
+                "Loading block index...".into(),
+            ))),
+        }
+    }
+
     #[tokio::test]
     async fn test_bitcoind_unreachable() {
         let client = mock_client_unreachable();
@@ -567,6 +591,24 @@ mod tests {
 
         let check = result.expect("retryable connection failure should defer");
         assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_bitcoind_warmup_deferred() {
+        let client = mock_client_warming_up();
+
+        let result = run_bitcoin_connectivity_and_network_checks(&client, Network::Regtest).await;
+
+        let check = result.expect("bitcoind warmup should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[test]
+    fn test_context_wrapped_bitcoind_warmup_is_retryable() {
+        let err = anyhow::Error::from(ClientError::Server(-28, "Loading block index...".into()))
+            .context("startup: could not connect to bitcoind via getblockchaininfo");
+
+        assert!(is_retryable_startup_error(&err));
     }
 
     #[tokio::test]
@@ -631,6 +673,18 @@ mod tests {
         let result = verify_l1_anchor_block(&client, commitment).await;
 
         let check = result.expect("retryable connection failure should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_l1_anchor_block_warmup_deferred() {
+        let hash = BlockHash::all_zeros();
+        let commitment = make_l1_block_commitment(42, hash);
+        let client = mock_client_block_hash_warming_up();
+
+        let result = verify_l1_anchor_block(&client, commitment).await;
+
+        let check = result.expect("bitcoind warmup should defer");
         assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
     }
 

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -110,51 +110,14 @@ async fn calculate_target_next_block(
     storage: &NodeStorage,
     genesis_l1_height: L1Height,
 ) -> anyhow::Result<L1Height> {
-    let client_state_target = calculate_client_state_target(storage).await?;
     let stored_l1_target = storage
         .l1()
         .get_canonical_chain_tip_async()
         .await?
         .map(|(height, _)| height.saturating_add(1))
         .unwrap_or(genesis_l1_height);
-    let target_next_block = client_state_target
-        .unwrap_or(genesis_l1_height)
-        .max(stored_l1_target)
-        .max(genesis_l1_height);
+    let target_next_block = stored_l1_target.max(genesis_l1_height);
     Ok(target_next_block)
-}
-
-async fn calculate_client_state_target(storage: &NodeStorage) -> anyhow::Result<Option<L1Height>> {
-    let Some((block, _)) = storage
-        .client_state()
-        .fetch_most_recent_state_async()
-        .await?
-    else {
-        return Ok(None);
-    };
-
-    match storage
-        .l1()
-        .get_canonical_blockid_at_height_async(block.height())
-        .await?
-    {
-        Some(blockid) if blockid == *block.blkid() => Ok(Some(block.height().saturating_add(1))),
-        Some(blockid) => {
-            warn!(
-                client_state_block = %block,
-                canonical_l1_blkid = %blockid,
-                "ignoring latest client-state height because it is not on the stored L1 canonical chain"
-            );
-            Ok(None)
-        }
-        None => {
-            warn!(
-                client_state_block = %block,
-                "ignoring latest client-state height because its L1 block is not stored as canonical"
-            );
-            Ok(None)
-        }
-    }
 }
 
 /// Inner function that actually does the reading task.
@@ -490,7 +453,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_falls_back_to_genesis_without_client_state() {
+    async fn calculate_target_next_block_starts_at_genesis_without_stored_l1() {
         let storage = test_storage();
 
         let target = calculate_target_next_block(&storage, 42)
@@ -501,9 +464,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_uses_latest_client_state_height() {
+    async fn calculate_target_next_block_uses_stored_l1_tip() {
         let storage = test_storage();
-        store_client_state(&storage, 100).await;
         store_l1_canonical(&storage, 100).await;
 
         let target = calculate_target_next_block(&storage, 42)
@@ -514,7 +476,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_ignores_client_state_without_l1_canonical_anchor() {
+    async fn calculate_target_next_block_ignores_client_state_without_stored_l1() {
         let storage = test_storage();
         store_client_state(&storage, 100).await;
 
@@ -526,9 +488,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_clamps_pregenesis_client_state_to_genesis() {
+    async fn calculate_target_next_block_clamps_pregenesis_l1_tip_to_genesis() {
         let storage = test_storage();
-        store_client_state(&storage, 10).await;
         store_l1_canonical(&storage, 10).await;
 
         let target = calculate_target_next_block(&storage, 42)
@@ -539,7 +500,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_does_not_replay_stored_l1_tip() {
+    async fn calculate_target_next_block_ignores_client_state_when_l1_tip_exists() {
         let storage = test_storage();
         store_client_state(&storage, 100).await;
         store_l1_canonical(&storage, 111).await;

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -7,7 +7,12 @@ use crate::writer::builder::EnvelopeError;
 
 /// Returns `true` when a Bitcoin RPC error may be resolved by retrying later.
 pub(crate) fn is_retryable_client_error(err: &ClientError) -> bool {
-    err.is_retriable()
+    err.is_retriable() || is_bitcoind_warmup_error(err)
+}
+
+/// Returns `true` when bitcoind is reachable but still in RPC warmup.
+fn is_bitcoind_warmup_error(err: &ClientError) -> bool {
+    matches!(err, ClientError::Server(-28, _))
 }
 
 /// Returns `true` when an [`anyhow::Error`] wraps a retryable Bitcoin RPC error.
@@ -62,9 +67,13 @@ mod tests {
     use crate::writer::builder::EnvelopeError;
 
     #[test]
-    fn client_errors_delegate_to_bitcoind_async_client() {
+    fn client_errors_include_bitcoind_warmup() {
         assert!(is_retryable_client_error(&ClientError::Connection(
             "connection refused".into()
+        )));
+        assert!(is_retryable_client_error(&ClientError::Server(
+            -28,
+            "Loading block index...".into()
         )));
         assert!(!is_retryable_client_error(&ClientError::Server(
             -25,
@@ -81,6 +90,14 @@ mod tests {
     }
 
     #[test]
+    fn anyhow_context_preserves_bitcoind_warmup_classification() {
+        let err = anyhow::Error::from(ClientError::Server(-28, "Loading block index...".into()))
+            .context("failed to poll Bitcoin client");
+
+        assert!(is_retryable_anyhow_error(&err));
+    }
+
+    #[test]
     fn envelope_prereq_fetch_uses_wrapped_retry_classification() {
         let source = anyhow::Error::from(ClientError::Timeout).context("network unavailable");
         let err = EnvelopeError::PrereqFetch(source);
@@ -92,6 +109,16 @@ mod tests {
     fn envelope_signing_rpc_outages_are_retryable() {
         let err =
             EnvelopeError::SignRawTransaction(ClientError::Connection("connection refused".into()));
+
+        assert!(is_retryable_envelope_error(&err));
+    }
+
+    #[test]
+    fn envelope_signing_bitcoind_warmup_is_retryable() {
+        let err = EnvelopeError::SignRawTransaction(ClientError::Server(
+            -28,
+            "Loading block index...".into(),
+        ));
 
         assert!(is_retryable_envelope_error(&err));
     }

--- a/crates/consensus-logic/Cargo.toml
+++ b/crates/consensus-logic/Cargo.toml
@@ -45,6 +45,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+strata-btc-verification.workspace = true
 strata-db-store-sled.workspace = true
 strata-ol-chain-types = { workspace = true, features = ["test-utils"] }
 strata-ol-state-support-types.workspace = true

--- a/crates/consensus-logic/Cargo.toml
+++ b/crates/consensus-logic/Cargo.toml
@@ -45,6 +45,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+strata-db-store-sled.workspace = true
 strata-ol-chain-types = { workspace = true, features = ["test-utils"] }
 strata-ol-state-support-types.workspace = true
 strata-ol-stf = { workspace = true, features = ["test-utils"] }

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -26,8 +26,10 @@ use tracing::{debug, info, warn};
 
 use crate::{asm_worker_context::AsmWorkerCtx, csm_worker_context::CsmWorkerContextImpl};
 
-const STARTUP_RECONCILE_RPC_ATTEMPTS: usize = 12;
+#[cfg(not(test))]
 const STARTUP_RECONCILE_RPC_RETRY_DELAY: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const STARTUP_RECONCILE_RPC_RETRY_DELAY: Duration = Duration::from_millis(1);
 
 /// Holds startup inputs that seed CSM before it subscribes to live ASM updates.
 struct CsmListenerStartup<'a> {
@@ -344,11 +346,11 @@ fn is_retryable_bitcoin_error(err: &anyhow::Error) -> bool {
     })
 }
 
-/// Runs a Bitcoin RPC operation with bounded retries for transient failures.
+/// Runs a Bitcoin RPC operation with retries for transient failures.
 ///
-/// Non-retryable errors fail immediately. Retryable errors are retried up to
-/// [`STARTUP_RECONCILE_RPC_ATTEMPTS`] with
-/// [`STARTUP_RECONCILE_RPC_RETRY_DELAY`] between attempts.
+/// Non-retryable errors fail immediately. Retryable errors are retried with
+/// [`STARTUP_RECONCILE_RPC_RETRY_DELAY`] between attempts so startup waits for
+/// bitcoind instead of aborting before the BTCIO reader is launched.
 async fn retry_bitcoin_startup_rpc<T, F, Fut>(
     operation: &'static str,
     mut f: F,
@@ -357,26 +359,23 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = anyhow::Result<T>>,
 {
-    for attempt in 1..=STARTUP_RECONCILE_RPC_ATTEMPTS {
+    let mut attempt = 1;
+    loop {
         match f().await {
             Ok(value) => return Ok(value),
-            Err(err)
-                if attempt < STARTUP_RECONCILE_RPC_ATTEMPTS && is_retryable_bitcoin_error(&err) =>
-            {
+            Err(err) if is_retryable_bitcoin_error(&err) => {
                 warn!(
                     operation,
                     attempt,
-                    max_attempts = STARTUP_RECONCILE_RPC_ATTEMPTS,
                     %err,
                     "retryable Bitcoin RPC error during startup reconciliation"
                 );
                 sleep(STARTUP_RECONCILE_RPC_RETRY_DELAY).await;
+                attempt += 1;
             }
             Err(err) => return Err(err),
         }
     }
-
-    unreachable!("retry loop always returns from inside the bounded range")
 }
 
 pub fn spawn_asm_worker_with_ctx(nodectx: &NodeContext) -> anyhow::Result<AsmWorkerHandle> {
@@ -455,7 +454,10 @@ fn prefill_asm_mmr(handle: &MmrIndexHandle, target_count: u64) -> anyhow::Result
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::Buf32;
@@ -484,6 +486,54 @@ mod tests {
                 .await
                 .expect("extend L1 canonical chain");
         }
+    }
+
+    /// Verifies startup Bitcoin RPCs keep retrying transient failures until success.
+    #[tokio::test]
+    async fn startup_rpc_retry_waits_for_retryable_errors() {
+        let attempts = AtomicUsize::new(0);
+
+        let value = retry_bitcoin_startup_rpc("test startup rpc", || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            async move {
+                if attempt < 3 {
+                    Err(anyhow::Error::from(ClientError::Connection(
+                        "connection refused".to_string(),
+                    )))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await
+        .expect("retryable errors should eventually succeed");
+
+        assert_eq!(value, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    /// Verifies startup Bitcoin RPCs fail immediately for non-retryable errors.
+    #[tokio::test]
+    async fn startup_rpc_retry_fails_fast_on_non_retryable_errors() {
+        let attempts = AtomicUsize::new(0);
+
+        let err = retry_bitcoin_startup_rpc("test startup rpc", || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err::<(), _>(anyhow::Error::from(ClientError::Server(
+                    -8,
+                    "block height out of range".to_string(),
+                )))
+            }
+        })
+        .await
+        .expect_err("non-retryable errors should fail immediately");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(
+            err.to_string().contains("block height out of range"),
+            "unexpected error: {err:#}"
+        );
     }
 
     /// Verifies fresh storage does not require Bitcoin RPCs during startup reconciliation.

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -261,6 +261,8 @@ where
             continue;
         }
 
+        let target = L1BlockCommitment::new(height, stored_blkid);
+
         if height < stored_tip_height {
             if bitcoind_is_behind && !observed_divergence {
                 info!(
@@ -277,6 +279,11 @@ where
                 );
             }
 
+            let deleted_asm_entries = storage
+                .asm()
+                .del_entries_after_async(target)
+                .await
+                .with_context(|| format!("deleting ASM entries after rewound L1 block {target}"))?;
             storage
                 .l1()
                 .revert_canonical_chain_async(height)
@@ -284,9 +291,16 @@ where
                 .with_context(|| {
                     format!("rewinding stored L1 canonical chain to height {height}")
                 })?;
+            if !deleted_asm_entries.is_empty() {
+                info!(
+                    deleted_asm_entries = deleted_asm_entries.len(),
+                    %target,
+                    "deleted orphaned ASM entries after startup L1 rewind"
+                );
+            }
         }
 
-        return Ok(Some(L1BlockCommitment::new(height, stored_blkid)));
+        return Ok(Some(target));
     }
 
     bail!(
@@ -464,8 +478,14 @@ mod tests {
         sync::atomic::{AtomicUsize, Ordering},
     };
 
+    use bitcoin::Network;
+    use strata_asm_common::{
+        AnchorState, AsmHistoryAccumulatorState, AuxData, ChainViewState, HeaderVerificationState,
+    };
+    use strata_btc_verification::L1Anchor;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::Buf32;
+    use strata_l1_txfmt::MagicBytes;
     use strata_storage::create_node_storage;
     use tokio::runtime::Handle;
 
@@ -491,6 +511,68 @@ mod tests {
                 .await
                 .expect("extend L1 canonical chain");
         }
+    }
+
+    /// Builds a minimal ASM state for storage reconciliation tests.
+    fn test_asm_state() -> StorageAsmState {
+        let anchor = L1Anchor {
+            block: L1BlockCommitment::default(),
+            next_target: 0,
+            epoch_start_timestamp: 0,
+            network: Network::Bitcoin,
+        };
+        let anchor_state = AnchorState {
+            magic: AnchorState::magic_ssz(MagicBytes::from(*b"ALPN")),
+            chain_view: ChainViewState {
+                pow_state: HeaderVerificationState::init(anchor),
+                history_accumulator: AsmHistoryAccumulatorState::new(0),
+            },
+            sections: Default::default(),
+        };
+        StorageAsmState::new(anchor_state, vec![])
+    }
+
+    /// Seeds ASM state and aux rows at each height.
+    fn seed_asm_states(storage: &NodeStorage, start: L1Height, end: L1Height) {
+        let state = test_asm_state();
+        for height in start..=end {
+            let block = L1BlockCommitment::new(height, blockid(height as u8));
+            storage
+                .asm()
+                .put_state_blocking(block, state.clone())
+                .expect("put ASM state");
+            storage
+                .asm()
+                .put_aux_data_blocking(block, AuxData::default())
+                .expect("put ASM aux data");
+        }
+    }
+
+    /// Asserts ASM state and aux data after `kept_height` were deleted.
+    fn assert_asm_suffix_deleted(
+        storage: &NodeStorage,
+        kept_height: L1Height,
+        deleted_height: L1Height,
+    ) {
+        let kept_block = L1BlockCommitment::new(kept_height, blockid(kept_height as u8));
+        let (latest, _) = storage
+            .asm()
+            .fetch_most_recent_state_blocking()
+            .expect("latest ASM state")
+            .expect("kept ASM state");
+        assert_eq!(latest, kept_block);
+
+        let deleted_block = L1BlockCommitment::new(deleted_height, blockid(deleted_height as u8));
+        assert!(storage
+            .asm()
+            .get_state_blocking(deleted_block)
+            .expect("deleted ASM state")
+            .is_none());
+        assert!(storage
+            .asm()
+            .get_aux_data_blocking(deleted_block)
+            .expect("deleted ASM aux data")
+            .is_none());
     }
 
     /// Verifies startup Bitcoin RPCs keep retrying transient failures until success.
@@ -688,6 +770,7 @@ mod tests {
     async fn startup_reconciliation_rewinds_orphaned_l1_suffix() {
         let storage = test_storage();
         seed_l1_chain(&storage, 10, 15).await;
+        seed_asm_states(&storage, 10, 15);
         let bitcoind_blocks: BTreeMap<_, _> = (10..=13)
             .map(|height| (height, blockid(height as u8)))
             .chain((14..=15).map(|height| (height, blockid((height + 100) as u8))))
@@ -716,6 +799,7 @@ mod tests {
             .await
             .expect("height 14")
             .is_none());
+        assert_asm_suffix_deleted(&storage, 13, 14);
     }
 
     /// Verifies shallow lagging bitcoind rewinds the unseen suffix for replay.
@@ -723,6 +807,7 @@ mod tests {
     async fn startup_reconciliation_rewinds_shallow_suffix_when_bitcoind_is_behind_same_chain() {
         let storage = test_storage();
         seed_l1_chain(&storage, 10, 15).await;
+        seed_asm_states(&storage, 10, 15);
 
         let target = reconcile_l1_canonical_storage(&storage, 10, 3, 13, |height| async move {
             Ok(blockid(height as u8))
@@ -746,6 +831,7 @@ mod tests {
             .await
             .expect("height 14")
             .is_none());
+        assert_asm_suffix_deleted(&storage, 13, 14);
     }
 
     /// Verifies deep lagging bitcoind fails without mutating storage.
@@ -807,6 +893,7 @@ mod tests {
     async fn startup_reconciliation_rewinds_when_lagging_bitcoind_observes_divergence() {
         let storage = test_storage();
         seed_l1_chain(&storage, 10, 15).await;
+        seed_asm_states(&storage, 10, 15);
         let bitcoind_blocks: BTreeMap<_, _> = [(14, blockid(114)), (13, blockid(13))]
             .into_iter()
             .collect();
@@ -828,6 +915,7 @@ mod tests {
                 .expect("stored tip"),
             (13, blockid(13))
         );
+        assert_asm_suffix_deleted(&storage, 13, 14);
     }
 
     /// Verifies startup fails without mutating storage when no safe pivot exists.

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -342,8 +342,13 @@ fn is_retryable_bitcoin_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause
             .downcast_ref::<ClientError>()
-            .is_some_and(ClientError::is_retriable)
+            .is_some_and(|err| err.is_retriable() || is_bitcoind_warmup_error(err))
     })
+}
+
+/// Returns `true` when bitcoind is reachable but still in RPC warmup.
+fn is_bitcoind_warmup_error(err: &ClientError) -> bool {
+    matches!(err, ClientError::Server(-28, _))
 }
 
 /// Runs a Bitcoin RPC operation with retries for transient failures.
@@ -510,6 +515,47 @@ mod tests {
 
         assert_eq!(value, 42);
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    /// Verifies startup Bitcoin RPCs retry bitcoind warmup responses.
+    #[tokio::test]
+    async fn startup_rpc_retry_waits_for_bitcoind_warmup() {
+        let attempts = AtomicUsize::new(0);
+
+        let value = retry_bitcoin_startup_rpc("test startup rpc", || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            async move {
+                if attempt < 3 {
+                    Err(anyhow::Error::from(ClientError::Server(
+                        -28,
+                        "Loading block index...".to_string(),
+                    )))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await
+        .expect("bitcoind warmup should eventually succeed");
+
+        assert_eq!(value, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    /// Verifies wrapped retryable startup errors are still classified.
+    #[test]
+    fn startup_rpc_retry_classifies_context_wrapped_errors() {
+        let connection_err =
+            anyhow::Error::from(ClientError::Connection("connection refused".to_string()))
+                .context("fetching Bitcoin block count during startup reconciliation");
+        let warmup_err = anyhow::Error::from(ClientError::Server(
+            -28,
+            "Loading block index...".to_string(),
+        ))
+        .context("fetching Bitcoin block hash during startup reconciliation");
+
+        assert!(is_retryable_bitcoin_error(&connection_err));
+        assert!(is_retryable_bitcoin_error(&warmup_err));
     }
 
     /// Verifies startup Bitcoin RPCs fail immediately for non-retryable errors.

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -113,6 +113,10 @@ pub async fn reconcile_l1_storage_and_submit_to_asm(
     genesis_l1_height: L1Height,
     l1_reorg_safe_depth: u32,
 ) -> anyhow::Result<Option<L1BlockCommitment>> {
+    if !should_reconcile_l1_storage_at_startup(storage.as_ref(), genesis_l1_height).await? {
+        return Ok(None);
+    }
+
     let bitcoind_tip_height = retry_bitcoin_startup_rpc("fetching Bitcoin block count", || {
         let bitcoin_client = bitcoin_client.clone();
         async move {
@@ -163,6 +167,32 @@ pub async fn reconcile_l1_storage_and_submit_to_asm(
         "submitted stored L1 canonical tip to ASM during startup"
     );
     Ok(Some(target))
+}
+
+/// Returns `true` when startup reconciliation needs Bitcoin RPC data.
+///
+/// Empty L1 storage and pre-genesis stored tips do not require reconciliation,
+/// so startup avoids Bitcoin RPCs and lets the BTCIO reader perform its normal
+/// retry loop.
+async fn should_reconcile_l1_storage_at_startup(
+    storage: &NodeStorage,
+    genesis_l1_height: L1Height,
+) -> anyhow::Result<bool> {
+    let Some((stored_tip_height, _)) = storage.l1().get_canonical_chain_tip_async().await? else {
+        debug!("no stored L1 canonical tip found during startup reconciliation");
+        return Ok(false);
+    };
+
+    if stored_tip_height < genesis_l1_height {
+        debug!(
+            stored_tip_height,
+            genesis_l1_height,
+            "stored L1 canonical tip is before ASM genesis; skipping startup ASM submission"
+        );
+        return Ok(false);
+    }
+
+    Ok(true)
 }
 
 /// Reconciles stored L1 canonical state against bitcoind.
@@ -457,6 +487,44 @@ mod tests {
                 .await
                 .expect("extend L1 canonical chain");
         }
+    }
+
+    /// Verifies fresh storage does not require Bitcoin RPCs during startup reconciliation.
+    #[tokio::test]
+    async fn startup_reconciliation_does_not_need_rpc_without_stored_l1_tip() {
+        let storage = test_storage();
+
+        let should_reconcile = should_reconcile_l1_storage_at_startup(&storage, 10)
+            .await
+            .expect("check reconciliation need");
+
+        assert!(!should_reconcile);
+    }
+
+    /// Verifies pre-genesis stored L1 tips do not require startup Bitcoin RPCs.
+    #[tokio::test]
+    async fn startup_reconciliation_does_not_need_rpc_before_asm_genesis() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 3, 5).await;
+
+        let should_reconcile = should_reconcile_l1_storage_at_startup(&storage, 10)
+            .await
+            .expect("check reconciliation need");
+
+        assert!(!should_reconcile);
+    }
+
+    /// Verifies post-genesis stored L1 tips require startup Bitcoin RPCs.
+    #[tokio::test]
+    async fn startup_reconciliation_needs_rpc_for_stored_l1_tip_at_asm_genesis() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 10).await;
+
+        let should_reconcile = should_reconcile_l1_storage_at_startup(&storage, 10)
+            .await
+            .expect("check reconciliation need");
+
+        assert!(should_reconcile);
     }
 
     /// Verifies reconciliation is a no-op when no stored L1 canonical tip exists.

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -2,39 +2,67 @@
 //! status.  Exposes handles to interact with fork choice manager and CSM
 //! executor and other core sync pipeline tasks.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc, time::Duration};
 
-use bitcoind_async_client::Client;
+use anyhow::{bail, Context};
+use bitcoind_async_client::{error::ClientError, traits::Reader, Client};
 use strata_asm_params::AsmParams;
 use strata_asm_spec::StrataAsmSpec;
 #[cfg(feature = "debug-asm")]
 use strata_asm_spec_debug::DebugAsmSpec;
 use strata_asm_worker::{AsmState as WorkerAsmState, AsmWorkerHandle, AsmWorkerStatus};
+use strata_btc_types::{BlockHashExt, L1BlockIdBitcoinExt};
 use strata_csm_worker::{CsmWorkerService, CsmWorkerState, CsmWorkerStatus};
 use strata_node_context::NodeContext;
 use strata_ol_state_types::MMR_SENTINEL_DUMMY_LEAF_HASH;
-use strata_primitives::prelude::L1BlockCommitment;
+use strata_primitives::prelude::{L1BlockCommitment, L1BlockId, L1Height};
 use strata_service::{ServiceBuilder, ServiceMonitor, SyncAsyncInput};
 use strata_state::asm_state::AsmState as StorageAsmState;
 use strata_status::StatusChannel;
 use strata_storage::{MmrId, MmrIndexHandle, NodeStorage};
 use strata_tasks::TaskExecutor;
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, time::sleep};
+use tracing::{debug, info, warn};
 
 use crate::{asm_worker_context::AsmWorkerCtx, csm_worker_context::CsmWorkerContextImpl};
 
+const STARTUP_RECONCILE_RPC_ATTEMPTS: usize = 12;
+const STARTUP_RECONCILE_RPC_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+/// Holds startup inputs that seed CSM before it subscribes to live ASM updates.
+struct CsmListenerStartup<'a> {
+    /// Sends CSM worker status updates to the node status channel.
+    status_channel: Arc<StatusChannel>,
+    /// Supplies live ASM status updates after the startup seed.
+    asm_monitor: &'a ServiceMonitor<AsmWorkerStatus>,
+    /// Reads Bitcoin blocks while CSM catches up from ASM commitments.
+    bitcoin_client: Arc<Client>,
+    /// Identifies the reconciled ASM block CSM should process first at startup.
+    startup_asm_block: Option<L1BlockCommitment>,
+}
+
+/// Spawns the CSM listener using node context and the reconciled ASM startup block.
+///
+/// The listener receives the reconciled startup block before live ASM updates so
+/// CSM can replay any canonical gap from its last persisted client-state anchor.
 pub fn spawn_csm_listener_with_ctx(
     nodectx: &NodeContext,
     asm_monitor: &ServiceMonitor<AsmWorkerStatus>,
+    startup_asm_block: Option<L1BlockCommitment>,
 ) -> anyhow::Result<ServiceMonitor<CsmWorkerStatus>> {
+    let startup = CsmListenerStartup {
+        status_channel: nodectx.status_channel().clone(),
+        asm_monitor,
+        bitcoin_client: nodectx.bitcoin_client().clone(),
+        startup_asm_block,
+    };
+
     spawn_csm_listener(
         nodectx.executor(),
         nodectx.asm_params().clone(),
         nodectx.config().btcio.l1_reorg_safe_depth,
         nodectx.storage().clone(),
-        nodectx.status_channel().clone(),
-        asm_monitor,
-        nodectx.bitcoin_client().clone(),
+        startup,
     )
 }
 
@@ -43,54 +71,25 @@ fn spawn_csm_listener(
     asm_params: Arc<AsmParams>,
     l1_reorg_safe_depth: u32,
     storage: Arc<NodeStorage>,
-    status_channel: Arc<StatusChannel>,
-    asm_monitor: &ServiceMonitor<AsmWorkerStatus>,
-    bitcoin_client: Arc<Client>,
+    startup: CsmListenerStartup<'_>,
 ) -> anyhow::Result<ServiceMonitor<CsmWorkerStatus>> {
     // Create CSM worker state.
     let ctx = CsmWorkerContextImpl::new(
         executor.handle().clone(),
-        bitcoin_client,
+        startup.bitcoin_client,
         asm_params,
         l1_reorg_safe_depth,
         storage.clone(),
-        status_channel,
+        startup.status_channel,
     );
     let csm_state = CsmWorkerState::init_from_context(ctx)?;
 
-    // Get the starting block from CSM's last processed block
-    // If CSM hasn't processed any blocks yet, we get the latest ASM state from storage
-    let from_block = if let Some(last_block) = csm_state.get_last_asm_block() {
-        last_block
-    } else {
-        // Get the latest ASM state as fallback
-        let (latest_block, _) = storage
-            .asm()
-            .fetch_most_recent_state_blocking()?
-            .expect("No ASM state available");
-        latest_block
-    };
+    let initial_updates = initial_asm_status_updates(storage.as_ref(), startup.startup_asm_block)?;
 
-    // Fetch historical ASM states starting from the next height.
-    let max_historical_blocks = 1000;
-    let nh = from_block.height() + 1;
-    let historical_states = storage.asm().get_states_from_blocking(
-        L1BlockCommitment::new(nh, Default::default()),
-        max_historical_blocks,
-    )?;
-
-    // Convert historical states to ASM worker status updates
-    let initial_updates: Vec<AsmWorkerStatus> = historical_states
-        .into_iter()
-        .map(|(block, state)| AsmWorkerStatus {
-            is_initialized: true,
-            cur_block: Some(block),
-            cur_state: Some(storage_to_worker_state(state)),
-        })
-        .collect();
-
-    // Create an input that listens to ASM status updates with historical prepended
-    let async_input = asm_monitor.create_listener_input_with(executor, initial_updates);
+    // Create an input that listens to ASM status updates with the startup seed prepended.
+    let async_input = startup
+        .asm_monitor
+        .create_listener_input_with(executor, initial_updates);
     // Wrap in SyncAsyncInput adapter since CSM worker is a sync service.
     let csm_input = SyncAsyncInput::new(async_input, executor.handle().clone());
 
@@ -101,6 +100,256 @@ fn spawn_csm_listener(
         .launch_sync("csm_worker", executor)?;
 
     Ok(csm_monitor)
+}
+
+/// Reconciles stored L1 canonical state during startup and submits the target to ASM.
+///
+/// Returns the reconciled canonical ASM block CSM should use as its startup
+/// seed. `None` means startup had no stored L1 canonical target to submit.
+pub async fn reconcile_l1_storage_and_submit_to_asm(
+    storage: Arc<NodeStorage>,
+    bitcoin_client: Arc<Client>,
+    asm_handle: &AsmWorkerHandle,
+    genesis_l1_height: L1Height,
+    l1_reorg_safe_depth: u32,
+) -> anyhow::Result<Option<L1BlockCommitment>> {
+    let bitcoind_tip_height = retry_bitcoin_startup_rpc("fetching Bitcoin block count", || {
+        let bitcoin_client = bitcoin_client.clone();
+        async move {
+            let height = bitcoin_client
+                .get_block_count()
+                .await
+                .context("fetching Bitcoin block count during startup reconciliation")?;
+            L1Height::try_from(height).context("Bitcoin block count exceeds L1 height range")
+        }
+    })
+    .await?;
+
+    let Some(target) = reconcile_l1_canonical_storage(
+        storage.as_ref(),
+        genesis_l1_height,
+        l1_reorg_safe_depth,
+        bitcoind_tip_height,
+        |height| {
+            let bitcoin_client = bitcoin_client.clone();
+            retry_bitcoin_startup_rpc("fetching Bitcoin block hash", move || {
+                let bitcoin_client = bitcoin_client.clone();
+                async move {
+                    let block_hash = bitcoin_client
+                        .get_block_hash(height as u64)
+                        .await
+                        .with_context(|| {
+                            format!("fetching Bitcoin block hash at startup height {height}")
+                        })?;
+                    Ok(block_hash.to_l1_block_id())
+                }
+            })
+        },
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+
+    let processed_blocks = asm_handle
+        .submit_block_async(target.blkid().to_block_hash())
+        .await
+        .with_context(|| format!("submitting startup L1 tip {target} to ASM"))?
+        .len();
+
+    info!(
+        %target,
+        processed_blocks,
+        "submitted stored L1 canonical tip to ASM during startup"
+    );
+    Ok(Some(target))
+}
+
+/// Reconciles stored L1 canonical state against bitcoind.
+///
+/// The returned block is the canonical ASM startup seed CSM should use. `None`
+/// means there was no stored L1 target that should be submitted.
+async fn reconcile_l1_canonical_storage<F, Fut>(
+    storage: &NodeStorage,
+    genesis_l1_height: L1Height,
+    l1_reorg_safe_depth: u32,
+    bitcoind_tip_height: L1Height,
+    mut canonical_blockid_at_height: F,
+) -> anyhow::Result<Option<L1BlockCommitment>>
+where
+    F: FnMut(L1Height) -> Fut,
+    Fut: Future<Output = anyhow::Result<L1BlockId>>,
+{
+    let Some((stored_tip_height, stored_tip_blkid)) =
+        storage.l1().get_canonical_chain_tip_async().await?
+    else {
+        debug!("no stored L1 canonical tip found during startup reconciliation");
+        return Ok(None);
+    };
+
+    if stored_tip_height < genesis_l1_height {
+        debug!(
+            stored_tip_height,
+            genesis_l1_height,
+            "stored L1 canonical tip is before ASM genesis; skipping startup ASM submission"
+        );
+        return Ok(None);
+    }
+
+    let search_tip = stored_tip_height.min(bitcoind_tip_height);
+    if search_tip < genesis_l1_height {
+        debug!(
+            stored_tip_height,
+            bitcoind_tip_height,
+            genesis_l1_height,
+            "bitcoind tip is before ASM genesis; skipping startup ASM submission"
+        );
+        return Ok(None);
+    }
+
+    let max_rewind_depth = l1_reorg_safe_depth.max(1).saturating_sub(1);
+    let safe_rewind_floor = stored_tip_height
+        .saturating_sub(max_rewind_depth)
+        .max(genesis_l1_height);
+    let floor = search_tip.min(safe_rewind_floor);
+    let bitcoind_is_behind = bitcoind_tip_height < stored_tip_height;
+    let mut observed_divergence = false;
+
+    for height in (floor..=search_tip).rev() {
+        let stored_blkid = if height == stored_tip_height {
+            stored_tip_blkid
+        } else {
+            storage
+                .l1()
+                .get_canonical_blockid_at_height_async(height)
+                .await?
+                .with_context(|| format!("stored L1 canonical chain is missing height {height}"))?
+        };
+        let bitcoin_blkid = canonical_blockid_at_height(height).await?;
+
+        if stored_blkid != bitcoin_blkid {
+            observed_divergence = true;
+            continue;
+        }
+
+        if height < stored_tip_height {
+            if bitcoind_is_behind && !observed_divergence {
+                info!(
+                    stored_tip_height,
+                    bitcoind_tip_height,
+                    matched_height = height,
+                    "bitcoind is behind stored L1 canonical tip; preserving stored suffix"
+                );
+                return Ok(Some(L1BlockCommitment::new(height, stored_blkid)));
+            }
+
+            warn!(
+                stored_tip_height,
+                pivot_height = height,
+                "stored L1 canonical suffix diverged from bitcoind; rewinding before startup"
+            );
+            storage
+                .l1()
+                .revert_canonical_chain_async(height)
+                .await
+                .with_context(|| {
+                    format!("rewinding stored L1 canonical chain to height {height}")
+                })?;
+        }
+
+        return Ok(Some(L1BlockCommitment::new(height, stored_blkid)));
+    }
+
+    bail!(
+        "stored L1 canonical tip {stored_tip_height} has no bitcoind pivot in startup lookback \
+         [{floor}, {search_tip}]"
+    )
+}
+
+/// Builds the initial ASM status seed for CSM startup.
+///
+/// When startup reconciled L1 storage, the seed is taken from that canonical
+/// target instead of the lexicographically latest ASM row, which may be an
+/// orphan left behind by an offline reorg.
+fn initial_asm_status_updates(
+    storage: &NodeStorage,
+    startup_asm_block: Option<L1BlockCommitment>,
+) -> anyhow::Result<Vec<AsmWorkerStatus>> {
+    let state = match startup_asm_block {
+        Some(block) => storage
+            .asm()
+            .get_state_blocking(block)?
+            .map(|state| (block, state))
+            .with_context(|| format!("startup ASM state {block} missing after reconciliation"))?,
+        None => {
+            let Some((block, state)) = storage.asm().fetch_most_recent_state_blocking()? else {
+                return Ok(Vec::new());
+            };
+            match storage
+                .l1()
+                .get_canonical_blockid_at_height(block.height())?
+            {
+                Some(blockid) if blockid == *block.blkid() => (block, state),
+                _ => {
+                    warn!(
+                        %block,
+                        "skipping startup ASM seed because it is not on the stored L1 canonical chain"
+                    );
+                    return Ok(Vec::new());
+                }
+            }
+        }
+    };
+
+    Ok(vec![AsmWorkerStatus {
+        is_initialized: true,
+        cur_block: Some(state.0),
+        cur_state: Some(storage_to_worker_state(state.1)),
+    }])
+}
+
+/// Returns `true` when an error wraps a retryable Bitcoin RPC failure.
+fn is_retryable_bitcoin_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<ClientError>()
+            .is_some_and(ClientError::is_retriable)
+    })
+}
+
+/// Runs a Bitcoin RPC operation with bounded retries for transient failures.
+///
+/// Non-retryable errors fail immediately. Retryable errors are retried up to
+/// [`STARTUP_RECONCILE_RPC_ATTEMPTS`] with
+/// [`STARTUP_RECONCILE_RPC_RETRY_DELAY`] between attempts.
+async fn retry_bitcoin_startup_rpc<T, F, Fut>(
+    operation: &'static str,
+    mut f: F,
+) -> anyhow::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    for attempt in 1..=STARTUP_RECONCILE_RPC_ATTEMPTS {
+        match f().await {
+            Ok(value) => return Ok(value),
+            Err(err)
+                if attempt < STARTUP_RECONCILE_RPC_ATTEMPTS && is_retryable_bitcoin_error(&err) =>
+            {
+                warn!(
+                    operation,
+                    attempt,
+                    max_attempts = STARTUP_RECONCILE_RPC_ATTEMPTS,
+                    %err,
+                    "retryable Bitcoin RPC error during startup reconciliation"
+                );
+                sleep(STARTUP_RECONCILE_RPC_RETRY_DELAY).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry loop always returns from inside the bounded range")
 }
 
 pub fn spawn_asm_worker_with_ctx(nodectx: &NodeContext) -> anyhow::Result<AsmWorkerHandle> {
@@ -175,4 +424,206 @@ fn prefill_asm_mmr(handle: &MmrIndexHandle, target_count: u64) -> anyhow::Result
         handle.append_leaf_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_identifiers::Buf32;
+    use strata_storage::create_node_storage;
+    use tokio::runtime::Handle;
+
+    use super::*;
+
+    /// Creates isolated node storage backed by a temporary sled database.
+    fn test_storage() -> NodeStorage {
+        create_node_storage(get_test_sled_backend(), Handle::current())
+            .expect("create test storage")
+    }
+
+    /// Builds a deterministic L1 block id for test fixtures.
+    fn blockid(byte: u8) -> L1BlockId {
+        L1BlockId::from(Buf32::from([byte; 32]))
+    }
+
+    /// Seeds contiguous stored L1 canonical entries for tests.
+    async fn seed_l1_chain(storage: &NodeStorage, start: L1Height, end: L1Height) {
+        for height in start..=end {
+            storage
+                .l1()
+                .extend_canonical_chain_async(&blockid(height as u8), height)
+                .await
+                .expect("extend L1 canonical chain");
+        }
+    }
+
+    /// Verifies reconciliation is a no-op when no stored L1 canonical tip exists.
+    #[tokio::test]
+    async fn startup_reconciliation_noops_without_stored_l1_tip() {
+        let storage = test_storage();
+
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 10, |_| async {
+            panic!("bitcoind should not be queried without stored L1 tip")
+        })
+        .await
+        .expect("reconcile");
+
+        assert_eq!(target, None);
+    }
+
+    /// Verifies pre-genesis stored L1 tips are ignored by ASM startup reconciliation.
+    #[tokio::test]
+    async fn startup_reconciliation_noops_when_tip_is_before_asm_genesis() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 3, 5).await;
+
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 10, |_| async {
+            panic!("bitcoind should not be queried before ASM genesis")
+        })
+        .await
+        .expect("reconcile");
+
+        assert_eq!(target, None);
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip")
+                .0,
+            5
+        );
+    }
+
+    /// Verifies a fully matching stored L1 tip is returned without mutation.
+    #[tokio::test]
+    async fn startup_reconciliation_submits_matching_l1_tip() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 15, |height| async move {
+            Ok(blockid(height as u8))
+        })
+        .await
+        .expect("reconcile");
+
+        assert_eq!(target, Some(L1BlockCommitment::new(15, blockid(15))));
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip"),
+            (15, blockid(15))
+        );
+    }
+
+    /// Verifies an orphaned stored L1 suffix is rewound to the matching pivot.
+    #[tokio::test]
+    async fn startup_reconciliation_rewinds_orphaned_l1_suffix() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+        let bitcoind_blocks: BTreeMap<_, _> = (10..=13)
+            .map(|height| (height, blockid(height as u8)))
+            .chain((14..=15).map(|height| (height, blockid((height + 100) as u8))))
+            .collect();
+
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 15, |height| {
+            let bitcoind_blocks = bitcoind_blocks.clone();
+            async move { Ok(*bitcoind_blocks.get(&height).expect("bitcoind height")) }
+        })
+        .await
+        .expect("reconcile");
+
+        assert_eq!(target, Some(L1BlockCommitment::new(13, blockid(13))));
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip"),
+            (13, blockid(13))
+        );
+        assert!(storage
+            .l1()
+            .get_canonical_blockid_at_height_async(14)
+            .await
+            .expect("height 14")
+            .is_none());
+    }
+
+    /// Verifies lagging bitcoind on the same chain does not cause a storage rewind.
+    #[tokio::test]
+    async fn startup_reconciliation_preserves_suffix_when_bitcoind_is_behind_same_chain() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 12, |height| async move {
+            Ok(blockid(height as u8))
+        })
+        .await
+        .expect("reconcile");
+
+        assert_eq!(target, Some(L1BlockCommitment::new(12, blockid(12))));
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip"),
+            (15, blockid(15))
+        );
+    }
+
+    /// Verifies lagging bitcoind can still trigger a safe rewind after divergence is observed.
+    #[tokio::test]
+    async fn startup_reconciliation_rewinds_when_lagging_bitcoind_observes_divergence() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+        let bitcoind_blocks: BTreeMap<_, _> = [(14, blockid(114)), (13, blockid(13))]
+            .into_iter()
+            .collect();
+
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 14, |height| {
+            let bitcoind_blocks = bitcoind_blocks.clone();
+            async move { Ok(*bitcoind_blocks.get(&height).expect("bitcoind height")) }
+        })
+        .await
+        .expect("reconcile");
+
+        assert_eq!(target, Some(L1BlockCommitment::new(13, blockid(13))));
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip"),
+            (13, blockid(13))
+        );
+    }
+
+    /// Verifies startup fails without mutating storage when no safe pivot exists.
+    #[tokio::test]
+    async fn startup_reconciliation_errors_when_no_pivot_exists_in_lookback() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+
+        let err = reconcile_l1_canonical_storage(&storage, 10, 2, 15, |height| async move {
+            Ok(blockid((height + 100) as u8))
+        })
+        .await
+        .expect_err("missing pivot should fail startup");
+
+        assert!(
+            err.to_string().contains("has no bitcoind pivot"),
+            "unexpected error: {err:#}"
+        );
+    }
 }

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -226,23 +226,20 @@ where
         return Ok(None);
     }
 
-    let search_tip = stored_tip_height.min(bitcoind_tip_height);
-    if search_tip < genesis_l1_height {
-        debug!(
-            stored_tip_height,
-            bitcoind_tip_height,
-            genesis_l1_height,
-            "bitcoind tip is before ASM genesis; skipping startup ASM submission"
-        );
-        return Ok(None);
-    }
-
     let max_rewind_depth = l1_reorg_safe_depth.max(1).saturating_sub(1);
     let safe_rewind_floor = stored_tip_height
         .saturating_sub(max_rewind_depth)
         .max(genesis_l1_height);
-    let floor = search_tip.min(safe_rewind_floor);
     let bitcoind_is_behind = bitcoind_tip_height < stored_tip_height;
+    if bitcoind_is_behind && bitcoind_tip_height < safe_rewind_floor {
+        bail!(
+            "bitcoind tip {bitcoind_tip_height} is too far behind stored L1 canonical tip \
+             {stored_tip_height}; waiting for bitcoind to reach at least {safe_rewind_floor}"
+        );
+    }
+
+    let search_tip = stored_tip_height.min(bitcoind_tip_height);
+    let floor = search_tip.min(safe_rewind_floor);
     let mut observed_divergence = false;
 
     for height in (floor..=search_tip).rev() {
@@ -268,16 +265,16 @@ where
                     stored_tip_height,
                     bitcoind_tip_height,
                     matched_height = height,
-                    "bitcoind is behind stored L1 canonical tip; preserving stored suffix"
+                    "bitcoind is behind stored L1 canonical tip; rewinding stored suffix for replay"
                 );
-                return Ok(Some(L1BlockCommitment::new(height, stored_blkid)));
+            } else {
+                warn!(
+                    stored_tip_height,
+                    pivot_height = height,
+                    "stored L1 canonical suffix diverged from bitcoind; rewinding before startup"
+                );
             }
 
-            warn!(
-                stored_tip_height,
-                pivot_height = height,
-                "stored L1 canonical suffix diverged from bitcoind; rewinding before startup"
-            );
             storage
                 .l1()
                 .revert_canonical_chain_async(height)
@@ -625,19 +622,79 @@ mod tests {
             .is_none());
     }
 
-    /// Verifies lagging bitcoind on the same chain does not cause a storage rewind.
+    /// Verifies shallow lagging bitcoind rewinds the unseen suffix for replay.
     #[tokio::test]
-    async fn startup_reconciliation_preserves_suffix_when_bitcoind_is_behind_same_chain() {
+    async fn startup_reconciliation_rewinds_shallow_suffix_when_bitcoind_is_behind_same_chain() {
         let storage = test_storage();
         seed_l1_chain(&storage, 10, 15).await;
 
-        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 12, |height| async move {
+        let target = reconcile_l1_canonical_storage(&storage, 10, 3, 13, |height| async move {
             Ok(blockid(height as u8))
         })
         .await
         .expect("reconcile");
 
-        assert_eq!(target, Some(L1BlockCommitment::new(12, blockid(12))));
+        assert_eq!(target, Some(L1BlockCommitment::new(13, blockid(13))));
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip"),
+            (13, blockid(13))
+        );
+        assert!(storage
+            .l1()
+            .get_canonical_blockid_at_height_async(14)
+            .await
+            .expect("height 14")
+            .is_none());
+    }
+
+    /// Verifies deep lagging bitcoind fails without mutating storage.
+    #[tokio::test]
+    async fn startup_reconciliation_errors_when_bitcoind_is_too_far_behind() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+
+        let err = reconcile_l1_canonical_storage(&storage, 10, 3, 12, |height| async move {
+            Ok(blockid(height as u8))
+        })
+        .await
+        .expect_err("deep lag should fail startup without mutation");
+
+        assert!(
+            err.to_string().contains("too far behind stored L1"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            storage
+                .l1()
+                .get_canonical_chain_tip_async()
+                .await
+                .expect("tip")
+                .expect("stored tip"),
+            (15, blockid(15))
+        );
+    }
+
+    /// Verifies post-genesis storage waits for bitcoind to reach ASM genesis.
+    #[tokio::test]
+    async fn startup_reconciliation_errors_when_bitcoind_is_before_asm_genesis() {
+        let storage = test_storage();
+        seed_l1_chain(&storage, 10, 15).await;
+
+        let err = reconcile_l1_canonical_storage(&storage, 10, 3, 9, |height| async move {
+            Ok(blockid(height as u8))
+        })
+        .await
+        .expect_err("bitcoind below genesis should fail startup without mutation");
+
+        assert!(
+            err.to_string().contains("too far behind stored L1"),
+            "unexpected error: {err:#}"
+        );
         assert_eq!(
             storage
                 .l1()

--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -835,6 +835,40 @@ mod tests {
         }
     }
 
+    /// Startup can seed CSM with only the latest ASM status. Even when that
+    /// latest status is more than the old 1000-state prepend behind CSM's
+    /// cursor, canonical gap-fill replays every missing block.
+    #[test]
+    fn gapped_block_over_1000_blocks_replays_skipped_blocks() {
+        let last = L1BlockCommitment::new(100, block_id_at(100));
+        let target = L1BlockCommitment::new(1_104, block_id_at(1_104));
+
+        let (mut state, storage) = create_test_state_with_ctx(|c| {
+            let mut c = c.with_canonical_block(100, block_id_at(100));
+            for height in 101..1_104 {
+                c = c.with_canonical_asm_state(
+                    height,
+                    block_id_at(height),
+                    make_asm_state(Vec::new()),
+                );
+            }
+            c
+        });
+        state.recent_asm_blocks = vec![last];
+
+        state
+            .process_asm_block(target, &[])
+            .expect("gap-fill should replay the full canonical gap");
+
+        assert_eq!(state.recent_asm_blocks.last(), Some(&target));
+        let (persisted, _) = storage
+            .client_state()
+            .fetch_most_recent_state()
+            .expect("query client state")
+            .expect("client state row");
+        assert_eq!(persisted, target);
+    }
+
     /// If a gap block can't be resolved, gap-fill fails and the persisted
     /// cursor stays pinned at the last contiguous block — a restart then
     /// re-processes from there instead of skipping the gap.

--- a/crates/db/store-sled/src/asm/db.rs
+++ b/crates/db/store-sled/src/asm/db.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use strata_asm_common::AuxData;
 use strata_db_types::DbResult;
 use strata_db_types::asm::AsmDatabase;
@@ -63,6 +65,48 @@ impl AsmDatabase for AsmDBSled {
             }
             _ => Ok(None),
         }
+    }
+
+    fn del_asm_entries_after(&self, block: L1BlockCommitment) -> DbResult<Vec<L1BlockCommitment>> {
+        let mut blocks_to_drop = BTreeSet::new();
+        for item in self.asm_state_tree.range(block..)? {
+            let (candidate, _) = item?;
+            if candidate > block {
+                blocks_to_drop.insert(candidate);
+            }
+        }
+        for item in self.asm_log_tree.range(block..)? {
+            let (candidate, _) = item?;
+            if candidate > block {
+                blocks_to_drop.insert(candidate);
+            }
+        }
+        for item in self.asm_aux_data_tree.range(block..)? {
+            let (candidate, _) = item?;
+            if candidate > block {
+                blocks_to_drop.insert(candidate);
+            }
+        }
+
+        let blocks_to_drop: Vec<_> = blocks_to_drop.into_iter().collect();
+        self.config.with_retry(
+            (
+                &self.asm_state_tree,
+                &self.asm_log_tree,
+                &self.asm_aux_data_tree,
+            ),
+            |(state_tree, log_tree, aux_tree)| {
+                for block in &blocks_to_drop {
+                    state_tree.remove(block)?;
+                    log_tree.remove(block)?;
+                    aux_tree.remove(block)?;
+                }
+
+                Ok(())
+            },
+        )?;
+
+        Ok(blocks_to_drop)
     }
 
     fn get_asm_states_from(

--- a/crates/db/tests/src/asm_tests.rs
+++ b/crates/db/tests/src/asm_tests.rs
@@ -2,6 +2,7 @@ use bitcoin::Network;
 use strata_asm_common::{AnchorState, AsmHistoryAccumulatorState, AuxData, ChainViewState};
 use strata_btc_verification::L1Anchor;
 use strata_db_types::asm::AsmDatabase;
+use strata_identifiers::Buf32;
 use strata_l1_txfmt::MagicBytes;
 use strata_primitives::l1::{L1BlockCommitment, L1BlockId};
 use strata_state::asm_state::AsmState;
@@ -18,6 +19,53 @@ pub fn test_get_asm(db: &impl AsmDatabase) {
 
     let update = db.get_asm_state(another_block).expect("test: get").unwrap();
     assert_eq!(update, state);
+}
+
+pub fn test_del_asm_entries_after(db: &impl AsmDatabase) {
+    let state = AsmState::new(make_anchor_state(), vec![]);
+    let pivot = L1BlockCommitment::new(10, L1BlockId::from(Buf32::from([10; 32])));
+    let same_height_orphan = L1BlockCommitment::new(10, L1BlockId::from(Buf32::from([250; 32])));
+    let higher = L1BlockCommitment::new(11, L1BlockId::from(Buf32::from([11; 32])));
+    let aux_only = L1BlockCommitment::new(12, L1BlockId::from(Buf32::from([12; 32])));
+
+    for block in [pivot, same_height_orphan, higher] {
+        db.put_asm_state(block, state.clone())
+            .expect("test: insert ASM state");
+        db.put_aux_data(block, AuxData::default())
+            .expect("test: insert aux data");
+    }
+    db.put_aux_data(aux_only, AuxData::default())
+        .expect("test: insert aux-only data");
+
+    let deleted = db
+        .del_asm_entries_after(pivot)
+        .expect("test: delete ASM suffix");
+
+    assert_eq!(deleted, vec![same_height_orphan, higher, aux_only]);
+    assert!(db
+        .get_asm_state(pivot)
+        .expect("test: get kept state")
+        .is_some());
+    assert!(db
+        .get_aux_data(pivot)
+        .expect("test: get kept aux data")
+        .is_some());
+    for block in [same_height_orphan, higher, aux_only] {
+        assert!(db
+            .get_asm_state(block)
+            .expect("test: get deleted state")
+            .is_none());
+        assert!(db
+            .get_aux_data(block)
+            .expect("test: get deleted aux data")
+            .is_none());
+    }
+
+    let (latest, _) = db
+        .get_latest_asm_state()
+        .expect("test: get latest state")
+        .expect("test: kept state remains");
+    assert_eq!(latest, pivot);
 }
 
 fn make_anchor_state() -> AnchorState {
@@ -68,6 +116,12 @@ macro_rules! asm_state_db_tests {
         fn test_put_get_aux_data() {
             let db = $setup_expr;
             $crate::asm_tests::test_put_get_aux_data(&db);
+        }
+
+        #[test]
+        fn test_del_asm_entries_after() {
+            let db = $setup_expr;
+            $crate::asm_tests::test_del_asm_entries_after(&db);
         }
     };
 }

--- a/crates/db/types/src/asm.rs
+++ b/crates/db/types/src/asm.rs
@@ -25,6 +25,9 @@ pub trait AsmDatabase: Send + Sync + 'static {
     /// Gets latest ASM state (the entry that corresponds to the highest l1 block).
     fn get_latest_asm_state(&self) -> DbResult<Option<(L1BlockCommitment, AsmState)>>;
 
+    /// Deletes ASM state, log, and auxiliary data rows strictly after `block`.
+    fn del_asm_entries_after(&self, block: L1BlockCommitment) -> DbResult<Vec<L1BlockCommitment>>;
+
     /// Gets ASM states starting from a given L1BlockCommitment up to a maximum count.
     ///
     /// Returns entries in ascending order (oldest first). If `from_block` doesn't exist,

--- a/crates/storage/src/managers/asm.rs
+++ b/crates/storage/src/managers/asm.rs
@@ -39,6 +39,22 @@ impl AsmStateManager {
         self.ops.get_latest_asm_state_async().await
     }
 
+    /// Deletes [`AsmState`], logs, and aux data strictly after `block`.
+    pub async fn del_entries_after_async(
+        &self,
+        block: L1BlockCommitment,
+    ) -> DbResult<Vec<L1BlockCommitment>> {
+        self.ops.del_asm_entries_after_async(block).await
+    }
+
+    /// Deletes [`AsmState`], logs, and aux data strictly after `block`.
+    pub fn del_entries_after_blocking(
+        &self,
+        block: L1BlockCommitment,
+    ) -> DbResult<Vec<L1BlockCommitment>> {
+        self.ops.del_asm_entries_after_blocking(block)
+    }
+
     /// Returns [`AsmState`] that corresponds to passed block.
     pub fn get_state_blocking(&self, block: L1BlockCommitment) -> DbResult<Option<AsmState>> {
         self.ops.get_asm_state_blocking(block)


### PR DESCRIPTION
## Description

Decouples BTCIO reader startup from client-state rows by deriving the next L1 read height only from stored L1 canonical storage and ASM genesis.

Adds startup reconciliation before CSM starts so stored L1 canonical state is checked against bitcoind, orphaned suffixes are rewound within the configured reorg lookback, and the reconciled tip is submitted to ASM. CSM startup now seeds from the reconciled/latest ASM state and relies on CSM’s canonical gap-fill instead of a capped historical ASM status list.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The BTCIO startup change is behavior-preserving because any previously accepted client-state target was already bounded by the stored L1 canonical tip.

Is this PR addressing any specification, design doc or external reference document?

- []  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3845