### PR TITLE
feat(params): add mainnet generation templates

### DIFF
--- a/.github/params/README.md
+++ b/.github/params/README.md
@@ -15,7 +15,7 @@ When adding a new environment or updating an existing one, commit the static val
 
 ```
 gh workflow run ci-genparams.yml --ref <branch> \
-  -f env=<staging-v2|prod> \
+  -f env=<staging-v2|prod|mainnet> \
   -f datatool_image_commit=<7-to-40-char-hex-sha> \
   -f genesis_l1_height=<height> \
   -f chain_config=<path-to-chainspec>
@@ -38,6 +38,8 @@ Workflow inputs:
 
 When `checkout_ref` is omitted, the job checks out the workflow run commit (`github.sha`) for params scripts/templates. In the common case, this is the commit selected by `--ref`.
 
+Use `crates/reth/chainspec/src/res/mainnet-chain.json` when generating the `mainnet` environment. The workflow passes `NETWORK=bitcoin` to datatool for that environment; other environments continue to use `signet`.
+
 Download the artifact:
 ```
 gh run download <run-id> -n params-<env>-<datatool-image-tag>
@@ -45,7 +47,7 @@ gh run download <run-id> -n params-<env>-<datatool-image-tag>
 
 ## GitHub Environment Setup
 
-Each environment in the workflow input (`staging-v2`, `prod`) must have a matching GitHub environment with these configured:
+Each environment in the workflow input (`staging-v2`, `prod`, `mainnet`) must have a matching GitHub environment with these configured:
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/.github/params/generate-params.sh
+++ b/.github/params/generate-params.sh
@@ -4,14 +4,14 @@ set -euo pipefail
 # Generate params from templates using prebuilt datatool image.
 #
 # Required env vars:
-#   DEPLOY_ENV            - environment (staging-v2, testnet-prod)
+#   DEPLOY_ENV            - environment (staging-v2, prod, mainnet)
 #   DATATOOL_IMAGE_TAG    - datatool image tag
 #   BTC_RPC_URL           - bitcoin RPC endpoint
 #   BTC_RPC_USER          - bitcoin RPC username
 #   BTC_RPC_PASSWORD      - bitcoin RPC password
 #   GENESIS_L1_HEIGHT     - genesis L1 block height
 #   CHAIN_CONFIG          - path to chainspec JSON
-#   NETWORK               - bitcoin network (default: signet)
+#   NETWORK               - bitcoin network (default: signet; bitcoin for DEPLOY_ENV=mainnet)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ECR_REGISTRY="496607027995.dkr.ecr.us-east-1.amazonaws.com"

--- a/.github/params/templates/mainnet/asm-params.json
+++ b/.github/params/templates/mainnet/asm-params.json
@@ -1,0 +1,78 @@
+{
+  "magic": "ALPN",
+  "anchor": "__ANCHOR__",
+  "subprotocols": [
+    {
+      "Admin": {
+        "strata_administrator": {
+          "keys": [
+            "038b8909c72c19f6165beae2a6127b462cf83bc27c0542a039dcf96b4085f51edd",
+            "03fceec575d5f1c1da2a143867aff92d652a6fd24337f040cb6370a43ca41942c0",
+            "0300f92fc119602ab9affa5e8e02ccdafb604163585f14f923a25a6f5b10b39cbc"
+          ],
+          "threshold": 2
+        },
+        "strata_sequencer_manager": {
+          "keys": [
+            "0268d9cbadbc9379cc160648560c43bcf671c5705da28d1ed3d4cb4cfafa5dab95",
+            "029e0bcd4cd3d1f78af131426ad3431f83440f5138af600e324cfcf1455e18252a",
+            "0390d0946a047787c5e03a452c1cac70ba3b1870410f6e3c08715ccb7cb5e6d644"
+          ],
+          "threshold": 2
+        },
+        "alpen_administrator": {
+          "keys": [
+            "031e4e781365f16774ef01d282ae5b40aa0e3ced25252657397e583741da10035b",
+            "03fa0c48d612b9c3191d1db2f0f41706831e52bba822300729432551f3da467fa5",
+            "03f32daff82d1627bc72126da54fa5c70f7b277fc8672345d54c120443c372f726"
+          ],
+          "threshold": 2
+        },
+        "strata_security_council": {
+          "keys": [
+            "0373633b52f26359bc1e9580d8767e099438267010c2c9f817a36a701b6c2a37e8",
+            "0249dd6827ed1b57157d02a74deee5fd66a4913d2287ba155c53e9471470369372",
+            "0343f066e7ac9065fbb99d08723f6703dd382e56f3c8d81d2242cda18ff91da890"
+          ],
+          "threshold": 2
+        },
+        "confirmation_depths": {
+          "strata_admin_multisig_update": 12,
+          "strata_seq_manager_multisig_update": 12,
+          "alpen_admin_multisig_update": 12,
+          "strata_security_council_multisig_update": 12,
+          "operator_update": 12,
+          "sequencer_update": 12,
+          "ol_stf_vk_update": 12,
+          "asm_stf_vk_update": 12,
+          "ee_stf_vk_update": 12,
+          "defcon3": 12,
+          "safe_harbour_address_update": 12
+        },
+        "max_seqno_gap": 10
+      }
+    },
+    {
+      "Checkpoint": {
+        "sequencer_predicate": "Bip340Schnorr:74acdd685f79c3e831590b0ab18711728f5b3c5c3ab9512b9b046363cf15d47e",
+        "checkpoint_predicate": "__CHECKPOINT_PREDICATE__",
+        "genesis_l1_height": "__GENESIS_L1_HEIGHT__",
+        "genesis_ol_blkid": "__GENESIS_OL_BLKID__"
+      }
+    },
+    {
+      "Bridge": {
+        "operators": [
+          "02485e0cfb6a4923d4fdce551f43d323cabb0503a0fb144c281ab69fc332f15bc6",
+          "028178910b555a27bc8cd120b4005ca7cca78b41b8b16de6d54fb60acce9db3202",
+          "02dcb416c8da99b89e1157003232aa526e301ee050c5f0e221071671088dbb3ef1"
+        ],
+        "denomination": 200000000,
+        "assignment_duration": 530,
+        "operator_fee": 300000,
+        "recovery_delay": 36,
+        "safe_harbour_address": "047dac92fd2e107fac7d68536f75de86e13819188a4b68cc8c827b68767232ffc5"
+      }
+    }
+  ]
+}

--- a/.github/params/templates/mainnet/ee-params.json
+++ b/.github/params/templates/mainnet/ee-params.json
@@ -1,0 +1,11 @@
+{
+  "account_id": "0101010101010101010101010101010101010101010101010101010101010101",
+  "genesis_blockhash": "__GENESIS_BLOCKHASH__",
+  "genesis_stateroot": "__GENESIS_STATEROOT__",
+  "genesis_blocknum": 0,
+  "bridge_params": {
+    "denomination": 200000000,
+    "max_withdrawal_amount": null,
+    "max_withdrawal_descriptor_len": 81
+  }
+}

--- a/.github/params/templates/mainnet/ol-params.json
+++ b/.github/params/templates/mainnet/ol-params.json
@@ -1,0 +1,23 @@
+{
+  "header": {
+    "timestamp": 0,
+    "slot": 0,
+    "epoch": 0,
+    "parent_blkid": "0000000000000000000000000000000000000000000000000000000000000000",
+    "body_root": "0000000000000000000000000000000000000000000000000000000000000000",
+    "logs_root": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "accounts": {
+    "0101010101010101010101010101010101010101010101010101010101010101": {
+      "predicate": "__ALPEN_PREDICATE__",
+      "inner_state": "__INNER_STATE__",
+      "balance": 0
+    }
+  },
+  "last_l1_block": "__LAST_L1_BLOCK__",
+  "bridge_params": {
+    "denomination": 200000000,
+    "max_withdrawal_amount": null,
+    "max_withdrawal_descriptor_len": 81
+  }
+}

--- a/.github/workflows/ci-genparams.yml
+++ b/.github/workflows/ci-genparams.yml
@@ -18,6 +18,7 @@ on:
         options:
           - staging-v2
           - prod
+          - mainnet
       datatool_image_commit:
         description: "Alpen commit whose first 7 chars identify the datatool image tag"
         required: true
@@ -150,6 +151,7 @@ jobs:
           COMMIT: ${{ steps.resolve.outputs.datatool_image_tag }}
           GENESIS_L1_HEIGHT: ${{ inputs.genesis_l1_height }}
           CHAIN_CONFIG: ${{ inputs.chain_config }}
+          NETWORK: ${{ inputs.env == 'mainnet' && 'bitcoin' || 'signet' }}
           BTC_RPC_URL: ${{ secrets.PARAMS_BTC_RPC_URL }}
           BTC_RPC_USER: ${{ secrets.PARAMS_BTC_RPC_USER }}
           BTC_RPC_PASSWORD: ${{ secrets.PARAMS_BTC_RPC_PASSWORD }}


### PR DESCRIPTION
## Description

Adds mainnet params templates for CI params generation and wires the genparams workflow so `env=mainnet` uses the Bitcoin mainnet network value expected by datatool: `NETWORK=bitcoin`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Mainnet templates were copied from the existing prod templates and then updated with canonical M0/mainnet values:

- ASM admin key sets and thresholds
- M0 confirmation depths
- canonical mainnet sequencer predicate
- three bridge operator keys
- bridge denomination, assignment duration, operator fee, recovery delay, and safe harbour address

The dynamic params fields remain as placeholders for CI generation: checkpoint predicate, genesis L1 height/anchor, genesis OL block ID, Alpen predicate, inner state, and EE genesis fields.

Validation run locally:

- `actionlint .github/workflows/ci-genparams.yml`
- `bash -n .github/params/generate-params.sh`
- `python3 -m json.tool` on all three mainnet template files
- `python3 .github/params/params-helper.py extract-keys --template-dir .github/params/templates/mainnet --output-dir /tmp/mainnet-param-keys`

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://app.notion.com/p/Mainnet-Params-3b3901ba000f80cfa447cf79fa816e6a
- https://app.notion.com/p/Chain-Core-Parameters-358901ba000f801bbffcc70a36d916de
- https://app.notion.com/p/M0-deployment-checklis-3b6901ba000f803caadecad376728313
- https://app.notion.com/p/Core-Deployment-Guide-356901ba000f80e7b4a4dd9e9d6eb8bc

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance notice: This PR was prepared with assistance from OpenAI Codex.

## Related Issues

