### PR TITLE
fix(btcio): retry broadcaster RPC warmup errors

### DIFF
--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -11,6 +11,7 @@ use strata_storage::BroadcastDbOps;
 use tracing::{debug, info, warn};
 
 use super::error::{BroadcasterError, BroadcasterResult};
+use crate::rpc_error::is_retryable_client_error;
 
 /// Classifies a bitcoind `-25` reject reason as benign (already accepted) or
 /// not. Bitcoind's reject strings use hyphenated tokens (see
@@ -121,7 +122,7 @@ impl WalletTxLookup for Client {
                 debug!(%err, %txid, "get_transaction: tx not found");
                 Ok(TxLookupOutcome::Missing)
             }
-            Err(err) if err.is_retriable() => {
+            Err(err) if is_retryable_client_error(&err) => {
                 warn!(%err, %txid, "get_transaction hit transient Bitcoin RPC error");
                 Ok(TxLookupOutcome::RetryLater {
                     reason: err.to_string(),
@@ -154,7 +155,7 @@ mod test_impls {
                     block_height: info.block_height,
                 })),
                 Err(err) if err.is_tx_not_found() => Ok(TxLookupOutcome::Missing),
-                Err(err) if err.is_retriable() => Ok(TxLookupOutcome::RetryLater {
+                Err(err) if is_retryable_client_error(&err) => Ok(TxLookupOutcome::RetryLater {
                     reason: err.to_string(),
                 }),
                 Err(err) => Err(BroadcasterError::Rpc(anyhow!(err))),
@@ -268,7 +269,7 @@ where
                 warn!(%txid, %err, "sendrawtransaction verify-rejected (treated as InvalidInputs)");
                 Ok(PublishTxOutcome::InvalidInputs)
             }
-            Err(err) if err.is_retriable() => {
+            Err(err) if is_retryable_client_error(&err) => {
                 warn!(%txid, %err, "sendrawtransaction hit transient Bitcoin RPC error");
                 Ok(PublishTxOutcome::RetryLater {
                     reason: err.to_string(),

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -144,7 +144,7 @@ mod test {
     use super::*;
     use crate::{
         broadcaster::io::BroadcasterIo,
-        test_utils::{gen_l1_tx_entry_with_status, TestBitcoinClient},
+        test_utils::{gen_l1_tx_entry_with_status, SendRawTransactionMode, TestBitcoinClient},
     };
 
     fn get_ops() -> Arc<BroadcastDbOps> {
@@ -273,5 +273,35 @@ mod test {
         let unf_entries = service_state.inner.unfinalized_entries;
         assert!(!unf_entries.iter().any(|e| e.item().is_finalized()));
         assert!(unf_entries.iter().all(|e| e.item().is_valid()));
+    }
+
+    #[tokio::test]
+    async fn bitcoind_warmup_does_not_terminate_broadcaster_poll() {
+        let ops = get_ops();
+        let entries = populate_broadcast_db(ops.clone()).await;
+        let client = TestBitcoinClient::new(0)
+            .with_send_raw_transaction_mode(SendRawTransactionMode::BitcoindWarmup);
+        let io = make_io(ops, client);
+        let mut service_state = BroadcasterServiceState::try_new(io, get_test_btcio_params())
+            .await
+            .unwrap();
+
+        service_state.process_input(TickMsg::Tick).await.unwrap();
+
+        let statuses: Vec<_> = service_state
+            .inner
+            .unfinalized_entries
+            .iter()
+            .map(|entry| entry.item().status.clone())
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                entries[0].1.status.clone(),
+                entries[1].1.status.clone(),
+                entries[3].1.status.clone(),
+            ],
+            "warmup must preserve broadcaster entries for the next poll"
+        );
     }
 }

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -63,6 +63,7 @@ pub enum SendRawTransactionMode {
     InvalidParameter,
     HttpInternalServerError,
     ConnectionError,
+    BitcoindWarmup,
     GenericError,
 }
 
@@ -292,6 +293,9 @@ impl Broadcaster for TestBitcoinClient {
             SendRawTransactionMode::ConnectionError => {
                 Err(ClientError::Connection("connection refused".to_string()))
             }
+            SendRawTransactionMode::BitcoindWarmup => {
+                Err(ClientError::Server(-28, "Loading wallet...".to_string()))
+            }
             SendRawTransactionMode::GenericError => Err(ClientError::Server(
                 -1,
                 "generic broadcast failure".to_string(),
@@ -346,6 +350,9 @@ impl Wallet for TestBitcoinClient {
     }
 
     async fn get_transaction(&self, txid: &Txid) -> ClientResult<GetTransaction> {
+        if self.send_raw_transaction_mode == SendRawTransactionMode::BitcoindWarmup {
+            return Err(ClientError::Server(-28, "Loading wallet...".to_string()));
+        }
         let some_tx = consensus::encode::deserialize_hex(SOME_TX).unwrap();
         Ok(GetTransaction {
             tx: some_tx,

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -33,7 +33,7 @@ use super::{
 };
 use crate::{
     broadcaster::{is_benign_minus25_message, L1BroadcastHandle},
-    rpc_error::{is_retryable_envelope_error, retryable_reason},
+    rpc_error::{is_retryable_client_error, is_retryable_envelope_error, retryable_reason},
     writer::builder::EnvelopeError,
     BtcioParams,
 };
@@ -504,7 +504,7 @@ async fn publish_commit_immediately<R: Broadcaster>(
             warn!(%txid, ?e, "commit broadcast rejected by mempool; will resign");
             Ok(CommitPublishResult::InvalidInputs)
         }
-        Err(e) if e.is_retriable() => Ok(CommitPublishResult::Deferred(e.to_string())),
+        Err(e) if is_retryable_client_error(&e) => Ok(CommitPublishResult::Deferred(e.to_string())),
         Err(e) => Err(e.into()),
     }
 }
@@ -1235,6 +1235,19 @@ mod tests {
             result,
             CommitPublishResult::Deferred(reason) if reason.contains("connection refused")
         ));
+    }
+
+    #[tokio::test]
+    async fn test_publish_commit_immediately_defers_bitcoind_warmup() {
+        let client = TestBitcoinClient::new(0)
+            .with_send_raw_transaction_mode(SendRawTransactionMode::BitcoindWarmup);
+        let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
+
+        let result = publish_commit_immediately(&client, &commit_tx_entry)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, CommitPublishResult::Deferred(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Btcio service errors out on bitcoind client calls when L1 is warming up(status code -28). This was gracefully handled for some of the interactions but not all. This PR fixes the issue for the remaining places.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
