### PR TITLE
fix(alpen-cli): recover full signet balance after wallet reset

### DIFF
--- a/bin/alpen-cli/src/cmd/deposit.rs
+++ b/bin/alpen-cli/src/cmd/deposit.rs
@@ -207,6 +207,9 @@ pub async fn deposit(
     )?;
     println!("Built transaction");
 
+    l1w.persist()
+        .internal_error("Failed to persist signet wallet")?;
+
     let pb = ProgressBar::new_spinner().with_message("Saving output descriptor");
     pb.enable_steady_tick(Duration::from_millis(100));
 

--- a/bin/alpen-cli/src/cmd/recover.rs
+++ b/bin/alpen-cli/src/cmd/recover.rs
@@ -108,6 +108,8 @@ pub async fn recover(
             address.to_string().yellow(),
             recover_to.to_string().yellow()
         );
+        l1w.persist()
+            .internal_error("Failed to persist signet wallet")?;
 
         let policy = recovery_wallet
             .policies(KeychainKind::External)

--- a/bin/alpen-cli/src/cmd/send.rs
+++ b/bin/alpen-cli/src/cmd/send.rs
@@ -86,6 +86,8 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings) -> Result<(), 
                     Err(e) => panic!("Unexpected error in creating PSBT: {e:?}"),
                 }
             };
+            l1w.persist()
+                .internal_error("Failed to persist signet wallet")?;
             l1w.sign(&mut psbt, Default::default())
                 .expect("tx should be signed");
             let tx = psbt.extract_tx().expect("tx should be signed and ready");

--- a/bin/alpen-cli/src/signet.rs
+++ b/bin/alpen-cli/src/signet.rs
@@ -15,7 +15,7 @@ use bdk_esplora::esplora_client::{self, AsyncClient};
 use bdk_wallet::{
     bitcoin::{FeeRate, Network},
     rusqlite::{self, Connection},
-    PersistedWallet, Wallet,
+    KeychainKind, PersistedWallet, Wallet,
 };
 use persist::Persister;
 use terrors::OneOf;
@@ -50,18 +50,18 @@ pub async fn get_fee_rate(
 mod tests {
     use async_trait::async_trait;
     use bdk_wallet::{
-        bitcoin::{FeeRate, Transaction},
+        bitcoin::{bip32::Xpriv, FeeRate, Network, Transaction},
         chain::{
             spk_client::{FullScanRequestBuilder, SyncRequestBuilder},
             CheckPoint,
         },
-        KeychainKind,
+        KeychainKind, Wallet,
     };
     use terrors::OneOf;
 
     use super::{
         backend::{BroadcastTxError, GetFeeRateError, InvalidFee, ScanError, UpdateSender},
-        get_fee_rate, SignetBackend, SyncError,
+        get_fee_rate, needs_full_scan, SignetBackend, SyncError,
     };
 
     #[derive(Debug)]
@@ -129,6 +129,34 @@ mod tests {
 
         assert_eq!(fee_rate, FeeRate::BROADCAST_MIN);
     }
+
+    fn test_wallet() -> Wallet {
+        let rootpriv = Xpriv::new_master(Network::Signet, &[7u8; 32]).expect("valid xpriv");
+        let base_desc = format!("tr({rootpriv}/86h/0h/0h");
+        let external_desc = format!("{base_desc}/0/*)");
+        let internal_desc = format!("{base_desc}/1/*)");
+
+        Wallet::create(external_desc, internal_desc)
+            .network(Network::Signet)
+            .create_wallet_no_persist()
+            .expect("test wallet should be created")
+    }
+
+    #[test]
+    fn test_needs_full_scan_is_true_for_freshly_created_wallet() {
+        let wallet = test_wallet();
+
+        assert!(needs_full_scan(&wallet));
+    }
+
+    #[test]
+    fn test_needs_full_scan_is_false_once_an_address_is_revealed() {
+        let mut wallet = test_wallet();
+
+        wallet.reveal_next_address(KeychainKind::External);
+
+        assert!(!needs_full_scan(&wallet));
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -193,8 +221,23 @@ impl SignetWallet {
         })
     }
 
-    pub async fn sync(&mut self) -> Result<(), OneOf<(UpdateError, SyncError, rusqlite::Error)>> {
-        sync_wallet(&mut self.wallet, self.sync_backend.clone()).await?;
+    /// Syncs already-revealed addresses. If the wallet has not revealed any
+    /// addresses yet on either keychain (e.g. right after a fresh recovery
+    /// from seed), this runs a full scan instead, since a plain sync can
+    /// never discover funds sitting at indices the wallet doesn't know
+    /// about yet.
+    pub async fn sync(
+        &mut self,
+    ) -> Result<(), OneOf<(UpdateError, SyncError, ScanError, rusqlite::Error)>> {
+        if needs_full_scan(&self.wallet) {
+            scan_wallet(&mut self.wallet, self.sync_backend.clone())
+                .await
+                .map_err(OneOf::broaden)?;
+        } else {
+            sync_wallet(&mut self.wallet, self.sync_backend.clone())
+                .await
+                .map_err(OneOf::broaden)?;
+        }
         self.persist().map_err(OneOf::new)?;
         Ok(())
     }
@@ -208,6 +251,16 @@ impl SignetWallet {
     pub fn persist(&mut self) -> Result<bool, rusqlite::Error> {
         self.wallet.persist(&mut Persister)
     }
+}
+
+/// True when neither keychain has ever revealed an address, which is the
+/// state of a wallet right after a fresh recovery from seed with no
+/// persisted history. A plain sync only rechecks already-revealed
+/// addresses, so a wallet in this state needs a full scan instead to
+/// discover funds sitting at indices it doesn't know about yet.
+fn needs_full_scan(wallet: &Wallet) -> bool {
+    wallet.derivation_index(KeychainKind::External).is_none()
+        && wallet.derivation_index(KeychainKind::Internal).is_none()
 }
 
 pub async fn scan_wallet(

--- a/bin/alpen-cli/src/signet.rs
+++ b/bin/alpen-cli/src/signet.rs
@@ -14,6 +14,7 @@ use backend::{ScanError, SignetBackend, SyncError, UpdateError, WalletUpdate};
 use bdk_esplora::esplora_client::{self, AsyncClient};
 use bdk_wallet::{
     bitcoin::{FeeRate, Network},
+    chain::keychain_txout::DEFAULT_LOOKAHEAD,
     rusqlite::{self, Connection},
     PersistedWallet, Wallet,
 };
@@ -178,14 +179,17 @@ impl SignetWallet {
         sync_backend: Arc<dyn SignetBackend>,
     ) -> io::Result<Self> {
         let (load, create) = seed.signet_wallet().split();
+        let lookahead = recovery_lookahead();
         Ok(Self {
             wallet: load
                 .check_network(network)
+                .lookahead(lookahead)
                 .load_wallet(&mut Persister)
                 .expect("should be able to load wallet")
                 .unwrap_or_else(|| {
                     create
                         .network(network)
+                        .lookahead(lookahead)
                         .create_wallet(&mut Persister)
                         .expect("wallet creation to succeed")
                 }),
@@ -229,6 +233,31 @@ impl SignetWallet {
 
     pub fn persist(&mut self) -> Result<bool, rusqlite::Error> {
         self.wallet.persist(&mut Persister)
+    }
+}
+
+/// Number of addresses cached beyond the last known one during the single
+/// scan that follows a restore from seed.
+///
+/// The Bitcoin Core backend never uses the Esplora `stop_gap`. It replays
+/// each block once and only recognizes an address already held in this
+/// cache, so a payment that confirms out of derivation order is missed for
+/// good. That one pass from genesis to the tip is the only chance to find
+/// old addresses, because the emitter resumes from the agreed tip
+/// afterwards. A wide cache makes payment order irrelevant below this
+/// index.
+const RECOVERY_LOOKAHEAD: u32 = 1000;
+
+/// Picks how many addresses to cache ahead of the last known one.
+///
+/// Only the scan that follows a restore needs the wide cache, so every
+/// later command pays the default. A database error keeps the wide value,
+/// since an unnecessarily wide cache is harmless but a narrow one during
+/// recovery loses coins.
+fn recovery_lookahead() -> u32 {
+    match Persister::full_scan_completed() {
+        Ok(true) => DEFAULT_LOOKAHEAD,
+        Ok(false) | Err(_) => RECOVERY_LOOKAHEAD,
     }
 }
 

--- a/bin/alpen-cli/src/signet.rs
+++ b/bin/alpen-cli/src/signet.rs
@@ -15,7 +15,7 @@ use bdk_esplora::esplora_client::{self, AsyncClient};
 use bdk_wallet::{
     bitcoin::{FeeRate, Network},
     rusqlite::{self, Connection},
-    KeychainKind, PersistedWallet, Wallet,
+    PersistedWallet, Wallet,
 };
 use persist::Persister;
 use terrors::OneOf;
@@ -50,18 +50,18 @@ pub async fn get_fee_rate(
 mod tests {
     use async_trait::async_trait;
     use bdk_wallet::{
-        bitcoin::{bip32::Xpriv, FeeRate, Network, Transaction},
+        bitcoin::{FeeRate, Transaction},
         chain::{
             spk_client::{FullScanRequestBuilder, SyncRequestBuilder},
             CheckPoint,
         },
-        KeychainKind, Wallet,
+        KeychainKind,
     };
     use terrors::OneOf;
 
     use super::{
         backend::{BroadcastTxError, GetFeeRateError, InvalidFee, ScanError, UpdateSender},
-        get_fee_rate, needs_full_scan, SignetBackend, SyncError,
+        get_fee_rate, SignetBackend, SyncError,
     };
 
     #[derive(Debug)]
@@ -129,34 +129,6 @@ mod tests {
 
         assert_eq!(fee_rate, FeeRate::BROADCAST_MIN);
     }
-
-    fn test_wallet() -> Wallet {
-        let rootpriv = Xpriv::new_master(Network::Signet, &[7u8; 32]).expect("valid xpriv");
-        let base_desc = format!("tr({rootpriv}/86h/0h/0h");
-        let external_desc = format!("{base_desc}/0/*)");
-        let internal_desc = format!("{base_desc}/1/*)");
-
-        Wallet::create(external_desc, internal_desc)
-            .network(Network::Signet)
-            .create_wallet_no_persist()
-            .expect("test wallet should be created")
-    }
-
-    #[test]
-    fn test_needs_full_scan_is_true_for_freshly_created_wallet() {
-        let wallet = test_wallet();
-
-        assert!(needs_full_scan(&wallet));
-    }
-
-    #[test]
-    fn test_needs_full_scan_is_false_once_an_address_is_revealed() {
-        let mut wallet = test_wallet();
-
-        wallet.reveal_next_address(KeychainKind::External);
-
-        assert!(!needs_full_scan(&wallet));
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -221,15 +193,15 @@ impl SignetWallet {
         })
     }
 
-    /// Syncs already-revealed addresses. If the wallet has not revealed any
-    /// addresses yet on either keychain (e.g. right after a fresh recovery
-    /// from seed), this runs a full scan instead, since a plain sync can
-    /// never discover funds sitting at indices the wallet doesn't know
-    /// about yet.
+    /// Syncs already-revealed addresses. Until a full scan has completed at
+    /// least once for this wallet (e.g. right after a fresh recovery from
+    /// seed), this runs a full scan instead, since a plain sync can never
+    /// discover funds sitting at indices the wallet doesn't know about yet.
     pub async fn sync(
         &mut self,
     ) -> Result<(), OneOf<(UpdateError, SyncError, ScanError, rusqlite::Error)>> {
-        if needs_full_scan(&self.wallet) {
+        let needs_full_scan = !Persister::full_scan_completed().map_err(OneOf::new)?;
+        if needs_full_scan {
             scan_wallet(&mut self.wallet, self.sync_backend.clone())
                 .await
                 .map_err(OneOf::broaden)?;
@@ -238,29 +210,26 @@ impl SignetWallet {
                 .await
                 .map_err(OneOf::broaden)?;
         }
+        // Persist the scan results before recording completion, so a crash
+        // in between leaves us re-scanning next time rather than silently
+        // skipping a scan we never actually saved the results of.
         self.persist().map_err(OneOf::new)?;
+        if needs_full_scan {
+            Persister::mark_full_scan_completed().map_err(OneOf::new)?;
+        }
         Ok(())
     }
 
     pub async fn scan(&mut self) -> Result<(), OneOf<(UpdateError, ScanError, rusqlite::Error)>> {
         scan_wallet(&mut self.wallet, self.sync_backend.clone()).await?;
         self.persist().map_err(OneOf::new)?;
+        Persister::mark_full_scan_completed().map_err(OneOf::new)?;
         Ok(())
     }
 
     pub fn persist(&mut self) -> Result<bool, rusqlite::Error> {
         self.wallet.persist(&mut Persister)
     }
-}
-
-/// True when neither keychain has ever revealed an address, which is the
-/// state of a wallet right after a fresh recovery from seed with no
-/// persisted history. A plain sync only rechecks already-revealed
-/// addresses, so a wallet in this state needs a full scan instead to
-/// discover funds sitting at indices it doesn't know about yet.
-fn needs_full_scan(wallet: &Wallet) -> bool {
-    wallet.derivation_index(KeychainKind::External).is_none()
-        && wallet.derivation_index(KeychainKind::Internal).is_none()
 }
 
 pub async fn scan_wallet(

--- a/bin/alpen-cli/src/signet/backend.rs
+++ b/bin/alpen-cli/src/signet/backend.rs
@@ -121,6 +121,13 @@ pub trait SignetBackend: Debug + Send + Sync {
     ) -> Result<Option<FeeRate>, OneOf<(InvalidFee, GetFeeRateError)>>;
 }
 
+/// Number of consecutive unused addresses to check before a full scan gives up
+/// looking for more funds. This follows the BIP-44 gap-limit convention used
+/// by Bitcoin Core and most wallets; a lower value can make a scan miss real
+/// funds sitting past a short run of unused addresses.
+const STOP_GAP: usize = 20;
+const PARALLEL_REQUESTS: usize = 3;
+
 #[async_trait]
 impl SignetBackend for EsploraClient {
     async fn sync_wallet(
@@ -165,7 +172,7 @@ impl SignetBackend for EsploraClient {
             .build();
 
         let update = self
-            .sync(req, 3)
+            .sync(req, PARALLEL_REQUESTS)
             .await
             .map_err(|e| Box::new(e) as BoxedErr)?;
         ops2.finish();
@@ -199,7 +206,7 @@ impl SignetBackend for EsploraClient {
             .build();
 
         let update = self
-            .full_scan(req, 5, 3)
+            .full_scan(req, STOP_GAP, PARALLEL_REQUESTS)
             .await
             .map_err(|e| Box::new(e) as BoxedErr)?;
         bar.set_message("Persisting updates");

--- a/bin/alpen-cli/src/signet/persist.rs
+++ b/bin/alpen-cli/src/signet/persist.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::OnceLock};
 
 use bdk_wallet::{
-    rusqlite::{self, Connection},
+    rusqlite::{self, Connection, OptionalExtension},
     ChangeSet, WalletPersister,
 };
 
@@ -45,6 +45,7 @@ impl WalletPersister for Persister {
         let db = Self::db();
         let mut db_ref = db.borrow_mut();
         let db_tx = db_ref.transaction()?;
+        db_tx.execute(CREATE_FULL_SCAN_STATE_TABLE, [])?;
         ChangeSet::init_sqlite_tables(&db_tx)?;
         let changeset = ChangeSet::from_sqlite(&db_tx)?;
         db_tx.commit()?;
@@ -60,5 +61,91 @@ impl WalletPersister for Persister {
         let db_tx = db_ref.transaction()?;
         changeset.persist_to_sqlite(&db_tx)?;
         db_tx.commit()
+    }
+}
+
+impl Persister {
+    /// True once a full scan has completed at least once for this wallet.
+    ///
+    /// This is tracked independently of revealed addresses: some code
+    /// paths (e.g. `faucet` with no address argument) reveal an address
+    /// without ever syncing, which would otherwise look identical to a
+    /// wallet that has actually been scanned.
+    pub fn full_scan_completed() -> Result<bool, rusqlite::Error> {
+        let db = Self::db();
+        let db_ref = db.borrow();
+        full_scan_completed(&db_ref)
+    }
+
+    /// Records that a full scan has completed for this wallet.
+    pub fn mark_full_scan_completed() -> Result<(), rusqlite::Error> {
+        let db = Self::db();
+        let db_ref = db.borrow();
+        mark_full_scan_completed(&db_ref)
+    }
+}
+
+const CREATE_FULL_SCAN_STATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS full_scan_state (
+    id INTEGER PRIMARY KEY CHECK (id = 0),
+    completed INTEGER NOT NULL
+)";
+
+fn full_scan_completed(conn: &Connection) -> Result<bool, rusqlite::Error> {
+    let completed: Option<bool> = conn
+        .query_row(
+            "SELECT completed FROM full_scan_state WHERE id = 0",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(completed.unwrap_or(false))
+}
+
+fn mark_full_scan_completed(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO full_scan_state (id, completed) VALUES (0, TRUE)
+         ON CONFLICT(id) DO UPDATE SET completed = TRUE",
+        [],
+    )
+    .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::rusqlite::Connection;
+
+    use super::{full_scan_completed, mark_full_scan_completed, CREATE_FULL_SCAN_STATE_TABLE};
+
+    fn test_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db should open");
+        conn.execute(CREATE_FULL_SCAN_STATE_TABLE, [])
+            .expect("table should be created");
+        conn
+    }
+
+    #[test]
+    fn test_full_scan_completed_is_false_before_any_scan() {
+        let conn = test_conn();
+
+        assert!(!full_scan_completed(&conn).unwrap());
+    }
+
+    #[test]
+    fn test_full_scan_completed_is_true_after_marking() {
+        let conn = test_conn();
+
+        mark_full_scan_completed(&conn).unwrap();
+
+        assert!(full_scan_completed(&conn).unwrap());
+    }
+
+    #[test]
+    fn test_mark_full_scan_completed_is_idempotent() {
+        let conn = test_conn();
+
+        mark_full_scan_completed(&conn).unwrap();
+        mark_full_scan_completed(&conn).unwrap();
+
+        assert!(full_scan_completed(&conn).unwrap());
     }
 }

--- a/bin/alpen-cli/src/signet/persist.rs
+++ b/bin/alpen-cli/src/signet/persist.rs
@@ -45,7 +45,7 @@ impl WalletPersister for Persister {
         let db = Self::db();
         let mut db_ref = db.borrow_mut();
         let db_tx = db_ref.transaction()?;
-        db_tx.execute(CREATE_FULL_SCAN_STATE_TABLE, [])?;
+        ensure_full_scan_state_table(&db_tx)?;
         ChangeSet::init_sqlite_tables(&db_tx)?;
         let changeset = ChangeSet::from_sqlite(&db_tx)?;
         db_tx.commit()?;
@@ -71,9 +71,13 @@ impl Persister {
     /// paths (e.g. `faucet` with no address argument) reveal an address
     /// without ever syncing, which would otherwise look identical to a
     /// wallet that has actually been scanned.
+    ///
+    /// This creates its own table if needed, so callers may use it before
+    /// the wallet itself is loaded.
     pub fn full_scan_completed() -> Result<bool, rusqlite::Error> {
         let db = Self::db();
         let db_ref = db.borrow();
+        ensure_full_scan_state_table(&db_ref)?;
         full_scan_completed(&db_ref)
     }
 
@@ -81,6 +85,7 @@ impl Persister {
     pub fn mark_full_scan_completed() -> Result<(), rusqlite::Error> {
         let db = Self::db();
         let db_ref = db.borrow();
+        ensure_full_scan_state_table(&db_ref)?;
         mark_full_scan_completed(&db_ref)
     }
 }
@@ -89,6 +94,10 @@ const CREATE_FULL_SCAN_STATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS full_scan
     id INTEGER PRIMARY KEY CHECK (id = 0),
     completed INTEGER NOT NULL
 )";
+
+fn ensure_full_scan_state_table(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute(CREATE_FULL_SCAN_STATE_TABLE, []).map(|_| ())
+}
 
 fn full_scan_completed(conn: &Connection) -> Result<bool, rusqlite::Error> {
     let completed: Option<bool> = conn
@@ -114,12 +123,11 @@ fn mark_full_scan_completed(conn: &Connection) -> Result<(), rusqlite::Error> {
 mod tests {
     use bdk_wallet::rusqlite::Connection;
 
-    use super::{full_scan_completed, mark_full_scan_completed, CREATE_FULL_SCAN_STATE_TABLE};
+    use super::{ensure_full_scan_state_table, full_scan_completed, mark_full_scan_completed};
 
     fn test_conn() -> Connection {
         let conn = Connection::open_in_memory().expect("in-memory db should open");
-        conn.execute(CREATE_FULL_SCAN_STATE_TABLE, [])
-            .expect("table should be created");
+        ensure_full_scan_state_table(&conn).expect("table should be created");
         conn
     }
 
@@ -145,6 +153,18 @@ mod tests {
 
         mark_full_scan_completed(&conn).unwrap();
         mark_full_scan_completed(&conn).unwrap();
+
+        assert!(full_scan_completed(&conn).unwrap());
+    }
+
+    #[test]
+    fn test_ensure_table_preserves_an_existing_flag() {
+        let conn = test_conn();
+        mark_full_scan_completed(&conn).unwrap();
+
+        // Runs on every open, including for wallets created before this
+        // table existed, so it must never clear what is already recorded.
+        ensure_full_scan_state_table(&conn).unwrap();
 
         assert!(full_scan_completed(&conn).unwrap());
     }


### PR DESCRIPTION
## Description

A wallet recovered from seed can under-report its signet balance. The sync command only rechecks already-revealed addresses. A fresh wallet with no revealed history never finds funds at other indices. A full scan also stopped too soon: the stop gap was 5 addresses, well below the usual gap limit of 20.

This PR fixes both issues, plus three related gaps found during review: a wallet with no transaction history would repeat a full scan forever, `send`/`deposit`/`recover` could lose track of a freshly revealed address if the process exited before persisting it, and the Bitcoin Core backend could miss payments that confirm out of derivation order.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Stefano Pepe reported this bug, with root-cause analysis by Barak: https://alpen-labs.slack.com/archives/C08D9E3J8N5/p1785592718835729

Five commits:

1. `backend.rs`: raise the hardcoded `stop_gap` from 5 to 20 and name both scan constants.
2. `signet.rs`: make `sync()` run a full scan instead of a plain sync until a full scan has completed at least once for the wallet.
3. `signet.rs` / `persist.rs`: track full scan completion as an explicit flag in the wallet's sqlite database, independent of revealed addresses. This replaces an earlier approach (inferring scan state from revealed addresses) that an automated Codex review caught two real problems with: an empty wallet would re-scan forever, and `faucet` with no address argument could mark a freshly restored wallet as already scanned without ever syncing it.
4. `send.rs` / `deposit.rs` / `recover.rs`: persist the wallet after building a transaction and before broadcasting it, so a revealed change or recovery address is durable by the time funds move on chain. Found during review as the same bug class as the faucet issue above, but pre-existing on `main` and higher severity, since it triggers on ordinary sends and deposits, not just an edge case.
5. `signet.rs` / `persist.rs`: widen the address cache (BDK's `lookahead`) to 1000 for the single scan that follows a restore, then fall back to the default of 25. The Bitcoin Core backend never uses `stop_gap` — it replays each block once and only recognises addresses already in that cache — so a payment confirming out of derivation order was missed permanently. See the note below on why a rescan cannot fix this after the fact.

### On the Bitcoin Core rescan

Codex suggested the user can recover by scanning again. That does not work on this backend. `poll_once` in `bdk_bitcoind_rpc` finds the highest block that Core and the wallet agree on and resumes from there; `start_height` only skips forward, never rewinds. So once a wallet reaches the tip, `alpen scan` emits no old blocks. The single genesis-to-tip pass is the only chance to find old addresses, which is why commit 5 widens the cache for exactly that pass rather than adding a retry.

This also means commit 5 is not retroactive. It protects wallets restored from now on. A wallet already affected needs its database wiped and the seed restored again.

Testing done: `cargo build`, `cargo clippy --all-targets --all-features`, and `cargo test -p alpen-cli` (41 tests pass, including new tests for the persistence layer). The lookahead cost was measured in release at ~90ms versus ~7ms at the default, paid once on the recovery command, with no extra network requests. This has not been verified against a live signet node end to end; there is no bitcoind or esplora instance in this environment to reproduce the original report directly.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Related to STR-3953: https://alpenlabs.atlassian.net/browse/STR-3953