### PR TITLE
test(ol/checkpoint): drop obsolete STR-3804 checkpoint-sidecar workaround

### DIFF
--- a/crates/ol/block-assembly/src/checkpoint_size.rs
+++ b/crates/ol/block-assembly/src/checkpoint_size.rs
@@ -18,9 +18,11 @@ pub(crate) const MAX_CHECKPOINT_PAYLOAD_SIZE: usize = 395_000;
 
 /// Maximum total OL log payload size per checkpoint (16 KiB per SPS-ol-chain-structures).
 ///
-/// ASM dropped this as a parse-side cap in v0.4.0-rc.1 because it is incoherent with
-/// the SSZ schema caps a payload must already satisfy on-chain. It survives here as
-/// the sequencer-side construction budget, which is where it always belonged.
+/// Set well below [`MAX_CHECKPOINT_PAYLOAD_SIZE`] to reserve room for the
+/// checkpoint's other components (e.g. state diff), by bounding logs in
+/// aggregate rather than lowering `MAX_LOG_PAYLOAD_LEN` (per-log) or
+/// `MAX_OL_LOGS_PER_CHECKPOINT`. It is intentionally separate from,
+/// and inconsistent with, those two limits.
 pub(crate) const MAX_TOTAL_LOG_PAYLOAD_BYTES: usize = 16 * 1024;
 
 /// Fixed overhead in the `CheckpointPayload` SSZ encoding.

--- a/crates/ol/checkpoint/src/state.rs
+++ b/crates/ol/checkpoint/src/state.rs
@@ -210,18 +210,15 @@ mod tests {
     use proptest::prelude::*;
     use strata_acct_types::{BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL, BitcoinAmount};
     use strata_asm_checkpoint_types::{
-        CheckpointPayload, CheckpointSidecar, CheckpointTip, OLLog as CheckpointOLLog,
-        TerminalHeaderComplement, test_utils::create_test_checkpoint_payload,
+        CheckpointPayload, CheckpointTip,
+        test_utils::{checkpoint_sidecar_strategy, create_test_checkpoint_payload},
     };
     use strata_bridge_params::BridgeParams;
     use strata_checkpoint_types::EpochSummary;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_identifiers::{
         AccountSerial, Buf32, Buf64, Epoch, L1BlockCommitment, L1BlockId, OLBlockCommitment,
-        test_utils::{
-            buf32_strategy, l1_block_commitment_strategy, ol_block_commitment_strategy,
-            ol_block_id_strategy,
-        },
+        test_utils::{buf32_strategy, l1_block_commitment_strategy, ol_block_commitment_strategy},
     };
     use strata_ledger_types::{IAccountState, IStateAccessor};
     use strata_ol_chain_types::{
@@ -261,50 +258,6 @@ mod tests {
                 .prop_map(|(account_serial, payload)| OLLog::new(account_serial, payload)),
             0..10,
         )
-    }
-
-    fn terminal_header_complement_strategy() -> impl Strategy<Value = TerminalHeaderComplement> {
-        (
-            any::<u64>(),
-            ol_block_id_strategy(),
-            buf32_strategy(),
-            buf32_strategy(),
-        )
-            .prop_map(|(timestamp, parent_blkid, body_root, logs_root)| {
-                TerminalHeaderComplement::new(timestamp, parent_blkid, body_root, logs_root)
-            })
-    }
-
-    /// Generates checkpoint OL logs whose *total* payload stays within the sidecar's
-    /// `MAX_TOTAL_LOG_PAYLOAD_BYTES` cap (at most 10 logs of up to 512 bytes each).
-    fn checkpoint_ol_logs_strategy() -> impl Strategy<Value = Vec<CheckpointOLLog>> {
-        prop::collection::vec(
-            (
-                any::<u32>().prop_map(AccountSerial::from),
-                prop::collection::vec(any::<u8>(), 0..=512),
-            )
-                .prop_map(|(account_serial, payload)| {
-                    CheckpointOLLog::new(account_serial, payload)
-                }),
-            0..10,
-        )
-    }
-
-    // TODO(STR-3804): drop this once https://github.com/alpenlabs/asm/pull/154 lands and we bump
-    // to a tag that includes it, then go back to
-    // `strata_asm_checkpoint_types::test_utils::checkpoint_sidecar_strategy`. The upstream
-    // strategy can emit ~40 KiB of logs and `CheckpointSidecar::new` rejects anything over the
-    // 16 KiB cap, so it panics. The local `checkpoint_ol_logs_strategy` stays well under the cap.
-    fn checkpoint_sidecar_strategy() -> impl Strategy<Value = CheckpointSidecar> {
-        (
-            state_diff_strategy(),
-            checkpoint_ol_logs_strategy(),
-            terminal_header_complement_strategy(),
-        )
-            .prop_map(|(state_diff, ol_logs, terminal_header_complement)| {
-                CheckpointSidecar::new(state_diff, ol_logs, terminal_header_complement)
-                    .expect("valid sidecar")
-            })
     }
 
     /// Test context that delegates everything to the real impl but stubs out

--- a/crates/storage/src/managers/ol_checkpoint.rs
+++ b/crates/storage/src/managers/ol_checkpoint.rs
@@ -493,15 +493,12 @@ mod tests {
     use std::sync::Arc;
 
     use proptest::prelude::*;
-    use strata_asm_checkpoint_types::test_utils::create_test_checkpoint_payload;
+    use strata_asm_checkpoint_types::test_utils::{
+        checkpoint_payload_strategy, create_test_checkpoint_payload,
+    };
     use strata_asm_checkpoint_types::CheckpointPayload;
     use strata_checkpoint_types::EpochSummary;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
-    // The upstream `checkpoint_payload_strategy` can generate sidecars whose total OL log
-    // payload exceeds the 16 KiB cap and panics; use the size-bounded local strategy
-    // instead. See the note
-    // on [`strata_db_tests::ol_checkpoint_tests::checkpoint_payload_strategy`].
-    use strata_db_tests::ol_checkpoint_tests::checkpoint_payload_strategy;
     use strata_db_types::backend::DatabaseBackend;
     use strata_identifiers::test_utils::{
         buf32_strategy, epoch_strategy, l1_block_commitment_strategy, ol_block_commitment_strategy,


### PR DESCRIPTION
## Description
- Remove the now-obsolete `STR-3804` test workaround in `ol/checkpoint` and switch back to the upstream (now-unconstrained) `checkpoint_sidecar_strategy`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3804](https://alpenlabs.atlassian.net/browse/STR-3804)


[STR-3815]: https://alpenlabs.atlassian.net/browse/STR-3815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[STR-3804]: https://alpenlabs.atlassian.net/browse/STR-3804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ