### PR TITLE
(fix): Correctly calculate `latest` epoch in checkpoint sync node + do not serve null epoch for genesis epoch

### DIFF
--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -442,14 +442,26 @@ pub(crate) fn ensure_genesis(
     let olgen_out = ensure_ol_genesis(storage, ol_params)?;
     let (l1blk, client_state) = ensure_client_state_genesis(storage, ol_params)?;
 
+    // Genesis (epoch 0) commitment carries the real genesis block id. Use it as the
+    // fallback before any checkpoint is seen so the status never reports the null
+    // (zeroed-blkid) epoch, which consumers would read as a chain mismatch. It is
+    // always present because `ensure_ol_genesis` above wrote the genesis summary;
+    // its absence is a constraint violation.
+    let genesis_epoch = storage
+        .ol_checkpoint()
+        .get_canonical_epoch_commitment_at_blocking(0)?
+        .ok_or(InitError::MissingGenesisEpochCommitment)?;
+
     // Create sync status and update status channel
     let sync_status = OLSyncStatus::new(
         olgen_out.tip_blk,
         olgen_out.epoch,
         olgen_out.is_terminal,
-        client_state.get_last_epoch().unwrap_or_default(),
-        client_state.get_last_epoch().unwrap_or_default(),
-        client_state.get_declared_final_epoch().unwrap_or_default(),
+        client_state.get_last_epoch().unwrap_or(genesis_epoch),
+        client_state.get_last_epoch().unwrap_or(genesis_epoch),
+        client_state
+            .get_declared_final_epoch()
+            .unwrap_or(genesis_epoch),
         l1blk,
     );
     status_channel.update_ol_sync_status(OLSyncStatusUpdate::new(sync_status));

--- a/bin/strata/src/errors.rs
+++ b/bin/strata/src/errors.rs
@@ -36,6 +36,9 @@ pub(crate) enum InitError {
     #[error("failed to create node storage: {0}")]
     StorageCreation(String),
 
+    #[error("missing genesis epoch commitment after OL genesis initialization")]
+    MissingGenesisEpochCommitment,
+
     #[error("missing sequencer config file: {0}")]
     MissingSequencerConfig(path::PathBuf),
 

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -742,7 +742,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         );
         let confirmed = chain_sync_status.confirmed_epoch;
         let finalized = chain_sync_status.finalized_epoch;
-        let latest = chain_sync_status.prev_epoch;
+        let latest = chain_sync_status.recently_complete_epoch;
 
         Ok(RpcOLChainStatus::new(tip, confirmed, finalized, latest))
     }

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -241,9 +241,9 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
             .ok_or_else(|| internal_error("OL sync status not available"))?;
 
         Ok(match tag {
-            OLBlockTag::Latest => sync_status.tip,
-            OLBlockTag::Confirmed => sync_status.confirmed_epoch.to_block_commitment(),
-            OLBlockTag::Finalized => sync_status.finalized_epoch.to_block_commitment(),
+            OLBlockTag::Latest => sync_status.tip(),
+            OLBlockTag::Confirmed => sync_status.confirmed_epoch().to_block_commitment(),
+            OLBlockTag::Finalized => sync_status.finalized_epoch().to_block_commitment(),
         })
     }
 
@@ -300,7 +300,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
         let finalized_slot = self
             .provider
             .get_ol_sync_status()
-            .map(|css| css.finalized_epoch.last_slot())
+            .map(|css| css.finalized_epoch().last_slot())
             .unwrap_or(0);
 
         let mut chain = Vec::new();
@@ -735,14 +735,14 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .ok_or_else(|| internal_error("OL sync status not available"))?;
 
         let tip = RpcOLBlockInfo::new(
-            *chain_sync_status.tip.blkid(),
-            chain_sync_status.tip.slot(),
-            chain_sync_status.tip_epoch,
-            chain_sync_status.tip_is_terminal,
+            *chain_sync_status.tip().blkid(),
+            chain_sync_status.tip().slot(),
+            chain_sync_status.tip_epoch(),
+            chain_sync_status.tip_is_terminal(),
         );
-        let confirmed = chain_sync_status.confirmed_epoch;
-        let finalized = chain_sync_status.finalized_epoch;
-        let latest = chain_sync_status.recently_complete_epoch;
+        let confirmed = chain_sync_status.confirmed_epoch();
+        let finalized = chain_sync_status.finalized_epoch();
+        let latest = chain_sync_status.recently_complete_epoch();
 
         Ok(RpcOLChainStatus::new(tip, confirmed, finalized, latest))
     }
@@ -843,7 +843,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             let is_finalized = self
                 .provider
                 .get_ol_sync_status()
-                .is_some_and(|sync_status| sync_status.finalized_epoch.epoch() >= epoch);
+                .is_some_and(|sync_status| sync_status.finalized_epoch().epoch() >= epoch);
 
             if is_finalized {
                 RpcCheckpointConfStatus::Finalized { l1_reference }
@@ -1035,7 +1035,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             .get_ol_sync_status()
             .ok_or_else(|| internal_error("OL sync status not available"))?;
         if let Some(current_seq_no) = self
-            .current_snark_account_seq_no(account_id, sync_status.tip)
+            .current_snark_account_seq_no(account_id, sync_status.tip())
             .await?
         {
             // Account state stores the next operation seqno. Published manifests
@@ -1046,7 +1046,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                 )));
             }
         }
-        for epoch in creation_epoch..=sync_status.tip_epoch {
+        for epoch in creation_epoch..=sync_status.tip_epoch() {
             let Some(records) = self
                 .provider
                 .get_account_update_records(epoch, account_id)
@@ -1246,7 +1246,7 @@ impl<P: OLRpcProvider> OLFullNodeRpcServer for OLRpcServer<P> {
             .provider
             .get_ol_sync_status()
             .ok_or_else(|| internal_error("OL sync status not available"))?
-            .tip
+            .tip()
             .blkid();
 
         let mut summaries = Vec::with_capacity(count as usize);

--- a/bin/strata/src/sequencer/tip.rs
+++ b/bin/strata/src/sequencer/tip.rs
@@ -15,7 +15,7 @@ pub(crate) async fn resolve_canonical_tip(
     status_channel: &StatusChannel,
     storage: &NodeStorage,
 ) -> DbResult<Option<OLBlockCommitment>> {
-    if let Some(tip) = status_channel.get_ol_sync_status().map(|s| s.tip) {
+    if let Some(tip) = status_channel.get_ol_sync_status().map(|s| s.tip()) {
         return Ok(Some(tip));
     }
     storage.ol_block().get_canonical_tip_async().await

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -396,7 +396,7 @@ fn start_mempool(nodectx: &NodeContext) -> Result<MempoolHandle> {
         .status_channel()
         .get_ol_sync_status()
         .expect("OL sync status must be set before starting mempool")
-        .tip;
+        .tip();
 
     let storage = nodectx.storage().clone();
     let status_channel = nodectx.status_channel().as_ref().clone();

--- a/crates/consensus-logic/src/checkpoint_sync/state.rs
+++ b/crates/consensus-logic/src/checkpoint_sync/state.rs
@@ -151,15 +151,19 @@ pub(crate) async fn build_ol_sync_status(
     let terminal = *summary.terminal();
     let epoch_num = summary.epoch();
     let new_l1 = *summary.new_l1();
-    // Epoch 0 has no predecessor; `null` is the canonical genesis-prev value.
-    let prev_epoch = summary
-        .get_prev_epoch_commitment()
-        .unwrap_or(EpochCommitment::null());
+    // The recently complete epoch for checkpoint sync service is the finalized epoch.
+    let recent_epoch = epoch;
 
     // Checkpoint sync always lands on terminal blocks, and for it
     // confirmed == finalized (5th and 6th args).
     Ok(OLSyncStatus::new(
-        terminal, epoch_num, true, prev_epoch, epoch, epoch, new_l1,
+        terminal,
+        epoch_num,
+        true,
+        recent_epoch,
+        epoch,
+        epoch,
+        new_l1,
     ))
 }
 

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -77,14 +77,8 @@ pub async fn start_fcm_service<C: FcmContext>(
     })
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct FcmService<C: FcmContext>(PhantomData<C>);
-
-impl<C: FcmContext> Default for FcmService<C> {
-    fn default() -> Self {
-        Self(PhantomData)
-    }
-}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct FcmStatus;
@@ -214,7 +208,7 @@ async fn process_fc_message<C: FcmContext>(
                     tip: canonical_tip,
                     tip_epoch: tip_block_data.header().epoch(),
                     tip_is_terminal: tip_block_data.header().is_terminal(),
-                    prev_epoch,
+                    recently_complete_epoch: prev_epoch,
                     confirmed_epoch,
                     finalized_epoch,
                     // FIXME(STR-3673): this is a bit convoluted, could this be simpler?
@@ -2138,7 +2132,7 @@ mod tests {
         let statuses = ctx.published_statuses();
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses[0].tip, block_commitment);
-        assert_eq!(statuses[0].prev_epoch, genesis_epoch);
+        assert_eq!(statuses[0].recently_complete_epoch, genesis_epoch);
         assert_eq!(statuses[0].confirmed_epoch, genesis_epoch);
         assert_eq!(statuses[0].finalized_epoch, genesis_epoch);
     }

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -204,16 +204,16 @@ async fn process_fc_message<C: FcmContext>(
                     .get_ol_block(*canonical_tip.blkid())
                     .await?
                     .ok_or(Error::MissingOLBlock(*canonical_tip.blkid()))?;
-                let status = OLSyncStatus {
-                    tip: canonical_tip,
-                    tip_epoch: tip_block_data.header().epoch(),
-                    tip_is_terminal: tip_block_data.header().is_terminal(),
-                    recently_complete_epoch: prev_epoch,
+                let status = OLSyncStatus::new(
+                    canonical_tip,
+                    tip_block_data.header().epoch(),
+                    tip_block_data.header().is_terminal(),
+                    prev_epoch,
                     confirmed_epoch,
                     finalized_epoch,
                     // FIXME(STR-3673): this is a bit convoluted, could this be simpler?
-                    safe_l1: last_l1_blk,
-                };
+                    last_l1_blk,
+                );
 
                 trace!(%blkid, "publishing new ol_state");
                 fcm_state.ctx().publish_sync_status(status);
@@ -1682,7 +1682,7 @@ mod tests {
         let statuses = fixture.ctx.published_statuses();
         assert_eq!(statuses.len(), 1);
         let status = &statuses[0];
-        assert_eq!(status.tip, fork.b3.commitment());
+        assert_eq!(status.tip(), fork.b3.commitment());
         assert_eq!(fcm_state.cur_best_block(), fork.b3.commitment());
         assert_eq!(fixture.ctx.executed_blocks(), vec![fork.b3.commitment()]);
 
@@ -1870,7 +1870,7 @@ mod tests {
         let statuses = fixture.ctx.published_statuses();
         assert_eq!(statuses.len(), 1);
         let status = &statuses[0];
-        assert_eq!(status.tip, chain.x4.commitment());
+        assert_eq!(status.tip(), chain.x4.commitment());
         assert_eq!(fcm_state.cur_best_block(), chain.x4.commitment());
         assert_eq!(fixture.ctx.executed_blocks(), vec![chain.x4.commitment()]);
         assert_eq!(
@@ -2131,10 +2131,10 @@ mod tests {
 
         let statuses = ctx.published_statuses();
         assert_eq!(statuses.len(), 1);
-        assert_eq!(statuses[0].tip, block_commitment);
-        assert_eq!(statuses[0].recently_complete_epoch, genesis_epoch);
-        assert_eq!(statuses[0].confirmed_epoch, genesis_epoch);
-        assert_eq!(statuses[0].finalized_epoch, genesis_epoch);
+        assert_eq!(statuses[0].tip(), block_commitment);
+        assert_eq!(statuses[0].recently_complete_epoch(), genesis_epoch);
+        assert_eq!(statuses[0].confirmed_epoch(), genesis_epoch);
+        assert_eq!(statuses[0].finalized_epoch(), genesis_epoch);
     }
 
     #[tokio::test]

--- a/crates/ol/mempool/src/service.rs
+++ b/crates/ol/mempool/src/service.rs
@@ -70,7 +70,7 @@ impl<P: StateProvider> AsyncService for MempoolService<P> {
             },
 
             MempoolInputMessage::ChainUpdate(update) => {
-                let new_tip = update.new_status().tip;
+                let new_tip = update.new_status().tip();
                 let ol_tip = OLBlockCommitment::new(new_tip.slot(), *new_tip.blkid());
                 state.handle_chain_update(ol_tip).await?;
             }

--- a/crates/ol/rpc/types/src/chain_status.rs
+++ b/crates/ol/rpc/types/src/chain_status.rs
@@ -63,7 +63,7 @@ pub struct RpcOLChainStatus {
     /// Finalized epoch commitment.
     pub finalized: EpochCommitment,
 
-    /// Latest epoch terminal block processed by the OL fork-choice manager.
+    /// Latest epoch terminal block processed.
     pub latest: EpochCommitment,
 }
 

--- a/crates/status/src/chain.rs
+++ b/crates/status/src/chain.rs
@@ -11,28 +11,32 @@ pub type OLSyncStatus = ChainSyncStatus;
 #[derive(Copy, Clone, Debug)]
 pub struct ChainSyncStatus {
     /// The current chain tip.
-    pub tip: L2BlockCommitment,
+    tip: L2BlockCommitment,
 
     /// The current chain tip epoch.
-    pub tip_epoch: Epoch,
+    tip_epoch: Epoch,
 
     /// Whether the current chain tip is epoch terminal.
-    pub tip_is_terminal: bool,
+    tip_is_terminal: bool,
 
     /// The previous epoch (ie. epoch most recently completed).
-    pub recently_complete_epoch: EpochCommitment,
+    recently_complete_epoch: EpochCommitment,
 
     /// The finalized epoch commitment, ie what's buried enough on L1.
-    pub finalized_epoch: EpochCommitment,
+    finalized_epoch: EpochCommitment,
 
     /// The confirmed epoch commitment (ie. epoch most recently seen on L1).
-    pub confirmed_epoch: EpochCommitment,
+    confirmed_epoch: EpochCommitment,
 
     /// The last L1 block commitment we've observed.
-    pub safe_l1: L1BlockCommitment,
+    safe_l1: L1BlockCommitment,
 }
 
 impl ChainSyncStatus {
+    pub fn tip(&self) -> OLBlockCommitment {
+        self.tip
+    }
+
     pub fn tip_slot(&self) -> u64 {
         self.tip.slot()
     }
@@ -45,6 +49,14 @@ impl ChainSyncStatus {
         self.tip_epoch
     }
 
+    pub fn confirmed_epoch(&self) -> EpochCommitment {
+        self.confirmed_epoch
+    }
+
+    pub fn finalized_epoch(&self) -> EpochCommitment {
+        self.finalized_epoch
+    }
+
     pub fn tip_is_terminal(&self) -> bool {
         self.tip_is_terminal
     }
@@ -54,7 +66,15 @@ impl ChainSyncStatus {
     }
 
     pub fn cur_epoch(&self) -> Epoch {
-        self.recently_complete_epoch.epoch() + 1
+        self.tip_epoch()
+    }
+
+    pub fn recently_complete_epoch(&self) -> EpochCommitment {
+        self.recently_complete_epoch
+    }
+
+    pub fn safe_l1(&self) -> L1BlockCommitment {
+        self.safe_l1
     }
 }
 

--- a/crates/status/src/chain.rs
+++ b/crates/status/src/chain.rs
@@ -20,7 +20,7 @@ pub struct ChainSyncStatus {
     pub tip_is_terminal: bool,
 
     /// The previous epoch (ie. epoch most recently completed).
-    pub prev_epoch: EpochCommitment,
+    pub recently_complete_epoch: EpochCommitment,
 
     /// The finalized epoch commitment, ie what's buried enough on L1.
     pub finalized_epoch: EpochCommitment,
@@ -54,7 +54,7 @@ impl ChainSyncStatus {
     }
 
     pub fn cur_epoch(&self) -> Epoch {
-        self.prev_epoch.epoch() + 1
+        self.recently_complete_epoch.epoch() + 1
     }
 }
 
@@ -63,7 +63,7 @@ impl ChainSyncStatus {
         tip: L2BlockCommitment,
         tip_epoch: Epoch,
         tip_is_terminal: bool,
-        prev_epoch: EpochCommitment,
+        recently_complete_epoch: EpochCommitment,
         confirmed_epoch: EpochCommitment,
         finalized_epoch: EpochCommitment,
         safe_l1: L1BlockCommitment,
@@ -72,7 +72,7 @@ impl ChainSyncStatus {
             tip,
             tip_epoch,
             tip_is_terminal,
-            prev_epoch,
+            recently_complete_epoch,
             confirmed_epoch,
             finalized_epoch,
             safe_l1,

--- a/functional-tests/common/rpc_types/strata.py
+++ b/functional-tests/common/rpc_types/strata.py
@@ -30,6 +30,7 @@ class ChainSyncStatus(TypedDict):
     tip: OLBlockInfo
     confirmed: EpochCommitment
     finalized: EpochCommitment
+    latest: EpochCommitment
 
 
 class RpcProofState(TypedDict):

--- a/functional-tests/tests/strata/test_checkpoint_sync_node.py
+++ b/functional-tests/tests/strata/test_checkpoint_sync_node.py
@@ -13,7 +13,7 @@ import flexitest
 
 from common.base_test import BaseTest
 from common.config.constants import ALPEN_ACCOUNT_ID, ServiceType
-from common.rpc_types.strata import AccountEpochSummary, ChainSyncStatus
+from common.rpc_types.strata import AccountEpochSummary, ChainSyncStatus, EpochCommitment
 from common.services.bitcoin import BitcoinService
 from common.services.strata import StrataService
 from common.wait import wait_until_with_value
@@ -117,7 +117,7 @@ def check_summaries_equivalent(seq_summary: AccountEpochSummary, node_summary: A
         assert su == nu
 
 
-def check_commitment_matches_checkpoint(seq_rpc, epoch: int, commitment: dict):
+def check_commitment_matches_checkpoint(seq_rpc, epoch: int, commitment: EpochCommitment):
     """Anchors the reconstructed epoch commitment to the published checkpoint.
 
     The terminal blkid hashes the reconstructed header (which commits to
@@ -146,9 +146,11 @@ def mine_and_get_status(strata: StrataService, btc_rpc) -> ChainSyncStatus:
 
 def check_epoch_ordering_invariant(status: ChainSyncStatus):
     """The latest (recently complete) epoch can never lag confirmed or finalized."""
+    tip = status["tip"]["epoch"]
     latest = status["latest"]["epoch"]
     confirmed = status["confirmed"]["epoch"]
     finalized = status["finalized"]["epoch"]
-    assert latest >= confirmed >= finalized, (
-        f"epoch ordering violated: latest={latest}, confirmed={confirmed}, finalized={finalized}"
+    assert tip >= latest >= confirmed >= finalized, (
+        f"epoch ordering violated: tip={tip}, latest={latest},"
+        "confirmed={confirmed}, finalized={finalized}"
     )

--- a/functional-tests/tests/strata/test_checkpoint_sync_node.py
+++ b/functional-tests/tests/strata/test_checkpoint_sync_node.py
@@ -139,4 +139,16 @@ def check_commitment_matches_checkpoint(seq_rpc, epoch: int, commitment: dict):
 def mine_and_get_status(strata: StrataService, btc_rpc) -> ChainSyncStatus:
     """Mines L1 blocks so OL checkpoints confirm, then returns the node's status."""
     btc_rpc.proxy.generatetoaddress(2, btc_rpc.proxy.getnewaddress())
-    return strata.get_sync_status()
+    status = strata.get_sync_status()
+    check_epoch_ordering_invariant(status)
+    return status
+
+
+def check_epoch_ordering_invariant(status: ChainSyncStatus):
+    """The latest (recently complete) epoch can never lag confirmed or finalized."""
+    latest = status["latest"]["epoch"]
+    confirmed = status["confirmed"]["epoch"]
+    finalized = status["finalized"]["epoch"]
+    assert latest >= confirmed >= finalized, (
+        f"epoch ordering violated: latest={latest}, confirmed={confirmed}, finalized={finalized}"
+    )


### PR DESCRIPTION
## Description
Also closes [STR-3957](https://alpenlabs.atlassian.net/browse/STR-3957).

While running alpen full node with checkpoint sync node, it was discovered that the `latest`(derived from `OLSyncStatus`'s `prev_epoch`) was behind the `confirmed/finalized` epochs and that alpen full node's ol tracker was erroring out.

This PR does the following:
- Renames the `prev_epoch` inside `OLSyncStatus` to `recently_complete_epoch` adhering to the docstring. The previous epoch framing was correct in the context of FCM only and with checkpoint sync, it is not correct.
- Correctly sets its value inside CSS's `build_ol_sync_status()` function to the finalized epoch instead of previous finalized epoch. This is because, for checkpoint sync node, the recently complete epoch is the finalized epoch itself as it has nothing beyond finalized checkpoint received from L1.
- Also fixes genesis commitment reported as null commitment(`000..`) instead of actual genesis commitment.
- `test_checkpoint_sync_node` now explicitly checks the ordering of the values in the RPC response.
- chore: makes `OLSyncStatus`'s fields private and exposes getters.

### Why was this not caught in the existing `test_checkpoint_sync_node` functional test?
- The behavior of this error is that it is treated as recoverable and thus even in the case of full node, the full node does nothing, but just continues in the loop trying to recover.
- In the functional test, we test that the alpen sequencer is able to sync from checkpoint sync node and submit updates to OL sequencer. This update path did not came across the check for `latest`/`confirmed` ordering which only happens in the tracker for full node. The component was erroring out and trying to recover, but since the update path was the one that determined the "pass"ing of the test, the issue was hidden.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->


[STR-3957]: https://alpenlabs.atlassian.net/browse/STR-3957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ