### PR TITLE
ci(build): mirror strata and alpen-client images to public ECR (STR-3894)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -242,6 +242,17 @@ jobs:
         with:
           mask-password: "true"
 
+      # Public ECR is a distinct registry (public.ecr.aws) with its own auth
+      # token, which must be requested from us-east-1. The same assumed role
+      # (SHARED_ECR_ROLE_ARN) is authorized to push the public node images —
+      # see alpen-infra github-actions-image-push (STR-3894). Only the programs
+      # published publicly need this login.
+      - name: Login to Amazon ECR Public
+        if: matrix.program == 'strata' || matrix.program == 'alpen-client'
+        run: |
+          aws ecr-public get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin public.ecr.aws
+
       # --- Download pre-built SP1 artifacts from shared job --------------------
       - name: Download SP1 artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -273,6 +284,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY_PREFIX: ${{ vars.SHARED_ECR_REPOSITORY_PREFIX }}
+          # Public ECR gallery base (fixed alias). External testnet operators
+          # pull node images from here without AWS credentials (STR-3894).
+          PUBLIC_ECR_BASE: public.ecr.aws/alpenlabs
           PROGRAM: ${{ matrix.program }}
           SHORT_TAG: ${{ steps.resolve.outputs.short_tag }}
           COMMIT_SHA: ${{ steps.resolve.outputs.commit_sha }}
@@ -280,6 +294,19 @@ jobs:
           DOCKERFILE_PATH="docker/${PROGRAM}/Dockerfile"
           ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}/${PROGRAM}"
           FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:${SHORT_TAG}"
+
+          # Always push the private image. Additionally push a public mirror for
+          # programs with an external-facing repo, mapping the internal program
+          # name to its public gallery repo name (alpen-client -> alpen).
+          TAGS=( -t "${FULL_IMAGE}" )
+          case "$PROGRAM" in
+            strata)       PUBLIC_REPO="strata" ;;
+            alpen-client) PUBLIC_REPO="alpen" ;;
+            *)            PUBLIC_REPO="" ;;
+          esac
+          if [ -n "$PUBLIC_REPO" ]; then
+            TAGS+=( -t "${PUBLIC_ECR_BASE}/${PUBLIC_REPO}:${SHORT_TAG}" )
+          fi
 
           # Bake prover features into the strata image. Other programs build
           # with default features. Relies on docker/strata/Dockerfile accepting
@@ -289,13 +316,15 @@ jobs:
             BUILD_ARGS+=( --build-arg "CARGO_FEATURES=sp1,prover" )
           fi
 
+          # Single build, multiple tags: buildx pushes to both the private and
+          # public registries from one image (same digest in both).
           docker buildx build \
             "${BUILD_ARGS[@]}" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
             --label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --push \
-            -t "${FULL_IMAGE}" \
+            "${TAGS[@]}" \
             -f "${DOCKERFILE_PATH}" .
 
           echo "Successfully pushed: ${FULL_IMAGE}"


### PR DESCRIPTION
## Summary

Publishes the `strata` and `alpen-client` node images to **public ECR** (`public.ecr.aws/alpenlabs`) alongside the existing private-ECR push, so external testnet operators can pull them without AWS credentials.

Depends on alpen-infra PR #142 (STR-3894), which created the public repos (`strata`, `alpen`, `checkpoint-sync`) and granted this repo's push role `ecr-public:*` access.

## Changes (`.github/workflows/ci-build.yml`)

- **New "Login to Amazon ECR Public" step**, gated to `strata` / `alpen-client`. Public ECR is a separate registry with a us-east-1-only auth token, so it needs its own `docker login public.ecr.aws`. Uses the same assumed role (`SHARED_ECR_ROLE_ARN` = `github-actions-ecr-push`), which already holds the `ecr-public:*` push perms — **no new secret**.
- **Multi-tag build/push** — one `buildx build --push` emits both the private tag and, for mapped programs, the public tag (same digest in both registries):
  - `strata` → `public.ecr.aws/alpenlabs/strata`
  - `alpen-client` → `public.ecr.aws/alpenlabs/alpen`
  - all other programs (`strata-signer`, `strata-datatool`) → private only, unchanged.

## Notes / known follow-ups (tracked in STR-3896)

- **`checkpoint-sync` is not covered here** — it isn't built in this repo. Its public repo exists but must be published from whatever repo builds it.
- **Public pushes are not gated to `main`** — this workflow also runs on cron/PR, matching current private-push behavior. A `main`-only guard for public tags is a deliberate open question.
- **No tag immutability on ECR Public** — SHA tags can be overwritten; consumers should pin by digest.
- Name flip `alpen-client` → `alpen` is encoded in a single `case` mapping.

STR-3896 tracks a standardization + security pass over this wiring (naming source-of-truth, hardcoded alias → var, main-only gating, image-content review, provenance).

Ticket: STR-3894
