### PR TITLE
fix(reth-statediff): add reconstructor prestate API and EIP-161 deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ dependencies = [
  "serde_json",
  "strata-codec",
  "strata-da-framework",
+ "strata-identifiers",
  "strata-mpt",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
 name = "alpen-reth-statediff"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "alloy-genesis",
  "alloy-primitives",
  "alpen-chainspec",
  "bincode",

--- a/bin/strata-dbtool/src/cmd/ee_da.rs
+++ b/bin/strata-dbtool/src/cmd/ee_da.rs
@@ -8,7 +8,9 @@
 use std::collections::{btree_map::Entry, BTreeMap};
 
 use alpen_ee_da_types::{reassemble_da_blob, DA_BLOB_VERSION, EE_DA_MAGIC_BYTES};
-use alpen_reth_statediff::{BatchStateDiff, StateReconstructor};
+use alpen_reth_statediff::{
+    apply_batch_state_diff_to_ethereum_state, ethereum_state_from_chain_spec, BatchStateDiff,
+};
 use argh::FromArgs;
 use sha2::{Digest, Sha256};
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
@@ -232,17 +234,13 @@ fn ordered_prefix(
 
 /// Replays ordered DA state diffs and returns the reconstructed state root.
 fn replay_state_root(chain: &str, ordered: &[&DecodedEnvelope]) -> Result<String, DisplayedError> {
-    let mut reconstructor = StateReconstructor::from_chain_spec(chain)
-        .internal_error("Failed to initialize state reconstructor from chain spec")?;
+    let mut state = ethereum_state_from_chain_spec(chain)
+        .internal_error("Failed to initialize Ethereum state from chain spec")?;
     for envelope in ordered {
-        reconstructor
-            .apply_diff(&envelope.state_diff)
+        apply_batch_state_diff_to_ethereum_state(&mut state, &envelope.state_diff)
             .internal_error("Failed to apply EE DA state diff")?;
     }
-    Ok(format!(
-        "0x{}",
-        hex::encode(reconstructor.state_root().as_slice())
-    ))
+    Ok(format!("0x{}", hex::encode(state.state_root().as_slice())))
 }
 
 #[cfg(test)]

--- a/crates/reth/statediff/Cargo.toml
+++ b/crates/reth/statediff/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+alloy-genesis.workspace = true
 alloy-primitives.workspace = true
 alpen-chainspec = { workspace = true, optional = true }
 eyre = { workspace = true, optional = true }

--- a/crates/reth/statediff/Cargo.toml
+++ b/crates/reth/statediff/Cargo.toml
@@ -17,6 +17,7 @@ rsp-mpt.workspace = true
 serde.workspace = true
 strata-codec.workspace = true
 strata-da-framework.workspace = true
+strata-identifiers.workspace = true
 strata-mpt.workspace = true
 thiserror.workspace = true
 

--- a/crates/reth/statediff/src/lib.rs
+++ b/crates/reth/statediff/src/lib.rs
@@ -63,8 +63,8 @@ pub use block::{AccountSnapshot, BlockAccountChange, BlockStateChanges, BlockSto
 #[cfg(feature = "chainspec")]
 pub use reconstruct::ethereum_state_from_chain_spec;
 pub use reconstruct::{
-    apply_batch_state_diff_to_ethereum_state, ethereum_state_from_genesis_accounts, GenesisAccount,
-    ReconstructError,
+    apply_batch_state_diff_to_ethereum_state, ethereum_state_from_genesis_accounts,
+    EthereumStateExt, GenesisAccount, ReconstructError,
 };
 #[cfg(feature = "serde")]
 pub use serde_impl::{AccountChangeSerde, AccountDiffSerde, BatchStateDiffSerde};

--- a/crates/reth/statediff/src/lib.rs
+++ b/crates/reth/statediff/src/lib.rs
@@ -10,15 +10,14 @@
 //!                                       ↓
 //! BlockStateChanges[n..m] → BatchBuilder → BatchStateDiff → DA (through Codec)
 //!                                              ↓
-//!                                 StateReconstructor.apply_diff()
+//!                         apply_batch_state_diff_to_ethereum_state()
 //! ```
 //!
 //! # Modules
 //!
 //! - [`block`]: Per-block changes types stored in DB (preserves original values)
 //! - [`batch`]: DA-optimized batch diff types (compact, no originals), actually posted on-chain
-//! - `reconstruct`: State reconstruction from diffs (see [`StateReconstructor`]), currently
-//!   experimental and used only in tests - will be adjusted later (for syncing from diffs).
+//! - `reconstruct`: State reconstruction helpers for applying DA diffs to EVM trie state.
 //!
 //! # Key Types
 //!
@@ -27,7 +26,6 @@
 //! | [`BlockStateChanges`] | `block` | Per-block changes for DB storage |
 //! | [`BatchStateDiff`] | `batch` | Aggregated diff for DA |
 //! | [`BatchBuilder`] | `batch` | Aggregates blocks with revert detection |
-//! | [`StateReconstructor`] | `reconstruct` | Applies diffs to rebuild state |
 //!
 //! # Features
 //!
@@ -62,8 +60,11 @@ pub(crate) mod test_utils;
 // Re-export main types at crate level for convenience
 pub use batch::{AccountChange, AccountDiff, BatchBuilder, BatchStateDiff, StorageDiff};
 pub use block::{AccountSnapshot, BlockAccountChange, BlockStateChanges, BlockStorageDiff};
+#[cfg(feature = "chainspec")]
+pub use reconstruct::ethereum_state_from_chain_spec;
 pub use reconstruct::{
-    apply_batch_state_diff_to_ethereum_state, ReconstructError, StateReconstructor,
+    apply_batch_state_diff_to_ethereum_state, ethereum_state_from_genesis_accounts, GenesisAccount,
+    ReconstructError,
 };
 #[cfg(feature = "serde")]
 pub use serde_impl::{AccountChangeSerde, AccountDiffSerde, BatchStateDiffSerde};

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -1,17 +1,12 @@
 //! State reconstruction from batch diffs.
 
-#[cfg(test)]
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-
+pub use alloy_genesis::GenesisAccount;
 #[cfg(feature = "chainspec")]
 use alpen_chainspec::chain_value_parser;
-use revm_primitives::{alloy_primitives::Address, B256, U256};
+use revm_primitives::{alloy_primitives::Address, B256};
 use rsp_mpt::EthereumState;
 use strata_da_framework::ContextlessDaWrite;
-#[cfg(feature = "chainspec")]
-use strata_mpt::KECCAK_EMPTY;
-use strata_mpt::{keccak, MptNode, StateAccount, EMPTY_ROOT};
+use strata_mpt::{keccak, StateAccount, EMPTY_ROOT, KECCAK_EMPTY};
 use thiserror::Error as ThisError;
 
 use crate::{
@@ -30,239 +25,87 @@ pub enum ReconstructError {
     Da(#[from] strata_da_framework::DaError),
 }
 
-/// Reconstructs EVM state by applying [`BatchStateDiff`]s sequentially.
-///
-/// Used primarily for testing to verify that state roots reconstructed
-/// from diffs match the actual state roots from EE blocks.
-#[derive(Clone, Default, Debug)]
-pub struct StateReconstructor {
-    state_trie: MptNode,
-    storage_trie: HashMap<Address, MptNode>,
+#[cfg(feature = "chainspec")]
+fn genesis_accounts_from_chain_spec(
+    spec: &str,
+) -> Result<Vec<(Address, GenesisAccount)>, eyre::Error> {
+    let chain_spec = chain_value_parser(spec)?;
+    let accounts = chain_spec
+        .genesis
+        .alloc
+        .iter()
+        .map(|(address, account)| (*address, account.clone()))
+        .collect();
+
+    Ok(accounts)
 }
 
-impl StateReconstructor {
-    /// Creates a new empty reconstructor.
-    pub fn new() -> Self {
-        Self::default()
+fn state_account_from_genesis(account: &GenesisAccount) -> StateAccount {
+    StateAccount {
+        nonce: account.nonce.unwrap_or(0),
+        balance: account.balance,
+        storage_root: EMPTY_ROOT,
+        code_hash: account
+            .code
+            .as_ref()
+            .map(|bytes| keccak(bytes).into())
+            .unwrap_or(KECCAK_EMPTY),
     }
+}
 
-    /// Creates a reconstructor initialized with genesis state from a chain spec.
-    #[cfg(feature = "chainspec")]
-    pub fn from_chain_spec(spec: &str) -> Result<Self, eyre::Error> {
-        let chain_spec = chain_value_parser(spec)?;
+/// Creates an [`EthereumState`] initialized with genesis state from a chain spec.
+#[cfg(feature = "chainspec")]
+pub fn ethereum_state_from_chain_spec(spec: &str) -> Result<EthereumState, eyre::Error> {
+    Ok(ethereum_state_from_genesis_accounts(
+        genesis_accounts_from_chain_spec(spec)?,
+    )?)
+}
 
-        let mut reconstructor = Self::new();
-        for (address, account) in chain_spec.genesis.alloc.iter() {
-            let mut state_account = StateAccount {
-                nonce: account.nonce.unwrap_or(0),
-                balance: account.balance,
-                storage_root: EMPTY_ROOT,
-                code_hash: account
-                    .code
-                    .as_ref()
-                    .map(|bytes| keccak(bytes).into())
-                    .unwrap_or(KECCAK_EMPTY),
-            };
+/// Creates an [`EthereumState`] initialized with explicit genesis accounts.
+///
+/// The implementation is a records-to-MPT construction pass: hash each account
+/// address, build that account's storage trie from non-zero slots, derive the
+/// storage root, and insert every explicit genesis alloc account into the state
+/// trie.
+pub fn ethereum_state_from_genesis_accounts(
+    accounts: impl IntoIterator<Item = (Address, GenesisAccount)>,
+) -> Result<EthereumState, ReconstructError> {
+    let mut state = EthereumState {
+        state_trie: Default::default(),
+        storage_tries: Default::default(),
+    };
 
-            if let Some(slots) = &account.storage {
-                if !slots.is_empty() {
-                    let acc_storage_trie = reconstructor.storage_trie.entry(*address).or_default();
-                    for (slot_key, slot_value) in slots.iter() {
-                        if slot_value != &B256::ZERO {
-                            acc_storage_trie.insert_rlp(&keccak(slot_key), *slot_value)?;
-                        }
-                    }
-                    state_account.storage_root = acc_storage_trie.hash();
-                }
+    for (address, account) in accounts {
+        let hashed_addr: B256 = keccak(address).into();
+        let mut state_account = state_account_from_genesis(&account);
+
+        let mut non_zero_storage_slots = account
+            .storage_slots()
+            .filter(|(_, slot_value)| !slot_value.is_zero())
+            .peekable();
+
+        if non_zero_storage_slots.peek().is_some() {
+            let acc_storage_trie = state.storage_tries.entry(hashed_addr).or_default();
+            for (slot_key, slot_value) in non_zero_storage_slots {
+                acc_storage_trie.insert_rlp(&keccak(slot_key.as_slice()), slot_value)?;
             }
 
-            reconstructor
-                .state_trie
-                .insert_rlp(&keccak(address), state_account)?;
+            state_account.storage_root = acc_storage_trie.hash();
         }
 
-        Ok(reconstructor)
+        state
+            .state_trie
+            .insert_rlp(hashed_addr.as_slice(), state_account)?;
     }
 
-    /// Applies a [`BatchStateDiff`] to the current state.
-    pub fn apply_diff(&mut self, diff: &BatchStateDiff) -> Result<(), ReconstructError> {
-        for (address, change) in &diff.accounts {
-            let acc_info_trie_path = keccak(address);
-
-            match change {
-                AccountChange::Created(account_diff) | AccountChange::Updated(account_diff) => {
-                    // Get current account state (if exists)
-                    let current: Option<StateAccount> = self
-                        .state_trie
-                        .get_rlp(&acc_info_trie_path)
-                        .unwrap_or_default();
-
-                    // Build snapshot from current state and apply diff
-                    let mut snapshot = current
-                        .as_ref()
-                        .map(AccountSnapshot::from)
-                        .unwrap_or_default();
-
-                    account_diff.apply(&mut snapshot)?;
-
-                    let mut state_account = StateAccount {
-                        nonce: snapshot.nonce,
-                        balance: snapshot.balance,
-                        storage_root: Default::default(),
-                        code_hash: snapshot.code_hash,
-                    };
-
-                    // Skip empty accounts
-                    if state_account.is_account_empty() {
-                        continue;
-                    }
-
-                    // Calculate storage root
-                    state_account.storage_root = {
-                        let acc_storage_trie = self.storage_trie.entry(*address).or_default();
-                        if let Some(storage_diff) = diff.storage.get(address) {
-                            for (slot_key, slot_value) in storage_diff.iter() {
-                                let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
-                                match slot_value {
-                                    Some(v) if !v.is_zero() => {
-                                        acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
-                                    }
-                                    _ => {
-                                        acc_storage_trie.delete(&slot_trie_path)?;
-                                    }
-                                }
-                            }
-                        }
-                        acc_storage_trie.hash()
-                    };
-
-                    self.state_trie
-                        .insert_rlp(&acc_info_trie_path, state_account)?;
-                }
-                AccountChange::Deleted => {
-                    self.state_trie.delete(&acc_info_trie_path)?;
-                    self.storage_trie.remove(address);
-                }
-            }
-        }
-
-        // Handle storage changes for accounts not in accounts map
-        // (e.g., storage-only changes)
-        for (address, storage_diff) in &diff.storage {
-            if diff.accounts.contains_key(address) {
-                continue; // Already handled above
-            }
-
-            let acc_info_trie_path = keccak(address);
-            let current: Option<StateAccount> = self
-                .state_trie
-                .get_rlp(&acc_info_trie_path)
-                .unwrap_or_default();
-
-            if let Some(mut state_account) = current {
-                let acc_storage_trie = self.storage_trie.entry(*address).or_default();
-                for (slot_key, slot_value) in storage_diff.iter() {
-                    let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
-                    match slot_value {
-                        Some(v) if !v.is_zero() => {
-                            acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
-                        }
-                        _ => {
-                            acc_storage_trie.delete(&slot_trie_path)?;
-                        }
-                    }
-                }
-                state_account.storage_root = acc_storage_trie.hash();
-                self.state_trie
-                    .insert_rlp(&acc_info_trie_path, state_account)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Returns the current state root.
-    pub fn state_root(&self) -> B256 {
-        self.state_trie.hash()
-    }
-
-    /// Returns the current storage root for an account.
-    pub fn storage_root(&self, address: Address) -> B256 {
-        self.storage_trie
-            .get(&address)
-            .map(|t| t.hash())
-            .unwrap_or(EMPTY_ROOT)
-    }
-
-    /// Returns the value at a storage slot.
-    pub fn storage_slot(&self, address: Address, slot_key: U256) -> U256 {
-        self.storage_trie
-            .get(&address)
-            .unwrap_or(&MptNode::default())
-            .get_rlp::<U256>(&keccak(slot_key.to_be_bytes::<32>()))
-            .unwrap_or_default()
-            .unwrap_or_default()
-    }
-
-    /// Returns the account state.
-    pub fn account(&self, address: Address) -> Option<StateAccount> {
-        self.state_trie
-            .get_rlp(&keccak(address))
-            .unwrap_or_default()
-    }
-
-    /// Creates a reconstructor from explicit canonical account and storage state.
-    ///
-    /// This helper exists for oracle tests that need to seed pre-state directly
-    /// from test fixtures instead of going through a chain spec or DB-backed
-    /// state source.
-    ///
-    /// Empty accounts are skipped during seeding, matching the canonical-state
-    /// oracle behavior used by the reconstruction tests.
-    #[cfg(test)]
-    pub(crate) fn from_state_parts(
-        accounts: &BTreeMap<Address, StateAccount>,
-        storage: &BTreeMap<Address, BTreeMap<U256, U256>>,
-    ) -> Result<Self, ReconstructError> {
-        let mut reconstructor = Self::new();
-
-        for (address, account) in accounts {
-            let mut state_account = account.clone();
-            if state_account.is_account_empty() {
-                continue;
-            }
-
-            let mut storage_trie = MptNode::default();
-
-            if let Some(account_storage) = storage.get(address) {
-                for (slot_key, slot_value) in account_storage {
-                    if slot_value.is_zero() {
-                        continue;
-                    }
-
-                    storage_trie.insert_rlp(&keccak(slot_key.to_be_bytes::<32>()), *slot_value)?;
-                }
-            }
-
-            state_account.storage_root = storage_trie.hash();
-            if !storage_trie.is_empty() {
-                reconstructor.storage_trie.insert(*address, storage_trie);
-            }
-
-            reconstructor
-                .state_trie
-                .insert_rlp(&keccak(address), state_account)?;
-        }
-
-        Ok(reconstructor)
-    }
+    Ok(state)
 }
 
 /// Applies a [`BatchStateDiff`] to a populated [`EthereumState`] sparse-MPT witness.
 ///
-/// This mirrors [`StateReconstructor::apply_diff`] but operates on the sparse MPT
-/// shape consumed by the EVM chunk witness pipeline, allowing the acct proof to
-/// apply a DA-published state diff to the same pre-state witness used for execution.
+/// This operates on the sparse MPT shape consumed by the EVM chunk witness
+/// pipeline, allowing the acct proof and verifier tooling to apply a
+/// DA-published state diff to the same pre-state witness used for execution.
 pub fn apply_batch_state_diff_to_ethereum_state(
     state: &mut EthereumState,
     diff: &BatchStateDiff,
@@ -356,11 +199,12 @@ pub fn apply_batch_state_diff_to_ethereum_state(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
     use proptest::prelude::*;
+    use revm_primitives::{alloy_primitives::Bytes, U256};
     use strata_codec::{decode_buf_exact, encode_to_vec};
-    use strata_mpt::EMPTY_ROOT;
+    use strata_mpt::{MptNode, EMPTY_ROOT};
 
     use super::*;
     use crate::{
@@ -372,12 +216,236 @@ mod tests {
         BlockStateChanges,
     };
 
+    /// Test-only reconstruction oracle retained from the pre-refactor MPT path.
+    ///
+    /// This is not public API. Tests use it to cross-check
+    /// [`apply_batch_state_diff_to_ethereum_state`] against the old
+    /// strata_mpt-backed reconstruction flow while the production API uses
+    /// [`EthereumState`].
+    #[derive(Clone, Default, Debug)]
+    struct TestStateReconstructor {
+        state_trie: MptNode,
+        storage_trie: HashMap<Address, MptNode>,
+    }
+
+    impl TestStateReconstructor {
+        /// Creates a new empty reconstructor.
+        fn new() -> Self {
+            Self::default()
+        }
+
+        /// Creates a reconstructor initialized with explicit genesis accounts.
+        fn from_genesis_accounts(
+            accounts: impl IntoIterator<Item = (Address, GenesisAccount)>,
+        ) -> Result<Self, ReconstructError> {
+            let mut reconstructor = Self::new();
+            for (address, account) in accounts {
+                let mut state_account = state_account_from_genesis(&account);
+
+                let mut storage_trie = MptNode::default();
+                let mut has_non_zero_storage = false;
+                for (slot_key, slot_value) in account.storage_slots() {
+                    if slot_value.is_zero() {
+                        continue;
+                    }
+
+                    storage_trie.insert_rlp(&keccak(slot_key.as_slice()), slot_value)?;
+                    has_non_zero_storage = true;
+                }
+
+                if has_non_zero_storage {
+                    state_account.storage_root = storage_trie.hash();
+                    reconstructor.storage_trie.insert(address, storage_trie);
+                }
+
+                reconstructor
+                    .state_trie
+                    .insert_rlp(&keccak(address), state_account)?;
+            }
+
+            Ok(reconstructor)
+        }
+
+        /// Applies a [`BatchStateDiff`] to the current state.
+        fn apply_diff(&mut self, diff: &BatchStateDiff) -> Result<(), ReconstructError> {
+            for (address, change) in &diff.accounts {
+                let acc_info_trie_path = keccak(address);
+
+                match change {
+                    AccountChange::Created(account_diff) | AccountChange::Updated(account_diff) => {
+                        // Get current account state (if exists)
+                        let current: Option<StateAccount> = self
+                            .state_trie
+                            .get_rlp(&acc_info_trie_path)
+                            .unwrap_or_default();
+
+                        // Build snapshot from current state and apply diff
+                        let mut snapshot = current
+                            .as_ref()
+                            .map(AccountSnapshot::from)
+                            .unwrap_or_default();
+
+                        account_diff.apply(&mut snapshot)?;
+
+                        let mut state_account = StateAccount {
+                            nonce: snapshot.nonce,
+                            balance: snapshot.balance,
+                            storage_root: Default::default(),
+                            code_hash: snapshot.code_hash,
+                        };
+
+                        // Skip empty accounts
+                        if state_account.is_account_empty() {
+                            continue;
+                        }
+
+                        // Calculate storage root
+                        state_account.storage_root = {
+                            let acc_storage_trie = self.storage_trie.entry(*address).or_default();
+                            if let Some(storage_diff) = diff.storage.get(address) {
+                                for (slot_key, slot_value) in storage_diff.iter() {
+                                    let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
+                                    match slot_value {
+                                        Some(v) if !v.is_zero() => {
+                                            acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
+                                        }
+                                        _ => {
+                                            acc_storage_trie.delete(&slot_trie_path)?;
+                                        }
+                                    }
+                                }
+                            }
+                            acc_storage_trie.hash()
+                        };
+
+                        self.state_trie
+                            .insert_rlp(&acc_info_trie_path, state_account)?;
+                    }
+                    AccountChange::Deleted => {
+                        self.state_trie.delete(&acc_info_trie_path)?;
+                        self.storage_trie.remove(address);
+                    }
+                }
+            }
+
+            // Handle storage changes for accounts not in accounts map
+            // (e.g., storage-only changes)
+            for (address, storage_diff) in &diff.storage {
+                if diff.accounts.contains_key(address) {
+                    continue; // Already handled above
+                }
+
+                let acc_info_trie_path = keccak(address);
+                let current: Option<StateAccount> = self
+                    .state_trie
+                    .get_rlp(&acc_info_trie_path)
+                    .unwrap_or_default();
+
+                if let Some(mut state_account) = current {
+                    let acc_storage_trie = self.storage_trie.entry(*address).or_default();
+                    for (slot_key, slot_value) in storage_diff.iter() {
+                        let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
+                        match slot_value {
+                            Some(v) if !v.is_zero() => {
+                                acc_storage_trie.insert_rlp(&slot_trie_path, *v)?;
+                            }
+                            _ => {
+                                acc_storage_trie.delete(&slot_trie_path)?;
+                            }
+                        }
+                    }
+                    state_account.storage_root = acc_storage_trie.hash();
+                    self.state_trie
+                        .insert_rlp(&acc_info_trie_path, state_account)?;
+                }
+            }
+
+            Ok(())
+        }
+
+        /// Returns the current state root.
+        fn state_root(&self) -> B256 {
+            self.state_trie.hash()
+        }
+
+        /// Returns the current storage root for an account.
+        fn storage_root(&self, address: Address) -> B256 {
+            self.storage_trie
+                .get(&address)
+                .map(|t| t.hash())
+                .unwrap_or(EMPTY_ROOT)
+        }
+
+        /// Returns the value at a storage slot.
+        fn storage_slot(&self, address: Address, slot_key: U256) -> U256 {
+            self.storage_trie
+                .get(&address)
+                .unwrap_or(&MptNode::default())
+                .get_rlp::<U256>(&keccak(slot_key.to_be_bytes::<32>()))
+                .unwrap_or_default()
+                .unwrap_or_default()
+        }
+
+        /// Returns the account state.
+        fn account(&self, address: Address) -> Option<StateAccount> {
+            self.state_trie
+                .get_rlp(&keccak(address))
+                .unwrap_or_default()
+        }
+
+        /// Creates a reconstructor from explicit canonical account and storage state.
+        ///
+        /// This helper exists for oracle tests that need to seed pre-state directly
+        /// from test fixtures instead of going through a chain spec or DB-backed
+        /// state source.
+        ///
+        /// Empty accounts are skipped during seeding, matching the canonical-state
+        /// oracle behavior used by the reconstruction tests.
+        fn from_state_parts(
+            accounts: &BTreeMap<Address, StateAccount>,
+            storage: &BTreeMap<Address, BTreeMap<U256, U256>>,
+        ) -> Result<Self, ReconstructError> {
+            let mut reconstructor = Self::new();
+
+            for (address, account) in accounts {
+                let mut state_account = account.clone();
+                if state_account.is_account_empty() {
+                    continue;
+                }
+
+                let mut storage_trie = MptNode::default();
+
+                if let Some(account_storage) = storage.get(address) {
+                    for (slot_key, slot_value) in account_storage {
+                        if slot_value.is_zero() {
+                            continue;
+                        }
+
+                        storage_trie
+                            .insert_rlp(&keccak(slot_key.to_be_bytes::<32>()), *slot_value)?;
+                    }
+                }
+
+                state_account.storage_root = storage_trie.hash();
+                if !storage_trie.is_empty() {
+                    reconstructor.storage_trie.insert(*address, storage_trie);
+                }
+
+                reconstructor
+                    .state_trie
+                    .insert_rlp(&keccak(address), state_account)?;
+            }
+
+            Ok(reconstructor)
+        }
+    }
+
     // The oracle below intentionally shares the same MPT primitives as the
     // reconstructor. These tests verify diff application produces the expected
     // post-state inputs and roots, not that the root algorithm is independently
     // reimplemented.
     fn assert_reconstruction_matches(
-        reconstructor: &StateReconstructor,
+        reconstructor: &TestStateReconstructor,
         expected_state: &CanonicalState,
         expected_slots: &[(Address, U256)],
         expected_bytecodes: &[(B256, &[u8])],
@@ -447,6 +515,192 @@ mod tests {
         decode_buf_exact(&encoded).unwrap()
     }
 
+    fn b256_from_u256(value: U256) -> B256 {
+        B256::from(value.to_be_bytes::<32>())
+    }
+
+    fn genesis_account(
+        balance: u64,
+        nonce: u64,
+        code: Option<&[u8]>,
+        storage: BTreeMap<U256, U256>,
+    ) -> GenesisAccount {
+        GenesisAccount {
+            nonce: Some(nonce),
+            balance: U256::from(balance),
+            code: code.map(Bytes::copy_from_slice),
+            storage: Some(
+                storage
+                    .into_iter()
+                    .map(|(slot_key, slot_value)| {
+                        (b256_from_u256(slot_key), b256_from_u256(slot_value))
+                    })
+                    .collect(),
+            ),
+            private_key: None,
+        }
+    }
+
+    #[test]
+    fn oracle_genesis_alloc_builds_canonical_state() {
+        let address = addr(0x10);
+        let slot_one = slot(1);
+        let slot_two = slot(2);
+        let code = [0x60, 0x80, 0x60, 0x40, 0x52];
+        let code_hash = keccak(code).into();
+        let expected_state = CanonicalState::new()
+            .with_account(address, state_account(100, 2, code_hash))
+            .set_storage_slot(address, slot_one, value(10));
+
+        let storage = BTreeMap::from([(slot_one, value(10)), (slot_two, U256::ZERO)]);
+        let reconstructor = TestStateReconstructor::from_genesis_accounts([(
+            address,
+            genesis_account(100, 2, Some(&code), storage),
+        )])
+        .unwrap();
+
+        assert_reconstruction_matches(
+            &reconstructor,
+            &expected_state,
+            &[(address, slot_one), (address, slot_two)],
+            &[],
+            &BatchStateDiff::default(),
+        );
+    }
+
+    #[test]
+    fn oracle_genesis_alloc_skips_zero_storage_entries() {
+        let address = addr(0x10);
+        let slot_key = slot(1);
+        let expected_state =
+            CanonicalState::new().with_account(address, state_account(100, 2, KECCAK_EMPTY));
+
+        let reconstructor = TestStateReconstructor::from_genesis_accounts([(
+            address,
+            genesis_account(100, 2, None, BTreeMap::from([(slot_key, U256::ZERO)])),
+        )])
+        .unwrap();
+
+        assert_reconstruction_matches(
+            &reconstructor,
+            &expected_state,
+            &[(address, slot_key)],
+            &[],
+            &BatchStateDiff::default(),
+        );
+        assert_eq!(reconstructor.storage_root(address), EMPTY_ROOT);
+    }
+
+    #[test]
+    fn genesis_alloc_builds_canonical_state() {
+        let address = addr(0x10);
+        let slot_one = slot(1);
+        let slot_two = slot(2);
+        let code = [0x60, 0x80, 0x60, 0x40, 0x52];
+        let code_hash = keccak(code).into();
+        let expected_state = CanonicalState::new()
+            .with_account(address, state_account(100, 2, code_hash))
+            .set_storage_slot(address, slot_one, value(10));
+
+        let state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(
+                100,
+                2,
+                Some(&code),
+                BTreeMap::from([(slot_one, value(10)), (slot_two, U256::ZERO)]),
+            ),
+        )])
+        .unwrap();
+
+        assert_eq!(
+            state.state_root(),
+            canonical_state_root(&expected_state).unwrap()
+        );
+    }
+
+    #[test]
+    fn genesis_alloc_avoids_zero_storage_trie_entries() {
+        let address = addr(0x10);
+        let slot_key = slot(1);
+        let expected_state =
+            CanonicalState::new().with_account(address, state_account(100, 2, KECCAK_EMPTY));
+
+        let state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(100, 2, None, BTreeMap::from([(slot_key, U256::ZERO)])),
+        )])
+        .unwrap();
+
+        let hashed_addr: B256 = keccak(address).into();
+        assert!(!state.storage_tries.contains_key(&hashed_addr));
+        assert_eq!(
+            state.state_root(),
+            canonical_state_root(&expected_state).unwrap()
+        );
+    }
+
+    #[test]
+    fn genesis_alloc_keeps_empty_account() {
+        let address = addr(0x10);
+
+        let state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(0, 0, None, BTreeMap::new()),
+        )])
+        .unwrap();
+
+        let hashed_addr: B256 = keccak(address).into();
+        let account = state
+            .state_trie
+            .get_rlp::<StateAccount>(hashed_addr.as_slice())
+            .unwrap()
+            .expect("explicit empty genesis alloc account is present in the state trie");
+        assert_eq!(account, state_account(0, 0, KECCAK_EMPTY));
+        assert!(!state.storage_tries.contains_key(&hashed_addr));
+
+        let mut expected_trie = MptNode::default();
+        expected_trie
+            .insert_rlp(hashed_addr.as_slice(), state_account(0, 0, KECCAK_EMPTY))
+            .unwrap();
+        assert_eq!(state.state_root(), expected_trie.hash());
+    }
+
+    #[test]
+    fn genesis_alloc_keeps_storage_only_account() {
+        let address = addr(0x10);
+        let slot_key = slot(1);
+        let slot_value = value(10);
+
+        let state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(0, 0, None, BTreeMap::from([(slot_key, slot_value)])),
+        )])
+        .unwrap();
+
+        let hashed_addr: B256 = keccak(address).into();
+        let account = state
+            .state_trie
+            .get_rlp::<StateAccount>(hashed_addr.as_slice())
+            .unwrap()
+            .expect("storage-only genesis alloc account is present in the state trie");
+        assert_eq!(account.nonce, 0);
+        assert_eq!(account.balance, U256::ZERO);
+        assert_eq!(account.code_hash, KECCAK_EMPTY);
+        assert_ne!(account.storage_root, EMPTY_ROOT);
+
+        let storage_trie = state
+            .storage_tries
+            .get(&hashed_addr)
+            .expect("storage-only genesis alloc account has a storage trie");
+        assert_eq!(
+            storage_trie
+                .get_rlp::<U256>(&keccak(slot_key.to_be_bytes::<32>()))
+                .unwrap(),
+            Some(slot_value)
+        );
+    }
+
     #[test]
     fn test_reconstruct_storage_only_change_matches_canonical_oracle() {
         let address = addr(0x11);
@@ -466,7 +720,8 @@ mod tests {
 
         let diff = roundtrip_batch_diff(&[block]);
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -494,7 +749,8 @@ mod tests {
 
         let diff = roundtrip_batch_diff(&[block]);
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -535,7 +791,8 @@ mod tests {
         assert!(diff.is_empty());
 
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -578,7 +835,8 @@ mod tests {
         assert!(diff.is_empty());
 
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -616,7 +874,8 @@ mod tests {
 
         let diff = roundtrip_batch_diff(&[block]);
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -662,7 +921,8 @@ mod tests {
 
         let diff = roundtrip_batch_diff(&[block_one, block_two]);
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         assert_reconstruction_matches(
@@ -802,7 +1062,7 @@ mod tests {
 
             let diff = roundtrip_batch_diff(&[block]);
             let mut reconstructor =
-                StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+                TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
             reconstructor.apply_diff(&diff).unwrap();
 
             assert_reconstruction_matches(
@@ -816,7 +1076,7 @@ mod tests {
     }
 
     /// Cross-verifies that [`apply_batch_state_diff_to_ethereum_state`]
-    /// produces the same post-state root as [`StateReconstructor::apply_diff`]
+    /// produces the same post-state root as [`TestStateReconstructor::apply_diff`]
     /// when both start from the same empty state and consume the same diff.
     #[test]
     fn apply_to_ethereum_state_matches_state_reconstructor_oracle() {
@@ -851,7 +1111,8 @@ mod tests {
         let diff = roundtrip_batch_diff(&[block]);
 
         let mut reconstructor =
-            StateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage).unwrap();
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
         reconstructor.apply_diff(&diff).unwrap();
 
         let mut state = EthereumState {

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -201,7 +201,10 @@ pub fn apply_batch_state_diff_to_ethereum_state(
                     code_hash: snapshot.code_hash,
                 };
 
+                // Empty accounts are absent from the state trie (EIP-161).
                 if state_account.is_account_empty() {
+                    state.state_trie.delete(hashed_addr.as_slice())?;
+                    state.storage_tries.remove(&hashed_addr);
                     continue;
                 }
 
@@ -393,8 +396,10 @@ mod tests {
                             code_hash: snapshot.code_hash,
                         };
 
-                        // Skip empty accounts
+                        // Empty accounts are absent from the state trie (EIP-161).
                         if state_account.is_account_empty() {
+                            self.state_trie.delete(&acc_info_trie_path)?;
+                            self.storage_trie.remove(address);
                             continue;
                         }
 
@@ -1285,6 +1290,42 @@ mod tests {
             canonical_state_root(&expected_state).unwrap(),
             "ethereum-state apply must match canonical post-state root"
         );
+    }
+
+    #[test]
+    fn apply_to_ethereum_state_deletes_account_emptied_by_diff() {
+        let address = addr(0xA2);
+        let slot_one = slot(1);
+        let empty_code_hash = KECCAK_EMPTY;
+        let expected_state = CanonicalState::new();
+        let mut state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(100, 1, None, BTreeMap::from([(slot_one, value(5))])),
+        )])
+        .unwrap();
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, empty_code_hash)),
+            Some(snapshot(0, 0, empty_code_hash)),
+        );
+        storage_change(&mut block, address, slot_one, value(5), U256::ZERO);
+        let diff = roundtrip_batch_diff(&[block]);
+
+        apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
+
+        assert_eq!(
+            state.state_root(),
+            canonical_state_root(&expected_state).unwrap()
+        );
+        assert_eq!(state.get_account_snapshot(address).unwrap(), None);
+        assert_eq!(
+            state.get_storage_slot(address, slot_one).unwrap(),
+            U256::ZERO
+        );
+        assert!(state.storage_tries.is_empty());
     }
 
     #[test]

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -3,9 +3,10 @@
 pub use alloy_genesis::GenesisAccount;
 #[cfg(feature = "chainspec")]
 use alpen_chainspec::chain_value_parser;
-use revm_primitives::{alloy_primitives::Address, B256};
+use revm_primitives::{alloy_primitives::Address, B256, U256};
 use rsp_mpt::EthereumState;
 use strata_da_framework::ContextlessDaWrite;
+use strata_identifiers::Buf32;
 use strata_mpt::{keccak, StateAccount, EMPTY_ROOT, KECCAK_EMPTY};
 use thiserror::Error as ThisError;
 
@@ -110,6 +111,60 @@ pub fn ethereum_state_from_genesis_accounts(
     }
 
     Ok(state)
+}
+
+/// Adds reconstruction-specific helper methods to [`rsp_mpt::EthereumState`].
+pub trait EthereumStateExt {
+    /// Returns the current Ethereum state root as [`Buf32`].
+    ///
+    /// This wraps the raw bytes from `self.state_root()` in [`Buf32`].
+    fn state_root_buf32(&self) -> Buf32;
+
+    /// Returns the reconstructed account snapshot for `address`.
+    ///
+    /// This reads the reconstructed trie state. It is not a presence or absence
+    /// proof against an externally supplied state root.
+    fn get_account_snapshot(
+        &self,
+        address: Address,
+    ) -> Result<Option<AccountSnapshot>, ReconstructError>;
+
+    /// Returns the reconstructed storage slot for `address` and `slot`.
+    ///
+    /// This reads the reconstructed trie state. It is not a presence or absence
+    /// proof against an externally supplied state root.
+    fn get_storage_slot(&self, address: Address, slot: U256) -> Result<U256, ReconstructError>;
+}
+
+impl EthereumStateExt for EthereumState {
+    fn state_root_buf32(&self) -> Buf32 {
+        Buf32::from(self.state_root().0)
+    }
+
+    fn get_account_snapshot(
+        &self,
+        address: Address,
+    ) -> Result<Option<AccountSnapshot>, ReconstructError> {
+        let hashed_addr: B256 = keccak(address).into();
+        let account = self
+            .state_trie
+            .get_rlp::<StateAccount>(hashed_addr.as_slice())?
+            .as_ref()
+            .map(AccountSnapshot::from);
+
+        Ok(account)
+    }
+
+    fn get_storage_slot(&self, address: Address, slot: U256) -> Result<U256, ReconstructError> {
+        let hashed_addr: B256 = keccak(address).into();
+        let Some(storage_trie) = self.storage_tries.get(&hashed_addr) else {
+            return Ok(U256::ZERO);
+        };
+
+        Ok(storage_trie
+            .get_rlp::<U256>(&keccak(slot.to_be_bytes::<32>()))?
+            .unwrap_or_default())
+    }
 }
 
 /// Applies a [`BatchStateDiff`] to a populated [`EthereumState`] sparse-MPT witness.
@@ -697,10 +752,20 @@ mod tests {
             ),
         )])
         .unwrap();
+        let expected_root = canonical_state_root(&expected_state).unwrap();
 
+        assert_eq!(state.state_root_buf32(), Buf32::from(expected_root.0));
         assert_eq!(
-            state.state_root(),
-            canonical_state_root(&expected_state).unwrap()
+            state.get_account_snapshot(address).unwrap(),
+            Some(snapshot(100, 2, code_hash))
+        );
+        assert_eq!(
+            state.get_storage_slot(address, slot_one).unwrap(),
+            value(10)
+        );
+        assert_eq!(
+            state.get_storage_slot(address, slot_two).unwrap(),
+            U256::ZERO
         );
     }
 
@@ -719,6 +784,10 @@ mod tests {
 
         let hashed_addr: B256 = keccak(address).into();
         assert!(!state.storage_tries.contains_key(&hashed_addr));
+        assert_eq!(
+            state.get_storage_slot(address, slot_key).unwrap(),
+            U256::ZERO
+        );
         assert_eq!(
             state.state_root(),
             canonical_state_root(&expected_state).unwrap()

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -19,10 +19,21 @@ use crate::{
 pub enum ReconstructError {
     #[error("MPT: {0}")]
     Mpt(#[from] strata_mpt::Error),
+
     #[error("sparse MPT: {0}")]
     SparseMpt(#[from] rsp_mpt::Error),
+
     #[error("DA apply: {0}")]
     Da(#[from] strata_da_framework::DaError),
+
+    #[error(
+        "missing storage trie for account {address} (hashed {hashed_address}) with storage root {storage_root}"
+    )]
+    MissingStorageTrie {
+        address: Address,
+        hashed_address: B256,
+        storage_root: B256,
+    },
 }
 
 #[cfg(feature = "chainspec")]
@@ -140,6 +151,12 @@ pub fn apply_batch_state_diff_to_ethereum_state(
                 }
 
                 if let Some(storage_diff) = diff.storage.get(address) {
+                    require_storage_trie_for_diff(
+                        state,
+                        *address,
+                        hashed_addr,
+                        state_account.storage_root,
+                    )?;
                     let acc_storage_trie = state.storage_tries.entry(hashed_addr).or_default();
                     for (slot_key, slot_value) in storage_diff.iter() {
                         let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
@@ -175,6 +192,12 @@ pub fn apply_batch_state_diff_to_ethereum_state(
         let current: Option<StateAccount> = state.state_trie.get_rlp(hashed_addr.as_slice())?;
 
         if let Some(mut state_account) = current {
+            require_storage_trie_for_diff(
+                state,
+                *address,
+                hashed_addr,
+                state_account.storage_root,
+            )?;
             let acc_storage_trie = state.storage_tries.entry(hashed_addr).or_default();
             for (slot_key, slot_value) in storage_diff.iter() {
                 let slot_trie_path = keccak(slot_key.to_be_bytes::<32>());
@@ -195,6 +218,27 @@ pub fn apply_batch_state_diff_to_ethereum_state(
     }
 
     Ok(())
+}
+
+/// Requires a storage trie when a diff updates an account with non-empty storage.
+///
+/// Missing storage tries are only invalid for non-empty roots because untouched
+/// slots must be preserved. Empty roots can safely start from a new trie.
+fn require_storage_trie_for_diff(
+    state: &EthereumState,
+    address: Address,
+    hashed_address: B256,
+    storage_root: B256,
+) -> Result<(), ReconstructError> {
+    if storage_root == EMPTY_ROOT || state.storage_tries.contains_key(&hashed_address) {
+        return Ok(());
+    }
+
+    Err(ReconstructError::MissingStorageTrie {
+        address,
+        hashed_address,
+        storage_root,
+    })
 }
 
 #[cfg(test)]
@@ -538,6 +582,47 @@ mod tests {
                     .collect(),
             ),
             private_key: None,
+        }
+    }
+
+    fn ethereum_state_with_account(address: Address, account: StateAccount) -> EthereumState {
+        let mut state = EthereumState {
+            state_trie: Default::default(),
+            storage_tries: Default::default(),
+        };
+        let hashed_addr: B256 = keccak(address).into();
+        state
+            .state_trie
+            .insert_rlp(hashed_addr.as_slice(), account)
+            .unwrap();
+        state
+    }
+
+    fn ethereum_storage_slot(state: &EthereumState, address: Address, slot_key: U256) -> U256 {
+        let hashed_addr: B256 = keccak(address).into();
+        state
+            .storage_tries
+            .get(&hashed_addr)
+            .and_then(|trie| {
+                trie.get_rlp::<U256>(&keccak(slot_key.to_be_bytes::<32>()))
+                    .unwrap()
+            })
+            .unwrap_or_default()
+    }
+
+    fn assert_missing_storage_trie(err: ReconstructError, address: Address, storage_root: B256) {
+        let hashed_address: B256 = keccak(address).into();
+        match err {
+            ReconstructError::MissingStorageTrie {
+                address: actual_address,
+                hashed_address: actual_hashed_address,
+                storage_root: actual_storage_root,
+            } => {
+                assert_eq!(actual_address, address);
+                assert_eq!(actual_hashed_address, hashed_address);
+                assert_eq!(actual_storage_root, storage_root);
+            }
+            other => panic!("expected missing storage trie error, got {other:?}"),
         }
     }
 
@@ -1131,6 +1216,140 @@ mod tests {
             canonical_state_root(&expected_state).unwrap(),
             "ethereum-state apply must match canonical post-state root"
         );
+    }
+
+    #[test]
+    fn account_update_rejects_missing_storage_trie_for_non_empty_root() {
+        let address = addr(0xD1);
+        let slot_key = slot(1);
+        let storage_root = hash(0xE1);
+        let mut account = state_account(100, 1, KECCAK_EMPTY);
+        account.storage_root = storage_root;
+        let mut state = ethereum_state_with_account(address, account);
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, KECCAK_EMPTY)),
+            Some(snapshot(101, 1, KECCAK_EMPTY)),
+        );
+        storage_change(&mut block, address, slot_key, value(5), value(7));
+        let diff = roundtrip_batch_diff(&[block]);
+
+        let err = apply_batch_state_diff_to_ethereum_state(&mut state, &diff)
+            .expect_err("non-empty storage root without trie must fail");
+        assert_missing_storage_trie(err, address, storage_root);
+    }
+
+    #[test]
+    fn account_update_preserves_untouched_storage_slots() {
+        let address = addr(0xD2);
+        let slot_one = slot(1);
+        let slot_two = slot(2);
+        let mut state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(100, 1, None, BTreeMap::from([(slot_one, value(5))])),
+        )])
+        .unwrap();
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, KECCAK_EMPTY)),
+            Some(snapshot(101, 1, KECCAK_EMPTY)),
+        );
+        storage_change(&mut block, address, slot_two, U256::ZERO, value(7));
+        let diff = roundtrip_batch_diff(&[block]);
+
+        apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
+
+        assert_eq!(ethereum_storage_slot(&state, address, slot_one), value(5));
+        assert_eq!(ethereum_storage_slot(&state, address, slot_two), value(7));
+    }
+
+    #[test]
+    fn account_update_creates_storage_trie_for_empty_root() {
+        let address = addr(0xD3);
+        let slot_key = slot(1);
+        let mut state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(100, 1, None, BTreeMap::new()),
+        )])
+        .unwrap();
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(100, 1, KECCAK_EMPTY)),
+            Some(snapshot(101, 1, KECCAK_EMPTY)),
+        );
+        storage_change(&mut block, address, slot_key, U256::ZERO, value(7));
+        let diff = roundtrip_batch_diff(&[block]);
+
+        apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
+
+        assert_eq!(ethereum_storage_slot(&state, address, slot_key), value(7));
+    }
+
+    #[test]
+    fn storage_only_update_rejects_missing_storage_trie_for_non_empty_root() {
+        let address = addr(0xD4);
+        let slot_key = slot(1);
+        let storage_root = hash(0xE4);
+        let mut account = state_account(100, 1, KECCAK_EMPTY);
+        account.storage_root = storage_root;
+        let mut state = ethereum_state_with_account(address, account);
+
+        let mut block = block_diff();
+        storage_change(&mut block, address, slot_key, value(5), value(7));
+        let diff = roundtrip_batch_diff(&[block]);
+
+        let err = apply_batch_state_diff_to_ethereum_state(&mut state, &diff)
+            .expect_err("non-empty storage root without trie must fail");
+        assert_missing_storage_trie(err, address, storage_root);
+    }
+
+    #[test]
+    fn storage_only_update_preserves_untouched_storage_slots() {
+        let address = addr(0xD5);
+        let slot_one = slot(1);
+        let slot_two = slot(2);
+        let mut state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(100, 1, None, BTreeMap::from([(slot_one, value(5))])),
+        )])
+        .unwrap();
+
+        let mut block = block_diff();
+        storage_change(&mut block, address, slot_two, U256::ZERO, value(7));
+        let diff = roundtrip_batch_diff(&[block]);
+
+        apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
+
+        assert_eq!(ethereum_storage_slot(&state, address, slot_one), value(5));
+        assert_eq!(ethereum_storage_slot(&state, address, slot_two), value(7));
+    }
+
+    #[test]
+    fn storage_only_update_creates_storage_trie_for_empty_root() {
+        let address = addr(0xD6);
+        let slot_key = slot(1);
+        let mut state = ethereum_state_from_genesis_accounts([(
+            address,
+            genesis_account(100, 1, None, BTreeMap::new()),
+        )])
+        .unwrap();
+
+        let mut block = block_diff();
+        storage_change(&mut block, address, slot_key, U256::ZERO, value(7));
+        let diff = roundtrip_batch_diff(&[block]);
+
+        apply_batch_state_diff_to_ethereum_state(&mut state, &diff).unwrap();
+
+        assert_eq!(ethereum_storage_slot(&state, address, slot_key), value(7));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Restructures `alpen-reth-statediff` around `rsp_mpt::EthereumState`, so tries are the single source of truth for reconstructed state. Also fixes two empty-account bugs and adds read helpers needed by downstream verifier code. Prerequisite for #1950 (STR-2404 EE DA verification tool).

- **Reuse `EthereumState` for reconstruction.** Removes `StateReconstructor`; adds `ethereum_state_from_genesis_accounts` and (feature-gated) `ethereum_state_from_chain_spec`. Genesis input uses `alloy_genesis::GenesisAccount`. `apply_batch_state_diff_to_ethereum_state` remains the sole apply boundary.
- **Preserve storage-only genesis accounts.** Main's `from_chain_spec` silently dropped accounts with empty state fields but declared storage. Skip only when both state fields and storage are empty.
- **`EthereumStateExt` read helpers.** Extension trait on `EthereumState`: `state_root_buf32`, `get_account_snapshot`, `get_storage_slot`. Doc comments note these are reconstructed-state accessors, not presence/absence proofs against an externally supplied state root.
- **EIP-161 empty-account deletion in apply.** When `apply_batch_state_diff_to_ethereum_state` produces an empty account, delete it from the state trie and remove its storage trie, matching Ethereum's post-Spurious Dragon semantics.

### Tests
- Genesis construction covers accounts with code, storage-only accounts, and zero-slot filtering.
- Existing cross-verification against a `strata_mpt`-backed test oracle preserved.
- `apply_batch_state_diff_to_ethereum_state` empty-account deletion covered.
- `EthereumStateExt` helpers exercised in genesis-construction tests.

This PR was created with help from Claude Code and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

STR-2404 (#1950) needs the prestate API to power snapshot-based partial replay in `alpen-ee-da-tool`. Scoping the reth-statediff work here keeps review with reth-statediff owners; #1950 then only needs an EE DA reviewer.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
