### PR TITLE
fix(btcio): decouple reader startup from client state and repair offline L1 reorgs

### DIFF
--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -5,7 +5,7 @@ use bitcoind_async_client::{
     Client, corepc_types::model::GetBlockchainInfo, error::ClientError, traits::Reader,
 };
 use strata_btc_types::BlockHashExt;
-use strata_btcio::is_bitcoind_warmup_error;
+use strata_btcio::{is_bitcoind_warmup_error, is_block_height_out_of_range_error};
 use strata_db_types::ol_block::BlockStatus;
 use strata_identifiers::{EpochCommitment, OLBlockCommitment, OLBlockId};
 use strata_node_context::NodeContext;
@@ -41,9 +41,11 @@ pub(crate) enum StartupBitcoinCheck {
 
 fn is_retryable_startup_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
-        cause
-            .downcast_ref::<ClientError>()
-            .is_some_and(|err| err.is_retriable() || is_bitcoind_warmup_error(err))
+        cause.downcast_ref::<ClientError>().is_some_and(|err| {
+            err.is_retriable()
+                || is_bitcoind_warmup_error(err)
+                || is_block_height_out_of_range_error(err)
+        })
     })
 }
 
@@ -580,6 +582,16 @@ mod tests {
         }
     }
 
+    fn mock_client_block_hash_height_out_of_range() -> MockBitcoinClient {
+        MockBitcoinClient {
+            blockchain_info_result: None,
+            block_hash_result: Some(MockResult::ClientError(ClientError::Server(
+                -8,
+                "Block height out of range".into(),
+            ))),
+        }
+    }
+
     #[tokio::test]
     async fn test_bitcoind_unreachable() {
         let client = mock_client_unreachable();
@@ -604,6 +616,14 @@ mod tests {
     fn test_context_wrapped_bitcoind_warmup_is_retryable() {
         let err = anyhow::Error::from(ClientError::Server(-28, "Loading block index...".into()))
             .context("startup: could not connect to bitcoind via getblockchaininfo");
+
+        assert!(is_retryable_startup_error(&err));
+    }
+
+    #[test]
+    fn test_context_wrapped_block_height_out_of_range_is_retryable() {
+        let err = anyhow::Error::from(ClientError::Server(-8, "Block height out of range".into()))
+            .context("startup: failed to fetch L1 block hash from bitcoind");
 
         assert!(is_retryable_startup_error(&err));
     }
@@ -682,6 +702,18 @@ mod tests {
         let result = verify_l1_anchor_block(&client, commitment).await;
 
         let check = result.expect("bitcoind warmup should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_l1_anchor_block_height_out_of_range_deferred() {
+        let hash = BlockHash::all_zeros();
+        let commitment = make_l1_block_commitment(42, hash);
+        let client = mock_client_block_hash_height_out_of_range();
+
+        let result = verify_l1_anchor_block(&client, commitment).await;
+
+        let check = result.expect("bitcoind missing anchor height should defer");
         assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
     }
 

--- a/bin/strata/src/startup_checks.rs
+++ b/bin/strata/src/startup_checks.rs
@@ -5,6 +5,7 @@ use bitcoind_async_client::{
     Client, corepc_types::model::GetBlockchainInfo, error::ClientError, traits::Reader,
 };
 use strata_btc_types::BlockHashExt;
+use strata_btcio::is_bitcoind_warmup_error;
 use strata_db_types::ol_block::BlockStatus;
 use strata_identifiers::{EpochCommitment, OLBlockCommitment, OLBlockId};
 use strata_node_context::NodeContext;
@@ -42,7 +43,7 @@ fn is_retryable_startup_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause
             .downcast_ref::<ClientError>()
-            .is_some_and(ClientError::is_retriable)
+            .is_some_and(|err| err.is_retriable() || is_bitcoind_warmup_error(err))
     })
 }
 
@@ -543,6 +544,16 @@ mod tests {
         }
     }
 
+    fn mock_client_warming_up() -> MockBitcoinClient {
+        MockBitcoinClient {
+            blockchain_info_result: Some(MockResult::ClientError(ClientError::Server(
+                -28,
+                "Loading block index...".into(),
+            ))),
+            block_hash_result: None,
+        }
+    }
+
     fn mock_client_with_block_hash(hash: BlockHash) -> MockBitcoinClient {
         MockBitcoinClient {
             blockchain_info_result: None,
@@ -559,6 +570,16 @@ mod tests {
         }
     }
 
+    fn mock_client_block_hash_warming_up() -> MockBitcoinClient {
+        MockBitcoinClient {
+            blockchain_info_result: None,
+            block_hash_result: Some(MockResult::ClientError(ClientError::Server(
+                -28,
+                "Loading block index...".into(),
+            ))),
+        }
+    }
+
     #[tokio::test]
     async fn test_bitcoind_unreachable() {
         let client = mock_client_unreachable();
@@ -567,6 +588,24 @@ mod tests {
 
         let check = result.expect("retryable connection failure should defer");
         assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_bitcoind_warmup_deferred() {
+        let client = mock_client_warming_up();
+
+        let result = run_bitcoin_connectivity_and_network_checks(&client, Network::Regtest).await;
+
+        let check = result.expect("bitcoind warmup should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[test]
+    fn test_context_wrapped_bitcoind_warmup_is_retryable() {
+        let err = anyhow::Error::from(ClientError::Server(-28, "Loading block index...".into()))
+            .context("startup: could not connect to bitcoind via getblockchaininfo");
+
+        assert!(is_retryable_startup_error(&err));
     }
 
     #[tokio::test]
@@ -631,6 +670,18 @@ mod tests {
         let result = verify_l1_anchor_block(&client, commitment).await;
 
         let check = result.expect("retryable connection failure should defer");
+        assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_l1_anchor_block_warmup_deferred() {
+        let hash = BlockHash::all_zeros();
+        let commitment = make_l1_block_commitment(42, hash);
+        let client = mock_client_block_hash_warming_up();
+
+        let result = verify_l1_anchor_block(&client, commitment).await;
+
+        let check = result.expect("bitcoind warmup should defer");
         assert!(matches!(check, StartupBitcoinCheck::Deferred { .. }));
     }
 

--- a/crates/btcio/src/lib.rs
+++ b/crates/btcio/src/lib.rs
@@ -11,4 +11,4 @@ pub mod test_utils;
 pub mod writer;
 
 pub use params::BtcioParams;
-pub use rpc_error::is_bitcoind_warmup_error;
+pub use rpc_error::{is_bitcoind_warmup_error, is_block_height_out_of_range_error};

--- a/crates/btcio/src/lib.rs
+++ b/crates/btcio/src/lib.rs
@@ -11,3 +11,4 @@ pub mod test_utils;
 pub mod writer;
 
 pub use params::BtcioParams;
+pub use rpc_error::is_bitcoind_warmup_error;

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -227,52 +227,65 @@ async fn init_reader_state<R: Reader>(
         );
     }
 
+    let stored_canonical_tip = ctx.storage.l1().get_canonical_chain_tip_async().await?;
     let mut real_cur_height;
-    if let Some((stored_tip_height, _stored_tip_blkid)) =
-        ctx.storage.l1().get_canonical_chain_tip_async().await?
-    {
-        let start_height = stored_tip_height.saturating_sub(lookback);
-        let stored_blockids = ctx
-            .storage
-            .l1()
-            .get_canonical_blockid_range_async(start_height, stored_tip_height + 1)
-            .await?;
-        debug!(
-            %start_height,
-            end_height = %stored_tip_height,
-            entries = stored_blockids.len(),
-            "loaded reader init range from stored L1 canonical chain"
-        );
-
-        for blockid in stored_blockids {
-            init_queue.push_back(blockid.to_block_hash());
-        }
-
-        if init_queue.is_empty() {
-            bail!(
-                "btcio: stored L1 canonical chain tip at height {stored_tip_height} \
-                 was missing from the reader startup range"
+    match stored_canonical_tip {
+        Some((stored_tip_height, _stored_tip_blkid))
+            if stored_tip_height.saturating_add(1) >= target_next_block =>
+        {
+            let start_height = stored_tip_height.saturating_sub(lookback);
+            let stored_blockids = ctx
+                .storage
+                .l1()
+                .get_canonical_blockid_range_async(start_height, stored_tip_height + 1)
+                .await?;
+            debug!(
+                %start_height,
+                end_height = %stored_tip_height,
+                entries = stored_blockids.len(),
+                "loaded reader init range from stored L1 canonical chain"
             );
+
+            for blockid in stored_blockids {
+                init_queue.push_back(blockid.to_block_hash());
+            }
+
+            if init_queue.is_empty() {
+                bail!(
+                    "btcio: stored L1 canonical chain tip at height {stored_tip_height} \
+                     was missing from the reader startup range"
+                );
+            }
+
+            real_cur_height = stored_tip_height;
         }
+        stored_tip => {
+            if let Some((stored_tip_height, _)) = stored_tip {
+                info!(
+                    %stored_tip_height,
+                    %target_next_block,
+                    %genesis_height,
+                    "stored L1 canonical tip is below configured genesis; seeding reader from Bitcoin client"
+                );
+            }
 
-        real_cur_height = stored_tip_height;
-    } else {
-        let chain_tip = chain_info.blocks as L1Height;
-        let start_height = target_next_block
-            .saturating_sub(lookback)
-            .max(pre_genesis)
-            .min(chain_tip);
-        let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
-        debug!(%start_height, %end_height, "queried L1 client, have init range");
+            let chain_tip = chain_info.blocks as L1Height;
+            let start_height = target_next_block
+                .saturating_sub(lookback)
+                .max(pre_genesis)
+                .min(chain_tip);
+            let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
+            debug!(%start_height, %end_height, "queried L1 client, have init range");
 
-        // Loop through the range we've determined to be okay and pull the blocks we want to look
-        // back through in.
-        real_cur_height = start_height;
-        for height in start_height..=end_height {
-            let blkid = client.get_block_hash(height as u64).await?;
-            debug!(%height, %blkid, "loaded recent L1 block");
-            init_queue.push_back(blkid);
-            real_cur_height = height;
+            // Loop through the range we've determined to be okay and pull the blocks we want to
+            // look back through in.
+            real_cur_height = start_height;
+            for height in start_height..=end_height {
+                let blkid = client.get_block_hash(height as u64).await?;
+                debug!(%height, %blkid, "loaded recent L1 block");
+                init_queue.push_back(blkid);
+                real_cur_height = height;
+            }
         }
     }
 
@@ -736,12 +749,20 @@ mod tests {
         storage: NodeStorage,
         client: ChainBitcoinClient,
     ) -> ReaderContext<ChainBitcoinClient> {
+        chain_reader_context_with_genesis(storage, client, 0)
+    }
+
+    fn chain_reader_context_with_genesis(
+        storage: NodeStorage,
+        client: ChainBitcoinClient,
+        genesis_l1_height: L1Height,
+    ) -> ReaderContext<ChainBitcoinClient> {
         let expected_l1_anchor = L1BlockCommitment::new(0, client.block_hash(0).to_l1_block_id());
         ReaderContext {
             client: Arc::new(client),
             storage: Arc::new(storage),
             config: Arc::new(ReaderConfig::default()),
-            btcio_params: BtcioParams::new(2, MagicBytes::new(*b"ALPN"), 0),
+            btcio_params: BtcioParams::new(2, MagicBytes::new(*b"ALPN"), genesis_l1_height),
             expected_network: Network::Regtest,
             expected_l1_anchor,
             status_channel: StatusChannel::new(
@@ -840,6 +861,40 @@ mod tests {
             .rev()
             .map(|height| (height, stored_chain.block_hash(height)))
             .collect::<Vec<_>>();
+        assert_eq!(recent_blocks, expected_blocks);
+    }
+
+    #[tokio::test]
+    async fn init_reader_state_ignores_pregenesis_stored_tip() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 101, 102]).await;
+        let bitcoind_chain = chain_client(&[0, 201, 202, 203, 204, 205, 206]).await;
+        let genesis_height = 4;
+
+        for height in 0..=2 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx =
+            chain_reader_context_with_genesis(storage, bitcoind_chain.clone(), genesis_height);
+        let state = init_reader_state(&ctx, genesis_height)
+            .await
+            .expect("test: initialize reader state");
+
+        assert_eq!(state.next_height(), genesis_height);
+        assert_eq!(
+            *state.best_block(),
+            bitcoind_chain.block_hash(genesis_height - 1)
+        );
+
+        let recent_blocks = state
+            .iter_blocks_back()
+            .map(|(height, block_hash)| (height, *block_hash))
+            .collect::<Vec<_>>();
+        let expected_blocks = Vec::from([(
+            genesis_height - 1,
+            bitcoind_chain.block_hash(genesis_height - 1),
+        )]);
         assert_eq!(recent_blocks, expected_blocks);
     }
 

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::bail;
 use bitcoin::{Block, BlockHash, Network};
-use bitcoind_async_client::{error::ClientError as BitcoinClientError, traits::Reader};
+use bitcoind_async_client::{corepc_types::model::GetBlockchainInfo, traits::Reader};
 use strata_btc_types::{BlockHashExt, L1BlockIdBitcoinExt};
 use strata_config::btcio::ReaderConfig;
 use strata_primitives::l1::{L1BlockCommitment, L1Height};
@@ -204,15 +204,48 @@ async fn init_reader_state<R: Reader>(
 ) -> anyhow::Result<ReaderState> {
     // Init the reader state using the blockid we were given, fill in a few blocks back.
     debug!(%target_next_block, "initializing reader state");
-    let mut init_queue = VecDeque::new();
 
     let lookback = ctx.btcio_params.l1_reorg_safe_depth() as L1Height * 2;
     let client = ctx.client.as_ref();
-    let genesis_height = ctx.btcio_params.genesis_l1_height();
-    let pre_genesis = genesis_height.saturating_sub(1);
 
     // Do some math to figure out where our start and end are.
     let chain_info = client.get_blockchain_info().await?;
+    validate_bitcoind(ctx, &chain_info).await?;
+
+    let stored_canonical_tip = ctx.storage.l1().get_canonical_chain_tip_async().await?;
+    let (init_queue, real_cur_height) = match stored_canonical_tip {
+        Some((stored_tip_height, _stored_tip_blkid))
+            if stored_tip_height.saturating_add(1) >= target_next_block =>
+        {
+            seed_queue_from_stored_chain(ctx, stored_tip_height, lookback).await?
+        }
+        stored_tip => {
+            let genesis_height = ctx.btcio_params.genesis_l1_height();
+            if let Some((stored_tip_height, _)) = stored_tip {
+                info!(
+                    %stored_tip_height,
+                    %target_next_block,
+                    %genesis_height,
+                    "stored L1 canonical tip is below configured genesis; seeding reader from Bitcoin client"
+                );
+            }
+            seed_queue_from_client(ctx, target_next_block, &chain_info, lookback).await?
+        }
+    };
+
+    let epoch = ctx.status_channel.get_cur_chain_epoch().unwrap_or(0);
+
+    // Note: Transaction filtering is no longer needed since the ASM STF handles
+    // parsing L1 blocks and producing manifests with logs.
+    let state = ReaderState::new(real_cur_height + 1, lookback as usize, init_queue, epoch);
+    Ok(state)
+}
+
+/// Validates Bitcoin client chain properties before reader ingestion starts.
+async fn validate_bitcoind<R: Reader>(
+    ctx: &ReaderContext<R>,
+    chain_info: &GetBlockchainInfo,
+) -> anyhow::Result<()> {
     if chain_info.chain != ctx.expected_network {
         bail!(
             "btcio: bitcoind network mismatch: expected {}, got {}",
@@ -221,7 +254,8 @@ async fn init_reader_state<R: Reader>(
         );
     }
 
-    let actual_hash = client
+    let actual_hash = ctx
+        .client
         .get_block_hash(ctx.expected_l1_anchor.height() as u64)
         .await?;
     let actual_block_id = actual_hash.to_l1_block_id();
@@ -233,74 +267,100 @@ async fn init_reader_state<R: Reader>(
         );
     }
 
-    let stored_canonical_tip = ctx.storage.l1().get_canonical_chain_tip_async().await?;
-    let mut real_cur_height;
-    match stored_canonical_tip {
-        Some((stored_tip_height, _stored_tip_blkid))
-            if stored_tip_height.saturating_add(1) >= target_next_block =>
+    Ok(())
+}
+
+/// Seeds a [`ReaderState`] queue from the stored canonical L1 chain.
+async fn seed_queue_from_stored_chain<R: Reader>(
+    ctx: &ReaderContext<R>,
+    stored_tip_height: L1Height,
+    lookback: L1Height,
+) -> anyhow::Result<(VecDeque<BlockHash>, L1Height)> {
+    let start_height = stored_tip_height.saturating_sub(lookback);
+    let genesis_height = ctx.btcio_params.genesis_l1_height();
+    let mut init_queue = VecDeque::new();
+    let mut height = stored_tip_height;
+
+    loop {
+        match ctx
+            .storage
+            .l1()
+            .get_canonical_blockid_at_height_async(height)
+            .await?
         {
-            let start_height = stored_tip_height.saturating_sub(lookback);
-            let stored_blockids = ctx
-                .storage
-                .l1()
-                .get_canonical_blockid_range_async(start_height, stored_tip_height + 1)
-                .await?;
-            debug!(
-                %start_height,
-                end_height = %stored_tip_height,
-                entries = stored_blockids.len(),
-                "loaded reader init range from stored L1 canonical chain"
-            );
-
-            for blockid in stored_blockids {
-                init_queue.push_back(blockid.to_block_hash());
-            }
-
-            if init_queue.is_empty() {
+            Some(blockid) => init_queue.push_front(blockid.to_block_hash()),
+            None if height < genesis_height => break,
+            None if height == stored_tip_height => {
                 bail!(
                     "btcio: stored L1 canonical chain tip at height {stored_tip_height} \
-                     was missing from the reader startup range"
+                     was missing from the reader startup walk"
                 );
             }
-
-            real_cur_height = stored_tip_height;
-        }
-        stored_tip => {
-            if let Some((stored_tip_height, _)) = stored_tip {
-                info!(
-                    %stored_tip_height,
-                    %target_next_block,
-                    %genesis_height,
-                    "stored L1 canonical tip is below configured genesis; seeding reader from Bitcoin client"
+            None => {
+                bail!(
+                    "btcio: stored L1 canonical chain has a gap at height {height} \
+                     while seeding reader state from tip {stored_tip_height}"
                 );
             }
-
-            let chain_tip = chain_info.blocks as L1Height;
-            let start_height = target_next_block
-                .saturating_sub(lookback)
-                .max(pre_genesis)
-                .min(chain_tip);
-            let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
-            debug!(%start_height, %end_height, "queried L1 client, have init range");
-
-            // Loop through the range we've determined to be okay and pull the blocks we want to
-            // look back through in.
-            real_cur_height = start_height;
-            for height in start_height..=end_height {
-                let blkid = client.get_block_hash(height as u64).await?;
-                debug!(%height, %blkid, "loaded recent L1 block");
-                init_queue.push_back(blkid);
-                real_cur_height = height;
-            }
         }
+
+        if height == start_height {
+            break;
+        }
+
+        height = height.saturating_sub(1);
     }
 
-    let epoch = ctx.status_channel.get_cur_chain_epoch().unwrap_or(0);
+    let loaded_start_height =
+        stored_tip_height.saturating_sub(init_queue.len().saturating_sub(1) as L1Height);
+    debug!(
+        %loaded_start_height,
+        end_height = %stored_tip_height,
+        entries = init_queue.len(),
+        "loaded reader init range from stored L1 canonical chain"
+    );
 
-    // Note: Transaction filtering is no longer needed since the ASM STF handles
-    // parsing L1 blocks and producing manifests with logs.
-    let state = ReaderState::new(real_cur_height + 1, lookback as usize, init_queue, epoch);
-    Ok(state)
+    if init_queue.is_empty() {
+        bail!(
+            "btcio: stored L1 canonical chain tip at height {stored_tip_height} \
+             was missing from the reader startup walk"
+        );
+    }
+
+    Ok((init_queue, stored_tip_height))
+}
+
+/// Seeds a [`ReaderState`] queue from the Bitcoin client.
+async fn seed_queue_from_client<R: Reader>(
+    ctx: &ReaderContext<R>,
+    target_next_block: L1Height,
+    chain_info: &GetBlockchainInfo,
+    lookback: L1Height,
+) -> anyhow::Result<(VecDeque<BlockHash>, L1Height)> {
+    let client = ctx.client.as_ref();
+    let genesis_height = ctx.btcio_params.genesis_l1_height();
+    let pre_genesis = genesis_height.saturating_sub(1);
+    let chain_tip = chain_info.blocks as L1Height;
+    let start_height = target_next_block
+        .saturating_sub(lookback)
+        .max(pre_genesis)
+        .min(chain_tip);
+    let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
+    let mut init_queue = VecDeque::new();
+    let mut real_cur_height = start_height;
+
+    debug!(%start_height, %end_height, "queried L1 client, have init range");
+
+    // Loop through the range we've determined to be okay and pull the blocks we want to
+    // look back through in.
+    for height in start_height..=end_height {
+        let blkid = client.get_block_hash(height as u64).await?;
+        debug!(%height, %blkid, "loaded recent L1 block");
+        init_queue.push_back(blkid);
+        real_cur_height = height;
+    }
+
+    Ok((init_queue, real_cur_height))
 }
 
 /// Polls the chain to see if there's new blocks to look at, possibly reorging
@@ -524,7 +584,8 @@ mod tests {
     };
     use strata_config::btcio::ReaderConfig;
     use strata_csm_types::{ClientState, ClientUpdateOutput, L1Status};
-    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_db_store_sled::{test_utils::get_test_sled_backend, SledBackend};
+    use strata_db_types::{backend::DatabaseBackend, l1::L1Database};
     use strata_l1_txfmt::MagicBytes;
     use strata_primitives::l1::{L1BlockCommitment, L1BlockId};
     use strata_status::StatusChannel;
@@ -662,8 +723,15 @@ mod tests {
     }
 
     fn test_storage() -> NodeStorage {
-        create_node_storage(get_test_sled_backend(), test_runtime_handle())
-            .expect("test: create node storage")
+        let (_, storage) = test_storage_with_backend();
+        storage
+    }
+
+    fn test_storage_with_backend() -> (Arc<SledBackend>, NodeStorage) {
+        let backend = get_test_sled_backend();
+        let storage = create_node_storage(backend.clone(), test_runtime_handle())
+            .expect("test: create node storage");
+        (backend, storage)
     }
 
     fn l1_block(height: L1Height) -> L1BlockCommitment {
@@ -854,6 +922,61 @@ mod tests {
             .map(|(height, block_hash)| (height, *block_hash))
             .collect::<Vec<_>>();
         let expected_blocks = (2..=6)
+            .rev()
+            .map(|height| (height, stored_chain.block_hash(height)))
+            .collect::<Vec<_>>();
+        assert_eq!(recent_blocks, expected_blocks);
+    }
+
+    #[tokio::test]
+    async fn init_reader_state_errors_on_stored_canonical_gap() {
+        let (backend, storage) = test_storage_with_backend();
+        let stored_chain = chain_client(&[0, 101, 102, 103, 104, 105, 106]).await;
+        let bitcoind_chain = chain_client(&[0, 201, 202, 203, 204, 205, 206]).await;
+
+        for height in 0..=6 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+        backend
+            .l1_db()
+            .remove_canonical_chain_entries(4, 4)
+            .expect("test: remove canonical chain entry");
+
+        let ctx = chain_reader_context(storage, bitcoind_chain);
+        let err = init_reader_state(&ctx, 7)
+            .await
+            .expect_err("test: stored canonical gap should fail initialization");
+
+        assert!(
+            err.to_string().contains("gap at height 4"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_reader_state_accepts_stored_chain_starting_at_genesis() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 101, 102, 103, 104]).await;
+        let bitcoind_chain = chain_client(&[0, 201, 202, 203, 204, 205, 206]).await;
+        let genesis_height = 2;
+
+        for height in genesis_height..=4 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context_with_genesis(storage, bitcoind_chain, genesis_height);
+        let state = init_reader_state(&ctx, 5)
+            .await
+            .expect("test: initialize reader state");
+
+        assert_eq!(state.next_height(), 5);
+        assert_eq!(*state.best_block(), stored_chain.block_hash(4));
+
+        let recent_blocks = state
+            .iter_blocks_back()
+            .map(|(height, block_hash)| (height, *block_hash))
+            .collect::<Vec<_>>();
+        let expected_blocks = (genesis_height..=4)
             .rev()
             .map(|height| (height, stored_chain.block_hash(height)))
             .collect::<Vec<_>>();

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -20,7 +20,10 @@ use tracing::*;
 use super::event::L1Event;
 use crate::{
     reader::{event::BlockData, handler::handle_bitcoin_event, state::ReaderState},
-    rpc_error::is_retryable_anyhow_error,
+    rpc_error::{
+        is_block_height_out_of_range_error, is_missing_block_height_anyhow_error,
+        is_retryable_anyhow_error,
+    },
     status::{apply_status_updates, L1StatusUpdate},
     BtcioParams,
 };
@@ -154,7 +157,10 @@ async fn do_reader_task<R: Reader>(
                     status_updates.push(L1StatusUpdate::RpcConnected(true));
                     state = Some(reader_state);
                 }
-                Err(err) if is_retryable_anyhow_error(&err) => {
+                Err(err)
+                    if is_retryable_anyhow_error(&err)
+                        || is_missing_block_height_anyhow_error(&err) =>
+                {
                     handle_poll_error(&err, &mut status_updates);
                 }
                 Err(err) => return Err(err),
@@ -441,7 +447,7 @@ async fn find_pivot_block(
 
         let queried_l1blkid = match client.get_block_hash(height as u64).await {
             Ok(block_hash) => block_hash,
-            Err(err) if is_missing_block_height_error(&err) => {
+            Err(err) if is_block_height_out_of_range_error(&err) => {
                 trace!(
                     %height,
                     %l1blkid,
@@ -459,16 +465,6 @@ async fn find_pivot_block(
     }
 
     Ok(None)
-}
-
-fn is_missing_block_height_error(err: &BitcoinClientError) -> bool {
-    match err {
-        BitcoinClientError::Server(-8, msg) => {
-            let msg = msg.to_ascii_lowercase();
-            msg.contains("height") && msg.contains("out of range")
-        }
-        _ => false,
-    }
 }
 
 /// Fetches a block at given height, extracts relevant transactions and emits an [`L1Event`].

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::bail;
 use bitcoin::{Block, BlockHash, Network};
 use bitcoind_async_client::traits::Reader;
-use strata_btc_types::BlockHashExt;
+use strata_btc_types::{BlockHashExt, L1BlockIdBitcoinExt};
 use strata_config::btcio::ReaderConfig;
 use strata_primitives::l1::{L1BlockCommitment, L1Height};
 use strata_state::BlockSubmitter;
@@ -227,22 +227,53 @@ async fn init_reader_state<R: Reader>(
         );
     }
 
-    let chain_tip = chain_info.blocks as L1Height;
-    let start_height = target_next_block
-        .saturating_sub(lookback)
-        .max(pre_genesis)
-        .min(chain_tip);
-    let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
-    debug!(%start_height, %end_height, "queried L1 client, have init range");
+    let mut real_cur_height;
+    if let Some((stored_tip_height, _stored_tip_blkid)) =
+        ctx.storage.l1().get_canonical_chain_tip_async().await?
+    {
+        let start_height = stored_tip_height.saturating_sub(lookback);
+        let stored_blockids = ctx
+            .storage
+            .l1()
+            .get_canonical_blockid_range_async(start_height, stored_tip_height + 1)
+            .await?;
+        debug!(
+            %start_height,
+            end_height = %stored_tip_height,
+            entries = stored_blockids.len(),
+            "loaded reader init range from stored L1 canonical chain"
+        );
 
-    // Loop through the range we've determined to be okay and pull the blocks we want to look back
-    // through in.
-    let mut real_cur_height = start_height;
-    for height in start_height..=end_height {
-        let blkid = client.get_block_hash(height as u64).await?;
-        debug!(%height, %blkid, "loaded recent L1 block");
-        init_queue.push_back(blkid);
-        real_cur_height = height;
+        for blockid in stored_blockids {
+            init_queue.push_back(blockid.to_block_hash());
+        }
+
+        if init_queue.is_empty() {
+            bail!(
+                "btcio: stored L1 canonical chain tip at height {stored_tip_height} \
+                 was missing from the reader startup range"
+            );
+        }
+
+        real_cur_height = stored_tip_height;
+    } else {
+        let chain_tip = chain_info.blocks as L1Height;
+        let start_height = target_next_block
+            .saturating_sub(lookback)
+            .max(pre_genesis)
+            .min(chain_tip);
+        let end_height = chain_tip.min(pre_genesis.max(target_next_block.saturating_sub(1)));
+        debug!(%start_height, %end_height, "queried L1 client, have init range");
+
+        // Loop through the range we've determined to be okay and pull the blocks we want to look
+        // back through in.
+        real_cur_height = start_height;
+        for height in start_height..=end_height {
+            let blkid = client.get_block_hash(height as u64).await?;
+            debug!(%height, %blkid, "loaded recent L1 block");
+            init_queue.push_back(blkid);
+            real_cur_height = height;
+        }
     }
 
     let epoch = ctx.status_channel.get_cur_chain_epoch().unwrap_or(0);
@@ -389,7 +420,15 @@ async fn process_block<R: Reader>(
 mod tests {
     use std::{collections::VecDeque, sync::Arc};
 
-    use bitcoin::{hashes::Hash, BlockHash, Network};
+    use bitcoin::{block::Header, hashes::Hash, Block, BlockHash, Network, Txid};
+    use bitcoind_async_client::{
+        corepc_types::model::{
+            EstimateSmartFee, GetBlockchainInfo, GetMempoolInfo, GetRawMempool,
+            GetRawMempoolVerbose, GetRawTransaction, GetRawTransactionVerbose, GetTxOut,
+        },
+        error::ClientError,
+        ClientResult,
+    };
     use strata_config::btcio::ReaderConfig;
     use strata_csm_types::{ClientState, ClientUpdateOutput, L1Status};
     use strata_db_store_sled::test_utils::get_test_sled_backend;
@@ -400,6 +439,134 @@ mod tests {
 
     use super::*;
     use crate::test_utils::TestBitcoinClient;
+
+    #[derive(Debug, Clone)]
+    struct ChainBitcoinClient {
+        blocks: Vec<Block>,
+        inner: TestBitcoinClient,
+    }
+
+    impl ChainBitcoinClient {
+        fn new(blocks: Vec<Block>) -> Self {
+            assert!(!blocks.is_empty());
+            Self {
+                blocks,
+                inner: TestBitcoinClient::new(0),
+            }
+        }
+
+        fn block_hash(&self, height: L1Height) -> BlockHash {
+            self.blocks[height as usize].block_hash()
+        }
+
+        fn block_by_hash(&self, hash: &BlockHash) -> ClientResult<Block> {
+            self.blocks
+                .iter()
+                .find(|block| block.block_hash() == *hash)
+                .cloned()
+                .ok_or_else(|| ClientError::Server(-8, format!("block not found: {hash}")))
+        }
+
+        fn block_at(&self, height: u64) -> ClientResult<Block> {
+            self.blocks.get(height as usize).cloned().ok_or_else(|| {
+                ClientError::Server(-8, format!("block height out of range: {height}"))
+            })
+        }
+    }
+
+    impl Reader for ChainBitcoinClient {
+        async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<EstimateSmartFee> {
+            self.inner.estimate_smart_fee(conf_target).await
+        }
+
+        async fn get_block_header(&self, hash: &BlockHash) -> ClientResult<Header> {
+            Ok(self.block_by_hash(hash)?.header)
+        }
+
+        async fn get_block(&self, hash: &BlockHash) -> ClientResult<Block> {
+            self.block_by_hash(hash)
+        }
+
+        async fn get_block_height(&self, hash: &BlockHash) -> ClientResult<u64> {
+            self.blocks
+                .iter()
+                .position(|block| block.block_hash() == *hash)
+                .map(|height| height as u64)
+                .ok_or_else(|| ClientError::Server(-8, format!("block not found: {hash}")))
+        }
+
+        async fn get_block_header_at(&self, height: u64) -> ClientResult<Header> {
+            Ok(self.block_at(height)?.header)
+        }
+
+        async fn get_block_at(&self, height: u64) -> ClientResult<Block> {
+            self.block_at(height)
+        }
+
+        async fn get_block_count(&self) -> ClientResult<u64> {
+            Ok(self.blocks.len() as u64 - 1)
+        }
+
+        async fn get_block_hash(&self, height: u64) -> ClientResult<BlockHash> {
+            Ok(self.block_at(height)?.block_hash())
+        }
+
+        async fn get_blockchain_info(&self) -> ClientResult<GetBlockchainInfo> {
+            let mut info = self.inner.get_blockchain_info().await?;
+            let block_count = self.blocks.len() as u32 - 1;
+            info.blocks = block_count;
+            info.headers = block_count;
+            info.best_block_hash = self
+                .blocks
+                .last()
+                .expect("test: nonempty chain")
+                .block_hash();
+            Ok(info)
+        }
+
+        async fn get_current_timestamp(&self) -> ClientResult<u32> {
+            self.inner.get_current_timestamp().await
+        }
+
+        async fn get_raw_mempool(&self) -> ClientResult<GetRawMempool> {
+            self.inner.get_raw_mempool().await
+        }
+
+        async fn get_raw_mempool_verbose(&self) -> ClientResult<GetRawMempoolVerbose> {
+            self.inner.get_raw_mempool_verbose().await
+        }
+
+        async fn get_mempool_info(&self) -> ClientResult<GetMempoolInfo> {
+            self.inner.get_mempool_info().await
+        }
+
+        async fn get_raw_transaction_verbosity_zero(
+            &self,
+            txid: &Txid,
+        ) -> ClientResult<GetRawTransaction> {
+            self.inner.get_raw_transaction_verbosity_zero(txid).await
+        }
+
+        async fn get_raw_transaction_verbosity_one(
+            &self,
+            txid: &Txid,
+        ) -> ClientResult<GetRawTransactionVerbose> {
+            self.inner.get_raw_transaction_verbosity_one(txid).await
+        }
+
+        async fn get_tx_out(
+            &self,
+            txid: &Txid,
+            vout: u32,
+            include_mempool: bool,
+        ) -> ClientResult<GetTxOut> {
+            self.inner.get_tx_out(txid, vout, include_mempool).await
+        }
+
+        async fn network(&self) -> ClientResult<Network> {
+            self.inner.network().await
+        }
+    }
 
     fn test_storage() -> NodeStorage {
         create_node_storage(get_test_sled_backend(), test_runtime_handle())
@@ -430,8 +597,37 @@ mod tests {
             .expect("test: extend canonical chain");
     }
 
+    async fn store_l1_canonical_hash(
+        storage: &NodeStorage,
+        height: L1Height,
+        block_hash: BlockHash,
+    ) {
+        storage
+            .l1()
+            .extend_canonical_chain_async(&block_hash.to_l1_block_id(), height)
+            .await
+            .expect("test: extend canonical chain");
+    }
+
     fn block_hash(byte: u8) -> BlockHash {
         BlockHash::from_byte_array([byte; 32])
+    }
+
+    async fn test_block(nonce: u32) -> Block {
+        let mut block = TestBitcoinClient::new(0)
+            .get_block_at(0)
+            .await
+            .expect("test: get base block");
+        block.header.nonce = nonce;
+        block
+    }
+
+    async fn chain_client(nonces: &[u32]) -> ChainBitcoinClient {
+        let mut blocks = Vec::with_capacity(nonces.len());
+        for nonce in nonces {
+            blocks.push(test_block(*nonce).await);
+        }
+        ChainBitcoinClient::new(blocks)
     }
 
     fn reader_context(storage: NodeStorage) -> ReaderContext<TestBitcoinClient> {
@@ -445,6 +641,28 @@ mod tests {
             status_channel: StatusChannel::new(
                 ClientState::default(),
                 l1_block(0),
+                L1Status::default(),
+                None,
+                None,
+            ),
+        }
+    }
+
+    fn chain_reader_context(
+        storage: NodeStorage,
+        client: ChainBitcoinClient,
+    ) -> ReaderContext<ChainBitcoinClient> {
+        let expected_l1_anchor = L1BlockCommitment::new(0, client.block_hash(0).to_l1_block_id());
+        ReaderContext {
+            client: Arc::new(client),
+            storage: Arc::new(storage),
+            config: Arc::new(ReaderConfig::default()),
+            btcio_params: BtcioParams::new(2, MagicBytes::new(*b"ALPN"), 0),
+            expected_network: Network::Regtest,
+            expected_l1_anchor,
+            status_channel: StatusChannel::new(
+                ClientState::default(),
+                expected_l1_anchor,
                 L1Status::default(),
                 None,
                 None,
@@ -510,6 +728,118 @@ mod tests {
             .expect("test: target block");
 
         assert_eq!(target, 112);
+    }
+
+    #[tokio::test]
+    async fn init_reader_state_seeds_from_stored_canonical_entries() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 101, 102, 103, 104, 105, 106]).await;
+        let bitcoind_chain = chain_client(&[0, 201, 202, 203, 204, 205, 206]).await;
+
+        for height in 0..=6 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context(storage, bitcoind_chain);
+        let state = init_reader_state(&ctx, 7)
+            .await
+            .expect("test: initialize reader state");
+
+        assert_eq!(state.next_height(), 7);
+        assert_eq!(*state.best_block(), stored_chain.block_hash(6));
+
+        let recent_blocks = state
+            .iter_blocks_back()
+            .map(|(height, block_hash)| (height, *block_hash))
+            .collect::<Vec<_>>();
+        let expected_blocks = (2..=6)
+            .rev()
+            .map(|height| (height, stored_chain.block_hash(height)))
+            .collect::<Vec<_>>();
+        assert_eq!(recent_blocks, expected_blocks);
+    }
+
+    #[tokio::test]
+    async fn poll_for_new_blocks_reverts_offline_reorg_then_continues() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 1, 2, 103, 104]).await;
+        let bitcoind_chain = chain_client(&[0, 1, 2, 203, 204, 205]).await;
+
+        for height in 0..=4 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context(storage, bitcoind_chain.clone());
+        let mut state = init_reader_state(&ctx, 5)
+            .await
+            .expect("test: initialize reader state");
+        let mut status_updates = Vec::new();
+
+        let events = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect("test: poll reorg");
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            L1Event::RevertTo(block) => {
+                assert_eq!(block.height(), 2);
+                assert_eq!(
+                    *block.blkid(),
+                    bitcoind_chain.block_hash(2).to_l1_block_id()
+                );
+            }
+            event => panic!("test: expected RevertTo event, got {event:?}"),
+        }
+        assert_eq!(state.next_height(), 3);
+        assert_eq!(*state.best_block(), bitcoind_chain.block_hash(2));
+
+        ctx.storage
+            .l1()
+            .revert_canonical_chain_async(2)
+            .await
+            .expect("test: apply revert");
+
+        let events = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect("test: poll new fork");
+
+        let new_block_heights = events
+            .iter()
+            .map(|event| match event {
+                L1Event::BlockData(block_data, _) => block_data.block_num(),
+                L1Event::RevertTo(block) => {
+                    panic!(
+                        "test: unexpected RevertTo event at height {}",
+                        block.height()
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(new_block_heights, vec![3, 4, 5]);
+        assert_eq!(state.next_height(), 6);
+        assert_eq!(*state.best_block(), bitcoind_chain.block_hash(5));
+    }
+
+    #[tokio::test]
+    async fn init_reader_state_without_stored_l1_seeds_from_bitcoind() {
+        let storage = test_storage();
+        let bitcoind_chain = chain_client(&[0, 1, 2, 3, 4, 5]).await;
+        let ctx = chain_reader_context(storage, bitcoind_chain.clone());
+
+        let state = init_reader_state(&ctx, 3)
+            .await
+            .expect("test: initialize reader state");
+
+        assert_eq!(state.next_height(), 3);
+        let recent_blocks = state
+            .iter_blocks_back()
+            .map(|(height, block_hash)| (height, *block_hash))
+            .collect::<Vec<_>>();
+        let expected_blocks = (0..=2)
+            .rev()
+            .map(|height| (height, bitcoind_chain.block_hash(height)))
+            .collect::<Vec<_>>();
+        assert_eq!(recent_blocks, expected_blocks);
     }
 
     #[tokio::test]

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -110,51 +110,14 @@ async fn calculate_target_next_block(
     storage: &NodeStorage,
     genesis_l1_height: L1Height,
 ) -> anyhow::Result<L1Height> {
-    let client_state_target = calculate_client_state_target(storage).await?;
     let stored_l1_target = storage
         .l1()
         .get_canonical_chain_tip_async()
         .await?
         .map(|(height, _)| height.saturating_add(1))
         .unwrap_or(genesis_l1_height);
-    let target_next_block = client_state_target
-        .unwrap_or(genesis_l1_height)
-        .max(stored_l1_target)
-        .max(genesis_l1_height);
+    let target_next_block = stored_l1_target.max(genesis_l1_height);
     Ok(target_next_block)
-}
-
-async fn calculate_client_state_target(storage: &NodeStorage) -> anyhow::Result<Option<L1Height>> {
-    let Some((block, _)) = storage
-        .client_state()
-        .fetch_most_recent_state_async()
-        .await?
-    else {
-        return Ok(None);
-    };
-
-    match storage
-        .l1()
-        .get_canonical_blockid_at_height_async(block.height())
-        .await?
-    {
-        Some(blockid) if blockid == *block.blkid() => Ok(Some(block.height().saturating_add(1))),
-        Some(blockid) => {
-            warn!(
-                client_state_block = %block,
-                canonical_l1_blkid = %blockid,
-                "ignoring latest client-state height because it is not on the stored L1 canonical chain"
-            );
-            Ok(None)
-        }
-        None => {
-            warn!(
-                client_state_block = %block,
-                "ignoring latest client-state height because its L1 block is not stored as canonical"
-            );
-            Ok(None)
-        }
-    }
 }
 
 /// Inner function that actually does the reading task.
@@ -490,7 +453,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_falls_back_to_genesis_without_client_state() {
+    async fn calculate_target_next_block_starts_at_genesis_without_stored_l1() {
         let storage = test_storage();
 
         let target = calculate_target_next_block(&storage, 42)
@@ -501,9 +464,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_uses_latest_client_state_height() {
+    async fn calculate_target_next_block_uses_stored_l1_tip() {
         let storage = test_storage();
-        store_client_state(&storage, 100).await;
         store_l1_canonical(&storage, 100).await;
 
         let target = calculate_target_next_block(&storage, 42)
@@ -514,7 +476,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_ignores_client_state_without_l1_canonical_anchor() {
+    async fn calculate_target_next_block_ignores_client_state_without_stored_l1() {
         let storage = test_storage();
         store_client_state(&storage, 100).await;
 
@@ -526,9 +488,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_clamps_pregenesis_client_state_to_genesis() {
+    async fn calculate_target_next_block_clamps_pregenesis_l1_tip_to_genesis() {
         let storage = test_storage();
-        store_client_state(&storage, 10).await;
         store_l1_canonical(&storage, 10).await;
 
         let target = calculate_target_next_block(&storage, 42)
@@ -539,7 +500,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn calculate_target_next_block_does_not_replay_stored_l1_tip() {
+    async fn calculate_target_next_block_ignores_client_state_when_l1_tip_exists() {
         let storage = test_storage();
         store_client_state(&storage, 100).await;
         store_l1_canonical(&storage, 111).await;

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::bail;
 use bitcoin::{Block, BlockHash, Network};
-use bitcoind_async_client::traits::Reader;
+use bitcoind_async_client::{error::ClientError as BitcoinClientError, traits::Reader};
 use strata_btc_types::{BlockHashExt, L1BlockIdBitcoinExt};
 use strata_config::btcio::ReaderConfig;
 use strata_primitives::l1::{L1BlockCommitment, L1Height};
@@ -306,7 +306,18 @@ async fn poll_for_new_blocks<R: Reader>(
 
     // First, check for a reorg if there is one.
     if let Some((pivot_height, pivot_blkid)) = find_pivot_block(ctx.client.as_ref(), state).await? {
-        if pivot_height < state.best_block_idx() {
+        let reader_best_height = state.best_block_idx();
+        if client_height < reader_best_height && pivot_height == client_height {
+            debug!(
+                %client_height,
+                %reader_best_height,
+                %pivot_blkid,
+                "Bitcoin client tip is a prefix of reader state; waiting for client to catch up"
+            );
+            return Ok(vec![]);
+        }
+
+        if pivot_height < reader_best_height {
             info!(%pivot_height, %pivot_blkid, "found apparent reorg");
             let block = L1BlockCommitment::new(pivot_height, pivot_blkid.to_l1_block_id());
             state.rollback_to_height(pivot_height);
@@ -364,7 +375,19 @@ async fn find_pivot_block(
             return Ok(Some((height, *l1blkid)));
         }
 
-        let queried_l1blkid = client.get_block_hash(height as u64).await?;
+        let queried_l1blkid = match client.get_block_hash(height as u64).await {
+            Ok(block_hash) => block_hash,
+            Err(err) if is_missing_block_height_error(&err) => {
+                trace!(
+                    %height,
+                    %l1blkid,
+                    err = %err,
+                    "Bitcoin client does not have tracked block height while finding pivot"
+                );
+                continue;
+            }
+            Err(err) => return Err(err.into()),
+        };
         trace!(%height, %l1blkid, %queried_l1blkid, "comparing blocks to find pivot");
         if queried_l1blkid == *l1blkid {
             return Ok(Some((height, *l1blkid)));
@@ -372,6 +395,16 @@ async fn find_pivot_block(
     }
 
     Ok(None)
+}
+
+fn is_missing_block_height_error(err: &BitcoinClientError) -> bool {
+    match err {
+        BitcoinClientError::Server(-8, msg) => {
+            let msg = msg.to_ascii_lowercase();
+            msg.contains("height") && msg.contains("out of range")
+        }
+        _ => false,
+    }
 }
 
 /// Fetches a block at given height, extracts relevant transactions and emits an [`L1Event`].
@@ -818,6 +851,66 @@ mod tests {
         assert_eq!(new_block_heights, vec![3, 4, 5]);
         assert_eq!(state.next_height(), 6);
         assert_eq!(*state.best_block(), bitcoind_chain.block_hash(5));
+    }
+
+    #[tokio::test]
+    async fn poll_for_new_blocks_waits_when_bitcoind_tip_is_matching_prefix() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 1, 2, 3, 4, 5]).await;
+        let bitcoind_chain = chain_client(&[0, 1, 2, 3]).await;
+
+        for height in 0..=5 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context(storage, bitcoind_chain);
+        let mut state = init_reader_state(&ctx, 6)
+            .await
+            .expect("test: initialize reader state");
+        let mut status_updates = Vec::new();
+
+        let events = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect("test: poll matching prefix");
+
+        assert!(events.is_empty());
+        assert_eq!(state.next_height(), 6);
+        assert_eq!(*state.best_block(), stored_chain.block_hash(5));
+    }
+
+    #[tokio::test]
+    async fn poll_for_new_blocks_reverts_when_shorter_bitcoind_chain_diverges() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 1, 2, 103, 104, 105]).await;
+        let bitcoind_chain = chain_client(&[0, 1, 202, 203]).await;
+
+        for height in 0..=5 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context(storage, bitcoind_chain.clone());
+        let mut state = init_reader_state(&ctx, 6)
+            .await
+            .expect("test: initialize reader state");
+        let mut status_updates = Vec::new();
+
+        let events = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect("test: poll shorter divergent chain");
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            L1Event::RevertTo(block) => {
+                assert_eq!(block.height(), 1);
+                assert_eq!(
+                    *block.blkid(),
+                    bitcoind_chain.block_hash(1).to_l1_block_id()
+                );
+            }
+            event => panic!("test: expected RevertTo event, got {event:?}"),
+        }
+        assert_eq!(state.next_height(), 2);
+        assert_eq!(*state.best_block(), bitcoind_chain.block_hash(1));
     }
 
     #[tokio::test]

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -328,6 +328,24 @@ async fn poll_for_new_blocks<R: Reader>(
         }
     } else {
         let reader_best_height = state.best_block_idx();
+        let lowest_tracked_height = state
+            .iter_blocks_back()
+            .last()
+            .map(|(height, _)| height)
+            .expect("reader: recent blocks is nonempty");
+        if client_height < lowest_tracked_height
+            && client_tip_matches_stored_canonical(ctx, client_height, fresh_best_block).await?
+        {
+            debug!(
+                %client_height,
+                %reader_best_height,
+                %fresh_best_block,
+                %lowest_tracked_height,
+                "Bitcoin client tip is a deeply lagging prefix of stored reader state; waiting for client to catch up"
+            );
+            return Ok(vec![]);
+        }
+
         let known_depth = state.iter_blocks_back().count();
         let err = ReaderError::PivotNotFound {
             client_height,
@@ -361,6 +379,39 @@ async fn poll_for_new_blocks<R: Reader>(
     }
 
     Ok(events)
+}
+
+async fn client_tip_matches_stored_canonical<R: Reader>(
+    ctx: &ReaderContext<R>,
+    client_height: L1Height,
+    client_tip_hash: BlockHash,
+) -> anyhow::Result<bool> {
+    let Some(stored_blockid) = ctx
+        .storage
+        .l1()
+        .get_canonical_blockid_at_height_async(client_height)
+        .await?
+    else {
+        debug!(
+            %client_height,
+            %client_tip_hash,
+            "stored L1 canonical chain is missing deeply lagging Bitcoin client tip height"
+        );
+        return Ok(false);
+    };
+
+    let client_tip_blockid = client_tip_hash.to_l1_block_id();
+    if stored_blockid != client_tip_blockid {
+        debug!(
+            %client_height,
+            %client_tip_hash,
+            %stored_blockid,
+            "deeply lagging Bitcoin client tip does not match stored L1 canonical chain"
+        );
+        return Ok(false);
+    }
+
+    Ok(true)
 }
 
 /// Finds the highest block index where we do agree with the node.  If we never
@@ -876,6 +927,63 @@ mod tests {
         assert!(events.is_empty());
         assert_eq!(state.next_height(), 6);
         assert_eq!(*state.best_block(), stored_chain.block_hash(5));
+    }
+
+    #[tokio::test]
+    async fn poll_for_new_blocks_waits_when_deeply_lagging_bitcoind_tip_is_matching_prefix() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 1, 2, 3, 104, 105, 106, 107, 108]).await;
+        let bitcoind_chain = chain_client(&[0, 1, 2, 3]).await;
+
+        for height in 0..=8 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context(storage, bitcoind_chain);
+        let mut state = init_reader_state(&ctx, 9)
+            .await
+            .expect("test: initialize reader state");
+        let mut status_updates = Vec::new();
+
+        let events = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect("test: poll deeply lagging matching prefix");
+
+        assert!(events.is_empty());
+        assert_eq!(state.next_height(), 9);
+        assert_eq!(*state.best_block(), stored_chain.block_hash(8));
+    }
+
+    #[tokio::test]
+    async fn poll_for_new_blocks_errors_when_deeply_lagging_bitcoind_chain_diverges() {
+        let storage = test_storage();
+        let stored_chain = chain_client(&[0, 1, 2, 3, 104, 105, 106, 107, 108]).await;
+        let bitcoind_chain = chain_client(&[0, 1, 202, 203]).await;
+
+        for height in 0..=8 {
+            store_l1_canonical_hash(&storage, height, stored_chain.block_hash(height)).await;
+        }
+
+        let ctx = chain_reader_context(storage, bitcoind_chain);
+        let mut state = init_reader_state(&ctx, 9)
+            .await
+            .expect("test: initialize reader state");
+        let mut status_updates = Vec::new();
+
+        let err = poll_for_new_blocks(&ctx, &mut state, &mut status_updates)
+            .await
+            .expect_err("test: poll deeply lagging divergent chain");
+
+        assert_eq!(
+            err.downcast_ref::<ReaderError>(),
+            Some(&ReaderError::PivotNotFound {
+                client_height: 3,
+                reader_best_height: 8,
+                known_depth: 5,
+            })
+        );
+        assert_eq!(state.next_height(), 9);
+        assert_eq!(*state.best_block(), stored_chain.block_hash(8));
     }
 
     #[tokio::test]

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -182,10 +182,15 @@ async fn do_reader_task<R: Reader>(
 
 /// Handles errors encountered during polling.
 fn handle_poll_error(err: &anyhow::Error, status_updates: &mut Vec<L1StatusUpdate>) {
-    warn!(%err, "failed to poll Bitcoin client");
+    let is_deferrable = is_retryable_anyhow_error(err) || is_missing_block_height_anyhow_error(err);
+    if is_deferrable {
+        warn!(%err, "failed to poll Bitcoin client");
+    } else {
+        error!(%err, "failed to poll Bitcoin client");
+    }
     status_updates.push(L1StatusUpdate::RpcError(err.to_string()));
 
-    if is_retryable_anyhow_error(err) {
+    if is_deferrable {
         status_updates.push(L1StatusUpdate::RpcConnected(false));
         return;
     }
@@ -431,10 +436,6 @@ async fn poll_for_new_blocks<R: Reader>(
             reader_best_height,
             known_depth,
         };
-        error!(
-            client_height,
-            reader_best_height, known_depth, "unable to find common block with client chain"
-        );
         return Err(err.into());
     }
 

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -15,6 +15,26 @@ pub fn is_bitcoind_warmup_error(err: &ClientError) -> bool {
     matches!(err, ClientError::Server(-28, _))
 }
 
+/// Returns `true` when bitcoind reports a missing block height.
+pub fn is_block_height_out_of_range_error(err: &ClientError) -> bool {
+    match err {
+        ClientError::Server(-8, msg) => {
+            let msg = msg.to_ascii_lowercase();
+            msg.contains("height") && msg.contains("out of range")
+        }
+        _ => false,
+    }
+}
+
+/// Returns `true` when an [`anyhow::Error`] wraps a missing block height error.
+pub(crate) fn is_missing_block_height_anyhow_error(err: &AnyhowError) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<ClientError>()
+            .is_some_and(is_block_height_out_of_range_error)
+    })
+}
+
 /// Returns `true` when an [`anyhow::Error`] wraps a retryable Bitcoin RPC error.
 pub(crate) fn is_retryable_anyhow_error(err: &AnyhowError) -> bool {
     if err.chain().any(|cause| {
@@ -61,6 +81,7 @@ mod tests {
     use bitcoind_async_client::error::ClientError;
 
     use super::{
+        is_block_height_out_of_range_error, is_missing_block_height_anyhow_error,
         is_retryable_anyhow_error, is_retryable_client_error, is_retryable_envelope_error,
         retryable_reason,
     };
@@ -79,6 +100,10 @@ mod tests {
             -25,
             "bad-txns-inputs-missingorspent".into()
         )));
+        assert!(!is_retryable_client_error(&ClientError::Server(
+            -8,
+            "Block height out of range".into()
+        )));
     }
 
     #[test]
@@ -95,6 +120,17 @@ mod tests {
             .context("failed to poll Bitcoin client");
 
         assert!(is_retryable_anyhow_error(&err));
+    }
+
+    #[test]
+    fn block_height_out_of_range_classification_is_scoped() {
+        let err = ClientError::Server(-8, "Block height out of range".into());
+        let wrapped = anyhow::Error::from(err.clone()).context("failed to fetch anchor block");
+
+        assert!(is_block_height_out_of_range_error(&err));
+        assert!(is_missing_block_height_anyhow_error(&wrapped));
+        assert!(!is_retryable_client_error(&err));
+        assert!(!is_retryable_anyhow_error(&wrapped));
     }
 
     #[test]

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -7,7 +7,12 @@ use crate::writer::builder::EnvelopeError;
 
 /// Returns `true` when a Bitcoin RPC error may be resolved by retrying later.
 pub(crate) fn is_retryable_client_error(err: &ClientError) -> bool {
-    err.is_retriable()
+    err.is_retriable() || is_bitcoind_warmup_error(err)
+}
+
+/// Returns `true` when bitcoind is reachable but still in RPC warmup.
+pub fn is_bitcoind_warmup_error(err: &ClientError) -> bool {
+    matches!(err, ClientError::Server(-28, _))
 }
 
 /// Returns `true` when an [`anyhow::Error`] wraps a retryable Bitcoin RPC error.
@@ -62,9 +67,13 @@ mod tests {
     use crate::writer::builder::EnvelopeError;
 
     #[test]
-    fn client_errors_delegate_to_bitcoind_async_client() {
+    fn client_errors_include_bitcoind_warmup() {
         assert!(is_retryable_client_error(&ClientError::Connection(
             "connection refused".into()
+        )));
+        assert!(is_retryable_client_error(&ClientError::Server(
+            -28,
+            "Loading block index...".into()
         )));
         assert!(!is_retryable_client_error(&ClientError::Server(
             -25,
@@ -81,6 +90,14 @@ mod tests {
     }
 
     #[test]
+    fn anyhow_context_preserves_bitcoind_warmup_classification() {
+        let err = anyhow::Error::from(ClientError::Server(-28, "Loading block index...".into()))
+            .context("failed to poll Bitcoin client");
+
+        assert!(is_retryable_anyhow_error(&err));
+    }
+
+    #[test]
     fn envelope_prereq_fetch_uses_wrapped_retry_classification() {
         let source = anyhow::Error::from(ClientError::Timeout).context("network unavailable");
         let err = EnvelopeError::PrereqFetch(source);
@@ -92,6 +109,16 @@ mod tests {
     fn envelope_signing_rpc_outages_are_retryable() {
         let err =
             EnvelopeError::SignRawTransaction(ClientError::Connection("connection refused".into()));
+
+        assert!(is_retryable_envelope_error(&err));
+    }
+
+    #[test]
+    fn envelope_signing_bitcoind_warmup_is_retryable() {
+        let err = EnvelopeError::SignRawTransaction(ClientError::Server(
+            -28,
+            "Loading block index...".into(),
+        ));
 
         assert!(is_retryable_envelope_error(&err));
     }


### PR DESCRIPTION
## Description

The btcio reader's startup depended on the downstream CSM/client-state watermark, coupling the upstream L1 reader to one downstream consumer ([STR-3845](https://alpenlabs.atlassian.net/browse/STR-3845)). Startup also seeded the reader's lookback window from `bitcoind`'s *current* chain, so an L1 reorg that happened while the node was offline silently discarded stored canonical history - no `RevertTo` was ever emitted and stored L1/ASM/CSM state stayed on a stale fork.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- **Seed startup from stored canonical entries**: when a stored L1 canonical tip exists, `init_reader_state()` seeds the recent-blocks lookback queue from stored canonical entries (`get_canonical_blockid_range_async`) with `next_height = stored_tip + 1`. The first `poll_for_new_blocks()` iteration then detects any offline reorg via the existing `find_pivot_block()` comparison against bitcoind and emits `L1Event::RevertTo` through the normal handler. Startup never mutates stored L1 state. A fresh DB still seeds from bitcoind at the genesis/anchor height.
- **Start-height decoupling** (ported from #2069): `calculate_target_next_block()` no longer reads client state; it uses only the stored L1 canonical tip with a genesis fallback.
- **Bitcoind warmup retry** (ported from #2069): RPC `-28` (warmup) is classified as retryable in btcio and defers node startup checks instead of failing them.
- **Shorter-bitcoind-chain robustness**: with stored seeding the tracked tip can exceed bitcoind's tip. The pivot search skips `-8 Block height out of range` responses; a matching-prefix bitcoind (merely behind/syncing) yields no events and no rollback; only an actual hash divergence at or below bitcoind's tip triggers `RevertTo`. Deep reorgs beyond the lookback window still surface as `PivotNotFound`.

The seven commits are independent and reviewable in order:

1. warmup classification in btcio
2. startup-check deferral
3. start-height decoupling
4. stored-canonical seeding (the core fix)
5. pivot-search robustness for a shorter `bitcoind` chain
6. wait for a deeply lagging `bitcoind` that is a matching prefix of the stored chain (addresses [review feedback](https://github.com/alpenlabs/alpen/pull/2074#discussion_r3529289755))
7. honor the genesis clamp when seeding from the stored chain (addresses [review feedback](https://github.com/alpenlabs/alpen/pull/2074#discussion_r3529554107)).

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

> **AI assistance notice**: this PR was implemented with Codex (GPT-5.5) orchestrated by Claude Code; all changes were human-reviewed.

## Related Issues

STR-3845

Supersedes #2069

[STR-3845]: https://alpenlabs.atlassian.net/browse/STR-3845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

