### PR TITLE
ci(build): scope concurrency per commit/dispatch to stop main serialization

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,9 +53,13 @@ on:
 env:
   AWS_REGION: us-east-1
 
-# Cancel in-progress runs for the same branch (except main — let those finish)
+# Keep independent work independent instead of serializing every run on main:
+#   - workflow_dispatch keys by run_id  -> manual builds never queue behind others
+#   - main push/schedule keys by commit -> different commits build in parallel;
+#                                          re-runs of the same commit still dedupe
+#   - branch pushes key by ref          -> a newer push cancels the superseded run
 concurrency:
-  group: ci-build-${{ github.ref }}
+  group: ci-build-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
## Problem

`ci-build` used a single concurrency group per ref:

```yaml
group: ci-build-${{ github.ref }}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

On `main`, `cancel-in-progress` is (correctly) false, but because **every** main
run shares the one group `ci-build-refs/heads/main`, runs **serialize**: a manual
`workflow_dispatch`, a scheduled run, and a new push all queue behind whatever
build is already in flight.

Observed: run `29561644543` (workflow_dispatch, `1a1deac`) sat **pending ~45 min**
behind an in-progress push build (`29559493694`, `4480dee`) — same group.

## Change

Scope the group by trigger so independent work runs independently, without losing
the "don't kill an in-flight main build" or "cancel superseded branch pushes"
behavior:

```yaml
group: ci-build-${{ github.event_name == 'workflow_dispatch' && github.run_id
  || github.ref == 'refs/heads/main' && github.sha
  || github.ref }}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

| Trigger | Group key | Effect |
|---------|-----------|--------|
| `workflow_dispatch` | `run_id` (unique) | manual builds never queue behind other runs |
| push / schedule on `main` | `github.sha` | different commits build in parallel; same-commit re-runs still dedupe |
| branch push | `github.ref` | unchanged — a newer push cancels the superseded run |

No job-level changes; image builds were already parallel via the matrix.

## Acceptance Criteria

- A `workflow_dispatch` on `main` starts immediately even while a push/scheduled build is in progress
- Two pushes of different commits to `main` build concurrently (not queued)
- A second push to the same feature branch still cancels the first run
- Re-running the exact same commit does not spawn a duplicate concurrent build

## Notes

- Forward-looking: the currently-pending run `29561644543` won't retroactively unstick — re-dispatch after merge (or let it drain behind the in-flight build).
- `actionlint` wasn't available locally; YAML validated with a parser. The `A && B || C` chain is the standard GitHub Actions ternary idiom.
