### PR TITLE
chore(params): rotate testnet-prod OL sequencer pubkey (STR-3990) [draft]

### DIFF
--- a/.github/params/templates/prod/asm-params.json
+++ b/.github/params/templates/prod/asm-params.json
@@ -54,7 +54,7 @@
     },
     {
       "Checkpoint": {
-        "sequencer_predicate": "Bip340Schnorr:9ee1eae0362787220373ed726ed592be9b8d73660f12a76bdd9fee421e4e443e",
+        "sequencer_predicate": "Bip340Schnorr:181a5fb69a2162bc95e15af9cf2688f8a12e52c9a0c04f699e327d5737ca26a6",
         "checkpoint_predicate": "__CHECKPOINT_PREDICATE__",
         "genesis_l1_height": "__GENESIS_L1_HEIGHT__",
         "genesis_ol_blkid": "__GENESIS_OL_BLKID__"


### PR DESCRIPTION
## What

Rotate the OL sequencer public key (`sequencer_predicate`) in the prod asm-params template.

```
.subprotocols[1].Checkpoint.sequencer_predicate
- Bip340Schnorr:9ee1eae0362787220373ed726ed592be9b8d73660f12a76bdd9fee421e4e443e
+ Bip340Schnorr:181a5fb69a2162bc95e15af9cf2688f8a12e52c9a0c04f699e327d5737ca26a6
```

Only `.github/params/templates/prod/asm-params.json` is changed; staging-v2 is untouched.

Ref: STR-3990
