### PR TITLE
[alpen-cli] set explicit gas in tx

### DIFF
--- a/bin/alpen-cli/src/cmd/send.rs
+++ b/bin/alpen-cli/src/cmd/send.rs
@@ -111,6 +111,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings) -> Result<(), 
             ))?;
             let tx = TransactionRequest::default()
                 .with_to(address)
+                .with_gas_price(1_100_000_000u128)
                 .with_value(U256::from(args.amount as u128 * SATS_TO_WEI));
             let res = l2w
                 .send_transaction(tx)


### PR DESCRIPTION
## Description
Our alpen-cli does not enable setting gas in transactions. Our tx are legacy type (no base and priority), and this does not play well with our EVM. We automatically set the gas too low, and the sequencer never picks them up (they remain in the mempool) -- why? I don't know. It's possible that the issue is mainly in bootstrap period, where we have no prior activity, and so the (gas) rpc that the cli uses (if such exists) returns minimal value. It can probably happen in very quite times as well.

OR: legacy txes don't set _max fee_ explicitly. may be related to that.

Should we care? Well, anyone that bridges funds will use the cli (in testnet, until we have the new UI available), and so their first tx after the funds are minted will probably be through the cli as well. So we should probably care.

So here we set the gas to be 1.1 gwei. It's an arbitrary value, but should be sufficient.

A lot of words for a small change...

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
