### PR TITLE
backport(releases/0.3): ci-build release-tag images + concurrent manual runs (#2137)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,8 @@ on:
     - cron: '30 4,10,16,22 * * *'  # Every 6hr, ~1.5hr before SP1 E2E test
   push:
     branches: [main]
+    tags:
+      - "v*"
     paths:
       # Only trigger when source code or Dockerfiles change
       - "bin/**"
@@ -53,9 +55,11 @@ on:
 env:
   AWS_REGION: us-east-1
 
-# Cancel in-progress runs for the same branch (except main — let those finish)
+# Cancel in-progress runs for the same branch (except main — let those finish).
+# Manual dispatches use unique groups so multiple requested builds can run at
+# the same time.
 concurrency:
-  group: ci-build-${{ github.ref }}
+  group: ci-build-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
@@ -206,12 +210,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          key: sp1-artifacts-builder
-          cache-on-failure: true
-
       - name: Install SP1 core runner override
         uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
@@ -302,6 +300,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          cache-binary: false
 
       # Authenticate to the shared ECR account
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## Backport of #2137 to `releases/0.3`

Cherry-picks the **squashed merge commit** of #2137 (`7dce1f91` on `main`, merged 2026-07-17) onto `releases/0.3` so release image builds can run from this branch.

Applied cleanly — the backport's `ci-build.yml` is **byte-identical** to what #2137 landed on `main` (0-line diff). Original author preserved; commit carries a `(cherry picked from commit 7dce1f91…)` trailer.

## Net change (`.github/workflows/ci-build.yml`)
- `on.push.tags: ["v*"]` — tagging a release triggers `CI — Build and Push Images`
- `concurrency.group: ci-build-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}` — manual dispatches use a unique group so they don't queue behind other runs
- removed the `Cache cargo` (Swatinem/rust-cache) step in `build-sp1-artifacts`
- `cache-binary: false` on `docker/setup-buildx-action`

## Acceptance Criteria

- Pushing a `v*` tag on `releases/0.3` triggers the image build
- A `workflow_dispatch` on `releases/0.3` runs without queueing behind another build
- Build succeeds without the removed rust-cache / buildx binary cache
- `ci-build.yml` matches #2137's merged version exactly (no drift)

## Notes

- Faithful backport of the squashed #2137. Once merged, release image builds can start off `releases/0.3`.
