### PR TITLE
feat(alpen-ee-params): introduce consolidated AlpenParams type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,8 @@ dependencies = [
  "reth-chainspec",
  "serde",
  "serde_json",
+ "strata-acct-types",
+ "strata-bridge-params",
  "strata-l1-txfmt",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,9 +1387,13 @@ dependencies = [
 name = "alpen-ee-params"
 version = "0.3.0-alpha.1"
 dependencies = [
+ "alloy-genesis",
+ "alpen-chainspec",
+ "reth-chainspec",
  "serde",
  "serde_json",
  "strata-l1-txfmt",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpen-ee-params"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "strata-l1-txfmt",
+]
+
+[[package]]
 name = "alpen-ee-rpc-api"
 version = "0.3.0-alpha.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,6 @@ dependencies = [
  "strata-acct-types",
  "strata-bridge-params",
  "strata-l1-txfmt",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/alpen-ee/engine",
   "crates/alpen-ee/genesis",
   "crates/alpen-ee/ol-tracker",
+  "crates/alpen-ee/params",
   "crates/alpen-ee/rpc/api",
   "crates/alpen-ee/rpc/server",
   "crates/alpen-ee/rpc/types",
@@ -140,6 +141,7 @@ alpen-ee-engine = { path = "crates/alpen-ee/engine" }
 alpen-ee-exec-chain = { path = "crates/alpen-ee/exec-chain" }
 alpen-ee-genesis = { path = "crates/alpen-ee/genesis" }
 alpen-ee-ol-tracker = { path = "crates/alpen-ee/ol-tracker" }
+alpen-ee-params = { path = "crates/alpen-ee/params" }
 alpen-ee-rpc-api = { path = "crates/alpen-ee/rpc/api" }
 alpen-ee-rpc-server = { path = "crates/alpen-ee/rpc/server" }
 alpen-ee-rpc-types = { path = "crates/alpen-ee/rpc/types" }

--- a/crates/alpen-ee/params/Cargo.toml
+++ b/crates/alpen-ee/params/Cargo.toml
@@ -8,12 +8,12 @@ workspace = true
 
 [dependencies]
 alpen-chainspec.workspace = true
+strata-acct-types.workspace = true
+strata-bridge-params.workspace = true
 strata-l1-txfmt.workspace = true
 
 alloy-genesis.workspace = true
 reth-chainspec.workspace = true
 serde.workspace = true
-thiserror.workspace = true
-
-[dev-dependencies]
 serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/alpen-ee/params/Cargo.toml
+++ b/crates/alpen-ee/params/Cargo.toml
@@ -7,9 +7,13 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [dependencies]
+alpen-chainspec.workspace = true
 strata-l1-txfmt.workspace = true
 
+alloy-genesis.workspace = true
+reth-chainspec.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/alpen-ee/params/Cargo.toml
+++ b/crates/alpen-ee/params/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2021"
+name = "alpen-ee-params"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[dependencies]
+strata-l1-txfmt.workspace = true
+
+serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/alpen-ee/params/Cargo.toml
+++ b/crates/alpen-ee/params/Cargo.toml
@@ -16,4 +16,3 @@ alloy-genesis.workspace = true
 reth-chainspec.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true

--- a/crates/alpen-ee/params/src/blob_spec.rs
+++ b/crates/alpen-ee/params/src/blob_spec.rs
@@ -1,0 +1,60 @@
+//! EE DA stream identity parameters.
+
+use serde::{Deserialize, Serialize};
+use strata_l1_txfmt::MagicBytes;
+
+/// Identity of the EE DA stream on L1.
+///
+/// Identifies the SPS-51 commit transactions that carry EE DA blobs.
+/// Consensus-relevant: all nodes must agree on it, but it is not expected to
+/// change across forks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BlobSpec {
+    /// `OP_RETURN` magic identifying the EE DA stream in the commit tx.
+    ///
+    /// Serialized as a 4-character string (e.g. `"ALPN"`) in JSON.
+    magic_bytes: MagicBytes,
+}
+
+impl BlobSpec {
+    /// Creates a new blob spec.
+    pub fn new(magic_bytes: MagicBytes) -> Self {
+        Self { magic_bytes }
+    }
+
+    /// Returns the DA stream magic bytes.
+    pub fn magic_bytes(&self) -> MagicBytes {
+        self.magic_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_l1_txfmt::MagicBytes;
+
+    use super::BlobSpec;
+
+    #[test]
+    fn json_roundtrip_preserves_magic_bytes() {
+        let spec = BlobSpec::new(MagicBytes::new(*b"ALPN"));
+
+        let json = serde_json::to_string(&spec).expect("blob spec should serialize");
+        assert_eq!(json, r#"{"magic_bytes":"ALPN"}"#);
+
+        let decoded: BlobSpec = serde_json::from_str(&json).expect("blob spec should deserialize");
+        assert_eq!(decoded, spec);
+    }
+
+    #[test]
+    fn json_rejects_wrong_length_magic_bytes() {
+        assert!(serde_json::from_str::<BlobSpec>(r#"{"magic_bytes":"ALP"}"#).is_err());
+        assert!(serde_json::from_str::<BlobSpec>(r#"{"magic_bytes":"ALPEN"}"#).is_err());
+    }
+
+    #[test]
+    fn json_rejects_unknown_fields() {
+        let json = r#"{"magic_bytes":"ALPN","max_chunk_payload":395000}"#;
+        assert!(serde_json::from_str::<BlobSpec>(json).is_err());
+    }
+}

--- a/crates/alpen-ee/params/src/evm_spec.rs
+++ b/crates/alpen-ee/params/src/evm_spec.rs
@@ -1,0 +1,158 @@
+//! Embedded EVM chain spec.
+
+use std::sync::Arc;
+
+use alloy_genesis::Genesis;
+use alpen_chainspec::{ee_genesis_block_info, AlpenEeGenesisBlockInfo};
+use reth_chainspec::ChainSpec;
+use serde::{Deserialize, Serialize, Serializer};
+use thiserror::Error;
+
+/// The embedded EVM chain spec: genesis document plus derived reth chain spec.
+///
+/// The JSON form is the standard EVM genesis document (chain config plus
+/// allocation), exactly what `--custom-chain` used to load as a separate
+/// file. Decoding eagerly derives the reth [`ChainSpec`], so every consumer
+/// reads the same value and no boot-time genesis cross-check is needed —
+/// agreement is structural.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "Genesis")]
+pub struct EvmSpec {
+    /// The parsed genesis document, authoritative for serialization.
+    genesis: Genesis,
+
+    /// Chain spec derived from `genesis`; never serialized.
+    ///
+    /// Stored as `Arc<ChainSpec>` — not because [`EvmSpec`] needs shared
+    /// ownership, but to match reth's boundary: the node's `command.chain`
+    /// field is `Arc<ChainSpec>`, so consumers hand it off with a cheap
+    /// refcount bump rather than deep-cloning the spec (or re-deriving it
+    /// from `genesis`) on every use.
+    chain_spec: Arc<ChainSpec>,
+}
+
+impl EvmSpec {
+    /// Returns the genesis document.
+    pub fn genesis(&self) -> &Genesis {
+        &self.genesis
+    }
+
+    /// Returns the derived reth chain spec.
+    pub fn chain_spec(&self) -> &Arc<ChainSpec> {
+        &self.chain_spec
+    }
+
+    /// Returns the genesis block facts, derived from the chain spec on demand.
+    pub fn genesis_info(&self) -> AlpenEeGenesisBlockInfo {
+        ee_genesis_block_info(&self.chain_spec)
+    }
+}
+
+impl TryFrom<Genesis> for EvmSpec {
+    type Error = EvmSpecError;
+
+    fn try_from(genesis: Genesis) -> Result<Self, Self::Error> {
+        // `Genesis` is struct-level `#[serde(default)]`, so an empty or
+        // misshapen document would otherwise decode to all-default values;
+        // these checks are the validate-on-decode backstop. A zero gas limit
+        // (the default) marks a document with no real block parameters, and
+        // an omitted chain id defaults to 1 so only an explicit zero can be
+        // caught here.
+        if genesis.number.is_none() {
+            return Err(EvmSpecError::MissingGenesisNumber);
+        }
+        if genesis.gas_limit == 0 {
+            return Err(EvmSpecError::ZeroGasLimit);
+        }
+        if genesis.config.chain_id == 0 {
+            return Err(EvmSpecError::ZeroChainId);
+        }
+
+        let chain_spec: Arc<ChainSpec> = Arc::new(genesis.clone().into());
+
+        Ok(Self {
+            genesis,
+            chain_spec,
+        })
+    }
+}
+
+impl Serialize for EvmSpec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.genesis.serialize(serializer)
+    }
+}
+
+// Compare the genesis document only: `ChainSpec`'s derived equality goes
+// through `SealedHeader`'s lazily initialized hash cache and is therefore
+// initialization-order-sensitive, and everything else here is derived from
+// `genesis` anyway.
+impl PartialEq for EvmSpec {
+    fn eq(&self, other: &Self) -> bool {
+        self.genesis == other.genesis
+    }
+}
+
+impl Eq for EvmSpec {}
+
+/// Error validating an EVM genesis document.
+#[derive(Debug, Error)]
+pub enum EvmSpecError {
+    /// The genesis document carries no block number.
+    #[error("genesis block number missing from EVM genesis document")]
+    MissingGenesisNumber,
+
+    /// The genesis document carries no (or a zero) gas limit.
+    #[error("gas limit missing or zero in EVM genesis document")]
+    ZeroGasLimit,
+
+    /// The genesis document carries an explicit zero chain id.
+    #[error("chain id is zero in EVM genesis document")]
+    ZeroChainId,
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_chainspec::{ee_genesis_block_info_from_json, DEV_CHAIN_SPEC};
+
+    use super::EvmSpec;
+
+    #[test]
+    fn json_roundtrip_preserves_evm_spec() {
+        let spec: EvmSpec = serde_json::from_str(DEV_CHAIN_SPEC).expect("dev chain should parse");
+
+        let json = serde_json::to_string(&spec).expect("evm spec should serialize");
+        let decoded: EvmSpec = serde_json::from_str(&json).expect("evm spec should reparse");
+
+        assert_eq!(decoded, spec);
+        assert_eq!(decoded.genesis_info(), spec.genesis_info());
+    }
+
+    #[test]
+    fn genesis_info_matches_chainspec_derivation() {
+        let spec: EvmSpec = serde_json::from_str(DEV_CHAIN_SPEC).expect("dev chain should parse");
+        let expected =
+            ee_genesis_block_info_from_json(DEV_CHAIN_SPEC).expect("dev chain should parse");
+
+        assert_eq!(spec.genesis_info(), expected);
+        assert_eq!(spec.chain_spec().genesis_hash(), expected.blockhash());
+    }
+
+    #[test]
+    fn json_rejects_degenerate_genesis() {
+        // `Genesis` is `#[serde(default)]`; these must not silently decode.
+        assert!(serde_json::from_str::<EvmSpec>("{}").is_err());
+        // Missing block number.
+        assert!(serde_json::from_str::<EvmSpec>(r#"{"config":{"chainId":2892}}"#).is_err());
+        // Missing gas limit.
+        assert!(serde_json::from_str::<EvmSpec>(r#"{"number":"0x0"}"#).is_err());
+        // Explicit zero chain id.
+        assert!(serde_json::from_str::<EvmSpec>(
+            r#"{"number":"0x0","gasLimit":"0x1c9c380","config":{"chainId":0}}"#
+        )
+        .is_err());
+    }
+}

--- a/crates/alpen-ee/params/src/evm_spec.rs
+++ b/crates/alpen-ee/params/src/evm_spec.rs
@@ -6,7 +6,6 @@ use alloy_genesis::Genesis;
 use alpen_chainspec::{ee_genesis_block_info, AlpenEeGenesisBlockInfo};
 use reth_chainspec::ChainSpec;
 use serde::{Deserialize, Serialize, Serializer};
-use thiserror::Error;
 
 /// The embedded EVM chain spec: genesis document plus derived reth chain spec.
 ///
@@ -15,8 +14,13 @@ use thiserror::Error;
 /// file. Decoding eagerly derives the reth [`ChainSpec`], so every consumer
 /// reads the same value and no boot-time genesis cross-check is needed —
 /// agreement is structural.
+///
+/// Validity of the document is reth's concern, not ours: decoding accepts
+/// exactly what reth's `Genesis -> ChainSpec` conversion accepts and derives
+/// the spec from it, rather than re-policing individual genesis fields (which
+/// would only diverge from — and lag behind — reth's own semantics).
 #[derive(Debug, Clone, Deserialize)]
-#[serde(try_from = "Genesis")]
+#[serde(from = "Genesis")]
 pub struct EvmSpec {
     /// The parsed genesis document, authoritative for serialization.
     genesis: Genesis,
@@ -48,32 +52,13 @@ impl EvmSpec {
     }
 }
 
-impl TryFrom<Genesis> for EvmSpec {
-    type Error = EvmSpecError;
-
-    fn try_from(genesis: Genesis) -> Result<Self, Self::Error> {
-        // `Genesis` is struct-level `#[serde(default)]`, so an empty or
-        // misshapen document would otherwise decode to all-default values;
-        // these checks are the validate-on-decode backstop. A zero gas limit
-        // (the default) marks a document with no real block parameters, and
-        // an omitted chain id defaults to 1 so only an explicit zero can be
-        // caught here.
-        if genesis.number.is_none() {
-            return Err(EvmSpecError::MissingGenesisNumber);
-        }
-        if genesis.gas_limit == 0 {
-            return Err(EvmSpecError::ZeroGasLimit);
-        }
-        if genesis.config.chain_id == 0 {
-            return Err(EvmSpecError::ZeroChainId);
-        }
-
+impl From<Genesis> for EvmSpec {
+    fn from(genesis: Genesis) -> Self {
         let chain_spec: Arc<ChainSpec> = Arc::new(genesis.clone().into());
-
-        Ok(Self {
+        Self {
             genesis,
             chain_spec,
-        })
+        }
     }
 }
 
@@ -97,22 +82,6 @@ impl PartialEq for EvmSpec {
 }
 
 impl Eq for EvmSpec {}
-
-/// Error validating an EVM genesis document.
-#[derive(Debug, Error)]
-pub enum EvmSpecError {
-    /// The genesis document carries no block number.
-    #[error("genesis block number missing from EVM genesis document")]
-    MissingGenesisNumber,
-
-    /// The genesis document carries no (or a zero) gas limit.
-    #[error("gas limit missing or zero in EVM genesis document")]
-    ZeroGasLimit,
-
-    /// The genesis document carries an explicit zero chain id.
-    #[error("chain id is zero in EVM genesis document")]
-    ZeroChainId,
-}
 
 #[cfg(test)]
 mod tests {
@@ -142,17 +111,11 @@ mod tests {
     }
 
     #[test]
-    fn json_rejects_degenerate_genesis() {
-        // `Genesis` is `#[serde(default)]`; these must not silently decode.
-        assert!(serde_json::from_str::<EvmSpec>("{}").is_err());
-        // Missing block number.
-        assert!(serde_json::from_str::<EvmSpec>(r#"{"config":{"chainId":2892}}"#).is_err());
-        // Missing gas limit.
-        assert!(serde_json::from_str::<EvmSpec>(r#"{"number":"0x0"}"#).is_err());
-        // Explicit zero chain id.
-        assert!(serde_json::from_str::<EvmSpec>(
-            r#"{"number":"0x0","gasLimit":"0x1c9c380","config":{"chainId":0}}"#
-        )
-        .is_err());
+    fn json_accepts_what_reth_accepts() {
+        // Validity is deferred to reth's `Genesis -> ChainSpec` conversion, so
+        // even a minimal document decodes and derives genesis info without
+        // policing individual fields (or panicking on an absent block number).
+        let spec: EvmSpec = serde_json::from_str("{}").expect("empty genesis is accepted");
+        let _ = spec.genesis_info();
     }
 }

--- a/crates/alpen-ee/params/src/lib.rs
+++ b/crates/alpen-ee/params/src/lib.rs
@@ -15,4 +15,4 @@ mod spec_activations;
 pub use blob_spec::BlobSpec;
 pub use evm_spec::{EvmSpec, EvmSpecError};
 pub use params::{AlpenParams, DEFAULT_ALPEN_EE_ACCOUNT_ID};
-pub use spec_activations::AlpenSpecActivations;
+pub use spec_activations::{AlpenSpecActivations, AlpenSpecId};

--- a/crates/alpen-ee/params/src/lib.rs
+++ b/crates/alpen-ee/params/src/lib.rs
@@ -9,6 +9,10 @@
 
 mod blob_spec;
 mod evm_spec;
+mod params;
+mod spec_activations;
 
 pub use blob_spec::BlobSpec;
 pub use evm_spec::{EvmSpec, EvmSpecError};
+pub use params::{AlpenParams, DEFAULT_ALPEN_EE_ACCOUNT_ID};
+pub use spec_activations::AlpenSpecActivations;

--- a/crates/alpen-ee/params/src/lib.rs
+++ b/crates/alpen-ee/params/src/lib.rs
@@ -1,0 +1,12 @@
+//! Consolidated Alpen chain parameters.
+//!
+//! Defines the single top-level params artifact that describes how an Alpen
+//! EE node interprets the chain: the EE account identity, bridge economics,
+//! DA stream identity, and the embedded EVM chain spec. It replaces the
+//! previously fragmented loaders (`--ee-params` JSON, `--custom-chain`
+//! genesis JSON, and DA-related CLI flags) with one validate-on-decode JSON
+//! document.
+
+mod blob_spec;
+
+pub use blob_spec::BlobSpec;

--- a/crates/alpen-ee/params/src/lib.rs
+++ b/crates/alpen-ee/params/src/lib.rs
@@ -13,6 +13,6 @@ mod params;
 mod spec_activations;
 
 pub use blob_spec::BlobSpec;
-pub use evm_spec::{EvmSpec, EvmSpecError};
+pub use evm_spec::EvmSpec;
 pub use params::{AlpenParams, DEFAULT_ALPEN_EE_ACCOUNT_ID};
 pub use spec_activations::{AlpenSpecActivations, AlpenSpecId};

--- a/crates/alpen-ee/params/src/lib.rs
+++ b/crates/alpen-ee/params/src/lib.rs
@@ -8,5 +8,7 @@
 //! document.
 
 mod blob_spec;
+mod evm_spec;
 
 pub use blob_spec::BlobSpec;
+pub use evm_spec::{EvmSpec, EvmSpecError};

--- a/crates/alpen-ee/params/src/params.rs
+++ b/crates/alpen-ee/params/src/params.rs
@@ -1,0 +1,191 @@
+//! Top-level Alpen params artifact.
+
+use std::sync::Arc;
+
+use alpen_chainspec::AlpenEeGenesisBlockInfo;
+use reth_chainspec::ChainSpec;
+use serde::{Deserialize, Serialize};
+use strata_acct_types::AccountId;
+use strata_bridge_params::BridgeParams;
+
+use crate::{AlpenSpecActivations, BlobSpec, EvmSpec};
+
+/// Default Alpen EE account id registered in generated OL params.
+pub const DEFAULT_ALPEN_EE_ACCOUNT_ID: AccountId = AccountId::new([1u8; 32]);
+
+/// Top-level Alpen chain params.
+///
+/// The single source of truth for how a node interprets the chain: the EE
+/// account identity, bridge economics, DA stream identity, the Alpen spec
+/// activations, and the embedded EVM chain spec. Loaded from one JSON artifact
+/// with validate-on-decode semantics on every field.
+///
+/// Unknown fields are rejected so that a params file written for a newer
+/// node version (e.g. one carrying spec activations this binary does not
+/// understand) fails loudly instead of being silently misread.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AlpenParams {
+    /// Account id of the EE in OL. Fork-invariant.
+    account_id: AccountId,
+
+    /// Bridge denomination and withdrawal policy.
+    bridge_params: BridgeParams,
+
+    /// DA stream identity.
+    blob_spec: BlobSpec,
+
+    /// Alpen protocol spec activations.
+    #[serde(default)]
+    spec_activations: AlpenSpecActivations,
+
+    /// Embedded EVM chain spec (genesis document + fork configuration).
+    evm_spec: EvmSpec,
+}
+
+impl AlpenParams {
+    /// Creates new chain params.
+    pub fn new(
+        account_id: AccountId,
+        bridge_params: BridgeParams,
+        blob_spec: BlobSpec,
+        spec_activations: AlpenSpecActivations,
+        evm_spec: EvmSpec,
+    ) -> Self {
+        Self {
+            account_id,
+            bridge_params,
+            blob_spec,
+            spec_activations,
+            evm_spec,
+        }
+    }
+
+    /// Parses chain params from a JSON string.
+    pub fn from_json_str(json: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(json)
+    }
+
+    /// Serializes chain params to pretty-printed JSON.
+    pub fn to_json_string_pretty(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Returns the EE account ID in the OL chain.
+    pub fn account_id(&self) -> AccountId {
+        self.account_id
+    }
+
+    /// Returns the bridge denomination and withdrawal policy.
+    pub fn bridge_params(&self) -> &BridgeParams {
+        &self.bridge_params
+    }
+
+    /// Returns the DA stream identity.
+    pub fn blob_spec(&self) -> BlobSpec {
+        self.blob_spec
+    }
+
+    /// Returns the Alpen spec activations.
+    pub fn spec_activations(&self) -> &AlpenSpecActivations {
+        &self.spec_activations
+    }
+
+    /// Returns the embedded EVM chain spec.
+    pub fn evm_spec(&self) -> &EvmSpec {
+        &self.evm_spec
+    }
+
+    /// Returns the derived reth chain spec.
+    pub fn chain_spec(&self) -> &Arc<ChainSpec> {
+        self.evm_spec.chain_spec()
+    }
+
+    /// Returns the derived execution genesis block facts.
+    pub fn genesis_block_info(&self) -> AlpenEeGenesisBlockInfo {
+        self.evm_spec.genesis_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alpen_chainspec::DEV_CHAIN_SPEC;
+    use serde_json::{json, Value};
+    use strata_bridge_params::BridgeParams;
+    use strata_l1_txfmt::MagicBytes;
+
+    use super::{AlpenParams, DEFAULT_ALPEN_EE_ACCOUNT_ID};
+    use crate::{AlpenSpecActivations, BlobSpec, EvmSpec};
+
+    fn sample_params() -> AlpenParams {
+        let evm_spec: EvmSpec =
+            serde_json::from_str(DEV_CHAIN_SPEC).expect("dev chain should parse");
+        AlpenParams::new(
+            DEFAULT_ALPEN_EE_ACCOUNT_ID,
+            BridgeParams::new_with_descriptor_limit(100_000_000, Some(1_000_000_000), 81)
+                .expect("valid bridge params"),
+            BlobSpec::new(MagicBytes::new(*b"ALPN")),
+            AlpenSpecActivations::default(),
+            evm_spec,
+        )
+    }
+
+    fn sample_json() -> Value {
+        serde_json::to_value(sample_params()).expect("params should serialize")
+    }
+
+    #[test]
+    fn json_roundtrip_preserves_params() {
+        let params = sample_params();
+
+        let json = params
+            .to_json_string_pretty()
+            .expect("params should serialize");
+        let decoded = AlpenParams::from_json_str(&json).expect("params should deserialize");
+
+        assert_eq!(decoded, params);
+    }
+
+    #[test]
+    fn json_defaults_missing_spec_activations_to_empty() {
+        let mut json = sample_json();
+        json.as_object_mut()
+            .expect("params should be an object")
+            .remove("spec_activations")
+            .expect("spec_activations should be present");
+
+        let decoded: AlpenParams = serde_json::from_value(json).expect("params should deserialize");
+        assert!(decoded.spec_activations().is_empty());
+    }
+
+    #[test]
+    fn json_rejects_missing_bridge_params() {
+        let mut json = sample_json();
+        json.as_object_mut()
+            .expect("params should be an object")
+            .remove("bridge_params")
+            .expect("bridge_params should be present");
+
+        assert!(serde_json::from_value::<AlpenParams>(json).is_err());
+    }
+
+    #[test]
+    fn json_rejects_unknown_fields() {
+        let mut json = sample_json();
+        json.as_object_mut()
+            .expect("params should be an object")
+            .insert("genesis_blockhash".to_owned(), json!("0xdeadbeef"));
+
+        assert!(serde_json::from_value::<AlpenParams>(json).is_err());
+    }
+
+    #[test]
+    fn json_rejects_malformed_account_id() {
+        let mut json = sample_json();
+        json.as_object_mut()
+            .expect("params should be an object")
+            .insert("account_id".to_owned(), json!("01"));
+
+        assert!(serde_json::from_value::<AlpenParams>(json).is_err());
+    }
+}

--- a/crates/alpen-ee/params/src/spec_activations.rs
+++ b/crates/alpen-ee/params/src/spec_activations.rs
@@ -1,22 +1,64 @@
 //! Alpen protocol spec activations.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use serde::{Deserialize, Serialize};
 
+/// Identifier of an Alpen protocol spec revision.
+///
+/// The set of specs is closed: only variants defined here are valid keys in an
+/// [`AlpenSpecActivations`], so an unknown or misspelled spec name fails to
+/// decode instead of being accepted as an activation the node cannot honor.
+///
+/// The enum is currently uninhabited, so `BTreeMap<AlpenSpecId, _>` is
+/// provably empty — exactly the placeholder invariant, enforced by the type
+/// system rather than a runtime check.
+// TODO(STR-3997): define the real spec variants and what each resolves to per
+// component (e.g. revm spec id, program VKs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlpenSpecId {}
+
+impl fmt::Display for AlpenSpecId {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Uninhabited today; the match becomes exhaustive once real variants
+        // exist.
+        match *self {}
+    }
+}
+
 /// Placeholder Alpen spec activations.
 ///
-/// Maps spec names to activation values so the params artifact already
-/// carries the `spec_activations` axis in its schema. The real activation
-/// types (spec-id enum, resolver) land with STR-3997 and replace the value
-/// type; until then the map is expected to stay empty.
+/// Maps [`AlpenSpecId`]s to activation values so the params artifact already
+/// carries the `spec_activations` axis in its schema. No specs are defined,
+/// so the map stays empty by construction.
+// TODO(STR-3997): refine the activation value type (height vs. timestamp) with the
+// real activations.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct AlpenSpecActivations(BTreeMap<String, u64>);
+pub struct AlpenSpecActivations(BTreeMap<AlpenSpecId, u64>);
 
 impl AlpenSpecActivations {
     /// Returns whether no spec activations are scheduled.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AlpenSpecActivations;
+
+    #[test]
+    fn empty_map_deserializes() {
+        let activations: AlpenSpecActivations =
+            serde_json::from_str("{}").expect("empty map is valid");
+        assert!(activations.is_empty());
+    }
+
+    #[test]
+    fn unknown_spec_id_is_rejected() {
+        // No `AlpenSpecId` variant exists yet, so any key fails to decode.
+        assert!(serde_json::from_str::<AlpenSpecActivations>(r#"{"upgrade":100}"#).is_err());
     }
 }

--- a/crates/alpen-ee/params/src/spec_activations.rs
+++ b/crates/alpen-ee/params/src/spec_activations.rs
@@ -1,0 +1,22 @@
+//! Alpen protocol spec activations.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Placeholder Alpen spec activations.
+///
+/// Maps spec names to activation values so the params artifact already
+/// carries the `spec_activations` axis in its schema. The real activation
+/// types (spec-id enum, resolver) land with STR-3997 and replace the value
+/// type; until then the map is expected to stay empty.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AlpenSpecActivations(BTreeMap<String, u64>);
+
+impl AlpenSpecActivations {
+    /// Returns whether no spec activations are scheduled.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}

--- a/crates/reth/chainspec/src/lib.rs
+++ b/crates/reth/chainspec/src/lib.rs
@@ -84,10 +84,7 @@ pub fn ee_genesis_block_info(chain_spec: &ChainSpec) -> AlpenEeGenesisBlockInfo 
     let genesis_header = chain_spec.genesis_header();
     let genesis_stateroot = genesis_header.state_root;
     let genesis_hash = chain_spec.genesis_hash();
-    let genesis_blocknum = chain_spec
-        .genesis()
-        .number
-        .expect("genesis block number should be present");
+    let genesis_blocknum = genesis_header.number;
 
     AlpenEeGenesisBlockInfo {
         blockhash: genesis_hash,

--- a/crates/reth/chainspec/src/lib.rs
+++ b/crates/reth/chainspec/src/lib.rs
@@ -13,7 +13,7 @@ pub const DEV_CHAIN_SPEC: &str = include_str!("res/alpen-dev-chain.json");
 pub const TESTNET3_CHAIN_SPEC: &str = include_str!("res/testnet3-chain.json");
 
 /// Genesis block data that must match the Alpen EE params file.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AlpenEeGenesisBlockInfo {
     blockhash: B256,
     stateroot: B256,


### PR DESCRIPTION
## Description

Introduces the `alpen-ee-params` crate defining `AlpenParams` — the single top-level artifact that will replace the four independent parameter loaders (`--ee-params` JSON, `--custom-chain` genesis JSON, `--ee-da-magic-bytes`, and DA constants). This PR only defines the type; #2134 migrates all read-sites onto it and deletes `AlpenEeParams`.

The design decision worth reviewing is how the EVM chain spec is embedded: reth's `ChainSpec` isn't serde, so `EvmSpec` stores the `alloy_genesis::Genesis` document (authoritative for serialization) and derives the `Arc<ChainSpec>` plus the genesis block facts eagerly at decode. That derivation is what makes the stored genesis blockhash/stateroot/blocknum triple — and the boot-time `validate_ee_params_genesis` cross-check — unnecessary in the follow-up: agreement becomes structural. Equality intentionally compares the `Genesis` only, because `ChainSpec`'s derived `PartialEq` goes through `SealedHeader`'s lazily initialized hash cache.

Other points of note:

- Document validity is reth's call: `EvmSpec` accepts exactly what reth accepts for a `Genesis` document instead of policing individual fields, since the derivation is what defines validity.
- `spec_activations` schedules activations of Alpen protocol spec revisions (deliberately *spec*, not *fork*/*version* — it names the protocol rule set, not node software). It is keyed by the closed `AlpenSpecId` enum, uninhabited until STR-3997 defines real spec variants, so the placeholder map is provably empty and unknown spec names fail to decode by construction. Unknown top-level fields are rejected so older binaries fail loudly on newer artifacts.
- `blob_spec` is deliberately thin (just the DA stream magic bytes) per the design doc — DA format changes are code gated on spec activations, not params data.
- `DEFAULT_ALPEN_EE_ACCOUNT_ID` is temporarily duplicated from `alpen-ee-config`; the old copy is removed with `AlpenEeParams` in the follow-up PR.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

No consumers yet — the crate compiles standalone and nothing else changes behavior (the only touch outside the new crate is deriving `Clone, Copy, PartialEq, Eq` on `AlpenEeGenesisBlockInfo`). Review entry point: `crates/alpen-ee/params/src/params.rs`, then `evm_spec.rs` for the embedding mechanics.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- [AlpenParams — Consolidating the Alpen Spec](https://app.notion.com/p/390901ba000f80e199fbeb20b5a73e02)
- Jira: [STR-3996](https://alpenlabs.atlassian.net/browse/STR-3996)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: this PR was developed with the help of Claude Code.

## Related Issues

- [STR-3996](https://alpenlabs.atlassian.net/browse/STR-3996)


[STR-3996]: https://alpenlabs.atlassian.net/browse/STR-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
