### PR TITLE
feat: bump version to 0.4.0 and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-benchmarks"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-chainspec"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-cli"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "aes-gcm-siv",
  "alloy",
@@ -1053,7 +1053,7 @@ dependencies = [
  "strata-l1-txfmt",
  "strata-ol-bridge-types",
  "strata-primitives",
- "strata-test-utils-btcio 0.1.0",
+ "strata-test-utils-btcio 0.4.0",
  "terrors",
  "tokio",
  "toml 0.5.11",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-client"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-block-assembly"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-config"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-common",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-da-provider"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-common",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-da-runtime"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-common",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-da-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-reth-statediff",
  "bitcoin",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-database"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-common",
  "alpen-reth-db",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-engine"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-exec-chain"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-common",
  "anyhow",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-genesis"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-common",
  "alpen-ee-config",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-ol-tracker"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-common",
  "anyhow",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-rpc-api"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-rpc-types",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-rpc-server"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-common",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-rpc-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-sequencer"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-block-assembly",
  "alpen-ee-common",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-db"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-reth-statediff",
  "bincode",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-evm"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-sol-types",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-exex"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-node"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-rpc"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-statediff"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-chainspec",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-witness"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14655,7 +14655,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strata"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -14679,7 +14679,7 @@ dependencies = [
  "strata-chain-worker",
  "strata-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0",
+ "strata-codec-utils 0.4.0",
  "strata-common",
  "strata-config",
  "strata-consensus-logic",
@@ -14729,7 +14729,7 @@ dependencies = [
 
 [[package]]
 name = "strata-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "digest 0.10.7",
  "proptest",
@@ -14784,7 +14784,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2)",
+ "strata-codec-utils 0.1.0",
  "strata-identifiers",
  "strata-msg-fmt",
  "strata-predicate",
@@ -14928,7 +14928,7 @@ dependencies = [
  "strata-codec",
  "strata-crypto",
  "strata-l1-txfmt",
- "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.2)",
+ "strata-test-utils-btcio 0.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -14988,7 +14988,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2)",
+ "strata-codec-utils 0.1.0",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
  "thiserror 2.0.18",
@@ -15106,7 +15106,7 @@ dependencies = [
 
 [[package]]
 name = "strata-bridge-params"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -15157,7 +15157,7 @@ dependencies = [
 
 [[package]]
 name = "strata-btcio"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -15191,7 +15191,7 @@ dependencies = [
 
 [[package]]
 name = "strata-chain-worker"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -15229,7 +15229,7 @@ dependencies = [
 
 [[package]]
 name = "strata-checkpoint-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -15268,7 +15268,7 @@ dependencies = [
 
 [[package]]
 name = "strata-cli-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [[package]]
 name = "strata-codec"
@@ -15291,16 +15291,6 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-dependencies = [
- "borsh",
- "ssz",
- "ssz_derive",
- "strata-codec",
-]
-
-[[package]]
-name = "strata-codec-utils"
-version = "0.1.0"
 source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "borsh",
@@ -15310,8 +15300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-codec-utils"
+version = "0.4.0"
+dependencies = [
+ "borsh",
+ "ssz",
+ "ssz_derive",
+ "strata-codec",
+]
+
+[[package]]
 name = "strata-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "deadpool",
  "futures",
@@ -15325,7 +15325,7 @@ dependencies = [
 
 [[package]]
 name = "strata-config"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "proptest",
@@ -15336,7 +15336,7 @@ dependencies = [
 
 [[package]]
 name = "strata-consensus-logic"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15406,7 +15406,7 @@ dependencies = [
 
 [[package]]
 name = "strata-csm-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -15426,7 +15426,7 @@ dependencies = [
 
 [[package]]
 name = "strata-csm-worker"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -15445,7 +15445,7 @@ dependencies = [
  "strata-checkpoint-types",
  "strata-checkpoint-verification",
  "strata-codec",
- "strata-codec-utils 0.1.0",
+ "strata-codec-utils 0.4.0",
  "strata-common",
  "strata-csm-types",
  "strata-db-store-sled",
@@ -15467,7 +15467,7 @@ dependencies = [
 
 [[package]]
 name = "strata-da-framework"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "sha2",
@@ -15478,7 +15478,7 @@ dependencies = [
 
 [[package]]
 name = "strata-datatool"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-chainspec",
@@ -15524,7 +15524,7 @@ dependencies = [
 
 [[package]]
 name = "strata-db-store-sled"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -15556,7 +15556,7 @@ dependencies = [
 
 [[package]]
 name = "strata-db-tests"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "hex",
@@ -15580,7 +15580,7 @@ dependencies = [
 
 [[package]]
 name = "strata-db-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -15614,7 +15614,7 @@ dependencies = [
 
 [[package]]
 name = "strata-dbtool"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-eips",
  "alpen-ee-common",
@@ -15654,7 +15654,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -15674,7 +15674,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "ssz",
@@ -15696,7 +15696,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "ssz",
@@ -15714,7 +15714,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-chunk-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -15728,7 +15728,7 @@ dependencies = [
 
 [[package]]
 name = "strata-evm-ee"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15788,7 +15788,7 @@ dependencies = [
 
 [[package]]
 name = "strata-key-derivation"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "secp256k1 0.29.1",
@@ -15820,7 +15820,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ledger-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-acct-types",
  "strata-asm-manifest-types",
@@ -15894,7 +15894,7 @@ dependencies = [
 
 [[package]]
 name = "strata-mpt"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alloy-rlp",
  "alloy-rlp-derive",
@@ -15917,7 +15917,7 @@ dependencies = [
 
 [[package]]
 name = "strata-node-context"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitcoind-async-client",
  "strata-asm-params",
@@ -15931,7 +15931,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-block-assembly"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15977,7 +15977,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-bridge-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -15994,7 +15994,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "int-enum",
  "proptest",
@@ -16019,7 +16019,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "metrics",
@@ -16046,7 +16046,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-da"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "proptest",
@@ -16070,7 +16070,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-genesis"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-acct-types",
  "strata-checkpoint-types",
@@ -16105,7 +16105,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-mempool"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "metrics",
@@ -16138,7 +16138,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-msg-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "strata-codec",
@@ -16148,7 +16148,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-params"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -16161,7 +16161,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-rpc-api"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "jsonrpsee",
  "strata-identifiers",
@@ -16174,7 +16174,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-rpc-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "schemars 1.2.1",
@@ -16203,7 +16203,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-sequencer"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16215,7 +16215,7 @@ dependencies = [
  "strata-asm-proto-checkpoint-txs",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0",
+ "strata-codec-utils 0.4.0",
  "strata-common",
  "strata-crypto",
  "strata-csm-types",
@@ -16237,7 +16237,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-state-provider"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "futures",
  "strata-db-types",
@@ -16249,7 +16249,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-state-support-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-acct-types",
  "strata-asm-manifest-types",
@@ -16268,7 +16268,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-state-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "ssz",
@@ -16279,7 +16279,7 @@ dependencies = [
  "strata-acct-types",
  "strata-asm-manifest-types",
  "strata-codec",
- "strata-codec-utils 0.1.0",
+ "strata-codec-utils 0.4.0",
  "strata-identifiers",
  "strata-ledger-types",
  "strata-merkle",
@@ -16293,7 +16293,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-stf"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "ssz_primitives",
@@ -16323,7 +16323,7 @@ dependencies = [
 
 [[package]]
 name = "strata-open-rpc"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -16332,7 +16332,7 @@ dependencies = [
 
 [[package]]
 name = "strata-open-rpc-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.14.0",
@@ -16344,7 +16344,7 @@ dependencies = [
 
 [[package]]
 name = "strata-paas"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -16377,7 +16377,7 @@ dependencies = [
 
 [[package]]
 name = "strata-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.11.0",
@@ -16393,7 +16393,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-alpen-acct"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-da-runtime",
  "alpen-ee-da-types",
@@ -16418,7 +16418,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-alpen-chunk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alpen-reth-evm",
  "k256",
@@ -16444,7 +16444,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "k256",
  "ssz",
@@ -16469,7 +16469,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-evm-ee-stf"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16498,7 +16498,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-predicate-keys"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "hex",
  "sp1-verifier",
@@ -16512,7 +16512,7 @@ dependencies = [
 
 [[package]]
 name = "strata-prover-core"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -16526,7 +16526,7 @@ dependencies = [
 
 [[package]]
 name = "strata-provers-perf"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-da-types",
  "alpen-reth-evm",
@@ -16572,7 +16572,7 @@ dependencies = [
 
 [[package]]
 name = "strata-rpc-openrpc-spec"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-rpc-api",
  "serde_json",
@@ -16598,7 +16598,7 @@ dependencies = [
 
 [[package]]
 name = "strata-signer"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -16619,7 +16619,7 @@ dependencies = [
 
 [[package]]
 name = "strata-signer-bin"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -16642,7 +16642,7 @@ dependencies = [
 
 [[package]]
 name = "strata-simple-ee"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "digest 0.10.7",
  "sha2",
@@ -16654,7 +16654,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -16668,7 +16668,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-sys"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "strata-acct-types",
@@ -16679,7 +16679,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "ssz",
@@ -16697,7 +16697,7 @@ dependencies = [
 
 [[package]]
 name = "strata-sp1-guest-builder"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "cargo_metadata 0.19.2",
@@ -16712,7 +16712,7 @@ dependencies = [
 
 [[package]]
 name = "strata-state"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -16729,7 +16729,7 @@ dependencies = [
 
 [[package]]
 name = "strata-status"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "strata-csm-types",
  "strata-identifiers",
@@ -16741,7 +16741,7 @@ dependencies = [
 
 [[package]]
 name = "strata-storage"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -16769,7 +16769,7 @@ dependencies = [
 
 [[package]]
 name = "strata-storage-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "lru 0.18.0",
  "thiserror 2.0.18",
@@ -16791,7 +16791,7 @@ dependencies = [
 
 [[package]]
 name = "strata-test-cli"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -16831,7 +16831,7 @@ dependencies = [
 
 [[package]]
 name = "strata-test-utils"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",
@@ -16858,20 +16858,6 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btcio"
 version = "0.1.0"
-dependencies = [
- "anyhow",
- "bitcoin",
- "bitcoind-async-client",
- "corepc-node",
- "musig2",
- "rand 0.8.5",
- "strata-crypto",
- "tokio",
-]
-
-[[package]]
-name = "strata-test-utils-btcio"
-version = "0.1.0"
 source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.2#45a1fa2f52289b483dd9767b4ec9c80545d5789b"
 dependencies = [
  "anyhow",
@@ -16879,6 +16865,20 @@ dependencies = [
  "bitcoind-async-client",
  "corepc-node",
  "musig2",
+ "strata-crypto",
+ "tokio",
+]
+
+[[package]]
+name = "strata-test-utils-btcio"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "bitcoind-async-client",
+ "corepc-node",
+ "musig2",
+ "rand 0.8.5",
  "strata-crypto",
  "tokio",
 ]
@@ -16906,7 +16906,7 @@ dependencies = [
 
 [[package]]
 name = "strata-test-utils-l2"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "k256",
@@ -16928,7 +16928,7 @@ dependencies = [
 
 [[package]]
 name = "strata-test-utils-ssz"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "ssz",
@@ -16937,7 +16937,7 @@ dependencies = [
 
 [[package]]
 name = "strata-zkvm-hosts"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "strata-sp1-guest-builder",
  "tokio",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpen-benchmarks"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]

--- a/bin/alpen-cli/Cargo.toml
+++ b/bin/alpen-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-cli"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/bin/alpen-client/Cargo.toml
+++ b/bin/alpen-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-client"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-datatool"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-provers-perf"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/bin/strata-dbtool/Cargo.toml
+++ b/bin/strata-dbtool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-dbtool"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [[bin]]
 name = "strata-dbtool"

--- a/bin/strata-signer/Cargo.toml
+++ b/bin/strata-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-signer-bin"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [lints]

--- a/bin/strata-test-cli/Cargo.toml
+++ b/bin/strata-test-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-test-cli"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 edition = "2021"
 
 [lints]

--- a/bin/strata/Cargo.toml
+++ b/bin/strata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [features]

--- a/crates/acct-types/Cargo.toml
+++ b/crates/acct-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/alpen-ee/block-assembly/Cargo.toml
+++ b/crates/alpen-ee/block-assembly/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-block-assembly"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/common/Cargo.toml
+++ b/crates/alpen-ee/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/config/Cargo.toml
+++ b/crates/alpen-ee/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-config"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/da/provider/Cargo.toml
+++ b/crates/alpen-ee/da/provider/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-da-provider"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/da/runtime/Cargo.toml
+++ b/crates/alpen-ee/da/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-da-runtime"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/da/types/Cargo.toml
+++ b/crates/alpen-ee/da/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-da-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/database/Cargo.toml
+++ b/crates/alpen-ee/database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-database"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/engine/Cargo.toml
+++ b/crates/alpen-ee/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-engine"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/exec-chain/Cargo.toml
+++ b/crates/alpen-ee/exec-chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-exec-chain"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/genesis/Cargo.toml
+++ b/crates/alpen-ee/genesis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-genesis"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/ol-tracker/Cargo.toml
+++ b/crates/alpen-ee/ol-tracker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-ol-tracker"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/rpc/api/Cargo.toml
+++ b/crates/alpen-ee/rpc/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-rpc-api"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/rpc/server/Cargo.toml
+++ b/crates/alpen-ee/rpc/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-rpc-server"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/rpc/types/Cargo.toml
+++ b/crates/alpen-ee/rpc/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-rpc-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/alpen-ee/sequencer/Cargo.toml
+++ b/crates/alpen-ee/sequencer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-ee-sequencer"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/bridge-params/Cargo.toml
+++ b/crates/bridge-params/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-bridge-params"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/bridge-types/Cargo.toml
+++ b/crates/bridge-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-ol-bridge-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-btcio"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/chain-worker/Cargo.toml
+++ b/crates/chain-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-chain-worker"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 description = "Chain worker implementation using the OL STF"
 

--- a/crates/checkpoint-types/Cargo.toml
+++ b/crates/checkpoint-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-checkpoint-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/cli-common/Cargo.toml
+++ b/crates/cli-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-cli-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/codec-utils/Cargo.toml
+++ b/crates/codec-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-codec-utils"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-config"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/consensus-logic/Cargo.toml
+++ b/crates/consensus-logic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-consensus-logic"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/csm-types/Cargo.toml
+++ b/crates/csm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-csm-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/csm-worker/Cargo.toml
+++ b/crates/csm-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-csm-worker"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/da-framework/Cargo.toml
+++ b/crates/da-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-da-framework"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/store-sled/Cargo.toml
+++ b/crates/db/store-sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-db-store-sled"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/tests/Cargo.toml
+++ b/crates/db/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-db-tests"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [lints]

--- a/crates/db/types/Cargo.toml
+++ b/crates/db/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-db-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/ee-acct-runtime/Cargo.toml
+++ b/crates/ee-acct-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ee-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [features]

--- a/crates/ee-acct-types/Cargo.toml
+++ b/crates/ee-acct-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ee-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ee-chain-types/Cargo.toml
+++ b/crates/ee-chain-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ee-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ee-chunk-runtime/Cargo.toml
+++ b/crates/ee-chunk-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ee-chunk-runtime"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/evm-ee/Cargo.toml
+++ b/crates/evm-ee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-evm-ee"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/key-derivation/Cargo.toml
+++ b/crates/key-derivation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-key-derivation"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/ledger-types/Cargo.toml
+++ b/crates/ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ledger-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Implementation of the Merkle-Patricia Trie"
 edition = "2021"
 name = "strata-mpt"
-version = "0.1.0"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/node-context/Cargo.toml
+++ b/crates/node-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-node-context"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/block-assembly/Cargo.toml
+++ b/crates/ol/block-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-block-assembly"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/ol/chain-types/Cargo.toml
+++ b/crates/ol/chain-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/checkpoint/Cargo.toml
+++ b/crates/ol/checkpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 description = "OL checkpoint builder service"
 publish = false

--- a/crates/ol/da/Cargo.toml
+++ b/crates/ol/da/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-da"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/genesis/Cargo.toml
+++ b/crates/ol/genesis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-genesis"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/mempool/Cargo.toml
+++ b/crates/ol/mempool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-mempool"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/ol/msg-types/Cargo.toml
+++ b/crates/ol/msg-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-msg-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/params/Cargo.toml
+++ b/crates/ol/params/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-params"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/ol/rpc/api/Cargo.toml
+++ b/crates/ol/rpc/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-ol-rpc-api"
-version = "0.1.0"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/ol/rpc/types/Cargo.toml
+++ b/crates/ol/rpc/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-ol-rpc-types"
-version = "0.1.0"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/ol/sequencer/Cargo.toml
+++ b/crates/ol/sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-sequencer"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/ol/state-provider/Cargo.toml
+++ b/crates/ol/state-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-state-provider"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/state-support-types/Cargo.toml
+++ b/crates/ol/state-support-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-state-support-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/state-types/Cargo.toml
+++ b/crates/ol/state-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-state-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/ol/stf/Cargo.toml
+++ b/crates/ol/stf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-ol-stf"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/paas/Cargo.toml
+++ b/crates/paas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-paas"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [lints]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/proof-impl/alpen-acct/Cargo.toml
+++ b/crates/proof-impl/alpen-acct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-proofimpl-alpen-acct"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/proof-impl/alpen-chunk/Cargo.toml
+++ b/crates/proof-impl/alpen-chunk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-proofimpl-alpen-chunk"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/proof-impl/checkpoint/Cargo.toml
+++ b/crates/proof-impl/checkpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-proofimpl-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/proof-impl/evm-ee-stf/Cargo.toml
+++ b/crates/proof-impl/evm-ee-stf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-proofimpl-evm-ee-stf"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/proof-impl/predicate-keys/Cargo.toml
+++ b/crates/proof-impl/predicate-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-proofimpl-predicate-keys"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [features]

--- a/crates/prover-core/Cargo.toml
+++ b/crates/prover-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-prover-core"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]

--- a/crates/reth/chainspec/Cargo.toml
+++ b/crates/reth/chainspec/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Definition of supported chainspecs."
 edition = "2021"
 name = "alpen-chainspec"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/db/Cargo.toml
+++ b/crates/reth/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-db"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/evm/Cargo.toml
+++ b/crates/reth/evm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-evm"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/exex/Cargo.toml
+++ b/crates/reth/exex/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-exex"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/node/Cargo.toml
+++ b/crates/reth/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-node"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/primitives/Cargo.toml
+++ b/crates/reth/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/rpc/Cargo.toml
+++ b/crates/reth/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-rpc"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/statediff/Cargo.toml
+++ b/crates/reth/statediff/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-statediff"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/reth/witness/Cargo.toml
+++ b/crates/reth/witness/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "alpen-reth-witness"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/rpc/open-rpc-macros/Cargo.toml
+++ b/crates/rpc/open-rpc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-open-rpc-macros"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/crates/rpc/open-rpc-spec/Cargo.toml
+++ b/crates/rpc/open-rpc-spec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-rpc-openrpc-spec"
-version = "0.1.0"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/rpc/open-rpc-spec/src/lib.rs
+++ b/crates/rpc/open-rpc-spec/src/lib.rs
@@ -9,7 +9,7 @@ use strata_open_rpc::Project;
 /// Builds the combined OpenRPC document for Alpen binary RPC methods.
 pub fn alpen_rpc_project() -> Project {
     let mut project = Project::new(
-        "0.1.0",
+        "0.4.0",
         "Alpen RPC",
         "Alpen JSON-RPC API",
         "Alpen Labs",

--- a/crates/rpc/open-rpc/Cargo.toml
+++ b/crates/rpc/open-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-open-rpc"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [lints]

--- a/crates/simple-ee/Cargo.toml
+++ b/crates/simple-ee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-simple-ee"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/snark-acct-runtime/Cargo.toml
+++ b/crates/snark-acct-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-snark-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [features]

--- a/crates/snark-acct-sys/Cargo.toml
+++ b/crates/snark-acct-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-snark-acct-sys"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/snark-acct-types/Cargo.toml
+++ b/crates/snark-acct-types/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "strata-snark-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-state"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/status/Cargo.toml
+++ b/crates/status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-status"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/storage-common/Cargo.toml
+++ b/crates/storage-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-storage-common"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-storage"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/strata-signer/Cargo.toml
+++ b/crates/strata-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-signer"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [lints]

--- a/crates/test-utils/btcio/Cargo.toml
+++ b/crates/test-utils/btcio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-test-utils-btcio"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/test-utils/l2/Cargo.toml
+++ b/crates/test-utils/l2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-test-utils-l2"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/test-utils/ssz/Cargo.toml
+++ b/crates/test-utils/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-test-utils-ssz"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 
 [lints]

--- a/crates/test-utils/test-utils/Cargo.toml
+++ b/crates/test-utils/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-test-utils"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/zkvm/hosts/Cargo.toml
+++ b/crates/zkvm/hosts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-zkvm-hosts"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [lints]
 workspace = true

--- a/provers/sp1/Cargo.toml
+++ b/provers/sp1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "strata-sp1-guest-builder"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 
 [dependencies]
 once_cell = "1.21.4"

--- a/provers/sp1/guest-alpen-acct/Cargo.lock
+++ b/provers/sp1/guest-alpen-acct/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-da-runtime"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alpen-ee-da-types",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-da-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-reth-statediff",
  "bitcoin",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-evm"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-sol-types",
@@ -577,11 +577,12 @@ dependencies = [
  "strata-identifiers",
  "strata-ol-bridge-types",
  "strata-primitives",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alpen-reth-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -591,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-statediff"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "revm",
@@ -2143,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "guest-sp1-alpen-acct"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-predicate",
  "strata-proofimpl-alpen-acct",
@@ -4941,7 +4942,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strata-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "digest 0.10.7",
  "sha2",
@@ -4962,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.2#45a1fa2f52289b483dd9767b4ec9c80545d5789b"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.11.0",
@@ -4978,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "strata-bridge-params"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "ssz",
@@ -4989,7 +4990,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5011,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -5020,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5029,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5053,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "strata-da-framework"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-codec",
  "thiserror 2.0.18",
@@ -5061,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -5078,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -5098,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -5113,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "strata-evm-ee"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rlp",
@@ -5146,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5167,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -5176,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5195,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "strata-mpt"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alloy-rlp",
  "alloy-rlp-derive",
@@ -5210,14 +5211,14 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "strata-ol-bridge-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5233,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-msg-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-codec",
  "strata-identifiers",
@@ -5243,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "hex",
  "k256",
@@ -5262,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "strata-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.11.0",
@@ -5277,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-alpen-acct"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alpen-ee-da-runtime",
  "alpen-ee-da-types",
@@ -5300,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -5313,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",

--- a/provers/sp1/guest-alpen-acct/Cargo.toml
+++ b/provers/sp1/guest-alpen-acct/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "guest-sp1-alpen-acct"
-version = "0.1.0"
+version = "0.4.0"
 
 [workspace]
 

--- a/provers/sp1/guest-alpen-chunk/Cargo.lock
+++ b/provers/sp1/guest-alpen-chunk/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-ee-da-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alpen-reth-statediff",
  "bitcoin",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-evm"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-sol-types",
@@ -558,11 +558,12 @@ dependencies = [
  "strata-identifiers",
  "strata-ol-bridge-types",
  "strata-primitives",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alpen-reth-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -572,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "alpen-reth-statediff"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "revm",
@@ -2124,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "guest-sp1-alpen-chunk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-proofimpl-alpen-chunk",
  "zkaleido-sp1-guest-env",
@@ -4921,7 +4922,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strata-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "digest 0.10.7",
  "sha2",
@@ -4942,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.2#45a1fa2f52289b483dd9767b4ec9c80545d5789b"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.11.0",
@@ -4958,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "strata-bridge-params"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "ssz",
@@ -4969,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4991,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -5000,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5009,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -5033,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "strata-da-framework"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-codec",
  "thiserror 2.0.18",
@@ -5041,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -5061,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -5076,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ee-chunk-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -5089,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "strata-evm-ee"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rlp",
@@ -5122,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5143,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -5152,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5171,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "strata-mpt"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alloy-rlp",
  "alloy-rlp-derive",
@@ -5186,14 +5187,14 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "strata-ol-bridge-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5209,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-msg-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-codec",
  "strata-identifiers",
@@ -5219,7 +5220,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "hex",
  "k256",
@@ -5238,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "strata-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.11.0",
@@ -5253,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-alpen-chunk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "alpen-reth-evm",
  "k256",
@@ -5272,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-runtime"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "rkyv",
  "rkyv_impl",
@@ -5285,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",

--- a/provers/sp1/guest-alpen-chunk/Cargo.toml
+++ b/provers/sp1/guest-alpen-chunk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "guest-sp1-alpen-chunk"
-version = "0.1.0"
+version = "0.4.0"
 
 [workspace]
 

--- a/provers/sp1/guest-checkpoint/Cargo.lock
+++ b/provers/sp1/guest-checkpoint/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "guest-sp1-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-proofimpl-checkpoint",
  "zkaleido-sp1-guest-env",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "strata-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "digest",
  "sha2",
@@ -1674,7 +1674,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2)",
+ "strata-codec-utils 0.1.0",
  "strata-identifiers",
  "strata-msg-fmt",
  "strata-predicate",
@@ -1727,7 +1727,7 @@ dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2)",
+ "strata-codec-utils 0.1.0",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
  "thiserror",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "strata-bridge-params"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "ssz",
@@ -1823,6 +1823,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "borsh",
  "ssz",
@@ -1832,8 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "strata-codec-utils"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
+version = "0.4.0"
 dependencies = [
  "borsh",
  "ssz",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "strata-da-framework"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-codec",
  "thiserror",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ledger-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-acct-types",
  "strata-asm-manifest-types",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-bridge-types"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-chain-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "int-enum",
  "ssz",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-da"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "strata-acct-types",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-msg-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-codec",
  "strata-identifiers",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-params"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "strata-bridge-params",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-state-support-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "strata-acct-types",
  "strata-asm-proto-checkpoint-types",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-state-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -2079,7 +2079,7 @@ dependencies = [
  "strata-acct-types",
  "strata-asm-manifest-types",
  "strata-codec",
- "strata-codec-utils 0.1.0",
+ "strata-codec-utils 0.4.0",
  "strata-identifiers",
  "strata-ledger-types",
  "strata-merkle",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "strata-ol-stf"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "strata-acct-types",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "strata-primitives"
-version = "0.3.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.11.0",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "k256",
  "ssz",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-sys"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "strata-acct-types",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "strata-snark-acct-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ssz",
  "ssz_codegen",

--- a/provers/sp1/guest-checkpoint/Cargo.toml
+++ b/provers/sp1/guest-checkpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "guest-sp1-checkpoint"
-version = "0.1.0"
+version = "0.4.0"
 
 [workspace]
 


### PR DESCRIPTION
## Description

Bump all crates and binaries and examples version to `0.4.0`.

`0.3.0` is the version in the `releases/0.3.0` and `main` has already breaking changes in both VK and DB schemas. Then `main` should be at least in `0.4.0`. It doesn't make sense for main to be in `0.3.0` or below anymore.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Needs backport with `0.3.0` as the version in `releases/0.3.0`

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues


