### PR TITLE
ci(ai-review): raise turn budget to 60 and gate on the posted comment

### DIFF
--- a/.github/workflows/ai-security-review.yml
+++ b/.github/workflows/ai-security-review.yml
@@ -7,6 +7,9 @@ name: AI Security Review
 # On `pull_request`, GitHub withholds secrets from EXTERNAL fork PRs, so this covers same-repo
 # branches; external-fork PRs are not reviewed. Do NOT switch to `pull_request_target` without
 # a security re-review — that trigger hands secrets + a writable token to untrusted PR content.
+# Pass/fail contract: the job is green iff the review comment was posted. Claude exiting non-zero
+# (typically `--max-turns` on a very large diff, which fires *after* it has already commented) is
+# downgraded to a warning; a run that posts nothing still fails.
 
 on:
   pull_request:
@@ -34,7 +37,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Headroom for the raised turn budget: ~12s/turn observed, so 60 turns is ~13min worst case.
+    timeout-minutes: 30
     steps:
       # Manual runs have access to secrets, so keep the automatic trigger's fork/dependabot boundary.
       - name: Validate manually selected PR
@@ -77,7 +81,16 @@ jobs:
           echo "model=$model" >> "$GITHUB_OUTPUT"
           { echo "### AI review model: \`$model\`"; echo '```'; printf '%s\n' "$files"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
 
+      # Anything the review posts must be newer than this, so a stale comment from an earlier run
+      # can't satisfy the gate below. One minute of slack absorbs runner/API clock skew.
+      - name: Record review start time
+        id: started
+        run: echo "at=$(date -u -d '-1 minute' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        id: review
+        # Never fail the job here — the "Require review comment" step below decides the outcome.
+        continue-on-error: true
         with:
           # Subscription first; fall back to the API key only when no OAuth token is configured.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -94,6 +107,15 @@ jobs:
             panics on untrusted input (watch Rust `unsafe`), input-validation gaps, unsafe error handling,
             resource exhaustion / DoS. Favor precision over recall.
 
+            TOOLS — this is the complete set you have. Every call outside it is denied and burns a
+            turn for nothing, so do not guess or retry with a different command:
+            - Read, Grep, Glob — use these for ALL file reading and searching. Grep replaces `rg`,
+              Read with offset/limit replaces `sed -n '10,40p'`, Glob replaces `find`.
+            - Bash, and only these commands: `gh pr diff`, `gh pr view`, `gh pr comment`, `cat`,
+              `ls`, `grep`, `head`, `tail`, `git diff`, `git log`, `git show`.
+            Notably unavailable: `sed`, `awk`, `find`, `rg`, `wc`, `sort`, `gh api`, `python`, and
+            anything that writes or executes. There is no way to request more; work within this set.
+
             Then post EXACTLY ONE PR comment via
             `gh pr comment ${{ github.event.pull_request.number || inputs.pr_number }} --repo ${{ github.repository }} --body "<markdown>"`,
             following these OUTPUT RULES strictly (a human reads this — keep it tight):
@@ -107,5 +129,33 @@ jobs:
           # Read-only allowlist: no `sed` (s///e exec), no blanket `git` (`-c alias=!cmd` exec), no `gh api` (write API).
           claude_args: |
             --model ${{ steps.pick.outputs.model }}
-            --max-turns 40
+            --max-turns 60
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(cat:*),Bash(ls:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
+
+      # The deliverable is the comment, not Claude's exit code. Hitting --max-turns generally means
+      # it commented on its last turn and had none left to sign off, which is a pass. Nothing posted
+      # (auth failure, crash, silent stop) is a real failure and still goes red.
+      - name: Require review comment
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          SINCE: ${{ steps.started.outputs.at }}
+          OUTCOME: ${{ steps.review.outcome }}
+        run: |
+          set -euo pipefail
+          posted=$(gh pr view "$PR" --repo "$REPO" --json comments | jq --arg since "$SINCE" '
+            [ .comments[]
+              | select(.author.login == "github-actions")
+              | select(.createdAt >= $since)
+              | select(.body | startswith("## 🔒 AI Security Review"))
+            ] | length')
+          if [ "$posted" -eq 0 ]; then
+            echo "::error::No AI security review comment was posted (claude-code-action outcome: $OUTCOME)."
+            exit 1
+          fi
+          if [ "$OUTCOME" != success ]; then
+            echo "::warning::claude-code-action ended as '$OUTCOME' (most likely --max-turns), but the review was posted — passing. If this recurs, raise --max-turns."
+          fi
+          echo "Review comment posted; claude-code-action outcome: $OUTCOME."


### PR DESCRIPTION
The security review of #1789 (+8,180 lines across 36 files) exhausted `--max-turns 40`. It had already posted its review comment on the final turn, but the SDK aborted with `error_max_turns` before Claude could sign off, so the job went red despite the review having landed.

Three changes:

- `--max-turns` 40 -> 60. Recent runs use 12-24 turns, so 40 was ample for typical PRs and only large diffs hit the ceiling. Job timeout goes 20 -> 30 minutes to match (~12s/turn observed).

- Enumerate the available tools in the prompt. Every run so far has burnt turns on denied calls (0, 3, 7, 8 and 9 across the last five runs — one run lost 9 of its 22 turns) because nothing told Claude what the read-only allowlist contains, so it kept guessing at `sed`, `find`, `rg` and friends. The allowlist itself is unchanged.

- Decide the job outcome on whether the review comment was posted, not on the action's exit code. `--max-turns` fires after the comment lands, so it is now a warning; a run that posts nothing (auth failure, crash) still fails.


Claude-Session: https://claude.ai/code/session_012vfKXW9dAtYzZHteiLbkwf

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
