### PR TITLE
backport(releases/0.3): add local Alpen fullnode compose

### DIFF
--- a/docker/.env.alpen-fullnode.example
+++ b/docker/.env.alpen-fullnode.example
@@ -1,0 +1,26 @@
+ALPEN_IMAGE=public.ecr.aws/alpenlabs/alpen:d24ebe2
+
+# WARNING: SEQUENCER_PUBKEY and GENESIS_L1_HEIGHT both change when the target
+# network is re-genesised, and a stale value does not fail loudly — it presents
+# as a sync or peering symptom, which is a long detour to debug. Re-derive them
+# from the target network before use rather than trusting the values here.
+#
+# For Testnet III these came from the live deployment on 2026-07-20:
+#   SEQUENCER_PUBKEY  -> secret testnet-prod-asm-secrets, EE_SEQUENCER_PUBLIC_KEY
+#   GENESIS_L1_HEIGHT -> strata-ol-config/asmParams.json, Checkpoint subprotocol
+#
+# Cheapest check that they are right: the node logs `EE genesis info blockhash=…`
+# at startup, and it must equal eth_getBlockByNumber("0x0") on the public RPC.
+SEQUENCER_PUBKEY=a90b390260da71f87d2af52f612a9f4f77797bdfaa010343cc1a435047aa05d7
+GENESIS_L1_HEIGHT=313553
+CHAIN_SPEC=testnet3
+
+# Strata/OL RPC endpoint used by the Alpen fullnode (http[s] and ws[s] both work).
+OL_CLIENT_URL=https://strata.testnet.alpen.org
+
+# Public Alpen EE RPC ingress.
+SEQUENCER_HTTP=https://alpen.testnet.alpen.org
+
+# Public Alpen EE fullnode P2P enodes.
+BOOTNODE_ENODE=enode://7148268aa1386af4b3a987d21ce7fab49254761b7c5f1859a3791f300090163c92caa61620c488d56e187f4ce31924eda678b4a7f683772954ec5977d1b7277c@bootnode-1.testnet.alpen.org:30303,enode://46dc0b4972b32e644f9289ed55be7dc114773ef202e028224e44b672eaf9570bbc7b585423f9e8061c0d8e1867ac8fa59b401eadbcc0bfc2b8adeabe0cdc4a62@bootnode-2.testnet.alpen.org:30303,enode://b44074ce9f9e9dbaec6980b75c9c9d8633a6f30b7116c7923f410ae19304f4ba16955bf74b3b9740eebfaf74e97ba2b97ed8f1354e6113375ae44d41fc072d58@bootnode-3.testnet.alpen.org:30303
+TRUSTED_PEERS=enode://7148268aa1386af4b3a987d21ce7fab49254761b7c5f1859a3791f300090163c92caa61620c488d56e187f4ce31924eda678b4a7f683772954ec5977d1b7277c@bootnode-1.testnet.alpen.org:30303,enode://46dc0b4972b32e644f9289ed55be7dc114773ef202e028224e44b672eaf9570bbc7b585423f9e8061c0d8e1867ac8fa59b401eadbcc0bfc2b8adeabe0cdc4a62@bootnode-2.testnet.alpen.org:30303,enode://b44074ce9f9e9dbaec6980b75c9c9d8633a6f30b7116c7923f410ae19304f4ba16955bf74b3b9740eebfaf74e97ba2b97ed8f1354e6113375ae44d41fc072d58@bootnode-3.testnet.alpen.org:30303

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -10,6 +10,11 @@ configs/*.hex
 configs/*.key
 configs/*.json
 
+# Exception: shipped with the repo rather than generated, so that
+# compose-fullnode.yml has an EE params file to mount on a fresh clone. Every
+# field in it is public. See the note in .env.alpen-fullnode.example.
+!configs/ee-params.testnet3.json
+
 .env
 .env.alpen
 .env.alpen-fullnode

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,13 +29,55 @@ The retained secondary compose files have narrower test/debug purposes:
 
 | Compose | Purpose |
 |---|---|
+| `compose-fullnode.yml` | Alpen EE fullnode |
 | `compose-checkpoint-sync.yml` | Checkpoint-sync OL node; use with a signet fullnode and mount pre-generated params under `configs/generated/` |
 | `docker-compose-eest.yml` | Ethereum execution spec test environment |
 | `docker-compose-p2p-test.yml` | Minimal EE P2P/gossip test |
 
-For checkpoint-sync, run `compose-signet.yml` in fullnode mode (`MINERENABLED=0`)
-with the target network's `SIGNETCHALLENGE` and an `ADDNODE` peer, then start
-`compose-checkpoint-sync.yml`.
+For operator-style fullnode validation, use `compose-fullnode.yml`. By default
+it runs the Alpen EE fullnode against the `OL_CLIENT_URL` configured in `.env`.
+
+Create the fullnode environment file before starting that stack:
+
+```bash
+cp .env.alpen-fullnode.example .env
+# Edit .env for the target network images and Alpen EE peers.
+```
+
+The fullnode compose mounts `configs/ee-params.testnet3.json`, which contains
+the Testnet III EE genesis metadata and bridge params consumed by
+`alpen-client --ee-params`.
+
+The compose defaults HTTP RPC to `eth,net,web3,txpool`; it does not expose
+`admin` or `debug` unless the operator explicitly overrides `HTTP_API`.
+
+Prepare the required key file mounted by the Alpen fullnode service:
+
+```bash
+mkdir -p configs/generated
+
+openssl rand -hex 32 > configs/generated/jwt.hex
+chmod 644 configs/generated/jwt.hex
+```
+
+To build the fullnode image from this checkout, set a local image name in
+`.env`:
+
+```bash
+ALPEN_IMAGE=alpen-client:local
+```
+
+Then build the image:
+
+```bash
+docker compose -f compose-fullnode.yml build alpen-fullnode
+```
+
+Then start the Alpen fullnode:
+
+```bash
+docker compose -f compose-fullnode.yml up -d
+```
 
 ## Just Recipes
 

--- a/docker/alpen-client/Dockerfile.local
+++ b/docker/alpen-client/Dockerfile.local
@@ -66,10 +66,9 @@ RUN mkdir -p /app/data /app/.cache /app/.local/share && \
 
 COPY --from=builder /usr/local/bin/alpen-client /usr/local/bin/alpen-client
 COPY docker/alpen-client/entrypoint.sh /usr/local/bin/entrypoint.sh
-# SP1 guest ELFs — staged by CI from the build-sp1-artifacts job.
-# Directory may be empty for local builds (uses --dev-native-prover instead).
-COPY docker/alpen-client/artifacts/elfs/ /app/elfs/
-RUN chmod 0555 /usr/local/bin/alpen-client /usr/local/bin/entrypoint.sh
+# Local builds run without staged SP1 guest ELFs.
+RUN mkdir -p /app/elfs && \
+    chmod 0555 /usr/local/bin/alpen-client /usr/local/bin/entrypoint.sh
 
 USER alpen
 

--- a/docker/compose-checkpoint-sync.yml
+++ b/docker/compose-checkpoint-sync.yml
@@ -7,12 +7,14 @@ services:
       context: ..
       dockerfile: docker/strata-checkpoint-sync/Dockerfile
     image: strata-checkpoint-sync:latest
-    env_file:
-      - .env
     environment:
       CONFIG_PATH: /app/configs/config.checkpoint-sync.toml
       OL_PARAMS_PATH: /app/configs/generated/ol-params.json
       ASM_PARAMS_PATH: /app/configs/generated/asm-params.json
+      BITCOIND_RPC_URL: ${BITCOIND_RPC_URL:-http://bitcoind:38332}
+      BITCOIND_RPC_USER: ${BITCOIND_RPC_USER:-bitcoin}
+      BITCOIND_RPC_PASSWORD: ${BITCOIND_RPC_PASSWORD:-bitcoin}
+      BITCOIN_NETWORK: ${BITCOIN_NETWORK:-signet}
       RUST_BACKTRACE: 1
     volumes:
       - ./configs/config.checkpoint-sync.toml:/app/configs/config.checkpoint-sync.toml:ro
@@ -26,7 +28,7 @@ services:
       - alpen_network
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz && curl -sf -X POST http://localhost:8432 -H 'content-type: application/json' --data '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"strata_getChainStatus\",\"params\":[]}' | grep -q '\"result\"'"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker/compose-fullnode.yml
+++ b/docker/compose-fullnode.yml
@@ -1,0 +1,53 @@
+services:
+  alpen-fullnode:
+    platform: linux/amd64
+    build:
+      context: ..
+      dockerfile: docker/alpen-client/Dockerfile.local
+    image: ${ALPEN_IMAGE:-alpen-client:latest}
+    environment:
+      RUST_LOG: ${RUST_LOG:-info,alpen_gossip=info}
+      HTTP_API: ${HTTP_API:-eth,net,web3,txpool}
+      SEQUENCER_PUBKEY: ${SEQUENCER_PUBKEY:-}
+      GENESIS_L1_HEIGHT: ${GENESIS_L1_HEIGHT:-}
+      CHAIN_SPEC: ${CHAIN_SPEC:-testnet3}
+      OL_CLIENT_URL: ${OL_CLIENT_URL:-https://strata.testnet.alpen.org}
+    command:
+      - --sequencer-http
+      - ${SEQUENCER_HTTP:-}
+      - --bootnodes
+      - ${BOOTNODE_ENODE:-}
+      - --trusted-peers
+      - ${TRUSTED_PEERS:-${BOOTNODE_ENODE:-}}
+    volumes:
+      - ./configs/generated/jwt.hex:/app/keys/jwt.hex:ro
+      # alpen-client always passes --ee-params, so this file must exist or the
+      # node exits at startup with `failed to read EE params file`. Checked in
+      # rather than generated: every value is public (the genesis hashes are
+      # readable via eth_getBlockByNumber("0x0")) and configs/generated/ is
+      # gitignored, so nothing would be there on a fresh clone.
+      # Re-genesis-sensitive — see the note in .env.alpen-fullnode.example.
+      - ./configs/ee-params.testnet3.json:/app/configs/generated/ee-params.json:ro
+      - alpen-fullnode-data:/app/data
+    ports:
+      - "9545:8545"
+      - "9546:8546"
+      - "30303:30303/tcp"
+      - "30303:30303/udp"
+    networks:
+      - alpen_network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  alpen-fullnode-data:
+
+networks:
+  alpen_network:
+    driver: bridge
+    name: alpen_network

--- a/docker/configs/config.checkpoint-sync.toml
+++ b/docker/configs/config.checkpoint-sync.toml
@@ -17,8 +17,8 @@ metrics_port = 9615
 
 [bitcoind]
 rpc_url = "http://bitcoind:38332"
-rpc_user = "rpcuser"
-rpc_password = "rpcpassword"
+rpc_user = "bitcoin"
+rpc_password = "bitcoin"
 network = "signet"
 retry_count = 255
 retry_interval = 5_000

--- a/docker/configs/ee-params.testnet3.json
+++ b/docker/configs/ee-params.testnet3.json
@@ -1,0 +1,11 @@
+{
+  "account_id": "0101010101010101010101010101010101010101010101010101010101010101",
+  "genesis_blockhash": "0xa0f19ca687f984785ab9d6f1558ec4ab31cc497679aa55bf73ee14328be15baf",
+  "genesis_stateroot": "0x0253f1b4ee3eb61b1ce6fb3718032f6d1201b7e1cb0bdcdb548248a5ba5bd070",
+  "genesis_blocknum": 0,
+  "bridge_params": {
+    "denomination": 200000000,
+    "max_withdrawal_amount": null,
+    "max_withdrawal_descriptor_len": 81
+  }
+}


### PR DESCRIPTION
## Description

Backports #1992 to `releases/0.3`.

This adds Docker support for running an Alpen EE fullnode against the public
Testnet III network:

- `compose-fullnode.yml` runs a single `alpen-fullnode` service.
- `.env.alpen-fullnode.example` carries the current Testnet III image, chain,
  sequencer pubkey, genesis height, public OL RPC endpoint, and EE peer values.
- `configs/ee-params.testnet3.json` is mounted as `--ee-params` and is the
  source for EE genesis metadata and bridge params.
- `Dockerfile.local` supports local image builds without requiring CI-staged
  SP1 ELF artifacts.

The default fullnode compose path does not run checkpoint-sync or bitcoind.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is a release-branch backport of #1992.

Validation run after cherry-pick:

```bash
docker compose --env-file .env.alpen-fullnode.example -f compose-fullnode.yml config
```

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: I used AI assistance to help prepare this PR.

## Related Issues

Backport of #1992.
