### PR TITLE
backport: support bitcoin network keys in datatool

### DIFF
--- a/bin/datatool/README.md
+++ b/bin/datatool/README.md
@@ -11,6 +11,15 @@ The basic flow to generate the params files looks like this:
 strata-datatool genxpriv sequencer.bin
 strata-datatool genxpriv operator1.bin
 strata-datatool genxpriv operator2.bin
+```
+
+Accepted `--bitcoin-network` and `BITCOIN_NETWORK` values are those supported by
+[`bitcoin::Network`].
+
+[`bitcoin::Network`]: https://docs.rs/bitcoin/latest/bitcoin/enum.Network.html
+
+```sh
+strata-datatool --bitcoin-network bitcoin genxpriv bitcoin-sequencer.bin
 
 # Generate the pubkeys, also on their original machines.
 strata-datatool genseqpubkey -f sequencer.bin

--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -15,8 +15,12 @@ use crate::{
 /// Args.
 #[derive(FromArgs)]
 pub(crate) struct Args {
-    #[argh(option, description = "network name [signet, regtest]", short = 'b')]
-    pub(crate) bitcoin_network: Option<String>,
+    #[argh(
+        option,
+        description = "bitcoin network name accepted by `bitcoin::Network`",
+        short = 'b'
+    )]
+    pub(crate) bitcoin_network: Option<Network>,
 
     #[argh(
         option,
@@ -399,7 +403,7 @@ pub(crate) struct CmdContext {
 pub(crate) fn resolve_context_and_subcommand(
     args: Args,
 ) -> anyhow::Result<(CmdContext, Subcommand)> {
-    let network = resolve_network(args.bitcoin_network.as_deref())?;
+    let network = resolve_network(args.bitcoin_network)?;
 
     let bitcoind_config = create_bitcoind_config(&args);
 

--- a/bin/datatool/src/cmd/asm_params.rs
+++ b/bin/datatool/src/cmd/asm_params.rs
@@ -479,7 +479,8 @@ mod tests {
 
     #[test]
     fn deposit_sats_defaults_to_the_ol_denomination() {
-        let ol_bridge_params = BridgeParams::new(50_000_000, None).expect("valid bridge params");
+        let ol_bridge_params = BridgeParams::new_with_descriptor_limit(50_000_000, None, 81)
+            .expect("valid bridge params");
 
         let deposit_sats =
             resolve_deposit_sats(None, &ol_bridge_params).expect("default should resolve");
@@ -489,7 +490,8 @@ mod tests {
 
     #[test]
     fn deposit_sats_may_restate_the_ol_denomination() {
-        let ol_bridge_params = BridgeParams::new(100_000_000, None).expect("valid bridge params");
+        let ol_bridge_params = BridgeParams::new_with_descriptor_limit(100_000_000, None, 81)
+            .expect("valid bridge params");
 
         let deposit_sats =
             resolve_deposit_sats(Some("100M"), &ol_bridge_params).expect("matching value is fine");
@@ -499,7 +501,8 @@ mod tests {
 
     #[test]
     fn deposit_sats_rejects_denomination_mismatch() {
-        let ol_bridge_params = BridgeParams::new(100_000_000, None).expect("valid bridge params");
+        let ol_bridge_params = BridgeParams::new_with_descriptor_limit(100_000_000, None, 81)
+            .expect("valid bridge params");
 
         let err = resolve_deposit_sats(Some("200M"), &ol_bridge_params).unwrap_err();
 

--- a/bin/datatool/src/util.rs
+++ b/bin/datatool/src/util.rs
@@ -19,30 +19,24 @@ const DEFAULT_NETWORK: Network = Network::Signet;
 /// Sequencer key environment variable.
 pub(crate) const SEQKEY_ENVVAR: &str = "STRATA_SEQ_KEY";
 
-/// Resolves a [`Network`] from a string.
+/// Resolves a [`Network`] from a string accepted by [`Network::from_str`].
 ///
 /// Priority:
 ///
 /// 1. Command-line argument (if provided)
 /// 2. `BITCOIN_NETWORK` environment variable (if set)
 /// 3. Default network (Signet)
-pub(crate) fn resolve_network(arg: Option<&str>) -> anyhow::Result<Network> {
+pub(crate) fn resolve_network(arg: Option<Network>) -> anyhow::Result<Network> {
     // First, check if a command-line argument was provided
-    if let Some(network_str) = arg {
-        return match network_str {
-            "signet" => Ok(Network::Signet),
-            "regtest" => Ok(Network::Regtest),
-            n => anyhow::bail!("unsupported network option: {n}"),
-        };
+    if let Some(network) = arg {
+        return Ok(network);
     }
 
     // If no argument provided, check environment variable
     if let Ok(env_network) = env::var(BITCOIN_NETWORK_ENVVAR) {
-        return match env_network.as_str() {
-            "signet" => Ok(Network::Signet),
-            "regtest" => Ok(Network::Regtest),
-            n => anyhow::bail!("unsupported network option in {BITCOIN_NETWORK_ENVVAR}: {n}"),
-        };
+        return Network::from_str(&env_network).map_err(|_| {
+            anyhow::anyhow!("unsupported network option in {BITCOIN_NETWORK_ENVVAR}: {env_network}")
+        });
     }
 
     // Fall back to default


### PR DESCRIPTION
## Description

Backports #2189 to `releases/0.3.0`.

This updates `strata-datatool --bitcoin-network` to parse values through [`bitcoin::Network`], so `genxpriv` can generate extended private keys for any network supported by that type.

[`bitcoin::Network`]: https://docs.rs/bitcoin/latest/bitcoin/enum.Network.html

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Cherry-picked from main commit `cd95d924c6f1f12af8264f415430153d1f6bf499`.

This PR was prepared with AI assistance.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

Tests run:

- `cargo fmt --package strata-datatool --check`

## Related Issues

Backport of #2189.
