### PR TITLE
ci: build images on release tags and allow concurrent manual runs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -210,12 +210,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          key: sp1-artifacts-builder
-          cache-on-failure: true
-
       - name: Install SP1 core runner override
         uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
@@ -306,6 +300,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          cache-binary: false
 
       # Authenticate to the shared ECR account
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,8 @@ on:
     - cron: '30 4,10,16,22 * * *'  # Every 6hr, ~1.5hr before SP1 E2E test
   push:
     branches: [main]
+    tags:
+      - "v*"
     paths:
       # Only trigger when source code or Dockerfiles change
       - "bin/**"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -55,9 +55,11 @@ on:
 env:
   AWS_REGION: us-east-1
 
-# Cancel in-progress runs for the same branch (except main — let those finish)
+# Cancel in-progress runs for the same branch (except main — let those finish).
+# Manual dispatches use unique groups so multiple requested builds can run at
+# the same time.
 concurrency:
-  group: ci-build-${{ github.ref }}
+  group: ci-build-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
## Description

Updates `ci-build` so image builds also run when version tags are pushed, and lets manually dispatched image builds run concurrently.

This keeps the existing image tagging behavior unchanged: images are still tagged by the short commit SHA of the checked-out commit.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The cache changes avoid Zizmor's cache-poisoning finding for a publishing workflow with a manual `ref` input; this trades CI speed for artifact provenance safety.

Validation performed:

- `actionlint .github/workflows/ci-build.yml`
- `zizmor .`
- `git diff --check`

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This CI workflow update was prepared with assistance from OpenAI Codex.

## Related Issues

