### PR TITLE
ci(build): checkpoint-sync repo-name fix, single-source map, dispatch checkboxes, SP1 skip (STR-3961) + image public-only (STR-3962)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,10 +25,26 @@ on:
       - "rust-toolchain.toml"
   workflow_dispatch:
     inputs:
-      programs:
-        description: "Comma-separated list of programs to build (leave empty for all)"
-        required: false
-        type: string
+      # One checkbox per program — tick any subset (one, two, or all). All
+      # default to true, so a plain dispatch builds everything. type:choice is
+      # single-select only, hence booleans for real multi-select. Names use
+      # underscores: hyphens break `inputs.x-y` (parsed as subtraction).
+      strata:
+        description: "Build strata (OL node)"
+        type: boolean
+        default: true
+      strata_checkpoint_sync:
+        description: "Build strata-checkpoint-sync"
+        type: boolean
+        default: true
+      alpen_client:
+        description: "Build alpen-client (EE)"
+        type: boolean
+        default: true
+      strata_signer:
+        description: "Build strata-signer"
+        type: boolean
+        default: true
       ref:
         description: "Git ref to build from (default: current branch)"
         required: false
@@ -92,18 +108,50 @@ jobs:
       - name: Set build matrix
         id: set-matrix
         env:
-          INPUT: ${{ inputs.programs }}
+          EVENT: ${{ github.event_name }}
+          SEL_STRATA: ${{ inputs.strata }}
+          SEL_CHECKPOINT_SYNC: ${{ inputs.strata_checkpoint_sync }}
+          SEL_ALPEN_CLIENT: ${{ inputs.alpen_client }}
+          SEL_STRATA_SIGNER: ${{ inputs.strata_signer }}
         run: |
-          # New architecture images only — pushed to shared ECR account
+          # New architecture images only — pushed to shared ECR account.
+          #
+          # Single source of truth: program -> public ECR repo. An empty value
+          # means private ECR only (no public mirror; e.g. strata-signer is
+          # in-house — private ECR only, never mirrored public). Public repo
+          # names differ from the internal program name where the gallery repo
+          # was named differently (alpen-client -> alpen). To publish a new
+          # program publicly, set its public_repo here — nothing else changes.
+          PROGRAM_CONFIG='{
+            "strata":                 {"public_repo":"strata"},
+            "strata-checkpoint-sync": {"public_repo":"strata-checkpoint-sync"},
+            "alpen-client":           {"public_repo":"alpen"},
+            "strata-signer":          {"public_repo":""}
+          }'
           ALL='["strata","strata-checkpoint-sync","alpen-client","strata-signer"]'
 
-          if [ -z "$INPUT" ]; then
-            echo "matrix={\"program\":${ALL}}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT" != "workflow_dispatch" ]; then
+            # Scheduled / push builds every program.
+            PROGRAMS="$ALL"
           else
-            # Convert comma-separated input to JSON array
-            JSON=$(echo "$INPUT" | jq -Rc 'split(",") | map(gsub("\\s"; ""))')
-            echo "matrix={\"program\":${JSON}}" >> "$GITHUB_OUTPUT"
+            # Manual dispatch: one checkbox per program, all default true, so a
+            # plain dispatch builds all. Include each ticked program.
+            SEL=()
+            if [ "$SEL_STRATA" = "true" ];          then SEL+=( '"strata"' ); fi
+            if [ "$SEL_CHECKPOINT_SYNC" = "true" ]; then SEL+=( '"strata-checkpoint-sync"' ); fi
+            if [ "$SEL_ALPEN_CLIENT" = "true" ];    then SEL+=( '"alpen-client"' ); fi
+            if [ "$SEL_STRATA_SIGNER" = "true" ];   then SEL+=( '"strata-signer"' ); fi
+            PROGRAMS="[$(IFS=,; echo "${SEL[*]}")]"
           fi
+
+          # Emit an include-only matrix so each job carries its program and the
+          # public_repo it maps to. Unknown programs default to private-only.
+          MATRIX=$(jq -cn \
+            --argjson progs "$PROGRAMS" \
+            --argjson cfg "$PROGRAM_CONFIG" \
+            '{include: ($progs | map({program: .} + ($cfg[.] // {public_repo: ""})))}')
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "Building: $PROGRAMS"
 
   # ---------------------------------------------------------------------------
   # Build SP1 artifacts (datatool + guest ELFs) — shared by all images
@@ -249,7 +297,7 @@ jobs:
       # see alpen-infra github-actions-image-push (STR-3894). Only the programs
       # published publicly need this login.
       - name: Login to Amazon ECR Public
-        if: matrix.program == 'strata' || matrix.program == 'strata-checkpoint-sync' || matrix.program == 'alpen-client'
+        if: matrix.public_repo != ''
         run: |
           aws ecr-public get-login-password --region us-east-1 \
             | docker login --username AWS --password-stdin public.ecr.aws
@@ -289,6 +337,9 @@ jobs:
           # pull node images from here without AWS credentials (STR-3894).
           PUBLIC_ECR_BASE: public.ecr.aws/alpenlabs
           PROGRAM: ${{ matrix.program }}
+          # Public gallery repo for this program, from the prepare-job map.
+          # Empty for private-only programs.
+          PUBLIC_REPO: ${{ matrix.public_repo }}
           SHORT_TAG: ${{ steps.resolve.outputs.short_tag }}
           COMMIT_SHA: ${{ steps.resolve.outputs.commit_sha }}
         run: |
@@ -296,18 +347,12 @@ jobs:
           ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}/${PROGRAM}"
           FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:${SHORT_TAG}"
 
-          # Always push the private image. Additionally push a public mirror for
-          # programs with an external-facing repo, mapping the internal program
-          # name to its public gallery repo name (alpen-client -> alpen,
-          # strata-checkpoint-sync -> checkpoint-sync). Keep the set of mapped
-          # programs in sync with the `Login to Amazon ECR Public` condition.
+          # Always push the private image. Additionally push a public mirror when
+          # this program maps to a public gallery repo (see the prepare job's
+          # PROGRAM_CONFIG — e.g. alpen-client -> alpen). The public repo name
+          # matches the private image and the deployments/IAM naming
+          # (strata-checkpoint-sync, not checkpoint-sync).
           TAGS=( -t "${FULL_IMAGE}" )
-          case "$PROGRAM" in
-            strata)                 PUBLIC_REPO="strata" ;;
-            strata-checkpoint-sync) PUBLIC_REPO="checkpoint-sync" ;;
-            alpen-client)           PUBLIC_REPO="alpen" ;;
-            *)                      PUBLIC_REPO="" ;;
-          esac
           if [ -n "$PUBLIC_REPO" ]; then
             TAGS+=( -t "${PUBLIC_ECR_BASE}/${PUBLIC_REPO}:${SHORT_TAG}" )
           fi

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -104,6 +104,10 @@ jobs:
     permissions: {}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      # true only when a selected program consumes SP1 artifacts (strata,
+      # alpen-client). Lets build-sp1-artifacts skip itself entirely when the
+      # run builds only non-SP1 images (strata-checkpoint-sync, strata-signer).
+      needs_sp1: ${{ steps.set-matrix.outputs.needs_sp1 }}
     steps:
       - name: Set build matrix
         id: set-matrix
@@ -153,13 +157,23 @@ jobs:
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "Building: $PROGRAMS"
 
+          # Only strata and alpen-client consume the SP1 artifacts (datatool +
+          # guest ELFs). If neither is selected, the SP1 build job is skipped.
+          NEEDS_SP1=$(jq -rn --argjson progs "$PROGRAMS" \
+            '($progs | any(. == "strata" or . == "alpen-client")) | tostring')
+          echo "needs_sp1=${NEEDS_SP1}" >> "$GITHUB_OUTPUT"
+          echo "needs_sp1: ${NEEDS_SP1}"
+
   # ---------------------------------------------------------------------------
   # Build SP1 artifacts (datatool + guest ELFs) — shared by all images
   # ---------------------------------------------------------------------------
   build-sp1-artifacts:
     name: Build SP1 artifacts
-    needs: [check-new-commits]
-    if: always() && (needs.check-new-commits.result == 'skipped' || needs.check-new-commits.outputs.should_run == 'true')
+    # Depends on prepare so it can read needs_sp1; skips entirely when no
+    # selected program consumes SP1 artifacts (prepare already carries the
+    # check-new-commits gating).
+    needs: [prepare]
+    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.needs_sp1 == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -242,7 +256,8 @@ jobs:
   build-and-push:
     name: "Build ${{ matrix.program }}"
     needs: [prepare, build-sp1-artifacts]
-    if: always() && needs.prepare.result == 'success' && needs.build-sp1-artifacts.result == 'success'
+    # SP1 job may legitimately be skipped (non-SP1 programs only) — accept both.
+    if: always() && needs.prepare.result == 'success' && (needs.build-sp1-artifacts.result == 'success' || needs.build-sp1-artifacts.result == 'skipped')
     runs-on: ubuntu-latest
     environment: prod
     permissions:
@@ -303,7 +318,10 @@ jobs:
             | docker login --username AWS --password-stdin public.ecr.aws
 
       # --- Download pre-built SP1 artifacts from shared job --------------------
+      # Only the SP1-consuming programs need these; for others the SP1 job is
+      # skipped and no artifact exists to download.
       - name: Download SP1 artifacts
+        if: matrix.program == 'strata' || matrix.program == 'alpen-client'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sp1-artifacts

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -126,9 +126,13 @@ jobs:
           # names differ from the internal program name where the gallery repo
           # was named differently (alpen-client -> alpen). To publish a new
           # program publicly, set its public_repo here — nothing else changes.
+          #
+          # "private":false makes a program public-only — skip the private ECR
+          # push entirely (e.g. strata-checkpoint-sync -> public ECR is the sole
+          # canonical image registry; STR-3962). Defaults to true when omitted.
           PROGRAM_CONFIG='{
             "strata":                 {"public_repo":"strata"},
-            "strata-checkpoint-sync": {"public_repo":"strata-checkpoint-sync"},
+            "strata-checkpoint-sync": {"public_repo":"strata-checkpoint-sync","private":false},
             "alpen-client":           {"public_repo":"alpen"},
             "strata-signer":          {"public_repo":""}
           }'
@@ -153,7 +157,7 @@ jobs:
           MATRIX=$(jq -cn \
             --argjson progs "$PROGRAMS" \
             --argjson cfg "$PROGRAM_CONFIG" \
-            '{include: ($progs | map({program: .} + ($cfg[.] // {public_repo: ""})))}')
+            '{include: ($progs | map({program: ., private: true} + ($cfg[.] // {public_repo: ""})))}')
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "Building: $PROGRAMS"
 
@@ -358,6 +362,10 @@ jobs:
           # Public gallery repo for this program, from the prepare-job map.
           # Empty for private-only programs.
           PUBLIC_REPO: ${{ matrix.public_repo }}
+          # Whether to push the private ECR image. false for public-only
+          # programs (strata-checkpoint-sync -> public ECR only; STR-3962).
+          # Defaults to true via the prepare job's matrix.
+          PUSH_PRIVATE: ${{ matrix.private }}
           SHORT_TAG: ${{ steps.resolve.outputs.short_tag }}
           COMMIT_SHA: ${{ steps.resolve.outputs.commit_sha }}
         run: |
@@ -365,14 +373,22 @@ jobs:
           ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}/${PROGRAM}"
           FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:${SHORT_TAG}"
 
-          # Always push the private image. Additionally push a public mirror when
-          # this program maps to a public gallery repo (see the prepare job's
+          # Push the private image unless this program is public-only
+          # (PUSH_PRIVATE=false, e.g. strata-checkpoint-sync -> public ECR is the
+          # sole canonical registry; STR-3962). Additionally push a public mirror
+          # when the program maps to a public gallery repo (see the prepare job's
           # PROGRAM_CONFIG — e.g. alpen-client -> alpen). The public repo name
-          # matches the private image and the deployments/IAM naming
-          # (strata-checkpoint-sync, not checkpoint-sync).
-          TAGS=( -t "${FULL_IMAGE}" )
+          # matches the deployments/IAM naming (strata-checkpoint-sync).
+          TAGS=()
+          if [ "$PUSH_PRIVATE" != "false" ]; then
+            TAGS+=( -t "${FULL_IMAGE}" )
+          fi
           if [ -n "$PUBLIC_REPO" ]; then
             TAGS+=( -t "${PUBLIC_ECR_BASE}/${PUBLIC_REPO}:${SHORT_TAG}" )
+          fi
+          if [ "${#TAGS[@]}" -eq 0 ]; then
+            echo "::error::No push target for ${PROGRAM}: private disabled and no public_repo set" >&2
+            exit 1
           fi
 
           # Bake prover features into the strata image. Other programs build
@@ -394,7 +410,7 @@ jobs:
             "${TAGS[@]}" \
             -f "${DOCKERFILE_PATH}" .
 
-          echo "Successfully pushed: ${FULL_IMAGE}"
+          echo "Successfully pushed ${PROGRAM}:${SHORT_TAG} -> ${TAGS[*]}"
 
       # --- Publish strata-datatool as its own image ---------------------------
       # Reuses the binary already staged at docker/strata/artifacts/ for the


### PR DESCRIPTION
## Summary

Reworks `ci-build.yml` (the image build/push pipeline) around a single source-of-truth program map, makes manual dispatch a per-program checkbox selection, skips the SP1 build when it isn't needed, fixes a broken public-repo name from #2094, and makes **strata-checkpoint-sync public-only** (STR-3962).

## Changes

**1. Single source-of-truth public-ECR map**
Replaces the `case` statement + the separate "Login to Amazon ECR Public" `if` (which had to be kept in sync by hand) with one `PROGRAM_CONFIG` map (program → public repo). The map drives both the public-login gate (`matrix.public_repo != ''`) and the pushed tag. Adding a future public program is now a one-line map edit.

**2. Fix checkpoint-sync public repo name (bug from #2094)**
#2094 maps `strata-checkpoint-sync → checkpoint-sync`, but that public repo does not exist and is not authorized by the `github-actions-ecr-push` role. The actual repo, the IAM allow-list, and the deployments values all use `strata-checkpoint-sync`. As-is on `main` the checkpoint-sync public push fails; this corrects the name so it lands.

**3. Per-program dispatch checkboxes**
Replaces the free-text `programs` string with one boolean input per program, all defaulting to `true`. GitHub `type: choice` is single-select only, so booleans are the way to pick one, some, or all. A plain dispatch still builds everything.

| Dispatch | Builds |
|---|---|
| default (all ticked) | all 4 |
| tick one / two | just those |
| none ticked | nothing |
| schedule / push (auto) | all 4 |

**4. Skip SP1 artifacts when unused**
Only `strata` and `alpen-client` consume the SP1 datatool + guest ELFs. `prepare` now emits `needs_sp1`; `build-sp1-artifacts` skips entirely when the run builds only `strata-checkpoint-sync` and/or `strata-signer`. `build-and-push` accepts the SP1 job as `success` or `skipped`, and the SP1 download step is gated to the consuming programs.

| Selection | SP1 job |
|---|---|
| checkpoint-sync / signer only | skipped |
| includes strata or alpen-client | runs |
| schedule / push (all 4) | runs |

**5. Make strata-checkpoint-sync image public-only (STR-3962)**
Adds a per-program `"private"` flag to `PROGRAM_CONFIG` (defaults `true`, injected via the matrix). `strata-checkpoint-sync` sets `"private": false`, so CI pushes it to **public ECR only** — the public repo becomes the sole canonical image registry and the private `strata/strata-checkpoint-sync` repo is retired under STR-3962. The build/push step gates the private `-t` tag on `PUSH_PRIVATE` and fails fast if a program resolves to zero push targets. Pairs with deployments#1095 (deployment values → public image).

## Push targets

| Program | Private | Public |
|---|---|---|
| `strata` | ✅ | `strata` |
| `strata-checkpoint-sync` | ❌ (retired, STR-3962) | `strata-checkpoint-sync` |
| `alpen-client` | ✅ | `alpen` |
| `strata-signer` | ✅ | — (private only, in-house) |

## Validation

**Live (real ECR, dispatched on this branch):**
- Checkbox selection resolves correctly (`Building: ["strata-checkpoint-sync"]` for a single-tick run).
- SP1 gate both directions: checkpoint-sync-only → `Build SP1 artifacts` **skipped**; all-apps → **runs**.
- Public push confirmed: tag present in `public.ecr.aws/alpenlabs/strata-checkpoint-sync` (corrected name, not `checkpoint-sync`).
- `actionlint` clean.

**Tag-resolution test cases (STR-3962 push-gating logic):**

| Program | `private` | `public_repo` | Resolved `-t` tags | Expected |
|---|---|---|---|---|
| `strata-checkpoint-sync` | `false` | `strata-checkpoint-sync` | `public.ecr.aws/alpenlabs/strata-checkpoint-sync:<tag>` | public only ✅ |
| `strata` | `true` (default) | `strata` | private `strata/strata:<tag>` + `public.ecr.aws/alpenlabs/strata:<tag>` | private + public mirror ✅ |
| `alpen-client` | `true` (default) | `alpen` | private + `public.ecr.aws/alpenlabs/alpen:<tag>` | private + public mirror ✅ |
| `strata-signer` | `true` (default) | `` (empty) | private `strata/strata-signer:<tag>` | private only ✅ |
| _hypothetical_ | `false` | `` (empty) | — | **fails fast**: `::error::No push target` ✅ |

All five cases verified by executing the exact `TAGS` shell logic. The empty-target guard prevents a silent no-push if a program is ever misconfigured as private-disabled with no public repo.

## Notes
- `strata-signer` stays private-only by design (internal signing service; no external consumer).
- `strata-checkpoint-sync` becomes public-only: external operators run the image directly on bare metal; internal deploys pull from public ECR (deployments#1095).
- No IAM changes — the `github-actions-ecr-push` role already authorizes the private `strata/*` and the public `strata` / `alpen` / `strata-checkpoint-sync` repos.
