### PR TITLE
ci(sp1-e2e): make SP1 proving config settable from GH variables

### DIFF
--- a/.github/sp1-e2e/.env.ci
+++ b/.github/sp1-e2e/.env.ci
@@ -11,10 +11,8 @@ RUST_LOG=info,strata_prover_core=debug,alpen_ee_da=debug,strata_sequencer=debug
 # Chainspec must match alpen-client's --custom-chain
 ALPEN_CHAIN_CONFIG=crates/reth/chainspec/src/res/testnet-chain.json
 
-# SP1 proving — NETWORK_PRIVATE_KEY injected via compose environment block
+# SP1 proving — the prover backend, endpoint and key are injected via the
+# compose environment block instead, so CI can override them per run
 CHECKPOINT_PREDICATE=sp1-groth16
 ALPEN_PREDICATE=sp1-groth16
-SP1_PROVER=network
-SP1_PROOF_STRATEGY=reserved
-NETWORK_RPC_URL=https://rpc.production.succinct.xyz
 ELF_BASE_PATH=/app/elfs/sp1

--- a/.github/sp1-e2e/compose-override.yml
+++ b/.github/sp1-e2e/compose-override.yml
@@ -7,6 +7,15 @@
 #     -f .github/sp1-e2e/compose-override.yml \
 #     up -d
 
+# Both services prove (strata: checkpoint, alpen-client: chunk), so they need
+# identical proving config. Values come from the CI shell, not .env.ci — see
+# run-test.sh for the defaults.
+x-sp1-proving: &sp1-proving
+  NETWORK_PRIVATE_KEY: ${NETWORK_PRIVATE_KEY}
+  SP1_PROVER: ${SP1_PROVER}
+  SP1_PROOF_STRATEGY: ${SP1_PROOF_STRATEGY}
+  NETWORK_RPC_URL: ${NETWORK_RPC_URL}
+
 services:
   strata:
     image: ${ECR_REGISTRY}/strata:${IMAGE_TAG}
@@ -15,7 +24,7 @@ services:
     env_file:
       - ../.github/sp1-e2e/.env.ci
     environment:
-      - NETWORK_PRIVATE_KEY=${NETWORK_PRIVATE_KEY}
+      <<: *sp1-proving
     volumes:
       - ../.github/sp1-e2e/config.seq.toml:/app/configs/config.seq.toml:ro
       - ../.github/sp1-e2e/sequencer.toml:/app/configs/sequencer.toml:ro
@@ -30,12 +39,12 @@ services:
     shm_size: '8gb'
     command: []
     environment:
-      - SEQUENCER_MODE=true
-      - NETWORK_PRIVATE_KEY=${NETWORK_PRIVATE_KEY}
-      - OL_SUBMIT_URL=ws://strata:8435
-      - STRATA_SUBMIT_RPC_TOKEN=dev-only-submit-token
-      - BTCIO_FEE_POLICY=fixed
-      - BTCIO_FEE_RATE=5
+      <<: *sp1-proving
+      SEQUENCER_MODE: "true"
+      OL_SUBMIT_URL: ws://strata:8435
+      STRATA_SUBMIT_RPC_TOKEN: dev-only-submit-token
+      BTCIO_FEE_POLICY: fixed
+      BTCIO_FEE_RATE: 5
     env_file:
       - ../.github/sp1-e2e/.env.ci
       - ./configs/generated/.env.alpen

--- a/.github/sp1-e2e/run-test.sh
+++ b/.github/sp1-e2e/run-test.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 #
 # Required env vars:
 #   ECR_REGISTRY, IMAGE_TAG, NETWORK_PRIVATE_KEY
+#
+# Optional env vars, defaulted below and set from GitHub Actions variables:
+#   SP1_PROVER, SP1_PROOF_STRATEGY, NETWORK_RPC_URL
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -43,6 +46,11 @@ export CHAIN_SPEC=testnet
 # CI-only throwaway value — 04 (P2TR type tag) + 32-byte x-only pubkey derived
 # from the "abandon" mnemonic. Not used for real funds.
 export SAFE_HARBOUR_ADDRESS="0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+# An unset GitHub Actions variable expands to empty, not absent — hence `:-`.
+export SP1_PROVER="${SP1_PROVER:-network}"
+export SP1_PROOF_STRATEGY="${SP1_PROOF_STRATEGY:-reserved}"
+export NETWORK_RPC_URL="${NETWORK_RPC_URL:-https://rpc.production.succinct.xyz}"
 
 # --- Low-level helpers ---
 
@@ -515,6 +523,8 @@ assert_no_always_accept() {
 # --- Orchestration ---
 
 rm -f "${FAILURE_REASON_FILE}"
+
+echo "=== SP1 proving: ${SP1_PROVER} (strategy=${SP1_PROOF_STRATEGY}, rpc=${NETWORK_RPC_URL}) ==="
 
 preflight_cleanup
 start_signet_fast

--- a/.github/workflows/ci-sp1-e2e.yml
+++ b/.github/workflows/ci-sp1-e2e.yml
@@ -3,6 +3,10 @@
 #
 # Reuses prebuilt images from ci-build (same SHA). If images are not yet
 # available, retries for up to 3 minutes before failing.
+#
+# Proving is configured by the optional `prod` environment variables SP1_PROVER,
+# SP1_PROOF_STRATEGY and NETWORK_RPC_URL; each falls back to the default in
+# .github/sp1-e2e/run-test.sh when unset.
 
 name: CI — SP1 E2E Proving Test
 
@@ -172,6 +176,9 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}/${{ vars.SHARED_ECR_REPOSITORY_PREFIX }}
           IMAGE_TAG: ${{ needs.check-new-commits.outputs.short_tag }}
           NETWORK_PRIVATE_KEY: ${{ secrets.NETWORK_PRIVATE_KEY }}
+          SP1_PROVER: ${{ vars.SP1_PROVER }}
+          SP1_PROOF_STRATEGY: ${{ vars.SP1_PROOF_STRATEGY }}
+          NETWORK_RPC_URL: ${{ vars.NETWORK_RPC_URL }}
         run: |
           chmod +x .github/sp1-e2e/run-test.sh
           .github/sp1-e2e/run-test.sh


### PR DESCRIPTION
## Description
Makes the SP1 E2E test's proving backend, proof strategy, and network endpoint settable from `prod` environment variables instead of being hardcoded in `.env.ci`; unset variables fall back to today's values.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update