### PR TITLE
STR-3311 Refactor sensitive MsgPayload uses to keep a Coin

### DIFF
--- a/crates/acct-types/src/messages.rs
+++ b/crates/acct-types/src/messages.rs
@@ -148,6 +148,11 @@ impl MsgPayload {
         &self.data
     }
 
+    /// Returns the SSZ-bounded message data list.
+    pub fn payload_data(&self) -> &MsgPayloadData {
+        &self.data
+    }
+
     /// Wraps the payload into a [`SentMessage`] to some dest account.
     pub fn into_sent(self, dest: AccountId) -> SentMessage {
         SentMessage::new(dest, self)

--- a/crates/ledger-types/src/coin.rs
+++ b/crates/ledger-types/src/coin.rs
@@ -4,6 +4,14 @@ use std::{mem, ops::Drop};
 
 use strata_acct_types::BitcoinAmount;
 
+/// Error arising from value-preserving [`Coin`] operations.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CoinError {
+    /// Tried to split off more value than the coin holds.
+    #[error("insufficient coin value (have {have} sats, want {want} sats)")]
+    InsufficientValue { have: u64, want: u64 },
+}
+
 /// A linear coin that must be explicitly created and destroyed.  This allows us
 /// to more safely reason about flow of funds between components and reduce the
 /// complexity of bookkeeping by making it more likely that accounting bugs are
@@ -22,9 +30,34 @@ impl Coin {
         Self(amt)
     }
 
+    /// Creates a coin with zero value.
+    ///
+    /// This is always safe since it creates no value.
+    pub fn zero() -> Self {
+        Self(BitcoinAmount::zero())
+    }
+
     /// Gets the amount of value this coin represents.
     pub fn amt(&self) -> BitcoinAmount {
         self.0
+    }
+
+    /// Splits `amt` off of this coin, reducing it by `amt` and returning a new
+    /// coin holding `amt`.
+    ///
+    /// This is value-preserving: the returned coin plus what remains in `self`
+    /// together hold exactly what `self` did before.  Returns an error, leaving
+    /// `self` untouched, if `amt` exceeds this coin's value.
+    pub fn split_out(&mut self, amt: BitcoinAmount) -> Result<Self, CoinError> {
+        let Some(remainder) = self.0.checked_sub(amt) else {
+            return Err(CoinError::InsufficientValue {
+                have: self.0.to_sat(),
+                want: amt.to_sat(),
+            });
+        };
+
+        self.0 = remainder;
+        Ok(Self(amt))
     }
 
     /// Consumes the coin without panicking.
@@ -34,6 +67,25 @@ impl Coin {
         // Since this is just flat bytes, we can do this to safely destroy
         // ourselves without calling `Drop::drop`.
         mem::forget(self);
+    }
+
+    /// Consumes a coin that must hold zero value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the coin still holds value.  Reaching this with a nonzero
+    /// coin means value went unaccounted for, which is a bug rather than a
+    /// recoverable condition.
+    pub fn consume_zero(self) {
+        // Consume first so a failed assert doesn't also trip the `Drop` panic
+        // and turn a clean panic into an abort.
+        let amt = self.0;
+        self.safely_consume_unchecked();
+        assert!(
+            amt.is_zero(),
+            "coin: consumed nonzero coin as zero ({} sats)",
+            amt.to_sat()
+        );
     }
 }
 
@@ -46,7 +98,9 @@ impl Drop for Coin {
 
 #[cfg(test)]
 mod tests {
-    use super::Coin;
+    use strata_acct_types::BitcoinAmount;
+
+    use super::{Coin, CoinError};
 
     #[test]
     fn test_coin_create_destroy() {
@@ -59,5 +113,53 @@ mod tests {
     fn test_coin_create_panic() {
         let _coin = Coin::new_unchecked(123.into());
         // should panic
+    }
+
+    #[test]
+    fn test_coin_zero_consume_zero() {
+        let coin = Coin::zero();
+        assert!(coin.amt().is_zero());
+        coin.consume_zero();
+    }
+
+    #[test]
+    fn test_coin_split_out_preserves_total() {
+        let mut coin = Coin::new_unchecked(BitcoinAmount::from_sat(100));
+        let taken = coin
+            .split_out(BitcoinAmount::from_sat(30))
+            .expect("split within value");
+        assert_eq!(taken.amt(), BitcoinAmount::from_sat(30));
+        assert_eq!(coin.amt(), BitcoinAmount::from_sat(70));
+        taken.safely_consume_unchecked();
+        coin.safely_consume_unchecked();
+    }
+
+    #[test]
+    fn test_coin_split_out_exact_leaves_zero() {
+        let mut coin = Coin::new_unchecked(BitcoinAmount::from_sat(42));
+        let taken = coin
+            .split_out(BitcoinAmount::from_sat(42))
+            .expect("split within value");
+        taken.safely_consume_unchecked();
+        coin.consume_zero();
+    }
+
+    #[test]
+    fn test_coin_split_out_insufficient_errors() {
+        let mut coin = Coin::new_unchecked(BitcoinAmount::from_sat(10));
+        let err = coin
+            .split_out(BitcoinAmount::from_sat(11))
+            .expect_err("split beyond value must fail");
+        assert_eq!(err, CoinError::InsufficientValue { have: 10, want: 11 });
+        // `coin` is untouched by the failed split, so it still must be consumed.
+        assert_eq!(coin.amt(), BitcoinAmount::from_sat(10));
+        coin.safely_consume_unchecked();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_coin_consume_zero_nonzero_panics() {
+        let coin = Coin::new_unchecked(BitcoinAmount::from_sat(1));
+        coin.consume_zero();
     }
 }

--- a/crates/ledger-types/src/lib.rs
+++ b/crates/ledger-types/src/lib.rs
@@ -34,7 +34,7 @@ mod proofs;
 mod state_accessor;
 
 pub use account::*;
-pub use coin::Coin;
+pub use coin::{Coin, CoinError};
 pub use errors::*;
 pub use pending_asm_log::PendingAsmLog;
 pub use proofs::*;

--- a/crates/ol/state-support-types/src/memory_state_layer.rs
+++ b/crates/ol/state-support-types/src/memory_state_layer.rs
@@ -152,6 +152,10 @@ impl IStateAccessorMut for MemoryStateBaseLayer {
         let cur = self.state.global.limbo_funds();
         let amt = coin.amt();
         if cur.checked_add(amt).is_none() {
+            // Defuse the coin before returning: the whole STF is discarded on
+            // this error, so no value is actually lost, and dropping a live coin
+            // would panic in `Coin::drop`.
+            coin.safely_consume_unchecked();
             return Err(StateError::LimboFundsOverflow { cur, add: amt });
         }
         self.state.global.add_limbo_funds_coin(coin);

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -716,13 +716,15 @@ impl IStateAccessorMut for TestState {
 
     fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
         let amt = coin.amt();
-        let new = self
-            .limbo_funds
-            .checked_add(amt)
-            .ok_or(StateError::LimboFundsOverflow {
+        let Some(new) = self.limbo_funds.checked_add(amt) else {
+            // Defuse the coin before returning so the mock upholds the same
+            // consume-always contract as the real layers (dropping it panics).
+            coin.safely_consume_unchecked();
+            return Err(StateError::LimboFundsOverflow {
                 cur: self.limbo_funds,
                 add: amt,
-            })?;
+            });
+        };
         self.limbo_funds = new;
         coin.safely_consume_unchecked();
         Ok(())

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -239,9 +239,13 @@ where
     fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
         let cur = self.limbo_funds();
         let amt = coin.amt();
-        let new = cur
-            .checked_add(amt)
-            .ok_or(StateError::LimboFundsOverflow { cur, add: amt })?;
+        let Some(new) = cur.checked_add(amt) else {
+            // Defuse the coin before returning: the whole STF is discarded on
+            // this error, so no value is actually lost, and dropping a live coin
+            // would panic in `Coin::drop`.
+            coin.safely_consume_unchecked();
+            return Err(StateError::LimboFundsOverflow { cur, add: amt });
+        };
         self.batch.global_writes_mut().limbo_funds_sats = Some(new.to_sat());
         coin.safely_consume_unchecked();
         Ok(())

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -2,7 +2,7 @@
 
 use bitcoin_bosd::Descriptor;
 use strata_acct_types::{
-    AccountId, BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BitcoinAmount, MsgPayload,
+    AccountId, BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, MsgPayload,
 };
 use strata_ledger_types::*;
 use strata_msg_fmt::MsgRef;
@@ -11,7 +11,10 @@ use strata_ol_msg_types::OLMessageExt;
 use strata_snark_acct_sys as snark_sys;
 use tracing::*;
 
-use crate::{context::BasicExecContext, errors::ExecResult, output::OutputCtx};
+use crate::{
+    context::BasicExecContext, errors::ExecResult, msg_payload_coin::MsgPayloadCoin,
+    output::OutputCtx,
+};
 
 /// Processes a message by delivering it to its destination, which might involve
 /// touching the ledger state.
@@ -19,7 +22,7 @@ pub(crate) fn process_message<S: IStateAccessorMut>(
     state: &mut S,
     sender: AccountId,
     target: AccountId,
-    msg: MsgPayload,
+    msg: MsgPayloadCoin,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
     match target {
@@ -30,19 +33,20 @@ pub(crate) fn process_message<S: IStateAccessorMut>(
 
         // Any other address we assume is a ledger account, so we have to look it up.
         _ => {
-            let coin = Coin::new_unchecked(msg.value());
-
             // Check if the account exists first.
             if !state.check_account_exists(target)? {
                 warn!(
                     %target,
                     %sender,
-                    value = %msg.value(),
+                    value = %msg.coin_amt(),
                     "limboing message to nonexistent target account",
                 );
-                handle_misplaced_funds(state, coin)?;
+                handle_misplaced_funds(state, msg.into_coin())?;
                 return Ok(());
             }
+
+            // Reconstitute the coin and a record payload for any snark inbox.
+            let (coin, record) = msg.into_coin_and_record();
 
             // Update the account within a closure.
             state.update_account(target, |acct_state| -> ExecResult<()> {
@@ -53,7 +57,7 @@ pub(crate) fn process_message<S: IStateAccessorMut>(
                 // for postprocessing.
                 if let Ok(sastate) = acct_state.as_snark_account_mut() {
                     // Call the handler fn now that we've increased the balance.
-                    handle_snark_account_message(sastate, sender, &msg, context)?;
+                    handle_snark_account_message(sastate, sender, &record, context)?;
                 }
                 // Empty accounts don't need any additional processing.
 
@@ -69,11 +73,9 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
     state: &mut S,
     _sender: AccountId,
     target: AccountId,
-    value: BitcoinAmount,
+    coin: Coin,
     _context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
-    let coin = Coin::new_unchecked(value);
-
     match target {
         // Bridge gateway transfer, not permitted.
         BRIDGE_GATEWAY_ACCT_ID => {
@@ -88,7 +90,7 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
             if !state.check_account_exists(target)? {
                 warn!(
                     %target,
-                    %value,
+                    value = %coin.amt(),
                     "limboing transfer to nonexistent target account",
                 );
                 handle_misplaced_funds(state, coin)?;
@@ -110,37 +112,36 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
 fn handle_bridge_gateway_message<S: IStateAccessorMut>(
     state: &mut S,
     sender: AccountId,
-    payload: MsgPayload,
+    payload: MsgPayloadCoin,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
-    let coin = Coin::new_unchecked(payload.value());
+    let amt_raw: u64 = payload.coin_amt().into();
 
     // 1. Parse the message from the payload data.
     let Ok(msg) = MsgRef::try_from(payload.data()) else {
         // Invalid message format, sweep to limbo.
         warn!(%sender, "limboing malformed message sent to bridge gateway acct");
-        handle_misplaced_funds(state, coin)?;
+        handle_misplaced_funds(state, payload.into_coin())?;
         return Ok(());
     };
 
     let Some(withdrawal_data) = msg.try_as_withdrawal() else {
         // Not a withdrawal message, or malformed, sweep to limbo.
         warn!(%sender, "limboing non-withdrawal message sent to bridge gateway acct");
-        handle_misplaced_funds(state, coin)?;
+        handle_misplaced_funds(state, payload.into_coin())?;
         return Ok(());
     };
 
     // 2. Validate the withdrawal amount against params.
-    let amt_raw: u64 = payload.value().into();
     let Some(bridge_params) = context.bridge_params() else {
         warn!(%sender, %amt_raw, "limboing withdrawal without bridge params sent to bridge gateway acct");
-        handle_misplaced_funds(state, coin)?;
+        handle_misplaced_funds(state, payload.into_coin())?;
         return Ok(());
     };
 
     if !bridge_params.validate_withdrawal_amount(amt_raw) {
         warn!(%sender, %amt_raw, "limboing bad amount sent to bridge gateway acct");
-        handle_misplaced_funds(state, coin)?;
+        handle_misplaced_funds(state, payload.into_coin())?;
         return Ok(());
     }
 
@@ -156,7 +157,7 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
             dest_desc_len,
             "limboing bad destination descriptor sent to bridge gateway acct",
         );
-        handle_misplaced_funds(state, coin)?;
+        handle_misplaced_funds(state, payload.into_coin())?;
         return Ok(());
     }
 
@@ -176,7 +177,8 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
         dest_desc_len,
         "emitted bridge withdrawal intent log",
     );
-    coin.safely_consume_unchecked();
+    // The value has left the OL as a withdrawal, so we consume it here.
+    payload.into_coin().safely_consume_unchecked();
 
     Ok(())
 }

--- a/crates/ol/stf/src/account_processing.rs
+++ b/crates/ol/stf/src/account_processing.rs
@@ -16,6 +16,52 @@ use crate::{
     output::OutputCtx,
 };
 
+/// Credits `coin` to `target`'s balance and runs `post` for any additional
+/// account-specific processing, within a single [`IStateAccessorMut::update_account`]
+/// transaction.
+///
+/// The coin is moved into the update closure only when it actually runs.  If
+/// `update_account` returns an error before invoking the closure (e.g. the
+/// account is missing), the coin is recovered from the slot and defused so the
+/// error propagates cleanly instead of tripping [`Coin`]'s drop panic; the whole
+/// STF is discarded on that error, so no value is lost.
+pub(crate) fn credit_account<S: IStateAccessorMut>(
+    state: &mut S,
+    target: AccountId,
+    coin: Coin,
+    post: impl FnOnce(&mut S::AccountStateMut) -> ExecResult<()>,
+) -> ExecResult<()> {
+    let mut slot = Some(coin);
+    let res = state.update_account(target, |acct_state| -> ExecResult<()> {
+        acct_state.add_balance(slot.take().expect("ol/stf: coin present in credit closure"));
+        post(acct_state)
+    });
+
+    match res {
+        // The closure ran, so `add_balance` consumed the coin already.
+        Ok(inner) => inner,
+        Err(e) => {
+            // The closure never ran; recover and defuse the still-live coin.
+            if let Some(coin) = slot.take() {
+                coin.safely_consume_unchecked();
+            }
+            Err(e.into())
+        }
+    }
+}
+
+/// Credits `coin` to `target`'s balance with no additional postprocessing.
+///
+/// This is the plain-transfer counterpart to [`credit_account`], sharing its
+/// coin-recovery behavior on a failed [`IStateAccessorMut::update_account`].
+pub(crate) fn credit_account_noop<S: IStateAccessorMut>(
+    state: &mut S,
+    target: AccountId,
+    coin: Coin,
+) -> ExecResult<()> {
+    credit_account(state, target, coin, |_| Ok(()))
+}
+
 /// Processes a message by delivering it to its destination, which might involve
 /// touching the ledger state.
 pub(crate) fn process_message<S: IStateAccessorMut>(
@@ -33,36 +79,37 @@ pub(crate) fn process_message<S: IStateAccessorMut>(
 
         // Any other address we assume is a ledger account, so we have to look it up.
         _ => {
-            // Check if the account exists first.
-            if !state.check_account_exists(target)? {
-                warn!(
-                    %target,
-                    %sender,
-                    value = %msg.coin_amt(),
-                    "limboing message to nonexistent target account",
-                );
-                handle_misplaced_funds(state, msg.into_coin())?;
-                return Ok(());
+            // Check if the account exists first.  Defuse the payload on error so
+            // it doesn't drop while still live.
+            match state.check_account_exists(target) {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        %target,
+                        %sender,
+                        value = %msg.coin_amt(),
+                        "limboing message to nonexistent target account",
+                    );
+                    handle_misplaced_funds(state, msg.into_coin())?;
+                    return Ok(());
+                }
+                Err(e) => {
+                    msg.into_coin().safely_consume_unchecked();
+                    return Err(e.into());
+                }
             }
 
             // Reconstitute the coin and a record payload for any snark inbox.
             let (coin, record) = msg.into_coin_and_record();
 
-            // Update the account within a closure.
-            state.update_account(target, |acct_state| -> ExecResult<()> {
-                // First, just increase the balance right now.
-                acct_state.add_balance(coin);
-
-                // Then depending on the type we call a different handler function
-                // for postprocessing.
+            // Credit the coin, then run snark postprocessing for snark accounts.
+            credit_account(state, target, coin, |acct_state| {
                 if let Ok(sastate) = acct_state.as_snark_account_mut() {
-                    // Call the handler fn now that we've increased the balance.
                     handle_snark_account_message(sastate, sender, &record, context)?;
                 }
                 // Empty accounts don't need any additional processing.
-
                 Ok(())
-            })??;
+            })?;
         }
     }
 
@@ -86,23 +133,27 @@ pub(crate) fn process_transfer<S: IStateAccessorMut>(
 
         // Any other address we assume is a ledger account, so we have to look it up.
         _ => {
-            // Check if the account exists first.
-            if !state.check_account_exists(target)? {
-                warn!(
-                    %target,
-                    value = %coin.amt(),
-                    "limboing transfer to nonexistent target account",
-                );
-                handle_misplaced_funds(state, coin)?;
-                return Ok(());
+            // Check if the account exists first.  Defuse the coin on error so it
+            // doesn't drop while still live.
+            match state.check_account_exists(target) {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        %target,
+                        value = %coin.amt(),
+                        "limboing transfer to nonexistent target account",
+                    );
+                    handle_misplaced_funds(state, coin)?;
+                    return Ok(());
+                }
+                Err(e) => {
+                    coin.safely_consume_unchecked();
+                    return Err(e.into());
+                }
             }
 
-            // Update the account within a closure.
-            state.update_account(target, |acct_state| -> ExecResult<()> {
-                // Just increase the balance right now.
-                acct_state.add_balance(coin);
-                Ok(())
-            })??;
+            // Credit the coin to the account.
+            credit_account_noop(state, target, coin)?;
         }
     }
 
@@ -169,7 +220,12 @@ fn handle_bridge_gateway_message<S: IStateAccessorMut>(
         selected_operator,
         dest,
     };
-    context.emit_typed_log(BRIDGE_GATEWAY_ACCT_SERIAL, &log_data)?;
+    // Defuse the payload on error so it doesn't drop while still live (the log
+    // block cap can be exceeded on an otherwise-valid withdrawal).
+    if let Err(e) = context.emit_typed_log(BRIDGE_GATEWAY_ACCT_SERIAL, &log_data) {
+        payload.into_coin().safely_consume_unchecked();
+        return Err(e);
+    }
     info!(
         %sender,
         amount_sat = amt_raw,

--- a/crates/ol/stf/src/lib.rs
+++ b/crates/ol/stf/src/lib.rs
@@ -9,6 +9,7 @@ mod constants;
 mod context;
 mod errors;
 mod manifest_processing;
+mod msg_payload_coin;
 mod output;
 mod proof_verification;
 mod sau_processing;

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -1,6 +1,8 @@
 //! ASM manifest processing.
 
-use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, L1BlockRecord, MsgPayloadData};
+use strata_acct_types::{
+    AccountId, BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, L1BlockRecord, MsgPayloadData,
+};
 use strata_asm_common::{AsmLogEntry, AsmManifest};
 use strata_asm_logs::{
     CheckpointTipUpdate, DepositLog, EePredicateKeyUpdate, constants::AsmLogTypeId,
@@ -237,10 +239,49 @@ fn process_deposit_log<S: IStateAccessorMut>(
 ) -> ExecResult<()> {
     let amt_btc = BitcoinAmount::from_sat(deposit.amount);
 
-    // Mint the coin once at the deposit ingress boundary; from here on the value
-    // is carried linearly and must be credited or swept to limbo exactly once.
-    let coin = Coin::new_unchecked(amt_btc);
+    // Resolve the destination before minting any value.  All the fallible steps
+    // run here so their errors propagate cleanly; only once we know whether the
+    // deposit is credited or swept do we mint the coin.  `None` means sweep to
+    // limbo.
+    let resolved = resolve_deposit_destination(state, real_height, deposit)?;
 
+    // Mint the coin exactly once, now that the deposit has been fully validated,
+    // and hand it to whichever sink takes it (both consume it on all paths).
+    let coin = Coin::new_unchecked(amt_btc);
+    match resolved {
+        None => {
+            handle_misplaced_funds(state, coin)?;
+        }
+        Some((dest_id, deposit_data)) => {
+            let msg_payload = MsgPayloadCoin::new(coin, deposit_data);
+
+            // Deliver the deposit message to the target account.
+            // TODO(STR-3677): need to tweak this a bit to deal with the changes to epoch contexts
+            account_processing::process_message(
+                state,
+                BRIDGE_GATEWAY_ACCT_ID,
+                dest_id,
+                msg_payload,
+                context,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolves a deposit's destination account and message payload without touching
+/// any value.
+///
+/// Returns [`None`] when the deposit should be swept to limbo (malformed
+/// descriptor or unknown account serial), or `Some` with the target account and
+/// its deposit message data.  Keeping this coin-free lets its fallible steps
+/// propagate errors without a live [`Coin`] in scope.
+fn resolve_deposit_destination<S: IStateAccessorMut>(
+    state: &S,
+    real_height: L1Height,
+    deposit: &DepositLog,
+) -> ExecResult<Option<(AccountId, MsgPayloadData)>> {
     // Parse the raw destination bytes into account serial + subject.
     let Ok(descriptor) = DepositDescriptor::decode_from_slice(&deposit.destination) else {
         // Malformed destination descriptor, sweep to limbo.
@@ -249,8 +290,7 @@ fn process_deposit_log<S: IStateAccessorMut>(
             amount_sat = deposit.amount,
             "limboing deposit with malformed destination descriptor",
         );
-        handle_misplaced_funds(state, coin)?;
-        return Ok(());
+        return Ok(None);
     };
 
     let acct_serial = *descriptor.dest_acct_serial();
@@ -265,8 +305,7 @@ fn process_deposit_log<S: IStateAccessorMut>(
             amount_sat = deposit.amount,
             "limboing deposit for unknown account serial",
         );
-        handle_misplaced_funds(state, coin)?;
-        return Ok(());
+        return Ok(None);
     };
 
     // Create the message payload containing the typed deposit message.
@@ -278,7 +317,6 @@ fn process_deposit_log<S: IStateAccessorMut>(
     let deposit_data: MsgPayloadData = deposit_data
         .try_into()
         .expect("deposit message payload bytes must fit within SSZ max length");
-    let msg_payload = MsgPayloadCoin::new(coin, deposit_data);
 
     info!(
         l1_height = real_height,
@@ -289,17 +327,7 @@ fn process_deposit_log<S: IStateAccessorMut>(
         "crediting deposit to account",
     );
 
-    // Deliver the deposit message to the target account.
-    // TODO(STR-3677): need to tweak this a bit to deal with the changes to epoch contexts
-    account_processing::process_message(
-        state,
-        BRIDGE_GATEWAY_ACCT_ID,
-        dest_id,
-        msg_payload,
-        context,
-    )?;
-
-    Ok(())
+    Ok(Some((dest_id, deposit_data)))
 }
 
 fn process_checkpoint_tip_update<S: IStateAccessorMut>(

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -1,6 +1,6 @@
 //! ASM manifest processing.
 
-use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, L1BlockRecord, MsgPayload};
+use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, L1BlockRecord, MsgPayloadData};
 use strata_asm_common::{AsmLogEntry, AsmManifest};
 use strata_asm_logs::{
     CheckpointTipUpdate, DepositLog, EePredicateKeyUpdate, constants::AsmLogTypeId,
@@ -17,6 +17,7 @@ use crate::{
     account_processing::{self, handle_misplaced_funds},
     context::BasicExecContext,
     errors::{ExecError, ExecResult},
+    msg_payload_coin::MsgPayloadCoin,
 };
 
 /// Buffers the ASM logs carried by a sequence of manifests into the intraepoch
@@ -236,10 +237,13 @@ fn process_deposit_log<S: IStateAccessorMut>(
 ) -> ExecResult<()> {
     let amt_btc = BitcoinAmount::from_sat(deposit.amount);
 
+    // Mint the coin once at the deposit ingress boundary; from here on the value
+    // is carried linearly and must be credited or swept to limbo exactly once.
+    let coin = Coin::new_unchecked(amt_btc);
+
     // Parse the raw destination bytes into account serial + subject.
     let Ok(descriptor) = DepositDescriptor::decode_from_slice(&deposit.destination) else {
         // Malformed destination descriptor, sweep to limbo.
-        let coin = Coin::new_unchecked(amt_btc);
         warn!(
             l1_height = real_height,
             amount_sat = deposit.amount,
@@ -255,7 +259,6 @@ fn process_deposit_log<S: IStateAccessorMut>(
     // Convert the account serial to account ID.
     let Some(dest_id) = state.find_account_id_by_serial(acct_serial)? else {
         // Account serial not found, sweep to limbo.
-        let coin = Coin::new_unchecked(amt_btc);
         warn!(
             l1_height = real_height,
             ?acct_serial,
@@ -272,8 +275,10 @@ fn process_deposit_log<S: IStateAccessorMut>(
     let deposit_data = OwnedMsg::new(DEPOSIT_MSG_TYPE_ID, deposit_body)
         .expect("deposit message body must fit into msg-fmt envelope")
         .to_vec();
-    let msg_payload = MsgPayload::from_bytes(deposit.amount.into(), deposit_data)
+    let deposit_data: MsgPayloadData = deposit_data
+        .try_into()
         .expect("deposit message payload bytes must fit within SSZ max length");
+    let msg_payload = MsgPayloadCoin::new(coin, deposit_data);
 
     info!(
         l1_height = real_height,

--- a/crates/ol/stf/src/msg_payload_coin.rs
+++ b/crates/ol/stf/src/msg_payload_coin.rs
@@ -1,0 +1,48 @@
+//! In-flight message payload carrying linear-typed value.
+
+use strata_acct_types::{BitcoinAmount, MsgPayload, MsgPayloadData};
+use strata_ledger_types::Coin;
+
+/// A message payload whose value is carried as a linear [`Coin`] rather than a
+/// plain [`BitcoinAmount`].
+///
+/// This is the execution-time counterpart to [`MsgPayload`]: it is used while
+/// value is in flight between accounts so that Rust enforces the value is
+/// eventually credited, limboed, or otherwise consumed exactly once.  It is not
+/// serialized or stored; [`MsgPayload`] remains the on-ledger record type.
+pub(crate) struct MsgPayloadCoin {
+    coin: Coin,
+    data: MsgPayloadData,
+}
+
+impl MsgPayloadCoin {
+    /// Creates a new payload pairing a coin with message data.
+    pub(crate) fn new(coin: Coin, data: MsgPayloadData) -> Self {
+        Self { coin, data }
+    }
+
+    /// Gets the value carried by the coin.
+    pub(crate) fn coin_amt(&self) -> BitcoinAmount {
+        self.coin.amt()
+    }
+
+    /// Gets the message data buffer.
+    pub(crate) fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Consumes the payload, discarding the data and returning the live coin.
+    pub(crate) fn into_coin(self) -> Coin {
+        self.coin
+    }
+
+    /// Splits the payload into its live coin and a reconstructed [`MsgPayload`]
+    /// record capturing the same value and data.
+    ///
+    /// The record is a copy for storage (e.g. a snark account inbox); the value
+    /// it names is not linear and does not track the returned coin.
+    pub(crate) fn into_coin_and_record(self) -> (Coin, MsgPayload) {
+        let record = MsgPayload::new(self.coin.amt(), self.data);
+        (self.coin, record)
+    }
+}

--- a/crates/ol/stf/src/tests/coin_error_paths.rs
+++ b/crates/ol/stf/src/tests/coin_error_paths.rs
@@ -1,0 +1,146 @@
+//! Tests covering the error paths that hold a live [`Coin`] / `MsgPayloadCoin`.
+//!
+//! A recent refactor made OL STF value handling carry funds as a linear
+//! [`Coin`], which panics on `Drop`.  Several fallible `?` early-returns used to
+//! drop a still-live coin, turning an expected [`ExecError`] into a node panic.
+//! These tests drive each such path and assert a clean `Err` is returned.
+//!
+//! Because a leaked coin panics on drop, every one of these tests *also*
+//! implicitly proves no coin was lost: if the fix regressed, the test would
+//! abort with `coin: accidentally destroyed value` rather than fail an assert.
+
+use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount, MsgPayloadData, TxEffects};
+use strata_ledger_types::{Coin, IStateAccessorMut, StateError};
+
+use crate::{
+    account_processing,
+    context::{BasicExecContext, BlockInfo},
+    errors::ExecError,
+    msg_payload_coin::MsgPayloadCoin,
+    output::ExecOutputBuffer,
+    test_utils::*,
+    transaction_processing,
+};
+
+/// T1: `credit_account` recovers and defuses the coin when `update_account`
+/// errors before the closure runs (the target account does not exist).
+#[test]
+fn credit_account_missing_account_returns_clean_error() {
+    let mut state = make_genesis_state();
+    let nonexistent = make_account_id(TEST_NONEXISTENT_ID);
+    let value = BitcoinAmount::from_sat(3_000_000);
+
+    let err = account_processing::credit_account_noop(
+        &mut state,
+        nonexistent,
+        Coin::new_unchecked(value),
+    )
+    .expect_err("crediting a nonexistent account should error, not panic");
+
+    assert!(
+        matches!(err, ExecError::State(StateError::MissingAccount(id)) if id == nonexistent),
+        "expected MissingAccount, got {err:?}",
+    );
+}
+
+/// T2: `handle_misplaced_funds` (via the limbo leaf impl) defuses the coin when
+/// the limbo balance would overflow, instead of dropping it live.
+#[test]
+fn limbo_overflow_returns_clean_error() {
+    let mut state = make_genesis_state();
+
+    // Fill limbo to just below the u64 sat ceiling so a further deposit overflows.
+    state
+        .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(u64::MAX - 100)))
+        .expect("seeding limbo near the ceiling should succeed");
+
+    let err = account_processing::handle_misplaced_funds(
+        &mut state,
+        Coin::new_unchecked(BitcoinAmount::from_sat(200)),
+    )
+    .expect_err("overflowing limbo should error, not panic");
+
+    assert!(
+        matches!(err, ExecError::State(StateError::LimboFundsOverflow { .. })),
+        "expected LimboFundsOverflow, got {err:?}",
+    );
+}
+
+/// T3: a valid bridge withdrawal whose intent log would exceed the block log cap
+/// defuses the payload on the `emit_typed_log` error instead of dropping it live.
+#[test]
+fn bridge_withdrawal_log_overflow_returns_clean_error() {
+    use strata_bridge_params::BridgeParams;
+    use strata_ol_chain_types::{MAX_LOGS_PER_BLOCK, OLLog};
+
+    let mut state = make_genesis_state();
+    let sender = make_account_id(TEST_SNARK_ACCOUNT_ID);
+
+    // A valid, denomination-multiple withdrawal to a well-formed descriptor so
+    // execution reaches the `emit_typed_log` call.
+    let withdrawal_amount = BitcoinAmount::from_sat(100_000_000);
+    let dest_desc = make_p2wpkh_bosd_descriptor(0x14);
+    let msg_bytes = make_withdrawal_payload(dest_desc);
+    let msg_data: MsgPayloadData = msg_bytes
+        .try_into()
+        .expect("withdrawal message payload should fit within SSZ max length");
+    let payload = MsgPayloadCoin::new(Coin::new_unchecked(withdrawal_amount), msg_data);
+
+    // Pre-fill the output buffer to the log cap so the withdrawal intent log
+    // pushes it over.
+    let outputs = ExecOutputBuffer::new_empty();
+    outputs
+        .emit_logs((0..MAX_LOGS_PER_BLOCK).map(|i| OLLog::new((i as u32).into(), vec![])))
+        .expect("filling logs to the cap should succeed");
+
+    let block_info = BlockInfo::new(1, 1, 1);
+    let context =
+        BasicExecContext::new(block_info, &outputs).with_bridge_params(BridgeParams::default());
+
+    let err = account_processing::process_message(
+        &mut state,
+        sender,
+        BRIDGE_GATEWAY_ACCT_ID,
+        payload,
+        &context,
+    )
+    .expect_err("a log-cap overflow on a valid withdrawal should error, not panic");
+
+    assert!(
+        matches!(err, ExecError::LogsOverflow { .. }),
+        "expected LogsOverflow, got {err:?}",
+    );
+}
+
+/// T4: `apply_tx_effects` defuses the still-undistributed `remaining` coin when a
+/// per-effect delivery errors mid-loop.
+#[test]
+fn apply_tx_effects_defuses_remaining_on_midloop_error() {
+    let mut state = make_genesis_state();
+    let source = make_account_id(TEST_SNARK_ACCOUNT_ID);
+    setup_genesis_with_snark_account(&mut state, source, 100_000_000);
+    let nonexistent = make_account_id(TEST_NONEXISTENT_ID);
+
+    // Fill limbo to the ceiling so the first transfer's sweep-to-limbo overflows.
+    state
+        .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(u64::MAX - 100)))
+        .expect("seeding limbo near the ceiling should succeed");
+
+    // Two transfers to a nonexistent account: the first sweeps to limbo and
+    // overflows, so the loop errors while `remaining` still holds the second
+    // effect's value.
+    let mut effects = TxEffects::default();
+    assert!(effects.push_transfer(nonexistent, 200));
+    assert!(effects.push_transfer(nonexistent, 50));
+
+    let outputs = ExecOutputBuffer::new_empty();
+    let context = BasicExecContext::new(BlockInfo::new(1, 0, 0), &outputs);
+
+    let err = transaction_processing::apply_tx_effects(&mut state, source, &effects, &context)
+        .expect_err("a mid-loop limbo overflow should error, not panic");
+
+    assert!(
+        matches!(err, ExecError::State(StateError::LimboFundsOverflow { .. })),
+        "expected LimboFundsOverflow, got {err:?}",
+    );
+}

--- a/crates/ol/stf/src/tests/limbo.rs
+++ b/crates/ol/stf/src/tests/limbo.rs
@@ -15,11 +15,11 @@
 //! limbo balance grew.
 
 use strata_acct_types::{
-    BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BitcoinAmount, MsgPayload,
+    BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BitcoinAmount, MsgPayloadData,
 };
 use strata_codec::encode_to_vec;
 use strata_identifiers::{AccountSerial, SubjectId};
-use strata_ledger_types::{IAccountState, IStateAccessor};
+use strata_ledger_types::{Coin, IAccountState, IStateAccessor};
 use strata_msg_fmt::{Msg, OwnedMsg};
 use strata_ol_msg_types::{DEFAULT_OPERATOR_FEE, WITHDRAWAL_MSG_TYPE_ID, WithdrawalMsgData};
 
@@ -27,6 +27,7 @@ use crate::{
     account_processing,
     assembly::BlockComponents,
     context::{BasicExecContext, BlockInfo},
+    msg_payload_coin::MsgPayloadCoin,
     output::ExecOutputBuffer,
     test_utils::*,
 };
@@ -47,8 +48,7 @@ fn limbo_message_to_nonexistent_account() {
     let context = BasicExecContext::new(block_info, &outputs);
 
     let value = BitcoinAmount::from_sat(2_500_000);
-    let payload = MsgPayload::from_bytes(value, vec![])
-        .expect("message payload bytes must fit within SSZ max length");
+    let payload = MsgPayloadCoin::new(Coin::new_unchecked(value), MsgPayloadData::default());
 
     account_processing::process_message(
         &mut state,
@@ -83,8 +83,14 @@ fn limbo_transfer_to_nonexistent_account() {
     let context = BasicExecContext::new(block_info, &outputs);
 
     let value = BitcoinAmount::from_sat(4_000_000);
-    account_processing::process_transfer(&mut state, sender_acct_id, nonexistent, value, &context)
-        .expect("process_transfer should not error");
+    account_processing::process_transfer(
+        &mut state,
+        sender_acct_id,
+        nonexistent,
+        Coin::new_unchecked(value),
+        &context,
+    )
+    .expect("process_transfer should not error");
 
     let limbo_after = state.limbo_funds();
     assert_eq!(

--- a/crates/ol/stf/src/tests/mod.rs
+++ b/crates/ol/stf/src/tests/mod.rs
@@ -3,6 +3,7 @@
 mod asm_manifests;
 mod chain;
 mod chain_processing;
+mod coin_error_paths;
 mod da_epoch_reconstruction;
 mod da_epoch_root_correctness;
 mod deposit_withdrawal;

--- a/crates/ol/stf/src/transaction_processing.rs
+++ b/crates/ol/stf/src/transaction_processing.rs
@@ -165,7 +165,7 @@ fn process_update_tx<S: IStateAccessorMut>(
 }
 
 /// Applies the effects of a transaction (transfers and messages) to account state.
-fn apply_tx_effects<S: IStateAccessorMut>(
+pub(crate) fn apply_tx_effects<S: IStateAccessorMut>(
     state: &mut S,
     source: AccountId,
     effects: &TxEffects,
@@ -179,21 +179,45 @@ fn apply_tx_effects<S: IStateAccessorMut>(
     // effects.
     let mut remaining = debit_source(state, source, total_sent)?;
 
-    // 2. Send funds out, splitting the debited coin per effect so Rust enforces
-    // that the pieces sum to exactly what we took.
-    for t in effects.transfers_iter() {
-        let coin = split_effect_value(&mut remaining, t.value());
-        account_processing::process_transfer(state, source, t.dest(), coin, context)?;
-    }
-
-    for m in effects.messages_iter() {
-        let coin = split_effect_value(&mut remaining, m.payload().value());
-        let msg = MsgPayloadCoin::new(coin, m.payload().payload_data().clone());
-        account_processing::process_message(state, source, m.dest(), msg, context)?;
+    // 2. Send funds out, splitting the debited coin per effect.  Each per-effect
+    // coin is owned by the callee, which consumes it on every path; if a call
+    // errors we still hold `remaining`, so we defuse it before propagating rather
+    // than dropping a live coin (the whole STF is discarded on that error, so no
+    // value is lost).
+    if let Err(e) = distribute_effects(state, source, effects, context, &mut remaining) {
+        remaining.safely_consume_unchecked();
+        return Err(e);
     }
 
     // Everything debited has been distributed; the remainder must be zero.
     remaining.consume_zero();
+
+    Ok(())
+}
+
+/// Distributes `remaining` across the transaction's effects, splitting a coin
+/// off for each transfer and message so Rust enforces that the pieces sum to
+/// exactly what was debited.
+///
+/// On error, `remaining` is left holding the undistributed value for the caller
+/// to dispose of.
+fn distribute_effects<S: IStateAccessorMut>(
+    state: &mut S,
+    source: AccountId,
+    effects: &TxEffects,
+    context: &BasicExecContext<'_>,
+    remaining: &mut Coin,
+) -> ExecResult<()> {
+    for t in effects.transfers_iter() {
+        let coin = split_effect_value(remaining, t.value());
+        account_processing::process_transfer(state, source, t.dest(), coin, context)?;
+    }
+
+    for m in effects.messages_iter() {
+        let coin = split_effect_value(remaining, m.payload().value());
+        let msg = MsgPayloadCoin::new(coin, m.payload().payload_data().clone());
+        account_processing::process_message(state, source, m.dest(), msg, context)?;
+    }
 
     Ok(())
 }

--- a/crates/ol/stf/src/transaction_processing.rs
+++ b/crates/ol/stf/src/transaction_processing.rs
@@ -10,6 +10,7 @@ use crate::{
     constants::SEQUENCER_ACCT_ID,
     context::{BasicExecContext, TxExecContext},
     errors::{ExecError, ExecResult},
+    msg_payload_coin::MsgPayloadCoin,
     proof_verification::{TxProofVerificationContext, TxProofVerifierImpl, TxProofsTracker},
     sau_processing,
 };
@@ -174,29 +175,59 @@ fn apply_tx_effects<S: IStateAccessorMut>(
         .get_total_value_sent()
         .ok_or(ExecError::AmountOverflow)?;
 
-    // 1. Subtract funds from account if not the magic sequencer account.
-    //
-    // In practice, right now, this shouldn't matter because we never use this
-    // account ID unless it's a GAM tx, which we separately check only sends 0
-    // value.
-    if source != SEQUENCER_ACCT_ID && !total_sent.is_zero() {
-        state.update_account(source, |astate| {
-            let coin = astate.take_balance(total_sent)?;
-            coin.safely_consume_unchecked(); // take from this later
-            ExecResult::Ok(())
-        })??;
-    }
+    // 1. Debit the source once, obtaining a single coin to split across the
+    // effects.
+    let mut remaining = debit_source(state, source, total_sent)?;
 
-    // 2. Send funds out.
+    // 2. Send funds out, splitting the debited coin per effect so Rust enforces
+    // that the pieces sum to exactly what we took.
     for t in effects.transfers_iter() {
-        account_processing::process_transfer(state, source, t.dest(), t.value(), context)?;
+        let coin = split_effect_value(&mut remaining, t.value());
+        account_processing::process_transfer(state, source, t.dest(), coin, context)?;
     }
 
     for m in effects.messages_iter() {
-        account_processing::process_message(state, source, m.dest(), m.payload().clone(), context)?;
+        let coin = split_effect_value(&mut remaining, m.payload().value());
+        let msg = MsgPayloadCoin::new(coin, m.payload().payload_data().clone());
+        account_processing::process_message(state, source, m.dest(), msg, context)?;
     }
 
+    // Everything debited has been distributed; the remainder must be zero.
+    remaining.consume_zero();
+
     Ok(())
+}
+
+/// Debits `total_sent` from the source account, returning it as a single
+/// [`Coin`] to be distributed across the transaction's effects.
+///
+/// A zero total needs no debit and yields an empty coin.  This also covers the
+/// magic sequencer account, which is never a real ledger account: it only
+/// appears for GAM txs, which we separately require to send zero value, so we
+/// never attempt to debit it.
+fn debit_source<S: IStateAccessorMut>(
+    state: &mut S,
+    source: AccountId,
+    total_sent: BitcoinAmount,
+) -> ExecResult<Coin> {
+    if total_sent.is_zero() {
+        return Ok(Coin::zero());
+    }
+
+    state.update_account(source, |astate| -> ExecResult<Coin> {
+        Ok(astate.take_balance(total_sent)?)
+    })?
+}
+
+/// Splits an effect's value off of the debited coin.
+///
+/// The value is guaranteed to fit because [`verify_effects_safe`] checks the
+/// per-effect values sum to `total_sent` before the debit, so this failing
+/// signals an accounting bug rather than bad input.
+fn split_effect_value(remaining: &mut Coin, value: BitcoinAmount) -> Coin {
+    remaining
+        .split_out(value)
+        .expect("ol/stf: effect value exceeds debited total")
 }
 
 /// Checks that a tx's constraints are valid for the current slot in state.


### PR DESCRIPTION
## Description

This PR adds a new `MsgPayloadCoin` type that works like `MsgPayload` but carries the value as a `Coin`, and uses it in various places where we were previously creating/destroying `Coin`s on an ad-hoc basis to be more deliberate about the bookkeeping.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
