### PR TITLE
feat(alpen-client): validate EE prover predicate key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "strata-ee-acct-types",
  "strata-ee-chain-types",
  "strata-identifiers",
+ "strata-predicate",
  "strata-snark-acct-types",
  "thiserror 2.0.18",
  "tokio",

--- a/bin/alpen-client/Cargo.toml
+++ b/bin/alpen-client/Cargo.toml
@@ -23,7 +23,12 @@ sequencer = [
 ]
 # SP1 remote proving for the EE chunk + acct provers. Required for
 # production; native-only test builds can drop this feature.
-sp1 = ["dep:zkaleido-sp1-host", "strata-paas/remote", "strata-zkvm-hosts/sp1"]
+sp1 = [
+  "dep:zkaleido-sp1-host",
+  "strata-paas/remote",
+  "strata-proofimpl-predicate-keys/sp1",
+  "strata-zkvm-hosts/sp1",
+]
 
 [[bin]]
 name = "alpen-client"

--- a/bin/alpen-client/src/dummy_ol_client.rs
+++ b/bin/alpen-client/src/dummy_ol_client.rs
@@ -11,7 +11,9 @@ use alpen_ee_common::{
 use async_trait::async_trait;
 use strata_acct_types::Hash;
 use strata_identifiers::{Buf32, Epoch, L1Height, OLBlockCommitment, OLTxId};
+use strata_predicate::PredicateKey;
 use strata_primitives::EpochCommitment;
+use strata_proofimpl_predicate_keys::{NativeAlpenAcctPredicateKey, PredicateKeyProvider};
 use strata_snark_acct_types::{ProofState, Seqno, SnarkAccountUpdate};
 
 /// A dummy OL client that returns mock responses for testing.
@@ -105,6 +107,12 @@ impl SequencerOLClient for DummyOLClient {
             seq_no,
             proof_state,
         })
+    }
+
+    async fn get_latest_account_update_vk(&self) -> Result<PredicateKey, OLClientError> {
+        Ok(NativeAlpenAcctPredicateKey
+            .predicate_key()
+            .expect("native account predicate key must be available"))
     }
 
     async fn get_asm_manifest_commitment(

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -39,7 +39,7 @@ use alpen_chainspec::{
 };
 use alpen_ee_common::{
     chain_status_checked, BatchStorage, BlockNumHash, ChunkStorage, ExecBlockStorage, OLClient,
-    Storage,
+    SequencerOLClient, Storage,
 };
 use alpen_ee_config::{AlpenEeConfig, AlpenEeParams};
 use alpen_ee_database::init_db_storage;
@@ -111,12 +111,14 @@ mod sequencer_imports {
     };
     pub(super) use alpen_reth_witness::RangeWitnessExtractor;
     pub(super) use strata_paas::{
-        ProverBuilder, ProverServiceBuilder, ReceiptStore, RetryConfig, TaskStore,
+        Prover, ProverBuilder, ProverHandle, ProverServiceBuilder, ReceiptStore, RetryConfig,
+        TaskStore,
     };
     pub(super) use strata_proofimpl_alpen_acct::EeAcctProgram;
     pub(super) use strata_proofimpl_alpen_chunk::EeChunkProgram;
     pub(super) use strata_proofimpl_predicate_keys::{
-        NativeAlpenChunkPredicateKey, PredicateKeyProvider,
+        validate_expected_predicate_key, NativeAlpenAcctPredicateKey, NativeAlpenChunkPredicateKey,
+        PredicateKeyProvider, Sp1Groth16PredicateKey,
     };
     #[cfg(feature = "sp1")]
     pub(super) use strata_zkvm_hosts::sp1::{alpen_acct_host, alpen_chunk_host};
@@ -790,67 +792,27 @@ fn main() {
                 ))
                 .retry(RetryConfig::default());
 
-                // Dev/test escape hatch: use zkaleido NativeHost instead of
-                // the SP1 remote host. This skips real Groth16 proving and
-                // the need for compiled guest ELFs — only safe for
-                // functional tests. The acct program is wired with the
-                // chunk program's deterministic test predicate key so the
-                // native-host Schnorr signature actually verifies.
-                let (chunk_prover, acct_prover) = if ext.dev_native_prover {
-                    info!(target: "alpen-client", component = "alpen", "EE chunk + acct provers: native host (dev/test only)");
-                    let chunk = chunk_builder.native(EeChunkProgram::native_host());
-                    let chunk_predicate_key = NativeAlpenChunkPredicateKey
-                        .predicate_key()
-                        .expect("native chunk predicate key must be available");
-                    let acct_program = EeAcctProgram::new(chunk_predicate_key);
-                    let acct = acct_builder.native(acct_program.native_host());
-                    (chunk, acct)
-                } else {
-                    #[cfg(feature = "sp1")]
-                    {
-                        let deadline_secs = ext
-                            .sp1_proof_deadline_secs
-                            .unwrap_or(DEFAULT_SP1_DEADLINE_SECS);
-                        let deadline = Duration::from_secs(deadline_secs);
-                        info!(target: "alpen-client", component = "alpen", deadline_secs, "sp1 EE prover deadline configured");
-                        let sp1_config = SP1HostConfig::default().with_deadline(deadline);
-                        let chunk_host: SP1Host =
-                            (**alpen_chunk_host(sp1_config.clone()).await).clone();
-                        let acct_host: SP1Host = (**alpen_acct_host(sp1_config).await).clone();
-                        (
-                            chunk_builder.remote(chunk_host),
-                            acct_builder.remote(acct_host),
-                        )
-                    }
-                    #[cfg(not(feature = "sp1"))]
-                    {
-                        return Err(eyre::eyre!(
-                            "remote SP1 prover is not compiled in; pass --dev-native-prover \
-                             or build with the `sp1` feature"
-                        ));
-                    }
-                };
+                let batch_prover = launch_validated_ee_batch_prover(
+                    ol_client.as_ref(),
+                    &service_executor,
+                    EeProverBuilders {
+                        chunk: chunk_builder,
+                        account: acct_builder,
+                    },
+                    EeProverStores {
+                        chunk_storage: chunk_storage_dyn,
+                        batch_proofs,
+                    },
+                    ext.dev_native_prover,
+                    ext.sp1_proof_deadline_secs,
+                )
+                .await?;
 
-                let prover_tick = Duration::from_secs(5);
-                let chunk_handle = ProverServiceBuilder::new(chunk_prover)
-                    .tick_interval(prover_tick)
-                    .launch(&service_executor)
-                    .await
-                    .map_err(|e| eyre::eyre!("launching chunk prover service: {e}"))?;
-                let acct_handle = ProverServiceBuilder::new(acct_prover)
-                    .tick_interval(prover_tick)
-                    .launch(&service_executor)
-                    .await
-                    .map_err(|e| eyre::eyre!("launching acct prover service: {e}"))?;
-
-                let batch_prover = Arc::new(PaasBatchProver::new(
-                    chunk_handle,
-                    acct_handle,
-                    chunk_storage_dyn,
-                    batch_proofs,
-                ));
-
-                info!(target: "alpen-client", component = "alpen", "EE chunk + acct paas provers started (SP1 remote)");
+                info!(
+                    target: "alpen-client",
+                    component = "alpen",
+                    "EE chunk + acct paas provers started"
+                );
 
                 let (batch_lifecycle_handle, batch_lifecycle_task) = create_batch_lifecycle_task(
                     None,
@@ -1251,6 +1213,201 @@ fn validate_ee_params_genesis(
     }
 
     Ok(())
+}
+
+#[cfg(feature = "sequencer")]
+async fn launch_validated_ee_batch_prover(
+    ol_client: &(impl SequencerOLClient + Send + Sync),
+    service_executor: &ServiceExecutor,
+    builders: EeProverBuilders,
+    stores: EeProverStores,
+    use_native_prover: bool,
+    sp1_deadline_secs: Option<u64>,
+) -> eyre::Result<Arc<PaasBatchProver>> {
+    let ol_account_update_vk = ol_client
+        .get_latest_account_update_vk()
+        .await
+        .context("failed to fetch OL account update_vk for prover validation")?;
+    let prover_config =
+        build_ee_prover_config(builders, use_native_prover, sp1_deadline_secs).await?;
+
+    validate_ee_account_prover_predicate_key(
+        &ol_account_update_vk,
+        &prover_config.account_predicate_key,
+    )?;
+
+    let (chunk_handle, acct_handle) =
+        launch_ee_prover_services(service_executor, prover_config.provers).await?;
+
+    Ok(Arc::new(PaasBatchProver::new(
+        chunk_handle,
+        acct_handle,
+        stores.chunk_storage,
+        stores.batch_proofs,
+    )))
+}
+
+#[cfg(feature = "sequencer")]
+struct EeProverBuilders {
+    chunk: ProverBuilder<ChunkSpec>,
+    account: ProverBuilder<AcctSpec>,
+}
+
+#[cfg(feature = "sequencer")]
+struct EeProverStores {
+    chunk_storage: Arc<dyn ChunkStorage>,
+    batch_proofs: Arc<EeBatchProofDbManager>,
+}
+
+#[cfg(feature = "sequencer")]
+struct EeProverConfig {
+    provers: EeProvers,
+    account_predicate_key: PredicateKey,
+}
+
+#[cfg(feature = "sequencer")]
+struct EeProvers {
+    chunk: Prover<ChunkSpec>,
+    account: Prover<AcctSpec>,
+}
+
+#[cfg(feature = "sequencer")]
+async fn build_ee_prover_config(
+    builders: EeProverBuilders,
+    use_native_prover: bool,
+    sp1_deadline_secs: Option<u64>,
+) -> eyre::Result<EeProverConfig> {
+    if use_native_prover {
+        return Ok(build_native_ee_prover_config(builders));
+    }
+
+    build_sp1_ee_prover_config(builders, sp1_deadline_secs).await
+}
+
+#[cfg(feature = "sequencer")]
+fn build_native_ee_prover_config(builders: EeProverBuilders) -> EeProverConfig {
+    info!(
+        target: "alpen-client",
+        "EE chunk + acct provers: native host (dev/test only)"
+    );
+
+    let chunk = builders.chunk.native(EeChunkProgram::native_host());
+    let chunk_predicate_key = NativeAlpenChunkPredicateKey
+        .predicate_key()
+        .expect("native chunk predicate key must be available");
+    let acct_program = EeAcctProgram::new(chunk_predicate_key);
+    let account = builders.account.native(acct_program.native_host());
+    let account_predicate_key = NativeAlpenAcctPredicateKey
+        .predicate_key()
+        .expect("native account predicate key must be available");
+
+    EeProverConfig {
+        provers: EeProvers { chunk, account },
+        account_predicate_key,
+    }
+}
+
+#[cfg(all(feature = "sequencer", feature = "sp1"))]
+async fn build_sp1_ee_prover_config(
+    builders: EeProverBuilders,
+    deadline_secs: Option<u64>,
+) -> eyre::Result<EeProverConfig> {
+    use zkaleido::ZkVmExecutor;
+
+    let deadline_secs = deadline_secs.unwrap_or(DEFAULT_SP1_DEADLINE_SECS);
+    let deadline = Duration::from_secs(deadline_secs);
+    info!(
+        target: "alpen-client",
+        deadline_secs,
+        "sp1 EE prover deadline configured"
+    );
+
+    let sp1_config = SP1HostConfig::default().with_deadline(deadline);
+    let chunk_host: SP1Host = (**alpen_chunk_host(sp1_config.clone()).await).clone();
+    let acct_host: SP1Host = (**alpen_acct_host(sp1_config).await).clone();
+    let account_predicate_key = Sp1Groth16PredicateKey::new(acct_host.program_id().0)
+        .predicate_key()
+        .map_err(|e| eyre::eyre!("failed to derive local SP1 account prover predicate key: {e}"))?;
+
+    Ok(EeProverConfig {
+        provers: EeProvers {
+            chunk: builders.chunk.remote(chunk_host),
+            account: builders.account.remote(acct_host),
+        },
+        account_predicate_key,
+    })
+}
+
+#[cfg(all(feature = "sequencer", not(feature = "sp1")))]
+async fn build_sp1_ee_prover_config(
+    _builders: EeProverBuilders,
+    _deadline_secs: Option<u64>,
+) -> eyre::Result<EeProverConfig> {
+    Err(eyre::eyre!(
+        "remote SP1 prover is not compiled in; pass --dev-native-prover \
+         or build with the `sp1` feature"
+    ))
+}
+
+#[cfg(feature = "sequencer")]
+async fn launch_ee_prover_services(
+    service_executor: &ServiceExecutor,
+    provers: EeProvers,
+) -> eyre::Result<(ProverHandle<ChunkSpec>, ProverHandle<AcctSpec>)> {
+    let prover_tick = Duration::from_secs(5);
+    let chunk_handle = ProverServiceBuilder::new(provers.chunk)
+        .tick_interval(prover_tick)
+        .launch(service_executor)
+        .await
+        .map_err(|e| eyre::eyre!("launching chunk prover service: {e}"))?;
+    let acct_handle = ProverServiceBuilder::new(provers.account)
+        .tick_interval(prover_tick)
+        .launch(service_executor)
+        .await
+        .map_err(|e| eyre::eyre!("launching acct prover service: {e}"))?;
+
+    Ok((chunk_handle, acct_handle))
+}
+
+#[cfg(feature = "sequencer")]
+fn validate_ee_account_prover_predicate_key(
+    ol_update_vk: &PredicateKey,
+    local_predicate_key: &PredicateKey,
+) -> eyre::Result<()> {
+    validate_expected_predicate_key(ol_update_vk, local_predicate_key).map_err(|e| {
+        eyre::eyre!(
+            "OL account update_vk does not match local EE account prover predicate key: {e}"
+        )
+    })
+}
+
+#[cfg(test)]
+mod additional_config_tests {
+    use strata_predicate::PredicateTypeId;
+
+    use super::*;
+
+    #[cfg(feature = "sequencer")]
+    #[test]
+    fn ee_account_prover_predicate_key_validation_accepts_match() {
+        let predicate = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3]);
+
+        validate_ee_account_prover_predicate_key(&predicate, &predicate).unwrap();
+    }
+
+    #[cfg(feature = "sequencer")]
+    #[test]
+    fn ee_account_prover_predicate_key_validation_rejects_mismatch() {
+        let ol_update_vk = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3]);
+        let local_predicate_key = PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![4, 5, 6]);
+
+        let err = validate_ee_account_prover_predicate_key(&ol_update_vk, &local_predicate_key)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("OL account update_vk does not match local EE account prover"));
+        assert!(err.contains("predicate key mismatch"));
+    }
 }
 
 /// Run node with logging

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -1228,8 +1228,14 @@ async fn launch_validated_ee_batch_prover(
         .get_latest_account_update_vk()
         .await
         .context("failed to fetch OL account update_vk for prover validation")?;
-    let prover_config =
-        build_ee_prover_config(builders, use_native_prover, sp1_deadline_secs).await?;
+    let backend = if use_native_prover {
+        EeProverBackend::Native
+    } else {
+        EeProverBackend::Sp1 {
+            deadline_secs: sp1_deadline_secs,
+        }
+    };
+    let prover_config = build_ee_prover_config(builders, backend).await?;
 
     validate_ee_account_prover_predicate_key(
         &ol_account_update_vk,
@@ -1272,81 +1278,73 @@ struct EeProvers {
 }
 
 #[cfg(feature = "sequencer")]
-async fn build_ee_prover_config(
-    builders: EeProverBuilders,
-    use_native_prover: bool,
-    sp1_deadline_secs: Option<u64>,
-) -> eyre::Result<EeProverConfig> {
-    if use_native_prover {
-        return Ok(build_native_ee_prover_config(builders));
-    }
-
-    build_sp1_ee_prover_config(builders, sp1_deadline_secs).await
+enum EeProverBackend {
+    Native,
+    Sp1 { deadline_secs: Option<u64> },
 }
 
 #[cfg(feature = "sequencer")]
-fn build_native_ee_prover_config(builders: EeProverBuilders) -> EeProverConfig {
-    info!(
-        target: "alpen-client",
-        "EE chunk + acct provers: native host (dev/test only)"
-    );
-
-    let chunk = builders.chunk.native(EeChunkProgram::native_host());
-    let chunk_predicate_key = NativeAlpenChunkPredicateKey
-        .predicate_key()
-        .expect("native chunk predicate key must be available");
-    let acct_program = EeAcctProgram::new(chunk_predicate_key);
-    let account = builders.account.native(acct_program.native_host());
-    let account_predicate_key = NativeAlpenAcctPredicateKey
-        .predicate_key()
-        .expect("native account predicate key must be available");
-
-    EeProverConfig {
-        provers: EeProvers { chunk, account },
-        account_predicate_key,
-    }
-}
-
-#[cfg(all(feature = "sequencer", feature = "sp1"))]
-async fn build_sp1_ee_prover_config(
+async fn build_ee_prover_config(
     builders: EeProverBuilders,
-    deadline_secs: Option<u64>,
+    backend: EeProverBackend,
 ) -> eyre::Result<EeProverConfig> {
-    use zkaleido::ZkVmExecutor;
+    match backend {
+        EeProverBackend::Native => {
+            info!(
+                target: "alpen-client",
+                "EE chunk + acct provers: native host (dev/test only)"
+            );
 
-    let deadline_secs = deadline_secs.unwrap_or(DEFAULT_SP1_DEADLINE_SECS);
-    let deadline = Duration::from_secs(deadline_secs);
-    info!(
-        target: "alpen-client",
-        deadline_secs,
-        "sp1 EE prover deadline configured"
-    );
+            let chunk = builders.chunk.native(EeChunkProgram::native_host());
+            let chunk_predicate_key = NativeAlpenChunkPredicateKey
+                .predicate_key()
+                .expect("native chunk predicate key must be available");
+            let acct_program = EeAcctProgram::new(chunk_predicate_key);
+            let account = builders.account.native(acct_program.native_host());
+            let account_predicate_key = NativeAlpenAcctPredicateKey
+                .predicate_key()
+                .expect("native account predicate key must be available");
 
-    let sp1_config = SP1HostConfig::default().with_deadline(deadline);
-    let chunk_host: SP1Host = (**alpen_chunk_host(sp1_config.clone()).await).clone();
-    let acct_host: SP1Host = (**alpen_acct_host(sp1_config).await).clone();
-    let account_predicate_key = Sp1Groth16PredicateKey::new(acct_host.program_id().0)
-        .predicate_key()
-        .map_err(|e| eyre::eyre!("failed to derive local SP1 account prover predicate key: {e}"))?;
+            Ok(EeProverConfig {
+                provers: EeProvers { chunk, account },
+                account_predicate_key,
+            })
+        }
+        #[cfg(feature = "sp1")]
+        EeProverBackend::Sp1 { deadline_secs } => {
+            use zkaleido::ZkVmExecutor;
 
-    Ok(EeProverConfig {
-        provers: EeProvers {
-            chunk: builders.chunk.remote(chunk_host),
-            account: builders.account.remote(acct_host),
-        },
-        account_predicate_key,
-    })
-}
+            let deadline_secs = deadline_secs.unwrap_or(DEFAULT_SP1_DEADLINE_SECS);
+            let deadline = Duration::from_secs(deadline_secs);
+            info!(
+                target: "alpen-client",
+                deadline_secs,
+                "sp1 EE prover deadline configured"
+            );
 
-#[cfg(all(feature = "sequencer", not(feature = "sp1")))]
-async fn build_sp1_ee_prover_config(
-    _builders: EeProverBuilders,
-    _deadline_secs: Option<u64>,
-) -> eyre::Result<EeProverConfig> {
-    Err(eyre::eyre!(
-        "remote SP1 prover is not compiled in; pass --dev-native-prover \
-         or build with the `sp1` feature"
-    ))
+            let sp1_config = SP1HostConfig::default().with_deadline(deadline);
+            let chunk_host: SP1Host = (**alpen_chunk_host(sp1_config.clone()).await).clone();
+            let acct_host: SP1Host = (**alpen_acct_host(sp1_config).await).clone();
+            let account_predicate_key = Sp1Groth16PredicateKey::new(acct_host.program_id().0)
+                .predicate_key()
+                .map_err(|e| {
+                    eyre::eyre!("failed to derive local SP1 account prover predicate key: {e}")
+                })?;
+
+            Ok(EeProverConfig {
+                provers: EeProvers {
+                    chunk: builders.chunk.remote(chunk_host),
+                    account: builders.account.remote(acct_host),
+                },
+                account_predicate_key,
+            })
+        }
+        #[cfg(not(feature = "sp1"))]
+        EeProverBackend::Sp1 { .. } => Err(eyre::eyre!(
+            "remote SP1 prover is not compiled in; pass --dev-native-prover \
+             or build with the `sp1` feature"
+        )),
+    }
 }
 
 #[cfg(feature = "sequencer")]

--- a/bin/alpen-client/src/ol_client.rs
+++ b/bin/alpen-client/src/ol_client.rs
@@ -6,6 +6,7 @@ use alpen_ee_common::{
 };
 use async_trait::async_trait;
 use strata_identifiers::{Epoch, EpochCommitment, Hash, L1Height, OLTxId};
+use strata_predicate::PredicateKey;
 use strata_snark_acct_types::SnarkAccountUpdate;
 
 use crate::{dummy_ol_client::DummyOLClient, rpc_client::RpcOLClient};
@@ -70,6 +71,13 @@ impl SequencerOLClient for OLClientKind {
         match self {
             Self::Rpc(client) => client.get_latest_account_state().await,
             Self::Dummy(client) => client.get_latest_account_state().await,
+        }
+    }
+
+    async fn get_latest_account_update_vk(&self) -> Result<PredicateKey, OLClientError> {
+        match self {
+            Self::Rpc(client) => client.get_latest_account_update_vk().await,
+            Self::Dummy(client) => client.get_latest_account_update_vk().await,
         }
     }
 

--- a/bin/alpen-client/src/rpc_client.rs
+++ b/bin/alpen-client/src/rpc_client.rs
@@ -20,6 +20,7 @@ use strata_ol_rpc_api::{OLClientRpcClient, OLSubmitRpcClient};
 use strata_ol_rpc_types::{
     OLBlockTag, RpcOLTransaction, RpcSnarkAccountUpdate, RpcTransactionPayload, RpcTxConstraints,
 };
+use strata_predicate::PredicateKey;
 use strata_snark_acct_types::{ProofState, SnarkAccountUpdate};
 use tracing::info;
 
@@ -340,6 +341,24 @@ impl SequencerOLClient for RpcOLClient {
                 snark_account_state.next_inbox_msg_idx(),
             ),
         })
+    }
+
+    async fn get_latest_account_update_vk(&self) -> Result<PredicateKey, OLClientError> {
+        retry_with_backoff_async(
+            "ol_client_get_latest_account_update_vk",
+            STARTUP_RPC_MAX_RETRIES,
+            &ExponentialBackoff::default(),
+            || async {
+                let snark_account_state = call_read_rpc!(
+                    self,
+                    get_snark_account_state_by_tag(self.account_id, OLBlockTag::Latest)
+                )?
+                .ok_or_else(|| OLClientError::Rpc("missing latest account state".into()))?;
+
+                Ok(snark_account_state.update_vk().clone())
+            },
+        )
+        .await
     }
 
     async fn get_asm_manifest_commitment(

--- a/crates/alpen-ee/common/Cargo.toml
+++ b/crates/alpen-ee/common/Cargo.toml
@@ -18,6 +18,7 @@ strata-codec.workspace = true
 strata-ee-acct-types.workspace = true
 strata-ee-chain-types.workspace = true
 strata-identifiers.workspace = true
+strata-predicate.workspace = true
 strata-snark-acct-types.workspace = true
 
 alloy-eips.workspace = true

--- a/crates/alpen-ee/common/src/traits/ol_client.rs
+++ b/crates/alpen-ee/common/src/traits/ol_client.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use strata_acct_types::MessageEntry;
 use strata_identifiers::{Epoch, EpochCommitment, Hash, L1Height, OLBlockCommitment, OLTxId};
+use strata_predicate::PredicateKey;
 use strata_snark_acct_types::{ProofState, Seqno, SnarkAccountUpdate};
 use thiserror::Error;
 
@@ -85,6 +86,9 @@ pub trait SequencerOLClient {
 
     /// Retrieves latest account state in the OL Chain for this account.
     async fn get_latest_account_state(&self) -> Result<OLAccountStateView, OLClientError>;
+
+    /// Retrieves the latest account-update predicate key committed in OL.
+    async fn get_latest_account_update_vk(&self) -> Result<PredicateKey, OLClientError>;
 
     /// Retrieves the canonical ASM manifest commitment for an L1 block height.
     ///

--- a/docker/docker-compose-eest.yml
+++ b/docker/docker-compose-eest.yml
@@ -42,6 +42,7 @@ services:
       - --sequencer-pubkey
       - ${SEQUENCER_PUBKEY}
       - --dummy-ol-client
+      - --dev-native-prover
       - --custom-chain
       - ${CHAIN_SPEC:-dev}
       - --datadir


### PR DESCRIPTION
## Description

Validate the EE account prover predicate key during `alpen-client` startup before launching prover services. The startup path now fetches the committed OL account `update_vk`, derives the local account prover predicate key for native or SP1 mode, and fails early if they differ.

The prover startup code was also refactored into focused helpers so prover selection, predicate-key validation, and service launch are easier to review independently.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://alpenlabs.atlassian.net/browse/STR-3848

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: I used Codex to help implement, refactor, test, and draft this PR.

## Verification

- `cargo test -p alpen-client ee_account_prover_predicate_key_validation`
- `cargo clippy -p alpen-client --all-targets --all-features -- -D warnings`
- `./run_tests.sh -g alpen_client`

Functional test datadir: `functional-tests/_dd/9-16-ksktw`

## Related Issues

- STR-3848: https://alpenlabs.atlassian.net/browse/STR-3848
