### PR TITLE
ci: publish strata-checkpoint-sync to public ECR

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -249,7 +249,7 @@ jobs:
       # see alpen-infra github-actions-image-push (STR-3894). Only the programs
       # published publicly need this login.
       - name: Login to Amazon ECR Public
-        if: matrix.program == 'strata' || matrix.program == 'alpen-client'
+        if: matrix.program == 'strata' || matrix.program == 'strata-checkpoint-sync' || matrix.program == 'alpen-client'
         run: |
           aws ecr-public get-login-password --region us-east-1 \
             | docker login --username AWS --password-stdin public.ecr.aws
@@ -298,12 +298,15 @@ jobs:
 
           # Always push the private image. Additionally push a public mirror for
           # programs with an external-facing repo, mapping the internal program
-          # name to its public gallery repo name (alpen-client -> alpen).
+          # name to its public gallery repo name (alpen-client -> alpen,
+          # strata-checkpoint-sync -> checkpoint-sync). Keep the set of mapped
+          # programs in sync with the `Login to Amazon ECR Public` condition.
           TAGS=( -t "${FULL_IMAGE}" )
           case "$PROGRAM" in
-            strata)       PUBLIC_REPO="strata" ;;
-            alpen-client) PUBLIC_REPO="alpen" ;;
-            *)            PUBLIC_REPO="" ;;
+            strata)                 PUBLIC_REPO="strata" ;;
+            strata-checkpoint-sync) PUBLIC_REPO="checkpoint-sync" ;;
+            alpen-client)           PUBLIC_REPO="alpen" ;;
+            *)                      PUBLIC_REPO="" ;;
           esac
           if [ -n "$PUBLIC_REPO" ]; then
             TAGS+=( -t "${PUBLIC_ECR_BASE}/${PUBLIC_REPO}:${SHORT_TAG}" )


### PR DESCRIPTION
## Summary

Publish the `strata-checkpoint-sync` image to the public ECR gallery.

`ci-build.yml` has built and pushed `strata-checkpoint-sync` to the private shared ECR since #2082. External testnet operators have no credentials for the shared account and pull node images from `public.ecr.aws/alpenlabs`, so the image never reaches them.

The public repository `public.ecr.aws/alpenlabs/checkpoint-sync` already exists and the CI role (`github-actions-ecr-push`) already holds `ecr-public:PutImage` on it — verified against the live IAM policy. Nothing was published because the workflow had no mapping for the program. It currently has **0 images**.

This adds `strata-checkpoint-sync` to the two places that gate public publishing, alongside `strata` and `alpen-client`:

- the `Login to Amazon ECR Public` step condition
- the internal-program → public-repo `case` mapping (`strata-checkpoint-sync` → `checkpoint-sync`; the public repo has no `strata-` prefix)

No infrastructure change is required.

## Behaviour

`buildx` tags one built image for both registries, so the private and public copies share a digest. Per-program tags after this change:

| Program | Private | Public |
|---|---|---|
| `strata` | `strata/strata` | `alpenlabs/strata` |
| `strata-checkpoint-sync` | `strata/strata-checkpoint-sync` | `alpenlabs/checkpoint-sync` |
| `alpen-client` | `strata/alpen-client` | `alpenlabs/alpen` |
| `strata-signer` | `strata/strata-signer` | — |

## Testing

- Workflow YAML parses.
- Asserted the login-step condition and the `case` arms cover exactly the same set of programs — a mismatch here would mean a push attempt without a registry login.
- Simulated the tag-construction shell logic for all four matrix programs: only the three mapped programs gain a second tag; `strata-signer` is unchanged.
- Confirmed all three public repos exist and are present in the live `ECRPublicPushImages` resource list.

## Notes

`releases/0.3.0` predates the public-ECR block entirely and is intentionally left alone — it publishes nothing publicly. The backport in #2093 stays a pure CI-build change so that this workflow has a single source of truth on `main`.

Refs STR-3894
