### PR TITLE
[DO NOT MERGE] feat(alpen-ee/da): EE DA reconstruction and state replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpen-ee-da-l1-extraction"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "alpen-ee-da-types",
+ "bitcoin",
+ "bitcoind-async-client",
+ "futures",
+ "proptest",
+ "strata-btcio",
+ "strata-codec",
+ "strata-common",
+ "strata-identifiers",
+ "strata-l1-envelope-fmt",
+ "strata-l1-txfmt",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "alpen-ee-da-provider"
 version = "0.3.0-alpha.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpen-ee-da-state-replay"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "alloy-primitives",
+ "alpen-ee-da-types",
+ "alpen-reth-statediff",
+ "proptest",
+ "rsp-mpt",
+ "serde",
+ "serde_json",
+ "strata-identifiers",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alpen-ee-da-types"
 version = "0.3.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/alpen-ee/da/l1-extraction",
   "crates/alpen-ee/da/provider",
   "crates/alpen-ee/da/runtime",
+  "crates/alpen-ee/da/state-replay",
   "crates/alpen-ee/da/types",
   "crates/alpen-ee/database",
   "crates/alpen-ee/engine",
@@ -136,6 +137,7 @@ alpen-ee-config = { path = "crates/alpen-ee/config" }
 alpen-ee-da-l1-extraction = { path = "crates/alpen-ee/da/l1-extraction" }
 alpen-ee-da-provider = { path = "crates/alpen-ee/da/provider" }
 alpen-ee-da-runtime = { path = "crates/alpen-ee/da/runtime" }
+alpen-ee-da-state-replay = { path = "crates/alpen-ee/da/state-replay" }
 alpen-ee-da-types = { path = "crates/alpen-ee/da/types" }
 alpen-ee-database = { path = "crates/alpen-ee/database", default-features = false }
 alpen-ee-engine = { path = "crates/alpen-ee/engine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/alpen-ee/exec-chain",
   "crates/alpen-ee/common",
   "crates/alpen-ee/config",
+  "crates/alpen-ee/da/l1-extraction",
   "crates/alpen-ee/da/provider",
   "crates/alpen-ee/da/runtime",
   "crates/alpen-ee/da/types",
@@ -132,6 +133,7 @@ alpen-chainspec = { path = "crates/reth/chainspec" }
 alpen-ee-block-assembly = { path = "crates/alpen-ee/block-assembly" }
 alpen-ee-common = { path = "crates/alpen-ee/common" }
 alpen-ee-config = { path = "crates/alpen-ee/config" }
+alpen-ee-da-l1-extraction = { path = "crates/alpen-ee/da/l1-extraction" }
 alpen-ee-da-provider = { path = "crates/alpen-ee/da/provider" }
 alpen-ee-da-runtime = { path = "crates/alpen-ee/da/runtime" }
 alpen-ee-da-types = { path = "crates/alpen-ee/da/types" }

--- a/crates/alpen-ee/da/l1-extraction/Cargo.toml
+++ b/crates/alpen-ee/da/l1-extraction/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition = "2021"
+name = "alpen-ee-da-l1-extraction"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[dependencies]
+alpen-ee-da-types.workspace = true
+strata-codec.workspace = true
+strata-common = { workspace = true, features = ["async"] }
+strata-identifiers.workspace = true
+strata-l1-txfmt.workspace = true
+
+bitcoin.workspace = true
+bitcoind-async-client.workspace = true
+futures.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+strata-btcio.workspace = true
+strata-l1-envelope-fmt.workspace = true

--- a/crates/alpen-ee/da/l1-extraction/src/fetch.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/fetch.rs
@@ -1,0 +1,535 @@
+//! Streams Bitcoin blocks from bitcoind with retry.
+
+use std::time::Duration;
+
+use bitcoin::{Block, BlockHash};
+use bitcoind_async_client::{error::ClientError, traits::Reader, ClientResult};
+use futures::{
+    future::BoxFuture,
+    stream::{self, BoxStream, StreamExt},
+};
+use strata_common::retry::{policies::ExponentialBackoff, Backoff};
+use strata_identifiers::L1Height;
+use thiserror::Error;
+use tokio::time::sleep;
+
+/// Maximum inclusive Bitcoin block count accepted by one extraction.
+///
+/// This bounds scanner memory use. Callers covering larger windows should
+/// split the scan into multiple ranges.
+pub const MAX_EXTRACTION_BLOCK_RANGE: u64 = 2_000;
+
+/// bitcoind RPC error code for "Block height out of range".
+const BITCOIND_BLOCK_HEIGHT_OUT_OF_RANGE: i32 = -8;
+
+/// bitcoind RPC error code for "Loading block index" (node warming up).
+const BITCOIND_WARMING_UP: i32 = -28;
+
+/// Raw Bitcoin block data paired with its fetch metadata.
+#[derive(Debug, Clone)]
+pub struct L1BlockData {
+    height: L1Height,
+    hash: BlockHash,
+    block: Block,
+}
+
+impl L1BlockData {
+    /// Creates fetched L1 block data.
+    pub fn new(height: L1Height, hash: BlockHash, block: Block) -> Self {
+        Self {
+            height,
+            hash,
+            block,
+        }
+    }
+
+    /// Returns the L1 height where the block was fetched.
+    pub fn height(&self) -> L1Height {
+        self.height
+    }
+
+    /// Returns the Bitcoin block hash for the fetched block.
+    pub fn hash(&self) -> BlockHash {
+        self.hash
+    }
+
+    /// Returns the fetched Bitcoin block.
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+pub enum FetchRangeError {
+    #[error("start height {start_height} must be <= end height {end_height}")]
+    Inverted {
+        start_height: L1Height,
+        end_height: L1Height,
+    },
+
+    #[error(
+        "extraction range too large: requested {}, max {}",
+        u64::from(*end_height - *start_height) + 1,
+        MAX_EXTRACTION_BLOCK_RANGE,
+    )]
+    TooLarge {
+        start_height: L1Height,
+        end_height: L1Height,
+    },
+}
+
+/// Ordered stream of per-block fetch results.
+pub type FetchStream<'a> = BoxStream<'a, Result<L1BlockData, FetchError>>;
+
+/// Result returned when constructing a bounded fetch stream.
+pub type FetchRangeResult<'a> = Result<FetchStream<'a>, FetchRangeError>;
+
+/// Retry policy for bounded L1 block fetches.
+#[derive(Clone, Copy, Debug)]
+pub struct FetchRetryPolicy {
+    max_retries: u16,
+    backoff: ExponentialBackoff,
+}
+
+impl FetchRetryPolicy {
+    /// Creates a fetch retry policy.
+    pub fn new(max_retries: u16, backoff: ExponentialBackoff) -> Self {
+        Self {
+            max_retries,
+            backoff,
+        }
+    }
+
+    /// Returns the maximum number of retries per RPC call.
+    pub fn max_retries(&self) -> u16 {
+        self.max_retries
+    }
+
+    /// Returns the retry backoff policy.
+    pub fn backoff(&self) -> &ExponentialBackoff {
+        &self.backoff
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum FetchError {
+    #[error("L1 block height out of range (height {height}): {source}")]
+    HeightOutOfRange {
+        height: L1Height,
+        #[source]
+        source: ClientError,
+    },
+
+    #[error(
+        "L1 block fetch retries exhausted (height {height}, max retries {max_retries}): {source}"
+    )]
+    RetriesExhausted {
+        height: L1Height,
+        max_retries: u16,
+        #[source]
+        source: ClientError,
+    },
+
+    #[error("L1 block fetch failed (height {height}): {source}")]
+    Client {
+        height: L1Height,
+        #[source]
+        source: ClientError,
+    },
+}
+
+/// Narrow adapter seam over the bitcoind block reader methods used by fetch.
+///
+/// This trait exists to unit-test fetch retry behavior without depending on a
+/// live bitcoind instance. It is not intended as a broad extension API.
+pub trait FetchReader: Send + Sync {
+    /// Fetches the block at `height`.
+    fn get_block_at(&self, height: L1Height) -> BoxFuture<'_, ClientResult<Block>>;
+}
+
+impl<T> FetchReader for T
+where
+    T: Reader + Send + Sync,
+{
+    fn get_block_at(&self, height: L1Height) -> BoxFuture<'_, ClientResult<Block>> {
+        Box::pin(Reader::get_block_at(self, u64::from(height)))
+    }
+}
+
+/// Returns an ordered stream of Bitcoin blocks using the supplied retry policy.
+pub fn fetch_range<'a, R>(
+    reader: &'a R,
+    start_height: L1Height,
+    end_height: L1Height,
+    policy: FetchRetryPolicy,
+) -> FetchRangeResult<'a>
+where
+    R: FetchReader + ?Sized,
+{
+    if start_height > end_height {
+        return Err(FetchRangeError::Inverted {
+            start_height,
+            end_height,
+        });
+    }
+
+    let requested_block_count = u64::from(end_height - start_height) + 1;
+    if requested_block_count > MAX_EXTRACTION_BLOCK_RANGE {
+        return Err(FetchRangeError::TooLarge {
+            start_height,
+            end_height,
+        });
+    }
+
+    Ok(stream::iter(start_height..=end_height)
+        .then(move |height| fetch_block_at(reader, height, policy))
+        .boxed())
+}
+
+fn is_retryable_fetch_error(err: &ClientError) -> bool {
+    matches!(
+        err,
+        ClientError::Connection(_)
+            | ClientError::Timeout
+            | ClientError::Request(_)
+            | ClientError::Server(BITCOIND_WARMING_UP, _)
+    )
+}
+
+fn is_height_out_of_range(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Server(BITCOIND_BLOCK_HEIGHT_OUT_OF_RANGE, _)
+    )
+}
+
+async fn fetch_block_at<R>(
+    reader: &R,
+    height: L1Height,
+    policy: FetchRetryPolicy,
+) -> Result<L1BlockData, FetchError>
+where
+    R: FetchReader + ?Sized,
+{
+    let mut retry_count = 0;
+    let mut delay_ms = policy.backoff().base_delay_ms();
+
+    loop {
+        match reader.get_block_at(height).await {
+            Ok(block) => {
+                let hash = block.block_hash();
+                return Ok(L1BlockData::new(height, hash, block));
+            }
+            Err(source) if is_height_out_of_range(&source) => {
+                return Err(FetchError::HeightOutOfRange { height, source });
+            }
+            Err(source) if matches!(source, ClientError::MaxRetriesExceeded(_)) => {
+                return Err(FetchError::RetriesExhausted {
+                    height,
+                    max_retries: policy.max_retries(),
+                    source,
+                });
+            }
+            Err(source) if !is_retryable_fetch_error(&source) => {
+                return Err(FetchError::Client { height, source });
+            }
+            Err(source) if retry_count >= policy.max_retries() => {
+                return Err(FetchError::RetriesExhausted {
+                    height,
+                    max_retries: policy.max_retries(),
+                    source,
+                });
+            }
+            Err(_) => {
+                retry_count += 1;
+                sleep(Duration::from_millis(delay_ms)).await;
+                delay_ms = policy.backoff().next_delay_ms(delay_ms);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::Mutex,
+    };
+
+    use bitcoin::{
+        block::{Header, Version},
+        hashes::Hash,
+        pow::CompactTarget,
+        Block, BlockHash, TxMerkleNode,
+    };
+    use bitcoind_async_client::error::ClientError;
+    use futures::TryStreamExt;
+
+    use super::*;
+
+    #[derive(Default, Debug)]
+    struct MockReader {
+        block_responses: Mutex<HashMap<L1Height, VecDeque<ClientResult<Block>>>>,
+        block_calls: Mutex<Vec<L1Height>>,
+    }
+
+    impl MockReader {
+        fn add_block_responses(
+            mut self,
+            height: L1Height,
+            responses: Vec<ClientResult<Block>>,
+        ) -> Self {
+            self.block_responses
+                .get_mut()
+                .expect("poisoned")
+                .insert(height, responses.into_iter().collect());
+            self
+        }
+
+        fn count_block_calls(&self, height: L1Height) -> usize {
+            self.block_calls
+                .lock()
+                .expect("poisoned")
+                .iter()
+                .filter(|h| **h == height)
+                .count()
+        }
+    }
+
+    impl FetchReader for MockReader {
+        fn get_block_at(&self, height: L1Height) -> BoxFuture<'_, ClientResult<Block>> {
+            self.block_calls.lock().expect("poisoned").push(height);
+
+            let response = self
+                .block_responses
+                .lock()
+                .expect("poisoned")
+                .get_mut(&height)
+                .and_then(|queue| queue.pop_front())
+                .expect("missing block response for height");
+
+            Box::pin(async move { response })
+        }
+    }
+
+    fn build_block(nonce: u32) -> Block {
+        Block {
+            header: Header {
+                version: Version::from_consensus(1),
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: CompactTarget::from_consensus(0),
+                nonce,
+            },
+            txdata: Vec::new(),
+        }
+    }
+
+    fn build_fetch_policy() -> FetchRetryPolicy {
+        FetchRetryPolicy::new(5, ExponentialBackoff::new(0, 150, 100))
+    }
+
+    fn fetch_range_with_test_policy<'a, R>(
+        reader: &'a R,
+        start_height: L1Height,
+        end_height: L1Height,
+    ) -> FetchRangeResult<'a>
+    where
+        R: FetchReader + ?Sized,
+    {
+        fetch_range(reader, start_height, end_height, build_fetch_policy())
+    }
+
+    #[test]
+    fn test_inverted_range() {
+        let reader = MockReader::default();
+
+        let Err(error) = fetch_range_with_test_policy(&reader, 12, 10) else {
+            panic!("invalid range must fail");
+        };
+
+        assert_eq!(
+            error,
+            FetchRangeError::Inverted {
+                start_height: 12,
+                end_height: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn test_max_range() {
+        let reader = MockReader::default();
+
+        // This test covers synchronous range validation only; consuming the
+        // stream would require mock responses for every block in the range.
+        let _stream =
+            fetch_range_with_test_policy(&reader, 0, (MAX_EXTRACTION_BLOCK_RANGE - 1) as L1Height)
+                .expect("range at maximum size must be accepted");
+    }
+
+    #[test]
+    fn test_oversized_range() {
+        let reader = MockReader::default();
+
+        let Err(error) =
+            fetch_range_with_test_policy(&reader, 0, MAX_EXTRACTION_BLOCK_RANGE as L1Height)
+        else {
+            panic!("range above maximum size must fail");
+        };
+
+        assert_eq!(
+            error,
+            FetchRangeError::TooLarge {
+                start_height: 0,
+                end_height: MAX_EXTRACTION_BLOCK_RANGE as L1Height,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_height_order() {
+        let heights: [L1Height; 3] = [10, 11, 12];
+        let expected = heights
+            .iter()
+            .map(|height| {
+                let block = build_block(*height);
+                (*height, block.block_hash(), block)
+            })
+            .collect::<Vec<_>>();
+
+        let mut reader = MockReader::default();
+        for (height, _, block) in &expected {
+            reader = reader.add_block_responses(*height, vec![Ok(block.clone())]);
+        }
+
+        let blocks = fetch_range_with_test_policy(&reader, 10, 12)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect("fetch must succeed");
+
+        assert_eq!(blocks.len(), expected.len());
+        for (block, (height, hash, _)) in blocks.iter().zip(expected.iter()) {
+            assert_eq!(block.height(), *height);
+            assert_eq!(block.hash(), *hash);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retryable_error() {
+        let block = build_block(8);
+        let hash = block.block_hash();
+        let reader = MockReader::default().add_block_responses(
+            8,
+            vec![
+                Err(ClientError::Connection("temporary".to_string())),
+                Ok(block),
+            ],
+        );
+
+        let blocks = fetch_range_with_test_policy(&reader, 8, 8)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect("block fetch must succeed after retry");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].hash(), hash);
+        assert_eq!(reader.count_block_calls(8), 2);
+    }
+
+    #[tokio::test]
+    async fn test_terminal_error() {
+        let reader = MockReader::default().add_block_responses(
+            1,
+            vec![Err(ClientError::Status(401, "Unauthorized".to_string()))],
+        );
+
+        let error = fetch_range_with_test_policy(&reader, 1, 1)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("auth error must fail without retries");
+
+        assert!(matches!(
+            error,
+            FetchError::Client {
+                source: ClientError::Status(401, _),
+                ..
+            }
+        ));
+        assert_eq!(reader.count_block_calls(1), 1);
+    }
+
+    #[tokio::test]
+    async fn test_missing_height() {
+        let reader = MockReader::default().add_block_responses(
+            42,
+            vec![Err(ClientError::Server(
+                -8,
+                "Block height out of range".to_string(),
+            ))],
+        );
+
+        let error = fetch_range_with_test_policy(&reader, 42, 42)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("missing height must fail");
+
+        assert!(matches!(
+            error,
+            FetchError::HeightOutOfRange {
+                source: ClientError::Server(-8, _),
+                ..
+            }
+        ));
+        assert_eq!(reader.count_block_calls(42), 1);
+    }
+
+    #[tokio::test]
+    async fn test_retry_exhaustion() {
+        let responses = (0..16)
+            .map(|_| Err(ClientError::Connection("temporary".to_string())))
+            .collect::<Vec<_>>();
+        let reader = MockReader::default().add_block_responses(9, responses);
+
+        let error = fetch_range_with_test_policy(&reader, 9, 9)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("persistent retryable errors must exhaust retries");
+
+        assert!(matches!(
+            error,
+            FetchError::RetriesExhausted {
+                max_retries: 5,
+                source: ClientError::Connection(_),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_client_retry_exhaustion() {
+        let reader = MockReader::default()
+            .add_block_responses(100, vec![Err(ClientError::MaxRetriesExceeded(3))]);
+
+        let error = fetch_range_with_test_policy(&reader, 100, 100)
+            .expect("valid range")
+            .try_collect::<Vec<L1BlockData>>()
+            .await
+            .expect_err("client max-retries error must map to retries exhausted");
+
+        assert!(matches!(
+            error,
+            FetchError::RetriesExhausted {
+                max_retries: 5,
+                source: ClientError::MaxRetriesExceeded(3),
+                ..
+            }
+        ));
+    }
+}

--- a/crates/alpen-ee/da/l1-extraction/src/lib.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/lib.rs
@@ -1,0 +1,31 @@
+//! EE DA extraction helpers for bounded L1 ranges.
+//!
+//! This crate is a stateless extractor for verifier-sized ranges.
+//!
+//! The intended verifier flow is fetch a bounded L1 range, scan it for
+//! commit/reveal envelopes, and reassemble the discovered DA blobs.
+//!
+//! Reassembly requires a unique DA blob candidate for each `update_seq_no`.
+//! If multiple candidates share the same sequence number, reassembly returns an
+//! error instead of selecting a winner.
+//!
+//! Scanning authenticates reveals against one sequencer key. Key rotation is not
+//! modeled in this crate; callers scanning across rotations must split ranges by
+//! key epoch or provide a higher-level key schedule.
+
+mod fetch;
+mod reassemble;
+mod scan;
+
+#[cfg(test)]
+mod test_utils;
+
+pub use fetch::{
+    fetch_range, FetchError, FetchRangeError, FetchRangeResult, FetchReader, FetchRetryPolicy,
+    FetchStream, L1BlockData, MAX_EXTRACTION_BLOCK_RANGE,
+};
+pub use reassemble::{reassemble_da_blobs, ReassembleError};
+pub use scan::{
+    CommitMarker, EeDaEnvelopeScanner, ParsedEnvelope, QuarantineReason, QuarantinedCandidate,
+    ScanError, ScanOutcome,
+};

--- a/crates/alpen-ee/da/l1-extraction/src/reassemble.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/reassemble.rs
@@ -1,0 +1,203 @@
+//! Reassembles parsed EE DA envelopes into decoded DA blobs.
+
+use alpen_ee_da_types::{reassemble_da_blob, DaBlob};
+use strata_codec::CodecError;
+use thiserror::Error;
+
+use crate::ParsedEnvelope;
+
+/// Errors raised while reassembling parsed EE DA envelopes.
+#[derive(Debug, Error)]
+pub enum ReassembleError {
+    #[error("failed to decode DA blob at envelope {index}: {source}")]
+    DecodeBlob {
+        index: usize,
+        #[source]
+        source: CodecError,
+    },
+
+    #[error("multiple candidates unsupported at update_seq_no {update_seq_no}")]
+    MultipleCandidatesUnsupported { update_seq_no: u64 },
+
+    #[error("update_seq_no gap: expected {expected}, got {actual}")]
+    MissingUpdateSeqNo { expected: u64, actual: u64 },
+}
+
+/// Reassembles parsed envelope chunks into decoded DA blobs.
+///
+/// The returned blobs are sorted by `update_seq_no`.
+///
+/// Gaps inside the returned range are rejected. Multiple candidates for the
+/// same sequence number are also rejected for now; resolving competing candidates requires
+/// comparing against the OL-published Snark account inner root.
+pub fn reassemble_da_blobs(
+    envelopes: impl IntoIterator<Item = ParsedEnvelope>,
+) -> Result<Vec<DaBlob>, ReassembleError> {
+    let mut blobs = Vec::new();
+
+    for (index, envelope) in envelopes.into_iter().enumerate() {
+        let blob = reassemble_da_blob(envelope.chunks())
+            .map_err(|source| ReassembleError::DecodeBlob { index, source })?;
+        blobs.push(blob);
+    }
+
+    blobs.sort_by_key(|blob| blob.update_seq_no);
+    reject_update_seq_no_gaps(&blobs)?;
+
+    Ok(blobs)
+}
+
+fn reject_update_seq_no_gaps(blobs: &[DaBlob]) -> Result<(), ReassembleError> {
+    for pair in blobs.windows(2) {
+        let current = pair[0].update_seq_no;
+        let next = pair[1].update_seq_no;
+        if current == next {
+            return Err(ReassembleError::MultipleCandidatesUnsupported {
+                update_seq_no: current,
+            });
+        }
+
+        let expected = current
+            .checked_add(1)
+            .expect("sorted blobs cannot place terminal update_seq_no before another blob");
+        if next != expected {
+            return Err(ReassembleError::MissingUpdateSeqNo {
+                expected,
+                actual: next,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use strata_codec::{encode_to_vec, CodecError};
+
+    use super::{reassemble_da_blobs, ReassembleError};
+    use crate::test_utils::{
+        build_da_blob, build_multi_chunk_da_blob, build_parsed_envelope_from_chunk_bytes,
+        multi_chunk_bytecode_len_strategy,
+    };
+
+    const MAX_TEST_CHUNK_BYTES: usize = 395_000;
+
+    fn encode_blob_chunks(blob: &alpen_ee_da_types::DaBlob) -> Vec<Vec<u8>> {
+        encode_to_vec(blob)
+            .expect("DA blob encodes")
+            .chunks(MAX_TEST_CHUNK_BYTES)
+            .map(|chunk| chunk.to_vec())
+            .collect()
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let blobs = reassemble_da_blobs(Vec::new()).expect("empty input is valid");
+        assert!(blobs.is_empty());
+    }
+
+    #[test]
+    fn test_update_seqno_order() {
+        let blob0 = build_da_blob(10);
+        let blob1 = build_da_blob(11);
+        let envelopes = vec![
+            build_parsed_envelope_from_chunk_bytes(encode_blob_chunks(&blob1)),
+            build_parsed_envelope_from_chunk_bytes(encode_blob_chunks(&blob0)),
+        ];
+
+        let blobs = reassemble_da_blobs(envelopes).expect("reassembly succeeds");
+
+        assert_eq!(
+            blobs
+                .iter()
+                .map(|blob| blob.update_seq_no)
+                .collect::<Vec<_>>(),
+            vec![10, 11]
+        );
+    }
+
+    #[test]
+    fn test_duplicate_update_seqno() {
+        let blob0 = build_da_blob(10);
+        let blob1 = build_da_blob(10);
+        let envelopes = vec![
+            build_parsed_envelope_from_chunk_bytes(encode_blob_chunks(&blob0)),
+            build_parsed_envelope_from_chunk_bytes(encode_blob_chunks(&blob1)),
+        ];
+
+        let err = reassemble_da_blobs(envelopes).expect_err("duplicate seqno must fail");
+
+        assert!(matches!(
+            err,
+            ReassembleError::MultipleCandidatesUnsupported { update_seq_no: 10 }
+        ));
+    }
+
+    #[test]
+    fn test_update_seqno_gap() {
+        let blob0 = build_da_blob(10);
+        let blob1 = build_da_blob(12);
+        let envelopes = vec![
+            build_parsed_envelope_from_chunk_bytes(encode_blob_chunks(&blob0)),
+            build_parsed_envelope_from_chunk_bytes(encode_blob_chunks(&blob1)),
+        ];
+
+        let err = reassemble_da_blobs(envelopes).expect_err("seqno gap must fail");
+
+        assert!(matches!(
+            err,
+            ReassembleError::MissingUpdateSeqNo {
+                expected: 11,
+                actual: 12
+            }
+        ));
+    }
+
+    proptest! {
+        #[test]
+        fn test_decode_failure_index(
+            valid_prefix_len in 0usize..=4,
+        ) {
+            let mut envelopes = (0..valid_prefix_len)
+                .map(|idx| build_da_blob(idx as u64))
+                .map(|blob| {
+                    build_parsed_envelope_from_chunk_bytes(
+                        encode_blob_chunks(&blob),
+                    )
+                })
+                .collect::<Vec<_>>();
+            envelopes.push(build_parsed_envelope_from_chunk_bytes(Vec::new()));
+
+            let err = reassemble_da_blobs(envelopes).expect_err("empty envelope must fail");
+            match err {
+                ReassembleError::DecodeBlob { index, source: CodecError::MalformedField(_) } => {
+                    prop_assert_eq!(index, valid_prefix_len);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_multi_chunk_blob(
+            block_num in any::<u64>(),
+            bytecode_len in multi_chunk_bytecode_len_strategy(),
+            fill_byte in any::<u8>(),
+        ) {
+            let expected = build_multi_chunk_da_blob(block_num, bytecode_len, fill_byte);
+            let chunks = encode_blob_chunks(&expected);
+            prop_assert!(chunks.len() > 1, "fixture must produce multiple chunks");
+
+            let envelopes = vec![build_parsed_envelope_from_chunk_bytes(chunks)];
+            let blobs = reassemble_da_blobs(envelopes).expect("reassembly succeeds");
+            prop_assert_eq!(blobs.len(), 1);
+
+            let actual_encoded =
+                strata_codec::encode_to_vec(&blobs[0]).expect("encode reassembled blob");
+            let expected_encoded =
+                strata_codec::encode_to_vec(&expected).expect("encode expected blob");
+            prop_assert_eq!(actual_encoded, expected_encoded);
+        }
+    }
+}

--- a/crates/alpen-ee/da/l1-extraction/src/scan.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/scan.rs
@@ -1,0 +1,1711 @@
+//! Extracts EE DA chunked envelopes from bounded L1 block data.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    iter::once,
+};
+
+use alpen_ee_da_types::{
+    extract_da_chunks, last_commit_reveal_vout, DaParseError, DA_BLOB_VERSION,
+};
+use bitcoin::{
+    opcodes::{
+        all::{OP_CHECKSIG, OP_ENDIF, OP_IF, OP_RETURN},
+        OP_FALSE,
+    },
+    script::Instruction,
+    secp256k1::XOnlyPublicKey,
+    taproot::LeafVersion,
+    Block, Script, Transaction, Txid,
+};
+use strata_l1_txfmt::MagicBytes;
+use thiserror::Error;
+
+/// Lightweight commit marker recognized during discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommitMarker {
+    version: u32,
+}
+
+impl CommitMarker {
+    /// Returns the commit marker version.
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+/// Inclusive commit-output range containing reveal slots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RevealSlotRange {
+    last_vout: u32,
+}
+
+impl RevealSlotRange {
+    fn new(last_vout: u32) -> Option<Self> {
+        (last_vout > 0).then_some(Self { last_vout })
+    }
+
+    fn last_vout(self) -> u32 {
+        self.last_vout
+    }
+
+    fn contains_vout(self, vout: u32) -> bool {
+        (1..=self.last_vout).contains(&vout)
+    }
+}
+
+/// Result of matching only the vout-0 commit-marker script.
+#[derive(Debug)]
+enum CommitMarkerMatch {
+    Unrelated,
+    MalformedSameMagic { source: DaParseError },
+    Supported(CommitMarker),
+    Unsupported { version: u32 },
+}
+
+/// Transaction classification used before scanner candidate handling.
+#[derive(Debug)]
+enum TxClassification {
+    Unrelated,
+    Commit {
+        marker: CommitMarker,
+        reveal_slots: RevealSlotRange,
+    },
+    QuarantinedCommit {
+        reason: QuarantineReason,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RevealSpendMatch {
+    None,
+    One { commit_txid: Txid },
+    Multiple { commit_txids: Vec<Txid> },
+}
+
+/// Parsed chunks for one commit/reveal envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedEnvelope {
+    commit_txid: Txid,
+    chunks: Vec<Vec<u8>>,
+}
+
+impl ParsedEnvelope {
+    pub(crate) fn new(commit_txid: Txid, chunks: Vec<Vec<u8>>) -> Self {
+        Self {
+            commit_txid,
+            chunks,
+        }
+    }
+
+    /// Returns the transaction id of the commit transaction.
+    pub fn commit_txid(&self) -> Txid {
+        self.commit_txid
+    }
+
+    /// Returns raw encoded DA chunks ordered by commit output vout.
+    pub fn chunks(&self) -> &[Vec<u8>] {
+        &self.chunks
+    }
+
+    /// Consumes the envelope and returns its ordered raw encoded DA chunks.
+    pub fn into_chunks(self) -> Vec<Vec<u8>> {
+        self.chunks
+    }
+}
+
+/// Result of scanning one bounded L1 range.
+#[derive(Debug, Default)]
+pub struct ScanOutcome {
+    /// Authenticated, fully parsed envelopes discovered in the range.
+    envelopes: Vec<ParsedEnvelope>,
+
+    /// Marker-compatible candidates skipped during envelope parsing.
+    quarantined: Vec<QuarantinedCandidate>,
+}
+
+impl ScanOutcome {
+    fn new(envelopes: Vec<ParsedEnvelope>, quarantined: Vec<QuarantinedCandidate>) -> Self {
+        Self {
+            envelopes,
+            quarantined,
+        }
+    }
+
+    /// Returns authenticated, fully parsed envelopes.
+    pub fn envelopes(&self) -> &[ParsedEnvelope] {
+        &self.envelopes
+    }
+
+    /// Returns marker-compatible candidates that did not form valid envelopes.
+    pub fn quarantined(&self) -> &[QuarantinedCandidate] {
+        &self.quarantined
+    }
+
+    /// Consumes the outcome and returns its envelopes and quarantined candidates.
+    pub fn into_parts(self) -> (Vec<ParsedEnvelope>, Vec<QuarantinedCandidate>) {
+        (self.envelopes, self.quarantined)
+    }
+}
+
+/// Marker-compatible candidate skipped during range scanning.
+#[derive(Debug)]
+pub struct QuarantinedCandidate {
+    commit_txid: Txid,
+    reason: QuarantineReason,
+}
+
+impl QuarantinedCandidate {
+    fn new(commit_txid: Txid, reason: QuarantineReason) -> Self {
+        Self {
+            commit_txid,
+            reason,
+        }
+    }
+
+    /// Returns the candidate commit transaction id.
+    pub fn commit_txid(&self) -> Txid {
+        self.commit_txid
+    }
+
+    /// Returns why the candidate was skipped.
+    pub fn reason(&self) -> &QuarantineReason {
+        &self.reason
+    }
+}
+
+/// Reasons a marker-compatible candidate was skipped during range scanning.
+#[derive(Debug, Error)]
+pub enum QuarantineReason {
+    #[error("commit has no reveal slots")]
+    MissingRevealSlots,
+
+    #[error("missing reveals: expected {expected_slots}, covered {covered_slots}")]
+    MissingReveals {
+        expected_slots: u32,
+        covered_slots: u32,
+    },
+
+    #[error("unauthenticated reveal {reveal_txid}")]
+    UnauthenticatedReveal { reveal_txid: Txid },
+
+    #[error("reveal {reveal_txid} spends slots from multiple commits")]
+    RevealCrossesCommits { reveal_txid: Txid },
+
+    #[error("malformed commit marker: {source}")]
+    MalformedMarker {
+        #[source]
+        source: DaParseError,
+    },
+
+    #[error("unsupported commit marker version {version}")]
+    UnsupportedVersion { version: u32 },
+
+    #[error("malformed envelope: {source}")]
+    MalformedEnvelope {
+        #[source]
+        source: DaParseError,
+    },
+}
+
+/// Errors raised while discovering or parsing EE DA chunked envelopes.
+#[derive(Debug, Error)]
+pub enum ScanError {
+    #[error("duplicate commit transaction id {txid}")]
+    DuplicateCommitTxid { txid: Txid },
+}
+
+#[derive(Debug)]
+struct CommitCandidate {
+    tx: Transaction,
+    txid: Txid,
+    reveal_slots: RevealSlotRange,
+}
+
+#[derive(Clone, Debug)]
+struct RevealCandidate {
+    tx: Transaction,
+    txid: Txid,
+}
+
+#[derive(Debug)]
+enum RevealAuthError {
+    MissingLeafScript { reveal_txid: Txid },
+    UnsupportedLeafVersion { reveal_txid: Txid },
+    InvalidSequencerPubkey { reveal_txid: Txid },
+}
+
+/// Incrementally scans a bounded L1 range for EE DA commit/reveal envelopes.
+///
+/// The scanner keeps only discovered commit and reveal candidate transactions;
+/// it does not retain every fetched Bitcoin block.
+#[derive(Debug)]
+pub struct EeDaEnvelopeScanner {
+    magic_bytes: MagicBytes,
+    sequencer_pubkey: XOnlyPublicKey,
+    commits_by_txid: BTreeMap<Txid, CommitCandidate>,
+    reveals_by_commit: BTreeMap<Txid, BTreeMap<Txid, RevealCandidate>>,
+    quarantined: Vec<QuarantinedCandidate>,
+}
+
+impl EeDaEnvelopeScanner {
+    /// Creates an empty scanner for one confirmed L1 range.
+    pub fn new(magic_bytes: MagicBytes, sequencer_pubkey: XOnlyPublicKey) -> Self {
+        Self {
+            magic_bytes,
+            sequencer_pubkey,
+            commits_by_txid: BTreeMap::new(),
+            reveals_by_commit: BTreeMap::new(),
+            quarantined: Vec::new(),
+        }
+    }
+
+    /// Ingests one fetched L1 block.
+    pub fn ingest_block(&mut self, block: &Block) -> Result<(), ScanError> {
+        for tx in &block.txdata {
+            self.ingest_transaction(tx)?;
+        }
+        Ok(())
+    }
+
+    fn ingest_transaction(&mut self, tx: &Transaction) -> Result<(), ScanError> {
+        let txid = tx.compute_txid();
+
+        match classify_transaction(tx, self.magic_bytes) {
+            TxClassification::Unrelated => {}
+            TxClassification::Commit {
+                marker,
+                reveal_slots,
+            } => {
+                debug_assert_eq!(marker.version(), DA_BLOB_VERSION);
+                let candidate = CommitCandidate {
+                    tx: tx.clone(),
+                    txid,
+                    reveal_slots,
+                };
+                if self.commits_by_txid.insert(txid, candidate).is_some() {
+                    return Err(ScanError::DuplicateCommitTxid { txid });
+                }
+            }
+            TxClassification::QuarantinedCommit { reason } => {
+                self.quarantined
+                    .push(QuarantinedCandidate::new(txid, reason));
+            }
+        }
+
+        // Bitcoin blocks order parents before children, so same-block reveals
+        // cannot appear before the commit output they spend. Check every
+        // transaction here: a tx can both publish a new commit marker and spend
+        // an earlier commit's reveal slot.
+        match match_reveal_spends(tx, &self.commits_by_txid) {
+            RevealSpendMatch::None => {}
+            RevealSpendMatch::One { commit_txid } => {
+                self.reveals_by_commit
+                    .entry(commit_txid)
+                    .or_default()
+                    .entry(txid)
+                    .or_insert_with(|| RevealCandidate {
+                        tx: tx.clone(),
+                        txid,
+                    });
+            }
+            RevealSpendMatch::Multiple { commit_txids } => {
+                for commit_txid in commit_txids {
+                    self.quarantined.push(QuarantinedCandidate::new(
+                        commit_txid,
+                        QuarantineReason::RevealCrossesCommits { reveal_txid: txid },
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn finalize_commit(
+        &self,
+        commit: &CommitCandidate,
+    ) -> Result<ParsedEnvelope, QuarantineReason> {
+        let reveals = self
+            .reveals_by_commit
+            .get(&commit.txid)
+            .map(|reveals| reveals.values().collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        authenticate_and_parse_envelope(commit, &reveals, self.sequencer_pubkey)
+    }
+
+    /// Finalizes all discovered commits into parsed envelopes.
+    ///
+    /// Envelopes are returned in commit transaction-id order, not L1 block or
+    /// transaction-position order. Marker-compatible candidates that do not
+    /// form complete authenticated envelopes are returned as quarantined
+    /// entries and do not block valid envelopes in the same range.
+    pub fn finish(mut self) -> ScanOutcome {
+        let mut envelopes = Vec::new();
+        let commit_txids = self.commits_by_txid.keys().copied().collect::<Vec<_>>();
+        let quarantined_commit_txids = self
+            .quarantined
+            .iter()
+            .map(QuarantinedCandidate::commit_txid)
+            .collect::<BTreeSet<_>>();
+
+        for commit_txid in commit_txids {
+            if quarantined_commit_txids.contains(&commit_txid) {
+                continue;
+            }
+            let commit = self
+                .commits_by_txid
+                .get(&commit_txid)
+                .expect("commit txid collected from map key");
+            match self.finalize_commit(commit) {
+                Ok(envelope) => envelopes.push(envelope),
+                Err(reason) => self
+                    .quarantined
+                    .push(QuarantinedCandidate::new(commit_txid, reason)),
+            }
+        }
+
+        ScanOutcome::new(envelopes, self.quarantined)
+    }
+}
+
+fn parse_commit_marker_payload(payload: [u8; 8]) -> CommitMarkerMatch {
+    let mut version = [0u8; 4];
+    version.copy_from_slice(&payload[4..]);
+    let version = u32::from_be_bytes(version);
+    if version != DA_BLOB_VERSION {
+        return CommitMarkerMatch::Unsupported { version };
+    }
+
+    CommitMarkerMatch::Supported(CommitMarker { version })
+}
+
+/// Classifies a transaction against the EE DA commit marker shape.
+///
+/// The stable marker discriminator is `magic || version`: bytes `0..4` are
+/// [`MagicBytes`], and bytes `4..8` are the big-endian version. The deployed v0
+/// marker is exactly 8 bytes. Same-magic OP_RETURN payloads with any other
+/// length are unrelated Alpen traffic, while exact marker payloads with extra
+/// opcodes are malformed DA markers.
+fn classify_transaction(tx: &Transaction, magic_bytes: MagicBytes) -> TxClassification {
+    let marker = match match_commit_marker(tx, magic_bytes) {
+        CommitMarkerMatch::Unrelated => return TxClassification::Unrelated,
+        CommitMarkerMatch::MalformedSameMagic { source } => {
+            return TxClassification::QuarantinedCommit {
+                reason: QuarantineReason::MalformedMarker { source },
+            };
+        }
+        CommitMarkerMatch::Unsupported { version } => {
+            return TxClassification::QuarantinedCommit {
+                reason: QuarantineReason::UnsupportedVersion { version },
+            };
+        }
+        CommitMarkerMatch::Supported(marker) => marker,
+    };
+
+    let reveal_slots = match last_commit_reveal_vout(tx) {
+        Ok(Some(last_reveal_vout)) => RevealSlotRange::new(last_reveal_vout),
+        Ok(None) => None,
+        Err(source) => {
+            return TxClassification::QuarantinedCommit {
+                reason: QuarantineReason::MalformedEnvelope { source },
+            };
+        }
+    };
+    let Some(reveal_slots) = reveal_slots else {
+        return TxClassification::QuarantinedCommit {
+            reason: QuarantineReason::MissingRevealSlots,
+        };
+    };
+
+    TxClassification::Commit {
+        marker,
+        reveal_slots,
+    }
+}
+
+fn match_commit_marker(tx: &Transaction, magic_bytes: MagicBytes) -> CommitMarkerMatch {
+    let Some(first_output) = tx.output.first() else {
+        return CommitMarkerMatch::Unrelated;
+    };
+    let mut instructions = first_output.script_pubkey.instructions();
+    let Some(push) = (match (instructions.next(), instructions.next()) {
+        (Some(Ok(Instruction::Op(OP_RETURN))), Some(Ok(Instruction::PushBytes(push))))
+            if push.as_bytes().starts_with(magic_bytes.as_bytes())
+                && push.as_bytes().len() == 8 =>
+        {
+            Some(push)
+        }
+        _ => None,
+    }) else {
+        return CommitMarkerMatch::Unrelated;
+    };
+    if instructions.next().is_some() {
+        return CommitMarkerMatch::MalformedSameMagic {
+            source: DaParseError::MalformedCommitMarker,
+        };
+    }
+
+    let mut payload = [0u8; 8];
+    payload.copy_from_slice(push.as_bytes());
+    parse_commit_marker_payload(payload)
+}
+
+fn match_reveal_spends(
+    tx: &Transaction,
+    commits_by_txid: &BTreeMap<Txid, CommitCandidate>,
+) -> RevealSpendMatch {
+    let mut commit_txids = Vec::new();
+    for input in &tx.input {
+        let commit_txid = input.previous_output.txid;
+        let Some(commit) = commits_by_txid.get(&commit_txid) else {
+            continue;
+        };
+        if !commit
+            .reveal_slots
+            .contains_vout(input.previous_output.vout)
+        {
+            continue;
+        }
+
+        if !commit_txids.contains(&commit_txid) {
+            commit_txids.push(commit_txid);
+        }
+    }
+
+    match commit_txids.as_slice() {
+        [] => RevealSpendMatch::None,
+        [commit_txid] => RevealSpendMatch::One {
+            commit_txid: *commit_txid,
+        },
+        _ => RevealSpendMatch::Multiple { commit_txids },
+    }
+}
+
+/// Authenticates and parses one grouped commit/reveal envelope.
+///
+/// This checks reveal completeness, validates every reveal script against the
+/// configured sequencer key, delegates chunk extraction to
+/// [`extract_da_chunks`], and maps per-envelope parse failures to
+/// [`QuarantineReason`].
+fn authenticate_and_parse_envelope(
+    commit: &CommitCandidate,
+    reveals: &[&RevealCandidate],
+    sequencer_pubkey: XOnlyPublicKey,
+) -> Result<ParsedEnvelope, QuarantineReason> {
+    let commit_txid = commit.txid;
+    let reveal_slots = commit.reveal_slots;
+
+    let covered_slots = count_covered_reveal_slots(commit_txid, reveal_slots, reveals);
+    if covered_slots < reveal_slots.last_vout() {
+        return Err(QuarantineReason::MissingReveals {
+            expected_slots: reveal_slots.last_vout(),
+            covered_slots,
+        });
+    }
+
+    for reveal in reveals {
+        authenticate_reveal(
+            &reveal.tx,
+            reveal.txid,
+            commit_txid,
+            reveal_slots,
+            sequencer_pubkey,
+        )
+        .map_err(quarantine_reason_from_auth_error)?;
+    }
+
+    let chunks = extract_da_chunks(once(&commit.tx).chain(reveals.iter().map(|r| &r.tx)))
+        .map_err(|source| QuarantineReason::MalformedEnvelope { source })?;
+
+    Ok(ParsedEnvelope::new(commit_txid, chunks))
+}
+
+fn count_covered_reveal_slots(
+    commit_txid: Txid,
+    reveal_slots: RevealSlotRange,
+    reveals: &[&RevealCandidate],
+) -> u32 {
+    let mut covered_slots = Vec::new();
+    for reveal in reveals {
+        for input in &reveal.tx.input {
+            if input.previous_output.txid != commit_txid {
+                continue;
+            }
+            if !reveal_slots.contains_vout(input.previous_output.vout) {
+                continue;
+            }
+            if !covered_slots.contains(&input.previous_output.vout) {
+                covered_slots.push(input.previous_output.vout);
+            }
+        }
+    }
+
+    covered_slots.len() as u32
+}
+
+fn quarantine_reason_from_auth_error(error: RevealAuthError) -> QuarantineReason {
+    match error {
+        RevealAuthError::MissingLeafScript { reveal_txid }
+        | RevealAuthError::UnsupportedLeafVersion { reveal_txid }
+        | RevealAuthError::InvalidSequencerPubkey { reveal_txid } => {
+            QuarantineReason::UnauthenticatedReveal { reveal_txid }
+        }
+    }
+}
+
+fn authenticate_reveal(
+    reveal: &Transaction,
+    reveal_txid: Txid,
+    commit_txid: Txid,
+    reveal_slots: RevealSlotRange,
+    sequencer_pubkey: XOnlyPublicKey,
+) -> Result<(), RevealAuthError> {
+    // Callers group reveal candidates by in-range commit-slot spends before
+    // authenticating. Keep this check visible so future direct callers don't
+    // accidentally treat "no matching input" as a successful auth result.
+    let mut matching_input_count = 0usize;
+
+    for input in &reveal.input {
+        if input.previous_output.txid != commit_txid {
+            continue;
+        }
+        if !reveal_slots.contains_vout(input.previous_output.vout) {
+            continue;
+        }
+        matching_input_count += 1;
+
+        let leaf = input
+            .witness
+            .taproot_leaf_script()
+            .ok_or(RevealAuthError::MissingLeafScript { reveal_txid })?;
+        if leaf.version != LeafVersion::TapScript {
+            return Err(RevealAuthError::UnsupportedLeafVersion { reveal_txid });
+        }
+        let leaf_script = leaf.script.to_owned();
+
+        if !script_matches_sequencer_envelope(&leaf_script, sequencer_pubkey) {
+            return Err(RevealAuthError::InvalidSequencerPubkey { reveal_txid });
+        }
+    }
+
+    debug_assert!(
+        matching_input_count > 0,
+        "authenticate_reveal called for a reveal not grouped by commit slot"
+    );
+
+    Ok(())
+}
+
+fn script_matches_sequencer_envelope(script: &Script, sequencer_pubkey: XOnlyPublicKey) -> bool {
+    // Envelope body elements are raw byte pushes. Minimal-instruction parsing
+    // would reject valid one-byte payload chunks such as `[1]`.
+    let mut instructions = script.instructions();
+
+    match instructions.next() {
+        Some(Ok(Instruction::PushBytes(bytes)))
+            if bytes.as_bytes() == sequencer_pubkey.serialize() => {}
+        _ => return false,
+    }
+
+    if !matches!(instructions.next(), Some(Ok(Instruction::Op(OP_CHECKSIG)))) {
+        return false;
+    }
+    match instructions.next() {
+        Some(Ok(Instruction::Op(op))) if op == OP_FALSE => {}
+        Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes().is_empty() => {}
+        _ => return false,
+    }
+    if !matches!(instructions.next(), Some(Ok(Instruction::Op(OP_IF)))) {
+        return false;
+    }
+
+    loop {
+        match instructions.next() {
+            Some(Ok(Instruction::PushBytes(_))) => {}
+            Some(Ok(Instruction::Op(OP_ENDIF))) => break,
+            _ => return false,
+        }
+    }
+
+    instructions.next().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime,
+        block::{Header, Version},
+        hashes::Hash,
+        opcodes::{
+            all::{OP_CHECKSIG, OP_DROP, OP_ENDIF, OP_IF, OP_NOT},
+            OP_FALSE, OP_TRUE,
+        },
+        pow::CompactTarget,
+        script::Builder,
+        secp256k1::Keypair,
+        taproot::LeafVersion,
+        transaction::Version as TxVersion,
+        Address, Amount, BlockHash, FeeRate, Network, OutPoint, ScriptBuf, Sequence, TxIn,
+        TxMerkleNode, TxOut, Txid, WPubkeyHash, Witness,
+    };
+    use bitcoind_async_client::corepc_types::model::ListUnspentItem;
+    use proptest::prelude::*;
+    use strata_btcio::writer::{
+        builder::EnvelopeConfig, chunked_envelope::build_chunked_envelope_txs,
+    };
+    use strata_l1_txfmt::{ParseConfig, TagDataRef};
+
+    use super::*;
+    use crate::{
+        fetch::L1BlockData,
+        test_utils::{
+            build_block_with_txs, build_commit_tx, build_reveal_tx, chunk_body_strategy,
+            magic_bytes_strategy, make_deterministic_keypair, make_deterministic_pubkey,
+        },
+    };
+
+    fn scan_preloaded_l1_blocks(
+        blocks: &[L1BlockData],
+        magic_bytes: MagicBytes,
+        sequencer_pubkey: XOnlyPublicKey,
+    ) -> Result<ScanOutcome, ScanError> {
+        let mut scanner = EeDaEnvelopeScanner::new(magic_bytes, sequencer_pubkey);
+        for block in blocks {
+            scanner.ingest_block(block.block())?;
+        }
+        Ok(scanner.finish())
+    }
+
+    fn make_alpen_magic_bytes() -> MagicBytes {
+        "ALPN".parse().expect("valid ASCII magic")
+    }
+
+    fn make_sequencer_pubkey() -> XOnlyPublicKey {
+        make_deterministic_pubkey(7)
+    }
+
+    fn make_non_sequencer_pubkey() -> XOnlyPublicKey {
+        make_deterministic_pubkey(8)
+    }
+
+    fn make_sequencer_keypair() -> Keypair {
+        make_deterministic_keypair(7)
+    }
+
+    fn make_commit_candidate(tx: Transaction) -> CommitCandidate {
+        let txid = tx.compute_txid();
+        let TxClassification::Commit { reveal_slots, .. } =
+            classify_transaction(&tx, make_alpen_magic_bytes())
+        else {
+            panic!("test commit must classify as a valid commit");
+        };
+
+        CommitCandidate {
+            tx,
+            txid,
+            reveal_slots,
+        }
+    }
+
+    fn make_reveal_candidate(tx: Transaction) -> RevealCandidate {
+        RevealCandidate {
+            txid: tx.compute_txid(),
+            tx,
+        }
+    }
+
+    fn make_reveal_candidates(txs: Vec<Transaction>) -> Vec<RevealCandidate> {
+        txs.into_iter().map(make_reveal_candidate).collect()
+    }
+
+    fn build_reveal_refs(reveals: &[RevealCandidate]) -> Vec<&RevealCandidate> {
+        reveals.iter().collect()
+    }
+
+    fn build_reveal_with_leaf_script(
+        mut reveal: Transaction,
+        leaf_script: ScriptBuf,
+    ) -> Transaction {
+        let control_block = reveal
+            .input
+            .first()
+            .and_then(|input| input.witness.iter().last())
+            .expect("standard reveal has control block")
+            .to_vec();
+
+        reveal.input[0].witness = Witness::new();
+        reveal.input[0].witness.push(Vec::<u8>::new());
+        reveal.input[0].witness.push(leaf_script);
+        reveal.input[0].witness.push(control_block);
+        reveal
+    }
+
+    fn build_reveal_with_leaf_version(
+        mut reveal: Transaction,
+        leaf_version: LeafVersion,
+    ) -> Transaction {
+        let mut witness_elements = reveal.input[0]
+            .witness
+            .iter()
+            .map(|element| element.to_vec())
+            .collect::<Vec<_>>();
+        let control_block = witness_elements
+            .last_mut()
+            .expect("standard reveal has control block");
+        control_block[0] = (control_block[0] & 1) | leaf_version.to_consensus();
+
+        let mut witness = Witness::new();
+        for element in witness_elements {
+            witness.push(element);
+        }
+        reveal.input[0].witness = witness;
+        reveal
+    }
+
+    fn make_future_leaf_version() -> LeafVersion {
+        LeafVersion::from_consensus(0xc2).expect("valid future leaf version")
+    }
+
+    fn make_distinct_commit_tx() -> Transaction {
+        let mut commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        commit.input[0].sequence = Sequence::MAX;
+        commit
+    }
+
+    fn make_writer_change_address() -> Address {
+        let script = ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros());
+        Address::from_script(&script, Network::Regtest).expect("valid P2WPKH address")
+    }
+
+    fn make_writer_funding_utxo(address: &Address) -> ListUnspentItem {
+        ListUnspentItem {
+            txid: "4cfbec13cf1510545f285cceceb6229bd7b6a918a8f6eba1dbee64d26226a3b7"
+                .parse::<Txid>()
+                .expect("valid txid"),
+            vout: 0,
+            address: address.as_unchecked().clone(),
+            script_pubkey: ScriptBuf::new(),
+            amount: Amount::from_btc(100.0).expect("valid amount"),
+            confirmations: 100,
+            spendable: true,
+            solvable: true,
+            label: String::new(),
+            safe: true,
+            redeem_script: None,
+            descriptor: None,
+            parent_descriptors: None,
+        }
+    }
+
+    fn make_fetched_l1_block(height: u32, txs: Vec<Transaction>) -> L1BlockData {
+        L1BlockData::new(
+            height,
+            BlockHash::from_byte_array([height as u8; 32]),
+            build_block_with_txs(txs),
+        )
+    }
+
+    fn build_commit_marker_with_extra_opcode() -> ScriptBuf {
+        let mut payload = [0u8; 8];
+        payload[..4].copy_from_slice(make_alpen_magic_bytes().as_bytes());
+
+        Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice(payload)
+            .push_opcode(OP_RETURN)
+            .into_script()
+    }
+
+    fn build_non_da_op_return_tx() -> Transaction {
+        Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: Builder::new()
+                    .push_opcode(OP_RETURN)
+                    .push_slice(*b"NOTE")
+                    .push_opcode(OP_RETURN)
+                    .into_script(),
+            }],
+        }
+    }
+
+    fn build_magic_prefixed_non_marker_tx() -> Transaction {
+        Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: Builder::new()
+                    .push_opcode(OP_RETURN)
+                    .push_slice(*b"ALPNnot-da")
+                    .into_script(),
+            }],
+        }
+    }
+
+    fn build_sps50_checkpoint_tx() -> Transaction {
+        let tag = TagDataRef::new(1, 1, &[]).expect("valid checkpoint-like tag");
+        let script_pubkey = ParseConfig::new(make_alpen_magic_bytes())
+            .encode_script_buf(&tag)
+            .expect("tag script encodes");
+
+        Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_valid_marker() {
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        assert!(matches!(
+            classify_transaction(&commit, make_alpen_magic_bytes()),
+            TxClassification::Commit { marker, .. } if marker.version() == 0
+        ));
+    }
+
+    proptest! {
+        #[test]
+        fn test_wrong_magic_ignored(wrong_magic in magic_bytes_strategy()) {
+            prop_assume!(wrong_magic != *b"ALPN");
+            let commit = build_commit_tx(MagicBytes::new(wrong_magic), 0, 1, false);
+            prop_assert!(matches!(
+                classify_transaction(&commit, make_alpen_magic_bytes()),
+                TxClassification::Unrelated
+            ));
+        }
+
+        #[test]
+        fn test_chunk_order(
+            chunk0 in chunk_body_strategy(32),
+            chunk1 in chunk_body_strategy(32),
+        ) {
+            let sequencer_pubkey = make_sequencer_pubkey();
+            let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 2, false);
+            let commit_txid = commit.compute_txid();
+            let reveal1 = build_reveal_tx(commit_txid, 2, sequencer_pubkey, &chunk1);
+            let reveal0 = build_reveal_tx(commit_txid, 1, sequencer_pubkey, &chunk0);
+            let commit = make_commit_candidate(commit);
+            let reveals = make_reveal_candidates(vec![reveal1, reveal0]);
+            let reveal_refs = build_reveal_refs(&reveals);
+            let parsed = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+                .expect("envelope parses");
+
+            prop_assert_eq!(parsed.commit_txid(), commit_txid);
+            prop_assert_eq!(parsed.chunks(), vec![chunk0, chunk1]);
+        }
+
+        #[test]
+        fn test_missing_reveal_rejected(chunk in chunk_body_strategy(32)) {
+            let sequencer_pubkey = make_sequencer_pubkey();
+            let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 2, false);
+            let reveal0 = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, &chunk);
+            let commit = make_commit_candidate(commit);
+            let reveals = make_reveal_candidates(vec![reveal0]);
+            let reveal_refs = build_reveal_refs(&reveals);
+            let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+                .expect_err("missing reveal must fail");
+
+            prop_assert!(
+                matches!(err, QuarantineReason::MissingReveals { expected_slots: 2, covered_slots: 1 }),
+                "expected missing reveal error, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn test_duplicate_reveal_rejected(
+            chunk0 in chunk_body_strategy(32),
+            chunk1 in chunk_body_strategy(32),
+        ) {
+            let sequencer_pubkey = make_sequencer_pubkey();
+            let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+            let commit_txid = commit.compute_txid();
+            let reveal0 = build_reveal_tx(commit_txid, 1, sequencer_pubkey, &chunk0);
+            let reveal1 = build_reveal_tx(commit_txid, 1, sequencer_pubkey, &chunk1);
+            let commit = make_commit_candidate(commit);
+            let reveals = make_reveal_candidates(vec![reveal0, reveal1]);
+            let reveal_refs = build_reveal_refs(&reveals);
+            let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+                .expect_err("duplicate reveal must fail");
+
+            prop_assert!(
+                matches!(err, QuarantineReason::MalformedEnvelope { source: DaParseError::DuplicateReveal { vout: 1 } }),
+                "expected duplicate reveal error, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_wrong_key_rejected() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let non_sequencer_pubkey = make_non_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, non_sequencer_pubkey, b"chunk");
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("wrong sequencer pubkey must fail");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_single_byte_chunk() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, &[1]);
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let parsed = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect("single-byte payload chunk must parse");
+
+        assert_eq!(parsed.chunks(), &[vec![1]]);
+    }
+
+    #[test]
+    fn test_checksig_override() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let malicious_script = Builder::new()
+            .push_slice(sequencer_pubkey.serialize())
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_DROP)
+            .push_opcode(OP_TRUE)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_slice(*b"chunk")
+            .push_opcode(OP_ENDIF)
+            .into_script();
+        let reveal = build_reveal_with_leaf_script(
+            build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk"),
+            malicious_script,
+        );
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("checksig result override must fail authentication");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_checksig_inversion() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let malicious_script = Builder::new()
+            .push_slice(sequencer_pubkey.serialize())
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_NOT)
+            .push_opcode(OP_IF)
+            .push_slice(*b"chunk")
+            .push_opcode(OP_ENDIF)
+            .into_script();
+        let reveal = build_reveal_with_leaf_script(
+            build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk"),
+            malicious_script,
+        );
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("checksig result inversion must fail authentication");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_trailing_opcode() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let malicious_script = Builder::new()
+            .push_slice(sequencer_pubkey.serialize())
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_slice(*b"chunk")
+            .push_opcode(OP_ENDIF)
+            .push_opcode(OP_DROP)
+            .into_script();
+        let reveal = build_reveal_with_leaf_script(
+            build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk"),
+            malicious_script,
+        );
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("trailing opcode after envelope must fail authentication");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_non_push_body_opcode() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let malicious_script = Builder::new()
+            .push_slice(sequencer_pubkey.serialize())
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_opcode(OP_TRUE)
+            .push_slice(*b"chunk")
+            .push_opcode(OP_ENDIF)
+            .into_script();
+        let reveal = build_reveal_with_leaf_script(
+            build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk"),
+            malicious_script,
+        );
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("non-push opcode inside envelope must fail authentication");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_missing_false_before_if() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let malicious_script = Builder::new()
+            .push_slice(sequencer_pubkey.serialize())
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_IF)
+            .push_slice(*b"chunk")
+            .push_opcode(OP_ENDIF)
+            .into_script();
+        let reveal = build_reveal_with_leaf_script(
+            build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk"),
+            malicious_script,
+        );
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("missing OP_FALSE before OP_IF must fail authentication");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_unsupported_version_quarantined() {
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 1, 1, false);
+
+        let TxClassification::QuarantinedCommit { reason } =
+            classify_transaction(&commit, make_alpen_magic_bytes())
+        else {
+            panic!("unsupported version must quarantine the commit");
+        };
+        assert!(matches!(
+            reason,
+            QuarantineReason::UnsupportedVersion { version: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_malformed_marker_quarantined() {
+        let mut commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        commit.output[0].script_pubkey = build_commit_marker_with_extra_opcode();
+
+        let TxClassification::QuarantinedCommit { reason } =
+            classify_transaction(&commit, make_alpen_magic_bytes())
+        else {
+            panic!("malformed marker must quarantine the commit");
+        };
+        assert!(matches!(reason, QuarantineReason::MalformedMarker { .. }));
+    }
+
+    #[test]
+    fn test_non_da_op_return_ignored() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let blocks = vec![make_fetched_l1_block(10, vec![build_non_da_op_return_tx()])];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert!(outcome.quarantined().is_empty());
+    }
+
+    #[test]
+    fn test_non_marker_magic_ignored() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let blocks = vec![make_fetched_l1_block(
+            10,
+            vec![build_magic_prefixed_non_marker_tx()],
+        )];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert!(outcome.quarantined().is_empty());
+    }
+
+    #[test]
+    fn test_checkpoint_tx_ignored() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let blocks = vec![make_fetched_l1_block(10, vec![build_sps50_checkpoint_tx()])];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert!(outcome.quarantined().is_empty());
+    }
+
+    #[test]
+    fn test_unsupported_version_isolated() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let unsupported_commit = build_commit_tx(make_alpen_magic_bytes(), 1, 1, false);
+        let valid_commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let valid_reveal =
+            build_reveal_tx(valid_commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![unsupported_commit.clone(), valid_commit.clone()]),
+            make_fetched_l1_block(11, vec![valid_reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert_eq!(outcome.envelopes().len(), 1);
+        assert_eq!(
+            outcome.envelopes()[0].commit_txid(),
+            valid_commit.compute_txid()
+        );
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert_eq!(
+            outcome.quarantined()[0].commit_txid(),
+            unsupported_commit.compute_txid()
+        );
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::UnsupportedVersion { version: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_malformed_marker_isolated() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let mut malformed_commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        malformed_commit.output[0].script_pubkey = build_commit_marker_with_extra_opcode();
+        let valid_commit = make_distinct_commit_tx();
+        let valid_reveal =
+            build_reveal_tx(valid_commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![malformed_commit.clone(), valid_commit.clone()]),
+            make_fetched_l1_block(11, vec![valid_reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert_eq!(outcome.envelopes().len(), 1);
+        assert_eq!(
+            outcome.envelopes()[0].commit_txid(),
+            valid_commit.compute_txid()
+        );
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert_eq!(
+            outcome.quarantined()[0].commit_txid(),
+            malformed_commit.compute_txid()
+        );
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::MalformedMarker { .. }
+        ));
+    }
+
+    #[test]
+    fn test_wrong_key_candidate_quarantined() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let non_sequencer_pubkey = make_non_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, non_sequencer_pubkey, b"chunk");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit.clone()]),
+            make_fetched_l1_block(11, vec![reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert_eq!(
+            outcome.quarantined()[0].commit_txid(),
+            commit.compute_txid()
+        );
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_non_tapscript_leaf_quarantined() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let reveal = build_reveal_with_leaf_version(
+            build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk"),
+            make_future_leaf_version(),
+        );
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit.clone()]),
+            make_fetched_l1_block(11, vec![reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert_eq!(
+            outcome.quarantined()[0].commit_txid(),
+            commit.compute_txid()
+        );
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::UnauthenticatedReveal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_no_slot_commit_reported() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 0, false);
+        let blocks = vec![make_fetched_l1_block(10, vec![commit.clone()])];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert_eq!(
+            outcome.quarantined()[0].commit_txid(),
+            commit.compute_txid()
+        );
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::MissingRevealSlots
+        ));
+    }
+
+    #[test]
+    fn test_missing_marker_ignored() {
+        let mut commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        commit.output.swap(0, 1);
+
+        assert!(matches!(
+            classify_transaction(&commit, make_alpen_magic_bytes()),
+            TxClassification::Unrelated
+        ));
+    }
+
+    #[test]
+    fn test_no_slot_commit_quarantined() {
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 0, false);
+
+        let TxClassification::QuarantinedCommit { reason } =
+            classify_transaction(&commit, make_alpen_magic_bytes())
+        else {
+            panic!("commit without reveal slots must be quarantined");
+        };
+        assert!(matches!(reason, QuarantineReason::MissingRevealSlots));
+    }
+
+    #[test]
+    fn test_multi_slot_reveal_rejected() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 2, false);
+        let mut reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let witness = reveal.input[0].witness.clone();
+        reveal.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: commit.compute_txid(),
+                vout: 2,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        });
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let err = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect_err("one reveal spending multiple slots must fail");
+
+        assert!(matches!(
+            err,
+            QuarantineReason::MalformedEnvelope {
+                source: DaParseError::RevealMultipleCommitSpends,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_ambiguous_p2tr_change_quarantined() {
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, true);
+
+        let TxClassification::QuarantinedCommit { reason } =
+            classify_transaction(&commit, make_alpen_magic_bytes())
+        else {
+            panic!("ambiguous P2TR change must quarantine the commit");
+        };
+        assert!(matches!(
+            reason,
+            QuarantineReason::MalformedEnvelope {
+                source: DaParseError::AmbiguousTaprootChangeOutput { .. },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_cross_block_envelope() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit.clone()]),
+            make_fetched_l1_block(11, vec![reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        let envelopes = outcome.envelopes();
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), commit.compute_txid());
+        assert_eq!(envelopes[0].chunks(), vec![b"chunk".to_vec()]);
+        assert!(outcome.quarantined().is_empty());
+    }
+
+    #[test]
+    fn test_envelope_txid_order() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit0 = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let commit1 = make_distinct_commit_tx();
+        let reveal0 = build_reveal_tx(commit0.compute_txid(), 1, sequencer_pubkey, b"chunk-0");
+        let reveal1 = build_reveal_tx(commit1.compute_txid(), 1, sequencer_pubkey, b"chunk-1");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit0.clone(), commit1.clone()]),
+            make_fetched_l1_block(11, vec![reveal0, reveal1]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+        let envelopes = outcome.envelopes();
+        let commit_txids = envelopes
+            .iter()
+            .map(ParsedEnvelope::commit_txid)
+            .collect::<Vec<_>>();
+
+        assert_eq!(envelopes.len(), 2);
+        assert!(outcome.quarantined().is_empty());
+        assert_eq!(
+            commit_txids[0],
+            commit0.compute_txid().min(commit1.compute_txid())
+        );
+        assert_eq!(
+            commit_txids[1],
+            commit0.compute_txid().max(commit1.compute_txid())
+        );
+    }
+
+    #[test]
+    fn test_missing_reveal_quarantined() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let blocks = vec![make_fetched_l1_block(10, vec![commit])];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::MissingReveals {
+                expected_slots: 1,
+                covered_slots: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_cross_commit_reveal_quarantined() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit0 = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let commit1 = make_distinct_commit_tx();
+        let mut reveal = build_reveal_tx(commit0.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let witness = reveal.input[0].witness.clone();
+        reveal.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: commit1.compute_txid(),
+                vout: 1,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        });
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit0, commit1]),
+            make_fetched_l1_block(11, vec![reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert!(outcome.envelopes().is_empty());
+        assert_eq!(outcome.quarantined().len(), 2);
+        assert!(outcome.quarantined().iter().all(|candidate| matches!(
+            candidate.reason(),
+            QuarantineReason::RevealCrossesCommits { .. }
+        )));
+    }
+
+    #[test]
+    fn test_malformed_envelope_isolated() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let malformed_commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let valid_commit = make_distinct_commit_tx();
+        let malformed_reveal0 = build_reveal_tx(
+            malformed_commit.compute_txid(),
+            1,
+            sequencer_pubkey,
+            b"chunk-0",
+        );
+        let mut malformed_reveal1 = build_reveal_tx(
+            malformed_commit.compute_txid(),
+            1,
+            sequencer_pubkey,
+            b"chunk-1",
+        );
+        malformed_reveal1.input[0].sequence = Sequence::MAX;
+        let valid_reveal =
+            build_reveal_tx(valid_commit.compute_txid(), 1, sequencer_pubkey, b"valid");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![malformed_commit.clone(), valid_commit.clone()]),
+            make_fetched_l1_block(11, vec![malformed_reveal0, malformed_reveal1, valid_reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        assert_eq!(outcome.envelopes().len(), 1);
+        assert_eq!(
+            outcome.envelopes()[0].commit_txid(),
+            valid_commit.compute_txid()
+        );
+        assert_eq!(outcome.quarantined().len(), 1);
+        assert_eq!(
+            outcome.quarantined()[0].commit_txid(),
+            malformed_commit.compute_txid()
+        );
+        assert!(matches!(
+            outcome.quarantined()[0].reason(),
+            QuarantineReason::MalformedEnvelope {
+                source: DaParseError::DuplicateReveal { vout: 1 },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_commit_txid_rejected() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit.clone()]),
+            make_fetched_l1_block(11, vec![commit.clone()]),
+        ];
+
+        let err = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect_err("duplicate commit txid must fail");
+
+        assert!(matches!(
+            err,
+            ScanError::DuplicateCommitTxid { txid } if txid == commit.compute_txid()
+        ));
+    }
+
+    #[test]
+    fn test_non_commit_blocks_ignored() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let reveal = build_reveal_tx(commit.compute_txid(), 1, sequencer_pubkey, b"chunk");
+        let reveal_block = Block {
+            header: Header {
+                version: Version::from_consensus(1),
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: CompactTarget::from_consensus(0),
+                nonce: 0,
+            },
+            txdata: vec![reveal],
+        };
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit.clone()]),
+            L1BlockData::new(11, BlockHash::from_byte_array([11; 32]), reveal_block),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        let envelopes = outcome.envelopes();
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), commit.compute_txid());
+        assert!(outcome.quarantined().is_empty());
+    }
+
+    #[test]
+    fn test_change_spend_ignored() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let commit_txid = commit.compute_txid();
+        let reveal = build_reveal_tx(commit_txid, 1, sequencer_pubkey, b"chunk");
+        let change_spend = Transaction {
+            version: TxVersion(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: commit_txid,
+                    vout: 2,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(500),
+                script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+            }],
+        };
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![commit.clone()]),
+            make_fetched_l1_block(11, vec![change_spend, reveal]),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        let envelopes = outcome.envelopes();
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), commit_txid);
+        assert_eq!(envelopes[0].chunks(), vec![b"chunk".to_vec()]);
+        assert!(outcome.quarantined().is_empty());
+    }
+
+    #[test]
+    fn test_non_slot_input_ignored() {
+        let sequencer_pubkey = make_sequencer_pubkey();
+        let commit = build_commit_tx(make_alpen_magic_bytes(), 0, 1, false);
+        let commit_txid = commit.compute_txid();
+        let mut reveal = build_reveal_tx(commit_txid, 1, sequencer_pubkey, b"chunk");
+        reveal.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout: 2,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        });
+        let commit = make_commit_candidate(commit);
+        let reveals = make_reveal_candidates(vec![reveal]);
+        let reveal_refs = build_reveal_refs(&reveals);
+        let parsed = authenticate_and_parse_envelope(&commit, &reveal_refs, sequencer_pubkey)
+            .expect("non-slot input does not require DA reveal authentication");
+
+        assert_eq!(parsed.commit_txid(), commit_txid);
+        assert_eq!(parsed.chunks(), vec![b"chunk".to_vec()]);
+    }
+
+    #[test]
+    fn test_btcio_writer_roundtrip() {
+        let keypair = make_sequencer_keypair();
+        let sequencer_pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
+        let change_address = make_writer_change_address();
+        let config = EnvelopeConfig::new(
+            make_alpen_magic_bytes(),
+            change_address.clone(),
+            Network::Regtest,
+            FeeRate::from_sat_per_vb_u32(1_000),
+            546,
+            None,
+        );
+        let chunks = vec![b"chunk-0".to_vec(), b"chunk-1".to_vec()];
+        let txs = build_chunked_envelope_txs(
+            &config,
+            &chunks,
+            &make_alpen_magic_bytes(),
+            DA_BLOB_VERSION,
+            &keypair,
+            vec![make_writer_funding_utxo(&change_address)],
+        )
+        .expect("btcio writer builds envelope");
+        let blocks = vec![
+            make_fetched_l1_block(10, vec![txs.commit_tx.clone()]),
+            make_fetched_l1_block(11, txs.reveal_txs),
+        ];
+
+        let outcome = scan_preloaded_l1_blocks(&blocks, make_alpen_magic_bytes(), sequencer_pubkey)
+            .expect("scan succeeds");
+
+        let envelopes = outcome.envelopes();
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].commit_txid(), txs.commit_tx.compute_txid());
+        assert_eq!(envelopes[0].chunks(), chunks);
+        assert!(outcome.quarantined().is_empty());
+    }
+}

--- a/crates/alpen-ee/da/l1-extraction/src/test_utils.rs
+++ b/crates/alpen-ee/da/l1-extraction/src/test_utils.rs
@@ -1,0 +1,211 @@
+use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+use bitcoin::{
+    absolute::LockTime,
+    block::{Header, Version},
+    hashes::{sha256, Hash},
+    opcodes::all::OP_RETURN,
+    pow::CompactTarget,
+    script::Builder,
+    secp256k1::{Keypair, Parity, Secp256k1, SecretKey, XOnlyPublicKey, SECP256K1},
+    taproot::{ControlBlock, LeafVersion, TaprootMerkleBranch},
+    transaction::Version as TxVersion,
+    Amount, Block, BlockHash, OutPoint, ScriptBuf, Sequence, TapNodeHash, Transaction, TxIn,
+    TxMerkleNode, TxOut, Txid, WPubkeyHash, Witness,
+};
+use proptest::{collection, prelude::*};
+use strata_l1_envelope_fmt::builder::EnvelopeScriptBuilder;
+use strata_l1_txfmt::MagicBytes;
+
+use crate::ParsedEnvelope;
+
+const BASE_TIMESTAMP: u64 = 1_700_000_000;
+const BASE_GAS_LIMIT: u64 = 30_000_000;
+const MIN_MULTI_CHUNK_BYTECODE_LEN: usize = 400_000;
+const MAX_MULTI_CHUNK_BYTECODE_LEN: usize = 450_000;
+
+pub(crate) fn build_commit_marker_script(magic: MagicBytes, version: u32) -> ScriptBuf {
+    let mut payload = [0u8; 8];
+    payload[..4].copy_from_slice(magic.as_bytes());
+    payload[4..].copy_from_slice(&version.to_be_bytes());
+
+    Builder::new()
+        .push_opcode(OP_RETURN)
+        .push_slice(payload)
+        .into_script()
+}
+
+pub(crate) fn build_commit_tx(
+    magic: MagicBytes,
+    version: u32,
+    reveal_slots: usize,
+    add_ambiguous_p2tr_change: bool,
+) -> Transaction {
+    let mut output = vec![TxOut {
+        value: Amount::from_sat(0),
+        script_pubkey: build_commit_marker_script(magic, version),
+    }];
+
+    let reveal_key = make_deterministic_pubkey(3);
+    for _ in 0..reveal_slots {
+        output.push(TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new_p2tr(SECP256K1, reveal_key, None),
+        });
+    }
+
+    output.push(TxOut {
+        value: Amount::from_sat(1_000),
+        script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+    });
+
+    if add_ambiguous_p2tr_change {
+        output.push(TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new_p2tr(SECP256K1, reveal_key, None),
+        });
+    }
+
+    Transaction {
+        version: TxVersion(2),
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output,
+    }
+}
+
+pub(crate) fn build_reveal_tx(
+    commit_txid: Txid,
+    commit_vout: u32,
+    sequencer_pubkey: XOnlyPublicKey,
+    chunk: &[u8],
+) -> Transaction {
+    let control_block = build_control_block(sequencer_pubkey);
+    let reveal_script = EnvelopeScriptBuilder::with_pubkey(&sequencer_pubkey.serialize())
+        .expect("pubkey accepted")
+        .add_envelope(chunk)
+        .expect("envelope payload accepted")
+        .build_without_min_check()
+        .expect("reveal script build succeeds");
+
+    let mut tx = Transaction {
+        version: TxVersion(2),
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout: commit_vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+        }],
+    };
+
+    tx.input[0].witness.push([1u8; 64]);
+    tx.input[0].witness.push(reveal_script);
+    tx.input[0].witness.push(control_block.serialize());
+    tx
+}
+
+pub(crate) fn build_block_with_txs(txs: Vec<Transaction>) -> Block {
+    Block {
+        header: Header {
+            version: Version::from_consensus(1),
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 0,
+        },
+        txdata: txs,
+    }
+}
+
+pub(crate) fn magic_bytes_strategy() -> impl Strategy<Value = [u8; 4]> {
+    any::<[u8; 4]>()
+}
+
+pub(crate) fn chunk_body_strategy(max_len: usize) -> impl Strategy<Value = Vec<u8>> {
+    collection::vec(any::<u8>(), 0..=max_len)
+}
+
+pub(crate) fn build_da_blob(block_num: u64) -> DaBlob {
+    DaBlob {
+        update_seq_no: block_num,
+        evm_header: build_evm_header(block_num),
+        state_diff: Default::default(),
+    }
+}
+
+pub(crate) fn build_multi_chunk_da_blob(
+    block_num: u64,
+    bytecode_len: usize,
+    fill_byte: u8,
+) -> DaBlob {
+    let mut blob = build_da_blob(block_num);
+    blob.state_diff
+        .deployed_bytecodes
+        .insert(Default::default(), vec![fill_byte; bytecode_len].into());
+    blob
+}
+
+pub(crate) fn multi_chunk_bytecode_len_strategy() -> impl Strategy<Value = usize> {
+    MIN_MULTI_CHUNK_BYTECODE_LEN..=MAX_MULTI_CHUNK_BYTECODE_LEN
+}
+
+pub(crate) fn build_parsed_envelope_from_chunk_bytes(chunks: Vec<Vec<u8>>) -> ParsedEnvelope {
+    let txid = Txid::from_byte_array(derive_synthetic_txid_bytes(&chunks));
+    ParsedEnvelope::new(txid, chunks)
+}
+
+fn build_evm_header(block_num: u64) -> EvmHeaderSummary {
+    let block_delta = block_num % 1_000_000;
+    let gas_used = BASE_GAS_LIMIT / 2 + (block_delta % 1_000);
+
+    EvmHeaderSummary {
+        block_num,
+        timestamp: BASE_TIMESTAMP + block_delta,
+        base_fee: 1_000_000_000 + block_delta,
+        gas_used,
+        gas_limit: BASE_GAS_LIMIT + (block_delta % 1_000),
+    }
+}
+
+pub(crate) fn make_deterministic_keypair(seed: u8) -> Keypair {
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[seed; 32]).expect("valid secret key");
+    Keypair::from_secret_key(&secp, &secret_key)
+}
+
+pub(crate) fn make_deterministic_pubkey(seed: u8) -> XOnlyPublicKey {
+    XOnlyPublicKey::from_keypair(&make_deterministic_keypair(seed)).0
+}
+
+fn build_control_block(internal_key: XOnlyPublicKey) -> ControlBlock {
+    let branch: [TapNodeHash; 0] = [];
+
+    ControlBlock {
+        leaf_version: LeafVersion::TapScript,
+        output_key_parity: Parity::Even,
+        internal_key,
+        merkle_branch: TaprootMerkleBranch::from(branch),
+    }
+}
+
+fn derive_synthetic_txid_bytes(chunks: &[Vec<u8>]) -> [u8; 32] {
+    let mut seed = Vec::new();
+    for chunk in chunks {
+        seed.extend_from_slice(&chunk.len().to_le_bytes());
+        seed.extend_from_slice(chunk);
+    }
+    sha256::Hash::hash(&seed).to_byte_array()
+}

--- a/crates/alpen-ee/da/runtime/src/verification/tests.rs
+++ b/crates/alpen-ee/da/runtime/src/verification/tests.rs
@@ -534,7 +534,7 @@ fn verify_da_witness_rejects_missing_reveal() {
 
     assert!(matches!(
         err,
-        DaVerificationError::Parse(DaParseError::MissingReveal(1))
+        DaVerificationError::Parse(DaParseError::MissingReveal { vout: 1 })
     ));
 }
 
@@ -575,7 +575,7 @@ fn verify_da_witness_rejects_duplicate_reveal() {
 
     assert!(matches!(
         err,
-        DaVerificationError::Parse(DaParseError::DuplicateReveal(1))
+        DaVerificationError::Parse(DaParseError::DuplicateReveal { vout: 1 })
     ));
 }
 

--- a/crates/alpen-ee/da/state-replay/Cargo.toml
+++ b/crates/alpen-ee/da/state-replay/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2021"
+name = "alpen-ee-da-state-replay"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[dependencies]
+alpen-ee-da-types.workspace = true
+alpen-reth-statediff.workspace = true
+strata-identifiers.workspace = true
+
+alloy-primitives.workspace = true
+rsp-mpt.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+alpen-reth-statediff = { workspace = true, features = ["test-utils"] }
+proptest.workspace = true
+serde_json.workspace = true

--- a/crates/alpen-ee/da/state-replay/src/error.rs
+++ b/crates/alpen-ee/da/state-replay/src/error.rs
@@ -1,0 +1,78 @@
+//! Replay error types.
+
+use alpen_reth_statediff::ReconstructError;
+use strata_identifiers::Buf32;
+
+/// Errors raised while replaying decoded DA blobs.
+#[derive(Debug, thiserror::Error)]
+pub enum ReplayError {
+    /// Genesis replay starts after the first EE DA update.
+    #[error("non-genesis start: expected update_seq_no 0, got {first_update_seq_no}")]
+    NonGenesisStart { first_update_seq_no: u64 },
+
+    /// The supplied snapshot artifact version is not supported.
+    #[error("unsupported snapshot version: expected {supported_version}, got {version}")]
+    UnsupportedSnapshotVersion {
+        version: u32,
+        supported_version: u32,
+    },
+
+    /// The supplied snapshot state does not produce its claimed state root.
+    #[error("snapshot root mismatch: expected {expected_state_root}, got {actual_state_root}")]
+    SnapshotRootMismatch {
+        expected_state_root: Buf32,
+        actual_state_root: Buf32,
+    },
+
+    /// The first replayed blob does not match the snapshot update anchor.
+    #[error("snapshot update_seq_no mismatch: expected {expected_update_seq_no}, got {actual_update_seq_no}")]
+    SnapshotUpdateSeqNoMismatch {
+        expected_update_seq_no: u64,
+        actual_update_seq_no: u64,
+    },
+
+    /// The first replayed blob does not follow the snapshot block anchor.
+    #[error("snapshot block anchor mismatch: expected first block after {last_applied_block_num}, got {first_blob_block_num}")]
+    SnapshotBlockAnchorMismatch {
+        last_applied_block_num: u64,
+        first_blob_block_num: u64,
+    },
+
+    /// The DA blob sequence skips an update sequence number.
+    #[error("update_seq_no gap at blob {blob_index}: expected {expected_update_seq_no}, got {actual_update_seq_no}")]
+    UpdateSeqNoGap {
+        blob_index: usize,
+        expected_update_seq_no: u64,
+        actual_update_seq_no: u64,
+    },
+
+    /// The DA blob sequence cannot continue after the terminal update sequence number.
+    #[error("terminal update_seq_no {update_seq_no} at blob {blob_index}")]
+    TerminalUpdateSeqNo {
+        blob_index: usize,
+        update_seq_no: u64,
+    },
+
+    /// The DA blob sequence repeats an update sequence number.
+    #[error("duplicate update_seq_no {update_seq_no} at blob {blob_index}")]
+    DuplicateUpdateSeqNo {
+        blob_index: usize,
+        update_seq_no: u64,
+    },
+
+    /// The DA blob sequence does not strictly increase EVM block numbers.
+    #[error("non-increasing block number at blob {blob_index}: expected greater than {previous_block_num}, got {current_block_num}")]
+    NonIncreasingBlockNumber {
+        blob_index: usize,
+        previous_block_num: u64,
+        current_block_num: u64,
+    },
+
+    /// The Ethereum state replay path rejects a blob state diff.
+    #[error("failed to apply state diff for blob {blob_index}: {source}")]
+    ApplyDiff {
+        blob_index: usize,
+        #[source]
+        source: ReconstructError,
+    },
+}

--- a/crates/alpen-ee/da/state-replay/src/lib.rs
+++ b/crates/alpen-ee/da/state-replay/src/lib.rs
@@ -1,0 +1,18 @@
+//! Replays decoded EE DA blobs into reconstructed execution state.
+//!
+//! This crate applies the state diff from each replayed DA blob. Snapshot
+//! artifacts carry replay state; bytecode preimage completeness is outside this
+//! crate's replay contract.
+//!
+//! Replay is externally stateless: callers provide initial state and own
+//! persistence of returned snapshots or state artifacts.
+
+mod error;
+mod replay;
+mod snapshot;
+mod summary;
+
+pub use error::ReplayError;
+pub use replay::{replay_da_blobs_from_genesis, replay_da_blobs_from_snapshot};
+pub use snapshot::{ReplayStateSnapshot, SNAPSHOT_FORMAT_VERSION};
+pub use summary::{AppliedExecBlockRange, ReplaySummary};

--- a/crates/alpen-ee/da/state-replay/src/replay.rs
+++ b/crates/alpen-ee/da/state-replay/src/replay.rs
@@ -1,0 +1,614 @@
+//! Replay entry points.
+
+use alpen_ee_da_types::DaBlob;
+use alpen_reth_statediff::{
+    apply_batch_state_diff_to_ethereum_state, EthereumStateExt, ReconstructError,
+};
+use rsp_mpt::EthereumState;
+
+use crate::{
+    error::ReplayError,
+    snapshot::{ReplayStateSnapshot, SNAPSHOT_FORMAT_VERSION},
+    summary::{AppliedExecBlockRange, ReplaySummary},
+};
+
+/// EVM genesis is block 0; the first block applied from DA is block 1.
+const GENESIS_LAST_APPLIED_BLOCK_NUM: u64 = 0;
+
+/// Replays genesis-start ordered DA blobs into an in-memory Ethereum state.
+///
+/// The input must be sorted by [`DaBlob::update_seq_no`] and must start at
+/// update sequence number 0 when non-empty. The caller must pass an Ethereum
+/// state initialized from chain-spec genesis; final-root reconstruction is
+/// meaningful only for a complete replay from the first posted EE DA update.
+/// Partial-range replay needs an explicit state snapshot, not just a
+/// state root.
+///
+/// Empty input returns the supplied genesis state's root as the final state root
+/// and no applied range.
+pub fn replay_da_blobs_from_genesis(
+    state: EthereumState,
+    blobs: &[DaBlob],
+) -> Result<ReplaySummary, ReplayError> {
+    if let Some(first) = blobs.first() {
+        if first.update_seq_no != 0 {
+            return Err(ReplayError::NonGenesisStart {
+                first_update_seq_no: first.update_seq_no,
+            });
+        }
+    }
+
+    replay_da_blobs_from_state(state, GENESIS_LAST_APPLIED_BLOCK_NUM, blobs)
+}
+
+/// Replays ordered DA blobs from an explicit state snapshot.
+///
+/// The snapshot must represent the EE state immediately before the first
+/// supplied blob. The state root is checked before any blob is applied.
+/// Empty input returns the snapshot root as the final state root and no applied
+/// range.
+pub fn replay_da_blobs_from_snapshot(
+    snapshot: ReplayStateSnapshot,
+    blobs: &[DaBlob],
+) -> Result<ReplaySummary, ReplayError> {
+    if snapshot.version() != SNAPSHOT_FORMAT_VERSION {
+        return Err(ReplayError::UnsupportedSnapshotVersion {
+            version: snapshot.version(),
+            supported_version: SNAPSHOT_FORMAT_VERSION,
+        });
+    }
+
+    let expected_state_root = snapshot.expected_state_root();
+    let next_update_seq_no = snapshot.next_update_seq_no();
+    let last_applied_block_num = snapshot.last_applied_block_num();
+    let state = snapshot.into_ethereum_state();
+    let actual_state_root = state.state_root_buf32();
+    if actual_state_root != expected_state_root {
+        return Err(ReplayError::SnapshotRootMismatch {
+            expected_state_root,
+            actual_state_root,
+        });
+    }
+
+    if let Some(first) = blobs.first() {
+        if first.update_seq_no != next_update_seq_no {
+            return Err(ReplayError::SnapshotUpdateSeqNoMismatch {
+                expected_update_seq_no: next_update_seq_no,
+                actual_update_seq_no: first.update_seq_no,
+            });
+        }
+
+        let first_blob_block_num = first.evm_header.block_num;
+        if first_blob_block_num <= last_applied_block_num {
+            return Err(ReplayError::SnapshotBlockAnchorMismatch {
+                last_applied_block_num,
+                first_blob_block_num,
+            });
+        }
+    }
+
+    replay_da_blobs_from_state(state, last_applied_block_num, blobs)
+}
+
+fn replay_da_blobs_from_state(
+    mut state: EthereumState,
+    last_applied_block_num: u64,
+    blobs: &[DaBlob],
+) -> Result<ReplaySummary, ReplayError> {
+    let mut previous_update_seq_no: Option<u64> = None;
+    let mut previous_block_num = Some(last_applied_block_num);
+    let mut applied_state_roots = Vec::with_capacity(blobs.len());
+
+    for (blob_index, blob) in blobs.iter().enumerate() {
+        if let Some(previous_update_seq_no) = previous_update_seq_no {
+            if blob.update_seq_no == previous_update_seq_no {
+                return Err(ReplayError::DuplicateUpdateSeqNo {
+                    blob_index,
+                    update_seq_no: blob.update_seq_no,
+                });
+            }
+
+            let expected_update_seq_no =
+                previous_update_seq_no
+                    .checked_add(1)
+                    .ok_or(ReplayError::TerminalUpdateSeqNo {
+                        blob_index,
+                        update_seq_no: previous_update_seq_no,
+                    })?;
+            if blob.update_seq_no != expected_update_seq_no {
+                return Err(ReplayError::UpdateSeqNoGap {
+                    blob_index,
+                    expected_update_seq_no,
+                    actual_update_seq_no: blob.update_seq_no,
+                });
+            }
+        }
+
+        let current_block_num = blob.evm_header.block_num;
+        if let Some(previous_block_num) = previous_block_num {
+            if current_block_num <= previous_block_num {
+                return Err(ReplayError::NonIncreasingBlockNumber {
+                    blob_index,
+                    previous_block_num,
+                    current_block_num,
+                });
+            }
+        }
+
+        apply_da_blob(&mut state, blob)
+            .map_err(|source| ReplayError::ApplyDiff { blob_index, source })?;
+        applied_state_roots.push(state.state_root_buf32());
+
+        previous_update_seq_no = Some(blob.update_seq_no);
+        previous_block_num = Some(current_block_num);
+    }
+
+    let final_state_root = state.state_root_buf32();
+    let applied_evm_headers = blobs.iter().map(|blob| blob.evm_header).collect();
+    let applied = match (blobs.first(), blobs.last()) {
+        (Some(first), Some(last)) => {
+            let Some(first_block_num) = last_applied_block_num.checked_add(1) else {
+                unreachable!("non-empty replay cannot follow terminal block anchor");
+            };
+            Some(AppliedExecBlockRange::new(
+                first_block_num,
+                first,
+                last,
+                blobs.len(),
+            ))
+        }
+        _ => None,
+    };
+
+    Ok(ReplaySummary::new(
+        applied,
+        applied_evm_headers,
+        applied_state_roots,
+        final_state_root,
+        state,
+    ))
+}
+
+fn apply_da_blob(state: &mut EthereumState, blob: &DaBlob) -> Result<(), ReconstructError> {
+    apply_batch_state_diff_to_ethereum_state(state, &blob.state_diff)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use alloy_primitives::{Address, B256};
+    use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+    use alpen_reth_statediff::{
+        apply_batch_state_diff_to_ethereum_state, ethereum_state_from_genesis_accounts,
+        test_utils::{
+            addr, hash, slot, snapshot as account_snapshot, value as storage_or_balance_value,
+        },
+        AccountChange, AccountDiff, BatchStateDiff, EthereumStateExt, GenesisAccount, StorageDiff,
+    };
+    use proptest::prelude::*;
+    use rsp_mpt::EthereumState;
+    use strata_identifiers::Buf32;
+
+    use crate::{
+        replay_da_blobs_from_genesis, replay_da_blobs_from_snapshot, ReplayError,
+        ReplayStateSnapshot, SNAPSHOT_FORMAT_VERSION,
+    };
+
+    const MAX_SEQUENCE_INCREMENT_SUM: u64 = 16;
+    const MAX_SEQUENCE_LEN: usize = 8;
+
+    #[test]
+    fn test_empty_genesis_replay() {
+        let state = build_empty_ethereum_state();
+
+        let summary =
+            replay_da_blobs_from_genesis(state.clone(), &[]).expect("replay must succeed");
+
+        assert_eq!(summary.applied(), None);
+        assert_eq!(summary.final_state_root(), state.state_root_buf32());
+    }
+
+    #[test]
+    fn test_empty_snapshot_replay() {
+        let snapshot = build_replay_snapshot(10, 100);
+        let expected_state_root = snapshot.expected_state_root();
+
+        let summary = replay_da_blobs_from_snapshot(snapshot, &[]).expect("replay must succeed");
+
+        assert_eq!(summary.applied(), None);
+        assert_eq!(summary.final_state_root(), expected_state_root);
+        assert_eq!(
+            summary.final_ethereum_state().state_root_buf32(),
+            expected_state_root
+        );
+    }
+
+    #[test]
+    fn test_snapshot_replay() {
+        let snapshot = build_replay_snapshot(5, 99);
+        let blobs = vec![build_da_blob(5, 100), build_da_blob(6, 101)];
+
+        let summary = replay_da_blobs_from_snapshot(snapshot, &blobs).expect("replay must succeed");
+        let applied = summary.applied().expect("applied range must be populated");
+
+        assert_eq!(applied.count(), 2);
+        assert_eq!(applied.first_update_seq_no(), 5);
+        assert_eq!(applied.last_update_seq_no(), 6);
+        assert_eq!(applied.first_block_num(), 100);
+        assert_eq!(applied.last_block_num(), 101);
+        assert_eq!(
+            summary.applied_evm_headers(),
+            blobs.iter().map(|blob| blob.evm_header).collect::<Vec<_>>()
+        );
+        assert_eq!(summary.applied_state_roots().len(), 2);
+    }
+
+    #[test]
+    fn test_snapshot_applied_range() {
+        let snapshot = build_replay_snapshot(5, 100);
+        let blobs = vec![build_da_blob(5, 105)];
+
+        let summary = replay_da_blobs_from_snapshot(snapshot, &blobs).expect("replay must succeed");
+        let applied = summary.applied().expect("applied range must be populated");
+
+        assert_eq!(applied.first_block_num(), 101);
+        assert_eq!(applied.last_block_num(), 105);
+    }
+
+    #[test]
+    fn test_genesis_applied_range() {
+        let blobs = vec![build_da_blob(0, 3)];
+
+        let summary = replay_da_blobs_from_genesis(build_empty_ethereum_state(), &blobs)
+            .expect("replay succeeds");
+        let applied = summary.applied().expect("applied range must be populated");
+
+        assert_eq!(applied.first_block_num(), 1);
+        assert_eq!(applied.last_block_num(), 3);
+    }
+
+    #[test]
+    fn test_snapshot_root_mismatch() {
+        let expected = Buf32::from([0x42; 32]);
+        let snapshot = parse_snapshot_json(build_snapshot_json_with_expected_state_root(expected));
+
+        let err =
+            replay_da_blobs_from_snapshot(snapshot, &[]).expect_err("replay must reject snapshot");
+
+        match err {
+            ReplayError::SnapshotRootMismatch {
+                expected_state_root,
+                ..
+            } => assert_eq!(expected_state_root, expected),
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_unsupported_snapshot_version() {
+        let snapshot = parse_snapshot_json(build_snapshot_json_with_version(999));
+
+        let err =
+            replay_da_blobs_from_snapshot(snapshot, &[]).expect_err("replay must reject snapshot");
+
+        match err {
+            ReplayError::UnsupportedSnapshotVersion {
+                version,
+                supported_version,
+            } => {
+                assert_eq!(version, 999);
+                assert_eq!(supported_version, SNAPSHOT_FORMAT_VERSION);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_snapshot_update_seq_no_mismatch() {
+        let snapshot = build_replay_snapshot(5, 99);
+        let blobs = vec![build_da_blob(6, 100)];
+
+        let err =
+            replay_da_blobs_from_snapshot(snapshot, &blobs).expect_err("replay must reject anchor");
+
+        match err {
+            ReplayError::SnapshotUpdateSeqNoMismatch {
+                expected_update_seq_no,
+                actual_update_seq_no,
+            } => {
+                assert_eq!(expected_update_seq_no, 5);
+                assert_eq!(actual_update_seq_no, 6);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_snapshot_block_anchor_mismatch() {
+        let snapshot = build_replay_snapshot(5, 100);
+        let blobs = vec![build_da_blob(5, 100)];
+
+        let err =
+            replay_da_blobs_from_snapshot(snapshot, &blobs).expect_err("replay must reject anchor");
+
+        match err {
+            ReplayError::SnapshotBlockAnchorMismatch {
+                last_applied_block_num,
+                first_blob_block_num,
+            } => {
+                assert_eq!(last_applied_block_num, 100);
+                assert_eq!(first_blob_block_num, 100);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_snapshot_update_seq_no_gap() {
+        let snapshot = build_replay_snapshot(5, 99);
+        let blobs = vec![build_da_blob(5, 100), build_da_blob(7, 101)];
+
+        let err =
+            replay_da_blobs_from_snapshot(snapshot, &blobs).expect_err("replay must reject gap");
+
+        match err {
+            ReplayError::UpdateSeqNoGap {
+                blob_index,
+                expected_update_seq_no,
+                actual_update_seq_no,
+            } => {
+                assert_eq!(blob_index, 1);
+                assert_eq!(expected_update_seq_no, 6);
+                assert_eq!(actual_update_seq_no, 7);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_contiguous_genesis_sequence(
+            first_block_num in 1u64..=(u64::MAX - MAX_SEQUENCE_INCREMENT_SUM),
+            count in 1usize..=MAX_SEQUENCE_LEN,
+        ) {
+            let blobs = build_contiguous_da_blobs(first_block_num, count);
+
+            let summary = replay_da_blobs_from_genesis(build_empty_ethereum_state(), &blobs).expect("replay must succeed");
+            let applied = summary.applied().expect("applied range must be populated");
+            prop_assert_eq!(applied.count(), count);
+            prop_assert_eq!(applied.first_update_seq_no(), 0);
+            prop_assert_eq!(applied.last_update_seq_no(), count as u64 - 1);
+            prop_assert_eq!(applied.first_block_num(), 1);
+            prop_assert_eq!(applied.last_block_num(), first_block_num + count as u64 - 1);
+        }
+
+        #[test]
+        fn test_non_genesis_start(
+            first_update_seq_no in 1u64..=u64::MAX,
+            first_block_num in any::<u64>(),
+        ) {
+            let blobs = vec![build_da_blob(first_update_seq_no, first_block_num)];
+
+            let err = replay_da_blobs_from_genesis(build_empty_ethereum_state(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::NonGenesisStart { first_update_seq_no: got } => {
+                    prop_assert_eq!(got, first_update_seq_no);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_update_seq_no_gap(
+            first_block_num in 1u64..=(u64::MAX - 2),
+        ) {
+            let blobs = vec![
+                build_da_blob(0, first_block_num),
+                build_da_blob(2, first_block_num + 1),
+            ];
+
+            let err = replay_da_blobs_from_genesis(build_empty_ethereum_state(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::UpdateSeqNoGap { blob_index, expected_update_seq_no, actual_update_seq_no } => {
+                    prop_assert_eq!(blob_index, 1);
+                    prop_assert_eq!(expected_update_seq_no, 1);
+                    prop_assert_eq!(actual_update_seq_no, 2);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_duplicate_update_seq_no(
+            first_block_num in 1u64..=(u64::MAX - 2),
+        ) {
+            let blobs = vec![
+                build_da_blob(0, first_block_num),
+                build_da_blob(0, first_block_num + 1),
+            ];
+
+            let err = replay_da_blobs_from_genesis(build_empty_ethereum_state(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::DuplicateUpdateSeqNo { blob_index, update_seq_no: got } => {
+                    prop_assert_eq!(blob_index, 1);
+                    prop_assert_eq!(got, 0);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_non_increasing_block_number(
+            first_block_num in 1u64..=u64::MAX,
+            non_increase in 0u64..=3,
+        ) {
+            let second_block_num = first_block_num.saturating_sub(non_increase);
+            let blobs = vec![
+                build_da_blob(0, first_block_num),
+                build_da_blob(1, second_block_num),
+            ];
+
+            let err = replay_da_blobs_from_genesis(build_empty_ethereum_state(), &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::NonIncreasingBlockNumber { blob_index, .. } => {
+                    prop_assert_eq!(blob_index, 1);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+
+        #[test]
+        fn test_terminal_update_seq_no(
+            block_num in 1u64..=(u64::MAX - 1),
+        ) {
+            let snapshot = build_replay_snapshot(u64::MAX, block_num - 1);
+            let blobs = vec![build_da_blob(u64::MAX, block_num), build_da_blob(0, block_num + 1)];
+
+            let err = replay_da_blobs_from_snapshot(snapshot, &blobs).expect_err("replay must fail");
+            match err {
+                ReplayError::TerminalUpdateSeqNo { blob_index, update_seq_no } => {
+                    prop_assert_eq!(blob_index, 1);
+                    prop_assert_eq!(update_seq_no, u64::MAX);
+                }
+                other => prop_assert!(false, "unexpected error: {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_non_empty_state_diffs() {
+        let address = addr(0x44);
+        let code_hash = hash(0x55);
+        let diff0 = build_account_creation_diff(address, code_hash);
+        let diff1 = build_account_update_diff(address, code_hash);
+        let blobs = vec![
+            build_da_blob_with_diff(0, 1, diff0.clone()),
+            build_da_blob_with_diff(1, 2, diff1.clone()),
+        ];
+
+        let genesis = build_empty_ethereum_state();
+        let mut expected_state = genesis.clone();
+        apply_batch_state_diff_to_ethereum_state(&mut expected_state, &diff0)
+            .expect("first diff applies");
+        let after_first_root = expected_state.state_root_buf32();
+        apply_batch_state_diff_to_ethereum_state(&mut expected_state, &diff1)
+            .expect("second diff applies");
+        let expected_final_root = expected_state.state_root_buf32();
+
+        let summary = replay_da_blobs_from_genesis(genesis, &blobs).expect("replay must succeed");
+
+        assert_ne!(after_first_root, expected_final_root);
+        assert_eq!(
+            summary.applied_state_roots(),
+            &[after_first_root, expected_final_root]
+        );
+        assert_eq!(summary.final_state_root(), expected_final_root);
+    }
+
+    fn build_da_blob(update_seq_no: u64, block_num: u64) -> DaBlob {
+        build_da_blob_with_diff(update_seq_no, block_num, BatchStateDiff::default())
+    }
+
+    fn build_da_blob_with_diff(
+        update_seq_no: u64,
+        block_num: u64,
+        state_diff: BatchStateDiff,
+    ) -> DaBlob {
+        let gas_used = block_num % 1_000;
+        DaBlob {
+            update_seq_no,
+            evm_header: EvmHeaderSummary {
+                block_num,
+                timestamp: block_num,
+                base_fee: block_num,
+                gas_used,
+                gas_limit: gas_used.saturating_add(1),
+            },
+            state_diff,
+        }
+    }
+
+    fn build_contiguous_da_blobs(first_block_num: u64, count: usize) -> Vec<DaBlob> {
+        (0..count)
+            .map(|idx| build_da_blob(idx as u64, first_block_num + idx as u64))
+            .collect()
+    }
+
+    fn build_replay_snapshot(
+        next_update_seq_no: u64,
+        last_applied_block_num: u64,
+    ) -> ReplayStateSnapshot {
+        let state = build_empty_ethereum_state();
+        ReplayStateSnapshot::new(
+            next_update_seq_no,
+            last_applied_block_num,
+            state,
+            Default::default(),
+        )
+    }
+
+    fn build_empty_ethereum_state() -> EthereumState {
+        ethereum_state_from_genesis_accounts(iter::empty::<(Address, GenesisAccount)>())
+            .expect("empty genesis state builds")
+    }
+
+    fn build_account_creation_diff(address: Address, code_hash: B256) -> BatchStateDiff {
+        let mut state_diff = BatchStateDiff::new();
+        state_diff.accounts.insert(
+            address,
+            AccountChange::Created(AccountDiff::new_created(
+                storage_or_balance_value(10),
+                1,
+                code_hash,
+            )),
+        );
+        let mut storage_diff = StorageDiff::new();
+        storage_diff.set_slot(slot(1), storage_or_balance_value(11));
+        state_diff.storage.insert(address, storage_diff);
+        state_diff
+    }
+
+    fn build_account_update_diff(address: Address, code_hash: B256) -> BatchStateDiff {
+        let original = account_snapshot(10, 1, code_hash);
+        let current = account_snapshot(15, 2, code_hash);
+        let mut state_diff = BatchStateDiff::new();
+        state_diff.accounts.insert(
+            address,
+            AccountChange::Updated(
+                AccountDiff::from_account_snapshot(&current, Some(&original), address)
+                    .expect("account changed"),
+            ),
+        );
+        let mut storage_diff = StorageDiff::new();
+        storage_diff.set_slot(slot(1), storage_or_balance_value(12));
+        state_diff.storage.insert(address, storage_diff);
+        state_diff
+    }
+
+    fn build_snapshot_json_with_expected_state_root(
+        expected_state_root: Buf32,
+    ) -> serde_json::Value {
+        build_snapshot_json(SNAPSHOT_FORMAT_VERSION, expected_state_root)
+    }
+
+    fn build_snapshot_json_with_version(version: u32) -> serde_json::Value {
+        let expected_state_root = build_empty_ethereum_state().state_root_buf32();
+        build_snapshot_json(version, expected_state_root)
+    }
+
+    fn build_snapshot_json(version: u32, expected_state_root: Buf32) -> serde_json::Value {
+        serde_json::json!({
+            "version": version,
+            "expected_state_root": expected_state_root,
+            "next_update_seq_no": 5,
+            "last_applied_block_num": 99,
+            "ethereum_state": build_empty_ethereum_state(),
+            "bytecodes": {},
+        })
+    }
+
+    fn parse_snapshot_json(value: serde_json::Value) -> ReplayStateSnapshot {
+        serde_json::from_value(value).expect("snapshot JSON deserializes")
+    }
+}

--- a/crates/alpen-ee/da/state-replay/src/snapshot.rs
+++ b/crates/alpen-ee/da/state-replay/src/snapshot.rs
@@ -1,0 +1,144 @@
+//! Replay state snapshot types.
+
+use std::collections::BTreeMap;
+
+use alloy_primitives::{Bytes, B256};
+use alpen_reth_statediff::EthereumStateExt;
+use rsp_mpt::EthereumState;
+use serde::{Deserialize, Serialize};
+use strata_identifiers::Buf32;
+
+/// Current JSON snapshot artifact version.
+///
+/// Version `1` is the initial schema. Bump this when the serialized shape
+/// changes, including upstream [`EthereumState`] serde changes.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+
+/// Explicit replay state for partial-range replay.
+///
+/// The snapshot represents the EE state immediately before
+/// [`ReplayStateSnapshot::next_update_seq_no`]. It carries the Ethereum
+/// state plus bytecode preimages for accounts that existed before the
+/// replayed DA range.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayStateSnapshot {
+    version: u32,
+    expected_state_root: Buf32,
+    next_update_seq_no: u64,
+    last_applied_block_num: u64,
+    ethereum_state: EthereumState,
+    bytecodes: BTreeMap<B256, Bytes>,
+}
+
+impl ReplayStateSnapshot {
+    /// Creates an explicit state snapshot for partial replay.
+    pub fn new(
+        next_update_seq_no: u64,
+        last_applied_block_num: u64,
+        ethereum_state: EthereumState,
+        bytecodes: BTreeMap<B256, Bytes>,
+    ) -> Self {
+        let expected_state_root = ethereum_state.state_root_buf32();
+        Self {
+            version: SNAPSHOT_FORMAT_VERSION,
+            expected_state_root,
+            next_update_seq_no,
+            last_applied_block_num,
+            ethereum_state,
+            bytecodes,
+        }
+    }
+
+    /// Returns the snapshot artifact version.
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+
+    /// Returns the expected root of the state.
+    pub fn expected_state_root(&self) -> Buf32 {
+        self.expected_state_root
+    }
+
+    /// Returns the first update sequence number accepted by this snapshot.
+    pub fn next_update_seq_no(&self) -> u64 {
+        self.next_update_seq_no
+    }
+
+    /// Returns the last EVM block number applied before this snapshot.
+    pub fn last_applied_block_num(&self) -> u64 {
+        self.last_applied_block_num
+    }
+
+    /// Returns the Ethereum state used to initialize replay.
+    pub fn ethereum_state(&self) -> &EthereumState {
+        &self.ethereum_state
+    }
+
+    /// Consumes the snapshot and returns its Ethereum state.
+    pub fn into_ethereum_state(self) -> EthereumState {
+        self.ethereum_state
+    }
+
+    /// Returns bytecode preimages for accounts that existed before replay.
+    pub fn bytecodes(&self) -> &BTreeMap<B256, Bytes> {
+        &self.bytecodes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_reth_statediff::{
+        ethereum_state_from_genesis_accounts,
+        test_utils::{addr, slot, value as storage_or_balance_value},
+        EthereumStateExt, GenesisAccount,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_snapshot_json_roundtrip() {
+        let ethereum_state = ethereum_state_from_genesis_accounts([(
+            addr(0x11),
+            build_genesis_account_with_storage(7, 100, 1, 2),
+        )])
+        .expect("genesis state builds");
+        let snapshot = ReplayStateSnapshot::new(
+            9,
+            123,
+            ethereum_state,
+            BTreeMap::from([(B256::from([0x44; 32]), Bytes::from_static(b"bytecode"))]),
+        );
+
+        let encoded = serde_json::to_string(&snapshot).expect("snapshot must serialize");
+        let decoded: ReplayStateSnapshot =
+            serde_json::from_str(&encoded).expect("snapshot must deserialize");
+
+        assert_eq!(decoded, snapshot);
+        assert_eq!(decoded.version(), SNAPSHOT_FORMAT_VERSION);
+        assert_eq!(
+            decoded.ethereum_state().state_root_buf32(),
+            decoded.expected_state_root()
+        );
+    }
+
+    fn build_genesis_account_with_storage(
+        nonce: u64,
+        balance: u64,
+        slot_key: u64,
+        slot_value: u64,
+    ) -> GenesisAccount {
+        let mut storage = BTreeMap::new();
+        storage.insert(
+            B256::from(slot(slot_key).to_be_bytes::<32>()),
+            B256::from(storage_or_balance_value(slot_value).to_be_bytes::<32>()),
+        );
+
+        GenesisAccount {
+            nonce: Some(nonce),
+            balance: storage_or_balance_value(balance),
+            code: None,
+            storage: Some(storage),
+            private_key: None,
+        }
+    }
+}

--- a/crates/alpen-ee/da/state-replay/src/summary.rs
+++ b/crates/alpen-ee/da/state-replay/src/summary.rs
@@ -1,0 +1,109 @@
+//! Replay output summary types.
+
+use alpen_ee_da_types::{DaBlob, EvmHeaderSummary};
+use rsp_mpt::EthereumState;
+use serde::Serialize;
+use strata_identifiers::Buf32;
+
+/// Range of EVM execution blocks applied during replay.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AppliedExecBlockRange {
+    first_update_seq_no: u64,
+    last_update_seq_no: u64,
+    first_block_num: u64,
+    last_block_num: u64,
+    count: usize,
+}
+
+impl AppliedExecBlockRange {
+    pub(crate) fn new(first_block_num: u64, first: &DaBlob, last: &DaBlob, count: usize) -> Self {
+        Self {
+            first_update_seq_no: first.update_seq_no,
+            last_update_seq_no: last.update_seq_no,
+            first_block_num,
+            last_block_num: last.evm_header.block_num,
+            count,
+        }
+    }
+
+    /// Returns the first applied EE DA update sequence number.
+    pub fn first_update_seq_no(&self) -> u64 {
+        self.first_update_seq_no
+    }
+
+    /// Returns the last applied EE DA update sequence number.
+    pub fn last_update_seq_no(&self) -> u64 {
+        self.last_update_seq_no
+    }
+
+    /// Returns the first applied EVM block number.
+    pub fn first_block_num(&self) -> u64 {
+        self.first_block_num
+    }
+
+    /// Returns the last applied EVM block number.
+    pub fn last_block_num(&self) -> u64 {
+        self.last_block_num
+    }
+
+    /// Returns the number of DA blobs applied.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+/// Replay-stage output summary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReplaySummary {
+    applied: Option<AppliedExecBlockRange>,
+    #[serde(skip)]
+    applied_evm_headers: Vec<EvmHeaderSummary>,
+    #[serde(skip)]
+    applied_state_roots: Vec<Buf32>,
+    final_state_root: Buf32,
+    #[serde(skip)]
+    final_ethereum_state: EthereumState,
+}
+
+impl ReplaySummary {
+    pub(crate) fn new(
+        applied: Option<AppliedExecBlockRange>,
+        applied_evm_headers: Vec<EvmHeaderSummary>,
+        applied_state_roots: Vec<Buf32>,
+        final_state_root: Buf32,
+        final_ethereum_state: EthereumState,
+    ) -> Self {
+        Self {
+            applied,
+            applied_evm_headers,
+            applied_state_roots,
+            final_state_root,
+            final_ethereum_state,
+        }
+    }
+
+    /// Returns the applied EVM block range, if any DA blobs were replayed.
+    pub fn applied(&self) -> Option<&AppliedExecBlockRange> {
+        self.applied.as_ref()
+    }
+
+    /// Returns the EVM header summaries for each applied DA blob.
+    pub fn applied_evm_headers(&self) -> &[EvmHeaderSummary] {
+        &self.applied_evm_headers
+    }
+
+    /// Returns the post-blob execution state root for each applied DA blob.
+    pub fn applied_state_roots(&self) -> &[Buf32] {
+        &self.applied_state_roots
+    }
+
+    /// Returns the reconstructed final state root.
+    pub fn final_state_root(&self) -> Buf32 {
+        self.final_state_root
+    }
+
+    /// Returns the final Ethereum state after replay.
+    pub fn final_ethereum_state(&self) -> &EthereumState {
+        &self.final_ethereum_state
+    }
+}

--- a/crates/alpen-ee/da/types/src/commit_reveal.rs
+++ b/crates/alpen-ee/da/types/src/commit_reveal.rs
@@ -6,35 +6,62 @@
 
 use std::collections::BTreeMap;
 
-use bitcoin::{opcodes::all::OP_RETURN, script::Instruction, Transaction, Txid};
+use bitcoin::{
+    opcodes::all::OP_RETURN, script::Instruction, taproot::LeafVersion, Transaction, Txid,
+};
 use strata_l1_envelope_fmt::{errors::EnvelopeParseError, parser::parse_envelope_payload};
 use thiserror::Error;
 
 /// Errors raised while parsing DA commit/reveal transactions.
 #[derive(Debug, Error)]
 pub enum DaParseError {
-    #[error("DA witness has no commit transaction")]
+    #[error("witness has no commit transaction")]
     MissingCommit,
-    #[error("DA witness has multiple commit transactions")]
+
+    #[error("witness has multiple commit transactions")]
     MultipleCommits,
-    #[error("DA commit OP_RETURN marker is malformed")]
+
+    #[error("commit OP_RETURN marker is malformed")]
     MalformedCommitMarker,
-    #[error("DA reveal tx has no inputs")]
+
+    #[error("reveal tx has no inputs")]
     RevealMissingInputs,
-    #[error("DA reveal tx witness has no tapscript leaf")]
+
+    #[error("reveal tx witness has no tapscript leaf")]
     RevealMissingLeafScript,
-    #[error("DA reveal tx does not spend the DA commit tx")]
+
+    #[error("reveal leaf uses non-TapScript version {version:?}")]
+    RevealUnsupportedLeafVersion { version: LeafVersion },
+
+    #[error("reveal tx does not spend the commit tx")]
     RevealWrongCommit,
-    #[error("DA reveal spends commit output 0, which is the OP_RETURN marker")]
+
+    #[error("reveal spends commit output 0 (OP_RETURN marker)")]
     RevealSpendsMarker,
-    #[error("duplicate DA reveal for commit output {0}")]
-    DuplicateReveal(u32),
-    #[error("unexpected DA reveal for commit output {0}")]
-    UnexpectedReveal(u32),
-    #[error("missing DA reveal for commit output {0}")]
-    MissingReveal(u32),
-    #[error("DA reveal envelope parse failed: {0}")]
-    RevealEnvelope(#[from] EnvelopeParseError),
+
+    #[error("reveal spends multiple outputs of the commit tx")]
+    RevealMultipleCommitSpends,
+
+    #[error("commit has no reveal slots")]
+    MissingRevealSlots,
+
+    #[error("duplicate reveal for commit output {vout}")]
+    DuplicateReveal { vout: u32 },
+
+    #[error("unexpected reveal for commit output {vout}")]
+    UnexpectedReveal { vout: u32 },
+
+    #[error("missing reveal for commit output {vout}")]
+    MissingReveal { vout: u32 },
+
+    #[error("ambiguous P2TR change output at commit output {vout}")]
+    AmbiguousTaprootChangeOutput { vout: u32 },
+
+    #[error("reveal envelope parse failed: {source}")]
+    RevealEnvelope {
+        #[from]
+        source: EnvelopeParseError,
+    },
 }
 
 /// Extracts and orders the DA payload chunks carried by a single DA blob.
@@ -67,26 +94,22 @@ pub fn extract_da_chunks<'a>(
 
     let commit = commit.ok_or(DaParseError::MissingCommit)?;
     let commit_txid = commit.compute_txid();
-    let last_reveal_vout = last_commit_reveal_vout(commit);
+    let last_reveal_vout =
+        last_commit_reveal_vout(commit)?.ok_or(DaParseError::MissingRevealSlots)?;
 
     let mut chunks_by_vout = BTreeMap::new();
     for tx in non_commit_txs {
-        let (vout, chunk) = extract_reveal_chunk(tx, commit_txid)?;
-        // A reveal beyond the contiguous P2TR run or any reveal at all when
-        // the commit has no reveal outputs, is unexpected.
-        if !matches!(last_reveal_vout, Some(last) if vout <= last) {
-            return Err(DaParseError::UnexpectedReveal(vout));
-        }
+        let (vout, chunk) = extract_reveal_chunk(tx, commit_txid, last_reveal_vout)?;
         if chunks_by_vout.insert(vout, chunk).is_some() {
-            return Err(DaParseError::DuplicateReveal(vout));
+            return Err(DaParseError::DuplicateReveal { vout });
         }
     }
 
-    if let Some(last_reveal_vout) = last_reveal_vout {
-        for expected_vout in 1..=last_reveal_vout {
-            if !chunks_by_vout.contains_key(&expected_vout) {
-                return Err(DaParseError::MissingReveal(expected_vout));
-            }
+    for expected_vout in 1..=last_reveal_vout {
+        if !chunks_by_vout.contains_key(&expected_vout) {
+            return Err(DaParseError::MissingReveal {
+                vout: expected_vout,
+            });
         }
     }
 
@@ -98,19 +121,37 @@ pub fn extract_da_chunks<'a>(
 ///
 /// Scans outputs starting at vout 1 (vout 0 is the OP_RETURN marker) and
 /// returns the last vout of the contiguous P2TR run.
-fn last_commit_reveal_vout(commit: &Transaction) -> Option<u32> {
-    commit
-        .output
-        .iter()
-        .enumerate()
-        .skip(1)
-        .take_while(|(_, output)| output.script_pubkey.is_p2tr())
-        .map(|(idx, _)| idx as u32)
-        .last()
+pub fn last_commit_reveal_vout(commit: &Transaction) -> Result<Option<u32>, DaParseError> {
+    let mut last_reveal_vout = None;
+    let mut reveal_run_closed = false;
+
+    for (idx, output) in commit.output.iter().enumerate().skip(1) {
+        if output.script_pubkey.is_p2tr() {
+            if reveal_run_closed {
+                return Err(DaParseError::AmbiguousTaprootChangeOutput { vout: idx as u32 });
+            }
+            last_reveal_vout = Some(idx as u32);
+        } else {
+            reveal_run_closed = true;
+        }
+    }
+
+    Ok(last_reveal_vout)
+}
+
+/// Returns whether `vout` is inside a commit transaction's reveal-slot range.
+///
+/// Returns `false` when the commit has no reveal slots.
+pub fn is_reveal_slot(vout: u32, last_reveal_vout: Option<u32>) -> bool {
+    matches!(last_reveal_vout, Some(last) if (1..=last).contains(&vout))
 }
 
 /// Reads the 8-byte OP_RETURN marker payload (`magic || version`) from a
 /// commit transaction's vout-0 output, if present.
+///
+/// Callers scanning arbitrary L1 traffic should pre-filter by magic to avoid
+/// spurious [`DaParseError::MalformedCommitMarker`] errors on unrelated
+/// OP_RETURN protocols.
 ///
 /// Returns:
 /// - `Ok(Some([u8; 8]))` if the first output is a well-formed OP_RETURN with exactly 8 pushed bytes
@@ -146,25 +187,295 @@ pub fn read_commit_marker_payload(tx: &Transaction) -> Result<Option<[u8; 8]>, D
 fn extract_reveal_chunk(
     reveal: &Transaction,
     commit_txid: Txid,
+    last_reveal_vout: u32,
 ) -> Result<(u32, Vec<u8>), DaParseError> {
-    let input = reveal
-        .input
-        .first()
-        .ok_or(DaParseError::RevealMissingInputs)?;
-    if input.previous_output.txid != commit_txid {
-        return Err(DaParseError::RevealWrongCommit);
+    if reveal.input.is_empty() {
+        return Err(DaParseError::RevealMissingInputs);
     }
+
+    let mut matching_input = None;
+    let mut unexpected_vout = None;
+    for input in &reveal.input {
+        if input.previous_output.txid != commit_txid {
+            continue;
+        }
+        let vout = input.previous_output.vout;
+        if vout == 0 {
+            return Err(DaParseError::RevealSpendsMarker);
+        }
+        if !is_reveal_slot(vout, Some(last_reveal_vout)) {
+            unexpected_vout.get_or_insert(vout);
+            continue;
+        }
+        if matching_input.replace(input).is_some() {
+            return Err(DaParseError::RevealMultipleCommitSpends);
+        }
+    }
+
+    let input = matching_input.ok_or_else(|| {
+        unexpected_vout.map_or(DaParseError::RevealWrongCommit, |vout| {
+            DaParseError::UnexpectedReveal { vout }
+        })
+    })?;
     let vout = input.previous_output.vout;
-    if vout == 0 {
-        return Err(DaParseError::RevealSpendsMarker);
-    }
 
     let leaf = input
         .witness
         .taproot_leaf_script()
         .ok_or(DaParseError::RevealMissingLeafScript)?;
+    if leaf.version != LeafVersion::TapScript {
+        return Err(DaParseError::RevealUnsupportedLeafVersion {
+            version: leaf.version,
+        });
+    }
     let script = leaf.script.into();
     let chunk = parse_envelope_payload(&script)?;
 
     Ok((vout, chunk))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        absolute::LockTime,
+        hashes::Hash,
+        opcodes::all::OP_RETURN,
+        script::Builder,
+        secp256k1::{Keypair, Parity, Secp256k1, SecretKey, XOnlyPublicKey, SECP256K1},
+        taproot::{ControlBlock, LeafVersion, TapNodeHash, TaprootMerkleBranch},
+        transaction::Version,
+        Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    };
+    use strata_l1_envelope_fmt::builder::EnvelopeScriptBuilder;
+
+    use super::*;
+
+    fn txid(seed: u8) -> Txid {
+        Txid::from_byte_array([seed; 32])
+    }
+
+    fn test_key(seed: u8) -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[seed; 32]).expect("valid secret key");
+        let keypair = Keypair::from_secret_key(&secp, &secret_key);
+        XOnlyPublicKey::from_keypair(&keypair).0
+    }
+
+    fn test_control_block(internal_key: XOnlyPublicKey) -> ControlBlock {
+        test_control_block_with_leaf_version(internal_key, LeafVersion::TapScript)
+    }
+
+    fn test_control_block_with_leaf_version(
+        internal_key: XOnlyPublicKey,
+        leaf_version: LeafVersion,
+    ) -> ControlBlock {
+        let branch: [TapNodeHash; 0] = [];
+
+        ControlBlock {
+            leaf_version,
+            output_key_parity: Parity::Even,
+            internal_key,
+            merkle_branch: TaprootMerkleBranch::from(branch),
+        }
+    }
+
+    fn reveal_script(chunk: &[u8]) -> ScriptBuf {
+        let sequencer_pubkey = test_key(7);
+        EnvelopeScriptBuilder::with_pubkey(&sequencer_pubkey.serialize())
+            .expect("pubkey accepted")
+            .add_envelope(chunk)
+            .expect("envelope payload accepted")
+            .build_without_min_check()
+            .expect("reveal script build succeeds")
+    }
+
+    fn commit_marker_script() -> ScriptBuf {
+        Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice([1, 2, 3, 4, 0, 0, 0, 0])
+            .into_script()
+    }
+
+    fn commit_tx(reveal_slots: usize) -> Transaction {
+        let reveal_key = test_key(3);
+        let mut output = vec![TxOut {
+            value: Amount::ZERO,
+            script_pubkey: commit_marker_script(),
+        }];
+
+        for _ in 0..reveal_slots {
+            output.push(TxOut {
+                value: Amount::from_sat(1000),
+                script_pubkey: ScriptBuf::new_p2tr(SECP256K1, reveal_key, None),
+            });
+        }
+
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output,
+        }
+    }
+
+    fn reveal_input(commit_txid: Txid, vout: u32, chunk: Option<&[u8]>) -> TxIn {
+        let mut witness = Witness::new();
+        if let Some(chunk) = chunk {
+            let sequencer_pubkey = test_key(7);
+            witness.push([1u8; 64]);
+            witness.push(reveal_script(chunk));
+            witness.push(test_control_block(sequencer_pubkey).serialize());
+        }
+
+        TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        }
+    }
+
+    fn reveal_input_with_leaf_version(
+        commit_txid: Txid,
+        vout: u32,
+        chunk: &[u8],
+        leaf_version: LeafVersion,
+    ) -> TxIn {
+        let sequencer_pubkey = test_key(7);
+        let mut witness = Witness::new();
+        witness.push([1u8; 64]);
+        witness.push(reveal_script(chunk));
+        witness
+            .push(test_control_block_with_leaf_version(sequencer_pubkey, leaf_version).serialize());
+
+        TxIn {
+            previous_output: OutPoint {
+                txid: commit_txid,
+                vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness,
+        }
+    }
+
+    fn reveal_tx(inputs: Vec<TxIn>) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: inputs,
+            output: vec![TxOut {
+                value: Amount::from_sat(1000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn chunks_are_ordered_by_commit_output() {
+        let commit = commit_tx(2);
+        let commit_txid = commit.compute_txid();
+        let reveal_2 = reveal_tx(vec![reveal_input(commit_txid, 2, Some(b"second"))]);
+        let reveal_1 = reveal_tx(vec![reveal_input(commit_txid, 1, Some(b"first"))]);
+
+        let chunks = extract_da_chunks([&commit, &reveal_2, &reveal_1].into_iter())
+            .expect("valid chunked envelope");
+
+        assert_eq!(chunks, vec![b"first".to_vec(), b"second".to_vec()]);
+    }
+
+    #[test]
+    fn missing_reveal_is_rejected() {
+        let commit = commit_tx(2);
+        let reveal = reveal_tx(vec![reveal_input(commit.compute_txid(), 1, Some(b"first"))]);
+
+        let error = extract_da_chunks([&commit, &reveal].into_iter())
+            .expect_err("missing reveal must fail");
+
+        assert!(matches!(error, DaParseError::MissingReveal { vout: 2 }));
+    }
+
+    #[test]
+    fn out_of_range_commit_input_is_ignored_when_slot_input_exists() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![
+            reveal_input(commit_txid, 1, Some(b"chunk")),
+            reveal_input(commit_txid, 2, None),
+        ]);
+
+        let (vout, chunk) = extract_reveal_chunk(&tx, commit_txid, 1).expect("valid reveal");
+
+        assert_eq!(vout, 1);
+        assert_eq!(chunk, b"chunk");
+    }
+
+    #[test]
+    fn only_out_of_range_commit_input_is_rejected() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![reveal_input(commit_txid, 2, None)]);
+
+        let error = extract_reveal_chunk(&tx, commit_txid, 1).expect_err("unexpected reveal");
+
+        assert!(matches!(error, DaParseError::UnexpectedReveal { vout: 2 }));
+    }
+
+    #[test]
+    fn multiple_slot_inputs_in_one_reveal_are_rejected() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![
+            reveal_input(commit_txid, 1, None),
+            reveal_input(commit_txid, 2, None),
+        ]);
+
+        let error = extract_reveal_chunk(&tx, commit_txid, 2).expect_err("multiple slot inputs");
+
+        assert!(matches!(error, DaParseError::RevealMultipleCommitSpends));
+    }
+
+    #[test]
+    fn marker_output_spend_is_rejected() {
+        let commit_txid = txid(1);
+        let tx = reveal_tx(vec![reveal_input(commit_txid, 0, None)]);
+
+        let error = extract_reveal_chunk(&tx, commit_txid, 1).expect_err("marker spend");
+
+        assert!(matches!(error, DaParseError::RevealSpendsMarker));
+    }
+
+    #[test]
+    fn input_spending_wrong_commit_is_rejected() {
+        let tx = reveal_tx(vec![reveal_input(txid(2), 1, None)]);
+
+        let error = extract_reveal_chunk(&tx, txid(1), 1).expect_err("wrong commit");
+
+        assert!(matches!(error, DaParseError::RevealWrongCommit));
+    }
+
+    #[test]
+    fn non_tapscript_leaf_is_rejected() {
+        let commit = commit_tx(1);
+        let future_leaf_version = LeafVersion::from_consensus(0xc2).expect("future leaf version");
+        let reveal = reveal_tx(vec![reveal_input_with_leaf_version(
+            commit.compute_txid(),
+            1,
+            b"chunk",
+            future_leaf_version,
+        )]);
+
+        let error = extract_da_chunks([&commit, &reveal].into_iter())
+            .expect_err("non-TapScript leaf must fail");
+
+        assert!(matches!(
+            error,
+            DaParseError::RevealUnsupportedLeafVersion { version } if version == future_leaf_version
+        ));
+    }
 }

--- a/crates/alpen-ee/da/types/src/lib.rs
+++ b/crates/alpen-ee/da/types/src/lib.rs
@@ -17,7 +17,10 @@ pub use bitcoin_merkle::{
     compute_bitcoin_merkle_root_from_proof, hash_pair_sha256d, wtxid_leaves, wtxids_root_from_txs,
 };
 pub use blob::{reassemble_da_blob, DaBlob, EvmHeaderSummary, DA_BLOB_VERSION, EE_DA_MAGIC_BYTES};
-pub use commit_reveal::{extract_da_chunks, read_commit_marker_payload, DaParseError};
+pub use commit_reveal::{
+    extract_da_chunks, is_reveal_slot, last_commit_reveal_vout, read_commit_marker_payload,
+    DaParseError,
+};
 pub use dedup_witness::{
     ArchivedBytecodePreimage, ArchivedDedupWitness, BytecodePreimage, DedupWitness,
 };

--- a/crates/common/src/retry/policies.rs
+++ b/crates/common/src/retry/policies.rs
@@ -13,7 +13,7 @@ use super::Backoff;
 ///   `multiplier_base = 100` represents a 1.5× multiplier.
 /// - `multiplier_base`: The denominator of the backoff multiplier. Used in conjunction with
 ///   `multiplier` to scale the delay after each retry.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ExponentialBackoff {
     /// Initial delay before the first retry, in milliseconds.
     base_delay_ms: u64,

--- a/crates/reth/statediff/Cargo.toml
+++ b/crates/reth/statediff/Cargo.toml
@@ -30,3 +30,4 @@ serde_json.workspace = true
 default = ["chainspec"]
 chainspec = ["dep:alpen-chainspec", "dep:eyre"]
 serde = []
+test-utils = []

--- a/crates/reth/statediff/src/lib.rs
+++ b/crates/reth/statediff/src/lib.rs
@@ -54,8 +54,8 @@ mod codec;
 mod reconstruct;
 #[cfg(feature = "serde")]
 mod serde_impl;
-#[cfg(test)]
-pub(crate) mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 
 // Re-export main types at crate level for convenience
 pub use batch::{AccountChange, AccountDiff, BatchBuilder, BatchStateDiff, StorageDiff};

--- a/crates/reth/statediff/src/test_utils.rs
+++ b/crates/reth/statediff/src/test_utils.rs
@@ -16,35 +16,35 @@ use crate::{
 };
 
 /// Canonical per-account storage view used by test oracles.
-pub(crate) type AccountStorage = BTreeMap<U256, U256>;
+pub type AccountStorage = BTreeMap<U256, U256>;
 
 /// Returns a deterministic address derived from a single-byte seed.
-pub(crate) fn addr(seed: u8) -> Address {
+pub fn addr(seed: u8) -> Address {
     Address::from([seed; 20])
 }
 
 /// Returns a deterministic `B256` hash derived from a single-byte seed.
-pub(crate) fn hash(seed: u8) -> B256 {
+pub fn hash(seed: u8) -> B256 {
     B256::from([seed; 32])
 }
 
 /// Returns a storage-slot key from a small integer.
-pub(crate) fn slot(value: u64) -> U256 {
+pub fn slot(value: u64) -> U256 {
     U256::from(value)
 }
 
 /// Returns a storage or balance value from a small integer.
-pub(crate) fn value(value: u64) -> U256 {
+pub fn value(value: u64) -> U256 {
     U256::from(value)
 }
 
 /// Copies bytecode into owned bytes for block-diff fixtures.
-pub(crate) fn bytecode(bytes: &[u8]) -> Bytes {
+pub fn bytecode(bytes: &[u8]) -> Bytes {
     Bytes::copy_from_slice(bytes)
 }
 
 /// Builds a compact account snapshot for test fixtures.
-pub(crate) fn snapshot(balance: u64, nonce: u64, code_hash: B256) -> AccountSnapshot {
+pub fn snapshot(balance: u64, nonce: u64, code_hash: B256) -> AccountSnapshot {
     AccountSnapshot {
         balance: U256::from(balance),
         nonce,
@@ -53,7 +53,7 @@ pub(crate) fn snapshot(balance: u64, nonce: u64, code_hash: B256) -> AccountSnap
 }
 
 /// Inserts an account-level change into a block diff fixture.
-pub(crate) fn account_change(
+pub fn account_change(
     diff: &mut BlockStateChanges,
     address: Address,
     original: Option<AccountSnapshot>,
@@ -64,7 +64,7 @@ pub(crate) fn account_change(
 }
 
 /// Inserts a storage-slot change into a block diff fixture.
-pub(crate) fn storage_change(
+pub fn storage_change(
     diff: &mut BlockStateChanges,
     address: Address,
     slot_key: U256,
@@ -79,21 +79,17 @@ pub(crate) fn storage_change(
 }
 
 /// Records deployed bytecode in a block diff fixture.
-pub(crate) fn deployed_bytecode(
-    diff: &mut BlockStateChanges,
-    code_hash: B256,
-    deployed_bytecode: Bytes,
-) {
+pub fn deployed_bytecode(diff: &mut BlockStateChanges, code_hash: B256, deployed_bytecode: Bytes) {
     diff.deployed_bytecodes.insert(code_hash, deployed_bytecode);
 }
 
 /// Creates an empty per-block state diff fixture.
-pub(crate) fn block_diff() -> BlockStateChanges {
+pub fn block_diff() -> BlockStateChanges {
     BlockStateChanges::new()
 }
 
 /// Aggregates a sequence of block diffs into a single batch diff.
-pub(crate) fn batch_diff(blocks: &[BlockStateChanges]) -> BatchStateDiff {
+pub fn batch_diff(blocks: &[BlockStateChanges]) -> BatchStateDiff {
     let mut builder = BatchBuilder::new();
     for block in blocks {
         builder.apply_block(block);
@@ -103,32 +99,27 @@ pub(crate) fn batch_diff(blocks: &[BlockStateChanges]) -> BatchStateDiff {
 
 /// Canonical account and storage state used by reconstruction oracles.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CanonicalState {
+pub struct CanonicalState {
     /// Final account records keyed by address.
-    pub(crate) accounts: BTreeMap<Address, StateAccount>,
+    pub accounts: BTreeMap<Address, StateAccount>,
     /// Final storage contents keyed by address and slot.
-    pub(crate) storage: BTreeMap<Address, AccountStorage>,
+    pub storage: BTreeMap<Address, AccountStorage>,
 }
 
 impl CanonicalState {
     /// Creates an empty canonical state.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Adds or replaces a canonical account entry.
-    pub(crate) fn with_account(mut self, address: Address, account: StateAccount) -> Self {
+    pub fn with_account(mut self, address: Address, account: StateAccount) -> Self {
         self.accounts.insert(address, account);
         self
     }
 
     /// Sets a canonical storage slot value for an account.
-    pub(crate) fn set_storage_slot(
-        mut self,
-        address: Address,
-        slot_key: U256,
-        slot_value: U256,
-    ) -> Self {
+    pub fn set_storage_slot(mut self, address: Address, slot_key: U256, slot_value: U256) -> Self {
         self.storage
             .entry(address)
             .or_default()
@@ -137,7 +128,7 @@ impl CanonicalState {
     }
 
     /// Removes a canonical storage slot and prunes empty account storage maps.
-    pub(crate) fn remove_storage_slot(mut self, address: Address, slot_key: U256) -> Self {
+    pub fn remove_storage_slot(mut self, address: Address, slot_key: U256) -> Self {
         if let Some(account_storage) = self.storage.get_mut(&address) {
             account_storage.remove(&slot_key);
             if account_storage.is_empty() {
@@ -149,7 +140,7 @@ impl CanonicalState {
 }
 
 /// Builds a canonical `StateAccount` with an empty storage root placeholder.
-pub(crate) fn state_account(balance: u64, nonce: u64, code_hash: B256) -> StateAccount {
+pub fn state_account(balance: u64, nonce: u64, code_hash: B256) -> StateAccount {
     StateAccount {
         nonce,
         balance: U256::from(balance),
@@ -159,7 +150,7 @@ pub(crate) fn state_account(balance: u64, nonce: u64, code_hash: B256) -> StateA
 }
 
 /// Builds canonical storage tries for every account present in the state view.
-pub(crate) fn canonical_storage_tries(
+pub fn canonical_storage_tries(
     state: &CanonicalState,
 ) -> Result<BTreeMap<Address, MptNode>, strata_mpt::Error> {
     let mut storage_tries = BTreeMap::new();
@@ -181,7 +172,7 @@ pub(crate) fn canonical_storage_tries(
 }
 
 /// Recomputes canonical accounts with storage roots derived from canonical storage.
-pub(crate) fn canonical_accounts(
+pub fn canonical_accounts(
     state: &CanonicalState,
 ) -> Result<BTreeMap<Address, StateAccount>, strata_mpt::Error> {
     let storage_tries = canonical_storage_tries(state)?;
@@ -200,7 +191,7 @@ pub(crate) fn canonical_accounts(
 }
 
 /// Computes the canonical global state root for the provided state view.
-pub(crate) fn canonical_state_root(state: &CanonicalState) -> Result<B256, strata_mpt::Error> {
+pub fn canonical_state_root(state: &CanonicalState) -> Result<B256, strata_mpt::Error> {
     let accounts = canonical_accounts(state)?;
     let mut state_trie = MptNode::default();
 


### PR DESCRIPTION
## Description

Two new crates for reader-side EE DA:
- **`alpen-ee-da-l1-extraction`** — fetch bounded L1 ranges from bitcoind, discover commit/reveal envelopes across blocks, reassemble into decoded `DaBlob`s.
- **`alpen-ee-da-state-replay`** — apply reassembled blobs to `rsp_mpt::EthereumState` with ordering, linkage, and snapshot-anchor invariants.

Reader-side building blocks: the EE DA verification tool (#1950) is the immediate consumer, but the crates also fit L1 sync bootstrap, proof witness assembly, and historical replay.

This PR was created with help from Codex and Claude Code.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

[SPS-53 Chunked Envelope Inscription](https://app.notion.com/p/SPS-53-Chunked-envelope-inscription-38e901ba000f80128280db9f445c4bbf?source=copy_link)
[sps-ee-da-structure Alpen EE DaBlob](https://app.notion.com/p/SPS-ee-da-structure-Alpen-EE-DaBlob-38e901ba000f8038aa6cd4ae71c3f83b?source=copy_link)

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
