### PR TITLE
fix(params): skip ci-build lookup for manual genparams

### DIFF
--- a/.github/params/README.md
+++ b/.github/params/README.md
@@ -1,6 +1,6 @@
 # CI Params Generation
 
-Generates deployment params (`ee-params.json`, `ol-params.json`, `asm-params.json`) using the prebuilt datatool image from a given commit.
+Generates deployment params (`ee-params.json`, `ol-params.json`, `asm-params.json`) using a prebuilt datatool image and the params scripts/templates from the checked-out repo ref. Manual runs validate that `datatool_image_commit` looks like a commit SHA, but they do not prove that the ECR tag came from a successful `ci-build.yml` run. A missing image tag still fails at `docker pull`.
 
 ## Templates
 
@@ -16,14 +16,31 @@ When adding a new environment or updating an existing one, commit the static val
 ```
 gh workflow run ci-genparams.yml --ref <branch> \
   -f env=<staging-v2|prod> \
-  -f commit=<short-sha> \
+  -f datatool_image_commit=<7-to-40-char-hex-sha> \
   -f genesis_l1_height=<height> \
   -f chain_config=<path-to-chainspec>
 ```
 
+Dispatch ref:
+
+| Argument | Description |
+|-------|-------------|
+| `--ref <branch>` | Branch/ref whose workflow file GitHub Actions runs. For normal runs, set this to the branch or commit to test and omit `checkout_ref`. |
+
+Workflow inputs:
+
+| Input | Description |
+|-------|-------------|
+| `datatool_image_commit` | Commit whose first 7 chars identify the prebuilt datatool image tag. Must be a 7-40 char lowercase hex SHA. |
+| `genesis_l1_height` | Genesis L1 block height. Must be a non-negative integer. |
+| `chain_config` | Path to a chainspec file. Must be single-line and exist in the checkout. |
+| `checkout_ref` | Optional override for the repo ref checked out inside the job for params scripts/templates. Use only when the workflow file should come from `--ref`, but params scripts/templates should come from a different ref. |
+
+When `checkout_ref` is omitted, the job checks out the workflow run commit (`github.sha`) for params scripts/templates. In the common case, this is the commit selected by `--ref`.
+
 Download the artifact:
 ```
-gh run download <run-id> -n params-<env>-<commit>
+gh run download <run-id> -n params-<env>-<datatool-image-tag>
 ```
 
 ## GitHub Environment Setup

--- a/.github/params/generate-params.sh
+++ b/.github/params/generate-params.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Required env vars:
 #   DEPLOY_ENV            - environment (staging-v2, testnet-prod)
-#   COMMIT                - alpen commit short SHA (datatool image tag)
+#   DATATOOL_IMAGE_TAG    - datatool image tag
 #   BTC_RPC_URL           - bitcoin RPC endpoint
 #   BTC_RPC_USER          - bitcoin RPC username
 #   BTC_RPC_PASSWORD      - bitcoin RPC password
@@ -18,22 +18,56 @@ ECR_REGISTRY="496607027995.dkr.ecr.us-east-1.amazonaws.com"
 DT_PLATFORM="linux/amd64"
 NETWORK="${NETWORK:-signet}"
 
-for var in DEPLOY_ENV COMMIT BTC_RPC_URL BTC_RPC_USER BTC_RPC_PASSWORD GENESIS_L1_HEIGHT CHAIN_CONFIG; do
-    if [ -z "${!var:-}" ]; then
-        echo "Missing required env var: ${var}" >&2
-        exit 1
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+require_env() {
+    local name="$1"
+
+    if [ -z "${!name:-}" ]; then
+        fail "Missing required env var: ${name}"
     fi
+}
+
+require_uint() {
+    local name="$1"
+    local value="$2"
+
+    if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+        fail "${name} must be a non-negative integer"
+    fi
+}
+
+require_existing_file() {
+    local name="$1"
+    local value="$2"
+
+    if [[ "${value}" == *$'\n'* || "${value}" == *$'\r'* ]]; then
+        fail "${name} must be single-line"
+    fi
+
+    if [ ! -f "${value}" ]; then
+        fail "${name} does not exist: ${value}"
+    fi
+}
+
+for var in DEPLOY_ENV DATATOOL_IMAGE_TAG BTC_RPC_URL BTC_RPC_USER BTC_RPC_PASSWORD GENESIS_L1_HEIGHT CHAIN_CONFIG; do
+    require_env "${var}"
 done
+
+require_uint GENESIS_L1_HEIGHT "${GENESIS_L1_HEIGHT}"
+require_existing_file CHAIN_CONFIG "${CHAIN_CONFIG}"
 
 TEMPLATE_DIR="${SCRIPT_DIR}/templates/${DEPLOY_ENV}"
 OUTPUT_DIR="${SCRIPT_DIR}/out/${DEPLOY_ENV}"
 
 if [ ! -d "${TEMPLATE_DIR}" ]; then
-    echo "No templates for '${DEPLOY_ENV}'. Available: $(ls "${SCRIPT_DIR}/templates/")" >&2
-    exit 1
+    fail "No templates for '${DEPLOY_ENV}'. Available: $(ls "${SCRIPT_DIR}/templates/")"
 fi
 
-DT_IMG="${ECR_REGISTRY}/strata/strata-datatool:${COMMIT}"
+DT_IMG="${ECR_REGISTRY}/strata/strata-datatool:${DATATOOL_IMAGE_TAG}"
 CHAIN_CONFIG_ABS="$(cd "$(dirname "${CHAIN_CONFIG}")" && pwd)/$(basename "${CHAIN_CONFIG}")"
 
 mkdir -p "${OUTPUT_DIR}"

--- a/.github/workflows/ci-genparams.yml
+++ b/.github/workflows/ci-genparams.yml
@@ -1,5 +1,5 @@
 # Generates deployment params (ee-params, ol-params, asm-params) using the prebuilt
-# datatool image from the specified commit. Static values (operator keys,
+# datatool image tag from the specified commit. Static values (operator keys,
 # denomination, etc.) come from pre-committed templates per environment;
 # dynamic values (VKs, genesis L1 anchor, genesis_ol_blkid) are filled in by
 # datatool.
@@ -18,12 +18,12 @@ on:
         options:
           - staging-v2
           - prod
-      commit:
-        description: "Alpen commit short SHA (must have a successful CI — Build and Push Images run)"
+      datatool_image_commit:
+        description: "Alpen commit whose first 7 chars identify the datatool image tag"
         required: true
         type: string
       checkout_ref:
-        description: "Repo ref to checkout (default: image commit SHA)"
+        description: "Repo ref for params scripts/templates (default: workflow ref)"
         required: false
         type: string
       genesis_l1_height:
@@ -46,56 +46,76 @@ concurrency:
 
 jobs:
   generate-params:
-    name: Generate params (${{ inputs.env }}, ${{ inputs.commit }})
+    name: Generate params (${{ inputs.env }}, ${{ inputs.datatool_image_commit }})
     runs-on: ubuntu-latest
     environment: ${{ inputs.env }}
     permissions:
-      actions: read
       contents: read
       id-token: write
     steps:
-      - name: Resolve image commit
+      - name: Resolve params inputs
         id: resolve
         env:
-          GH_TOKEN: ${{ github.token }}
-          INPUT_COMMIT: ${{ inputs.commit }}
+          DATATOOL_IMAGE_COMMIT: ${{ inputs.datatool_image_commit }}
           INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          WORKFLOW_REF_SHA: ${{ github.sha }}
         run: |
           set_output() {
             echo "$1=$2" >> "$GITHUB_OUTPUT"
           }
 
-          SHORT_TAG="${INPUT_COMMIT:0:7}"
-          BUILD_SHA=$(gh run list -R "${{ github.repository }}" \
-            --workflow ci-build.yml \
-            --status success \
-            --limit 100 \
-            --json headSha \
-            --jq ".[] | select(.headSha | startswith(\"${SHORT_TAG}\")) | .headSha" | head -n1)
-
-          if [ -z "${BUILD_SHA}" ]; then
-            echo "::error::No successful ci-build found for ${SHORT_TAG}"
+          fail() {
+            echo "::error::$1"
             exit 1
-          fi
+          }
 
-          if [ -n "${INPUT_CHECKOUT_REF}" ]; then
-            # Manual override: use caller-provided scripts/templates.
-            CHECKOUT_REF="${INPUT_CHECKOUT_REF}"
-          else
-            # Default path: checkout the same commit that produced the image.
-            CHECKOUT_REF="${BUILD_SHA}"
-          fi
+          require_single_line() {
+            local name="$1"
+            local value="$2"
 
-          set_output short_tag "${SHORT_TAG}"
-          set_output commit_sha "${BUILD_SHA}"
-          set_output checkout_ref "${CHECKOUT_REF}"
-          echo "Selected image build: ${SHORT_TAG} (${BUILD_SHA})"
-          echo "Checkout ref: ${CHECKOUT_REF}"
+            if [[ "${value}" == *$'\n'* || "${value}" == *$'\r'* ]]; then
+              fail "${name} must be single-line"
+            fi
+          }
+
+          datatool_image_tag_from_commit() {
+            local commit="$1"
+
+            # Commit used only to derive the prebuilt datatool Docker image tag.
+            if ! [[ "${commit}" =~ ^[0-9a-f]{7,40}$ ]]; then
+              fail "datatool_image_commit must be a 7-40 char lowercase hex commit SHA"
+            fi
+
+            printf '%s\n' "${commit:0:7}"
+          }
+
+          params_source_ref() {
+            local checkout_ref="$1"
+
+            # Optional caller-selected repo ref for params scripts/templates.
+            if [ -n "${checkout_ref}" ]; then
+              require_single_line checkout_ref "${checkout_ref}"
+              printf '%s\n' "${checkout_ref}"
+              return
+            fi
+
+            # By default, use the commit that GitHub Actions is running this workflow from.
+            printf '%s\n' "${WORKFLOW_REF_SHA}"
+          }
+
+          DATATOOL_IMAGE_TAG=$(datatool_image_tag_from_commit "${DATATOOL_IMAGE_COMMIT}")
+          PARAMS_SOURCE_REF=$(params_source_ref "${INPUT_CHECKOUT_REF}")
+
+          set_output datatool_image_tag "${DATATOOL_IMAGE_TAG}"
+          set_output params_source_ref "${PARAMS_SOURCE_REF}"
+          echo "Datatool image commit: ${DATATOOL_IMAGE_COMMIT}"
+          echo "Datatool image tag: ${DATATOOL_IMAGE_TAG}"
+          echo "Params source ref: ${PARAMS_SOURCE_REF}"
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.resolve.outputs.checkout_ref }}
+          ref: ${{ steps.resolve.outputs.params_source_ref }}
           persist-credentials: false
 
       - name: Configure AWS credentials
@@ -112,8 +132,8 @@ jobs:
 
       - name: Pull datatool image
         env:
-          COMMIT: ${{ steps.resolve.outputs.short_tag }}
-        run: docker pull "${DATATOOL_REPO}:${COMMIT}"
+          DATATOOL_IMAGE_TAG: ${{ steps.resolve.outputs.datatool_image_tag }}
+        run: docker pull "${DATATOOL_REPO}:${DATATOOL_IMAGE_TAG}"
 
       - name: Verify chainspec
         env:
@@ -125,7 +145,9 @@ jobs:
       - name: Generate params
         env:
           DEPLOY_ENV: ${{ inputs.env }}
-          COMMIT: ${{ steps.resolve.outputs.short_tag }}
+          DATATOOL_IMAGE_TAG: ${{ steps.resolve.outputs.datatool_image_tag }}
+          # Backward-compatibility alias for older params scripts.
+          COMMIT: ${{ steps.resolve.outputs.datatool_image_tag }}
           GENESIS_L1_HEIGHT: ${{ inputs.genesis_l1_height }}
           CHAIN_CONFIG: ${{ inputs.chain_config }}
           BTC_RPC_URL: ${{ secrets.PARAMS_BTC_RPC_URL }}
@@ -154,6 +176,6 @@ jobs:
       - name: Upload params artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: params-${{ inputs.env }}-${{ steps.resolve.outputs.short_tag }}
+          name: params-${{ inputs.env }}-${{ steps.resolve.outputs.datatool_image_tag }}
           path: .github/params/out/${{ inputs.env }}/
           retention-days: 30


### PR DESCRIPTION
## Description

Forward-ports `d581c03958920fbff0258b1d462f9f8707bceefe` from the old release branch onto `main`.

This updates manual params generation so callers provide the datatool image commit directly instead of requiring the workflow to find a successful `ci-build.yml` run for that SHA. It also clarifies checkout/image inputs and validates manual inputs before pulling the image or generating params.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Conflict resolution kept `main`'s `ee-params` coverage while preserving the manual datatool image and checkout hardening from the original commit.

Validation performed:

- `actionlint .github/workflows/ci-genparams.yml`
- `bash -n .github/params/generate-params.sh`
- `git diff --check`

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This forward-port PR was prepared with assistance from OpenAI Codex.

## Related Issues

