### PR TITLE
fix(alpen-cli): correct inverted recovery descriptor cleanup condition

### DIFF
--- a/bin/alpen-cli/Cargo.toml
+++ b/bin/alpen-cli/Cargo.toml
@@ -70,6 +70,7 @@ keyring = { version = "3.3.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+strata-bridge-params = { workspace = true, features = ["test-defaults"] }
 strata-test-utils-btcio.workspace = true
 toml.workspace = true
 

--- a/bin/alpen-cli/src/cmd/recover.rs
+++ b/bin/alpen-cli/src/cmd/recover.rs
@@ -27,6 +27,11 @@ pub struct RecoverArgs {
     fee_rate: Option<u64>,
 }
 
+/// Returns whether an already-claimed descriptor's cleanup grace window has elapsed.
+fn cleanup_delay_elapsed(recover_at: u32, current_height: u32) -> bool {
+    current_height >= recover_at.saturating_add(RECOVERY_DESC_CLEANUP_DELAY)
+}
+
 pub async fn recover(
     args: RecoverArgs,
     seed: Seed,
@@ -81,7 +86,7 @@ pub async fn recover(
         let needs_recovery = recovery_wallet.balance().confirmed > Amount::ZERO;
 
         if !needs_recovery {
-            if key.recover_at + RECOVERY_DESC_CLEANUP_DELAY > current_height {
+            if cleanup_delay_elapsed(key.recover_at, current_height) {
                 descriptor_file
                     .remove(&key)
                     .internal_error("Failed to remove old descriptor")?;
@@ -155,4 +160,48 @@ pub async fn recover(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cleanup_delay_not_elapsed_keeps_descriptor() {
+        let recover_at = 1_000;
+
+        assert!(!cleanup_delay_elapsed(recover_at, recover_at));
+        assert!(!cleanup_delay_elapsed(
+            recover_at,
+            recover_at + RECOVERY_DESC_CLEANUP_DELAY - 1
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_delay_exactly_elapsed_removes_descriptor() {
+        let recover_at = 1_000;
+
+        assert!(cleanup_delay_elapsed(
+            recover_at,
+            recover_at + RECOVERY_DESC_CLEANUP_DELAY
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_delay_well_past_removes_descriptor() {
+        let recover_at = 1_000;
+
+        assert!(cleanup_delay_elapsed(
+            recover_at,
+            recover_at + RECOVERY_DESC_CLEANUP_DELAY + 1_000
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_delay_saturates_near_max_height() {
+        let recover_at = u32::MAX;
+
+        assert!(cleanup_delay_elapsed(recover_at, u32::MAX));
+        assert!(!cleanup_delay_elapsed(recover_at, u32::MAX - 1));
+    }
 }


### PR DESCRIPTION
## Description

`alpen recover` deletes recovery descriptors backwards. The cleanup check in
`recover.rs` was:

    if key.recover_at + RECOVERY_DESC_CLEANUP_DELAY > current_height

which is true while the 100-block grace window is still open, not after it.
Two consequences:

- A zero-balance descriptor got deleted right away, inside the window where a
  reorg could still return funds to the recovery path. If that happened, the
  wallet had already thrown away the descriptor needed to claim them.
- Descriptors past the window were never deleted, so every `recover` run
  re-synced a throwaway wallet for each stale entry.

The condition dates back to the original import of this code and doesn't match
the printed message ("removed old, already claimed descriptor") or the constant
name, so this was a bug, not a design choice.

The fix extracts the check into a `cleanup_delay_elapsed` helper that removes a
descriptor only once `current_height >= recover_at + RECOVERY_DESC_CLEANUP_DELAY`
(saturating add, so no overflow near `u32::MAX`), with unit tests on both sides
of the boundary.

One extra change: `alpen-cli`'s test target didn't compile at all because the
`withdraw.rs` tests call `BridgeParams::new`, which is gated behind the
`test-defaults` feature. Added that feature to the dev-dependency, same as
other crates in the workspace already do.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The behavior change is one comparison; the rest is the helper extraction and
tests. Worth double-checking my reading of the intent: the delay exists so a
just-claimed descriptor survives a possible reorg before we delete it. If the
delay was meant for something else, the fix direction changes.

The `Cargo.toml` change only affects test builds (dev-dependency feature flag).

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

**AI assistance notice:** this fix was developed with AI assistance (Claude Code
and Codex); I reviewed the diff and ran the tests, fmt, and clippy locally.

## Related Issues

