### PR TITLE
fix(alpen-cli): correct inverted recovery descriptor cleanup condition (#2143)

### DIFF
--- a/bin/alpen-cli/Cargo.toml
+++ b/bin/alpen-cli/Cargo.toml
@@ -69,6 +69,7 @@ keyring = { version = "3.3.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+strata-bridge-params = { workspace = true, features = ["test-defaults"] }
 strata-test-utils-btcio.workspace = true
 toml.workspace = true
 

--- a/bin/alpen-cli/src/cmd/recover.rs
+++ b/bin/alpen-cli/src/cmd/recover.rs
@@ -27,6 +27,11 @@ pub struct RecoverArgs {
     fee_rate: Option<u64>,
 }
 
+/// Returns whether an already-claimed descriptor's cleanup grace window has elapsed.
+fn cleanup_delay_elapsed(recover_at: u32, current_height: u32) -> bool {
+    current_height >= recover_at.saturating_add(RECOVERY_DESC_CLEANUP_DELAY)
+}
+
 pub async fn recover(
     args: RecoverArgs,
     seed: Seed,
@@ -81,7 +86,7 @@ pub async fn recover(
         let needs_recovery = recovery_wallet.balance().confirmed > Amount::ZERO;
 
         if !needs_recovery {
-            if key.recover_at + RECOVERY_DESC_CLEANUP_DELAY > current_height {
+            if cleanup_delay_elapsed(key.recover_at, current_height) {
                 descriptor_file
                     .remove(&key)
                     .internal_error("Failed to remove old descriptor")?;
@@ -155,4 +160,48 @@ pub async fn recover(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cleanup_delay_not_elapsed_keeps_descriptor() {
+        let recover_at = 1_000;
+
+        assert!(!cleanup_delay_elapsed(recover_at, recover_at));
+        assert!(!cleanup_delay_elapsed(
+            recover_at,
+            recover_at + RECOVERY_DESC_CLEANUP_DELAY - 1
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_delay_exactly_elapsed_removes_descriptor() {
+        let recover_at = 1_000;
+
+        assert!(cleanup_delay_elapsed(
+            recover_at,
+            recover_at + RECOVERY_DESC_CLEANUP_DELAY
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_delay_well_past_removes_descriptor() {
+        let recover_at = 1_000;
+
+        assert!(cleanup_delay_elapsed(
+            recover_at,
+            recover_at + RECOVERY_DESC_CLEANUP_DELAY + 1_000
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_delay_saturates_near_max_height() {
+        let recover_at = u32::MAX;
+
+        assert!(cleanup_delay_elapsed(recover_at, u32::MAX));
+        assert!(!cleanup_delay_elapsed(recover_at, u32::MAX - 1));
+    }
 }


### PR DESCRIPTION
backport of #2143 

---

The cleanup check removed already-claimed recovery descriptors while their reorg-safety grace window (RECOVERY_DESC_CLEANUP_DELAY) was still open and kept stale ones forever. Extract the predicate into cleanup_delay_elapsed, delete only once the window has elapsed, and add unit tests. Enable strata-bridge-params test-defaults in dev-dependencies so the crate's tests compile again.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
