### PR TITLE
fix(ol/rpc): use tip state for snark acct manifest bound

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -548,13 +548,15 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
         )))
     }
 
-    /// Resolves an epoch to its terminal-block OL state. Errors if either the
-    /// canonical commitment or the terminal-block state is missing.
+    /// Resolves an epoch to its terminal-block OL state.
+    ///
+    /// Errors if either the canonical epoch commitment or the terminal-block
+    /// state is missing.
     async fn get_toplevel_ol_state_for_epoch(
         &self,
         epoch: Epoch,
     ) -> RpcResult<(EpochCommitment, Arc<OLState>)> {
-        let epoch_commitment = self
+        let Some(epoch_commitment) = self
             .provider
             .get_canonical_epoch_commitment_at(epoch)
             .await
@@ -562,12 +564,14 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                 error!(?e, ?epoch, "Failed to get canonical epoch commitment");
                 db_error(e)
             })?
-            .ok_or_else(|| {
-                not_found_error(format!("No canonical commitment found for epoch {epoch}"))
-            })?;
+        else {
+            return Err(not_found_error(format!(
+                "No canonical commitment found for epoch {epoch}"
+            )));
+        };
 
         let terminal_commitment = epoch_commitment.to_block_commitment();
-        let ol_state = self
+        let Some(ol_state) = self
             .provider
             .get_toplevel_ol_state(terminal_commitment)
             .await
@@ -575,22 +579,39 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                 error!(?e, %terminal_commitment, "Failed to get OL state");
                 db_error(e)
             })?
-            .ok_or_else(|| {
-                not_found_error(format!(
-                    "No OL state found for terminal block {terminal_commitment}"
-                ))
-            })?;
+        else {
+            return Err(internal_error(format!(
+                "No OL state found for terminal block {terminal_commitment}"
+            )));
+        };
 
         Ok((epoch_commitment, ol_state))
     }
 
-    /// Returns the account's current Snark update seqno at the tip epoch.
+    /// Returns the account's current Snark update seqno at the current OL tip.
+    ///
+    /// This is an optimization for out-of-range manifest queries. The sync
+    /// status tip is used directly so in-progress, non-terminal epochs still
+    /// retain the cheap upper-bound check.
     async fn current_snark_account_seq_no(
         &self,
         account_id: AccountId,
-        tip_epoch: Epoch,
+        tip_commitment: OLBlockCommitment,
     ) -> RpcResult<Option<u64>> {
-        let (_, tip_ol_state) = self.get_toplevel_ol_state_for_epoch(tip_epoch).await?;
+        let tip_ol_state = self
+            .provider
+            .get_toplevel_ol_state(tip_commitment)
+            .await
+            .map_err(|e| {
+                error!(?e, %tip_commitment, "Failed to get OL state");
+                db_error(e)
+            })?
+            .ok_or_else(|| {
+                internal_error(format!(
+                    "No OL state found for sync status tip {tip_commitment}"
+                ))
+            })?;
+
         Ok(tip_ol_state
             .get_account_state(&account_id)
             .and_then(|state| state.as_snark_account().ok())
@@ -1009,13 +1030,12 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .ok_or_else(|| {
                 not_found_error(format!("No creation epoch found for account {account_id}"))
             })?;
-        let tip_epoch = self
+        let sync_status = self
             .provider
             .get_ol_sync_status()
-            .ok_or_else(|| internal_error("OL sync status not available"))?
-            .tip_epoch;
+            .ok_or_else(|| internal_error("OL sync status not available"))?;
         if let Some(current_seq_no) = self
-            .current_snark_account_seq_no(account_id, tip_epoch)
+            .current_snark_account_seq_no(account_id, sync_status.tip)
             .await?
         {
             // Account state stores the next operation seqno. Published manifests
@@ -1026,7 +1046,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                 )));
             }
         }
-        for epoch in creation_epoch..=tip_epoch {
+        for epoch in creation_epoch..=sync_status.tip_epoch {
             let Some(records) = self
                 .provider
                 .get_account_update_records(epoch, account_id)

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -2577,6 +2577,29 @@ async fn epoch_summary_nonexistent_epoch_errors() {
 }
 
 #[tokio::test]
+async fn epoch_summary_rejects_canonical_epoch_without_terminal_state() {
+    let epoch_commitment = test_epoch_commitment(1, 10, 0x35);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            epoch_commitment.to_block_commitment(),
+            1,
+            true,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_epoch_commitment(1, epoch_commitment);
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_acct_epoch_summary(test_account_id(1), 1)
+        .await
+        .expect_err("canonical epoch without terminal state should be rejected");
+
+    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
+}
+
+#[tokio::test]
 async fn epoch_summary_nonexistent_account_errors() {
     let block = make_block(10, 0, null_blkid());
     let blkid = block.header().compute_blkid();
@@ -3171,6 +3194,42 @@ async fn snark_acct_update_manifest_returns_record_with_indexed_range() {
 }
 
 #[tokio::test]
+async fn snark_acct_manifest_bounds_seqno_at_noncanonical_tip() {
+    let account_id = test_account_id(8);
+    let tip_epoch_commitment = test_epoch_commitment(2, 10, 0x28);
+    let fetch_count = Arc::new(AtomicUsize::new(0));
+    let fetch_count_for_closure = fetch_count.clone();
+
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            2,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 1)
+        .with_state_at(
+            tip_epoch_commitment.to_block_commitment(),
+            ol_state_with_snark_account(account_id, 10, 10, 5),
+        )
+        .with_update_records_fetch_fn(move |_epoch, _account| {
+            fetch_count_for_closure.fetch_add(1, Ordering::Relaxed);
+            Ok(None)
+        });
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 10)
+        .await
+        .expect_err("out-of-range seqno should be rejected");
+
+    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    assert_eq!(fetch_count.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
 async fn snark_acct_update_manifest_unknown_account_errors() {
     let rpc = make_rpc(MockProvider::new());
 
@@ -3262,6 +3321,30 @@ async fn snark_acct_update_manifest_errors_when_ol_sync_unavailable() {
 
     assert_eq!(err.code(), INTERNAL_ERROR_CODE);
     assert_eq!(err.message(), "OL sync status not available");
+}
+
+#[tokio::test]
+async fn snark_acct_manifest_rejects_missing_sync_tip_state() {
+    let account_id = test_account_id(2);
+    let tip_epoch_commitment = test_epoch_commitment(2, 10, 0x29);
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip_epoch_commitment.to_block_commitment(),
+            2,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, 1);
+    let rpc = make_rpc(provider);
+
+    let err = rpc
+        .get_snark_acct_update_manifest(account_id, 1)
+        .await
+        .expect_err("missing sync status tip state should be rejected");
+
+    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

Fixes `strata_getSnarkAcctUpdateManifest` when the current tip epoch is still in progress.

Found while working on STR-2404 (see #1950) : the manifest RPC used terminal epoch state for its current-seqno upper-bound check. During an in-progress epoch, that can require a canonical epoch commitment that does not exist yet, even though the node has current tip state and indexed update records.

- Uses `OLSyncStatus.tip` to load current OL tip state for the manifest current-seqno bound.
- Preserves the cheap `seq_no >= current_seq_no` rejection for in-progress, non-terminal epochs.
- Keeps terminal epoch state lookups strict for RPCs that actually require terminal epoch state.
- Treats missing state for the advertised sync-status tip as an internal server inconsistency.
- Adds regression coverage for manifest lookup while the tip epoch is not canonical.

This PR was created with help from Codex and Claude Code.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
