### PR TITLE
fix(rpc): expose SAU operation seqno in OL summaries

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -10,7 +10,10 @@ use jsonrpsee::core::RpcResult;
 use ssz::{Decode, Encode};
 use strata_acct_types::MessageEntry;
 use strata_checkpoint_types::EpochSummary;
-use strata_db_types::{ol_block::BlockAvailability, ol_state_index::InboxMessageRecord};
+use strata_db_types::{
+    ol_block::BlockAvailability,
+    ol_state_index::{AccountUpdateRecord, InboxMessageRecord},
+};
 use strata_identifiers::{
     AccountId, Epoch, EpochCommitment, Hash, L1BlockCommitment, L1Height, L2BlockCommitment,
     OLBlockCommitment, OLBlockId, OLTxId, RBuf32,
@@ -123,6 +126,22 @@ fn local_inbox_message_range(
     })?;
 
     Ok(local_start..local_end)
+}
+
+/// Returns the SAU operation seqno for an indexed update record.
+///
+/// Indexed update records store post-state account seqnos. Missing operation
+/// seqnos indicate an indexing invariant violation and fail the RPC.
+fn require_operation_seq_no(
+    account_id: AccountId,
+    epoch: Epoch,
+    record: &AccountUpdateRecord,
+) -> RpcResult<u64> {
+    record.orig_acct_seq_no().ok_or_else(|| {
+        internal_error(format!(
+            "missing operation seq_no in update record for account {account_id} epoch {epoch}",
+        ))
+    })
 }
 
 impl<P: OLRpcProvider> OLRpcServer<P> {
@@ -422,7 +441,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
         // `Pending` triple capturing the inbox slice they consumed.
         struct Pending {
             block_commitment: OLBlockCommitment,
-            seq_no: u64,
+            operation_seq_no: u64,
             new_state_root: Hash,
             extra_data: Vec<u8>,
             cursor_start: u64,
@@ -455,6 +474,8 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                         continue;
                     }
 
+                    let operation_seq_no = require_operation_seq_no(account_id, epoch, &r)?;
+
                     // Block-attributed `DirectSet` (no `extra_data`) is not
                     // produced by current write paths. Keep the soft fail in
                     // case the invariant ever breaks.
@@ -470,7 +491,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
 
                     pending.push(Pending {
                         block_commitment,
-                        seq_no: r.seq_no(),
+                        operation_seq_no,
                         new_state_root: meta.new_state_root(),
                         extra_data,
                         cursor_start: r.prev_next_inbox_idx(),
@@ -512,7 +533,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                     .entry(p.block_commitment)
                     .or_default()
                     .push(UpdateInputData::new(
-                        p.seq_no,
+                        p.operation_seq_no,
                         messages,
                         UpdateStateData::new(
                             ProofState::new(p.new_state_root, p.cursor_end),
@@ -528,7 +549,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                     .entry(p.block_commitment)
                     .or_default()
                     .push(UpdateInputData::new(
-                        p.seq_no,
+                        p.operation_seq_no,
                         Vec::new(),
                         UpdateStateData::new(
                             ProofState::new(p.new_state_root, p.cursor_end),
@@ -710,7 +731,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             let skip_fetch = epoch == 0;
 
             struct Pending {
-                seq_no: u64,
+                operation_seq_no: u64,
                 new_state_root: Option<Hash>,
                 extra_data: Vec<u8>,
                 cursor_start: u64,
@@ -720,6 +741,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             let mut pending = Vec::with_capacity(records.len());
             for r in &records {
                 let new_state_root = r.update_meta().map(|m| m.new_state_root());
+                let operation_seq_no = require_operation_seq_no(account_id, epoch, r)?;
                 let extra_data = r
                     .extra_data()
                     .ok_or_else(|| {
@@ -731,7 +753,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                     .to_vec();
 
                 pending.push(Pending {
-                    seq_no: r.seq_no(),
+                    operation_seq_no,
                     new_state_root,
                     extra_data,
                     cursor_start: r.prev_next_inbox_idx(),
@@ -764,7 +786,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
                     messages_in_range[message_range].to_vec()
                 };
                 out.push(RpcUpdateInputData {
-                    seq_no: p.seq_no,
+                    seq_no: p.operation_seq_no,
                     next_inbox_msg_idx: p.cursor_end,
                     new_state_root: p.new_state_root.map(|root| root.0.into()),
                     extra_data: p.extra_data.into(),
@@ -1127,12 +1149,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             };
 
             for record in records {
-                let operation_seq_no = record.orig_acct_seq_no().ok_or_else(|| {
-                    internal_error(format!(
-                        "update record for account {account_id} epoch {epoch} has invalid \
-                         post-state seq_no 0",
-                    ))
-                })?;
+                let operation_seq_no = require_operation_seq_no(account_id, epoch, &record)?;
 
                 if operation_seq_no != seq_no {
                     continue;

--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -10,10 +10,7 @@ use jsonrpsee::core::RpcResult;
 use ssz::{Decode, Encode};
 use strata_acct_types::MessageEntry;
 use strata_checkpoint_types::EpochSummary;
-use strata_db_types::{
-    ol_block::BlockAvailability,
-    ol_state_index::{AccountUpdateRecord, InboxMessageRecord},
-};
+use strata_db_types::{ol_block::BlockAvailability, ol_state_index::InboxMessageRecord};
 use strata_identifiers::{
     AccountId, Epoch, EpochCommitment, Hash, L1BlockCommitment, L1Height, L2BlockCommitment,
     OLBlockCommitment, OLBlockId, OLTxId, RBuf32,
@@ -126,22 +123,6 @@ fn local_inbox_message_range(
     })?;
 
     Ok(local_start..local_end)
-}
-
-/// Returns the SAU operation seqno for an indexed update record.
-///
-/// Indexed update records store post-state account seqnos. Missing operation
-/// seqnos indicate an indexing invariant violation and fail the RPC.
-fn require_operation_seq_no(
-    account_id: AccountId,
-    epoch: Epoch,
-    record: &AccountUpdateRecord,
-) -> RpcResult<u64> {
-    record.orig_acct_seq_no().ok_or_else(|| {
-        internal_error(format!(
-            "missing operation seq_no in update record for account {account_id} epoch {epoch}",
-        ))
-    })
 }
 
 impl<P: OLRpcProvider> OLRpcServer<P> {
@@ -474,7 +455,7 @@ impl<P: OLRpcProvider> OLRpcServer<P> {
                         continue;
                     }
 
-                    let operation_seq_no = require_operation_seq_no(account_id, epoch, &r)?;
+                    let operation_seq_no = r.orig_acct_seq_no();
 
                     // Block-attributed `DirectSet` (no `extra_data`) is not
                     // produced by current write paths. Keep the soft fail in
@@ -741,7 +722,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             let mut pending = Vec::with_capacity(records.len());
             for r in &records {
                 let new_state_root = r.update_meta().map(|m| m.new_state_root());
-                let operation_seq_no = require_operation_seq_no(account_id, epoch, r)?;
+                let operation_seq_no = r.orig_acct_seq_no();
                 let extra_data = r
                     .extra_data()
                     .ok_or_else(|| {
@@ -1149,7 +1130,7 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
             };
 
             for record in records {
-                let operation_seq_no = require_operation_seq_no(account_id, epoch, &record)?;
+                let operation_seq_no = record.orig_acct_seq_no();
 
                 if operation_seq_no != seq_no {
                     continue;

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -2078,7 +2078,7 @@ async fn blocks_summaries_populates_updates_and_new_inbox_messages_from_index() 
     assert_eq!(summaries[0].updates().len(), 1);
 
     let update = rpc_update_to_input(summaries[0].updates()[0].clone());
-    assert_eq!(update.seq_no(), 6);
+    assert_eq!(update.seq_no(), 5);
     assert_eq!(update.extra_data(), extra_data.as_slice());
     assert_eq!(update.new_state().inner_state(), final_state_root);
     assert_eq!(update.new_state().next_inbox_msg_idx(), 2);
@@ -2098,6 +2098,99 @@ async fn blocks_summaries_populates_updates_and_new_inbox_messages_from_index() 
     assert_eq!(
         returned_messages[0].payload_buf(),
         inbox_message.payload_buf()
+    );
+}
+
+#[tokio::test]
+async fn summaries_match_manifest_operation_seqno_by_root() {
+    let account_id = test_account_id(1);
+    let epoch: Epoch = 1;
+    let post_state_seq_no = 553;
+    let operation_seq_no = 552;
+    let next_inbox_msg_idx = 9;
+
+    let genesis_block = make_block(0, 0, null_blkid());
+    let genesis_blkid = genesis_block.header().compute_blkid();
+    let prev_epoch_commitment = EpochCommitment::new(0, 0, genesis_blkid);
+
+    let block = make_terminal_block(5, epoch, genesis_blkid);
+    let commitment = OLBlockCommitment::new(5, block.header().compute_blkid());
+    let epoch_commitment = EpochCommitment::new(epoch, 5, block.header().compute_blkid());
+    let resulting_state_root = fixed_buf32(0x3F);
+    let record = update_record_with_prev(
+        Some(AccountUpdateMeta::new(
+            Some(commitment),
+            resulting_state_root,
+        )),
+        post_state_seq_no,
+        next_inbox_msg_idx,
+        next_inbox_msg_idx,
+        Some(vec![0xC3, 0x51]),
+    );
+
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            commitment,
+            epoch,
+            true,
+            prev_epoch_commitment,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_account_creation_epoch(account_id, epoch)
+        .with_epoch_commitment(0, prev_epoch_commitment)
+        .with_epoch_commitment(epoch, epoch_commitment)
+        .with_block_and_state(&genesis_block, genesis_ol_state())
+        .with_block_and_state(
+            &block,
+            ol_state_with_snark_account(account_id, 5, post_state_seq_no, next_inbox_msg_idx),
+        )
+        .with_account_update_records(account_id, epoch, vec![record]);
+    let rpc = make_rpc(provider);
+
+    let epoch_summary = rpc
+        .get_acct_epoch_summary(account_id, epoch)
+        .await
+        .expect("epoch summary");
+    let epoch_update = epoch_summary
+        .update_inputs()
+        .iter()
+        .find(|update| {
+            update
+                .new_state_root
+                .as_ref()
+                .is_some_and(|root| root.0 == resulting_state_root.0)
+        })
+        .expect("epoch update with matching state root");
+    assert_eq!(epoch_update.seq_no, operation_seq_no);
+
+    let block_summaries = rpc
+        .get_blocks_summaries(account_id, 5, 5)
+        .await
+        .expect("block summary");
+    assert_eq!(block_summaries.len(), 1);
+    let block_summary = &block_summaries[0];
+    assert_eq!(block_summary.next_seq_no(), post_state_seq_no);
+    let block_update = block_summary
+        .updates()
+        .iter()
+        .find(|update| {
+            update
+                .new_state_root
+                .as_ref()
+                .is_some_and(|root| root.0 == resulting_state_root.0)
+        })
+        .expect("block update with matching state root");
+    assert_eq!(block_update.seq_no, operation_seq_no);
+
+    let manifest = rpc
+        .get_snark_acct_update_manifest(account_id, operation_seq_no)
+        .await
+        .expect("manifest");
+    assert_eq!(manifest.seq_no(), operation_seq_no);
+    assert_eq!(
+        manifest.new_inner_state_root().expect("state root").0,
+        resulting_state_root.0
     );
 }
 
@@ -2523,8 +2616,38 @@ async fn blocks_summaries_out_of_chain_directset_does_not_fail_rpc() {
     assert_eq!(summaries[0].updates().len(), 1);
 
     let update = rpc_update_to_input(summaries[0].updates()[0].clone());
-    assert_eq!(update.seq_no(), 2);
+    assert_eq!(update.seq_no(), 1);
     assert_eq!(update.extra_data(), [0xA0]);
+}
+
+#[tokio::test]
+async fn blocks_summaries_rejects_zero_post_state_seqno() {
+    let account_id = test_account_id(1);
+    let block = make_block(0, 0, null_blkid());
+    let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
+    let record = update_record(
+        Some(AccountUpdateMeta::new(Some(commitment), [0x44; 32].into())),
+        0,
+        0,
+        Some(vec![0xA0]),
+    );
+
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            commitment,
+            0,
+            false,
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+            EpochCommitment::null(),
+        ))
+        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 0, 0))
+        .with_account_update_records(account_id, 0, vec![record]);
+    let rpc = make_rpc(provider);
+
+    rpc.get_blocks_summaries(account_id, 0, 0)
+        .await
+        .expect_err("blocks summary accepted zero post-state seq_no");
 }
 
 #[tokio::test]
@@ -2627,7 +2750,7 @@ proptest! {
         generated_updates in prop::collection::vec(
             (
                 any::<bool>(),
-                any::<u16>(),
+                1u16..=u16::MAX,
                 any::<[u8; 32]>(),
                 prop::collection::vec(any::<u8>(), 0..16)
             ),
@@ -2696,7 +2819,7 @@ proptest! {
             summaries[0].updates().iter().zip(expected_block0.iter())
         {
             let update = rpc_update_to_input(rpc_update.clone());
-            prop_assert_eq!(update.seq_no(), u64::from(*seq_no));
+            prop_assert_eq!(update.seq_no(), u64::from(*seq_no) - 1);
             prop_assert_eq!(update.extra_data(), extra_data.as_slice());
             prop_assert_eq!(
                 update.new_state().inner_state(),
@@ -2710,7 +2833,7 @@ proptest! {
             summaries[1].updates().iter().zip(expected_block1.iter())
         {
             let update = rpc_update_to_input(rpc_update.clone());
-            prop_assert_eq!(update.seq_no(), u64::from(*seq_no));
+            prop_assert_eq!(update.seq_no(), u64::from(*seq_no) - 1);
             prop_assert_eq!(update.extra_data(), extra_data.as_slice());
             prop_assert_eq!(
                 update.new_state().inner_state(),
@@ -3034,12 +3157,12 @@ async fn epoch_summary_multi_record_slices_messages_per_update() {
     let updates = summary.update_inputs();
     assert_eq!(updates.len(), 3);
 
-    assert_eq!(updates[0].seq_no, 10);
+    assert_eq!(updates[0].seq_no, 9);
     assert_eq!(updates[0].messages.len(), 2);
     assert_eq!(rpc_messages_to_entries(&updates[0].messages), msgs_1);
-    assert_eq!(updates[1].seq_no, 11);
+    assert_eq!(updates[1].seq_no, 10);
     assert!(updates[1].messages.is_empty());
-    assert_eq!(updates[2].seq_no, 12);
+    assert_eq!(updates[2].seq_no, 11);
     assert_eq!(updates[2].messages.len(), 3);
     assert_eq!(rpc_messages_to_entries(&updates[2].messages), msgs_3);
 }
@@ -3096,6 +3219,32 @@ async fn epoch_summary_checkpoint_sync_populates_terminal_root_only() {
         summary.final_state_root().0,
         "terminal update surfaces post-epoch root"
     );
+}
+
+#[tokio::test]
+async fn epoch_summary_rejects_zero_post_state_seqno() {
+    let epoch: Epoch = 2;
+    let account_id = test_account_id(7);
+    let epoch_commitment = test_epoch_commitment(epoch, 40, 0x62);
+    let prev_epoch_commitment = test_epoch_commitment(epoch - 1, 30, 0x61);
+    let record = update_record_with_prev(
+        Some(AccountUpdateMeta::new(None, Hash::zero())),
+        0,
+        0,
+        0,
+        Some(vec![0xA0]),
+    );
+
+    let provider = MockProvider::new()
+        .with_epoch_commitment(epoch, epoch_commitment)
+        .with_epoch_commitment(epoch - 1, prev_epoch_commitment)
+        .with_snark_state_at_terminal(epoch_commitment, account_id, 0, 0)
+        .with_account_update_records(account_id, epoch, vec![record]);
+    let rpc = make_rpc(provider);
+
+    rpc.get_acct_epoch_summary(account_id, epoch)
+        .await
+        .expect_err("epoch summary accepted zero post-state seq_no");
 }
 
 #[tokio::test]
@@ -3587,7 +3736,7 @@ async fn snark_acct_update_manifest_no_message_update_returns_empty_extra_data()
 }
 
 #[tokio::test]
-async fn snark_acct_update_manifest_rejects_invalid_stored_seqno_zero() {
+async fn snark_acct_update_manifest_rejects_zero_post_state_seqno() {
     let account_id = test_account_id(6);
     let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x60);
     let provider = MockProvider::new()
@@ -3613,13 +3762,9 @@ async fn snark_acct_update_manifest_rejects_invalid_stored_seqno_zero() {
         );
     let rpc = make_rpc(provider);
 
-    let err = rpc
-        .get_snark_acct_update_manifest(account_id, 0)
+    rpc.get_snark_acct_update_manifest(account_id, 0)
         .await
-        .expect_err("stored post-state seqno 0 should be invalid");
-
-    assert_eq!(err.code(), INTERNAL_ERROR_CODE);
-    assert!(err.message().contains("invalid post-state seq_no 0"));
+        .expect_err("manifest accepted zero post-state seq_no");
 }
 
 #[tokio::test]

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    num::NonZeroU64,
     ops::Range,
     slice,
     sync::{
@@ -68,7 +69,7 @@ fn update_record_with_prev(
 ) -> AccountUpdateRecord {
     AccountUpdateRecord::new(
         update_meta,
-        seq_no,
+        NonZeroU64::new(seq_no).expect("record post-state seqno must be non-zero"),
         prev_next_inbox_idx,
         next_inbox_idx,
         extra_data,
@@ -2621,36 +2622,6 @@ async fn blocks_summaries_out_of_chain_directset_does_not_fail_rpc() {
 }
 
 #[tokio::test]
-async fn blocks_summaries_rejects_zero_post_state_seqno() {
-    let account_id = test_account_id(1);
-    let block = make_block(0, 0, null_blkid());
-    let commitment = OLBlockCommitment::new(0, block.header().compute_blkid());
-    let record = update_record(
-        Some(AccountUpdateMeta::new(Some(commitment), [0x44; 32].into())),
-        0,
-        0,
-        Some(vec![0xA0]),
-    );
-
-    let provider = MockProvider::new()
-        .with_sync_status(make_sync_status(
-            commitment,
-            0,
-            false,
-            EpochCommitment::null(),
-            EpochCommitment::null(),
-            EpochCommitment::null(),
-        ))
-        .with_block_and_state(&block, ol_state_with_snark_account(account_id, 0, 0, 0))
-        .with_account_update_records(account_id, 0, vec![record]);
-    let rpc = make_rpc(provider);
-
-    rpc.get_blocks_summaries(account_id, 0, 0)
-        .await
-        .expect_err("blocks summary accepted zero post-state seq_no");
-}
-
-#[tokio::test]
 async fn blocks_summaries_reads_ranges_past_checkpoint_sync_row() {
     let account_id = test_account_id(1);
     let epoch: Epoch = 2;
@@ -3222,32 +3193,6 @@ async fn epoch_summary_checkpoint_sync_populates_terminal_root_only() {
 }
 
 #[tokio::test]
-async fn epoch_summary_rejects_zero_post_state_seqno() {
-    let epoch: Epoch = 2;
-    let account_id = test_account_id(7);
-    let epoch_commitment = test_epoch_commitment(epoch, 40, 0x62);
-    let prev_epoch_commitment = test_epoch_commitment(epoch - 1, 30, 0x61);
-    let record = update_record_with_prev(
-        Some(AccountUpdateMeta::new(None, Hash::zero())),
-        0,
-        0,
-        0,
-        Some(vec![0xA0]),
-    );
-
-    let provider = MockProvider::new()
-        .with_epoch_commitment(epoch, epoch_commitment)
-        .with_epoch_commitment(epoch - 1, prev_epoch_commitment)
-        .with_snark_state_at_terminal(epoch_commitment, account_id, 0, 0)
-        .with_account_update_records(account_id, epoch, vec![record]);
-    let rpc = make_rpc(provider);
-
-    rpc.get_acct_epoch_summary(account_id, epoch)
-        .await
-        .expect_err("epoch summary accepted zero post-state seq_no");
-}
-
-#[tokio::test]
 async fn epoch_summary_epoch_zero_has_no_messages() {
     let epoch = 0;
     let account_id = test_account_id(12);
@@ -3733,38 +3678,6 @@ async fn snark_acct_update_manifest_no_message_update_returns_empty_extra_data()
         manifest.new_inner_state_root().expect("state root").0,
         final_state_root.0
     );
-}
-
-#[tokio::test]
-async fn snark_acct_update_manifest_rejects_zero_post_state_seqno() {
-    let account_id = test_account_id(6);
-    let tip_epoch_commitment = test_epoch_commitment(0, 0, 0x60);
-    let provider = MockProvider::new()
-        .with_sync_status(make_sync_status(
-            tip_epoch_commitment.to_block_commitment(),
-            0,
-            false,
-            EpochCommitment::null(),
-            EpochCommitment::null(),
-            EpochCommitment::null(),
-        ))
-        .with_account_creation_epoch(account_id, 0)
-        .with_snark_tip_state(tip_epoch_commitment, account_id, 1, 0)
-        .with_account_update_records(
-            account_id,
-            0,
-            vec![update_record(
-                Some(AccountUpdateMeta::new(None, [0x11; 32].into())),
-                0,
-                0,
-                Some(Vec::new()),
-            )],
-        );
-    let rpc = make_rpc(provider);
-
-    rpc.get_snark_acct_update_manifest(account_id, 0)
-        .await
-        .expect_err("manifest accepted zero post-state seq_no");
 }
 
 #[tokio::test]

--- a/crates/chain-worker/src/context.rs
+++ b/crates/chain-worker/src/context.rs
@@ -3,7 +3,7 @@
 //! This module provides [`ChainWorkerContextImpl`], a production implementation
 //! of the worker context that uses the storage layer managers for database access.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, num::NonZeroU64, sync::Arc};
 
 use ssz::Encode;
 use strata_acct_types::{
@@ -26,6 +26,7 @@ use strata_ol_chain_types::{
     SnarkAccountUpdateLogData,
 };
 use strata_ol_params::OLParams;
+use strata_ol_state_support_types::SnarkAcctStateUpdate;
 use strata_ol_state_types::{OLAccountState, OLState, WriteBatch};
 use strata_primitives::epoch::EpochCommitment;
 use strata_status::StatusChannel;
@@ -453,7 +454,7 @@ fn build_indexing_writes(
         let meta = AccountUpdateMeta::new(Some(commitment), state);
         let record = AccountUpdateRecord::new(
             Some(meta),
-            *update.seqno().inner(),
+            post_update_seqno(update)?,
             update.prev_next_read_idx(),
             update.next_read_idx(),
             Some(log.extra_data().to_vec()),
@@ -481,6 +482,16 @@ fn build_indexing_writes(
         account_updates,
         account_inbox_writes,
     ))
+}
+
+/// Returns the post-update account seqno carried by a tracked snark state update.
+///
+/// The STF writes `operation seqno + 1` when applying an update, so a zero here means the
+/// tracked update did not come from an applied update transaction.
+fn post_update_seqno(update: &SnarkAcctStateUpdate) -> WorkerResult<NonZeroU64> {
+    NonZeroU64::new(*update.seqno().inner()).ok_or(WorkerError::SnarkUpdateZeroSeqno {
+        account_id: update.account_id(),
+    })
 }
 
 /// Decodes the [`SnarkAccountUpdateLogData`] logs from `logs`, in emission order, skipping logs
@@ -551,7 +562,7 @@ pub(crate) fn build_checkpoint_indexing_writes(
             .map(|root| AccountUpdateMeta::new(None, root));
         let record = AccountUpdateRecord::new(
             update_meta,
-            *update.seqno().inner(),
+            post_update_seqno(update)?,
             update.prev_next_read_idx(),
             update.next_read_idx(),
             Some(log.extra_data().to_vec()),

--- a/crates/chain-worker/src/errors.rs
+++ b/crates/chain-worker/src/errors.rs
@@ -172,6 +172,11 @@ pub enum WorkerError {
     #[error("snark update log next_read_idx mismatch (expected {expected}, got {found})")]
     SnarkUpdateLogMismatch { expected: u64, found: u64 },
 
+    /// A tracked snark state update carried a zero post-update seqno. The STF writes
+    /// `operation seqno + 1`, so this cannot come from an applied update transaction.
+    #[error("snark update has zero post-update seqno for account {account_id}")]
+    SnarkUpdateZeroSeqno { account_id: AccountId },
+
     /// Missing a required dependency for operation.
     #[error("missing required dependency: {0}")]
     MissingDependency(&'static str),

--- a/crates/db/tests/src/ol_state_indexing_tests.rs
+++ b/crates/db/tests/src/ol_state_indexing_tests.rs
@@ -1,6 +1,7 @@
 //! OL state indexing database tests.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU64;
 
 use strata_db_types::ol_state_index::{
     AccountCreatedRecord, AccountUpdateMeta, AccountUpdateRecord, EpochIndexingData,
@@ -32,6 +33,7 @@ fn record(
     idx: u64,
     extra: Option<Vec<u8>>,
 ) -> AccountUpdateRecord {
+    let seq = NonZeroU64::new(seq).expect("record post-state seqno must be non-zero");
     AccountUpdateRecord::new(meta, seq, 0, idx, extra)
 }
 
@@ -69,7 +71,7 @@ pub fn test_apply_epoch_indexing_round_trip(db: &impl OLStateIndexingDatabase) {
 
     let commitment = epoch_commit(epoch, 9);
     let mut updates = BTreeMap::new();
-    updates.insert(acct_a, vec![record(None, 0, 0, Some(vec![1, 2, 3]))]);
+    updates.insert(acct_a, vec![record(None, 1, 0, Some(vec![1, 2, 3]))]);
     let mut inbox = BTreeMap::new();
     inbox.insert(acct_b, vec![InboxMessageRecord::new(vec![9, 9], None)]);
 
@@ -258,7 +260,7 @@ pub fn test_account_active_in_multiple_epochs_creation_epoch_unchanged(
         acct_a,
         vec![record(
             Some(AccountUpdateMeta::new(Some(block(2, 2)), hash(1))),
-            0,
+            1,
             0,
             None,
         )],

--- a/crates/db/types/src/ol_state_index.rs
+++ b/crates/db/types/src/ol_state_index.rs
@@ -8,6 +8,7 @@
 //! are stored in their raw SSZ byte form; callers convert at the boundaries.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU64;
 
 use serde::{Deserialize, Serialize};
 use strata_codec::Codec;
@@ -191,16 +192,24 @@ impl AccountUpdateMeta {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AccountUpdateRecord {
     update_meta: Option<AccountUpdateMeta>,
-    seq_no: u64,
+
+    /// Account seqno after this update.
+    ///
+    /// The STF writes `operation seqno + 1`, so the minimum is 1, from an
+    /// account's first update.
+    seq_no: NonZeroU64,
+
     prev_next_inbox_idx: u64,
+
     next_inbox_idx: u64,
+
     extra_data: Option<Vec<u8>>,
 }
 
 impl AccountUpdateRecord {
     pub fn new(
         update_meta: Option<AccountUpdateMeta>,
-        seq_no: u64,
+        seq_no: NonZeroU64,
         prev_next_inbox_idx: u64,
         next_inbox_idx: u64,
         extra_data: Option<Vec<u8>>,
@@ -218,16 +227,18 @@ impl AccountUpdateRecord {
         self.update_meta.as_ref()
     }
 
+    /// Returns the post-update account seqno.
     pub fn seq_no(&self) -> u64 {
-        self.seq_no
+        self.seq_no.get()
     }
 
     /// Returns the operation seqno that produced this record.
     ///
-    /// The record stores the post-update account seqno. Snark account updates
-    /// publish the pre-update operation seqno, so this is `seq_no - 1`.
-    pub fn orig_acct_seq_no(&self) -> Option<u64> {
-        self.seq_no.checked_sub(1)
+    /// The record stores the post-update account seqno, and snark account
+    /// updates declare the pre-update operation seqno, so this is `seq_no - 1`.
+    /// It is zero for an account's first update.
+    pub fn orig_acct_seq_no(&self) -> u64 {
+        self.seq_no.get() - 1
     }
 
     pub fn prev_next_inbox_idx(&self) -> u64 {

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -12,9 +12,6 @@ use strata_primitives::{HexBytes, HexBytes32, HexBytes64, OLBlockCommitment};
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "strata"))]
 pub trait OLClientRpc {
     /// Get an account's epoch summary for a given epoch.
-    ///
-    /// Snark account `update_inputs[*].seq_no` values are SAU operation
-    /// sequence numbers. They are not the post-update account `next_seq_no`.
     #[method(name = "getAccountEpochSummary")]
     async fn get_acct_epoch_summary(
         &self,
@@ -50,15 +47,10 @@ pub trait OLClientRpc {
 
     /// Get account-specific summaries for blocks in a slot range.
     ///
-    /// Returns the account's post-block state (`balance`, `next_seq_no`, inbox
-    /// position) at each block in the range `[start_slot, end_slot]`.
-    ///
-    /// Snark account `updates[*].seq_no` values are SAU operation sequence
-    /// numbers. They are not the post-update account `next_seq_no`.
-    ///
-    /// This is useful for clients that need to track how an account's state
-    /// evolved over a series of blocks, such as snark account provers that need
-    /// to know inbox messages and state transitions.
+    /// Returns the account's state (balance, sequence number, inbox position) at each block
+    /// in the range `[start_slot, end_slot]`. This is useful for clients that need to track
+    /// how an account's state evolved over a series of blocks, such as snark account provers
+    /// that need to know inbox messages and state transitions.
     ///
     /// Results are returned in ascending slot order. Only blocks on the canonical chain
     /// are included; the implementation walks parent references to ensure chain continuity.
@@ -91,9 +83,6 @@ pub trait OLClientRpc {
     ) -> RpcResult<Option<RpcSnarkAccountState>>;
 
     /// Get published manifest metadata for a Snark account update.
-    ///
-    /// The `seq_no` parameter is the SAU operation sequence number, not the
-    /// post-update account `next_seq_no`.
     ///
     /// The consumed inbox range inside the resulting [`RpcSnarkAcctUpdateManifest`] is half-open:
     /// `[prev_next_msg_idx, new_next_msg_idx)`.

--- a/crates/ol/rpc/api/src/lib.rs
+++ b/crates/ol/rpc/api/src/lib.rs
@@ -12,6 +12,9 @@ use strata_primitives::{HexBytes, HexBytes32, HexBytes64, OLBlockCommitment};
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "strata"))]
 pub trait OLClientRpc {
     /// Get an account's epoch summary for a given epoch.
+    ///
+    /// Snark account `update_inputs[*].seq_no` values are SAU operation
+    /// sequence numbers. They are not the post-update account `next_seq_no`.
     #[method(name = "getAccountEpochSummary")]
     async fn get_acct_epoch_summary(
         &self,
@@ -47,10 +50,15 @@ pub trait OLClientRpc {
 
     /// Get account-specific summaries for blocks in a slot range.
     ///
-    /// Returns the account's state (balance, sequence number, inbox position) at each block
-    /// in the range `[start_slot, end_slot]`. This is useful for clients that need to track
-    /// how an account's state evolved over a series of blocks, such as snark account provers
-    /// that need to know inbox messages and state transitions.
+    /// Returns the account's post-block state (`balance`, `next_seq_no`, inbox
+    /// position) at each block in the range `[start_slot, end_slot]`.
+    ///
+    /// Snark account `updates[*].seq_no` values are SAU operation sequence
+    /// numbers. They are not the post-update account `next_seq_no`.
+    ///
+    /// This is useful for clients that need to track how an account's state
+    /// evolved over a series of blocks, such as snark account provers that need
+    /// to know inbox messages and state transitions.
     ///
     /// Results are returned in ascending slot order. Only blocks on the canonical chain
     /// are included; the implementation walks parent references to ensure chain continuity.
@@ -83,6 +91,9 @@ pub trait OLClientRpc {
     ) -> RpcResult<Option<RpcSnarkAccountState>>;
 
     /// Get published manifest metadata for a Snark account update.
+    ///
+    /// The `seq_no` parameter is the SAU operation sequence number, not the
+    /// post-update account `next_seq_no`.
     ///
     /// The consumed inbox range inside the resulting [`RpcSnarkAcctUpdateManifest`] is half-open:
     /// `[prev_next_msg_idx, new_next_msg_idx)`.

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -14,13 +14,17 @@ use strata_snark_acct_types::{ProofState, UpdateInputData};
 pub struct RpcAccountEpochSummary {
     /// The epoch commitment.
     epoch_commitment: EpochCommitment,
+
     /// Previous epoch commitment.
     prev_epoch_commitment: EpochCommitment,
+
     /// Balance of account at the end of this epoch in sats.
     final_balance: u64,
+
     /// Account's state root at the end of this epoch.
     final_state_root: HexBytes32,
-    /// Update inputs for this epoch if present
+
+    /// Update inputs for this epoch.
     update_inputs: Vec<RpcUpdateInputData>,
 }
 
@@ -77,16 +81,22 @@ impl RpcAccountEpochSummary {
 pub struct RpcAccountBlockSummary {
     /// Account Id
     pub account: HexBytes32,
+
     /// Block commitment.
     pub block_commitment: OLBlockCommitment,
+
     /// Balance of account after block execution in sats.
     pub balance: u64,
-    /// Next expected sequence number for account after block execution.
+
+    /// Next expected account sequence number after block execution.
     pub next_seq_no: u64,
+
     /// Account's updates processed in the block.
     pub updates: Vec<RpcUpdateInputData>,
+
     /// New messages added to account's inbox in this block.
     pub new_inbox_messages: Vec<RpcMessageEntry>,
+
     /// Next expected message inbox accumulator index after block execution.
     pub next_inbox_msg_idx: u64,
 }
@@ -128,7 +138,7 @@ impl RpcAccountBlockSummary {
         self.balance
     }
 
-    /// Returns the next expected sequence number for account after block execution.
+    /// Returns the next expected account sequence number after block execution.
     pub fn next_seq_no(&self) -> u64 {
         self.next_seq_no
     }
@@ -152,17 +162,21 @@ impl RpcAccountBlockSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct RpcUpdateInputData {
-    /// Sequence number of the update.
+    /// Operation sequence number consumed by this update.
     pub seq_no: u64,
+
     /// Inbox cursor after this update.
     pub next_inbox_msg_idx: u64,
+
     /// Inner state root after this update. On checkpoint-sync nodes only the
     /// terminal update of an epoch carries a root (the recoverable post-epoch
     /// root); earlier updates are `None`, since intermediate roots are not in
     /// the checkpoint DA. The epoch's `final_state_root` is always populated.
     pub new_state_root: Option<HexBytes32>,
+
     /// Extra data posted with this update.
     pub extra_data: HexBytes,
+
     /// Account inbox messages processed in this update.
     pub messages: Vec<RpcMessageEntry>,
 }
@@ -171,14 +185,18 @@ pub struct RpcUpdateInputData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct RpcSnarkAcctUpdateManifest {
-    /// Sequence number of the update.
+    /// Operation sequence number consumed by this update.
     seq_no: u64,
+
     /// Inner state root after this update, if stored by the serving node.
     new_inner_state_root: Option<HexBytes32>,
+
     /// Inbox cursor before this update.
     prev_next_msg_idx: u64,
+
     /// Inbox cursor after this update.
     new_next_msg_idx: u64,
+
     /// Extra data posted with this update, if stored by the serving node.
     extra_data: Option<HexBytes>,
 }
@@ -216,7 +234,7 @@ impl RpcSnarkAcctUpdateManifest {
         }
     }
 
-    /// Returns the update sequence number.
+    /// Returns the operation sequence number consumed by this update.
     pub fn seq_no(&self) -> u64 {
         self.seq_no
     }

--- a/functional-tests/tests/alpen_client/test_real_bridge_deposit_withdraw.py
+++ b/functional-tests/tests/alpen_client/test_real_bridge_deposit_withdraw.py
@@ -288,7 +288,7 @@ def wait_for_output_snark_update(
 def wait_for_account_update_seq(
     rpc,
     account_id_hex: str,
-    min_next_seq_no: int,
+    min_operation_seq_no: int,
     start_epoch: int,
     btc_rpc,
     miner_addr: str,
@@ -315,10 +315,10 @@ def wait_for_account_update_seq(
             for update in updates:
                 seq_no = int(update.get("seq_no", -1))
                 last_seen_seq_no = max(last_seen_seq_no, seq_no)
-                if seq_no >= min_next_seq_no:
+                if seq_no >= min_operation_seq_no:
                     return epoch
     raise AssertionError(
-        f"account update seq_no >= {min_next_seq_no} not found from epoch {start_epoch}; "
+        f"account update seq_no >= {min_operation_seq_no} not found from epoch {start_epoch}; "
         f"last_terminal_epoch={last_terminal_epoch}, last_seen_seq_no={last_seen_seq_no}"
     )
 
@@ -586,7 +586,7 @@ class TestRealBridgeDepositWithdraw(BaseTest):
         saw_update_at_epoch = wait_for_account_update_seq(
             strata_rpc,
             ALPEN_ACCOUNT_ID,
-            min_next_seq_no=submitted_seq_no,
+            min_operation_seq_no=submitted_seq_no,
             start_epoch=start_terminal_epoch,
             btc_rpc=btc_rpc,
             miner_addr=miner_addr,


### PR DESCRIPTION
## Description

Fixes OL account summary RPCs to expose the SAU operation sequence number for update inputs instead of the stored post-state account sequence.

## Details

- Uses `AccountUpdateRecord::orig_acct_seq_no()` in block and epoch summary paths.
- Keeps `next_seq_no` as the post-state account value.
- Documents the operation `seq_no` vs post-state `next_seq_no` distinction.
- Adds regression coverage correlating epoch summary, block summary, and manifest by state root.

Commit 2 takes a different approach:
- Types `AccountUpdateRecord::seq_no` as `NonZeroU64`, making
  `orig_acct_seq_no()` infallible (`u64` rather than `Option<u64>`) and
  removing the per-call-site guards in the summary and manifest paths.
- Adds `WorkerError::SnarkUpdateZeroSeqno`, so a zero post-update seqno fails
  at indexing rather than surfacing as an RPC internal error.
- Drops the three tests that covered those guards; they could only be written
  by constructing a record the type now rejects.

If commit 2 is a better approach, we can fold 1 and 2. Basically keep commit 2 approach.

The PR was created with help from Codex and Claude.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-4102](https://alpenlabs.atlassian.net/browse/STR-4102)

[STR-4102]: https://alpenlabs.atlassian.net/browse/STR-4102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ