### PR TITLE
fix(evm): preserve EIP-7702 bytecode through EE proof witnesses

### DIFF
--- a/crates/evm-ee/src/execution.rs
+++ b/crates/evm-ee/src/execution.rs
@@ -3,7 +3,7 @@
 //! This module provides the core ExecutionEnvironment implementation for EVM blocks,
 //! using RSP's sparse state and Reth's EVM execution engine.
 
-use std::sync::Arc;
+use std::{mem, sync::Arc};
 
 use alloy_consensus::Block as AlloyBlock;
 use alpen_reth_evm::{evm::AlpenEvmFactory, extract_withdrawal_intents};
@@ -70,6 +70,23 @@ fn convert_withdrawal_intents_to_messages(
         let message = OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, payload);
         outputs.add_message(message);
     }
+}
+
+/// Converts one block's execution state into the writes carried to the next block.
+///
+/// Contract code is separate from the hashed account/storage state in reth's
+/// execution output. Moving it into the write batch is therefore required for
+/// a later block in the same proof chunk to execute code deployed by this one.
+fn into_write_batch(
+    mut execution_output: BlockExecutionOutput<EthereumReceipt>,
+    block_number: u64,
+) -> EvmWriteBatch {
+    let deployed_bytecodes = mem::take(&mut execution_output.state.contracts)
+        .into_iter()
+        .collect();
+    let hashed_post_state = compute_hashed_post_state(execution_output, block_number);
+
+    EvmWriteBatch::new(hashed_post_state, deployed_bytecodes)
 }
 
 impl EvmExecutionEnvironment {
@@ -147,14 +164,12 @@ impl ExecutionEnvironment for EvmExecutionEnvironment {
         )
         .map_err(|_| EnvError::InvalidBlock)?;
 
-        // Step 6: Convert execution outcome to HashedPostState.
+        // Step 6: Convert execution state and newly deployed code into the
+        // writes carried to subsequent blocks in this proof chunk.
         let block_number = header_intrinsics.number();
-        let hashed_post_state = compute_hashed_post_state(execution_output, block_number);
+        let write_batch = into_write_batch(execution_output, block_number);
 
-        // Step 7: Split state writes from execution-derived header commitments.
-        let write_batch = EvmWriteBatch::new(hashed_post_state);
-
-        // Step 8: Create ExecOutputs with withdrawal intent messages.
+        // Step 7: Create ExecOutputs with withdrawal intent messages.
         let mut outputs = ExecOutputs::new_empty();
         convert_withdrawal_intents_to_messages(withdrawal_intents, &mut outputs);
 
@@ -209,8 +224,8 @@ mod tests {
 
     use alloy_consensus::Sealable;
     use reth_primitives_traits::Block as RethBlockTrait;
-    use revm::{DatabaseRef, state::Bytecode};
-    use revm_primitives::{B256, alloy_primitives::Bloom};
+    use revm::{DatabaseRef, database::BundleState, state::Bytecode};
+    use revm_primitives::{B256, Bytes, alloy_primitives::Bloom};
     use rsp_client_executor::io::EthClientExecutorInput;
     use serde::Deserialize;
     use strata_ee_acct_types::{ExecBlock, ExecHeader};
@@ -230,6 +245,22 @@ mod tests {
             .into_iter()
             .map(|bytecode| (bytecode.hash_slow(), bytecode))
             .collect()
+    }
+
+    #[test]
+    fn write_batch_preserves_contracts_created_by_execution() {
+        let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x2a, 0x5f, 0x52]));
+        let code_hash = bytecode.hash_slow();
+        let mut state = BundleState::default();
+        state.contracts.insert(code_hash, bytecode.clone());
+        let execution_output = BlockExecutionOutput {
+            result: Default::default(),
+            state,
+        };
+
+        let write_batch = into_write_batch(execution_output, 1);
+
+        assert_eq!(write_batch.bytecodes().get(&code_hash), Some(&bytecode));
     }
 
     #[test]

--- a/crates/evm-ee/src/types/partial_state.rs
+++ b/crates/evm-ee/src/types/partial_state.rs
@@ -174,9 +174,15 @@ impl EvmPartialState {
 
     /// Merges a write batch into this state by applying the hashed post state changes.
     ///
-    /// This updates the internal EthereumState with the changes from the write batch.
+    /// This updates the internal EthereumState and makes code deployed by the
+    /// block available to subsequent blocks executed against this partial state.
     pub fn merge_write_batch(&mut self, wb: &EvmWriteBatch) {
         self.ethereum_state.update(wb.hashed_post_state());
+        for (hash, bytecode) in wb.bytecodes() {
+            self.bytecodes
+                .entry(*hash)
+                .or_insert_with(|| bytecode.clone());
+        }
     }
 }
 

--- a/crates/evm-ee/src/types/tests.rs
+++ b/crates/evm-ee/src/types/tests.rs
@@ -1,16 +1,22 @@
 //! Tests for EVM types Codec implementations.
 
-use std::{collections::BTreeMap, fs::read_to_string, path::PathBuf};
+use std::{collections::BTreeMap, fs::read_to_string, path::PathBuf, sync::Arc};
 
 use alloy_consensus::{Header, Sealable};
+use alpen_reth_evm::evm::AlpenEvmFactory;
+use reth_chainspec::ChainSpec;
+use reth_primitives_traits::Block as _;
+use reth_trie::HashedPostState;
 use revm::{DatabaseRef, state::Bytecode};
-use revm_primitives::alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+use revm_primitives::alloy_primitives::{Address, B64, B256, Bloom, Bytes, U256};
 use rsp_client_executor::io::EthClientExecutorInput;
 use serde::Deserialize;
-use strata_codec::{decode_buf_exact, encode_to_vec};
-use strata_ee_acct_types::ExecHeader;
+use strata_codec::{CodecError, decode_buf_exact, encode_to_vec};
+use strata_ee_acct_types::{ExecBlock, ExecHeader, ExecPayload, ExecutionEnvironment};
+use strata_ee_chain_types::ExecInputs;
 
-use super::{EvmBlock, EvmBlockBody, EvmHeader, EvmPartialState};
+use super::{EvmBlock, EvmBlockBody, EvmHeader, EvmPartialState, EvmWriteBatch};
+use crate::EvmExecutionEnvironment;
 
 #[derive(Deserialize)]
 struct TestData {
@@ -46,8 +52,6 @@ fn rehashed_fixture_bytecodes(bytecodes: Vec<Bytecode>) -> BTreeMap<B256, Byteco
 
 /// Helper function to create a test header with realistic values
 fn create_test_header() -> Header {
-    use revm_primitives::alloy_primitives::B64;
-
     Header {
         parent_hash: B256::from([1u8; 32]),
         ommers_hash: B256::from([2u8; 32]),
@@ -179,7 +183,6 @@ fn test_evm_block_body_codec_roundtrip() {
     // Load witness data and extract block body
     let witness = load_witness_test_data();
 
-    use reth_primitives_traits::Block;
     let block_body = witness.current_block.body().clone();
     let body = EvmBlockBody::from_alloy_body(block_body.clone());
 
@@ -202,7 +205,6 @@ fn test_evm_block_codec_roundtrip() {
     // Load witness data and construct block
     let witness = load_witness_test_data();
 
-    use reth_primitives_traits::Block;
     let header = witness.current_block.header().clone();
     let evm_header = EvmHeader::new(header.clone());
 
@@ -341,16 +343,6 @@ fn test_evm_partial_state_rejects_invalid_ancestor_parent_hash() {
 /// into hash digests, losing the resolved trie data needed for execution.
 #[test]
 fn test_evm_partial_state_codec_roundtrip_execution() {
-    use std::sync::Arc;
-
-    use alpen_reth_evm::evm::AlpenEvmFactory;
-    use reth_chainspec::ChainSpec;
-    use reth_primitives_traits::Block as _;
-    use strata_ee_acct_types::{ExecBlock, ExecPayload, ExecutionEnvironment};
-    use strata_ee_chain_types::ExecInputs;
-
-    use crate::EvmExecutionEnvironment;
-
     let witness = load_witness_test_data();
 
     // Build partial state and verify execution works on the original.
@@ -385,12 +377,11 @@ fn test_evm_partial_state_codec_roundtrip_execution() {
 
 #[test]
 fn test_evm_write_batch_codec_roundtrip() {
-    use reth_trie::HashedPostState;
-
-    use super::EvmWriteBatch;
-
     let hashed_post_state = HashedPostState::default();
-    let write_batch = EvmWriteBatch::new(hashed_post_state);
+    let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x01, 0x5f, 0x55]));
+    let code_hash = bytecode.hash_slow();
+    let bytecodes = BTreeMap::from([(code_hash, bytecode.clone())]);
+    let write_batch = EvmWriteBatch::new(hashed_post_state, bytecodes);
 
     // Encode
     let encoded = encode_to_vec(&write_batch).expect("encode failed");
@@ -398,6 +389,65 @@ fn test_evm_write_batch_codec_roundtrip() {
     // Decode
     let decoded: EvmWriteBatch = decode_buf_exact(&encoded).expect("decode failed");
 
+    assert_eq!(
+        decoded
+            .bytecodes()
+            .get(&code_hash)
+            .expect("deployed bytecode must survive codec roundtrip")
+            .original_bytes(),
+        bytecode.original_bytes(),
+    );
+
     let reencoded = encode_to_vec(&decoded).expect("re-encode failed");
     assert_eq!(reencoded, encoded);
+}
+
+#[test]
+fn test_evm_write_batch_codec_rejects_mismatched_bytecode_hash() {
+    let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x01, 0x5f, 0x55]));
+    let code_hash = bytecode.hash_slow();
+    let write_batch = EvmWriteBatch::new(
+        HashedPostState::default(),
+        BTreeMap::from([(code_hash, bytecode)]),
+    );
+    let mut encoded = encode_to_vec(&write_batch).expect("encode failed");
+    let final_hash_byte = encoded
+        .last_mut()
+        .expect("write batch encoding must contain the bytecode hash");
+    *final_hash_byte ^= 0x01;
+
+    let error = decode_buf_exact::<EvmWriteBatch>(&encoded)
+        .expect_err("a bytecode stored under the wrong hash must be rejected");
+
+    assert!(matches!(error, CodecError::MalformedField("bytecode hash")));
+}
+
+#[test]
+fn test_evm_partial_state_merges_deployed_bytecodes() {
+    let witness = load_witness_test_data();
+    let chain_spec: Arc<ChainSpec> = Arc::new((&witness.genesis).try_into().unwrap());
+    let ee = EvmExecutionEnvironment::new(chain_spec, AlpenEvmFactory::default());
+    let mut partial_state = EvmPartialState::new(
+        witness.parent_state,
+        rehashed_fixture_bytecodes(witness.bytecodes),
+        witness.ancestor_headers,
+    );
+    let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x2a, 0x5f, 0x52]));
+    let code_hash = bytecode.hash_slow();
+    let write_batch = EvmWriteBatch::new(
+        HashedPostState::default(),
+        BTreeMap::from([(code_hash, bytecode.clone())]),
+    );
+
+    ee.merge_write_into_state(&mut partial_state, &write_batch)
+        .expect("write batch should merge into the partial state");
+
+    assert_eq!(
+        partial_state
+            .create_witness_db()
+            .code_by_hash_ref(code_hash)
+            .expect("code deployed by an earlier chunk block must be executable")
+            .original_bytes(),
+        bytecode.original_bytes(),
+    );
 }

--- a/crates/evm-ee/src/types/witness_db.rs
+++ b/crates/evm-ee/src/types/witness_db.rs
@@ -111,11 +111,12 @@ impl<'a> DatabaseRef for WitnessDB<'a> {
         // Look up bytecode by hash and clone it (required by DatabaseRef trait)
         // This clone is unavoidable as the trait requires returning owned Bytecode,
         // but it happens only once per unique bytecode during execution (EVM caches it)
-        Ok(self
-            .bytecodes
-            .get(&code_hash)
-            .cloned()
-            .expect("Bytecode must be present in witness"))
+        Ok(self.bytecodes.get(&code_hash).cloned().unwrap_or_else(|| {
+            panic!(
+                "bytecode {code_hash} must be present in witness ({} bytecodes available)",
+                self.bytecodes.len()
+            )
+        }))
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {

--- a/crates/evm-ee/src/types/write_batch.rs
+++ b/crates/evm-ee/src/types/write_batch.rs
@@ -1,9 +1,16 @@
 //! EVM write batch implementation.
 
+use std::collections::BTreeMap;
+
 use reth_trie::HashedPostState;
+use revm::state::Bytecode;
+use revm_primitives::B256;
 use strata_codec::{Codec, CodecError};
 
-use crate::codec_shims::{decode_hashed_post_state, encode_hashed_post_state};
+use crate::codec_shims::{
+    decode_bytes_with_length, decode_hashed_post_state, encode_bytes_with_length,
+    encode_hashed_post_state,
+};
 
 /// Write batch for EVM execution containing state changes.
 ///
@@ -13,17 +20,27 @@ use crate::codec_shims::{decode_hashed_post_state, encode_hashed_post_state};
 #[derive(Clone, Debug)]
 pub struct EvmWriteBatch {
     hashed_post_state: HashedPostState,
+    /// Bytecodes deployed while executing the block, keyed by code hash.
+    bytecodes: BTreeMap<B256, Bytecode>,
 }
 
 impl EvmWriteBatch {
     /// Creates a new EvmWriteBatch from execution state changes.
-    pub fn new(hashed_post_state: HashedPostState) -> Self {
-        Self { hashed_post_state }
+    pub fn new(hashed_post_state: HashedPostState, bytecodes: BTreeMap<B256, Bytecode>) -> Self {
+        Self {
+            hashed_post_state,
+            bytecodes,
+        }
     }
 
     /// Gets a reference to the underlying HashedPostState.
     pub fn hashed_post_state(&self) -> &HashedPostState {
         &self.hashed_post_state
+    }
+
+    /// Gets bytecodes deployed by the block.
+    pub fn bytecodes(&self) -> &BTreeMap<B256, Bytecode> {
+        &self.bytecodes
     }
 
     /// Consumes self and returns the underlying HashedPostState.
@@ -34,11 +51,48 @@ impl EvmWriteBatch {
 
 impl Codec for EvmWriteBatch {
     fn encode(&self, enc: &mut impl strata_codec::Encoder) -> Result<(), CodecError> {
-        encode_hashed_post_state(&self.hashed_post_state, enc)
+        encode_hashed_post_state(&self.hashed_post_state, enc)?;
+
+        let bytecode_count =
+            u32::try_from(self.bytecodes.len()).map_err(|_| CodecError::OverflowContainer)?;
+        bytecode_count.encode(enc)?;
+        for (hash, bytecode) in &self.bytecodes {
+            encode_bytes_with_length(&bytecode.original_bytes(), enc)?;
+            enc.write_buf(hash.as_slice())?;
+        }
+
+        Ok(())
     }
 
     fn decode(dec: &mut impl strata_codec::Decoder) -> Result<Self, CodecError> {
         let hashed_post_state = decode_hashed_post_state(dec)?;
-        Ok(Self { hashed_post_state })
+        let bytecode_count = u32::decode(dec)? as usize;
+        let mut bytecodes = BTreeMap::new();
+        let mut previous_hash = None;
+
+        for _ in 0..bytecode_count {
+            let bytes = decode_bytes_with_length(dec)?;
+            let bytecode = Bytecode::new_raw_checked(bytes.into())
+                .map_err(|_| CodecError::MalformedField("bytecode"))?;
+
+            let mut hash_bytes = [0u8; 32];
+            dec.read_buf(&mut hash_bytes)?;
+            let hash = B256::from(hash_bytes);
+
+            if bytecode.hash_slow() != hash {
+                return Err(CodecError::MalformedField("bytecode hash"));
+            }
+            if previous_hash.is_some_and(|previous| hash <= previous) {
+                return Err(CodecError::UnsortedContainer);
+            }
+
+            previous_hash = Some(hash);
+            bytecodes.insert(hash, bytecode);
+        }
+
+        Ok(Self {
+            hashed_post_state,
+            bytecodes,
+        })
     }
 }

--- a/crates/reth/exex/src/accessed_state_exex.rs
+++ b/crates/reth/exex/src/accessed_state_exex.rs
@@ -24,7 +24,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{keccak256, B256};
+use alloy_primitives::{keccak256, B256, KECCAK256_EMPTY};
 use alpen_ee_common::{AccessedAccount, AccessedStateRecord, AccessedStateStore};
 use alpen_reth_witness::CacheDBProvider;
 use futures_util::TryStreamExt;
@@ -38,7 +38,7 @@ use reth_primitives::{Block, EthPrimitives};
 use reth_primitives_traits::Block as _;
 use reth_provider::{BlockReader, Chain, StateProviderFactory};
 use reth_revm::{
-    db::{BundleState, CacheDB},
+    db::{BundleState, CacheDB, CacheState},
     state::Bytecode,
 };
 use strata_acct_types::Hash;
@@ -233,8 +233,9 @@ where
     let cache_provider = CacheDBProvider::new(history);
     let cache_db = CacheDB::new(&cache_provider);
 
-    let executor = BasicBlockExecutor::new(evm_config, cache_db);
-    let output = executor.execute(&recovered)?;
+    let mut executor = BasicBlockExecutor::new(evm_config, cache_db);
+    executor.execute_one(&recovered)?;
+    let execution_state = executor.into_state();
 
     let accessed = cache_provider.get_accessed_state();
 
@@ -253,8 +254,11 @@ where
         .collect();
     accounts.sort_by_key(|a| a.address);
 
-    let collected_bytecodes =
-        collect_block_bytecodes(accessed.accessed_contracts(), &output.state)?;
+    let collected_bytecodes = collect_block_bytecodes(
+        accessed.accessed_contracts(),
+        &execution_state.cache,
+        &execution_state.bundle_state,
+    )?;
     let bytecode_hashes = collected_bytecodes.iter().map(|(hash, _)| hash.0).collect();
 
     let mut ancestor_block_numbers: Vec<u64> =
@@ -280,16 +284,38 @@ where
 /// The access-tracking database records code fetched from the parent state, but
 /// revm can satisfy code loads from its in-memory execution state without
 /// consulting that database. This happens notably for code installed by an
-/// earlier transaction and for EIP-7702 delegation designations. The execution
-/// bundle is therefore a second required source of witness bytecode.
+/// earlier transaction and for EIP-7702 delegation designations. Both the live
+/// execution cache and the merged execution bundle are therefore required
+/// sources of witness bytecode.
 fn collect_block_bytecodes<'a>(
     accessed_contracts: impl IntoIterator<Item = (&'a B256, &'a Bytecode)>,
+    execution_cache: &CacheState,
     bundle: &BundleState,
 ) -> eyre::Result<Vec<(B256, Vec<u8>)>> {
     let mut bytecodes = BTreeMap::new();
 
     for (hash, code) in accessed_contracts {
         insert_bytecode(&mut bytecodes, *hash, code, "access tracker")?;
+    }
+    for (hash, code) in &execution_cache.contracts {
+        insert_bytecode(&mut bytecodes, *hash, code, "execution cache")?;
+    }
+    for account in execution_cache.accounts.values() {
+        let Some(info) = account.account.as_ref().map(|account| &account.info) else {
+            continue;
+        };
+        let Some(code) = &info.code else {
+            continue;
+        };
+        if info.is_empty_code_hash() {
+            continue;
+        }
+        insert_bytecode(
+            &mut bytecodes,
+            info.code_hash,
+            code,
+            "execution cache account info",
+        )?;
     }
     for (hash, code) in &bundle.contracts {
         insert_bytecode(&mut bytecodes, *hash, code, "execution bundle")?;
@@ -324,6 +350,10 @@ fn insert_bytecode(
     source: &'static str,
 ) -> eyre::Result<()> {
     let bytes = code.original_bytes();
+    if bytes.is_empty() && (expected_hash.is_zero() || expected_hash == KECCAK256_EMPTY) {
+        return Ok(());
+    }
+
     let actual_hash = keccak256(&bytes);
     if actual_hash != expected_hash {
         eyre::bail!(
@@ -364,11 +394,46 @@ mod tests {
         let bytecode = Bytecode::new_raw(runtime.clone());
         let code_hash = bytecode.hash_slow();
 
-        let entries =
-            collect_block_bytecodes(once((&code_hash, &bytecode)), &BundleState::default())
-                .unwrap();
+        let entries = collect_block_bytecodes(
+            once((&code_hash, &bytecode)),
+            &CacheState::default(),
+            &BundleState::default(),
+        )
+        .unwrap();
 
         assert_eq!(entries, vec![(code_hash, runtime.to_vec())]);
+    }
+
+    #[test]
+    fn captures_execution_cache_contract_missing_from_other_sources() {
+        let code = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x2a, 0x60, 0x00, 0x52]));
+        let code_hash = code.hash_slow();
+        let mut execution_cache = CacheState::default();
+        execution_cache.contracts.insert(code_hash, code.clone());
+
+        let entries =
+            collect_block_bytecodes(empty(), &execution_cache, &BundleState::default()).unwrap();
+
+        assert_eq!(entries, vec![(code_hash, code.original_bytes().to_vec())]);
+    }
+
+    #[test]
+    fn captures_execution_cache_account_attached_code() {
+        let code = Bytecode::new_eip7702(Address::repeat_byte(0x33));
+        let code_hash = code.hash_slow();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: Some(code.clone()),
+        };
+        let mut execution_cache = CacheState::default();
+        execution_cache.insert_account(Address::repeat_byte(0x77), info);
+
+        let entries =
+            collect_block_bytecodes(empty(), &execution_cache, &BundleState::default()).unwrap();
+
+        assert_eq!(entries, vec![(code_hash, code.original_bytes().to_vec())]);
     }
 
     #[test]
@@ -388,7 +453,7 @@ mod tests {
             BundleAccount::new(None, Some(info), Default::default(), AccountStatus::Changed),
         );
 
-        let entries = collect_block_bytecodes(empty(), &bundle).unwrap();
+        let entries = collect_block_bytecodes(empty(), &CacheState::default(), &bundle).unwrap();
 
         assert_eq!(entries, vec![(code_hash, code.original_bytes().to_vec())]);
     }
@@ -400,7 +465,7 @@ mod tests {
         let mut bundle = BundleState::default();
         bundle.contracts.insert(code_hash, code.clone());
 
-        let entries = collect_block_bytecodes(empty(), &bundle).unwrap();
+        let entries = collect_block_bytecodes(empty(), &CacheState::default(), &bundle).unwrap();
 
         assert_eq!(entries, vec![(code_hash, code.original_bytes().to_vec())]);
     }
@@ -420,8 +485,25 @@ mod tests {
             BundleAccount::new(None, Some(info), Default::default(), AccountStatus::Changed),
         );
 
-        let err = collect_block_bytecodes(empty(), &bundle).unwrap_err();
+        let err = collect_block_bytecodes(empty(), &CacheState::default(), &bundle).unwrap_err();
 
         assert!(err.to_string().contains("bytecode hash mismatch"));
+    }
+
+    #[test]
+    fn ignores_empty_bytecode_sentinels() {
+        let empty_code = Bytecode::default();
+        let mut execution_cache = CacheState::default();
+        execution_cache
+            .contracts
+            .insert(B256::ZERO, empty_code.clone());
+        execution_cache
+            .contracts
+            .insert(KECCAK256_EMPTY, empty_code);
+
+        let entries =
+            collect_block_bytecodes(empty(), &execution_cache, &BundleState::default()).unwrap();
+
+        assert!(entries.is_empty());
     }
 }

--- a/crates/reth/exex/src/accessed_state_exex.rs
+++ b/crates/reth/exex/src/accessed_state_exex.rs
@@ -21,10 +21,10 @@
 //! are content-addressed and never deleted — same contract referenced by
 //! many chunks shares one stored copy.
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use alloy_eips::BlockNumHash;
-use alloy_primitives::B256;
+use alloy_primitives::{keccak256, B256};
 use alpen_ee_common::{AccessedAccount, AccessedStateRecord, AccessedStateStore};
 use alpen_reth_witness::CacheDBProvider;
 use futures_util::TryStreamExt;
@@ -37,7 +37,10 @@ use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives::{Block, EthPrimitives};
 use reth_primitives_traits::Block as _;
 use reth_provider::{BlockReader, Chain, StateProviderFactory};
-use reth_revm::{db::CacheDB, state::Bytecode};
+use reth_revm::{
+    db::{BundleState, CacheDB},
+    state::Bytecode,
+};
 use strata_acct_types::Hash;
 use tokio::task;
 use tracing::{debug, error, warn};
@@ -231,7 +234,7 @@ where
     let cache_db = CacheDB::new(&cache_provider);
 
     let executor = BasicBlockExecutor::new(evm_config, cache_db);
-    let _output = executor.execute(&recovered)?;
+    let output = executor.execute(&recovered)?;
 
     let accessed = cache_provider.get_accessed_state();
 
@@ -250,12 +253,9 @@ where
         .collect();
     accounts.sort_by_key(|a| a.address);
 
-    let mut bytecode_hashes: Vec<[u8; 32]> = accessed
-        .accessed_contracts()
-        .keys()
-        .map(|hash| hash.0)
-        .collect();
-    bytecode_hashes.sort();
+    let collected_bytecodes =
+        collect_block_bytecodes(accessed.accessed_contracts(), &output.state)?;
+    let bytecode_hashes = collected_bytecodes.iter().map(|(hash, _)| hash.0).collect();
 
     let mut ancestor_block_numbers: Vec<u64> =
         accessed.accessed_block_idxs().iter().copied().collect();
@@ -267,17 +267,79 @@ where
         ancestor_block_numbers,
     };
 
-    let bytecodes = bytecode_entries_from_accessed_contracts(accessed.accessed_contracts().iter());
+    let bytecodes = collected_bytecodes
+        .into_iter()
+        .map(|(hash, code)| (hash_from_b256(hash), code))
+        .collect();
 
     Ok((record, bytecodes))
 }
 
-fn bytecode_entries_from_accessed_contracts<'a>(
-    bytecodes: impl Iterator<Item = (&'a B256, &'a Bytecode)>,
-) -> Vec<BytecodeEntry> {
-    bytecodes
-        .map(|(hash, code)| (hash_from_b256(*hash), code.original_bytes().to_vec()))
-        .collect()
+/// Collects every bytecode that may be required to replay a block.
+///
+/// The access-tracking database records code fetched from the parent state, but
+/// revm can satisfy code loads from its in-memory execution state without
+/// consulting that database. This happens notably for code installed by an
+/// earlier transaction and for EIP-7702 delegation designations. The execution
+/// bundle is therefore a second required source of witness bytecode.
+fn collect_block_bytecodes<'a>(
+    accessed_contracts: impl IntoIterator<Item = (&'a B256, &'a Bytecode)>,
+    bundle: &BundleState,
+) -> eyre::Result<Vec<(B256, Vec<u8>)>> {
+    let mut bytecodes = BTreeMap::new();
+
+    for (hash, code) in accessed_contracts {
+        insert_bytecode(&mut bytecodes, *hash, code, "access tracker")?;
+    }
+    for (hash, code) in &bundle.contracts {
+        insert_bytecode(&mut bytecodes, *hash, code, "execution bundle")?;
+    }
+    for account in bundle.state.values() {
+        for info in [account.original_info.as_ref(), account.info.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            let Some(code) = &info.code else {
+                continue;
+            };
+            if info.is_empty_code_hash() {
+                continue;
+            }
+            insert_bytecode(
+                &mut bytecodes,
+                info.code_hash,
+                code,
+                "execution account info",
+            )?;
+        }
+    }
+
+    Ok(bytecodes.into_iter().collect())
+}
+
+fn insert_bytecode(
+    bytecodes: &mut BTreeMap<B256, Vec<u8>>,
+    expected_hash: B256,
+    code: &Bytecode,
+    source: &'static str,
+) -> eyre::Result<()> {
+    let bytes = code.original_bytes();
+    let actual_hash = keccak256(&bytes);
+    if actual_hash != expected_hash {
+        eyre::bail!(
+            "{source} bytecode hash mismatch: expected={expected_hash}, actual={actual_hash}"
+        );
+    }
+
+    if let Some(existing) = bytecodes.get(&expected_hash) {
+        if existing.as_slice() != bytes.as_ref() {
+            eyre::bail!("conflicting bytecodes for hash {expected_hash}: source={source}");
+        }
+        return Ok(());
+    }
+
+    bytecodes.insert(expected_hash, bytes.to_vec());
+    Ok(())
 }
 
 fn hash_from_b256(hash: B256) -> Hash {
@@ -286,23 +348,80 @@ fn hash_from_b256(hash: B256) -> Hash {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::once;
+    use std::iter::{empty, once};
 
-    use alloy_primitives::Bytes;
+    use alloy_primitives::{Address, Bytes, U256};
+    use reth_revm::{
+        db::{AccountStatus, BundleAccount},
+        state::AccountInfo,
+    };
 
     use super::*;
 
     #[test]
     fn bytecode_entries_preserve_original_runtime_bytes() {
-        let code_hash = B256::from([0x12; 32]);
         let runtime = Bytes::from_static(&[0x60, 0x01, 0x5f, 0x55]);
         let bytecode = Bytecode::new_raw(runtime.clone());
+        let code_hash = bytecode.hash_slow();
 
-        assert_eq!(bytecode.original_bytes(), runtime);
-        assert_ne!(bytecode.bytes(), runtime);
+        let entries =
+            collect_block_bytecodes(once((&code_hash, &bytecode)), &BundleState::default())
+                .unwrap();
 
-        let entries = bytecode_entries_from_accessed_contracts(once((&code_hash, &bytecode)));
+        assert_eq!(entries, vec![(code_hash, runtime.to_vec())]);
+    }
 
-        assert_eq!(entries, vec![(hash_from_b256(code_hash), runtime.to_vec())]);
+    #[test]
+    fn captures_account_attached_code_missing_from_contract_maps() {
+        let address = Address::repeat_byte(0x42);
+        let code = Bytecode::new_eip7702(Address::repeat_byte(0x24));
+        let code_hash = code.hash_slow();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: Some(code.clone()),
+        };
+        let mut bundle = BundleState::default();
+        bundle.state.insert(
+            address,
+            BundleAccount::new(None, Some(info), Default::default(), AccountStatus::Changed),
+        );
+
+        let entries = collect_block_bytecodes(empty(), &bundle).unwrap();
+
+        assert_eq!(entries, vec![(code_hash, code.original_bytes().to_vec())]);
+    }
+
+    #[test]
+    fn captures_execution_bundle_contract_missing_from_tracker() {
+        let code = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x2a, 0x60, 0x00, 0x52]));
+        let code_hash = code.hash_slow();
+        let mut bundle = BundleState::default();
+        bundle.contracts.insert(code_hash, code.clone());
+
+        let entries = collect_block_bytecodes(empty(), &bundle).unwrap();
+
+        assert_eq!(entries, vec![(code_hash, code.original_bytes().to_vec())]);
+    }
+
+    #[test]
+    fn rejects_account_attached_code_with_wrong_hash() {
+        let code = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00, 0x56]));
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash: B256::repeat_byte(0x11),
+            code: Some(code),
+        };
+        let mut bundle = BundleState::default();
+        bundle.state.insert(
+            Address::repeat_byte(0x55),
+            BundleAccount::new(None, Some(info), Default::default(), AccountStatus::Changed),
+        );
+
+        let err = collect_block_bytecodes(empty(), &bundle).unwrap_err();
+
+        assert!(err.to_string().contains("bytecode hash mismatch"));
     }
 }

--- a/crates/reth/node/src/block_witness.rs
+++ b/crates/reth/node/src/block_witness.rs
@@ -15,11 +15,12 @@
 use std::collections::BTreeMap;
 
 use alloy_consensus::Header;
-use alloy_primitives::{keccak256, Bytes, B256};
+use alloy_primitives::{keccak256, Address, Bytes, B256};
 use reth_provider::{HeaderProvider, StateProofProvider};
-use reth_revm::{db::State, witness::ExecutionWitnessRecord, Database};
+use reth_revm::{db::State, state::Bytecode, witness::ExecutionWitnessRecord, Database};
 use reth_trie::TrieInput;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 /// Persisted per-block proof-witness, keyed by execution block hash.
 ///
@@ -72,7 +73,10 @@ impl BlockWitnessRecord {
 /// `codes`, BLOCKHASH range) via reth's [`ExecutionWitnessRecord`].
 /// `state_provider` must be the parent state (it serves the depth-0
 /// [`StateProofProvider::witness`] trie nodes), and `header_provider` must cover
-/// the BLOCKHASH ancestor range.
+/// the BLOCKHASH ancestor range. `authorization_targets` must contain every
+/// EIP-7702 target declared by the block's signed transactions, including
+/// invalid authorizations; content-addressed extras are safe, while omissions
+/// can make transient delegation code unavailable during guest replay.
 pub fn build_block_witness_from_executed_state<DB, SP, HP>(
     executed_state: &State<DB>,
     state_provider: &SP,
@@ -80,6 +84,7 @@ pub fn build_block_witness_from_executed_state<DB, SP, HP>(
     block_num: u64,
     block_rlp: Vec<u8>,
     parent_header: &Header,
+    authorization_targets: impl IntoIterator<Item = Address>,
 ) -> eyre::Result<BlockWitnessRecord>
 where
     DB: Database,
@@ -103,7 +108,14 @@ where
         .map(|node| node.to_vec())
         .collect();
 
-    let codes = collect_accessed_codes(executed_state, codes)?;
+    let (codes, authorization_bytecodes_added) =
+        collect_accessed_codes(executed_state, codes, authorization_targets)?;
+    debug!(
+        block_num,
+        authorization_bytecodes_added,
+        total_bytecodes = codes.len(),
+        "closed block witness over execution and EIP-7702 bytecode"
+    );
 
     // BLOCKHASH ancestor headers: the contiguous range from the lowest block
     // referenced (or just the parent) up to the parent.
@@ -142,14 +154,17 @@ where
 fn collect_accessed_codes<DB>(
     executed_state: &State<DB>,
     record_codes: Vec<Bytes>,
-) -> eyre::Result<Vec<Vec<u8>>>
+    authorization_targets: impl IntoIterator<Item = Address>,
+) -> eyre::Result<(Vec<Vec<u8>>, usize)>
 where
     DB: Database,
 {
-    let mut codes_by_hash: BTreeMap<B256, Bytes> = record_codes
-        .into_iter()
-        .map(|code| (keccak256(&code), code))
-        .collect();
+    let mut codes_by_hash = BTreeMap::new();
+
+    for code in record_codes {
+        let code_hash = keccak256(&code);
+        insert_code(&mut codes_by_hash, code_hash, code, "execution witness")?;
+    }
 
     for account in executed_state.cache.accounts.values() {
         let Some(plain) = &account.account else {
@@ -162,30 +177,74 @@ where
             continue;
         };
 
-        // The guest content-addresses code by `keccak256(bytes)`, so code stored
-        // under a hash that disagrees with its bytes would be unreachable there.
-        // Surface the inconsistency as a build failure now, not a guest panic.
-        let actual_hash = code.hash_slow();
-        if actual_hash != plain.info.code_hash {
-            eyre::bail!(
-                "accessed account bytecode hash mismatch: expected_code_hash={}, actual_hash={actual_hash}",
-                plain.info.code_hash,
-            );
-        }
-
-        codes_by_hash
-            .entry(plain.info.code_hash)
-            .or_insert_with(|| code.original_bytes());
+        insert_code(
+            &mut codes_by_hash,
+            plain.info.code_hash,
+            code.original_bytes(),
+            "accessed account",
+        )?;
     }
 
-    Ok(codes_by_hash
+    // Revm synthesizes an EIP-7702 delegation designation directly from each
+    // valid authorization target. A designation can then be replaced or
+    // cleared in the same block, so it may be absent from both the execution
+    // witness and the final account state even though guest replay still needs
+    // to resolve its code hash. Include every non-reset target from the signed
+    // transaction inputs. Invalid authorizations may add inert content-addressed
+    // bytes; duplicating revm's validity rules here would be a second consensus
+    // implementation and risks rejecting valid future inputs.
+    let mut authorization_bytecodes_added = 0;
+    for target in authorization_targets {
+        if target.is_zero() {
+            continue;
+        }
+
+        let designation = Bytecode::new_eip7702(target);
+        if insert_code(
+            &mut codes_by_hash,
+            designation.hash_slow(),
+            designation.original_bytes(),
+            "EIP-7702 authorization",
+        )? {
+            authorization_bytecodes_added += 1;
+        }
+    }
+
+    let codes = codes_by_hash
         .into_values()
         .map(|code| code.to_vec())
-        .collect())
+        .collect();
+    Ok((codes, authorization_bytecodes_added))
+}
+
+fn insert_code(
+    codes_by_hash: &mut BTreeMap<B256, Bytes>,
+    expected_hash: B256,
+    code: Bytes,
+    source: &'static str,
+) -> eyre::Result<bool> {
+    let actual_hash = keccak256(&code);
+    if actual_hash != expected_hash {
+        eyre::bail!(
+            "{source} bytecode hash mismatch: expected={expected_hash}, actual={actual_hash}"
+        );
+    }
+
+    if let Some(existing) = codes_by_hash.get(&expected_hash) {
+        if existing != &code {
+            eyre::bail!("conflicting {source} bytecode for hash {expected_hash}");
+        }
+        return Ok(false);
+    }
+
+    codes_by_hash.insert(expected_hash, code);
+    Ok(true)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::iter::empty;
+
     use alloy_primitives::{Address, U256};
     use reth_revm::db::{states::cache_account::CacheAccount, EmptyDB, State};
     use revm::state::{AccountInfo, Bytecode};
@@ -217,12 +276,14 @@ mod tests {
 
         // `record_executed_state` produced no codes (dedup map was empty), the
         // exact condition that dropped the bytecode before the fix.
-        let codes = collect_accessed_codes(&state, Vec::new()).unwrap();
+        let (codes, authorization_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), empty()).unwrap();
 
         assert!(
             codes.iter().any(|c| keccak256(c) == code_hash),
             "accessed contract code must be captured even when only on info.code"
         );
+        assert_eq!(authorization_bytecodes_added, 0);
     }
 
     /// An empty-code (EOA) account must not contribute a bytecode entry.
@@ -239,9 +300,11 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        assert!(collect_accessed_codes(&state, Vec::new())
-            .unwrap()
-            .is_empty());
+        let (codes, authorization_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), empty()).unwrap();
+
+        assert!(codes.is_empty());
+        assert_eq!(authorization_bytecodes_added, 0);
     }
 
     /// Locks the exact bug shape: reth's raw `ExecutionWitnessRecord` can miss
@@ -272,11 +335,13 @@ mod tests {
             "raw reth record should reproduce the missing-code condition"
         );
 
-        let codes = collect_accessed_codes(&state, record.codes).unwrap();
+        let (codes, authorization_bytecodes_added) =
+            collect_accessed_codes(&state, record.codes, empty()).unwrap();
         assert!(
             codes.iter().any(|code| keccak256(code) == code_hash),
             "block witness codes must include every accessed account info.code"
         );
+        assert_eq!(authorization_bytecodes_added, 0);
     }
 
     /// Account-attached bytecode must be content-addressed by the account's
@@ -297,7 +362,7 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        let err = collect_accessed_codes(&state, Vec::new()).unwrap_err();
+        let err = collect_accessed_codes(&state, Vec::new(), empty()).unwrap_err();
         assert!(
             err.to_string().contains("bytecode hash mismatch"),
             "unexpected error: {err}"
@@ -325,9 +390,30 @@ mod tests {
         );
 
         // The same bytecode arrives via reth's record_codes and the account.
-        let codes = collect_accessed_codes(&state, vec![raw]).unwrap();
+        let (codes, authorization_bytecodes_added) =
+            collect_accessed_codes(&state, vec![raw], empty()).unwrap();
 
         assert_eq!(codes.len(), 1, "duplicate code must collapse to one entry");
         assert_eq!(keccak256(&codes[0]), code_hash);
+        assert_eq!(authorization_bytecodes_added, 0);
+    }
+
+    /// A designation synthesized and cleared during one block can be absent
+    /// from both reth's execution witness and every final account. The signed
+    /// authorization target must still make that transient code replayable.
+    #[test]
+    fn collects_transient_eip7702_designations_from_authorizations() {
+        let target = Address::repeat_byte(0x77);
+        let designation = Bytecode::new_eip7702(target);
+        let designation_hash = designation.hash_slow();
+        let state = State::builder().with_database(EmptyDB::default()).build();
+
+        let (codes, authorization_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), [target, Address::ZERO, target]).unwrap();
+
+        assert_eq!(authorization_bytecodes_added, 1);
+        assert_eq!(codes.len(), 1);
+        assert_eq!(keccak256(&codes[0]), designation_hash);
+        assert_eq!(codes[0], designation.original_bytes());
     }
 }

--- a/crates/reth/node/src/block_witness.rs
+++ b/crates/reth/node/src/block_witness.rs
@@ -16,8 +16,13 @@ use std::collections::BTreeMap;
 
 use alloy_consensus::Header;
 use alloy_primitives::{keccak256, Address, Bytes, B256};
-use reth_provider::{HeaderProvider, StateProofProvider};
-use reth_revm::{db::State, state::Bytecode, witness::ExecutionWitnessRecord, Database};
+use reth_provider::{BytecodeReader, HeaderProvider, StateProofProvider};
+use reth_revm::{
+    db::State,
+    state::{AccountInfo, Bytecode},
+    witness::ExecutionWitnessRecord,
+    Database,
+};
 use reth_trie::TrieInput;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -88,7 +93,7 @@ pub fn build_block_witness_from_executed_state<DB, SP, HP>(
 ) -> eyre::Result<BlockWitnessRecord>
 where
     DB: Database,
-    SP: StateProofProvider,
+    SP: StateProofProvider + BytecodeReader,
     HP: HeaderProvider<Header = Header>,
 {
     // Access set read straight out of the post-execution state — no re-run.
@@ -108,13 +113,24 @@ where
         .map(|node| node.to_vec())
         .collect();
 
-    let (codes, authorization_bytecodes_added) =
-        collect_accessed_codes(executed_state, codes, authorization_targets)?;
+    let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+        collect_accessed_codes(executed_state, codes, authorization_targets, |code_hash| {
+            state_provider
+                .bytecode_by_hash(code_hash)
+                .map(|code| code.map(|code| code.original_bytes()))
+                .map_err(|error| {
+                    eyre::eyre!(
+                        "read parent-state bytecode {code_hash} while closing block witness: \
+                             {error}"
+                    )
+                })
+        })?;
     debug!(
         block_num,
         authorization_bytecodes_added,
+        parent_state_bytecodes_added,
         total_bytecodes = codes.len(),
-        "closed block witness over execution and EIP-7702 bytecode"
+        "closed block witness over execution, parent-state, and EIP-7702 bytecode"
     );
 
     // BLOCKHASH ancestor headers: the contiguous range from the lowest block
@@ -148,41 +164,27 @@ where
 /// via its account's `info.code` — a warm load that never issued a by-hash
 /// fetch — is silently left out.
 ///
-/// This starts from reth's `record_codes` and adds the code of every accessed
-/// account that carries one, so the result is complete regardless of how each
-/// contract's code was loaded.
-fn collect_accessed_codes<DB>(
+/// This starts from reth's `record_codes`, adds every transient EIP-7702
+/// designation declared by the block, then closes both the live cache and the
+/// execution bundle over bytecode. Account entries are allowed to carry only a
+/// code hash; those hashes are resolved against the block's parent-state
+/// provider. The bundle's `original_info` is required for contracts replaced or
+/// cleared during the block, while its final `info` covers newly installed code.
+fn collect_accessed_codes<DB, F>(
     executed_state: &State<DB>,
     record_codes: Vec<Bytes>,
     authorization_targets: impl IntoIterator<Item = Address>,
-) -> eyre::Result<(Vec<Vec<u8>>, usize)>
+    mut parent_bytecode_by_hash: F,
+) -> eyre::Result<(Vec<Vec<u8>>, usize, usize)>
 where
     DB: Database,
+    F: FnMut(&B256) -> eyre::Result<Option<Bytes>>,
 {
     let mut codes_by_hash = BTreeMap::new();
 
     for code in record_codes {
         let code_hash = keccak256(&code);
         insert_code(&mut codes_by_hash, code_hash, code, "execution witness")?;
-    }
-
-    for account in executed_state.cache.accounts.values() {
-        let Some(plain) = &account.account else {
-            continue;
-        };
-        if plain.info.is_empty_code_hash() {
-            continue;
-        }
-        let Some(code) = &plain.info.code else {
-            continue;
-        };
-
-        insert_code(
-            &mut codes_by_hash,
-            plain.info.code_hash,
-            code.original_bytes(),
-            "accessed account",
-        )?;
     }
 
     // Revm synthesizes an EIP-7702 delegation designation directly from each
@@ -210,11 +212,92 @@ where
         }
     }
 
+    let mut parent_state_bytecodes_added = 0;
+    for (address, account) in &executed_state.cache.accounts {
+        let Some(plain) = &account.account else {
+            continue;
+        };
+
+        if collect_account_info_code(
+            &mut codes_by_hash,
+            *address,
+            &plain.info,
+            "execution cache account",
+            &mut parent_bytecode_by_hash,
+        )? {
+            parent_state_bytecodes_added += 1;
+        }
+    }
+
+    for (address, account) in &executed_state.bundle_state.state {
+        if let Some(original_info) = &account.original_info {
+            if collect_account_info_code(
+                &mut codes_by_hash,
+                *address,
+                original_info,
+                "execution bundle pre-state account",
+                &mut parent_bytecode_by_hash,
+            )? {
+                parent_state_bytecodes_added += 1;
+            }
+        }
+
+        if let Some(info) = &account.info {
+            if collect_account_info_code(
+                &mut codes_by_hash,
+                *address,
+                info,
+                "execution bundle post-state account",
+                &mut parent_bytecode_by_hash,
+            )? {
+                parent_state_bytecodes_added += 1;
+            }
+        }
+    }
+
     let codes = codes_by_hash
         .into_values()
         .map(|code| code.to_vec())
         .collect();
-    Ok((codes, authorization_bytecodes_added))
+    Ok((
+        codes,
+        authorization_bytecodes_added,
+        parent_state_bytecodes_added,
+    ))
+}
+
+fn collect_account_info_code<F>(
+    codes_by_hash: &mut BTreeMap<B256, Bytes>,
+    address: Address,
+    info: &AccountInfo,
+    source: &'static str,
+    parent_bytecode_by_hash: &mut F,
+) -> eyre::Result<bool>
+where
+    F: FnMut(&B256) -> eyre::Result<Option<Bytes>>,
+{
+    if info.is_empty_code_hash() {
+        return Ok(false);
+    }
+
+    if let Some(code) = &info.code {
+        insert_code(codes_by_hash, info.code_hash, code.original_bytes(), source)?;
+        return Ok(false);
+    }
+
+    if codes_by_hash.contains_key(&info.code_hash) {
+        return Ok(false);
+    }
+
+    let code = parent_bytecode_by_hash(&info.code_hash)?.ok_or_else(|| {
+        eyre::eyre!(
+            "{source} {address} references bytecode {} but the parent-state provider returned \
+             no bytes",
+            info.code_hash
+        )
+    })?;
+    insert_code(codes_by_hash, info.code_hash, code, source)?;
+    Ok(true)
 }
 
 fn insert_code(
@@ -246,10 +329,14 @@ mod tests {
     use std::iter::empty;
 
     use alloy_primitives::{Address, U256};
-    use reth_revm::db::{states::cache_account::CacheAccount, EmptyDB, State};
+    use reth_revm::db::{states::cache_account::CacheAccount, BundleState, EmptyDB, State};
     use revm::state::{AccountInfo, Bytecode};
 
     use super::*;
+
+    fn no_parent_bytecode(_: &B256) -> eyre::Result<Option<Bytes>> {
+        Ok(None)
+    }
 
     /// A contract whose code is attached to its account `info.code` but never
     /// entered `cache.contracts` (the in-memory bytecode store
@@ -276,14 +363,15 @@ mod tests {
 
         // `record_executed_state` produced no codes (dedup map was empty), the
         // exact condition that dropped the bytecode before the fix.
-        let (codes, authorization_bytecodes_added) =
-            collect_accessed_codes(&state, Vec::new(), empty()).unwrap();
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), empty(), no_parent_bytecode).unwrap();
 
         assert!(
             codes.iter().any(|c| keccak256(c) == code_hash),
             "accessed contract code must be captured even when only on info.code"
         );
         assert_eq!(authorization_bytecodes_added, 0);
+        assert_eq!(parent_state_bytecodes_added, 0);
     }
 
     /// An empty-code (EOA) account must not contribute a bytecode entry.
@@ -300,11 +388,12 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        let (codes, authorization_bytecodes_added) =
-            collect_accessed_codes(&state, Vec::new(), empty()).unwrap();
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), empty(), no_parent_bytecode).unwrap();
 
         assert!(codes.is_empty());
         assert_eq!(authorization_bytecodes_added, 0);
+        assert_eq!(parent_state_bytecodes_added, 0);
     }
 
     /// Locks the exact bug shape: reth's raw `ExecutionWitnessRecord` can miss
@@ -335,13 +424,14 @@ mod tests {
             "raw reth record should reproduce the missing-code condition"
         );
 
-        let (codes, authorization_bytecodes_added) =
-            collect_accessed_codes(&state, record.codes, empty()).unwrap();
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(&state, record.codes, empty(), no_parent_bytecode).unwrap();
         assert!(
             codes.iter().any(|code| keccak256(code) == code_hash),
             "block witness codes must include every accessed account info.code"
         );
         assert_eq!(authorization_bytecodes_added, 0);
+        assert_eq!(parent_state_bytecodes_added, 0);
     }
 
     /// Account-attached bytecode must be content-addressed by the account's
@@ -362,7 +452,8 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        let err = collect_accessed_codes(&state, Vec::new(), empty()).unwrap_err();
+        let err =
+            collect_accessed_codes(&state, Vec::new(), empty(), no_parent_bytecode).unwrap_err();
         assert!(
             err.to_string().contains("bytecode hash mismatch"),
             "unexpected error: {err}"
@@ -390,12 +481,13 @@ mod tests {
         );
 
         // The same bytecode arrives via reth's record_codes and the account.
-        let (codes, authorization_bytecodes_added) =
-            collect_accessed_codes(&state, vec![raw], empty()).unwrap();
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(&state, vec![raw], empty(), no_parent_bytecode).unwrap();
 
         assert_eq!(codes.len(), 1, "duplicate code must collapse to one entry");
         assert_eq!(keccak256(&codes[0]), code_hash);
         assert_eq!(authorization_bytecodes_added, 0);
+        assert_eq!(parent_state_bytecodes_added, 0);
     }
 
     /// A designation synthesized and cleared during one block can be absent
@@ -408,12 +500,122 @@ mod tests {
         let designation_hash = designation.hash_slow();
         let state = State::builder().with_database(EmptyDB::default()).build();
 
-        let (codes, authorization_bytecodes_added) =
-            collect_accessed_codes(&state, Vec::new(), [target, Address::ZERO, target]).unwrap();
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(
+                &state,
+                Vec::new(),
+                [target, Address::ZERO, target],
+                no_parent_bytecode,
+            )
+            .unwrap();
 
         assert_eq!(authorization_bytecodes_added, 1);
+        assert_eq!(parent_state_bytecodes_added, 0);
         assert_eq!(codes.len(), 1);
         assert_eq!(keccak256(&codes[0]), designation_hash);
         assert_eq!(codes[0], designation.original_bytes());
+    }
+
+    /// A loaded contract can carry only its code hash because revm expects a
+    /// later database lookup. Inline witness capture must perform that lookup
+    /// before the parent state disappears behind a chunk boundary.
+    #[test]
+    fn resolves_hash_only_accessed_account_from_parent_state() {
+        let address = Address::repeat_byte(0x61);
+        let raw = Bytes::from_static(&[0x60, 0x01, 0x56]);
+        let code_hash = keccak256(&raw);
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        state.cache.accounts.insert(
+            address,
+            CacheAccount::new_loaded(
+                AccountInfo {
+                    balance: U256::ZERO,
+                    nonce: 1,
+                    code_hash,
+                    code: None,
+                },
+                Default::default(),
+            ),
+        );
+
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), empty(), |requested_hash| {
+                assert_eq!(*requested_hash, code_hash);
+                Ok(Some(raw.clone()))
+            })
+            .unwrap();
+
+        assert_eq!(codes, vec![raw.to_vec()]);
+        assert_eq!(authorization_bytecodes_added, 0);
+        assert_eq!(parent_state_bytecodes_added, 1);
+    }
+
+    /// Clearing or replacing a contract removes its old code from the final
+    /// account info. The bundle's original info still references that prestate
+    /// code and must keep it available for guest replay.
+    #[test]
+    fn resolves_hash_only_bundle_prestate_code_after_account_clearing() {
+        let address = Address::repeat_byte(0x62);
+        let raw = Bytes::from_static(&[0x60, 0x02, 0x60, 0x00, 0x52]);
+        let code_hash = keccak256(&raw);
+        let original_info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: None,
+        };
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        state.bundle_state = BundleState::builder(0..=0)
+            .state_original_account_info(address, original_info)
+            .build();
+
+        let (codes, authorization_bytecodes_added, parent_state_bytecodes_added) =
+            collect_accessed_codes(&state, Vec::new(), empty(), |requested_hash| {
+                assert_eq!(*requested_hash, code_hash);
+                Ok(Some(raw.clone()))
+            })
+            .unwrap();
+
+        assert_eq!(codes, vec![raw.to_vec()]);
+        assert_eq!(authorization_bytecodes_added, 0);
+        assert_eq!(parent_state_bytecodes_added, 1);
+    }
+
+    /// Missing parent code is rejected while building the payload instead of
+    /// surfacing later as an opaque prover panic.
+    #[test]
+    fn rejects_unresolved_hash_only_account_code() {
+        let address = Address::repeat_byte(0x63);
+        let code_hash = B256::repeat_byte(0xa5);
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        state.cache.accounts.insert(
+            address,
+            CacheAccount::new_loaded(
+                AccountInfo {
+                    balance: U256::ZERO,
+                    nonce: 1,
+                    code_hash,
+                    code: None,
+                },
+                Default::default(),
+            ),
+        );
+
+        let error =
+            collect_accessed_codes(&state, Vec::new(), empty(), no_parent_bytecode).unwrap_err();
+
+        let message = error.to_string();
+        assert!(
+            message.contains(&address.to_string()),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains(&code_hash.to_string()),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("parent-state provider returned no bytes"),
+            "unexpected error: {message}"
+        );
     }
 }

--- a/crates/reth/node/src/payload_builder.rs
+++ b/crates/reth/node/src/payload_builder.rs
@@ -314,6 +314,11 @@ where
     // the payload build, so a block is never produced without its witness.
     let block_num = block.header().number;
     let block_rlp = alloy_rlp::encode(block.sealed_block().clone_block());
+    let authorization_targets = block
+        .body()
+        .transactions()
+        .flat_map(|tx| tx.authorization_list().into_iter().flatten())
+        .map(|authorization| *authorization.address());
     let record = build_block_witness_from_executed_state(
         &db,
         &state_provider,
@@ -321,6 +326,7 @@ where
         block_num,
         block_rlp,
         parent_header.header(),
+        authorization_targets,
     )
     .map_err(|e| PayloadBuilderError::other(io::Error::other(format!("witness capture: {e}"))))?;
     let block_witness = record.encode().map_err(|e| {

--- a/crates/reth/statediff/src/batch/account.rs
+++ b/crates/reth/statediff/src/batch/account.rs
@@ -17,7 +17,7 @@ use crate::{
 ///
 /// - `balance`: Counter (signed U256 delta, trimmed encoding)
 /// - `nonce`: Counter (signed delta, varint-encoded)
-/// - `code_hash`: Register (only changes on contract creation)
+/// - `code_hash`: Register (changes on creation or whenever account code changes)
 ///
 /// # Delta vs Full Value Replacement
 ///
@@ -43,7 +43,7 @@ pub struct AccountDiff {
     pub balance: DaCounter<CtrU256BySignedU256>,
     /// Nonce delta (signed, supports both increments and decrements).
     pub nonce: DaCounter<CtrU64BySignedVarInt>,
-    /// Code hash change (only on contract creation).
+    /// Code hash change, including explicit transitions to [`KECCAK_EMPTY`].
     pub code_hash: DaRegister<CodecB256>,
 }
 
@@ -123,11 +123,12 @@ impl AccountDiff {
         let nonce_delta = (current.nonce as i64) - (orig_nonce as i64);
         let nonce = nonce_delta_to_counter(nonce_delta);
 
-        let code_hash = match orig_code_hash {
-            Some(oc) if oc == current.code_hash => DaRegister::new_unset(),
-            _ if current.code_hash == KECCAK_EMPTY => DaRegister::new_unset(),
-            _ => DaRegister::new_set(CodecB256(current.code_hash)),
-        };
+        // A missing account starts with the canonical empty-code hash. An unset
+        // register means "do not write", so existing code must be explicitly
+        // overwritten when EIP-7702 clears a delegation designation.
+        let original_code_hash = CodecB256(orig_code_hash.unwrap_or(KECCAK_EMPTY));
+        let current_code_hash = CodecB256(current.code_hash);
+        let code_hash = DaRegister::compare(&original_code_hash, &current_code_hash);
 
         let diff = Self {
             balance,
@@ -376,5 +377,47 @@ mod tests {
         ContextlessDaWrite::apply(&decoded, &mut snapshot).unwrap();
         assert_eq!(snapshot.balance, U256::from(999_000));
         assert_eq!(snapshot.nonce, 6);
+    }
+
+    #[test]
+    fn test_account_diff_explicitly_clears_existing_code_hash() {
+        let original = AccountSnapshot {
+            balance: U256::from(1000),
+            nonce: 5,
+            code_hash: B256::from([0x11u8; 32]),
+        };
+        let current = AccountSnapshot {
+            code_hash: KECCAK_EMPTY,
+            ..original.clone()
+        };
+
+        let diff =
+            AccountDiff::from_account_snapshot(&current, Some(&original), Address::ZERO).unwrap();
+        assert_eq!(
+            diff.code_hash.new_value().map(|hash| hash.0),
+            Some(KECCAK_EMPTY)
+        );
+
+        let encoded = encode_to_vec(&diff).unwrap();
+        let decoded: AccountDiff = decode_buf_exact(&encoded).unwrap();
+        let mut reconstructed = original;
+        ContextlessDaWrite::apply(&decoded, &mut reconstructed).unwrap();
+        assert_eq!(reconstructed, current);
+    }
+
+    #[test]
+    fn test_account_diff_elides_default_code_hash_for_new_account() {
+        let current = AccountSnapshot {
+            balance: U256::from(1000),
+            nonce: 1,
+            code_hash: KECCAK_EMPTY,
+        };
+
+        let diff = AccountDiff::from_account_snapshot(&current, None, Address::ZERO).unwrap();
+        assert!(diff.code_hash.new_value().is_none());
+
+        let mut reconstructed = AccountSnapshot::default();
+        ContextlessDaWrite::apply(&diff, &mut reconstructed).unwrap();
+        assert_eq!(reconstructed, current);
     }
 }

--- a/crates/reth/statediff/src/reconstruct.rs
+++ b/crates/reth/statediff/src/reconstruct.rs
@@ -1047,6 +1047,32 @@ mod tests {
     }
 
     #[test]
+    fn test_reconstruct_code_clearing_matches_canonical_oracle() {
+        let address = addr(0x17);
+        let old_hash = hash(0x29);
+        let pre_state =
+            CanonicalState::new().with_account(address, state_account(500, 8, old_hash));
+        let expected_state =
+            CanonicalState::new().with_account(address, state_account(500, 8, KECCAK_EMPTY));
+
+        let mut block = block_diff();
+        account_change(
+            &mut block,
+            address,
+            Some(snapshot(500, 8, old_hash)),
+            Some(snapshot(500, 8, KECCAK_EMPTY)),
+        );
+
+        let diff = roundtrip_batch_diff(&[block]);
+        let mut reconstructor =
+            TestStateReconstructor::from_state_parts(&pre_state.accounts, &pre_state.storage)
+                .unwrap();
+        reconstructor.apply_diff(&diff).unwrap();
+
+        assert_reconstruction_matches(&reconstructor, &expected_state, &[], &[], &diff);
+    }
+
+    #[test]
     fn test_reconstruct_selfdestruct_recreate_matches_canonical_oracle() {
         let address = addr(0x16);
         let old_hash = hash(0x27);

--- a/crates/reth/witness/src/range_witness_extractor.rs
+++ b/crates/reth/witness/src/range_witness_extractor.rs
@@ -15,7 +15,7 @@ use alloy_consensus::Header;
 use alloy_primitives::{
     keccak256,
     map::{B256Set, DefaultHashBuilder, HashMap},
-    Address, B256, U256,
+    Address, B256, KECCAK256_EMPTY, U256,
 };
 use alpen_ee_common::AccessedStateStore;
 use eyre::{eyre, Result};
@@ -296,11 +296,37 @@ where
         // a different key if legacy-analysis padding was materialized as input.
         // In revm, "legacy" is the normal non-EIP-7702 contract bytecode path.
         // https://github.com/bluealloy/revm/blob/main/crates/bytecode/src/legacy/analysis.rs#L42-L47
-        let bytecodes = accessed
+        let mut bytecodes: BTreeMap<B256, Bytecode> = accessed
             .bytecodes
             .iter()
             .map(|(hash, bytecode)| (*hash, bytecode.clone()))
             .collect();
+
+        // Close the initial sparse state over bytecode. The transition proof
+        // includes every touched account as it existed before the range, so a
+        // non-empty code hash in one of those account leaves must be resolvable
+        // by WitnessDB even when no individual block record observed a by-hash
+        // code fetch. This occurs when a chunk boundary falls between EIP-7702
+        // setup and the transaction that consumes or replaces the delegation.
+        let pre_state_accounts = pre_proofs.iter().filter_map(|(address, proof)| {
+            proof
+                .info
+                .as_ref()
+                .and_then(|account| account.bytecode_hash)
+                .map(|code_hash| (*address, code_hash))
+        });
+        let added =
+            supplement_pre_state_bytecodes(&mut bytecodes, pre_state_accounts, |code_hash| {
+                Ok(pre_state
+                    .bytecode_by_hash(&code_hash)?
+                    .map(|bytecode| bytecode.0))
+            })?;
+        debug!(
+            pre_state_bytecodes_added = added,
+            total_bytecodes = bytecodes.len(),
+            "closed range witness over pre-state account bytecode"
+        );
+
         Ok((state, bytecodes))
     }
 
@@ -329,9 +355,121 @@ where
     }
 }
 
+/// Adds bytecode referenced by accessed accounts in the range's initial state.
+///
+/// Per-block access records are necessary but not sufficient for a multi-block
+/// witness: they describe execution-time fetches, while the sparse pre-state
+/// independently contains account leaves with code hashes. Including the code
+/// behind every non-empty pre-state hash makes that witness self-contained.
+fn supplement_pre_state_bytecodes(
+    bytecodes: &mut BTreeMap<B256, Bytecode>,
+    accounts: impl IntoIterator<Item = (Address, B256)>,
+    mut bytecode_by_hash: impl FnMut(B256) -> Result<Option<Bytecode>>,
+) -> Result<usize> {
+    let mut added = 0;
+
+    for (address, code_hash) in accounts {
+        if code_hash == KECCAK256_EMPTY {
+            continue;
+        }
+
+        if let Some(existing) = bytecodes.get(&code_hash) {
+            validate_bytecode_hash(existing, code_hash, address)?;
+            continue;
+        }
+
+        let bytecode = bytecode_by_hash(code_hash)?.ok_or_else(|| {
+            eyre!("pre-state bytecode {code_hash} for accessed account {address} was not found")
+        })?;
+        validate_bytecode_hash(&bytecode, code_hash, address)?;
+        bytecodes.insert(code_hash, bytecode);
+        added += 1;
+    }
+
+    Ok(added)
+}
+
+fn validate_bytecode_hash(bytecode: &Bytecode, expected: B256, address: Address) -> Result<()> {
+    let actual = keccak256(bytecode.original_bytes());
+    if actual != expected {
+        return Err(eyre!(
+            "pre-state bytecode hash mismatch for accessed account {address}: \
+             expected={expected}, actual={actual}"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Default)]
 struct AccumulatedState {
     accounts: HashMap<Address, HashSet<StorageKey>>,
     bytecodes: HashMap<B256, Bytecode>,
     block_idxs: HashSet<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::once;
+
+    use alloy_primitives::Bytes;
+
+    use super::*;
+
+    #[test]
+    fn supplements_delegation_code_referenced_only_by_pre_state_account() {
+        let account = Address::repeat_byte(0x42);
+        let bytecode = Bytecode::new_eip7702(Address::repeat_byte(0x24));
+        let code_hash = bytecode.hash_slow();
+        let mut bytecodes = BTreeMap::new();
+
+        let added = supplement_pre_state_bytecodes(
+            &mut bytecodes,
+            once((account, code_hash)),
+            |requested| {
+                assert_eq!(requested, code_hash);
+                Ok(Some(bytecode.clone()))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(added, 1);
+        assert_eq!(bytecodes.get(&code_hash), Some(&bytecode));
+    }
+
+    #[test]
+    fn does_not_refetch_bytecode_already_captured_by_block_record() {
+        let account = Address::repeat_byte(0x42);
+        let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x2a, 0x00]));
+        let code_hash = bytecode.hash_slow();
+        let mut bytecodes = BTreeMap::from([(code_hash, bytecode)]);
+
+        let added = supplement_pre_state_bytecodes(
+            &mut bytecodes,
+            once((account, code_hash)),
+            |_| -> Result<Option<Bytecode>> {
+                panic!("existing bytecode must not be fetched again")
+            },
+        )
+        .unwrap();
+
+        assert_eq!(added, 0);
+        assert_eq!(bytecodes.len(), 1);
+    }
+
+    #[test]
+    fn reports_missing_pre_state_bytecode_before_guest_execution() {
+        let account = Address::repeat_byte(0x42);
+        let code_hash = B256::repeat_byte(0x57);
+        let mut bytecodes = BTreeMap::new();
+
+        let err =
+            supplement_pre_state_bytecodes(&mut bytecodes, once((account, code_hash)), |_| {
+                Ok(None)
+            })
+            .unwrap_err();
+
+        assert!(err.to_string().contains("pre-state bytecode"));
+        assert!(err.to_string().contains(&code_hash.to_string()));
+        assert!(err.to_string().contains(&account.to_string()));
+    }
 }

--- a/crates/reth/witness/src/range_witness_extractor.rs
+++ b/crates/reth/witness/src/range_witness_extractor.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy_consensus::Header;
+use alloy_consensus::{Header, Transaction};
 use alloy_primitives::{
     keccak256,
     map::{B256Set, DefaultHashBuilder, HashMap},
@@ -230,6 +230,24 @@ where
             acc.block_idxs
                 .extend(record.ancestor_block_numbers.iter().copied());
 
+            // EIP-7702 delegation designations are synthesized from transaction
+            // inputs. A designation can be installed and replaced or cleared in
+            // the same block, so neither the parent state nor the final execution
+            // state is guaranteed to retain its bytecode. The guest still needs
+            // that transient code when replaying transactions in order.
+            let designation_targets = block
+                .body
+                .transactions()
+                .flat_map(|tx| tx.authorization_list().into_iter().flatten())
+                .map(|authorization| *authorization.address());
+            let added =
+                supplement_authorization_bytecodes(&mut acc.bytecodes, designation_targets)?;
+            debug!(
+                block_num = blk_num,
+                authorization_bytecodes_added = added,
+                "closed range witness over EIP-7702 transaction bytecode"
+            );
+
             blocks.push(block);
         }
 
@@ -355,6 +373,43 @@ where
     }
 }
 
+/// Adds every non-reset EIP-7702 delegation designation declared by transactions.
+///
+/// Authorization validity is deliberately not re-evaluated here. Including an
+/// invalid authorization's content-addressed designation is harmless, while
+/// trying to duplicate execution's chain-id, signature, nonce, and account-code
+/// checks would create a second consensus implementation in the witness builder.
+fn supplement_authorization_bytecodes(
+    bytecodes: &mut HashMap<B256, Bytecode>,
+    targets: impl IntoIterator<Item = Address>,
+) -> Result<usize> {
+    let mut added = 0;
+
+    for target in targets {
+        // A zero target clears delegation code and does not install a
+        // designation (EIP-7702 step 8 special case).
+        if target.is_zero() {
+            continue;
+        }
+
+        let bytecode = Bytecode::new_eip7702(target);
+        let code_hash = bytecode.hash_slow();
+        if let Some(existing) = bytecodes.get(&code_hash) {
+            if existing.original_bytes() != bytecode.original_bytes() {
+                return Err(eyre!(
+                    "conflicting EIP-7702 designation bytecode for hash {code_hash}: target={target}"
+                ));
+            }
+            continue;
+        }
+
+        bytecodes.insert(code_hash, bytecode);
+        added += 1;
+    }
+
+    Ok(added)
+}
+
 /// Adds bytecode referenced by accessed accounts in the range's initial state.
 ///
 /// Per-block access records are necessary but not sufficient for a multi-block
@@ -409,11 +464,53 @@ struct AccumulatedState {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::once;
+    use std::iter::{empty, once};
 
     use alloy_primitives::Bytes;
 
     use super::*;
+
+    #[test]
+    fn supplements_transient_eip7702_authorization_bytecode() {
+        let target = Address::repeat_byte(0x24);
+        let expected = Bytecode::new_eip7702(target);
+        let code_hash = expected.hash_slow();
+        let mut bytecodes = HashMap::default();
+
+        let added =
+            supplement_authorization_bytecodes(&mut bytecodes, [target, Address::ZERO, target])
+                .unwrap();
+
+        assert_eq!(added, 1);
+        assert_eq!(bytecodes.len(), 1);
+        assert_eq!(bytecodes.get(&code_hash), Some(&expected));
+    }
+
+    #[test]
+    fn rejects_conflicting_authorization_bytecode() {
+        let target = Address::repeat_byte(0x24);
+        let code_hash = Bytecode::new_eip7702(target).hash_slow();
+        let mut bytecodes = HashMap::from_iter([(
+            code_hash,
+            Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00])),
+        )]);
+
+        let err = supplement_authorization_bytecodes(&mut bytecodes, once(target)).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("conflicting EIP-7702 designation bytecode"));
+    }
+
+    #[test]
+    fn empty_authorization_targets_do_not_change_bytecodes() {
+        let mut bytecodes = HashMap::default();
+
+        let added = supplement_authorization_bytecodes(&mut bytecodes, empty()).unwrap();
+
+        assert_eq!(added, 0);
+        assert!(bytecodes.is_empty());
+    }
 
     #[test]
     fn supplements_delegation_code_referenced_only_by_pre_state_account() {


### PR DESCRIPTION
## What changed

- Carry bytecode created during EVM execution through `EvmWriteBatch` and `EvmPartialState`, so later blocks in the same EE proof chunk can execute it.
- Include cached, transient, and parent-state bytecode in range and inline witnesses; verify code hashes and fail payload construction explicitly when required code cannot be resolved.
- Encode EIP-7702 delegation-code clearing in the EE DA state diff so reconstruction matches the execution state root.
- Add regression coverage for deployed code across blocks, hash-only prestate accounts, transient EIP-7702 code, and delegation clearing.

## Root cause

Arbitrary EEST workloads exposed three related state-closure gaps:

1. `BundleState::contracts` was discarded between blocks in an EE proof chunk.
2. Range and inline witnesses could retain an account code hash without the corresponding bytecode when that code lived in execution caches, transient state, or the parent provider.
3. Clearing EIP-7702 delegation code was not represented in the DA account update, so reconstructed state could diverge from the execution root.

These gaps produced missing-bytecode proof failures at chunk boundaries and `PostApplyStateRootMismatch` failures even when the individual EEST transaction had executed successfully.

## Validation

- Broad proof-enabled Prague state-test run: https://github.com/alpenlabs/e2e-runner/actions/runs/31638858529
  - Configuration contract passed before build; exact Alpen commit `28ea0ed90af1e57afb37b2abe9925342c04e0c8f` and EEST commit `af77c56ab299fdecfd6d80d11492aaa4472fc03a`
  - 4,678/4,678 selected cases executed: 3,344 passed, 1,334 skipped, 0 failed, 0 errors
  - 13,852 observed EE transaction hashes across blocks 1–2,539
  - EE chunk proofs covered the complete emitted block range, 1–2,539
  - 1,018 prover tasks observed: 1,016 completed, 2 dependency-waiting at shutdown, 0 pending/proving/transient/permanent failures
- Focused proof-enabled Prague route: https://github.com/alpenlabs/e2e-runner/actions/runs/31636733279
  - 551/551 selected cases executed: 499 passed, 52 skipped, 0 failed, 0 errors
  - EE chunk proofs covered blocks 1–413
- Human report: https://legendary-meme-p34qz8k.pages.github.io/reports/31638858529/
- Machine report: https://legendary-meme-p34qz8k.pages.github.io/reports/31638858529/report.json
- `cargo test -p alpen-reth-node --locked` — 19 passed
- `cargo test -p alpen-reth-witness --locked` — 6 passed
- `cargo test -p strata-evm-ee --locked` — 25 passed
- `cargo clippy -p alpen-reth-node --all-targets --all-features --locked -- -D warnings`
- All Alpen PR checks passed, including workspace lint, unit/doc tests, independent-crate checks, prover guest checks, and functional tests.
