### PR TITLE
Fix: sequencer init logic should not run in non sequencer mode

### DIFF
--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -45,7 +45,7 @@ use alpen_ee_config::{AlpenEeConfig, AlpenEeParams};
 use alpen_ee_database::init_db_storage;
 use alpen_ee_engine::{create_engine_control_task, sync_chainstate_to_engine, AlpenRethExecEngine};
 #[cfg(feature = "sequencer")]
-use alpen_ee_exec_chain::init_exec_chain_state_from_storage;
+use alpen_ee_exec_chain::{init_exec_chain_state_from_storage, ExecChainState};
 #[cfg(feature = "sequencer")]
 use alpen_ee_genesis::ensure_finalized_exec_chain_genesis;
 use alpen_ee_genesis::{ensure_batch_genesis, ensure_genesis_ee_account_state};
@@ -53,9 +53,10 @@ use alpen_ee_ol_tracker::init_ol_tracker_state;
 use alpen_ee_rpc_server::{AlpenEeRpcServer, EeRpcServer};
 #[cfg(feature = "sequencer")]
 use alpen_ee_sequencer::{
-    block_builder_task, build_ol_chain_tracker, init_ol_chain_tracker_state, BlockBuilderConfig,
+    block_builder_task, build_ol_chain_tracker, init_batch_builder_state, init_lifecycle_state,
+    init_ol_chain_tracker_state, sealing_policy::block_count_policy::BlockCountPolicy,
+    BatchBuilderState, BatchLifecycleState, BlockBuilderConfig, OLChainTrackerState,
 };
-use alpen_ee_sequencer::{init_batch_builder_state, init_lifecycle_state};
 use alpen_reth_evm::evm::AlpenEvmFactory;
 #[cfg(feature = "sequencer")]
 use alpen_reth_exex::{AccessedStateGenerator, StateDiffGenerator};
@@ -167,6 +168,18 @@ const DEFAULT_SP1_DEADLINE_SECS: u64 = 4 * 60 * 60;
 /// Default capacity for the batch builder → chunk builder event channel.
 #[cfg(feature = "sequencer")]
 const DEFAULT_BATCH_EVENT_CHANNEL_CAPACITY: usize = 64;
+
+/// Startup state that only the EE sequencer needs.
+///
+/// Bundled into one value so it can be gated behind a single runtime
+/// `--sequencer` check and carried as a single `Option`.
+#[cfg(feature = "sequencer")]
+struct SequencerBootState {
+    ol_chain_tracker: OLChainTrackerState,
+    exec_chain: ExecChainState,
+    batch_builder: BatchBuilderState<BlockCountPolicy>,
+    batch_lifecycle: BatchLifecycleState,
+}
 
 fn main() {
     sigsegv_handler::install();
@@ -342,24 +355,41 @@ fn main() {
                 .await
                 .context("ol tracker state initialization should not fail")?;
 
+            // Sequencer-only startup state. Gated on the runtime `--sequencer` flag.
             #[cfg(feature = "sequencer")]
-            let ol_chain_tracker_state =
-                init_ol_chain_tracker_state(storage.as_ref(), ol_client.as_ref())
-                    .instrument(info_span!("init_ol_chain_tracker", component = "alpen"))
+            let sequencer_boot_state = if ext.sequencer {
+                let ol_chain_tracker =
+                    init_ol_chain_tracker_state(storage.as_ref(), ol_client.as_ref())
+                        .instrument(info_span!("init_ol_chain_tracker", component = "alpen"))
+                        .await
+                        .context("ol chain tracker state initialization should not fail")?;
+                let exec_chain = init_exec_chain_state_from_storage(storage.as_ref())
+                    .instrument(info_span!("init_exec_chain", component = "alpen"))
                     .await
-                    .context("ol chain tracker state initialization should not fail")?;
-
-            #[cfg(feature = "sequencer")]
-            let exec_chain_state = init_exec_chain_state_from_storage(storage.as_ref())
-                .instrument(info_span!("init_exec_chain", component = "alpen"))
-                .await
-                .context("exec chain state initialization should not fail")?;
+                    .context("exec chain state initialization should not fail")?;
+                let batch_builder = init_batch_builder_state(storage.as_ref())
+                    .instrument(info_span!("init_batch_builder", component = "alpen"))
+                    .await
+                    .context("batch builder state initialization should not fail")?;
+                let batch_lifecycle = init_lifecycle_state(storage.as_ref())
+                    .instrument(info_span!("init_lifecycle", component = "alpen"))
+                    .await
+                    .context("batch lifecycle state initialization should not fail")?;
+                Some(SequencerBootState {
+                    ol_chain_tracker,
+                    exec_chain,
+                    batch_builder,
+                    batch_lifecycle,
+                })
+            } else {
+                None
+            };
 
             let initial_preconf_head = {
                 #[cfg(feature = "sequencer")]
                 {
-                    if ext.sequencer {
-                        exec_chain_state.tip_blocknumhash()
+                    if let Some(boot) = sequencer_boot_state.as_ref() {
+                        boot.exec_chain.tip_blocknumhash()
                     } else {
                         // In non-sequencer mode, we only have the hash from OL tracker.
                         // Use block number 0 as initial value; it will be updated by gossip.
@@ -375,16 +405,6 @@ fn main() {
                     BlockNumHash::new(hash, 0)
                 }
             };
-
-            let batch_builder_state = init_batch_builder_state(storage.as_ref())
-                .instrument(info_span!("init_batch_builder", component = "alpen"))
-                .await
-                .context("batch builder state initialization should not fail")?;
-
-            let batch_lifecycle_state = init_lifecycle_state(storage.as_ref())
-                .instrument(info_span!("init_lifecycle", component = "alpen"))
-                .await
-                .context("batch lifecycle state initialization should not fail")?;
             // --- INITIALIZE SERVICES ---
 
             // Create gossip channel before building the node so we can register it early
@@ -541,6 +561,13 @@ fn main() {
                 };
 
                 use crate::gas_data_provider::RethGasDataProvider;
+
+                let SequencerBootState {
+                    ol_chain_tracker: ol_chain_tracker_state,
+                    exec_chain: exec_chain_state,
+                    batch_builder: batch_builder_state,
+                    batch_lifecycle: batch_lifecycle_state,
+                } = sequencer_boot_state.expect("sequencer boot state built in sequencer mode");
 
                 let payload_engine = Arc::new(AlpenRethPayloadEngine::new(
                     node.payload_builder_handle.clone(),

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -550,7 +550,13 @@ fn main() {
             );
 
             #[cfg(feature = "sequencer")]
-            if ext.sequencer {
+            if let Some(SequencerBootState {
+                ol_chain_tracker: ol_chain_tracker_state,
+                exec_chain: exec_chain_state,
+                batch_builder: batch_builder_state,
+                batch_lifecycle: batch_lifecycle_state,
+            }) = sequencer_boot_state
+            {
                 // sequencer specific tasks
 
                 use alpen_ee_common::{require_latest_batch, BlockNumHash};
@@ -566,13 +572,6 @@ fn main() {
                 };
 
                 use crate::gas_data_provider::RethGasDataProvider;
-
-                let SequencerBootState {
-                    ol_chain_tracker: ol_chain_tracker_state,
-                    exec_chain: exec_chain_state,
-                    batch_builder: batch_builder_state,
-                    batch_lifecycle: batch_lifecycle_state,
-                } = sequencer_boot_state.expect("sequencer boot state built in sequencer mode");
 
                 let payload_engine = Arc::new(AlpenRethPayloadEngine::new(
                     node.payload_builder_handle.clone(),

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -340,10 +340,15 @@ fn main() {
                 .await
                 .context("failed to fetch account genesis epoch from OL")?;
 
-            ensure_genesis(config.as_ref(), &genesis_epoch, storage.as_ref())
-                .instrument(info_span!("ensure_genesis", component = "alpen"))
-                .await
-                .context("genesis should not fail")?;
+            ensure_genesis(
+                config.as_ref(),
+                &genesis_epoch,
+                storage.as_ref(),
+                ext.sequencer,
+            )
+            .instrument(info_span!("ensure_genesis", component = "alpen"))
+            .await
+            .context("genesis should not fail")?;
 
             let ol_chain_status = chain_status_checked(ol_client.as_ref())
                 .instrument(info_span!("chain_status_check", component = "alpen"))
@@ -1678,12 +1683,18 @@ async fn ensure_genesis<TStorage: Storage + ExecBlockStorage + BatchStorage>(
     config: &AlpenEeConfig,
     genesis_epoch: &EpochCommitment,
     storage: &TStorage,
+    is_sequencer: bool,
 ) -> eyre::Result<()> {
     ensure_genesis_ee_account_state(config, genesis_epoch, storage).await?;
+
     #[cfg(feature = "sequencer")]
-    ensure_finalized_exec_chain_genesis(config, genesis_epoch.to_block_commitment(), storage)
-        .await?;
-    #[cfg(feature = "sequencer")]
-    ensure_batch_genesis(config, storage).await?;
+    if is_sequencer {
+        ensure_finalized_exec_chain_genesis(config, genesis_epoch.to_block_commitment(), storage)
+            .await?;
+        ensure_batch_genesis(config, storage).await?;
+    }
+    #[cfg(not(feature = "sequencer"))]
+    let _ = is_sequencer;
+
     Ok(())
 }


### PR DESCRIPTION
## Description
Some sequencer specific init logic were gated behind sequencer feature flag, but not behind the --sequencer arg. So a non-sequencer (fullnode) mode run on a build with sequencer feature flag enabled runs these specific init logics.

One of the init steps involves a sequencer specific RPC call, that can fail when connected to OL fullnodes.

This fix gates all sequencer specific init logic behind both the feature flag and the --sequencer mode arg.
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

https://alpenlabs.atlassian.net/browse/STR-3968

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
