### PR TITLE
chore(params): rotate prod bridge operator slot 1 + safe_harbour_address

### DIFF
--- a/.github/params/templates/prod/asm-params.json
+++ b/.github/params/templates/prod/asm-params.json
@@ -73,7 +73,7 @@
         "assignment_duration": 536,
         "operator_fee": 300000,
         "recovery_delay": 36,
-        "safe_harbour_address": "04ff79389655916a41e7f8278c1de678ed34c17171122afece179b8a7583a84450"
+        "safe_harbour_address": "04b01d8e0e12eceae5436f6a58ce8228de2f8ddf3c589492cf1052f59f4ddea1d7"
       }
     }
   ]

--- a/.github/params/templates/prod/asm-params.json
+++ b/.github/params/templates/prod/asm-params.json
@@ -63,7 +63,7 @@
     {
       "Bridge": {
         "operators": [
-          "02157d08fa2eb6071cef0750bcf1c0c9e94c2f05f629cdbdb3982851dce9472cd0",
+          "025a46d9052f64ad8f3a6ad65342ddead4f4f76f92ac184868ca402b8bed627cb8",
           "02444d7dca618168c1c4963a1556c2cab7d9172f0702cc3498dff72015717c0968",
           "02bff82939acd1deaeed90d6620b64ec475c6ff80a30fd07fca05315ddb1df873d",
           "02a96ec5406c02be9b6a7b254af44acf15b23b908b21619f9be583d82f943b6fb2",


### PR DESCRIPTION
## Summary

Two changes to `.github/params/templates/prod/asm-params.json` ahead of the Testnet III re-genesis. The `staging-v2` template is not affected by either.

### 1. Rotate bridge operator slot 1

```
operators[0]  02157d08…  ->  025a46d9…
```

Alpen operator-1 (bridge-1). Derived with `dev-cli 6d4451df` (signet), the commit pinned for the deployed secret-service image. Slots 2-5 untouched.

### 2. Rotate `safe_harbour_address` to a dedicated key

```
safe_harbour_address  04ff793896…  ->  04b01d8e…
address               tb1pkqwcursjan4w2sm0dfvvaq3gmchcmheutz2f9ncs2t6e7nw758tsam4nu8
```

The previous value embedded `ff793896…`, which is **op-1's previous-generation musig2** — a retired operator covenant key. Two problems:

- It is a **covenant signing key**, so spending needs federation aggregation. The safe harbour exists for emergencies, which is exactly when the federation may not be cooperating.
- It couples a protocol-level emergency destination to one operator's decommissioned key material.

The replacement is a dedicated key generated for this purpose only, via the same path as the bridge operator keys: `dev-cli 6d4451df`, `derive-keys <hex-seed> signet`, taking `general_wallet_descriptor` — already a `04`-prefixed P2TR descriptor, and single-sig spendable.

That construction is **proven, not assumed**: it is the same shape as the operator general wallets, which have moved funds on-chain (op-1's has 39 txs; the previous generation was swept to zero).

Seed is stored in AWS SM `testnet-prod/safe_harbour_keys` with the descriptor, address, and derivation recipe recorded alongside it.

## What safe_harbour_address does

Per `asm/crates/subprotocols/bridge-v1/types/src/safe_harbour.rs`, it is the Bitcoin output script descriptor used to **redirect bridge flows under emergency conditions**:

- **Activation** — `Defcon` signal from the admin subprotocol, restricted to the **strata security council**
- **Rotation** — restricted to the **strata administrator**, "so the same authority cannot both trigger a sweep and pick its destination"
- **Frozen once activated** — further rotation is rejected, so bridge nodes always observe a single destination
- Must be P2TR; the invariant is enforced on `TryFrom`, `Deserialize`, and SSZ decode
- `safe_harbour_address_update: 144` gates address changes by bury depth

Because it is genesis-baked and freezes on activation, it is worth getting right before re-genesis rather than inheriting.

## Verification

- JSON parses; `operators` slots 2-5 byte-identical to `main`
- Stored seed re-derives the descriptor exactly
- Descriptor payload equals the bech32m witness program of the address
- Type tag is `0x04` = P2TR (note: `P2TR_TYPE_TAG = 4` in bosd — the `DescriptorType` variant order is not the wire encoding, since `to_u8` maps both `P2wpkh`/`P2wsh` to 3 and `P2a`/`P2tr` to 4)
- `functional-tests/tests/params/test_template_drift.py` compares field *structure* against datatool output, not values, so neither change affects it

## Open question — custody

The new safe harbour is still a **single key held in Secrets Manager**. That is strictly better than pointing at a retired operator key, but it is not governance-controlled. `testnet-prod/asm-admin/strata_security_council/keys` exists with `scheme: 2-of-3, threshold: 2` — worth deciding whether the destination should be a 2-of-3 taproot instead of one seed.

Note the protocol's separation of duties concerns *who sets* the address vs *who triggers* the sweep; it does not dictate who can spend from the destination. So custody is a genuine design choice, not something the code settles.

## Related

Mirrors `alpenlabs/deployments` `clusters/testnet-prod/values/bridge-stack/client/base.yaml` + `strata-ol-values.yaml`, and `alpenlabs/bridge-onboarding` `environments/testnet/shared/asm-params.json`. All three should merge together.

Merge is gated on sweeping the superseded operator wallets and on external operators (Stakely, Chainflow) updating their rosters — see the deployments PR for detail.
