### PR TITLE
chore(deps): bump `strata-common` to `v0.4.0-rc.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8243,7 +8243,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "serde",
  "ssz",
@@ -8254,7 +8254,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-bridge-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -8273,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "borsh",
  "proptest",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -8318,12 +8318,12 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "strata-asm-checkpoint-types",
  "strata-asm-common",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2)",
  "strata-identifiers",
  "strata-msg-fmt",
  "strata-predicate",
@@ -8332,7 +8332,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -8354,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "serde",
  "strata-asm-admin-types",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -8390,7 +8390,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-admin-txs",
@@ -8399,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "strata-asm-bridge-types",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -8452,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-state"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -8473,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -8486,14 +8486,14 @@ dependencies = [
  "strata-codec",
  "strata-crypto",
  "strata-l1-txfmt",
- "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1)",
+ "strata-test-utils-btcio 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "strata-asm-checkpoint-types",
  "strata-asm-common",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -8523,13 +8523,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "strata-asm-checkpoint-types",
  "strata-asm-common",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2)",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
  "thiserror 2.0.18",
@@ -8538,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-txs-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "rand 0.8.5",
@@ -8550,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -8562,7 +8562,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-state"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "serde",
  "ssz",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -8761,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin-bosd",
  "ssz",
@@ -8789,7 +8789,7 @@ version = "0.3.0-alpha.1"
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -8816,7 +8816,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "borsh",
  "ssz",
@@ -8900,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "strata-db-macros"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9155,7 +9155,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -9189,7 +9189,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -9198,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -9223,11 +9223,12 @@ dependencies = [
 [[package]]
 name = "strata-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "serde",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -9237,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -9257,7 +9258,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle-node-store"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "strata-merkle",
  "thiserror 2.0.18",
@@ -9266,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "strata-metrics"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "metrics",
  "metrics-exporter-otel",
@@ -9284,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -9461,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "strata-ol-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -9746,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "hex",
@@ -9868,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "strata-service"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "anyhow",
  "futures",
@@ -10038,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "strata-tasks"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -10096,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-arb"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",
@@ -10105,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "strata-identifiers",
@@ -10128,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-btcio"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -10142,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-checkpoint"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "borsh",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,54 +148,54 @@ strata-test-utils-ssz = { path = "crates/test-utils/ssz" }
 strata-zkvm-hosts = { path = "crates/zkvm/hosts" }
 
 # strata-common
-strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
+strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
 strata-codec = { git = "https://github.com/alpenlabs/strata-common", features = [
   "derive",
-], tag = "v0.3.0" }
-strata-codec-tests = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-db-macros = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
+], tag = "v0.4.0-rc.2" }
+strata-codec-tests = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-db-macros = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "legacy_compact",
-], tag = "v0.3.0" }
-strata-merkle-node-store = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-msg-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-ol-logs = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
+], tag = "v0.4.0-rc.2" }
+strata-merkle-node-store = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-msg-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-ol-logs = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
 strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [
   "serde",
-], tag = "v0.3.0" }
-strata-service = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
-strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0" }
+], tag = "v0.4.0-rc.2" }
+strata-service = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
+strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.4.0-rc.2" }
 
 # asm
-strata-asm-admin-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-bridge-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-logs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-manifest-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-admin = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-admin-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-bridge = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-bridge-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-bridge-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-checkpoint-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-proto-txs-test-utils = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-stf = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-btc-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-checkpoint-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-test-utils-btc = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
-strata-test-utils-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.1" }
+strata-asm-admin-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-bridge-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-logs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-manifest-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-admin = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-admin-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-bridge = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-bridge-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-bridge-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-checkpoint-msgs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-proto-txs-test-utils = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-stf = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-btc-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-checkpoint-verification = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-test-utils-btc = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
+strata-test-utils-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.4.0-rc.2" }
 
 # sled wrapper
 typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }

--- a/bin/datatool/src/cmd/asm_params.rs
+++ b/bin/datatool/src/cmd/asm_params.rs
@@ -167,11 +167,13 @@ pub(super) fn exec(cmd: SubcAsmParams, ctx: &mut CmdContext) -> anyhow::Result<(
 
     let bridge = BridgeInitConfig {
         operators,
-        denomination: BitcoinAmount::from_sat(deposit_sats),
+        denomination: BitcoinAmount::try_from(deposit_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         assignment_duration: cmd
             .assignment_duration
             .unwrap_or(DEFAULT_ASSIGNMENT_DURATION),
-        operator_fee: BitcoinAmount::from_sat(cmd.operator_fee.unwrap_or(DEFAULT_OPERATOR_FEE)),
+        operator_fee: BitcoinAmount::try_from(cmd.operator_fee.unwrap_or(DEFAULT_OPERATOR_FEE))
+            .expect("amount must not exceed the Bitcoin money supply"),
         recovery_delay: cmd.recovery_delay.unwrap_or(DEFAULT_RECOVERY_DELAY),
         safe_harbour_address,
     };
@@ -369,10 +371,10 @@ fn resolve_sequencer_predicate(seq_pk: Option<&str>) -> anyhow::Result<Predicate
     };
 
     let xonly = XOnlyPublicKey::from_str(pk_hex)?;
-    Ok(PredicateKey::new(
+    Ok(PredicateKey::try_new(
         PredicateTypeId::Bip340Schnorr,
         xonly.serialize().to_vec(),
-    ))
+    )?)
 }
 
 fn resolve_safe_harbour_address(descriptor: &str) -> anyhow::Result<SafeHarbourAddress> {

--- a/bin/datatool/src/cmd/ol_params.rs
+++ b/bin/datatool/src/cmd/ol_params.rs
@@ -86,7 +86,8 @@ mod tests {
         let account = accounts.values().next().unwrap();
         assert_eq!(
             account.predicate,
-            PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![0xde, 0xad, 0xbe, 0xef])
+            PredicateKey::try_new(PredicateTypeId::Sp1Groth16, vec![0xde, 0xad, 0xbe, 0xef])
+                .expect("predicate condition must fit within the maximum length")
         );
         assert_eq!(account.inner_state, INNER_STATE.parse().unwrap());
         assert_eq!(account.balance.to_sat(), 7);

--- a/bin/strata-dbtool/src/cmd/mmr.rs
+++ b/bin/strata-dbtool/src/cmd/mmr.rs
@@ -1215,8 +1215,11 @@ mod tests {
         let mmr_id = MmrId::SnarkMsgInbox(account_id);
         let raw_mmr_id = mmr_id.to_bytes();
         let leaf_pos = LeafPos::new(0);
-        let payload =
-            MsgPayload::from_bytes(BitcoinAmount::from_sat(42), vec![0xaa, 0xbb]).expect("payload");
+        let payload = MsgPayload::from_bytes(
+            BitcoinAmount::try_from(42).expect("amount must not exceed the Bitcoin money supply"),
+            vec![0xaa, 0xbb],
+        )
+        .expect("payload");
         let message = MessageEntry::new(source, 12, payload);
         let leaf_hash = message.compute_msg_commitment();
         let preimage = message.as_ssz_bytes();

--- a/bin/strata-signer/src/main.rs
+++ b/bin/strata-signer/src/main.rs
@@ -26,7 +26,7 @@ use strata_common::{
     ws_client::{ManagedWsClient, WsClientConfig},
 };
 use strata_logging::{
-    format_service_name, init_logging_from_config_with_layers, LoggingInitConfig,
+    format_service_name, init_logging_from_config_with_layers, LoggingInitConfigRef,
 };
 use strata_metrics::{MetricsConfig, MetricsInitConfig, MetricsLayer};
 use strata_signer::SignerBuilder;
@@ -77,7 +77,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     init_logging_from_config_with_layers(
-        LoggingInitConfig {
+        LoggingInitConfigRef {
             service_base_name: "strata-signer",
             service_label: config.logging.service_label.as_deref(),
             otlp_url: config.logging.otlp_url.as_deref(),

--- a/bin/strata-test-cli/src/mock_ee/withdrawal.rs
+++ b/bin/strata-test-cli/src/mock_ee/withdrawal.rs
@@ -44,8 +44,11 @@ pub(crate) fn build_snark_withdrawal_json(
     let owned_msg =
         OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).context("failed to create OwnedMsg")?;
 
-    let msg_payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(amount), owned_msg.to_vec())
-        .expect("withdrawal message payload bytes must fit within SSZ max length");
+    let msg_payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(amount).expect("amount must not exceed the Bitcoin money supply"),
+        owned_msg.to_vec(),
+    )
+    .expect("withdrawal message payload bytes must fit within SSZ max length");
 
     let output_message = OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, msg_payload);
     let outputs = UpdateOutputs::new_empty().with_messages(vec![output_message]);
@@ -215,7 +218,8 @@ mod tests {
         assert_eq!(output_msg.dest(), BRIDGE_GATEWAY_ACCT_ID);
         assert_eq!(
             output_msg.payload().value(),
-            BitcoinAmount::from_sat(100_000_000)
+            BitcoinAmount::try_from(100_000_000)
+                .expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
@@ -317,9 +321,12 @@ mod tests {
                 .unwrap();
         let encoded_body = strata_codec::encode_to_vec(&withdrawal_msg_data).unwrap();
         let owned_msg = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).unwrap();
-        let msg_payload =
-            MsgPayload::from_bytes(BitcoinAmount::from_sat(100_000_000), owned_msg.to_vec())
-                .expect("withdrawal message payload bytes must fit within SSZ max length");
+        let msg_payload = MsgPayload::from_bytes(
+            BitcoinAmount::try_from(100_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+            owned_msg.to_vec(),
+        )
+        .expect("withdrawal message payload bytes must fit within SSZ max length");
         let output_message = OutputMessage::new(BRIDGE_GATEWAY_ACCT_ID, msg_payload);
         let outputs = UpdateOutputs::new_empty().with_messages(vec![output_message]);
         let claim_ssz = sign_claim_ssz(Seqno::new(seq_no), &proof_state, &proof_state, &outputs);

--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -842,7 +842,8 @@ mod tests {
         };
 
         let configured = NativeCheckpointPredicateKey.predicate_key().unwrap();
-        let expected = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0u8; 32]);
+        let expected = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0u8; 32])
+            .expect("predicate condition must fit within the maximum length");
 
         let err = validate_expected_predicate_key(&configured, &expected).unwrap_err();
 

--- a/bin/strata/src/main.rs
+++ b/bin/strata/src/main.rs
@@ -10,7 +10,7 @@ use argh::from_env;
 use strata_common::healthz::{HealthCheckState, start_health_check_server};
 use strata_db_types as _;
 use strata_logging::{
-    LoggingInitConfig, format_service_name, init_logging_from_config_with_layers,
+    LoggingInitConfigRef, format_service_name, init_logging_from_config_with_layers,
 };
 use strata_metrics::{MetricsConfig, MetricsInitConfig, MetricsLayer};
 #[cfg(test)]
@@ -160,7 +160,7 @@ fn init_logging(rt: &Handle, config: &strata_config::Config) -> Result<()> {
     }
 
     init_logging_from_config_with_layers(
-        LoggingInitConfig {
+        LoggingInitConfigRef {
             service_base_name: "strata-client",
             service_label: config.logging.service_label.as_deref(),
             otlp_url: config.logging.otlp_url.as_deref(),

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -638,7 +638,7 @@ fn ol_state_with_snark_account_and_inbox_entries(
     let mut state = MemoryStateBaseLayer::new(base);
     state.set_cur_slot(slot);
     let new_acct = NewAccountData::new(
-        BitcoinAmount::from(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         NewAccountTypeState::Snark {
             update_vk: PredicateKey::always_accept(),
             initial_state_root: Hash::zero(),
@@ -661,7 +661,10 @@ fn ol_state_with_empty_account(account_id: AccountId, slot: Slot) -> OLState {
     let base = genesis_ol_state();
     let mut state = MemoryStateBaseLayer::new(base);
     state.set_cur_slot(slot);
-    let new_acct = NewAccountData::new(BitcoinAmount::from(0), NewAccountTypeState::Empty);
+    let new_acct = NewAccountData::new(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        NewAccountTypeState::Empty,
+    );
     state.create_new_account(account_id, new_acct).unwrap();
     state.into_inner()
 }
@@ -669,7 +672,8 @@ fn ol_state_with_empty_account(account_id: AccountId, slot: Slot) -> OLState {
 fn empty_account_state(serial: u32, balance_sats: u64) -> OLAccountState {
     OLAccountState::new(
         AccountSerial::from(serial),
-        BitcoinAmount::from_sat(balance_sats),
+        BitcoinAmount::try_from(balance_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         OLAccountTypeState::Empty,
     )
 }
@@ -713,8 +717,12 @@ fn make_message_entry(
     payload_value_sat: u64,
     payload_buf: Vec<u8>,
 ) -> MessageEntry {
-    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(payload_value_sat), payload_buf)
-        .expect("message payload bytes must fit within SSZ max length");
+    let payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(payload_value_sat)
+            .expect("amount must not exceed the Bitcoin money supply"),
+        payload_buf,
+    )
+    .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(source, incl_epoch, payload)
 }
 
@@ -1937,7 +1945,10 @@ async fn blocks_summaries_snark_vs_non_snark() {
 
     let snark_state = ol_state_with_snark_account(snark_id, 0, 42, DEFAULT_NEXT_INBOX_MSG_IDX);
     let mut state = MemoryStateBaseLayer::new(snark_state);
-    let empty_acct = NewAccountData::new(BitcoinAmount::from(0), NewAccountTypeState::Empty);
+    let empty_acct = NewAccountData::new(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        NewAccountTypeState::Empty,
+    );
     state.create_new_account(empty_id, empty_acct).unwrap();
     let state = state.into_inner();
 

--- a/bin/strata/src/rpc/provider.rs
+++ b/bin/strata/src/rpc/provider.rs
@@ -236,14 +236,22 @@ mod tests {
             MessageEntry::new(
                 test_account_id(2),
                 3,
-                MsgPayload::from_bytes(BitcoinAmount::from_sat(10), vec![0xaa])
-                    .expect("message payload bytes must fit within SSZ max length"),
+                MsgPayload::from_bytes(
+                    BitcoinAmount::try_from(10)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    vec![0xaa],
+                )
+                .expect("message payload bytes must fit within SSZ max length"),
             ),
             MessageEntry::new(
                 test_account_id(3),
                 3,
-                MsgPayload::from_bytes(BitcoinAmount::from_sat(20), vec![0xbb, 0xcc])
-                    .expect("message payload bytes must fit within SSZ max length"),
+                MsgPayload::from_bytes(
+                    BitcoinAmount::try_from(20)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    vec![0xbb, 0xcc],
+                )
+                .expect("message payload bytes must fit within SSZ max length"),
             ),
         ];
         let preimages = messages.iter().map(Encode::as_ssz_bytes).collect();

--- a/crates/acct-types/src/effects.rs
+++ b/crates/acct-types/src/effects.rs
@@ -27,7 +27,10 @@ impl TxEffects {
     /// Constructs a [`SentTransfer`] internally and appends it.  Returns false
     /// if the transfer list is full.
     pub fn push_transfer(&mut self, dest: AccountId, sats: u64) -> bool {
-        self.add_transfer(SentTransfer::new(dest, BitcoinAmount::from_sat(sats)))
+        self.add_transfer(SentTransfer::new(
+            dest,
+            BitcoinAmount::try_from(sats).expect("amount must not exceed the Bitcoin money supply"),
+        ))
     }
 
     /// Returns an iterator over the transfers.
@@ -65,7 +68,10 @@ impl TxEffects {
         sats: u64,
         data: Vec<u8>,
     ) -> Result<bool, MsgPayloadError> {
-        let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(sats), data)?;
+        let payload = MsgPayload::from_bytes(
+            BitcoinAmount::try_from(sats).expect("amount must not exceed the Bitcoin money supply"),
+            data,
+        )?;
         Ok(self.add_message(SentMessage::new(dest, payload)))
     }
 
@@ -84,6 +90,7 @@ impl TxEffects {
         self.transfers_iter()
             .map(|t| t.value())
             .chain(self.messages_iter().map(|m| m.payload().value()))
-            .try_fold(BitcoinAmount::zero(), |acc, e| acc.checked_add(e))
+            .try_fold(0u64, |acc, amount| acc.checked_add(amount.to_sat()))
+            .and_then(|sats| BitcoinAmount::try_from(sats).ok())
     }
 }

--- a/crates/acct-types/src/effects.rs
+++ b/crates/acct-types/src/effects.rs
@@ -25,12 +25,12 @@ impl TxEffects {
     /// Adds a transfer to the given destination with the specified satoshi amount.
     ///
     /// Constructs a [`SentTransfer`] internally and appends it.  Returns false
-    /// if the transfer list is full.
-    pub fn push_transfer(&mut self, dest: AccountId, sats: u64) -> bool {
-        self.add_transfer(SentTransfer::new(
-            dest,
-            BitcoinAmount::try_from(sats).expect("amount must not exceed the Bitcoin money supply"),
-        ))
+    /// if the transfer list is full, and errors if `sats` exceeds the Bitcoin
+    /// money supply.
+    pub fn push_transfer(&mut self, dest: AccountId, sats: u64) -> Result<bool, MsgPayloadError> {
+        let value =
+            BitcoinAmount::try_from(sats).map_err(|_| MsgPayloadError::ValueTooLarge { sats })?;
+        Ok(self.add_transfer(SentTransfer::new(dest, value)))
     }
 
     /// Returns an iterator over the transfers.
@@ -61,17 +61,18 @@ impl TxEffects {
     /// Adds a message to the given destination with the specified value and data.
     ///
     /// Constructs a [`SentMessage`] (with [`MsgPayload`]) internally and appends
-    /// it.  Returns false if the message list is full.
+    /// it.  Returns false if the message list is full, and errors if `sats`
+    /// exceeds the Bitcoin money supply or the data exceeds the SSZ maximum
+    /// length.
     pub fn push_message(
         &mut self,
         dest: AccountId,
         sats: u64,
         data: Vec<u8>,
     ) -> Result<bool, MsgPayloadError> {
-        let payload = MsgPayload::from_bytes(
-            BitcoinAmount::try_from(sats).expect("amount must not exceed the Bitcoin money supply"),
-            data,
-        )?;
+        let value =
+            BitcoinAmount::try_from(sats).map_err(|_| MsgPayloadError::ValueTooLarge { sats })?;
+        let payload = MsgPayload::from_bytes(value, data)?;
         Ok(self.add_message(SentMessage::new(dest, payload)))
     }
 
@@ -92,5 +93,54 @@ impl TxEffects {
             .chain(self.messages_iter().map(|m| m.payload().value()))
             .try_fold(0u64, |acc, amount| acc.checked_add(amount.to_sat()))
             .and_then(|sats| BitcoinAmount::try_from(sats).ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
+    fn test_account_id() -> AccountId {
+        AccountId::from([1u8; 32])
+    }
+
+    #[test]
+    fn push_transfer_accepts_max_money() {
+        let mut effects = TxEffects::default();
+
+        assert!(
+            effects
+                .push_transfer(test_account_id(), MAX_BITCOIN_MONEY_SATS)
+                .expect("max-money transfer amount must succeed")
+        );
+        assert_eq!(effects.transfers_iter().count(), 1);
+    }
+
+    #[test]
+    fn push_transfer_rejects_oversized_amount() {
+        let mut effects = TxEffects::default();
+        let sats = MAX_BITCOIN_MONEY_SATS + 1;
+
+        let err = effects
+            .push_transfer(test_account_id(), sats)
+            .expect_err("oversized transfer amount must fail");
+
+        assert_eq!(err, MsgPayloadError::ValueTooLarge { sats });
+        assert_eq!(effects.transfers_iter().count(), 0);
+    }
+
+    #[test]
+    fn push_message_rejects_oversized_value() {
+        let mut effects = TxEffects::default();
+        let sats = MAX_BITCOIN_MONEY_SATS + 1;
+
+        let err = effects
+            .push_message(test_account_id(), sats, vec![])
+            .expect_err("oversized message value must fail");
+
+        assert_eq!(err, MsgPayloadError::ValueTooLarge { sats });
+        assert_eq!(effects.messages_iter().count(), 0);
     }
 }

--- a/crates/acct-types/src/messages.rs
+++ b/crates/acct-types/src/messages.rs
@@ -15,12 +15,16 @@ use crate::{
 /// SSZ-bounded message payload data.
 pub type MsgPayloadData = VariableList<u8, { MAX_MSG_PAYLOAD_DATA_BYTES as usize }>;
 
-/// Error constructing a [`MsgPayload`] from raw bytes.
+/// Error constructing a [`MsgPayload`] or effect value from raw inputs.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum MsgPayloadError {
     /// Raw message data exceeds the SSZ maximum length.
     #[error("message payload data too large (len {len} > max {max})")]
     DataTooLarge { len: usize, max: usize },
+
+    /// Raw satoshi value exceeds the Bitcoin money supply.
+    #[error("value exceeds the Bitcoin money supply ({sats} sats)")]
+    ValueTooLarge { sats: u64 },
 }
 
 impl SentMessage {

--- a/crates/acct-types/src/messages.rs
+++ b/crates/acct-types/src/messages.rs
@@ -36,7 +36,7 @@ impl SentMessage {
 
     /// Creates a new instance with empty data and 0 value.
     pub fn new_empty(dest: AccountId) -> Self {
-        Self::new_dataless(dest, BitcoinAmount::zero())
+        Self::new_dataless(dest, BitcoinAmount::default())
     }
 
     /// Returns the destination account ID.
@@ -60,7 +60,7 @@ impl SentTransfer {
     ///
     /// This shouldn't normally happen but it's a convenience.
     pub fn zero(dest: AccountId) -> Self {
-        Self::new(dest, BitcoinAmount::zero())
+        Self::new(dest, BitcoinAmount::default())
     }
 
     /// Returns the destination account ID.
@@ -87,7 +87,7 @@ impl ReceivedMessage {
 
     /// Creates a new instance with empty data and 0 value.
     pub fn new_empty(dest: AccountId) -> Self {
-        Self::new_dataless(dest, BitcoinAmount::zero())
+        Self::new_dataless(dest, BitcoinAmount::default())
     }
 
     /// Returns the source account ID.
@@ -127,17 +127,17 @@ impl MsgPayload {
 
     /// Creates a new instance with some data and 0 value.
     pub fn new_valueless(data: MsgPayloadData) -> Self {
-        Self::new(BitcoinAmount::zero(), data)
+        Self::new(BitcoinAmount::default(), data)
     }
 
     /// Creates a new instance from raw data and 0 value.
     pub fn from_bytes_valueless(data: Vec<u8>) -> Result<Self, MsgPayloadError> {
-        Self::from_bytes(BitcoinAmount::zero(), data)
+        Self::from_bytes(BitcoinAmount::default(), data)
     }
 
     /// Creates a new instance with empty data and 0 value.
     pub fn new_empty() -> Self {
-        Self::new_dataless(BitcoinAmount::zero())
+        Self::new_dataless(BitcoinAmount::default())
     }
 
     pub fn value(&self) -> BitcoinAmount {
@@ -237,25 +237,36 @@ mod tests {
 
     use super::*;
 
+    const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
     mod msg_payload {
         use super::*;
 
         ssz_proptest!(
             MsgPayload,
-            (any::<u64>(), prop::collection::vec(any::<u8>(), 0..100)).prop_map(|(sats, data)| {
-                MsgPayload {
-                    value: BitcoinAmount::from_sat(sats),
-                    data: data
-                        .try_into()
-                        .expect("message payload bytes must fit within SSZ max length"),
-                }
-            })
+            (
+                0..=MAX_BITCOIN_MONEY_SATS,
+                prop::collection::vec(any::<u8>(), 0..100)
+            )
+                .prop_map(|(sats, data)| {
+                    MsgPayload {
+                        value: BitcoinAmount::try_from(sats)
+                            .expect("amount must not exceed the Bitcoin money supply"),
+                        data: data
+                            .try_into()
+                            .expect("message payload bytes must fit within SSZ max length"),
+                    }
+                })
         );
 
         #[test]
         fn test_zero_ssz() {
-            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![])
-                .expect("message payload bytes must fit within SSZ max length");
+            let payload = MsgPayload::from_bytes(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                vec![],
+            )
+            .expect("message payload bytes must fit within SSZ max length");
             let encoded = payload.as_ssz_bytes();
             let decoded = MsgPayload::from_ssz_bytes(&encoded).unwrap();
             assert_eq!(payload.value(), decoded.value());
@@ -265,8 +276,12 @@ mod tests {
         #[test]
         fn accepts_max_size_payload() {
             let data = vec![0u8; MAX_MSG_PAYLOAD_DATA_BYTES as usize];
-            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), data)
-                .expect("max size message payload bytes must fit within SSZ max length");
+            let payload = MsgPayload::from_bytes(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                data,
+            )
+            .expect("max size message payload bytes must fit within SSZ max length");
 
             assert_eq!(payload.data().len(), MAX_MSG_PAYLOAD_DATA_BYTES as usize);
         }
@@ -274,8 +289,12 @@ mod tests {
         #[test]
         fn rejects_oversized_payload() {
             let max = MAX_MSG_PAYLOAD_DATA_BYTES as usize;
-            let err = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![0u8; max + 1])
-                .expect_err("oversized message payload bytes must fail");
+            let err = MsgPayload::from_bytes(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                vec![0u8; max + 1],
+            )
+            .expect_err("oversized message payload bytes must fail");
 
             assert_eq!(err, MsgPayloadError::DataTooLarge { len: max + 1, max });
         }
@@ -283,9 +302,17 @@ mod tests {
         #[test]
         fn new_accepts_prebuilt_payload_data() {
             let data = MsgPayloadData::default();
-            let payload = MsgPayload::new(BitcoinAmount::from_sat(42), data);
+            let payload = MsgPayload::new(
+                BitcoinAmount::try_from(42)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                data,
+            );
 
-            assert_eq!(payload.value(), BitcoinAmount::from_sat(42));
+            assert_eq!(
+                payload.value(),
+                BitcoinAmount::try_from(42)
+                    .expect("amount must not exceed the Bitcoin money supply")
+            );
             assert!(payload.data().is_empty());
         }
     }
@@ -297,14 +324,15 @@ mod tests {
             SentMessage,
             (
                 any::<[u8; 32]>(),
-                any::<u64>(),
+                0..=MAX_BITCOIN_MONEY_SATS,
                 prop::collection::vec(any::<u8>(), 0..100)
             )
                 .prop_map(|(id, sats, data)| {
                     SentMessage {
                         dest: AccountId::new(id),
                         payload: MsgPayload {
-                            value: BitcoinAmount::from_sat(sats),
+                            value: BitcoinAmount::try_from(sats)
+                                .expect("amount must not exceed the Bitcoin money supply"),
                             data: data
                                 .try_into()
                                 .expect("message payload bytes must fit within SSZ max length"),
@@ -317,8 +345,12 @@ mod tests {
         fn test_zero_ssz() {
             let msg = SentMessage::new(
                 AccountId::new([0u8; 32]),
-                MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![])
-                    .expect("message payload bytes must fit within SSZ max length"),
+                MsgPayload::from_bytes(
+                    BitcoinAmount::try_from(0)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    vec![],
+                )
+                .expect("message payload bytes must fit within SSZ max length"),
             );
             let encoded = msg.as_ssz_bytes();
             let decoded = SentMessage::from_ssz_bytes(&encoded).unwrap();
@@ -333,14 +365,15 @@ mod tests {
             ReceivedMessage,
             (
                 any::<[u8; 32]>(),
-                any::<u64>(),
+                0..=MAX_BITCOIN_MONEY_SATS,
                 prop::collection::vec(any::<u8>(), 0..100)
             )
                 .prop_map(|(id, sats, data)| {
                     ReceivedMessage {
                         source: AccountId::new(id),
                         payload: MsgPayload {
-                            value: BitcoinAmount::from_sat(sats),
+                            value: BitcoinAmount::try_from(sats)
+                                .expect("amount must not exceed the Bitcoin money supply"),
                             data: data
                                 .try_into()
                                 .expect("message payload bytes must fit within SSZ max length"),
@@ -353,8 +386,12 @@ mod tests {
         fn test_zero_ssz() {
             let msg = ReceivedMessage::new(
                 AccountId::new([0u8; 32]),
-                MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![])
-                    .expect("message payload bytes must fit within SSZ max length"),
+                MsgPayload::from_bytes(
+                    BitcoinAmount::try_from(0)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    vec![],
+                )
+                .expect("message payload bytes must fit within SSZ max length"),
             );
             let encoded = msg.as_ssz_bytes();
             let decoded = ReceivedMessage::from_ssz_bytes(&encoded).unwrap();

--- a/crates/acct-types/src/state.rs
+++ b/crates/acct-types/src/state.rs
@@ -70,7 +70,7 @@ impl AccountIntrinsicState {
 
     /// Creates a new empty account with no balance.
     pub fn new_empty(serial: AccountSerial) -> Self {
-        Self::new(AccountTypeId::Empty, serial, 0.into())
+        Self::new(AccountTypeId::Empty, serial, BitcoinAmount::default())
     }
 
     pub fn raw_ty(&self) -> RawAccountTypeId {
@@ -115,18 +115,23 @@ mod tests {
 
     use super::*;
 
+    const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
     mod account_intrinsic_state {
         use super::*;
 
         ssz_proptest!(
             AccountIntrinsicState,
-            (any::<u16>(), any::<u32>(), any::<u64>()).prop_map(|(raw_ty, serial, sats)| {
-                AccountIntrinsicState {
-                    raw_ty,
-                    serial: AccountSerial::new(serial),
-                    balance: BitcoinAmount::from_sat(sats),
+            (any::<u16>(), any::<u32>(), 0..=MAX_BITCOIN_MONEY_SATS).prop_map(
+                |(raw_ty, serial, sats)| {
+                    AccountIntrinsicState {
+                        raw_ty,
+                        serial: AccountSerial::new(serial),
+                        balance: BitcoinAmount::try_from(sats)
+                            .expect("amount must not exceed the Bitcoin money supply"),
+                    }
                 }
-            })
+            )
         );
 
         #[test]
@@ -148,7 +153,7 @@ mod tests {
             (
                 any::<u16>(),
                 any::<u32>(),
-                any::<u64>(),
+                0..=MAX_BITCOIN_MONEY_SATS,
                 prop::collection::vec(any::<u8>(), 0..100)
             )
                 .prop_map(|(raw_ty, serial, sats, encoded)| {
@@ -156,7 +161,8 @@ mod tests {
                         intrinsics: AccountIntrinsicState {
                             raw_ty,
                             serial: AccountSerial::new(serial),
-                            balance: BitcoinAmount::from_sat(sats),
+                            balance: BitcoinAmount::try_from(sats)
+                                .expect("amount must not exceed the Bitcoin money supply"),
                         },
                         encoded_state: encoded
                             .try_into()
@@ -185,18 +191,23 @@ mod tests {
 
         ssz_proptest!(
             AcctStateSummary,
-            (any::<u16>(), any::<u32>(), any::<u64>(), any::<[u8; 32]>()).prop_map(
-                |(raw_ty, serial, sats, root)| {
+            (
+                any::<u16>(),
+                any::<u32>(),
+                0..=MAX_BITCOIN_MONEY_SATS,
+                any::<[u8; 32]>()
+            )
+                .prop_map(|(raw_ty, serial, sats, root)| {
                     AcctStateSummary {
                         intrinsics: AccountIntrinsicState {
                             raw_ty,
                             serial: AccountSerial::new(serial),
-                            balance: BitcoinAmount::from_sat(sats),
+                            balance: BitcoinAmount::try_from(sats)
+                                .expect("amount must not exceed the Bitcoin money supply"),
                         },
                         typed_state_root: root.into(),
                     }
-                }
-            )
+                })
         );
 
         #[test]

--- a/crates/chain-worker/src/context.rs
+++ b/crates/chain-worker/src/context.rs
@@ -683,9 +683,12 @@ mod tests {
     }
 
     fn message_entry(source_seed: u8, value_sats: u64) -> MessageEntry {
-        let payload =
-            MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), vec![source_seed])
-                .expect("message payload bytes must fit within SSZ max length");
+        let payload = MsgPayload::from_bytes(
+            BitcoinAmount::try_from(value_sats)
+                .expect("amount must not exceed the Bitcoin money supply"),
+            vec![source_seed],
+        )
+        .expect("message payload bytes must fit within SSZ max length");
         MessageEntry::new(AccountId::from([source_seed; 32]), 0, payload)
     }
 

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -1037,7 +1037,7 @@ mod tests {
             .create_new_account(
                 account_id,
                 NewAccountData::new(
-                    BitcoinAmount::zero(),
+                    BitcoinAmount::default(),
                     NewAccountTypeState::Snark {
                         update_vk: PredicateKey::always_accept(),
                         initial_state_root: final_root,

--- a/crates/chain-worker/src/tests/exec_block.rs
+++ b/crates/chain-worker/src/tests/exec_block.rs
@@ -183,7 +183,8 @@ fn test_exec_single_block_epoch_persists_before_summary() {
         0,
         snark_serial,
         SubjectId::from([42u8; 32]),
-        BitcoinAmount::from_sat(150_000_000),
+        BitcoinAmount::try_from(150_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
     );
     run_terminal(&mut state, &mut blocks, &genesis_header, manifest);
     let terminal_block = blocks.pop().expect("terminal block built");

--- a/crates/chain-worker/src/tests/fixture.rs
+++ b/crates/chain-worker/src/tests/fixture.rs
@@ -289,7 +289,8 @@ fn make_feature_manifest(
             0,
             snark_serial,
             SubjectId::from([42u8; 32]),
-            BitcoinAmount::from_sat(150_000_000),
+            BitcoinAmount::try_from(150_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
         ),
         ManifestPlan::Empty => make_empty_manifest(height, height as u8),
     }

--- a/crates/ledger-types/src/account.rs
+++ b/crates/ledger-types/src/account.rs
@@ -82,7 +82,7 @@ impl NewAccountData {
     }
 
     pub fn new_empty(type_state: NewAccountTypeState) -> Self {
-        Self::new(BitcoinAmount::zero(), type_state)
+        Self::new(BitcoinAmount::default(), type_state)
     }
 
     /// Creates a new snark account with the given balance, verification key, and initial state

--- a/crates/ledger-types/src/coin.rs
+++ b/crates/ledger-types/src/coin.rs
@@ -34,7 +34,7 @@ impl Coin {
     ///
     /// This is always safe since it creates no value.
     pub fn zero() -> Self {
-        Self(BitcoinAmount::zero())
+        Self(BitcoinAmount::default())
     }
 
     /// Gets the amount of value this coin represents.
@@ -49,14 +49,15 @@ impl Coin {
     /// together hold exactly what `self` did before.  Returns an error, leaving
     /// `self` untouched, if `amt` exceeds this coin's value.
     pub fn split_out(&mut self, amt: BitcoinAmount) -> Result<Self, CoinError> {
-        let Some(remainder) = self.0.checked_sub(amt) else {
+        let Some(remainder_sats) = self.0.to_sat().checked_sub(amt.to_sat()) else {
             return Err(CoinError::InsufficientValue {
                 have: self.0.to_sat(),
                 want: amt.to_sat(),
             });
         };
 
-        self.0 = remainder;
+        self.0 = BitcoinAmount::try_from(remainder_sats)
+            .expect("subtracting from a valid amount must remain valid");
         Ok(Self(amt))
     }
 
@@ -82,7 +83,7 @@ impl Coin {
         let amt = self.0;
         self.safely_consume_unchecked();
         assert!(
-            amt.is_zero(),
+            amt == BitcoinAmount::default(),
             "coin: consumed nonzero coin as zero ({} sats)",
             amt.to_sat()
         );
@@ -104,41 +105,57 @@ mod tests {
 
     #[test]
     fn test_coin_create_destroy() {
-        let coin = Coin::new_unchecked(123.into());
+        let coin = Coin::new_unchecked(BitcoinAmount::try_from(123).expect("valid test amount"));
         coin.safely_consume_unchecked();
     }
 
     #[test]
     #[should_panic]
     fn test_coin_create_panic() {
-        let _coin = Coin::new_unchecked(123.into());
+        let _coin = Coin::new_unchecked(BitcoinAmount::try_from(123).expect("valid test amount"));
         // should panic
     }
 
     #[test]
     fn test_coin_zero_consume_zero() {
         let coin = Coin::zero();
-        assert!(coin.amt().is_zero());
+        assert_eq!(coin.amt(), BitcoinAmount::default());
         coin.consume_zero();
     }
 
     #[test]
     fn test_coin_split_out_preserves_total() {
-        let mut coin = Coin::new_unchecked(BitcoinAmount::from_sat(100));
+        let mut coin = Coin::new_unchecked(
+            BitcoinAmount::try_from(100).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let taken = coin
-            .split_out(BitcoinAmount::from_sat(30))
+            .split_out(
+                BitcoinAmount::try_from(30)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
             .expect("split within value");
-        assert_eq!(taken.amt(), BitcoinAmount::from_sat(30));
-        assert_eq!(coin.amt(), BitcoinAmount::from_sat(70));
+        assert_eq!(
+            taken.amt(),
+            BitcoinAmount::try_from(30).expect("amount must not exceed the Bitcoin money supply")
+        );
+        assert_eq!(
+            coin.amt(),
+            BitcoinAmount::try_from(70).expect("amount must not exceed the Bitcoin money supply")
+        );
         taken.safely_consume_unchecked();
         coin.safely_consume_unchecked();
     }
 
     #[test]
     fn test_coin_split_out_exact_leaves_zero() {
-        let mut coin = Coin::new_unchecked(BitcoinAmount::from_sat(42));
+        let mut coin = Coin::new_unchecked(
+            BitcoinAmount::try_from(42).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let taken = coin
-            .split_out(BitcoinAmount::from_sat(42))
+            .split_out(
+                BitcoinAmount::try_from(42)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
             .expect("split within value");
         taken.safely_consume_unchecked();
         coin.consume_zero();
@@ -146,20 +163,30 @@ mod tests {
 
     #[test]
     fn test_coin_split_out_insufficient_errors() {
-        let mut coin = Coin::new_unchecked(BitcoinAmount::from_sat(10));
+        let mut coin = Coin::new_unchecked(
+            BitcoinAmount::try_from(10).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let err = coin
-            .split_out(BitcoinAmount::from_sat(11))
+            .split_out(
+                BitcoinAmount::try_from(11)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
             .expect_err("split beyond value must fail");
         assert_eq!(err, CoinError::InsufficientValue { have: 10, want: 11 });
         // `coin` is untouched by the failed split, so it still must be consumed.
-        assert_eq!(coin.amt(), BitcoinAmount::from_sat(10));
+        assert_eq!(
+            coin.amt(),
+            BitcoinAmount::try_from(10).expect("amount must not exceed the Bitcoin money supply")
+        );
         coin.safely_consume_unchecked();
     }
 
     #[test]
     #[should_panic]
     fn test_coin_consume_zero_nonzero_panics() {
-        let coin = Coin::new_unchecked(BitcoinAmount::from_sat(1));
+        let coin = Coin::new_unchecked(
+            BitcoinAmount::try_from(1).expect("amount must not exceed the Bitcoin money supply"),
+        );
         coin.consume_zero();
     }
 }

--- a/crates/ledger-types/src/errors.rs
+++ b/crates/ledger-types/src/errors.rs
@@ -53,6 +53,9 @@ pub enum StateError {
         add: BitcoinAmount,
     },
 
+    #[error("total ledger funds exceed the Bitcoin money supply")]
+    TotalFundsOverflow,
+
     #[error("out-of-order seqno change (cur {cur:?}, new {new:?})")]
     OooSeqnoChange { cur: Seqno, new: Seqno },
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -3169,7 +3169,8 @@ mod tests {
         for account_id in &account_ids {
             assert_eq!(
                 account_balance(&output.post_state, *account_id),
-                BitcoinAmount::from_sat(INITIAL_BALANCE),
+                BitcoinAmount::try_from(INITIAL_BALANCE)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 "cyclic transfers should preserve per-account net balance for every account"
             );
         }

--- a/crates/ol/block-assembly/src/test_utils.rs
+++ b/crates/ol/block-assembly/src/test_utils.rs
@@ -148,8 +148,12 @@ pub(crate) fn create_test_message(source_id: u8, epoch: u32, value_sats: u64) ->
         .unwrap()
         .current();
     let payload_bytes = sampled_message.payload().data().to_vec();
-    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), payload_bytes)
-        .expect("message payload bytes must fit within SSZ max length");
+    let payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(value_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
+        payload_bytes,
+    )
+    .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(source, epoch, payload)
 }
 
@@ -445,7 +449,8 @@ pub(crate) fn withdrawal_output_message(
     let encoded_body = encode_to_vec(&withdrawal_data).expect("encode withdrawal body");
     let withdrawal_msg = OwnedMsg::new(WITHDRAWAL_MSG_TYPE_ID, encoded_body).expect("msg format");
     let payload = MsgPayload::from_bytes(
-        BitcoinAmount::from_sat(amount_sats),
+        BitcoinAmount::try_from(amount_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         withdrawal_msg.to_vec(),
     )
     .expect("withdrawal message payload bytes must fit within SSZ max length");
@@ -568,9 +573,12 @@ impl MempoolSnarkTxBuilder {
             self.outputs
                 .into_iter()
                 .map(|(dest, value_sats)| {
-                    let payload =
-                        MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), vec![])
-                            .expect("message payload bytes must fit within SSZ max length");
+                    let payload = MsgPayload::from_bytes(
+                        BitcoinAmount::try_from(value_sats)
+                            .expect("amount must not exceed the Bitcoin money supply"),
+                        vec![],
+                    )
+                    .expect("message payload bytes must fit within SSZ max length");
                     OutputMessage::new(dest, payload)
                 })
                 .collect()
@@ -604,7 +612,8 @@ pub(crate) fn add_snark_account_to_state(
     initial_balance: u64,
 ) {
     let new_acct = NewAccountData::new(
-        BitcoinAmount::from_sat(initial_balance),
+        BitcoinAmount::try_from(initial_balance)
+            .expect("amount must not exceed the Bitcoin money supply"),
         NewAccountTypeState::Snark {
             update_vk: PredicateKey::always_accept(),
             initial_state_root: test_hash(state_root_seed),
@@ -712,8 +721,12 @@ pub(crate) fn generate_message_entries(
                 })
                 .collect();
 
-            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), data)
-                .expect("message payload bytes must fit within SSZ max length");
+            let payload = MsgPayload::from_bytes(
+                BitcoinAmount::try_from(value_sats)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                data,
+            )
+            .expect("message payload bytes must fit within SSZ max length");
             MessageEntry::new(source_account, incl_epoch, payload)
         })
         .collect()

--- a/crates/ol/block-assembly/src/tests/effects.rs
+++ b/crates/ol/block-assembly/src/tests/effects.rs
@@ -55,12 +55,14 @@ async fn test_transfer_balances_update() {
 
     assert_eq!(
         account_balance(&output.post_state, sender),
-        BitcoinAmount::from_sat(DEFAULT_ACCOUNT_BALANCE - transfer_sats),
+        BitcoinAmount::try_from(DEFAULT_ACCOUNT_BALANCE - transfer_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "sender balance should be debited by transfer amount"
     );
     assert_eq!(
         account_balance(&output.post_state, receiver),
-        BitcoinAmount::from_sat(transfer_sats),
+        BitcoinAmount::try_from(transfer_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "receiver balance should be credited by transfer amount"
     );
 }
@@ -151,12 +153,14 @@ async fn test_rollback_preserves_first_tx_effects() {
 
     assert_eq!(
         account_balance(&output.post_state, sender),
-        BitcoinAmount::from_sat(DEFAULT_ACCOUNT_BALANCE - first_transfer_sats),
+        BitcoinAmount::try_from(DEFAULT_ACCOUNT_BALANCE - first_transfer_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "sender should reflect only first tx debit"
     );
     assert_eq!(
         account_balance(&output.post_state, receiver),
-        BitcoinAmount::from_sat(first_transfer_sats),
+        BitcoinAmount::try_from(first_transfer_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "receiver should reflect only first tx credit"
     );
 }
@@ -267,17 +271,19 @@ async fn test_rollback_on_insufficient_balance_preserves_prior_effects() {
 
     assert_eq!(
         account_balance(&output.post_state, rich),
-        BitcoinAmount::from_sat(DEFAULT_ACCOUNT_BALANCE - tx1_amount),
+        BitcoinAmount::try_from(DEFAULT_ACCOUNT_BALANCE - tx1_amount)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "rich account should reflect only tx1 debit"
     );
     assert_eq!(
         account_balance(&output.post_state, receiver),
-        BitcoinAmount::from_sat(tx1_amount),
+        BitcoinAmount::try_from(tx1_amount)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "receiver should reflect only tx1 credit"
     );
     assert_eq!(
         account_balance(&output.post_state, poor),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "failing tx2 should not mutate poor account balance"
     );
 }

--- a/crates/ol/block-assembly/src/tests/messaging.rs
+++ b/crates/ol/block-assembly/src/tests/messaging.rs
@@ -54,14 +54,20 @@ async fn test_multi_sender_attribution() {
     let expected_msg_from_a = MessageEntry::new(
         sender_a,
         epoch,
-        MsgPayload::from_bytes(BitcoinAmount::from_sat(100), vec![])
-            .expect("message payload bytes must fit within SSZ max length"),
+        MsgPayload::from_bytes(
+            BitcoinAmount::try_from(100).expect("amount must not exceed the Bitcoin money supply"),
+            vec![],
+        )
+        .expect("message payload bytes must fit within SSZ max length"),
     );
     let expected_msg_from_b = MessageEntry::new(
         sender_b,
         epoch,
-        MsgPayload::from_bytes(BitcoinAmount::from_sat(250), vec![])
-            .expect("message payload bytes must fit within SSZ max length"),
+        MsgPayload::from_bytes(
+            BitcoinAmount::try_from(250).expect("amount must not exceed the Bitcoin money supply"),
+            vec![],
+        )
+        .expect("message payload bytes must fit within SSZ max length"),
     );
     let included_block1 = included_txids(&output_block1.template);
     assert_eq!(
@@ -210,12 +216,12 @@ async fn test_message_value_flow_balance_updates() {
 
     assert_eq!(
         account_balance(&output.post_state, sender),
-        BitcoinAmount::from_sat(600),
+        BitcoinAmount::try_from(600).expect("amount must not exceed the Bitcoin money supply"),
         "sender balance should be debited by message value"
     );
     assert_eq!(
         account_balance(&output.post_state, receiver),
-        BitcoinAmount::from_sat(400),
+        BitcoinAmount::try_from(400).expect("amount must not exceed the Bitcoin money supply"),
         "receiver balance should be credited by message value"
     );
     assert_eq!(

--- a/crates/ol/chain-types/src/test_utils.rs
+++ b/crates/ol/chain-types/src/test_utils.rs
@@ -19,9 +19,12 @@ use strata_predicate::{PredicateKey, PredicateTypeId};
 
 use crate::{block_flags::BlockFlags, ssz_generated::ssz::block::*, *};
 
+const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
 /// Creates a [`PredicateKey`] for a BIP-340 Schnorr sequencer pubkey.
 pub fn schnorr_predicate(pubkey: &Buf32) -> PredicateKey {
-    PredicateKey::new(PredicateTypeId::Bip340Schnorr, pubkey.as_slice().to_vec())
+    PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, pubkey.as_slice().to_vec())
+        .expect("BIP-340 public key must fit in a predicate condition")
 }
 
 /// Generates a random, valid BIP-340 Schnorr keypair as `(secret_key, x_only_pubkey)` for tests.
@@ -128,14 +131,15 @@ pub fn message_entry_strategy() -> impl Strategy<Value = MessageEntry> {
     (
         any::<[u8; 32]>(),
         any::<u32>(),
-        any::<u64>(),
+        0..=MAX_BITCOIN_MONEY_SATS,
         prop::collection::vec(any::<u8>(), 0..256),
     )
         .prop_map(|(source_bytes, incl_epoch, value, data)| MessageEntry {
             source: AccountId::from(source_bytes),
             incl_epoch,
             payload: MsgPayload {
-                value: BitcoinAmount::from_sat(value),
+                value: BitcoinAmount::try_from(value)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 data: data
                     .try_into()
                     .expect("message payload bytes must fit within SSZ max length"),

--- a/crates/ol/chain-types/src/transaction.rs
+++ b/crates/ol/chain-types/src/transaction.rs
@@ -320,7 +320,7 @@ impl OLTransactionData {
         let mut effects = TxEffects::default();
         effects.add_message(SentMessage::new(
             dest,
-            MsgPayload::new(BitcoinAmount::zero(), data),
+            MsgPayload::new(BitcoinAmount::default(), data),
         ));
         Self {
             payload,

--- a/crates/ol/checkpoint/src/state.rs
+++ b/crates/ol/checkpoint/src/state.rs
@@ -772,7 +772,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .balance(),
-            BitcoinAmount::from_sat(0),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
             "withdrawal must debit the full seeded balance"
         );
     }

--- a/crates/ol/da/src/types/mod.rs
+++ b/crates/ol/da/src/types/mod.rs
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn test_da_message_entry_decode_rejects_oversize_payload() {
         let payload = MsgPayload::from_bytes(
-            BitcoinAmount::from_sat(0),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
             vec![0u8; MAX_MSG_PAYLOAD_BYTES + 1],
         )
         .expect("message payload bytes must fit within SSZ max length");

--- a/crates/ol/da/src/types/payload.rs
+++ b/crates/ol/da/src/types/payload.rs
@@ -137,8 +137,9 @@ impl<S: IStateAccessorMut> DaWrite for OLStateDiff<S> {
         target.set_cur_slot(cur_slot);
 
         if let Some(d) = self.diff.global.limbo_funds_sats.diff() {
-            let amt = BitcoinAmount::try_from(d.magnitude())
-                .expect("amount must not exceed the Bitcoin money supply");
+            let amt = BitcoinAmount::try_from(d.magnitude()).map_err(|_| {
+                DaError::InvalidStateDiff("limbo funds delta exceeds the Bitcoin money supply")
+            })?;
             if d.is_positive() {
                 let coin = Coin::new_unchecked(amt);
                 target
@@ -282,14 +283,21 @@ fn apply_balance_delta<T: IAccountStateMut>(
     acct: &mut T,
     incr: &SignedVarInt,
 ) -> Result<(), DaError> {
+    let delta = BitcoinAmount::try_from(incr.magnitude())
+        .map_err(|_| DaError::InvalidStateDiff("balance delta exceeds the Bitcoin money supply"))?;
     if incr.is_positive() {
-        let delta = BitcoinAmount::try_from(incr.magnitude())
-            .expect("amount must not exceed the Bitcoin money supply");
+        // `add_balance` panics past the money-supply cap, so check the post-add
+        // amount first and reject the diff cleanly.
+        acct.balance()
+            .to_sat()
+            .checked_add(delta.to_sat())
+            .and_then(|sats| BitcoinAmount::try_from(sats).ok())
+            .ok_or(DaError::InvalidStateDiff(
+                "account balance after delta exceeds the Bitcoin money supply",
+            ))?;
         let coin = Coin::new_unchecked(delta);
         acct.add_balance(coin);
     } else {
-        let delta = BitcoinAmount::try_from(incr.magnitude())
-            .expect("amount must not exceed the Bitcoin money supply");
         let coin = acct
             .take_balance(delta)
             .map_err(|_| DaError::InvalidStateDiff("insufficient balance for diff"))?;
@@ -737,6 +745,76 @@ mod tests {
         );
     }
 
+    /// A balance delta above the Bitcoin money supply must be rejected with a `DaError`,
+    /// not panic on the amount conversion.
+    #[test]
+    fn test_ol_state_diff_apply_rejects_oversized_balance_delta() {
+        let mut state = make_genesis_state();
+        let account_id = test_account_id(32);
+        let serial = seed_empty_account(&mut state, account_id, 500);
+
+        let diff = StateDiff::new(
+            GlobalStateDiff::default(),
+            build::ledger_diff(
+                Vec::new(),
+                vec![AccountDiffEntry::new(
+                    serial,
+                    build::balance_diff(SignedVarInt::positive(u64::MAX)),
+                )],
+            ),
+        );
+
+        let result = apply_ol_state_diff(&mut state, diff);
+
+        assert!(matches!(
+            result,
+            Err(DaError::InvalidStateDiff(
+                "balance delta exceeds the Bitcoin money supply"
+            ))
+        ));
+        assert_eq!(
+            account_balance(&state, account_id),
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply")
+        );
+    }
+
+    /// A positive balance delta that is itself valid but pushes the account past
+    /// the Bitcoin money supply must be rejected with a `DaError`, not panic in
+    /// `add_balance`.
+    #[test]
+    fn test_ol_state_diff_apply_rejects_balance_delta_past_cap() {
+        const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
+        let mut state = make_genesis_state();
+        let account_id = test_account_id(33);
+        let serial = seed_empty_account(&mut state, account_id, MAX_BITCOIN_MONEY_SATS - 1);
+
+        let diff = StateDiff::new(
+            GlobalStateDiff::default(),
+            build::ledger_diff(
+                Vec::new(),
+                vec![AccountDiffEntry::new(
+                    serial,
+                    build::balance_diff(SignedVarInt::positive(2)),
+                )],
+            ),
+        );
+
+        let result = apply_ol_state_diff(&mut state, diff);
+
+        assert!(matches!(
+            result,
+            Err(DaError::InvalidStateDiff(
+                "account balance after delta exceeds the Bitcoin money supply"
+            ))
+        ));
+        assert_eq!(
+            account_balance(&state, account_id),
+            BitcoinAmount::try_from(MAX_BITCOIN_MONEY_SATS - 1)
+                .expect("amount must not exceed the Bitcoin money supply")
+        );
+    }
+
     #[test]
     fn test_ol_state_diff_apply_updates_limbo_funds() {
         let mut state = make_genesis_state();
@@ -788,6 +866,30 @@ mod tests {
             result,
             Err(DaError::InvalidStateDiff(
                 "insufficient limbo funds for diff"
+            ))
+        ));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
+        );
+    }
+
+    /// A limbo funds delta above the Bitcoin money supply must be rejected with a `DaError`,
+    /// not panic on the amount conversion.
+    #[test]
+    fn test_ol_state_diff_apply_rejects_oversized_limbo_funds_delta() {
+        let mut state = make_genesis_state();
+
+        let diff = StateDiff::new(
+            build::global_diff(0, Some(SignedVarInt::positive(u64::MAX))),
+            LedgerDiff::default(),
+        );
+        let result = apply_ol_state_diff(&mut state, diff);
+
+        assert!(matches!(
+            result,
+            Err(DaError::InvalidStateDiff(
+                "limbo funds delta exceeds the Bitcoin money supply"
             ))
         ));
         assert_eq!(

--- a/crates/ol/da/src/types/payload.rs
+++ b/crates/ol/da/src/types/payload.rs
@@ -137,7 +137,8 @@ impl<S: IStateAccessorMut> DaWrite for OLStateDiff<S> {
         target.set_cur_slot(cur_slot);
 
         if let Some(d) = self.diff.global.limbo_funds_sats.diff() {
-            let amt = BitcoinAmount::from_sat(d.magnitude());
+            let amt = BitcoinAmount::try_from(d.magnitude())
+                .expect("amount must not exceed the Bitcoin money supply");
             if d.is_positive() {
                 let coin = Coin::new_unchecked(amt);
                 target
@@ -282,11 +283,13 @@ fn apply_balance_delta<T: IAccountStateMut>(
     incr: &SignedVarInt,
 ) -> Result<(), DaError> {
     if incr.is_positive() {
-        let delta = BitcoinAmount::from_sat(incr.magnitude());
+        let delta = BitcoinAmount::try_from(incr.magnitude())
+            .expect("amount must not exceed the Bitcoin money supply");
         let coin = Coin::new_unchecked(delta);
         acct.add_balance(coin);
     } else {
-        let delta = BitcoinAmount::from_sat(incr.magnitude());
+        let delta = BitcoinAmount::try_from(incr.magnitude())
+            .expect("amount must not exceed the Bitcoin money supply");
         let coin = acct
             .take_balance(delta)
             .map_err(|_| DaError::InvalidStateDiff("insufficient balance for diff"))?;
@@ -365,7 +368,11 @@ mod tests {
         state
             .create_new_account(
                 id,
-                NewAccountData::new(BitcoinAmount::from_sat(sats), NewAccountTypeState::Empty),
+                NewAccountData::new(
+                    BitcoinAmount::try_from(sats)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    NewAccountTypeState::Empty,
+                ),
             )
             .expect("create empty account")
     }
@@ -404,7 +411,8 @@ mod tests {
         /// Empty new-account init with the given balance.
         pub(super) fn empty_init(balance_sats: u64) -> AccountInit {
             AccountInit::new(
-                BitcoinAmount::from_sat(balance_sats),
+                BitcoinAmount::try_from(balance_sats)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 AccountTypeInit::Empty,
             )
         }
@@ -412,7 +420,8 @@ mod tests {
         /// Snark new-account init with the given balance, state root, and VK bytes.
         pub(super) fn snark_init(balance_sats: u64, root: Hash, vk: Vec<u8>) -> AccountInit {
             AccountInit::new(
-                BitcoinAmount::from_sat(balance_sats),
+                BitcoinAmount::try_from(balance_sats)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 AccountTypeInit::Snark(SnarkAccountInit::new(root, vk)),
             )
         }
@@ -463,8 +472,12 @@ mod tests {
             len: usize,
             byte: u8,
         ) -> DaMessageEntry {
-            let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![byte; len])
-                .expect("message payload bytes must fit SSZ max length");
+            let payload = MsgPayload::from_bytes(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                vec![byte; len],
+            )
+            .expect("message payload bytes must fit SSZ max length");
             DaMessageEntry::new(source, incl_epoch, payload)
         }
 
@@ -502,7 +515,10 @@ mod tests {
         let snark_acct = build::snark_init(
             500,
             Hash::from([0x11u8; 32]),
-            PredicateKey::always_accept().as_buf_ref().to_bytes(),
+            PredicateKey::always_accept()
+                .try_as_buf_ref()
+                .expect("predicate key must be valid")
+                .to_bytes(),
         );
         let new_accounts = vec![
             NewAccountEntry::new(test_account_id(0xA1), build::empty_init(1_000)),
@@ -661,7 +677,8 @@ mod tests {
 
         assert_eq!(
             account_balance(&state, account_id),
-            BitcoinAmount::from_sat(2_000)
+            BitcoinAmount::try_from(2_000)
+                .expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
@@ -686,7 +703,8 @@ mod tests {
 
         assert_eq!(
             account_balance(&state, account_id),
-            BitcoinAmount::from_sat(1_250)
+            BitcoinAmount::try_from(1_250)
+                .expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
@@ -715,14 +733,17 @@ mod tests {
         ));
         assert_eq!(
             account_balance(&state, account_id),
-            BitcoinAmount::from_sat(500)
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
     #[test]
     fn test_ol_state_diff_apply_updates_limbo_funds() {
         let mut state = make_genesis_state();
-        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(0));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         let diff = StateDiff::new(
             build::global_diff(0, Some(SignedVarInt::positive(1_500))),
@@ -730,7 +751,11 @@ mod tests {
         );
         apply_ol_state_diff(&mut state, diff).expect("apply limbo add diff");
 
-        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(1_500));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(1_500)
+                .expect("amount must not exceed the Bitcoin money supply")
+        );
 
         let diff = StateDiff::new(
             build::global_diff(0, Some(SignedVarInt::negative(400))),
@@ -738,13 +763,20 @@ mod tests {
         );
         apply_ol_state_diff(&mut state, diff).expect("apply limbo take diff");
 
-        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(1_100));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(1_100)
+                .expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
     fn test_ol_state_diff_apply_rejects_insufficient_limbo_funds() {
         let mut state = make_genesis_state();
-        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(0));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         let diff = StateDiff::new(
             build::global_diff(0, Some(SignedVarInt::negative(1))),
@@ -758,7 +790,10 @@ mod tests {
                 "insufficient limbo funds for diff"
             ))
         ));
-        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(0));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
@@ -766,7 +801,7 @@ mod tests {
         let mut state = make_genesis_state();
         let account_id = test_account_id(4);
         let new_acct = NewAccountData::new(
-            BitcoinAmount::from_sat(500),
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply"),
             NewAccountTypeState::Snark {
                 update_vk: PredicateKey::always_accept(),
                 initial_state_root: Hash::from([0x11u8; 32]),
@@ -806,7 +841,7 @@ mod tests {
         let mut state = make_genesis_state();
         let account_id = test_account_id(5);
         let new_acct = NewAccountData::new(
-            BitcoinAmount::from_sat(500),
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply"),
             NewAccountTypeState::Snark {
                 update_vk: PredicateKey::always_accept(),
                 initial_state_root: Hash::from([0x11u8; 32]),
@@ -816,9 +851,20 @@ mod tests {
             .create_new_account(account_id, new_acct)
             .expect("create snark account");
 
-        let new_vk = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0x42u8; 32]);
-        let snark_diff =
-            build::snark_diff(1, None, 0, Vec::new(), Some(new_vk.as_buf_ref().to_bytes()));
+        let new_vk = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0x42u8; 32])
+            .expect("predicate condition must fit within the maximum length");
+        let snark_diff = build::snark_diff(
+            1,
+            None,
+            0,
+            Vec::new(),
+            Some(
+                new_vk
+                    .try_as_buf_ref()
+                    .expect("predicate key must be valid")
+                    .to_bytes(),
+            ),
+        );
         let account_diff = AccountDiff::new(DaCounter::new_unchanged(), snark_diff);
         let diff = StateDiff::new(
             GlobalStateDiff::default(),
@@ -849,7 +895,7 @@ mod tests {
         let mut state = make_genesis_state();
         let account_id = test_account_id(5);
         let new_acct = NewAccountData::new(
-            BitcoinAmount::from_sat(500),
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply"),
             NewAccountTypeState::Snark {
                 update_vk: PredicateKey::always_accept(),
                 initial_state_root: Hash::from([0x11u8; 32]),
@@ -896,14 +942,19 @@ mod tests {
         let empty_serial = state
             .create_new_account(
                 empty_id,
-                NewAccountData::new(BitcoinAmount::from_sat(1_000), NewAccountTypeState::Empty),
+                NewAccountData::new(
+                    BitcoinAmount::try_from(1_000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    NewAccountTypeState::Empty,
+                ),
             )
             .expect("create empty account");
         let snark_serial = state
             .create_new_account(
                 snark_id,
                 NewAccountData::new(
-                    BitcoinAmount::from_sat(500),
+                    BitcoinAmount::try_from(500)
+                        .expect("amount must not exceed the Bitcoin money supply"),
                     NewAccountTypeState::Snark {
                         update_vk: PredicateKey::always_accept(),
                         initial_state_root: Hash::from([0x11u8; 32]),
@@ -964,17 +1015,27 @@ mod tests {
         let mut expected = pre_accounts.state.clone();
         expected.set_cur_slot(expected.cur_slot() + 4);
         expected
-            .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(800)))
+            .add_limbo_funds_coin(Coin::new_unchecked(
+                BitcoinAmount::try_from(800)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ))
             .expect("add limbo");
         expected
             .create_new_account(
                 new_id,
-                NewAccountData::new(BitcoinAmount::from_sat(2_000), NewAccountTypeState::Empty),
+                NewAccountData::new(
+                    BitcoinAmount::try_from(2_000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    NewAccountTypeState::Empty,
+                ),
             )
             .expect("create new account");
         expected
             .update_account(pre_accounts.empty.id, |acct| {
-                acct.add_balance(Coin::new_unchecked(BitcoinAmount::from_sat(250)));
+                acct.add_balance(Coin::new_unchecked(
+                    BitcoinAmount::try_from(250)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                ));
                 Ok::<(), DaError>(())
             })
             .expect("update empty")
@@ -1077,13 +1138,20 @@ mod tests {
             .expect("apply rich diff");
 
         assert_eq!(state.cur_slot(), pre_slot + 5);
-        assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(900));
+        assert_eq!(
+            state.limbo_funds(),
+            BitcoinAmount::try_from(900).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         let empty = state
             .get_account_state(pre_accounts.empty.id)
             .unwrap()
             .expect("empty account");
-        assert_eq!(empty.balance(), BitcoinAmount::from_sat(1_250));
+        assert_eq!(
+            empty.balance(),
+            BitcoinAmount::try_from(1_250)
+                .expect("amount must not exceed the Bitcoin money supply")
+        );
 
         let snark = state
             .get_account_state(pre_accounts.snark.id)
@@ -1107,11 +1175,12 @@ mod tests {
         );
         assert_eq!(
             account_balance(&state, new_id_a),
-            BitcoinAmount::from_sat(1_000)
+            BitcoinAmount::try_from(1_000)
+                .expect("amount must not exceed the Bitcoin money supply")
         );
         assert_eq!(
             account_balance(&state, new_id_b),
-            BitcoinAmount::from_sat(500)
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
@@ -1285,7 +1354,7 @@ mod tests {
     #[test]
     fn test_da_message_entry_round_trips_at_max_payload() {
         let payload = MsgPayload::from_bytes(
-            BitcoinAmount::from_sat(0),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
             vec![0x5Au8; MAX_MSG_PAYLOAD_BYTES],
         )
         .expect("payload at boundary fits SSZ max");

--- a/crates/ol/mempool/src/test_utils.rs
+++ b/crates/ol/mempool/src/test_utils.rs
@@ -201,7 +201,10 @@ pub(crate) fn create_test_ol_state_with_account(
     let mut layer = MemoryStateBaseLayer::new(state);
     layer.set_cur_slot(slot);
     // Create an empty account so it exists for validation
-    let new_acct = NewAccountData::new(BitcoinAmount::from(0), NewAccountTypeState::Empty);
+    let new_acct = NewAccountData::new(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        NewAccountTypeState::Empty,
+    );
     layer.create_new_account(account_id, new_acct).unwrap();
     layer
 }
@@ -225,7 +228,7 @@ pub(crate) fn create_test_ol_state_with_snark_account(
     layer.set_cur_slot(slot);
     // Create a fresh snark account, then update its sequence number
     let new_acct = NewAccountData::new(
-        BitcoinAmount::from(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         NewAccountTypeState::Snark {
             update_vk: PredicateKey::always_accept(),
             initial_state_root: Hash::zero(),
@@ -396,7 +399,7 @@ pub(crate) fn create_test_ol_state_for_tip(slot: u64) -> OLState {
     for id_byte in 0..=255u8 {
         let account_id = create_test_account_id_with(id_byte);
         let new_acct = NewAccountData::new(
-            BitcoinAmount::from(0),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
             NewAccountTypeState::Snark {
                 update_vk: PredicateKey::always_accept(),
                 initial_state_root: Hash::zero(),

--- a/crates/ol/mmr-index/src/test_utils.rs
+++ b/crates/ol/mmr-index/src/test_utils.rs
@@ -30,7 +30,11 @@ pub(crate) fn build_target_state_with_empty_l1_block_refs_mmr() -> OLState {
 }
 
 pub(crate) fn build_snark_inbox_message(seed: u8) -> MessageEntry {
-    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(1), vec![seed]).expect("payload");
+    let payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(1).expect("amount must not exceed the Bitcoin money supply"),
+        vec![seed],
+    )
+    .expect("payload");
     MessageEntry::new(AccountId::new([seed; 32]), 0, payload)
 }
 
@@ -44,7 +48,7 @@ pub(crate) fn build_target_state_with_snark_account(account_id: AccountId) -> OL
         GenesisSnarkAccountData {
             predicate: PredicateKey::always_accept(),
             inner_state: Hash::zero(),
-            balance: BitcoinAmount::ZERO,
+            balance: BitcoinAmount::default(),
         },
     );
 

--- a/crates/ol/params/src/account.rs
+++ b/crates/ol/params/src/account.rs
@@ -10,7 +10,7 @@ use strata_predicate::PredicateKey;
 /// Data for a single genesis snark account.
 ///
 /// The `predicate` and `inner_state` fields are required. The `balance` field
-/// defaults to [`BitcoinAmount::ZERO`] if omitted.
+/// defaults to a zero [`BitcoinAmount`] if omitted.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct GenesisSnarkAccountData {
@@ -20,7 +20,7 @@ pub struct GenesisSnarkAccountData {
     /// Inner state root commitment.
     pub inner_state: Buf32,
 
-    /// Initial balance as a [`BitcoinAmount`]. Defaults to [`BitcoinAmount::ZERO`].
-    #[serde(default = "BitcoinAmount::zero")]
+    /// Initial balance as a [`BitcoinAmount`]. Defaults to zero.
+    #[serde(default = "BitcoinAmount::default")]
     pub balance: BitcoinAmount,
 }

--- a/crates/ol/params/src/lib.rs
+++ b/crates/ol/params/src/lib.rs
@@ -102,7 +102,8 @@ mod tests {
             GenesisSnarkAccountData {
                 predicate: PredicateKey::always_accept(),
                 inner_state: Buf32::zero(),
-                balance: BitcoinAmount::from_sat(1000),
+                balance: BitcoinAmount::try_from(1000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
             },
         );
 
@@ -111,7 +112,7 @@ mod tests {
             GenesisSnarkAccountData {
                 predicate: PredicateKey::always_accept(),
                 inner_state: Buf32::from([0xab; 32]),
-                balance: BitcoinAmount::ZERO,
+                balance: BitcoinAmount::default(),
             },
         );
 
@@ -169,8 +170,11 @@ mod tests {
         let id1 = AccountId::from([1u8; 32]);
         let id2 = AccountId::from([2u8; 32]);
 
-        assert_eq!(params.accounts[&id1].balance, BitcoinAmount::from_sat(500));
-        assert_eq!(params.accounts[&id2].balance, BitcoinAmount::ZERO);
+        assert_eq!(
+            params.accounts[&id1].balance,
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply")
+        );
+        assert_eq!(params.accounts[&id2].balance, BitcoinAmount::default());
     }
 
     #[test]

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -357,11 +357,9 @@ impl TryFrom<RpcMsgPayload> for MsgPayload {
     type Error = MsgPayloadError;
 
     fn try_from(rpc: RpcMsgPayload) -> Result<Self, Self::Error> {
-        MsgPayload::from_bytes(
-            BitcoinAmount::try_from(rpc.value)
-                .expect("amount must not exceed the Bitcoin money supply"),
-            rpc.data.into(),
-        )
+        let value = BitcoinAmount::try_from(rpc.value)
+            .map_err(|_| MsgPayloadError::ValueTooLarge { sats: rpc.value })?;
+        MsgPayload::from_bytes(value, rpc.data.into())
     }
 }
 
@@ -399,5 +397,38 @@ impl RpcProofState {
 impl From<RpcProofState> for ProofState {
     fn from(rpc: RpcProofState) -> Self {
         ProofState::new(rpc.inner_state.0.into(), rpc.next_inbox_msg_idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
+    #[test]
+    fn rpc_msg_payload_accepts_max_money_value() {
+        let rpc = RpcMsgPayload {
+            value: MAX_BITCOIN_MONEY_SATS,
+            data: vec![1, 2, 3].into(),
+        };
+
+        let payload = MsgPayload::try_from(rpc).expect("max-money value must convert");
+
+        assert_eq!(payload.value().to_sat(), MAX_BITCOIN_MONEY_SATS);
+        assert_eq!(payload.data(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn rpc_msg_payload_rejects_oversized_value() {
+        let sats = MAX_BITCOIN_MONEY_SATS + 1;
+        let rpc = RpcMsgPayload {
+            value: sats,
+            data: vec![].into(),
+        };
+
+        let err = MsgPayload::try_from(rpc).expect_err("oversized value must fail");
+
+        assert_eq!(err, MsgPayloadError::ValueTooLarge { sats });
     }
 }

--- a/crates/ol/rpc/types/src/account_summary.rs
+++ b/crates/ol/rpc/types/src/account_summary.rs
@@ -357,7 +357,11 @@ impl TryFrom<RpcMsgPayload> for MsgPayload {
     type Error = MsgPayloadError;
 
     fn try_from(rpc: RpcMsgPayload) -> Result<Self, Self::Error> {
-        MsgPayload::from_bytes(BitcoinAmount::from_sat(rpc.value), rpc.data.into())
+        MsgPayload::from_bytes(
+            BitcoinAmount::try_from(rpc.value)
+                .expect("amount must not exceed the Bitcoin money supply"),
+            rpc.data.into(),
+        )
     }
 }
 

--- a/crates/ol/rpc/types/src/tx.rs
+++ b/crates/ol/rpc/types/src/tx.rs
@@ -485,7 +485,8 @@ mod tests {
 
     #[test]
     fn test_sau_conversion_with_new_predicate() {
-        let key = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![3u8; 32]);
+        let key = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![3u8; 32])
+            .expect("predicate condition must fit within the maximum length");
         let outputs = UpdateOutputs::new_empty().with_new_predicate(key.clone());
         let tx = convert(make_rpc_sau_update(outputs));
         assert_eq!(tx_new_predicate(&tx), Some(key));

--- a/crates/ol/state-support-types/src/batch_diff_layer.rs
+++ b/crates/ol/state-support-types/src/batch_diff_layer.rs
@@ -111,9 +111,10 @@ impl<'batches, 'base, S: IStateAccessor + IComputeStateRootWithWrites> IStateAcc
     fn limbo_funds(&self) -> BitcoinAmount {
         self.resolve(
             |b| {
-                b.global_writes()
-                    .limbo_funds_sats
-                    .map(BitcoinAmount::from_sat)
+                b.global_writes().limbo_funds_sats.map(|sats| {
+                    BitcoinAmount::try_from(sats)
+                        .expect("limbo funds must not exceed the Bitcoin money supply")
+                })
             },
             || self.base.limbo_funds(),
         )
@@ -325,7 +326,10 @@ mod tests {
         // Create a batch with an account
         let mut batch = WriteBatch::default();
         let snark_state = test_snark_account_state(1);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(5000));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial = base_layer.next_account_serial();
         batch
             .ledger_mut()
@@ -337,7 +341,10 @@ mod tests {
         // Should read from batch
         let account = diff_state.get_account_state(account_id).unwrap().unwrap();
         assert_eq!(account.serial(), serial);
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(5000));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
@@ -347,7 +354,10 @@ mod tests {
 
         let mut batch = WriteBatch::default();
         let snark_state = test_snark_account_state(1);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(5000));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial = base_layer.next_account_serial();
         batch
             .ledger_mut()
@@ -386,7 +396,10 @@ mod tests {
         // First batch: account with 1000 sats
         let mut batch1 = WriteBatch::default();
         let snark_state1 = test_snark_account_state(1);
-        let new_acct1 = test_new_snark_account_data(&snark_state1, BitcoinAmount::from_sat(1000));
+        let new_acct1 = test_new_snark_account_data(
+            &snark_state1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial1 = base_layer.next_account_serial();
         batch1
             .ledger_mut()
@@ -396,7 +409,10 @@ mod tests {
         // This batch shadows the first, so uses a different serial
         let mut batch2 = WriteBatch::default();
         let snark_state2 = test_snark_account_state(2);
-        let new_acct2 = test_new_snark_account_data(&snark_state2, BitcoinAmount::from_sat(5000));
+        let new_acct2 = test_new_snark_account_data(
+            &snark_state2,
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial2 = AccountSerial::from(SYSTEM_RESERVED_ACCTS + 1);
         batch2
             .ledger_mut()
@@ -407,7 +423,10 @@ mod tests {
         let diff_state = BatchDiffState::new(&base_layer, &batches);
 
         let account = diff_state.get_account_state(account_id).unwrap().unwrap();
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(5000));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
@@ -419,7 +438,10 @@ mod tests {
         // First batch: account 1
         let mut batch1 = WriteBatch::default();
         let snark_state1 = test_snark_account_state(1);
-        let new_acct1 = test_new_snark_account_data(&snark_state1, BitcoinAmount::from_sat(1000));
+        let new_acct1 = test_new_snark_account_data(
+            &snark_state1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial1 = base_layer.next_account_serial();
         batch1
             .ledger_mut()
@@ -428,7 +450,10 @@ mod tests {
         // Second batch: account 2 only
         let mut batch2 = WriteBatch::default();
         let snark_state2 = test_snark_account_state(2);
-        let new_acct2 = test_new_snark_account_data(&snark_state2, BitcoinAmount::from_sat(2000));
+        let new_acct2 = test_new_snark_account_data(
+            &snark_state2,
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial2 = AccountSerial::from(SYSTEM_RESERVED_ACCTS + 1);
         batch2
             .ledger_mut()
@@ -439,23 +464,35 @@ mod tests {
 
         // Account 1 should be found in batch1 (falls through from batch2)
         let account1 = diff_state.get_account_state(account_id_1).unwrap().unwrap();
-        assert_eq!(account1.balance(), BitcoinAmount::from_sat(1000));
+        assert_eq!(
+            account1.balance(),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         // Account 2 should be found in batch2
         let account2 = diff_state.get_account_state(account_id_2).unwrap().unwrap();
-        assert_eq!(account2.balance(), BitcoinAmount::from_sat(2000));
+        assert_eq!(
+            account2.balance(),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
     fn test_read_falls_through_to_base() {
         let account_id_base = test_account_id(1);
         let account_id_batch = test_account_id(2);
-        let (base_layer, _) =
-            setup_layer_with_snark_account(account_id_base, 1, BitcoinAmount::from_sat(1000));
+        let (base_layer, _) = setup_layer_with_snark_account(
+            account_id_base,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let mut batch = WriteBatch::default();
         let snark_state = test_snark_account_state(2);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(2000));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial = base_layer.next_account_serial();
         batch
             .ledger_mut()
@@ -469,14 +506,20 @@ mod tests {
             .get_account_state(account_id_base)
             .unwrap()
             .unwrap();
-        assert_eq!(base_account.balance(), BitcoinAmount::from_sat(1000));
+        assert_eq!(
+            base_account.balance(),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         // Account in batch should also be found
         let batch_account = diff_state
             .get_account_state(account_id_batch)
             .unwrap()
             .unwrap();
-        assert_eq!(batch_account.balance(), BitcoinAmount::from_sat(2000));
+        assert_eq!(
+            batch_account.balance(),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
@@ -486,7 +529,10 @@ mod tests {
 
         let mut batch = WriteBatch::default();
         let snark_state = test_snark_account_state(1);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(1000));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial = base_layer.next_account_serial();
         batch
             .ledger_mut()
@@ -508,14 +554,18 @@ mod tests {
         let base_layer = create_test_base_layer();
 
         let mut batch = WriteBatch::default();
-        batch.epochal_writes_mut().total_ledger_balance = Some(BitcoinAmount::from_sat(1_000_000));
+        batch.epochal_writes_mut().total_ledger_balance = Some(
+            BitcoinAmount::try_from(1_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let batches = vec![batch];
         let diff_state = BatchDiffState::new(&base_layer, &batches);
 
         assert_eq!(
             diff_state.total_ledger_balance(),
-            BitcoinAmount::from_sat(1_000_000)
+            BitcoinAmount::try_from(1_000_000)
+                .expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
@@ -534,7 +584,9 @@ mod tests {
         batch1.epochal_writes_mut().last_l1_blkid = Some(older_blkid);
 
         let mut batch2 = WriteBatch::default();
-        batch2.epochal_writes_mut().total_ledger_balance = Some(BitcoinAmount::from_sat(42));
+        batch2.epochal_writes_mut().total_ledger_balance = Some(
+            BitcoinAmount::try_from(42).expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let batches = vec![batch1, batch2];
         let diff_state = BatchDiffState::new(&base_layer, &batches);
@@ -544,7 +596,7 @@ mod tests {
         assert_eq!(*diff_state.last_l1_blkid(), older_blkid);
         assert_eq!(
             diff_state.total_ledger_balance(),
-            BitcoinAmount::from_sat(42)
+            BitcoinAmount::try_from(42).expect("amount must not exceed the Bitcoin money supply")
         );
     }
 
@@ -557,7 +609,10 @@ mod tests {
 
         let mut batch = WriteBatch::default();
         let snark_state = test_snark_account_state(1);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(5000));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial = base_layer.next_account_serial();
         batch
             .ledger_mut()
@@ -584,7 +639,10 @@ mod tests {
         // Inner layer adds account 1.
         let mut batch1 = WriteBatch::default();
         let snark_state1 = test_snark_account_state(1);
-        let new_acct1 = test_new_snark_account_data(&snark_state1, BitcoinAmount::from_sat(1000));
+        let new_acct1 = test_new_snark_account_data(
+            &snark_state1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial1 = base_layer.next_account_serial();
         batch1
             .ledger_mut()
@@ -596,7 +654,10 @@ mod tests {
         // Outer layer stacks another batch adding account 2 on top of `inner`.
         let mut batch2 = WriteBatch::default();
         let snark_state2 = test_snark_account_state(2);
-        let new_acct2 = test_new_snark_account_data(&snark_state2, BitcoinAmount::from_sat(2000));
+        let new_acct2 = test_new_snark_account_data(
+            &snark_state2,
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let serial2 = inner.next_account_serial();
         batch2
             .ledger_mut()
@@ -607,9 +668,15 @@ mod tests {
 
         // Both accounts are visible through the outer layer.
         let acct1 = outer.get_account_state(account_id_1).unwrap().unwrap();
-        assert_eq!(acct1.balance(), BitcoinAmount::from_sat(1000));
+        assert_eq!(
+            acct1.balance(),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply")
+        );
         let acct2 = outer.get_account_state(account_id_2).unwrap().unwrap();
-        assert_eq!(acct2.balance(), BitcoinAmount::from_sat(2000));
+        assert_eq!(
+            acct2.balance(),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         // Serial lookups resolve through both layers.
         assert_eq!(
@@ -646,8 +713,11 @@ mod tests {
             .map(|(i, id)| {
                 let mut batch = WriteBatch::default();
                 let snark_state = test_snark_account_state(i as u8 + 1);
-                let new_acct =
-                    test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(1000));
+                let new_acct = test_new_snark_account_data(
+                    &snark_state,
+                    BitcoinAmount::try_from(1000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                );
                 let serial = AccountSerial::from(base_serial + i as u32);
                 batch
                     .ledger_mut()

--- a/crates/ol/state-support-types/src/common_tests.rs
+++ b/crates/ol/state-support-types/src/common_tests.rs
@@ -81,17 +81,23 @@ impl Fixture {
     /// Slot the base is seeded at.
     pub(crate) const SLOT: u64 = 100;
 
-    /// Balance of the snark account that already exists in the base.
-    pub(crate) const ACCOUNT_BALANCE: BitcoinAmount = BitcoinAmount::from_sat(1_000);
+    /// Returns the balance of the snark account that already exists in the base.
+    pub(crate) fn account_balance() -> BitcoinAmount {
+        BitcoinAmount::try_from(1_000).expect("fixture amount must be valid")
+    }
 
     /// Inner state root seed of the account that already exists in the base.
     pub(crate) const ACCOUNT_STATE_SEED: u8 = 1;
 
-    /// Limbo funds seeded on the base.
-    pub(crate) const LIMBO_FUNDS: BitcoinAmount = BitcoinAmount::from_sat(2_000);
+    /// Returns the limbo funds seeded on the base.
+    pub(crate) fn limbo_funds() -> BitcoinAmount {
+        BitcoinAmount::try_from(2_000).expect("fixture amount must be valid")
+    }
 
-    /// Total ledger balance seeded on the base.
-    pub(crate) const TOTAL_LEDGER_BALANCE: BitcoinAmount = BitcoinAmount::from_sat(9_000);
+    /// Returns the total ledger balance seeded on the base.
+    pub(crate) fn total_ledger_balance() -> BitcoinAmount {
+        BitcoinAmount::try_from(9_000).expect("fixture amount must be valid")
+    }
 
     /// Number of pending ASM logs buffered on the base.
     pub(crate) const PENDING_LOGS: usize = 3;
@@ -106,14 +112,14 @@ impl Fixture {
                 account_id,
                 test_new_snark_account_data(
                     &test_snark_account_state(Self::ACCOUNT_STATE_SEED),
-                    Self::ACCOUNT_BALANCE,
+                    Self::account_balance(),
                 ),
             )
             .expect("fixture: create account");
 
-        base.add_limbo_funds_coin(Coin::new_unchecked(Self::LIMBO_FUNDS))
+        base.add_limbo_funds_coin(Coin::new_unchecked(Self::limbo_funds()))
             .expect("fixture: add limbo funds");
-        base.set_total_ledger_balance(Self::TOTAL_LEDGER_BALANCE);
+        base.set_total_ledger_balance(Self::total_ledger_balance());
         base.set_asm_recorded_epoch(Self::asm_recorded_epoch());
 
         // Indices into the L1 block refs MMR are L1 heights, so the record has
@@ -168,12 +174,14 @@ impl Fixture {
 
 /// Returns `amt` increased by `sats`.
 fn plus_sats(amt: BitcoinAmount, sats: u64) -> BitcoinAmount {
-    BitcoinAmount::from_sat(amt.to_sat() + sats)
+    BitcoinAmount::try_from(amt.to_sat() + sats)
+        .expect("amount must not exceed the Bitcoin money supply")
 }
 
 /// Returns `amt` decreased by `sats`.
 fn minus_sats(amt: BitcoinAmount, sats: u64) -> BitcoinAmount {
-    BitcoinAmount::from_sat(amt.to_sat() - sats)
+    BitcoinAmount::try_from(amt.to_sat() - sats)
+        .expect("amount must not exceed the Bitcoin money supply")
 }
 
 // =============================================================================
@@ -184,7 +192,7 @@ fn minus_sats(amt: BitcoinAmount, sats: u64) -> BitcoinAmount {
 pub(crate) fn read_falls_back_to_base<S: IStateAccessor>(fx: &Fixture, layer: &S) {
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
     assert_eq!(account.serial(), fx.serial());
-    assert_eq!(account.balance(), Fixture::ACCOUNT_BALANCE);
+    assert_eq!(account.balance(), Fixture::account_balance());
 }
 
 /// `check_account_exists` reflects presence in the base.
@@ -231,8 +239,11 @@ pub(crate) fn reads_all_fields_from_base<S: IStateAccessor>(fx: &Fixture, layer:
     // comparisons above are meaningful rather than trivially true.
     assert_eq!(layer.cur_epoch(), Fixture::EPOCH);
     assert_eq!(layer.cur_slot(), Fixture::SLOT);
-    assert_eq!(layer.limbo_funds(), Fixture::LIMBO_FUNDS);
-    assert_eq!(layer.total_ledger_balance(), Fixture::TOTAL_LEDGER_BALANCE);
+    assert_eq!(layer.limbo_funds(), Fixture::limbo_funds());
+    assert_eq!(
+        layer.total_ledger_balance(),
+        Fixture::total_ledger_balance()
+    );
     assert_eq!(*layer.asm_recorded_epoch(), Fixture::asm_recorded_epoch());
     assert_eq!(layer.pending_asm_logs_len(), Fixture::PENDING_LOGS);
     assert!(!layer.pending_asm_logs_full());
@@ -283,12 +294,18 @@ pub(crate) fn find_serial_returns_none_for_unknown<S: IStateAccessor>(_fx: &Fixt
 pub(crate) fn update_account_isolated_from_base<S: IStateAccessorMut>(fx: &Fixture, layer: &mut S) {
     layer
         .update_account(fx.account_id(), |acct| {
-            acct.add_balance(Coin::new_unchecked(BitcoinAmount::from_sat(500)));
+            acct.add_balance(Coin::new_unchecked(
+                BitcoinAmount::try_from(500)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ));
         })
         .unwrap();
 
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
-    assert_eq!(account.balance(), plus_sats(Fixture::ACCOUNT_BALANCE, 500));
+    assert_eq!(
+        account.balance(),
+        plus_sats(Fixture::account_balance(), 500)
+    );
 
     // Base is untouched.
     let base_account = fx
@@ -296,24 +313,33 @@ pub(crate) fn update_account_isolated_from_base<S: IStateAccessorMut>(fx: &Fixtu
         .get_account_state(fx.account_id())
         .unwrap()
         .unwrap();
-    assert_eq!(base_account.balance(), Fixture::ACCOUNT_BALANCE);
+    assert_eq!(base_account.balance(), Fixture::account_balance());
 }
 
 /// Repeated updates to the same account accumulate on the layer's copy.
 pub(crate) fn repeated_update_accumulates<S: IStateAccessorMut>(fx: &Fixture, layer: &mut S) {
     layer
         .update_account(fx.account_id(), |acct| {
-            acct.add_balance(Coin::new_unchecked(BitcoinAmount::from_sat(500)));
+            acct.add_balance(Coin::new_unchecked(
+                BitcoinAmount::try_from(500)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ));
         })
         .unwrap();
     layer
         .update_account(fx.account_id(), |acct| {
-            acct.add_balance(Coin::new_unchecked(BitcoinAmount::from_sat(100)));
+            acct.add_balance(Coin::new_unchecked(
+                BitcoinAmount::try_from(100)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ));
         })
         .unwrap();
 
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
-    assert_eq!(account.balance(), plus_sats(Fixture::ACCOUNT_BALANCE, 600));
+    assert_eq!(
+        account.balance(),
+        plus_sats(Fixture::account_balance(), 600)
+    );
 }
 
 /// Taking balance from an account debits it and yields a [`Coin`] of the taken
@@ -321,14 +347,20 @@ pub(crate) fn repeated_update_accumulates<S: IStateAccessorMut>(fx: &Fixture, la
 pub(crate) fn take_balance_reads_back<S: IStateAccessorMut>(fx: &Fixture, layer: &mut S) {
     let coin = layer
         .update_account(fx.account_id(), |acct| {
-            acct.take_balance(BitcoinAmount::from_sat(300))
+            acct.take_balance(
+                BitcoinAmount::try_from(300)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .unwrap()
         .unwrap();
     coin.safely_consume_unchecked();
 
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
-    assert_eq!(account.balance(), minus_sats(Fixture::ACCOUNT_BALANCE, 300));
+    assert_eq!(
+        account.balance(),
+        minus_sats(Fixture::account_balance(), 300)
+    );
 }
 
 /// Taking an account's entire balance leaves it at zero rather than erroring.
@@ -338,15 +370,15 @@ pub(crate) fn take_balance_exact_empties_account<S: IStateAccessorMut>(
 ) {
     let coin = layer
         .update_account(fx.account_id(), |acct| {
-            acct.take_balance(Fixture::ACCOUNT_BALANCE)
+            acct.take_balance(Fixture::account_balance())
         })
         .unwrap()
         .unwrap();
-    assert_eq!(coin.amt(), Fixture::ACCOUNT_BALANCE);
+    assert_eq!(coin.amt(), Fixture::account_balance());
     coin.safely_consume_unchecked();
 
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
-    assert_eq!(account.balance(), BitcoinAmount::ZERO);
+    assert_eq!(account.balance(), BitcoinAmount::default());
 }
 
 /// Taking more balance than an account holds errors with
@@ -354,7 +386,7 @@ pub(crate) fn take_balance_exact_empties_account<S: IStateAccessorMut>(
 pub(crate) fn take_balance_insufficient_errors<S: IStateAccessorMut>(fx: &Fixture, layer: &mut S) {
     let result = layer
         .update_account(fx.account_id(), |acct| {
-            acct.take_balance(plus_sats(Fixture::ACCOUNT_BALANCE, 1))
+            acct.take_balance(plus_sats(Fixture::account_balance(), 1))
         })
         .unwrap();
     assert!(matches!(
@@ -363,21 +395,26 @@ pub(crate) fn take_balance_insufficient_errors<S: IStateAccessorMut>(fx: &Fixtur
     ));
 
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
-    assert_eq!(account.balance(), Fixture::ACCOUNT_BALANCE);
+    assert_eq!(account.balance(), Fixture::account_balance());
 }
 
 /// A freshly created account is visible through the layer and resolvable by
 /// serial.
 pub(crate) fn create_account_visible<S: IStateAccessorMut>(_fx: &Fixture, layer: &mut S) {
     let account_id = Fixture::unused_account_id(0);
-    let new_acct =
-        test_new_snark_account_data(&test_snark_account_state(2), BitcoinAmount::from_sat(5000));
+    let new_acct = test_new_snark_account_data(
+        &test_snark_account_state(2),
+        BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let serial = layer.create_new_account(account_id, new_acct).unwrap();
 
     assert!(layer.check_account_exists(account_id).unwrap());
     let account = layer.get_account_state(account_id).unwrap().unwrap();
     assert_eq!(account.serial(), serial);
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(5000));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(
         layer.find_account_id_by_serial(serial).unwrap(),
         Some(account_id)
@@ -388,12 +425,18 @@ pub(crate) fn create_account_visible<S: IStateAccessorMut>(_fx: &Fixture, layer:
 /// asking for its snark state errors with [`StateError::MismatchedAcctType`].
 pub(crate) fn create_empty_account<S: IStateAccessorMut>(_fx: &Fixture, layer: &mut S) {
     let account_id = Fixture::unused_account_id(0);
-    let new_acct = NewAccountData::new(BitcoinAmount::from_sat(42), NewAccountTypeState::Empty);
+    let new_acct = NewAccountData::new(
+        BitcoinAmount::try_from(42).expect("amount must not exceed the Bitcoin money supply"),
+        NewAccountTypeState::Empty,
+    );
     layer.create_new_account(account_id, new_acct).unwrap();
 
     let account = layer.get_account_state(account_id).unwrap().unwrap();
     assert_eq!(account.ty(), AccountTypeId::Empty);
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(42));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(42).expect("amount must not exceed the Bitcoin money supply")
+    );
     assert!(matches!(
         account.as_snark_account(),
         Err(StateError::MismatchedAcctType { .. })
@@ -405,17 +448,26 @@ pub(crate) fn create_empty_account<S: IStateAccessorMut>(_fx: &Fixture, layer: &
 pub(crate) fn create_then_update_account<S: IStateAccessorMut>(_fx: &Fixture, layer: &mut S) {
     let account_id = Fixture::unused_account_id(0);
     let snark_state = test_snark_account_state(2);
-    let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(1_000));
+    let new_acct = test_new_snark_account_data(
+        &snark_state,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     layer.create_new_account(account_id, new_acct).unwrap();
 
     layer
         .update_account(account_id, |acct| {
-            acct.add_balance(Coin::new_unchecked(BitcoinAmount::from_sat(250)));
+            acct.add_balance(Coin::new_unchecked(
+                BitcoinAmount::try_from(250)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ));
         })
         .unwrap();
 
     let account = layer.get_account_state(account_id).unwrap().unwrap();
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(1_250));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(1_250).expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(
         account.as_snark_account().unwrap().inner_state_root(),
         snark_state.inner_state_root()
@@ -435,14 +487,22 @@ pub(crate) fn next_serial_advances_across_creates<S: IStateAccessorMut>(
     let serial_a: u32 = layer
         .create_new_account(
             acct_a,
-            test_new_snark_account_data(&test_snark_account_state(2), BitcoinAmount::from_sat(1)),
+            test_new_snark_account_data(
+                &test_snark_account_state(2),
+                BitcoinAmount::try_from(1)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ),
         )
         .unwrap()
         .into();
     let serial_b: u32 = layer
         .create_new_account(
             acct_b,
-            test_new_snark_account_data(&test_snark_account_state(3), BitcoinAmount::from_sat(2)),
+            test_new_snark_account_data(
+                &test_snark_account_state(3),
+                BitcoinAmount::try_from(2)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ),
         )
         .unwrap()
         .into();
@@ -475,13 +535,20 @@ pub(crate) fn create_duplicate_account_errors<S: IStateAccessorMut>(_fx: &Fixtur
     layer
         .create_new_account(
             account_id,
-            test_new_snark_account_data(&test_snark_account_state(2), BitcoinAmount::from_sat(100)),
+            test_new_snark_account_data(
+                &test_snark_account_state(2),
+                BitcoinAmount::try_from(100)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ),
         )
         .unwrap();
 
     let result = layer.create_new_account(
         account_id,
-        test_new_snark_account_data(&test_snark_account_state(3), BitcoinAmount::from_sat(200)),
+        test_new_snark_account_data(
+            &test_snark_account_state(3),
+            BitcoinAmount::try_from(200).expect("amount must not exceed the Bitcoin money supply"),
+        ),
     );
     assert!(matches!(result, Err(StateError::AccountExists(_))));
 }
@@ -499,14 +566,17 @@ pub(crate) fn create_duplicate_of_base_account_errors<S: IStateAccessorMut>(
 
     let result = layer.create_new_account(
         fx.account_id(),
-        test_new_snark_account_data(&test_snark_account_state(2), BitcoinAmount::from_sat(999)),
+        test_new_snark_account_data(
+            &test_snark_account_state(2),
+            BitcoinAmount::try_from(999).expect("amount must not exceed the Bitcoin money supply"),
+        ),
     );
     assert!(matches!(result, Err(StateError::AccountExists(_))));
 
     assert_eq!(layer.next_account_serial(), serial_before);
     let account = layer.get_account_state(fx.account_id()).unwrap().unwrap();
     assert_eq!(account.serial(), fx.serial());
-    assert_eq!(account.balance(), Fixture::ACCOUNT_BALANCE);
+    assert_eq!(account.balance(), Fixture::account_balance());
     assert_eq!(
         account.as_snark_account().unwrap().inner_state_root(),
         test_hash(Fixture::ACCOUNT_STATE_SEED)
@@ -561,18 +631,26 @@ pub(crate) fn roundtrip_cur_epoch<S: IStateAccessorMut>(_fx: &Fixture, layer: &m
 /// [`take_limbo_funds_coin`](IStateAccessorMut::take_limbo_funds_coin) read back
 /// via [`limbo_funds`](IStateAccessor::limbo_funds).
 pub(crate) fn roundtrip_limbo_funds<S: IStateAccessorMut>(_fx: &Fixture, layer: &mut S) {
-    assert_eq!(layer.limbo_funds(), Fixture::LIMBO_FUNDS);
+    assert_eq!(layer.limbo_funds(), Fixture::limbo_funds());
 
     layer
-        .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(1_000)))
+        .add_limbo_funds_coin(Coin::new_unchecked(
+            BitcoinAmount::try_from(1_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        ))
         .unwrap();
-    assert_eq!(layer.limbo_funds(), plus_sats(Fixture::LIMBO_FUNDS, 1_000));
+    assert_eq!(
+        layer.limbo_funds(),
+        plus_sats(Fixture::limbo_funds(), 1_000)
+    );
 
     let taken = layer
-        .take_limbo_funds_coin(BitcoinAmount::from_sat(400))
+        .take_limbo_funds_coin(
+            BitcoinAmount::try_from(400).expect("amount must not exceed the Bitcoin money supply"),
+        )
         .unwrap();
     taken.safely_consume_unchecked();
-    assert_eq!(layer.limbo_funds(), plus_sats(Fixture::LIMBO_FUNDS, 600));
+    assert_eq!(layer.limbo_funds(), plus_sats(Fixture::limbo_funds(), 600));
 }
 
 /// Taking more limbo funds than are available errors with
@@ -581,31 +659,40 @@ pub(crate) fn take_limbo_funds_insufficient_errors<S: IStateAccessorMut>(
     _fx: &Fixture,
     layer: &mut S,
 ) {
-    let result = layer.take_limbo_funds_coin(plus_sats(Fixture::LIMBO_FUNDS, 1));
+    let result = layer.take_limbo_funds_coin(plus_sats(Fixture::limbo_funds(), 1));
     assert!(matches!(
         result,
         Err(StateError::InsufficientLimboFunds { .. })
     ));
-    assert_eq!(layer.limbo_funds(), Fixture::LIMBO_FUNDS);
+    assert_eq!(layer.limbo_funds(), Fixture::limbo_funds());
 }
 
 /// Adding limbo funds that would overflow the accumulator errors with
 /// [`StateError::LimboFundsOverflow`], consumes the rejected [`Coin`] rather
 /// than panicking on drop, and leaves the balance unchanged.
 pub(crate) fn add_limbo_funds_overflow_errors<S: IStateAccessorMut>(_fx: &Fixture, layer: &mut S) {
-    let result = layer.add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::MAX));
+    let max_money = BitcoinAmount::try_from(21_000_000 * 100_000_000)
+        .expect("maximum Bitcoin money supply must be valid");
+    let result = layer.add_limbo_funds_coin(Coin::new_unchecked(max_money));
     assert!(matches!(result, Err(StateError::LimboFundsOverflow { .. })));
-    assert_eq!(layer.limbo_funds(), Fixture::LIMBO_FUNDS);
+    assert_eq!(layer.limbo_funds(), Fixture::limbo_funds());
 }
 
 /// [`set_total_ledger_balance`](IStateAccessorMut::set_total_ledger_balance)
 /// reads back via [`total_ledger_balance`](IStateAccessor::total_ledger_balance).
 pub(crate) fn roundtrip_total_ledger_balance<S: IStateAccessorMut>(_fx: &Fixture, layer: &mut S) {
-    assert_eq!(layer.total_ledger_balance(), Fixture::TOTAL_LEDGER_BALANCE);
-    layer.set_total_ledger_balance(BitcoinAmount::from_sat(1_000_000));
     assert_eq!(
         layer.total_ledger_balance(),
-        BitcoinAmount::from_sat(1_000_000)
+        Fixture::total_ledger_balance()
+    );
+    layer.set_total_ledger_balance(
+        BitcoinAmount::try_from(1_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
+    );
+    assert_eq!(
+        layer.total_ledger_balance(),
+        BitcoinAmount::try_from(1_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 }
 

--- a/crates/ol/state-support-types/src/da_accumulating_layer.rs
+++ b/crates/ol/state-support-types/src/da_accumulating_layer.rs
@@ -116,7 +116,13 @@ impl SnarkDelta {
         let base_seq_no = *state.seqno().inner();
         let base_proof_state =
             DaProofState::new(state.inner_state_root(), state.next_inbox_msg_idx());
-        let base_update_vk = U16LenBytes::new(state.update_vk().as_buf_ref().to_bytes());
+        let base_update_vk = U16LenBytes::new(
+            state
+                .update_vk()
+                .try_as_buf_ref()
+                .expect("stored predicate key must be valid")
+                .to_bytes(),
+        );
         Self {
             base_seq_no,
             final_seq_no: base_seq_no,
@@ -132,7 +138,13 @@ impl SnarkDelta {
         self.final_seq_no = *state.seqno().inner();
         self.final_proof_state =
             DaProofState::new(state.inner_state_root(), state.next_inbox_msg_idx());
-        self.final_update_vk = U16LenBytes::new(state.update_vk().as_buf_ref().to_bytes());
+        self.final_update_vk = U16LenBytes::new(
+            state
+                .update_vk()
+                .try_as_buf_ref()
+                .expect("stored predicate key must be valid")
+                .to_bytes(),
+        );
     }
 
     fn build_diff(&self) -> Result<SnarkAccountDiff, DaAccumulationError> {
@@ -511,8 +523,8 @@ impl EpochDaAccumulator {
             // CtrU64BySignedVarInt::compare is total over (u64, u64) — every pair
             // produces a valid signed delta, so this never returns None.
             let balance = {
-                let a: u64 = *delta.base_balance;
-                let b: u64 = *delta.final_balance;
+                let a = delta.base_balance.to_sat();
+                let b = delta.final_balance.to_sat();
                 let delta = CtrU64BySignedVarInt::compare(a, b)
                     .expect("CtrU64BySignedVarInt covers all u64 pairs");
                 DaCounter::new_changed(delta)
@@ -894,7 +906,11 @@ fn account_init_from_state<T: IAccountState>(state: &T) -> AccountInit {
         AccountTypeStateRef::Snark(snark_state) => {
             let init = SnarkAccountInit::new(
                 snark_state.inner_state_root(),
-                snark_state.update_vk().as_buf_ref().to_bytes(),
+                snark_state
+                    .update_vk()
+                    .try_as_buf_ref()
+                    .expect("stored predicate key must be valid")
+                    .to_bytes(),
             );
             AccountInit::new(balance, AccountTypeInit::Snark(init))
         }

--- a/crates/ol/state-support-types/src/indexer_layer.rs
+++ b/crates/ol/state-support-types/src/indexer_layer.rs
@@ -646,8 +646,11 @@ mod tests {
     #[test]
     fn test_tracks_inbox_message_writes() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Insert a message into the inbox
@@ -671,8 +674,11 @@ mod tests {
     #[test]
     fn test_tracks_multiple_inbox_writes_same_account() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Insert multiple messages
@@ -712,7 +718,8 @@ mod tests {
             .create_new_account(
                 account_id_1,
                 NewAccountData::new(
-                    BitcoinAmount::from_sat(1000),
+                    BitcoinAmount::try_from(1000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
                     NewAccountTypeState::Snark {
                         update_vk: snark_state_1.update_vk().clone(),
                         initial_state_root: snark_state_1.inner_state_root(),
@@ -724,7 +731,8 @@ mod tests {
             .create_new_account(
                 account_id_2,
                 NewAccountData::new(
-                    BitcoinAmount::from_sat(2000),
+                    BitcoinAmount::try_from(2000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
                     NewAccountTypeState::Snark {
                         update_vk: snark_state_2.update_vk().clone(),
                         initial_state_root: snark_state_2.inner_state_root(),
@@ -796,14 +804,20 @@ mod tests {
     #[test]
     fn test_modification_flag_on_balance_add() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Add balance
         indexer
             .update_account(account_id, |acct| {
-                let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+                let coin = Coin::new_unchecked(
+                    BitcoinAmount::try_from(500)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                );
                 acct.add_balance(coin);
             })
             .unwrap();
@@ -811,20 +825,31 @@ mod tests {
         // Verify the balance was actually updated in inner state
         let (inner, _) = indexer.into_parts();
         let account = inner.get_account_state(account_id).unwrap().unwrap();
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(1500));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(1500).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
     fn test_modification_flag_on_balance_take() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Take balance
         indexer
             .update_account(account_id, |acct| {
-                let coin = acct.take_balance(BitcoinAmount::from_sat(300)).unwrap();
+                let coin = acct
+                    .take_balance(
+                        BitcoinAmount::try_from(300)
+                            .expect("amount must not exceed the Bitcoin money supply"),
+                    )
+                    .unwrap();
                 coin.safely_consume_unchecked();
             })
             .unwrap();
@@ -832,14 +857,20 @@ mod tests {
         // Verify the balance was actually updated in inner state
         let (inner, _) = indexer.into_parts();
         let account = inner.get_account_state(account_id).unwrap().unwrap();
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(700));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(700).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
     fn test_modification_flag_on_snark_update() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Update snark state
@@ -864,8 +895,11 @@ mod tests {
     #[test]
     fn test_no_modification_when_closure_doesnt_mutate() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let original_root = state.compute_state_root().unwrap();
         let mut indexer = IndexerState::new(state);
 
@@ -892,7 +926,8 @@ mod tests {
     #[test]
     fn test_direct_vs_wrapped_inbox_insert() {
         let account_id = test_account_id(1);
-        let balance = BitcoinAmount::from_sat(1000);
+        let balance =
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply");
 
         // Create two identical states
         let (mut direct_state, _) = setup_layer_with_snark_account(account_id, 1, balance);
@@ -951,7 +986,8 @@ mod tests {
     #[test]
     fn test_direct_vs_wrapped_balance_update() {
         let account_id = test_account_id(1);
-        let balance = BitcoinAmount::from_sat(1000);
+        let balance =
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply");
 
         // Create two identical states
         let (mut direct_state, _) = setup_layer_with_snark_account(account_id, 1, balance);
@@ -959,7 +995,8 @@ mod tests {
         let mut wrapped_state = IndexerState::new(base_state);
 
         // Apply balance change to both
-        let add_amount = BitcoinAmount::from_sat(500);
+        let add_amount =
+            BitcoinAmount::try_from(500).expect("amount must not exceed the Bitcoin money supply");
 
         direct_state
             .update_account(account_id, |acct| {
@@ -983,7 +1020,10 @@ mod tests {
         let wrapped_acct = inner_state.get_account_state(account_id).unwrap().unwrap();
 
         assert_eq!(direct_acct.balance(), wrapped_acct.balance());
-        assert_eq!(wrapped_acct.balance(), BitcoinAmount::from_sat(1500));
+        assert_eq!(
+            wrapped_acct.balance(),
+            BitcoinAmount::try_from(1500).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     // =========================================================================
@@ -993,8 +1033,11 @@ mod tests {
     #[test]
     fn test_inbox_write_captures_pre_insertion_index() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Insert three messages sequentially
@@ -1021,8 +1064,11 @@ mod tests {
     #[test]
     fn test_inbox_write_captures_correct_account_id() {
         let account_id = test_account_id(42);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         let msg = test_message_entry(1, 0, 1000);
@@ -1052,8 +1098,11 @@ mod tests {
     #[test]
     fn test_into_parts_returns_inner_and_writes() {
         let account_id = test_account_id(1);
-        let (state, serial) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, serial) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Make a modification
@@ -1084,8 +1133,11 @@ mod tests {
     #[test]
     fn test_tracks_direct_set() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Update proof state directly
@@ -1117,8 +1169,11 @@ mod tests {
     #[test]
     fn test_tracks_multiple_snark_state_updates() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Multiple proof state updates
@@ -1159,13 +1214,21 @@ mod tests {
         state
             .create_new_account(
                 account_id_1,
-                test_new_snark_account_data(&snark_state_1, BitcoinAmount::from_sat(1000)),
+                test_new_snark_account_data(
+                    &snark_state_1,
+                    BitcoinAmount::try_from(1000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                ),
             )
             .unwrap();
         state
             .create_new_account(
                 account_id_2,
-                test_new_snark_account_data(&snark_state_2, BitcoinAmount::from_sat(2000)),
+                test_new_snark_account_data(
+                    &snark_state_2,
+                    BitcoinAmount::try_from(2000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                ),
             )
             .unwrap();
 
@@ -1207,8 +1270,11 @@ mod tests {
     #[test]
     fn test_is_empty_includes_state_updates() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Initially empty
@@ -1233,8 +1299,11 @@ mod tests {
     #[test]
     fn test_tracks_predicate_key_update() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         let new_vk = PredicateKey::never_accept();
@@ -1261,8 +1330,11 @@ mod tests {
     #[test]
     fn test_state_update_captures_inner_state_change() {
         let account_id = test_account_id(1);
-        let (state, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (state, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let mut indexer = IndexerState::new(state);
 
         // Update proof state

--- a/crates/ol/state-support-types/src/memory_state_layer.rs
+++ b/crates/ol/state-support-types/src/memory_state_layer.rs
@@ -151,7 +151,11 @@ impl IStateAccessorMut for MemoryStateBaseLayer {
     fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
         let cur = self.state.global.limbo_funds();
         let amt = coin.amt();
-        if cur.checked_add(amt).is_none() {
+        let new_limbo_funds = cur
+            .to_sat()
+            .checked_add(amt.to_sat())
+            .and_then(|sats| BitcoinAmount::try_from(sats).ok());
+        if new_limbo_funds.is_none() {
             // Defuse the coin before returning: the whole STF is discarded on
             // this error, so no value is actually lost, and dropping a live coin
             // would panic in `Coin::drop`.
@@ -305,7 +309,11 @@ mod tests {
         let serial = layer.next_account_serial();
 
         let snark_state = test_snark_account_state(7);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(1_234));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(1_234)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let mut batch = WriteBatch::default();
         batch

--- a/crates/ol/state-support-types/src/test_utils.rs
+++ b/crates/ol/state-support-types/src/test_utils.rs
@@ -55,8 +55,12 @@ pub(crate) fn test_snark_account_state(state_root_seed: u8) -> OLSnarkAccountSta
 
 /// Create a test message entry for inbox testing.
 pub(crate) fn test_message_entry(source_seed: u8, epoch: u32, value_sats: u64) -> MessageEntry {
-    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(value_sats), vec![source_seed])
-        .expect("message payload bytes must fit within SSZ max length");
+    let payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(value_sats)
+            .expect("amount must not exceed the Bitcoin money supply"),
+        vec![source_seed],
+    )
+    .expect("message payload bytes must fit within SSZ max length");
     MessageEntry::new(test_account_id(source_seed), epoch, payload)
 }
 

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -30,8 +30,11 @@ use crate::{
 #[test]
 fn test_indexer_over_write_tracking_basic() {
     let account_id = test_account_id(1);
-    let (base_layer, _serial) =
-        setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let (base_layer, _serial) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
 
     // Create the layer stack: IndexerState<WriteTrackingState<&MemoryStateBaseLayer>>
     let tracking = WriteTrackingState::new_empty(&base_layer);
@@ -39,15 +42,21 @@ fn test_indexer_over_write_tracking_basic() {
 
     // Verify we can read through both layers
     let account = indexer.get_account_state(account_id).unwrap().unwrap();
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(1_000));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply")
+    );
 }
 
 /// Test inbox message tracking through both layers.
 #[test]
 fn test_combined_inbox_message_tracking() {
     let account_id = test_account_id(1);
-    let (base_layer, _serial) =
-        setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let (base_layer, _serial) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
 
     let tracking = WriteTrackingState::new_empty(&base_layer);
     let mut indexer = IndexerState::new(tracking);
@@ -110,8 +119,11 @@ fn test_combined_manifest_tracking() {
 #[test]
 fn test_combined_balance_modification() {
     let account_id = test_account_id(1);
-    let (base_layer, _serial) =
-        setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let (base_layer, _serial) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
 
     let tracking = WriteTrackingState::new_empty(&base_layer);
     let mut indexer = IndexerState::new(tracking);
@@ -119,7 +131,10 @@ fn test_combined_balance_modification() {
     // Modify balance through the combined stack
     indexer
         .update_account(account_id, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(500)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
         })
         .unwrap();
@@ -130,11 +145,17 @@ fn test_combined_balance_modification() {
 
     // Verify the account is in the batch with updated balance
     let batch_account = batch.ledger().get_account(&account_id).unwrap();
-    assert_eq!(batch_account.balance(), BitcoinAmount::from_sat(1_500));
+    assert_eq!(
+        batch_account.balance(),
+        BitcoinAmount::try_from(1_500).expect("amount must not exceed the Bitcoin money supply")
+    );
 
     // Verify base state is unchanged
     let base_account = base_layer.get_account_state(account_id).unwrap().unwrap();
-    assert_eq!(base_account.balance(), BitcoinAmount::from_sat(1_000));
+    assert_eq!(
+        base_account.balance(),
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply")
+    );
 }
 
 /// Test account creation through combined layers.
@@ -146,8 +167,10 @@ fn test_combined_account_creation() {
 
     // Create a new account through the combined stack
     let account_id = test_account_id(1);
-    let new_acct =
-        test_new_snark_account_data(&test_snark_account_state(1), BitcoinAmount::from_sat(5_000));
+    let new_acct = test_new_snark_account_data(
+        &test_snark_account_state(1),
+        BitcoinAmount::try_from(5_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
 
     let serial = indexer.create_new_account(account_id, new_acct).unwrap();
 
@@ -155,7 +178,10 @@ fn test_combined_account_creation() {
     assert!(indexer.check_account_exists(account_id).unwrap());
     let account = indexer.get_account_state(account_id).unwrap().unwrap();
     assert_eq!(account.serial(), serial);
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(5_000));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(5_000).expect("amount must not exceed the Bitcoin money supply")
+    );
 
     // Extract and verify it's in the batch
     let (tracking, _) = indexer.into_parts();
@@ -193,15 +219,20 @@ fn test_combined_multiple_operations() {
     let account_id_2 = test_account_id(2);
 
     // Setup base layer with one account
-    let (base_layer, _) =
-        setup_layer_with_snark_account(account_id_1, 1, BitcoinAmount::from_sat(1_000));
+    let (base_layer, _) = setup_layer_with_snark_account(
+        account_id_1,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
 
     let tracking = WriteTrackingState::new_empty(&base_layer);
     let mut indexer = IndexerState::new(tracking);
 
     // Create a new account
-    let new_acct =
-        test_new_snark_account_data(&test_snark_account_state(2), BitcoinAmount::from_sat(2_000));
+    let new_acct = test_new_snark_account_data(
+        &test_snark_account_state(2),
+        BitcoinAmount::try_from(2_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     indexer.create_new_account(account_id_2, new_acct).unwrap();
 
     // Insert messages to both accounts
@@ -261,8 +292,10 @@ fn test_write_tracking_over_batch_diff_reads_from_pending_batch() {
 
     let account_id_in_batch = test_account_id(1);
     let mut pending_batch = WriteBatch::default();
-    let new_acct =
-        test_new_snark_account_data(&test_snark_account_state(1), BitcoinAmount::from_sat(3000));
+    let new_acct = test_new_snark_account_data(
+        &test_snark_account_state(1),
+        BitcoinAmount::try_from(3000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let serial = base_layer.next_account_serial();
     pending_batch
         .ledger_mut()
@@ -280,7 +313,10 @@ fn test_write_tracking_over_batch_diff_reads_from_pending_batch() {
         .get_account_state(account_id_in_batch)
         .unwrap()
         .unwrap();
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(3000));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(3000).expect("amount must not exceed the Bitcoin money supply")
+    );
 
     // Global and epochal reads resolve to the pending batch, not the base.
     assert_eq!(tracking.cur_slot(), 50);
@@ -321,8 +357,10 @@ fn test_write_tracking_over_batch_diff_update_account_from_pending_batch() {
 
     let account_id = test_account_id(1);
     let mut pending_batch = WriteBatch::default();
-    let new_acct =
-        test_new_snark_account_data(&test_snark_account_state(1), BitcoinAmount::from_sat(3000));
+    let new_acct = test_new_snark_account_data(
+        &test_snark_account_state(1),
+        BitcoinAmount::try_from(3000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let serial = base_layer.next_account_serial();
     pending_batch
         .ledger_mut()
@@ -335,19 +373,25 @@ fn test_write_tracking_over_batch_diff_update_account_from_pending_batch() {
     // Copy-on-write from the pending batch into this layer's write batch.
     tracking
         .update_account(account_id, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(500)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
         })
         .unwrap();
 
     let account = tracking.get_account_state(account_id).unwrap().unwrap();
-    assert_eq!(account.balance(), BitcoinAmount::from_sat(3500));
+    assert_eq!(
+        account.balance(),
+        BitcoinAmount::try_from(3500).expect("amount must not exceed the Bitcoin money supply")
+    );
 
     let batch = tracking.into_batch();
     assert!(batch.ledger().contains_account(&account_id));
     assert_eq!(
         batch.ledger().get_account(&account_id).unwrap().balance(),
-        BitcoinAmount::from_sat(3500)
+        BitcoinAmount::try_from(3500).expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -357,13 +401,20 @@ fn test_write_tracking_over_batch_diff_update_account_from_pending_batch() {
 
 fn build_simple_blob() -> Vec<u8> {
     let account_id = test_account_id(1);
-    let (mut layer, _) =
-        setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+    let (mut layer, _) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let source_account_id = test_account_id(7);
     layer
         .create_new_account(
             source_account_id,
-            test_new_snark_account_data(&test_snark_account_state(2), BitcoinAmount::from_sat(0)),
+            test_new_snark_account_data(
+                &test_snark_account_state(2),
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ),
         )
         .unwrap();
     let mut da_state = DaAccumulatingState::new(layer);
@@ -373,7 +424,10 @@ fn build_simple_blob() -> Vec<u8> {
     let msg = test_message_entry(7, 0, 2000);
     da_state
         .update_account(account_id, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(500)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
             acct.as_snark_account_mut()
                 .unwrap()
@@ -400,7 +454,8 @@ impl TestSnarkState {
     fn new(update_vk: Vec<u8>) -> Self {
         let generic_mmr = CompactMmr64::<[u8; 32]>::new(64);
         let inbox_mmr = Mmr64::from_generic(&generic_mmr);
-        let update_vk = PredicateKey::new(PredicateTypeId::AlwaysAccept, update_vk);
+        let update_vk = PredicateKey::try_new(PredicateTypeId::AlwaysAccept, update_vk)
+            .expect("predicate condition must fit within the maximum length");
         Self {
             update_vk,
             inner_state_root: Hash::from([0u8; 32]),
@@ -521,7 +576,8 @@ impl IAccountStateMut for TestAccountState {
 
     fn add_balance(&mut self, coin: Coin) {
         let new_balance = self.balance.to_sat() + coin.amt().to_sat();
-        self.balance = BitcoinAmount::from_sat(new_balance);
+        self.balance = BitcoinAmount::try_from(new_balance)
+            .expect("amount must not exceed the Bitcoin money supply");
         coin.safely_consume_unchecked();
     }
 
@@ -559,12 +615,12 @@ impl TestState {
             next_serial: AccountSerial::one(),
             serial_overrides: VecDeque::from(serials),
             cur_slot: 0,
-            limbo_funds: BitcoinAmount::ZERO,
+            limbo_funds: BitcoinAmount::default(),
             cur_epoch: 0,
             last_l1_blkid: L1BlockId::from(Buf32::zero()),
             last_l1_height: L1Height::from(0u32),
             asm_recorded_epoch: EpochCommitment::null(),
-            total_ledger_balance: BitcoinAmount::ZERO,
+            total_ledger_balance: BitcoinAmount::default(),
             pending_asm_logs: Vec::new(),
         }
     }
@@ -650,7 +706,12 @@ impl IStateAccessorMut for TestState {
 
     fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
         let amt = coin.amt();
-        let Some(new) = self.limbo_funds.checked_add(amt) else {
+        let new = self
+            .limbo_funds
+            .to_sat()
+            .checked_add(amt.to_sat())
+            .and_then(|sats| BitcoinAmount::try_from(sats).ok());
+        let Some(new) = new else {
             // Defuse the coin before returning so the mock upholds the same
             // consume-always contract as the real layers (dropping it panics).
             coin.safely_consume_unchecked();
@@ -665,14 +726,14 @@ impl IStateAccessorMut for TestState {
     }
 
     fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
-        let new = self
-            .limbo_funds
-            .checked_sub(amt)
-            .ok_or(StateError::InsufficientLimboFunds {
+        let new_sats = self.limbo_funds.to_sat().checked_sub(amt.to_sat()).ok_or(
+            StateError::InsufficientLimboFunds {
                 need: amt,
                 have: self.limbo_funds,
-            })?;
-        self.limbo_funds = new;
+            },
+        )?;
+        self.limbo_funds = BitcoinAmount::try_from(new_sats)
+            .expect("subtracting from valid limbo funds must remain valid");
         Ok(Coin::new_unchecked(amt))
     }
 
@@ -754,7 +815,8 @@ fn test_account_diffs_ordered_by_serial() {
             account_id_1,
             test_new_snark_account_data(
                 &test_snark_account_state(1),
-                BitcoinAmount::from_sat(1000),
+                BitcoinAmount::try_from(1000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
             ),
         )
         .unwrap();
@@ -763,7 +825,8 @@ fn test_account_diffs_ordered_by_serial() {
             account_id_2,
             test_new_snark_account_data(
                 &test_snark_account_state(2),
-                BitcoinAmount::from_sat(2000),
+                BitcoinAmount::try_from(2000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
             ),
         )
         .unwrap();
@@ -773,13 +836,19 @@ fn test_account_diffs_ordered_by_serial() {
     // Update higher serial first, then lower serial.
     da_state
         .update_account(account_id_2, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(50));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(50)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
         })
         .unwrap();
     da_state
         .update_account(account_id_1, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(75));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(75)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
         })
         .unwrap();
@@ -805,7 +874,7 @@ fn test_new_account_post_state_encoded() {
     let update_vk = vec![7u8; 4];
     let snark_state = TestSnarkState::new(update_vk.clone());
     let new_acct = NewAccountData::new(
-        BitcoinAmount::from_sat(100),
+        BitcoinAmount::try_from(100).expect("amount must not exceed the Bitcoin money supply"),
         NewAccountTypeState::Snark {
             update_vk: snark_state.update_vk.clone(),
             initial_state_root: snark_state.inner_state_root,
@@ -815,7 +884,10 @@ fn test_new_account_post_state_encoded() {
 
     da_state
         .update_account(account_id, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(50));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(50)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
             acct.as_snark_account_mut()
                 .unwrap()
@@ -833,16 +905,24 @@ fn test_new_account_post_state_encoded() {
     assert_eq!(new_accounts.len(), 1);
     let entry = &new_accounts[0];
     assert_eq!(entry.account_id, account_id);
-    assert_eq!(entry.init.balance, BitcoinAmount::from_sat(150));
+    assert_eq!(
+        entry.init.balance,
+        BitcoinAmount::try_from(150).expect("amount must not exceed the Bitcoin money supply")
+    );
     match &entry.init.type_state {
         AccountTypeInit::Snark(init) => {
             assert_eq!(init.initial_state_root, test_hash(9));
             // The VK is stored with the predicate type ID prefix, so we need to compare
             // with the full predicate key bytes (type ID + raw VK bytes)
-            let expected_vk = PredicateKey::new(PredicateTypeId::AlwaysAccept, update_vk.clone());
+            let expected_vk =
+                PredicateKey::try_new(PredicateTypeId::AlwaysAccept, update_vk.clone())
+                    .expect("predicate condition must fit within the maximum length");
             assert_eq!(
                 init.update_vk.as_slice(),
-                expected_vk.as_buf_ref().to_bytes()
+                expected_vk
+                    .try_as_buf_ref()
+                    .expect("predicate key must be valid")
+                    .to_bytes()
             );
         }
         _ => panic!("expected snark account init"),
@@ -857,7 +937,7 @@ fn test_new_account_vk_persisted_from_ol_state() {
     let account_id = test_account_id(10);
     let snark_state = OLSnarkAccountState::new_fresh(PredicateKey::always_accept(), test_hash(4));
     let new_acct = NewAccountData::new(
-        BitcoinAmount::from_sat(100),
+        BitcoinAmount::try_from(100).expect("amount must not exceed the Bitcoin money supply"),
         NewAccountTypeState::Snark {
             update_vk: snark_state.update_vk().clone(),
             initial_state_root: snark_state.inner_state_root(),
@@ -877,7 +957,11 @@ fn test_new_account_vk_persisted_from_ol_state() {
         AccountTypeInit::Snark(init) => {
             assert_eq!(
                 init.update_vk.as_slice(),
-                snark_state.update_vk().as_buf_ref().to_bytes()
+                snark_state
+                    .update_vk()
+                    .try_as_buf_ref()
+                    .expect("predicate key must be valid")
+                    .to_bytes()
             );
         }
         _ => panic!("expected snark account init"),
@@ -887,13 +971,20 @@ fn test_new_account_vk_persisted_from_ol_state() {
 #[test]
 fn test_take_resets_accumulator() {
     let account_id = test_account_id(1);
-    let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+    let (layer, _) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let mut da_state = DaAccumulatingState::new(layer);
 
     // Finalize once after making changes.
     da_state
         .update_account(account_id, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(123));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(123)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
         })
         .unwrap();
@@ -919,13 +1010,21 @@ fn test_limbo_funds_encoded_in_blob() {
     // Drive the limbo funds up then partially back down; the net change is what
     // the accumulator's limbo `DaCounter` should encode.
     da_state
-        .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(1_000)))
+        .add_limbo_funds_coin(Coin::new_unchecked(
+            BitcoinAmount::try_from(1_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        ))
         .unwrap();
     let taken = da_state
-        .take_limbo_funds_coin(BitcoinAmount::from_sat(400))
+        .take_limbo_funds_coin(
+            BitcoinAmount::try_from(400).expect("amount must not exceed the Bitcoin money supply"),
+        )
         .unwrap();
     taken.safely_consume_unchecked();
-    assert_eq!(da_state.limbo_funds(), BitcoinAmount::from_sat(600));
+    assert_eq!(
+        da_state.limbo_funds(),
+        BitcoinAmount::try_from(600).expect("amount must not exceed the Bitcoin money supply")
+    );
 
     let blob_bytes = da_state
         .take_completed_epoch_da_blob()
@@ -959,7 +1058,7 @@ fn test_da_blob_size_limit() {
         let account_id = test_account_id(i);
         let snark_state = TestSnarkState::new(vk_data.clone());
         let new_acct = NewAccountData::new(
-            BitcoinAmount::from_sat(0),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
             NewAccountTypeState::Snark {
                 update_vk: snark_state.update_vk.clone(),
                 initial_state_root: snark_state.inner_state_root,
@@ -985,7 +1084,7 @@ fn test_vk_size_at_predicate_limit_roundtrips() {
     let vk_len = MAX_CONDITION_LEN as usize;
     let snark_state = TestSnarkState::new(vec![0u8; vk_len]);
     let new_acct = NewAccountData::new(
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         NewAccountTypeState::Snark {
             update_vk: snark_state.update_vk.clone(),
             initial_state_root: snark_state.inner_state_root,
@@ -1016,7 +1115,7 @@ fn test_estimated_encoded_size_scales_with_new_account_vk_len() {
         let account_id = test_account_id(1);
         let snark_state = TestSnarkState::new(vec![0u8; vk_len]);
         let new_acct = NewAccountData::new(
-            BitcoinAmount::from_sat(0),
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
             NewAccountTypeState::Snark {
                 update_vk: snark_state.update_vk.clone(),
                 initial_state_root: snark_state.inner_state_root,
@@ -1037,20 +1136,28 @@ fn test_estimated_encoded_size_scales_with_new_account_vk_len() {
 }
 
 #[test]
-#[should_panic(expected = "valid length")]
-fn test_oversized_predicate_key_panics() {
+fn test_oversized_predicate_key_is_rejected() {
     let oversized_vk_len = MAX_CONDITION_LEN as usize + 1;
-    let _ = PredicateKey::new(PredicateTypeId::AlwaysAccept, vec![0u8; oversized_vk_len]);
+    assert!(
+        PredicateKey::try_new(PredicateTypeId::AlwaysAccept, vec![0u8; oversized_vk_len]).is_err()
+    );
 }
 
 #[test]
 fn test_message_source_missing_is_rejected() {
     let account_id = test_account_id(1);
-    let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let (layer, _) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let mut da_state = DaAccumulatingState::new(layer);
 
-    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![0u8; 4])
-        .expect("message payload bytes must fit within SSZ max length");
+    let payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        vec![0u8; 4],
+    )
+    .expect("message payload bytes must fit within SSZ max length");
     let missing_source = test_account_id(99);
     let msg = MessageEntry::new(missing_source, 0, payload);
     da_state
@@ -1072,11 +1179,18 @@ fn test_message_source_missing_is_rejected() {
 #[test]
 fn test_special_message_source_is_encoded() {
     let account_id = test_account_id(1);
-    let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let (layer, _) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let mut da_state = DaAccumulatingState::new(layer);
 
-    let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(0), vec![0u8; 4])
-        .expect("message payload bytes must fit within SSZ max length");
+    let payload = MsgPayload::from_bytes(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        vec![0u8; 4],
+    )
+    .expect("message payload bytes must fit within SSZ max length");
     let special_source = AccountId::special(0x10);
     let msg = MessageEntry::new(special_source, 0, payload);
     da_state
@@ -1103,11 +1217,15 @@ fn test_special_message_source_is_encoded() {
 #[test]
 fn test_message_payload_size_limit() {
     let account_id = test_account_id(1);
-    let (layer, _) = setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1_000));
+    let (layer, _) = setup_layer_with_snark_account(
+        account_id,
+        1,
+        BitcoinAmount::try_from(1_000).expect("amount must not exceed the Bitcoin money supply"),
+    );
     let mut da_state = DaAccumulatingState::new(layer);
 
     let payload = MsgPayload::from_bytes(
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         vec![0u8; MAX_MSG_PAYLOAD_BYTES + 1],
     )
     .expect("message payload bytes must fit within SSZ max length");
@@ -1172,7 +1290,8 @@ fn test_expected_first_serial_mismatch() {
 #[test]
 fn test_combined_layers_preserve_base_state() {
     let account_id = test_account_id(1);
-    let initial_balance = BitcoinAmount::from_sat(1000);
+    let initial_balance =
+        BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply");
     let (base_layer, _) = setup_layer_with_snark_account(account_id, 1, initial_balance);
 
     // Save original values
@@ -1195,7 +1314,10 @@ fn test_combined_layers_preserve_base_state() {
     indexer.set_cur_epoch(99);
     indexer
         .update_account(account_id, |acct| {
-            let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+            let coin = Coin::new_unchecked(
+                BitcoinAmount::try_from(500)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            );
             acct.add_balance(coin);
             acct.as_snark_account_mut()
                 .unwrap()

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -97,7 +97,10 @@ where
         self.batch
             .global_writes()
             .limbo_funds_sats
-            .map(BitcoinAmount::from_sat)
+            .map(|sats| {
+                BitcoinAmount::try_from(sats)
+                    .expect("limbo funds must not exceed the Bitcoin money supply")
+            })
             .unwrap_or_else(|| self.base.limbo_funds())
     }
 
@@ -258,27 +261,32 @@ where
     fn add_limbo_funds_coin(&mut self, coin: Coin) -> StateResult<()> {
         let cur = self.limbo_funds();
         let amt = coin.amt();
-        let Some(new) = cur.checked_add(amt) else {
+        let Some(new_sats) = cur.to_sat().checked_add(amt.to_sat()) else {
             // Defuse the coin before returning: the whole STF is discarded on
             // this error, so no value is actually lost, and dropping a live coin
             // would panic in `Coin::drop`.
             coin.safely_consume_unchecked();
             return Err(StateError::LimboFundsOverflow { cur, add: amt });
         };
-        self.batch.global_writes_mut().limbo_funds_sats = Some(new.to_sat());
+        if BitcoinAmount::try_from(new_sats).is_err() {
+            coin.safely_consume_unchecked();
+            return Err(StateError::LimboFundsOverflow { cur, add: amt });
+        }
+        self.batch.global_writes_mut().limbo_funds_sats = Some(new_sats);
         coin.safely_consume_unchecked();
         Ok(())
     }
 
     fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
         let cur = self.limbo_funds();
-        let new = cur
-            .checked_sub(amt)
-            .ok_or(StateError::InsufficientLimboFunds {
-                need: amt,
-                have: cur,
-            })?;
-        self.batch.global_writes_mut().limbo_funds_sats = Some(new.to_sat());
+        let new_sats =
+            cur.to_sat()
+                .checked_sub(amt.to_sat())
+                .ok_or(StateError::InsufficientLimboFunds {
+                    need: amt,
+                    have: cur,
+                })?;
+        self.batch.global_writes_mut().limbo_funds_sats = Some(new_sats);
         Ok(Coin::new_unchecked(amt))
     }
 
@@ -441,8 +449,11 @@ mod tests {
     #[test]
     fn test_write_copies_to_batch() {
         let account_id = test_account_id(1);
-        let (base_layer, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (base_layer, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let original_balance = base_layer
             .get_account_state(account_id)
             .unwrap()
@@ -454,7 +465,10 @@ mod tests {
         // Modify account
         tracking
             .update_account(account_id, |acct: &mut OLAccountState| {
-                let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+                let coin = Coin::new_unchecked(
+                    BitcoinAmount::try_from(500)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                );
                 acct.add_balance(coin);
             })
             .unwrap();
@@ -464,7 +478,10 @@ mod tests {
 
         // Verify the modified balance through tracking state
         let modified_account = tracking.get_account_state(account_id).unwrap().unwrap();
-        assert_eq!(modified_account.balance(), BitcoinAmount::from_sat(1500));
+        assert_eq!(
+            modified_account.balance(),
+            BitcoinAmount::try_from(1500).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         // Verify base state is unchanged
         let base_account = base_layer.get_account_state(account_id).unwrap().unwrap();
@@ -483,7 +500,10 @@ mod tests {
 
         let account_id = test_account_id(1);
         let snark_state = test_snark_account_state(1);
-        let new_acct = test_new_snark_account_data(&snark_state, BitcoinAmount::from_sat(5000));
+        let new_acct = test_new_snark_account_data(
+            &snark_state,
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let serial = tracking.create_new_account(account_id, new_acct).unwrap();
 
@@ -493,7 +513,10 @@ mod tests {
         // Verify we can retrieve it
         let account = tracking.get_account_state(account_id).unwrap().unwrap();
         assert_eq!(account.serial(), serial);
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(5000));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         // Verify base is unchanged
         assert!(!base_layer.check_account_exists(account_id).unwrap());
@@ -569,8 +592,11 @@ mod tests {
     #[test]
     fn test_into_batch_returns_modifications() {
         let account_id = test_account_id(1);
-        let (base_layer, _) =
-            setup_layer_with_snark_account(account_id, 1, BitcoinAmount::from_sat(1000));
+        let (base_layer, _) = setup_layer_with_snark_account(
+            account_id,
+            1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
         let diff = BatchDiffState::new(&base_layer, &[]);
         let mut tracking = WriteTrackingState::new_empty(&diff);
 
@@ -578,7 +604,10 @@ mod tests {
         tracking.set_cur_slot(100);
         tracking
             .update_account(account_id, |acct: &mut OLAccountState| {
-                let coin = Coin::new_unchecked(BitcoinAmount::from_sat(500));
+                let coin = Coin::new_unchecked(
+                    BitcoinAmount::try_from(500)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                );
                 acct.add_balance(coin);
             })
             .unwrap();
@@ -591,7 +620,10 @@ mod tests {
         assert!(batch.ledger().contains_account(&account_id));
 
         let account = batch.ledger().get_account(&account_id).unwrap();
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(1500));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(1500).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]

--- a/crates/ol/state-types/src/account.rs
+++ b/crates/ol/state-types/src/account.rs
@@ -75,21 +75,25 @@ impl IAccountStateMut for OLAccountState {
     type SnarkAccountStateMut = OLSnarkAccountState;
 
     fn add_balance(&mut self, coin: Coin) {
-        self.balance = self
+        let balance_sats = self
             .balance
-            .checked_add(coin.amt())
+            .to_sat()
+            .checked_add(coin.amt().to_sat())
             .expect("ledger: overflow balance");
+        self.balance =
+            BitcoinAmount::try_from(balance_sats).expect("ledger: balance exceeds money supply");
         coin.safely_consume_unchecked();
     }
 
     fn take_balance(&mut self, amt: BitcoinAmount) -> StateResult<Coin> {
-        self.balance = self
-            .balance
-            .checked_sub(amt)
-            .ok_or(StateError::InsufficientBalance {
+        let balance_sats = self.balance.to_sat().checked_sub(amt.to_sat()).ok_or(
+            StateError::InsufficientBalance {
                 need: amt,
                 have: self.balance,
-            })?;
+            },
+        )?;
+        self.balance = BitcoinAmount::try_from(balance_sats)
+            .expect("subtracting from a valid balance must remain valid");
         Ok(Coin::new_unchecked(amt))
     }
 

--- a/crates/ol/state-types/src/global.rs
+++ b/crates/ol/state-types/src/global.rs
@@ -41,15 +41,19 @@ impl GlobalState {
 
     /// Gets the amount of funds in limbo.
     pub fn limbo_funds(&self) -> BitcoinAmount {
-        BitcoinAmount::from_sat(self.limbo_funds_sats)
+        BitcoinAmount::try_from(self.limbo_funds_sats)
+            .expect("amount must not exceed the Bitcoin money supply")
     }
 
     /// Attempts to add limbo funds.
     pub fn add_limbo_funds(&mut self, amt: BitcoinAmount) -> bool {
-        let Some(new_lf) = self.limbo_funds().checked_add(amt) else {
+        let Some(new_lf_sats) = self.limbo_funds_sats.checked_add(amt.to_sat()) else {
             return false;
         };
-        self.limbo_funds_sats = new_lf.to_sat();
+        if BitcoinAmount::try_from(new_lf_sats).is_err() {
+            return false;
+        }
+        self.limbo_funds_sats = new_lf_sats;
         true
     }
 
@@ -70,12 +74,14 @@ impl GlobalState {
     pub fn take_limbo_funds_coin(&mut self, amt: BitcoinAmount) -> Option<Coin> {
         let lf = self.limbo_funds();
 
-        let new_lf = lf.checked_sub(amt)?;
+        let new_lf_sats = lf.to_sat().checked_sub(amt.to_sat())?;
+        let new_lf = BitcoinAmount::try_from(new_lf_sats)
+            .expect("subtracting from valid limbo funds must remain valid");
 
         // This sanity check should be optimized out.
         assert_eq!(
-            new_lf.checked_add(amt),
-            Some(lf),
+            new_lf.to_sat().checked_add(amt.to_sat()),
+            Some(lf.to_sat()),
             "ol/state: inconsistent limbo funds change"
         );
 

--- a/crates/ol/state-types/src/ledger.rs
+++ b/crates/ol/state-types/src/ledger.rs
@@ -89,13 +89,17 @@ impl TsnlLedgerAccountsTable {
     }
 
     /// Calculates the total funds across all accounts in the ledger.
-    pub(crate) fn calculate_total_funds(&self) -> BitcoinAmount {
-        let total_sats = self.accounts.iter().fold(0u64, |acc, entry| {
-            acc.checked_add(entry.state.balance.to_sat())
-                .expect("ol/state: total funds overflow")
-        });
-        BitcoinAmount::try_from(total_sats)
-            .expect("ol/state: total funds exceed the Bitcoin money supply")
+    ///
+    /// Errors if the total exceeds the Bitcoin money supply.
+    pub(crate) fn calculate_total_funds(&self) -> StateResult<BitcoinAmount> {
+        let total_sats = self
+            .accounts
+            .iter()
+            .try_fold(0u64, |acc, entry| {
+                acc.checked_add(entry.state.balance.to_sat())
+            })
+            .ok_or(StateError::TotalFundsOverflow)?;
+        BitcoinAmount::try_from(total_sats).map_err(|_| StateError::TotalFundsOverflow)
     }
 }
 
@@ -281,6 +285,58 @@ mod tests {
         let account_id = test_account_id(1);
         let state = table.get_account_state(&account_id);
         assert!(state.is_none());
+    }
+
+    #[test]
+    fn test_calculate_total_funds_sums_balances() {
+        let mut table = TsnlLedgerAccountsTable::new_empty();
+        let mut next_serial = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
+
+        for i in 1..=3u8 {
+            let serial = next_serial;
+            next_serial = serial.incr();
+            let balance = BitcoinAmount::try_from(i as u64 * 100)
+                .expect("amount must not exceed the Bitcoin money supply");
+            let account_state = create_empty_account_state(serial, balance);
+
+            table
+                .create_account(test_account_id(i), account_state)
+                .unwrap();
+        }
+
+        let total = table
+            .calculate_total_funds()
+            .expect("total within the money supply must succeed");
+        assert_eq!(
+            total,
+            BitcoinAmount::try_from(600).expect("amount must not exceed the Bitcoin money supply")
+        );
+    }
+
+    #[test]
+    fn test_calculate_total_funds_rejects_oversized_total() {
+        const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
+        let mut table = TsnlLedgerAccountsTable::new_empty();
+        let mut next_serial = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
+
+        // Two individually valid max-money balances whose sum is above the cap.
+        for i in 1..=2u8 {
+            let serial = next_serial;
+            next_serial = serial.incr();
+            let balance = BitcoinAmount::try_from(MAX_BITCOIN_MONEY_SATS)
+                .expect("amount must not exceed the Bitcoin money supply");
+            let account_state = create_empty_account_state(serial, balance);
+
+            table
+                .create_account(test_account_id(i), account_state)
+                .unwrap();
+        }
+
+        let err = table
+            .calculate_total_funds()
+            .expect_err("total above the money supply must fail");
+        assert!(matches!(err, StateError::TotalFundsOverflow));
     }
 
     #[test]

--- a/crates/ol/state-types/src/ledger.rs
+++ b/crates/ol/state-types/src/ledger.rs
@@ -90,12 +90,12 @@ impl TsnlLedgerAccountsTable {
 
     /// Calculates the total funds across all accounts in the ledger.
     pub(crate) fn calculate_total_funds(&self) -> BitcoinAmount {
-        self.accounts
-            .iter()
-            .fold(BitcoinAmount::ZERO, |acc, entry| {
-                acc.checked_add(entry.state.balance)
-                    .expect("ol/state: total funds overflow")
-            })
+        let total_sats = self.accounts.iter().fold(0u64, |acc, entry| {
+            acc.checked_add(entry.state.balance.to_sat())
+                .expect("ol/state: total funds overflow")
+        });
+        BitcoinAmount::try_from(total_sats)
+            .expect("ol/state: total funds exceed the Bitcoin money supply")
     }
 }
 
@@ -147,7 +147,8 @@ mod tests {
         // Create an account
         let account_id = test_account_id(1);
         let serial = AccountSerial::zero();
-        let balance = BitcoinAmount::from_sat(1000);
+        let balance =
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply");
         let account_state = create_empty_account_state(serial, balance);
 
         // Add the account
@@ -182,7 +183,8 @@ mod tests {
         for (i, account_id) in account_ids.iter().enumerate() {
             let serial = next_serial;
             next_serial = serial.incr();
-            let balance = BitcoinAmount::from_sat((i as u64 + 1) * 100);
+            let balance = BitcoinAmount::try_from((i as u64 + 1) * 100)
+                .expect("amount must not exceed the Bitcoin money supply");
             let account_state = create_empty_account_state(serial, balance);
 
             let result = table.create_account(*account_id, account_state);
@@ -214,14 +216,20 @@ mod tests {
         // Create first account
         let account_id = test_account_id(1);
         let serial1 = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
-        let account_state1 = create_empty_account_state(serial1, BitcoinAmount::from_sat(1000));
+        let account_state1 = create_empty_account_state(
+            serial1,
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let result1 = table.create_account(account_id, account_state1);
         assert!(result1.is_ok());
 
         // Try to create account with same ID
         let serial2 = serial1.incr();
-        let account_state2 = create_empty_account_state(serial2, BitcoinAmount::from_sat(2000));
+        let account_state2 = create_empty_account_state(
+            serial2,
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply"),
+        );
 
         let result2 = table.create_account(account_id, account_state2);
         assert!(result2.is_err());
@@ -242,7 +250,8 @@ mod tests {
         // Create an account
         let account_id = test_account_id(1);
         let serial = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
-        let initial_balance = BitcoinAmount::from_sat(1000);
+        let initial_balance =
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply");
         let account_state = create_empty_account_state(serial, initial_balance);
 
         table.create_account(account_id, account_state).unwrap();
@@ -299,7 +308,8 @@ mod tests {
             let account_id = test_account_id(i);
             let serial = next_serial;
             next_serial = serial.incr();
-            let balance = BitcoinAmount::from_sat((i as u64) * 1000);
+            let balance = BitcoinAmount::try_from((i as u64) * 1000)
+                .expect("amount must not exceed the Bitcoin money supply");
             let account_state = create_empty_account_state(serial, balance);
 
             table.create_account(account_id, account_state).unwrap();

--- a/crates/ol/state-types/src/test_utils.rs
+++ b/crates/ol/state-types/src/test_utils.rs
@@ -13,6 +13,8 @@ use strata_predicate::PredicateKey;
 
 use crate::ssz_generated::ssz::state::*;
 
+const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
 /// Creates a genesis OLState using minimal empty parameters.
 pub fn create_test_genesis_state() -> OLState {
     let params = OLParams::default();
@@ -20,7 +22,9 @@ pub fn create_test_genesis_state() -> OLState {
 }
 
 pub fn bitcoin_amount_strategy() -> impl Strategy<Value = BitcoinAmount> {
-    any::<u64>().prop_map(BitcoinAmount::from_sat)
+    (0..=MAX_BITCOIN_MONEY_SATS).prop_map(|sats| {
+        BitcoinAmount::try_from(sats).expect("strategy only generates valid Bitcoin amounts")
+    })
 }
 
 pub fn global_state_strategy() -> impl Strategy<Value = GlobalState> {

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -53,7 +53,7 @@ impl OLState {
             ledger.create_account(*id, state)?;
         }
 
-        let total_ledger_funds = ledger.calculate_total_funds();
+        let total_ledger_funds = ledger.calculate_total_funds()?;
 
         let global = GlobalState::new(params.header.slot, next_serial);
         let epoch = EpochalState::new(

--- a/crates/ol/state-types/src/toplevel.rs
+++ b/crates/ol/state-types/src/toplevel.rs
@@ -376,7 +376,7 @@ mod tests {
 
         // Create a new account in the batch.
         let new_acct = NewAccountData::new_snark(
-            BitcoinAmount::from_sat(1000),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
             PredicateKey::always_accept(),
             [0u8; 32].into(),
         );
@@ -392,7 +392,10 @@ mod tests {
         // Verify account exists and has correct balance.
         assert!(state.get_account_state(&account_id).is_some());
         let account = state.get_account_state(&account_id).unwrap();
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(1000));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply")
+        );
         assert_eq!(account.serial(), serial);
     }
 
@@ -404,7 +407,7 @@ mod tests {
 
         // Create an account directly in state.
         let new_acct = NewAccountData::new_snark(
-            BitcoinAmount::from_sat(1000),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
             PredicateKey::always_accept(),
             [0u8; 32].into(),
         );
@@ -419,7 +422,7 @@ mod tests {
             OLSnarkAccountState::new_fresh(PredicateKey::always_accept(), [1u8; 32].into());
         let updated_account = OLAccountState::new(
             serial,
-            BitcoinAmount::from_sat(2000),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply"),
             OLAccountTypeState::Snark(snark_state_updated),
         );
         batch
@@ -431,7 +434,10 @@ mod tests {
 
         // Verify account was updated.
         let account = state.get_account_state(&account_id).unwrap();
-        assert_eq!(account.balance(), BitcoinAmount::from_sat(2000));
+        assert_eq!(
+            account.balance(),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
@@ -450,7 +456,7 @@ mod tests {
 
         // Create two new accounts.
         let new_acct_1 = NewAccountData::new_snark(
-            BitcoinAmount::from_sat(1000),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
             PredicateKey::always_accept(),
             [0u8; 32].into(),
         );
@@ -460,7 +466,7 @@ mod tests {
             .create_account_from_data(account_id_1, new_acct_1, serial_1);
 
         let new_acct_2 = NewAccountData::new_snark(
-            BitcoinAmount::from_sat(2000),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply"),
             PredicateKey::always_accept(),
             [1u8; 32].into(),
         );
@@ -479,10 +485,16 @@ mod tests {
         assert!(state.get_account_state(&account_id_2).is_some());
 
         let account_1 = state.get_account_state(&account_id_1).unwrap();
-        assert_eq!(account_1.balance(), BitcoinAmount::from_sat(1000));
+        assert_eq!(
+            account_1.balance(),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply")
+        );
 
         let account_2 = state.get_account_state(&account_id_2).unwrap();
-        assert_eq!(account_2.balance(), BitcoinAmount::from_sat(2000));
+        assert_eq!(
+            account_2.balance(),
+            BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply")
+        );
     }
 
     #[test]
@@ -512,7 +524,7 @@ mod tests {
 
         // Create an existing account in state first.
         let new_acct = NewAccountData::new_snark(
-            BitcoinAmount::from_sat(1000),
+            BitcoinAmount::try_from(1000).expect("amount must not exceed the Bitcoin money supply"),
             PredicateKey::always_accept(),
             [0u8; 32].into(),
         );
@@ -529,7 +541,7 @@ mod tests {
             OLSnarkAccountState::new_fresh(PredicateKey::always_accept(), [1u8; 32].into());
         let updated_account = OLAccountState::new(
             existing_serial,
-            BitcoinAmount::from_sat(5000),
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply"),
             OLAccountTypeState::Snark(updated_snark),
         );
         batch
@@ -538,7 +550,7 @@ mod tests {
 
         // Create a new account.
         let new_acct_data = NewAccountData::new_snark(
-            BitcoinAmount::from_sat(3000),
+            BitcoinAmount::try_from(3000).expect("amount must not exceed the Bitcoin money supply"),
             PredicateKey::always_accept(),
             [2u8; 32].into(),
         );
@@ -552,12 +564,18 @@ mod tests {
 
         // Verify existing account was updated.
         let existing_account = state.get_account_state(&existing_id).unwrap();
-        assert_eq!(existing_account.balance(), BitcoinAmount::from_sat(5000));
+        assert_eq!(
+            existing_account.balance(),
+            BitcoinAmount::try_from(5000).expect("amount must not exceed the Bitcoin money supply")
+        );
         assert_eq!(existing_account.serial(), existing_serial);
 
         // Verify new account was created.
         let new_account = state.get_account_state(&new_id).unwrap();
-        assert_eq!(new_account.balance(), BitcoinAmount::from_sat(3000));
+        assert_eq!(
+            new_account.balance(),
+            BitcoinAmount::try_from(3000).expect("amount must not exceed the Bitcoin money supply")
+        );
         assert_eq!(new_account.serial(), new_serial);
     }
 

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -241,8 +241,7 @@ fn process_deposit_log<S: IStateAccessorMut>(
     deposit: &DepositLog,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
-    let amt_btc = BitcoinAmount::try_from(deposit.amount)
-        .expect("amount must not exceed the Bitcoin money supply");
+    let amt_btc = BitcoinAmount::try_from(deposit.amount).map_err(|_| ExecError::AmountOverflow)?;
 
     // Resolve the destination before minting any value.  All the fallible steps
     // run here so their errors propagate cleanly; only once we know whether the

--- a/crates/ol/stf/src/manifest_processing.rs
+++ b/crates/ol/stf/src/manifest_processing.rs
@@ -241,7 +241,8 @@ fn process_deposit_log<S: IStateAccessorMut>(
     deposit: &DepositLog,
     context: &BasicExecContext<'_>,
 ) -> ExecResult<()> {
-    let amt_btc = BitcoinAmount::from_sat(deposit.amount);
+    let amt_btc = BitcoinAmount::try_from(deposit.amount)
+        .expect("amount must not exceed the Bitcoin money supply");
 
     // Resolve the destination before minting any value.  All the fallible steps
     // run here so their errors propagate cleanly; only once we know whether the
@@ -422,8 +423,13 @@ fn process_ee_predicate_key_update<S: IStateAccessorMut>(
 /// wrapped in the standard SPS-52 message format under
 /// [`PREDICATE_UPDATE_MSG_TYPE_ID`].
 pub(crate) fn build_predicate_update_payload(new_vk: &PredicateKey) -> MsgPayload {
-    let msg_data = PredicateUpdateMsgData::new(new_vk.as_buf_ref().to_bytes())
-        .expect("predicate key fits in message data");
+    let msg_data = PredicateUpdateMsgData::new(
+        new_vk
+            .try_as_buf_ref()
+            .expect("predicate update key must be valid")
+            .to_bytes(),
+    )
+    .expect("predicate key fits in message data");
     let body = encode_to_vec(&msg_data).expect("predicate update message data should encode");
     let msg = OwnedMsg::new(PREDICATE_UPDATE_MSG_TYPE_ID, body)
         .expect("predicate update message body must fit into msg-fmt envelope");

--- a/crates/ol/stf/src/proof_verification.rs
+++ b/crates/ol/stf/src/proof_verification.rs
@@ -301,7 +301,8 @@ mod tests {
 
     #[test]
     fn sp1_groth16_predicate_verifier_is_available() {
-        let predicate_key = PredicateKey::new(PredicateTypeId::Sp1Groth16, Vec::new());
+        let predicate_key = PredicateKey::try_new(PredicateTypeId::Sp1Groth16, Vec::new())
+            .expect("predicate condition must fit within the maximum length");
         let err = predicate_key
             .verify_claim_witness(&[], &[])
             .expect_err("empty condition is invalid, but verifier must be compiled in");

--- a/crates/ol/stf/src/test_utils.rs
+++ b/crates/ol/stf/src/test_utils.rs
@@ -30,7 +30,7 @@
 //! let recipient_id = make_account_id(TEST_RECIPIENT_ID);
 //! let mut fixture = OLStfFixture::builder()
 //!     .with_genesis_snark_account(snark_acct_id, |acct| {
-//!         acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+//!         acct.with_balance(BitcoinAmount::try_from(100_000_000).expect("amount must not exceed the Bitcoin money supply"))
 //!     })
 //!     .with_genesis_empty_account(recipient_id)
 //!     .execute_genesis();
@@ -38,11 +38,11 @@
 //! fixture
 //!     .child_block()
 //!     .with_sau(snark_acct_id, |sau| {
-//!         sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+//!         sau.transfer(recipient_id, BitcoinAmount::try_from(10_000_000).expect("amount must not exceed the Bitcoin money supply"))
 //!     })
 //!     .execute();
 //!
-//! assert_eq!(fixture.account_balance(recipient_id), BitcoinAmount::from_sat(10_000_000));
+//! assert_eq!(fixture.account_balance(recipient_id), BitcoinAmount::try_from(10_000_000).expect("amount must not exceed the Bitcoin money supply"));
 //! ```
 //!
 //! For failure-path tests, use `execute_err()`, inspect `err.into_base()`, and
@@ -426,8 +426,12 @@ pub fn build_chain_with_transactions(
             let msg_entry = MessageEntry::new(
                 crate::SEQUENCER_ACCT_ID,
                 epoch,
-                MsgPayload::from_bytes(BitcoinAmount::from_sat(0), msg_data.clone())
-                    .expect("message payload bytes must fit within SSZ max length"),
+                MsgPayload::from_bytes(
+                    BitcoinAmount::try_from(0)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    msg_data.clone(),
+                )
+                .expect("message payload bytes must fit within SSZ max length"),
             );
             let proof = inbox_tracker.add_message(&msg_entry);
             pending_msgs.push(msg_entry);
@@ -1092,7 +1096,7 @@ pub struct FixtureSnarkAccountBuilder {
 impl FixtureSnarkAccountBuilder {
     fn new() -> Self {
         Self {
-            balance: BitcoinAmount::zero(),
+            balance: BitcoinAmount::default(),
             update_vk: PredicateKey::always_accept(),
             initial_state_root: make_state_root(1),
         }
@@ -1801,8 +1805,10 @@ pub fn setup_genesis_with_snark_accounts(
         insert_snark_account_with_settings(
             state,
             account_id,
-            FixtureSnarkAccountBuilder::new()
-                .with_balance(BitcoinAmount::from_sat(initial_balance)),
+            FixtureSnarkAccountBuilder::new().with_balance(
+                BitcoinAmount::try_from(initial_balance)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            ),
         );
     }
 
@@ -1816,7 +1822,10 @@ fn insert_fixture_snark_account(state: &mut impl IStateAccessorMut) {
     insert_snark_account_with_settings(
         state,
         make_account_id(TEST_SNARK_ACCOUNT_ID),
-        FixtureSnarkAccountBuilder::new().with_balance(BitcoinAmount::from_sat(100_000_000)),
+        FixtureSnarkAccountBuilder::new().with_balance(
+            BitcoinAmount::try_from(100_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        ),
     );
 }
 
@@ -1948,9 +1957,11 @@ impl SnarkUpdateBuilder {
 
     /// Add a single transfer effect
     pub fn with_transfer(mut self, dest: AccountId, amount: u64) -> Self {
-        let added = self
-            .effects
-            .add_transfer(SentTransfer::new(dest, BitcoinAmount::from_sat(amount)));
+        let added = self.effects.add_transfer(SentTransfer::new(
+            dest,
+            BitcoinAmount::try_from(amount)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        ));
         // This builder only constructs test fixtures; fail fast instead of silently dropping
         // an effect that exceeds the protocol list capacity.
         assert!(added, "test: too many transfer effects");
@@ -1959,8 +1970,12 @@ impl SnarkUpdateBuilder {
 
     /// Add a single message effect
     pub fn with_output_message(mut self, dest: AccountId, amount: u64, data: Vec<u8>) -> Self {
-        let payload = MsgPayload::from_bytes(BitcoinAmount::from_sat(amount), data)
-            .expect("message payload bytes must fit within SSZ max length");
+        let payload = MsgPayload::from_bytes(
+            BitcoinAmount::try_from(amount)
+                .expect("amount must not exceed the Bitcoin money supply"),
+            data,
+        )
+        .expect("message payload bytes must fit within SSZ max length");
         let added = self.effects.add_message(SentMessage::new(dest, payload));
         // This builder only constructs test fixtures; fail fast instead of silently dropping
         // an effect that exceeds the protocol list capacity.
@@ -2085,8 +2100,11 @@ pub fn snark_inbox_msg_with_data(data: &[u8]) -> MessageEntry {
     MessageEntry::new(
         crate::SEQUENCER_ACCT_ID,
         1,
-        MsgPayload::from_bytes(BitcoinAmount::from_sat(0), data.to_vec())
-            .expect("inbox msg payload"),
+        MsgPayload::from_bytes(
+            BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+            data.to_vec(),
+        )
+        .expect("inbox msg payload"),
     )
 }
 
@@ -2101,7 +2119,8 @@ pub fn epoch_runner_seed_accounts(state: &mut MemoryStateBaseLayer) -> AccountSe
         .create_new_account(
             make_account_id(TEST_SNARK_ACCOUNT_ID),
             NewAccountData::new(
-                BitcoinAmount::from_sat(100_000_000),
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 NewAccountTypeState::Snark {
                     update_vk: PredicateKey::always_accept(),
                     initial_state_root: make_state_root(1),

--- a/crates/ol/stf/src/tests/asm_manifests.rs
+++ b/crates/ol/stf/src/tests/asm_manifests.rs
@@ -3,20 +3,26 @@
 use strata_acct_types::{AccountSerial, BitcoinAmount};
 use strata_asm_checkpoint_types::CheckpointTip;
 use strata_asm_common::AsmLogEntry;
-use strata_asm_logs::{CheckpointTipUpdate, constants::AsmLogTypeId};
+use strata_asm_logs::{CheckpointTipUpdate, DepositLog, constants::AsmLogTypeId};
 use strata_bridge_params::BridgeParams;
 use strata_codec::decode_buf_exact;
 use strata_identifiers::{
-    Buf32, EpochCommitment, L1Height, OLBlockCommitment, OLBlockId, SubjectId,
+    Buf32, EpochCommitment, L1Height, OLBlockCommitment, OLBlockId, SubjectId, SubjectIdBytes,
 };
 use strata_ledger_types::{IAccountState, ISnarkAccountState, IStateAccessor};
 use strata_msg_fmt::MAX_TYPE;
+use strata_ol_bridge_types::DepositDescriptor;
 use strata_ol_chain_types::MAX_SEALING_MANIFEST_COUNT;
 use strata_ol_da::OLDaPayloadV1;
 use strata_ol_state_support_types::DaAccumulatingState;
 
 use crate::{
-    assembly::BlockComponents, context::BlockInfo, errors::ExecError, execute_block_batch_predrain,
+    assembly::BlockComponents,
+    context::{BasicExecContext, BlockInfo},
+    errors::ExecError,
+    execute_block_batch_predrain,
+    output::ExecOutputBuffer,
+    process_block_manifests, process_epoch_terminal,
     test_utils::*,
 };
 
@@ -327,4 +333,38 @@ fn test_manifest_processing_skips_malformed_deposit_log() {
         GENESIS_MANIFEST_SENTINEL_COUNT + 1
     );
     assert_eq!(state.limbo_funds(), BitcoinAmount::default());
+}
+
+/// A decoded deposit log whose raw amount exceeds the Bitcoin money supply must
+/// surface a clean [`ExecError`] at the epoch terminal drain, not panic on the
+/// amount conversion.
+#[test]
+fn test_oversized_deposit_amount_returns_clean_error() {
+    let mut state = make_genesis_state();
+
+    // A well-formed descriptor so processing reaches the amount conversion.
+    let dest_subject_bytes = SubjectIdBytes::try_new(SubjectId::from([42u8; 32]).inner().to_vec())
+        .expect("valid subject bytes");
+    let descriptor = DepositDescriptor::new(AccountSerial::new(9_999), dest_subject_bytes)
+        .expect("valid deposit descriptor");
+    let deposit = DepositLog::new(descriptor.encode_to_varvec(), u64::MAX);
+    let deposit_log = AsmLogEntry::from_log(&deposit).expect("deposit log should encode");
+
+    let manifest = FixtureAsmManifestBuilder::new_at_height(1)
+        .with_log(deposit_log)
+        .build();
+    process_block_manifests(&mut state, &[manifest])
+        .expect("buffering the manifest should succeed");
+
+    let outputs = ExecOutputBuffer::new_empty();
+    let block_info = BlockInfo::new(1, 1, 1);
+    let context = BasicExecContext::new(block_info, &outputs);
+
+    let err = process_epoch_terminal(&mut state, &context)
+        .expect_err("an oversized deposit amount should error, not panic");
+
+    assert!(
+        matches!(err.into_base(), ExecError::AmountOverflow),
+        "expected AmountOverflow"
+    );
 }

--- a/crates/ol/stf/src/tests/asm_manifests.rs
+++ b/crates/ol/stf/src/tests/asm_manifests.rs
@@ -163,7 +163,8 @@ fn test_manifest_processing_skips_unknown_serial_deposit() {
     let deposit_log = make_deposit_log_for_account(
         AccountSerial::new(9_999),
         SubjectId::from([42u8; 32]),
-        BitcoinAmount::from_sat(100_000_000),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
     );
     let asm_manifest = FixtureAsmManifestBuilder::new_at_height(1)
         .with_log(deposit_log)
@@ -171,26 +172,37 @@ fn test_manifest_processing_skips_unknown_serial_deposit() {
 
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_manifest(asm_manifest)
         .execute_genesis();
     let state = fixture.state();
 
     let (ol_account_state, account_state) = state.expect_snark_account_state(snark_acct_id);
-    assert_eq!(ol_account_state.balance(), BitcoinAmount::from_sat(0));
+    assert_eq!(
+        ol_account_state.balance(),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(account_state.inbox_mmr().num_entries(), 0);
-    assert_eq!(state.limbo_funds(), BitcoinAmount::from_sat(100_000_000));
+    assert_eq!(
+        state.limbo_funds(),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(state.last_l1_height(), 1);
 }
 
 #[test]
 fn test_deposit_terminal_drain_has_no_logs_or_predrain_effects() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
-    let deposit_amount = BitcoinAmount::from_sat(100_000_000);
+    let deposit_amount = BitcoinAmount::try_from(100_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::zero())
+            acct.with_balance(BitcoinAmount::default())
         })
         .execute_genesis();
     let snark_serial = fixture.account_serial(snark_acct_id);
@@ -260,7 +272,7 @@ fn test_deposit_terminal_drain_has_no_logs_or_predrain_effects() {
         .expect("snark account should exist");
     assert_eq!(
         predrain_account.balance(),
-        BitcoinAmount::zero(),
+        BitcoinAmount::default(),
         "checkpoint pre-drain replay must not apply ASM drain state effects"
     );
     let predrain_snark_account = predrain_account
@@ -314,5 +326,5 @@ fn test_manifest_processing_skips_malformed_deposit_log() {
         state.l1_block_refs_mmr().num_entries(),
         GENESIS_MANIFEST_SENTINEL_COUNT + 1
     );
-    assert_eq!(state.limbo_funds(), BitcoinAmount::zero());
+    assert_eq!(state.limbo_funds(), BitcoinAmount::default());
 }

--- a/crates/ol/stf/src/tests/coin_error_paths.rs
+++ b/crates/ol/stf/src/tests/coin_error_paths.rs
@@ -22,13 +22,21 @@ use crate::{
     transaction_processing,
 };
 
+const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
+fn max_money() -> BitcoinAmount {
+    BitcoinAmount::try_from(MAX_BITCOIN_MONEY_SATS)
+        .expect("Bitcoin maximum money supply must be valid")
+}
+
 /// T1: `credit_account` recovers and defuses the coin when `update_account`
 /// errors before the closure runs (the target account does not exist).
 #[test]
 fn credit_account_missing_account_returns_clean_error() {
     let mut state = make_genesis_state();
     let nonexistent = make_account_id(TEST_NONEXISTENT_ID);
-    let value = BitcoinAmount::from_sat(3_000_000);
+    let value = BitcoinAmount::try_from(3_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
 
     let err = account_processing::credit_account_noop(
         &mut state,
@@ -49,14 +57,16 @@ fn credit_account_missing_account_returns_clean_error() {
 fn limbo_overflow_returns_clean_error() {
     let mut state = make_genesis_state();
 
-    // Fill limbo to just below the u64 sat ceiling so a further deposit overflows.
+    // Fill limbo to the Bitcoin money-supply ceiling so a further deposit overflows.
     state
-        .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(u64::MAX - 100)))
-        .expect("seeding limbo near the ceiling should succeed");
+        .add_limbo_funds_coin(Coin::new_unchecked(max_money()))
+        .expect("seeding limbo at the ceiling should succeed");
 
     let err = account_processing::handle_misplaced_funds(
         &mut state,
-        Coin::new_unchecked(BitcoinAmount::from_sat(200)),
+        Coin::new_unchecked(
+            BitcoinAmount::try_from(200).expect("amount must not exceed the Bitcoin money supply"),
+        ),
     )
     .expect_err("overflowing limbo should error, not panic");
 
@@ -78,7 +88,8 @@ fn bridge_withdrawal_log_overflow_returns_clean_error() {
 
     // A valid, denomination-multiple withdrawal to a well-formed descriptor so
     // execution reaches the `emit_typed_log` call.
-    let withdrawal_amount = BitcoinAmount::from_sat(100_000_000);
+    let withdrawal_amount = BitcoinAmount::try_from(100_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
     let dest_desc = make_p2wpkh_bosd_descriptor(0x14);
     let msg_bytes = make_withdrawal_payload(dest_desc);
     let msg_data: MsgPayloadData = msg_bytes
@@ -121,10 +132,10 @@ fn apply_tx_effects_defuses_remaining_on_midloop_error() {
     setup_genesis_with_snark_account(&mut state, source, 100_000_000);
     let nonexistent = make_account_id(TEST_NONEXISTENT_ID);
 
-    // Fill limbo to the ceiling so the first transfer's sweep-to-limbo overflows.
+    // Fill limbo to the money-supply ceiling so the first transfer's sweep-to-limbo overflows.
     state
-        .add_limbo_funds_coin(Coin::new_unchecked(BitcoinAmount::from_sat(u64::MAX - 100)))
-        .expect("seeding limbo near the ceiling should succeed");
+        .add_limbo_funds_coin(Coin::new_unchecked(max_money()))
+        .expect("seeding limbo at the ceiling should succeed");
 
     // Two transfers to a nonexistent account: the first sweeps to limbo and
     // overflows, so the loop errors while `remaining` still holds the second

--- a/crates/ol/stf/src/tests/coin_error_paths.rs
+++ b/crates/ol/stf/src/tests/coin_error_paths.rs
@@ -141,8 +141,16 @@ fn apply_tx_effects_defuses_remaining_on_midloop_error() {
     // overflows, so the loop errors while `remaining` still holds the second
     // effect's value.
     let mut effects = TxEffects::default();
-    assert!(effects.push_transfer(nonexistent, 200));
-    assert!(effects.push_transfer(nonexistent, 50));
+    assert!(
+        effects
+            .push_transfer(nonexistent, 200)
+            .expect("test transfer amount should be within the money supply")
+    );
+    assert!(
+        effects
+            .push_transfer(nonexistent, 50)
+            .expect("test transfer amount should be within the money supply")
+    );
 
     let outputs = ExecOutputBuffer::new_empty();
     let context = BasicExecContext::new(BlockInfo::new(1, 0, 0), &outputs);

--- a/crates/ol/stf/src/tests/da_epoch_reconstruction.rs
+++ b/crates/ol/stf/src/tests/da_epoch_reconstruction.rs
@@ -50,7 +50,8 @@ fn test_apply_da_epoch_deposit_manifest_only() {
             1,
             snark_serial,
             SubjectId::from([42u8; 32]),
-            BitcoinAmount::from_sat(150_000_000),
+            BitcoinAmount::try_from(150_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
         ),
     );
 
@@ -95,7 +96,8 @@ fn test_apply_da_epoch_snark_update_with_rotation() {
     );
 
     let (_, snark_state) = get_snark_state_expect(&state, snark_id);
-    let new_vk = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0x42u8; 32]);
+    let new_vk = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0x42u8; 32])
+        .expect("predicate condition must fit within the maximum length");
     let update_tx = SnarkUpdateBuilder::from_snark_state(snark_state.clone())
         .with_new_predicate(new_vk)
         .build(snark_id, make_state_root(2), vec![0u8; 32]);
@@ -129,7 +131,8 @@ fn test_apply_da_epoch_snark_update_and_deposit() {
             1,
             snark_serial,
             SubjectId::from([42u8; 32]),
-            BitcoinAmount::from_sat(150_000_000),
+            BitcoinAmount::try_from(150_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
         ),
     );
 
@@ -166,7 +169,7 @@ fn test_apply_da_epoch_withdrawal() {
         .balance();
     assert_eq!(
         snark_balance,
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "withdrawal must debit the full seeded balance"
     );
 
@@ -197,7 +200,8 @@ fn test_apply_da_epoch_cases_produce_distinct_roots() {
                 1,
                 snark_serial,
                 SubjectId::from([42u8; 32]),
-                BitcoinAmount::from_sat(150_000_000),
+                BitcoinAmount::try_from(150_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
             ),
         );
         reconstruct_epoch(&pre_epoch_state, &genesis, &terminal, &blocks)
@@ -233,7 +237,8 @@ fn test_apply_da_epoch_cases_produce_distinct_roots() {
                 1,
                 snark_serial,
                 SubjectId::from([42u8; 32]),
-                BitcoinAmount::from_sat(150_000_000),
+                BitcoinAmount::try_from(150_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
             ),
         );
         reconstruct_epoch(&pre_epoch_state, &genesis, &terminal, &blocks)

--- a/crates/ol/stf/src/tests/da_epoch_root_correctness.rs
+++ b/crates/ol/stf/src/tests/da_epoch_root_correctness.rs
@@ -45,7 +45,8 @@ fn test_epoch_root_round_trip_with_deposit_manifest() {
         1,
         snark_acct_serial,
         SubjectId::from([42u8; 32]),
-        BitcoinAmount::from_sat(150_000_000),
+        BitcoinAmount::try_from(150_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
     );
     let terminal = execute_terminal(&mut state, &last_pre_terminal_header, terminal_manifest);
     epoch_blocks.push(to_ol_block(&terminal));
@@ -68,7 +69,8 @@ fn test_epoch_root_round_trip_with_limbo_deposit_manifest() {
         state.last_l1_height() + 1,
         1,
         Vec::new(),
-        BitcoinAmount::from_sat(75_000_000),
+        BitcoinAmount::try_from(75_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
     );
     let terminal = execute_terminal(&mut state, &last_pre_terminal_header, terminal_manifest);
     epoch_blocks.push(to_ol_block(&terminal));

--- a/crates/ol/stf/src/tests/deposit_withdrawal.rs
+++ b/crates/ol/stf/src/tests/deposit_withdrawal.rs
@@ -13,7 +13,8 @@ use crate::test_utils::*;
 #[test]
 fn test_snark_account_deposit_and_withdrawal() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
-    let deposit_amount = BitcoinAmount::from_sat(150_000_000); // 1.5 BTC; enough to cover withdrawal.
+    let deposit_amount = BitcoinAmount::try_from(150_000_000)
+        .expect("amount must not exceed the Bitcoin money supply"); // 1.5 BTC; enough to cover withdrawal.
     let dest_subject = SubjectId::from([42u8; 32]);
 
     let fixture_builder = OLStfFixture::builder();
@@ -50,7 +51,8 @@ fn test_snark_account_deposit_and_withdrawal() {
     let deposit_msg = make_deposit_message_entry(0, dest_subject, deposit_amount);
     let deposit_msg_proof = inbox_tracker.add_message(&deposit_msg);
 
-    let withdrawal_amount = BitcoinAmount::from_sat(100_000_000); // Withdraw exactly 1 BTC.
+    let withdrawal_amount = BitcoinAmount::try_from(100_000_000)
+        .expect("amount must not exceed the Bitcoin money supply"); // Withdraw exactly 1 BTC.
     let withdrawal_dest_desc = make_p2wpkh_bosd_descriptor(0x14);
     let withdrawal_payload = make_withdrawal_payload(withdrawal_dest_desc.clone());
 
@@ -70,7 +72,8 @@ fn test_snark_account_deposit_and_withdrawal() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(50_000_000),
+        BitcoinAmount::try_from(50_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Account balance should be reduced by withdrawal amount"
     );
 
@@ -99,7 +102,10 @@ fn test_bridge_gateway_direct_transfer_is_silently_dropped() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -108,20 +114,26 @@ fn test_bridge_gateway_direct_transfer_is_silently_dropped() {
         .child_block()
         .with_sau(snark_acct_id, |sau| {
             // Pins the current footgun: funds are deducted from sender but never delivered.
-            sau.transfer(BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount::from_sat(10_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                BRIDGE_GATEWAY_ACCT_ID,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute_with_outputs();
 
     assert_no_bridge_gateway_logs(&output);
     assert_eq!(
         fixture.state().limbo_funds(),
-        BitcoinAmount::from_sat(limbo_before.to_sat() + 10_000_000),
+        BitcoinAmount::try_from(limbo_before.to_sat() + 10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "direct bridge-gateway transfer should sweep value into limbo"
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(90_000_000)
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(
         *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
@@ -135,7 +147,10 @@ fn test_bridge_gateway_non_denomination_withdrawal_is_silently_dropped() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -146,7 +161,8 @@ fn test_bridge_gateway_non_denomination_withdrawal_is_silently_dropped() {
             // Pins the current footgun: funds are deducted from sender but never delivered.
             sau.output_message(
                 BRIDGE_GATEWAY_ACCT_ID,
-                BitcoinAmount::from_sat(50_000_000),
+                BitcoinAmount::try_from(50_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 make_withdrawal_payload(b"bc1qnondenomination".to_vec()),
             )
             .with_state_root(make_state_root(2))
@@ -156,12 +172,14 @@ fn test_bridge_gateway_non_denomination_withdrawal_is_silently_dropped() {
     assert_no_bridge_gateway_logs(&output);
     assert_eq!(
         fixture.state().limbo_funds(),
-        BitcoinAmount::from_sat(limbo_before.to_sat() + 50_000_000),
+        BitcoinAmount::try_from(limbo_before.to_sat() + 50_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "non-denomination withdrawal should sweep value into limbo"
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(50_000_000)
+        BitcoinAmount::try_from(50_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(
         *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
@@ -175,7 +193,10 @@ fn test_bridge_gateway_oversized_withdrawal_descriptor_is_silently_dropped() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -188,7 +209,8 @@ fn test_bridge_gateway_oversized_withdrawal_descriptor_is_silently_dropped() {
         .with_sau(snark_acct_id, |sau| {
             sau.output_message(
                 BRIDGE_GATEWAY_ACCT_ID,
-                BitcoinAmount::from_sat(100_000_000),
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 make_withdrawal_payload(oversized_descriptor),
             )
             .with_state_root(make_state_root(2))
@@ -198,12 +220,13 @@ fn test_bridge_gateway_oversized_withdrawal_descriptor_is_silently_dropped() {
     assert_no_bridge_gateway_logs(&output);
     assert_eq!(
         fixture.state().limbo_funds(),
-        BitcoinAmount::from_sat(limbo_before.to_sat() + 100_000_000),
+        BitcoinAmount::try_from(limbo_before.to_sat() + 100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "oversized withdrawal descriptor should sweep value into limbo"
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::zero()
+        BitcoinAmount::default()
     );
     assert_eq!(
         *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
@@ -217,7 +240,10 @@ fn test_bridge_gateway_malformed_withdrawal_descriptor_is_silently_dropped() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -227,7 +253,8 @@ fn test_bridge_gateway_malformed_withdrawal_descriptor_is_silently_dropped() {
         .with_sau(snark_acct_id, |sau| {
             sau.output_message(
                 BRIDGE_GATEWAY_ACCT_ID,
-                BitcoinAmount::from_sat(100_000_000),
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 make_withdrawal_payload(vec![0x03, 0x01, 0x02, 0x03]),
             )
             .with_state_root(make_state_root(2))
@@ -237,12 +264,13 @@ fn test_bridge_gateway_malformed_withdrawal_descriptor_is_silently_dropped() {
     assert_no_bridge_gateway_logs(&output);
     assert_eq!(
         fixture.state().limbo_funds(),
-        BitcoinAmount::from_sat(limbo_before.to_sat() + 100_000_000),
+        BitcoinAmount::try_from(limbo_before.to_sat() + 100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "malformed withdrawal descriptor should sweep value into limbo"
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::zero()
+        BitcoinAmount::default()
     );
     assert_eq!(
         *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
@@ -256,7 +284,10 @@ fn test_bridge_gateway_zero_amount_withdrawal_is_silently_dropped() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -266,7 +297,8 @@ fn test_bridge_gateway_zero_amount_withdrawal_is_silently_dropped() {
         .with_sau(snark_acct_id, |sau| {
             sau.output_message(
                 BRIDGE_GATEWAY_ACCT_ID,
-                BitcoinAmount::from_sat(0),
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 make_withdrawal_payload(b"bc1qzeroamount".to_vec()),
             )
             .with_state_root(make_state_root(2))
@@ -281,7 +313,8 @@ fn test_bridge_gateway_zero_amount_withdrawal_is_silently_dropped() {
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000)
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(
         *fixture.expect_snark_account(snark_acct_id).seqno().inner(),

--- a/crates/ol/stf/src/tests/ee_predicate_update.rs
+++ b/crates/ol/stf/src/tests/ee_predicate_update.rs
@@ -14,7 +14,8 @@ use crate::{
 /// Builds a non-trivial predicate key with a unique condition payload, used to
 /// distinguish "before" and "after" states in tests.
 fn make_marker_predicate(marker: &[u8]) -> PredicateKey {
-    PredicateKey::new(PredicateTypeId::AlwaysAccept, marker.to_vec())
+    PredicateKey::try_new(PredicateTypeId::AlwaysAccept, marker.to_vec())
+        .expect("predicate condition must fit within the maximum length")
 }
 
 /// Builds a predicate key with a type id outside the registry (only 0, 1, 10,

--- a/crates/ol/stf/src/tests/inbox.rs
+++ b/crates/ol/stf/src/tests/inbox.rs
@@ -9,8 +9,11 @@ use strata_ledger_types::ISnarkAccountState;
 use crate::{SEQUENCER_ACCT_ID, errors::ExecError, test_utils::*};
 
 fn msg_payload_from_bytes(data: Vec<u8>) -> MsgPayload {
-    MsgPayload::from_bytes(BitcoinAmount::from_sat(0), data)
-        .expect("message payload bytes must fit within SSZ max length")
+    MsgPayload::from_bytes(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        data,
+    )
+    .expect("message payload bytes must fit within SSZ max length")
 }
 
 #[test]
@@ -19,7 +22,10 @@ fn test_snark_inbox_message_insertion() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -48,7 +54,8 @@ fn test_snark_inbox_message_insertion() {
     // Balance unchanged (GAM messages have 0 value)
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Snark account balance should be unchanged"
     );
 }
@@ -60,7 +67,10 @@ fn test_snark_update_process_inbox_message_with_valid_mmr_proof() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -106,7 +116,11 @@ fn test_snark_update_process_inbox_message_with_valid_mmr_proof() {
         .child_block()
         .with_sau(snark_acct_id, |sau| {
             sau.with_processed_messages(vec![gam_msg_entry], vec![gam_proof])
-                .transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+                .transfer(
+                    recipient_id,
+                    BitcoinAmount::try_from(10_000_000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                )
                 .with_state_root(make_state_root(2))
                 .with_proof(vec![0u8; 32])
         })
@@ -122,7 +136,8 @@ fn test_snark_update_process_inbox_message_with_valid_mmr_proof() {
     // Verify the update was applied
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender account should be debited"
     );
 
@@ -141,7 +156,8 @@ fn test_snark_update_process_inbox_message_with_valid_mmr_proof() {
 
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should receive transfer"
     );
 }
@@ -153,7 +169,10 @@ fn test_snark_update_invalid_message_index() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -163,9 +182,13 @@ fn test_snark_update_invalid_message_index() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
-                .force_next_inbox_msg_idx(5)
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .force_next_inbox_msg_idx(5)
+            .with_state_root(make_state_root(2))
         })
         .execute_err();
 
@@ -186,7 +209,10 @@ fn test_snark_update_invalid_message_proof() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -247,7 +273,10 @@ fn test_snark_update_skip_message_out_of_order() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -273,9 +302,13 @@ fn test_snark_update_skip_message_out_of_order() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
-                .force_next_inbox_msg_idx(2)
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .force_next_inbox_msg_idx(2)
+            .with_state_root(make_state_root(2))
         })
         .execute_err();
 
@@ -299,7 +332,10 @@ fn test_snark_update_rejects_reversed_processed_messages() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -342,7 +378,11 @@ fn test_snark_update_rejects_reversed_processed_messages() {
                 vec![second_msg, first_msg],
                 vec![second_proof, first_proof],
             )
-            .transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+            .transfer(
+                recipient_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
             .with_state_root(make_state_root(2))
         })
         .execute_err();
@@ -360,13 +400,14 @@ fn test_snark_update_rejects_reversed_processed_messages() {
     let account_state = fixture.expect_snark_account(snark_acct_id);
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000)
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(*account_state.seqno().inner(), 0);
     assert_eq!(account_state.next_inbox_msg_idx(), 0);
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(0)
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -376,7 +417,10 @@ fn test_snark_update_rejects_duplicate_processed_message() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -420,7 +464,11 @@ fn test_snark_update_rejects_duplicate_processed_message() {
                 vec![first_msg.clone(), first_msg],
                 vec![first_proof.clone(), first_proof],
             )
-            .transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+            .transfer(
+                recipient_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
             .with_state_root(make_state_root(2))
         })
         .execute_err();
@@ -438,12 +486,13 @@ fn test_snark_update_rejects_duplicate_processed_message() {
     let account_state = fixture.expect_snark_account(snark_acct_id);
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000)
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(*account_state.seqno().inner(), 0);
     assert_eq!(account_state.next_inbox_msg_idx(), 0);
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(0)
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
     );
 }

--- a/crates/ol/stf/src/tests/intraepoch_buffering.rs
+++ b/crates/ol/stf/src/tests/intraepoch_buffering.rs
@@ -21,14 +21,18 @@ use crate::{errors::ExecError, process_block_manifests, test_utils::*};
 fn manifest_in_non_terminal_block_buffers_then_drains_at_terminal() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
     let dest_subject = SubjectId::from([42u8; 32]);
-    let deposit_amount = BitcoinAmount::from_sat(150_000_000);
+    let deposit_amount = BitcoinAmount::try_from(150_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
 
     let fixture_builder = OLStfFixture::builder();
     let snark_acct_serial = fixture_builder.next_account_serial();
     let mut fixture = fixture_builder
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
-                .with_state_root(make_state_root(1))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(1))
         })
         .execute_genesis();
 
@@ -53,7 +57,7 @@ fn manifest_in_non_terminal_block_buffers_then_drains_at_terminal() {
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "deposit effect must not be applied before the terminal"
     );
     assert_eq!(
@@ -114,14 +118,18 @@ fn manifest_in_non_terminal_block_buffers_then_drains_at_terminal() {
 fn multi_block_epoch_manifests_spread_across_blocks() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
     let dest_subject = SubjectId::from([7u8; 32]);
-    let amount = BitcoinAmount::from_sat(50_000_000);
+    let amount = BitcoinAmount::try_from(50_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
 
     let fixture_builder = OLStfFixture::builder();
     let serial = fixture_builder.next_account_serial();
     let mut fixture = fixture_builder
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
-                .with_state_root(make_state_root(1))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(1))
         })
         .execute_genesis();
 
@@ -153,7 +161,7 @@ fn multi_block_epoch_manifests_spread_across_blocks() {
     assert_eq!(fixture.state().pending_asm_logs_len(), 2);
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0)
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(fixture.state().last_l1_height(), 2);
 
@@ -173,7 +181,8 @@ fn multi_block_epoch_manifests_spread_across_blocks() {
     assert_eq!(fixture.state().pending_asm_logs_len(), 0);
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(150_000_000),
+        BitcoinAmount::try_from(150_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "all three buffered deposits applied at the terminal"
     );
     assert_eq!(

--- a/crates/ol/stf/src/tests/ledger_references.rs
+++ b/crates/ol/stf/src/tests/ledger_references.rs
@@ -80,7 +80,10 @@ fn test_snark_update_with_valid_ledger_reference() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -91,16 +94,21 @@ fn test_snark_update_with_valid_ledger_reference() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
-                .with_ledger_refs(vec![claim], vec![proof])
-                .with_state_root(make_state_root(2))
-                .with_proof(vec![0u8; 32])
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_ledger_refs(vec![claim], vec![proof])
+            .with_state_root(make_state_root(2))
+            .with_proof(vec![0u8; 32])
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender balance should be reduced"
     );
     assert_eq!(
@@ -110,7 +118,8 @@ fn test_snark_update_with_valid_ledger_reference() {
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should receive transfer"
     );
 }
@@ -121,7 +130,10 @@ fn test_snark_update_with_invalid_ledger_reference() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -158,7 +170,10 @@ fn test_snark_update_with_mismatched_ledger_reference_proof_index() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -192,7 +207,10 @@ fn test_snark_update_rejects_proof_for_wrong_ledger_reference_claim() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
     let mut manifest_tracker = ManifestMmrTracker::new();
@@ -264,7 +282,10 @@ fn test_snark_update_rejects_extra_ledger_reference_proof() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -287,7 +308,10 @@ fn test_snark_update_rejects_accumulator_proof_without_ledger_refs() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -309,7 +333,10 @@ fn test_snark_update_rejects_extra_predicate_satisfier() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 

--- a/crates/ol/stf/src/tests/limbo.rs
+++ b/crates/ol/stf/src/tests/limbo.rs
@@ -47,7 +47,8 @@ fn limbo_message_to_nonexistent_account() {
     let outputs = ExecOutputBuffer::new_empty();
     let context = BasicExecContext::new(block_info, &outputs);
 
-    let value = BitcoinAmount::from_sat(2_500_000);
+    let value = BitcoinAmount::try_from(2_500_000)
+        .expect("amount must not exceed the Bitcoin money supply");
     let payload = MsgPayloadCoin::new(Coin::new_unchecked(value), MsgPayloadData::default());
 
     account_processing::process_message(
@@ -82,7 +83,8 @@ fn limbo_transfer_to_nonexistent_account() {
     let outputs = ExecOutputBuffer::new_empty();
     let context = BasicExecContext::new(block_info, &outputs);
 
-    let value = BitcoinAmount::from_sat(4_000_000);
+    let value = BitcoinAmount::try_from(4_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
     account_processing::process_transfer(
         &mut state,
         sender_acct_id,
@@ -233,7 +235,8 @@ fn limbo_bad_withdrawal_amount_to_bridge_gateway() {
 fn limbo_deposit_with_malformed_descriptor() {
     let mut state = make_genesis_state();
     let limbo_before = state.limbo_funds();
-    let deposit_amount = BitcoinAmount::from_sat(75_000_000);
+    let deposit_amount = BitcoinAmount::try_from(75_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
 
     // Empty destination: `DepositDescriptor::decode_from_slice` returns
     // `EmptyDescriptor` for this.
@@ -249,7 +252,8 @@ fn limbo_deposit_with_malformed_descriptor() {
 
     let limbo_after = state.limbo_funds();
     assert_eq!(
-        BitcoinAmount::from_sat(limbo_after.to_sat() - limbo_before.to_sat()),
+        BitcoinAmount::try_from(limbo_after.to_sat() - limbo_before.to_sat())
+            .expect("amount must not exceed the Bitcoin money supply"),
         deposit_amount,
         "Deposit with malformed descriptor should sweep amount into limbo"
     );
@@ -261,7 +265,8 @@ fn limbo_deposit_with_malformed_descriptor() {
 fn limbo_deposit_to_unknown_account_serial() {
     let mut state = make_genesis_state();
     let limbo_before = state.limbo_funds();
-    let deposit_amount = BitcoinAmount::from_sat(50_000_000);
+    let deposit_amount = BitcoinAmount::try_from(50_000_000)
+        .expect("amount must not exceed the Bitcoin money supply");
 
     // No accounts have been created, so any non-reserved serial is unknown.
     let unknown_serial = AccountSerial::new(12345);
@@ -283,7 +288,8 @@ fn limbo_deposit_to_unknown_account_serial() {
 
     let limbo_after = state.limbo_funds();
     assert_eq!(
-        BitcoinAmount::from_sat(limbo_after.to_sat() - limbo_before.to_sat()),
+        BitcoinAmount::try_from(limbo_after.to_sat() - limbo_before.to_sat())
+            .expect("amount must not exceed the Bitcoin money supply"),
         deposit_amount,
         "Deposit for unknown account serial should sweep amount into limbo"
     );

--- a/crates/ol/stf/src/tests/partial_execution.rs
+++ b/crates/ol/stf/src/tests/partial_execution.rs
@@ -59,7 +59,9 @@ fn assert_mid_block_failure_state(
 
 fn make_invalid_gam_with_transfer(target: AccountId, transfer_dest: AccountId) -> OLTransaction {
     let mut effects = TxEffects::default();
-    effects.push_transfer(transfer_dest, 1);
+    effects
+        .push_transfer(transfer_dest, 1)
+        .expect("test transfer amount should be within the money supply");
 
     OLTransaction::new(
         OLTransactionData::new(

--- a/crates/ol/stf/src/tests/partial_execution.rs
+++ b/crates/ol/stf/src/tests/partial_execution.rs
@@ -30,7 +30,8 @@ fn assert_mid_block_failure_state(
     );
     assert_eq!(
         ledger_account_state.balance(),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "first tx should have deducted sender balance"
     );
 
@@ -40,7 +41,8 @@ fn assert_mid_block_failure_state(
         .expect("recipient_ok should exist");
     assert_eq!(
         recipient_ok_state.balance(),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "first tx recipient should receive funds"
     );
 
@@ -50,7 +52,7 @@ fn assert_mid_block_failure_state(
         .expect("recipient_not_executed should exist");
     assert_eq!(
         recipient_not_executed_state.balance(),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "third tx should not execute after mid-block failure"
     );
 }
@@ -78,7 +80,10 @@ fn test_execute_block_mid_failure_keeps_prior_mutations() {
 
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_ok)
         .with_genesis_empty_account(recipient_not_executed)
@@ -133,7 +138,10 @@ fn test_verify_block_mid_failure_returns_txexec() {
 
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_ok)
         .with_genesis_empty_account(recipient_not_executed)

--- a/crates/ol/stf/src/tests/sau_limits.rs
+++ b/crates/ol/stf/src/tests/sau_limits.rs
@@ -6,23 +6,29 @@ use strata_ol_chain_types::SAU_MAX_EXTRA_DATA_BYTES;
 
 use crate::{errors::ExecError, test_utils::*};
 
+const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
+fn max_money() -> BitcoinAmount {
+    BitcoinAmount::try_from(MAX_BITCOIN_MONEY_SATS)
+        .expect("maximum Bitcoin money supply must be valid")
+}
+
 #[test]
 fn test_snark_update_max_bitcoin_supply() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
+    let max_minus_one = BitcoinAmount::try_from(MAX_BITCOIN_MONEY_SATS - 1)
+        .expect("amount below the maximum money supply must be valid");
 
     let mut fixture = OLStfFixture::builder()
-        .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::MAX_MONEY)
-        })
+        .with_genesis_snark_account(snark_acct_id, |acct| acct.with_balance(max_minus_one))
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
 
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::MAX_MONEY)
-                .transfer(recipient_id, BitcoinAmount::from_sat(1))
+            sau.transfer(recipient_id, max_money())
                 .with_state_root(make_state_root(2))
         })
         .execute_err();
@@ -34,7 +40,7 @@ fn test_snark_update_max_bitcoin_supply() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::MAX_MONEY,
+        max_minus_one,
         "Balance should be unchanged after failed update"
     );
     assert_eq!(
@@ -44,96 +50,19 @@ fn test_snark_update_max_bitcoin_supply() {
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should not receive failed update"
     );
 }
 
 #[test]
-fn test_snark_update_single_transfer_exceeding_max_bitcoin_suceeds() {
-    let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
-    let recipient_id = make_account_id(TEST_RECIPIENT_ID);
-
-    let more_than_max_bitcoin = BitcoinAmount::from_sat(BitcoinAmount::MAX_MONEY.to_sat() + 1);
-    let mut fixture = OLStfFixture::builder()
-        .with_genesis_snark_account(snark_acct_id, |acct| {
-            // Intentionally above MAX_MONEY to pin current BitcoinAmount behavior.
-            acct.with_balance(BitcoinAmount::MAX)
-        })
-        .with_genesis_empty_account(recipient_id)
-        .execute_genesis();
-
-    fixture
-        .child_block()
-        .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, more_than_max_bitcoin)
-                .with_state_root(make_state_root(2))
-        })
-        .execute();
-
-    let expected_sender_balance = BitcoinAmount::MAX
-        .checked_sub(more_than_max_bitcoin)
-        .expect("MAX - (MAX_MONEY + 1) should not underflow");
-    assert_eq!(
-        fixture.account_balance(snark_acct_id),
-        expected_sender_balance,
-        "Sender balance should be reduced by transfer amount"
-    );
-    assert_eq!(
-        *fixture.expect_snark_account(snark_acct_id).seqno().inner(),
-        1,
-        "Sequence number should increment"
-    );
-    assert_eq!(
-        fixture.account_balance(recipient_id),
-        more_than_max_bitcoin,
-        "Recipient should receive the transfer amount exceeding 21M BTC"
-    );
+fn test_bitcoin_amount_rejects_value_above_max_supply() {
+    assert!(BitcoinAmount::try_from(MAX_BITCOIN_MONEY_SATS + 1).is_err());
 }
 
 #[test]
-fn test_snark_update_overflow_u64_boundary() {
-    let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
-    let recipient1_id = make_account_id(TEST_RECIPIENT_ID + 1);
-    let recipient2_id = make_account_id(TEST_RECIPIENT_ID + 2);
-    let initial_balance = u64::MAX - 100;
-
-    let mut fixture = OLStfFixture::builder()
-        .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(initial_balance))
-        })
-        .with_genesis_empty_account(recipient1_id)
-        .with_genesis_empty_account(recipient2_id)
-        .execute_genesis();
-
-    let err = fixture
-        .child_block()
-        .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::from_sat(u64::MAX - 100))
-                .transfer(recipient2_id, BitcoinAmount::from_sat(101))
-                .with_state_root(make_state_root(2))
-        })
-        .execute_err();
-
-    assert!(
-        matches!(err.into_base(), ExecError::AmountOverflow),
-        "Expected AmountOverflow"
-    );
-    assert_eq!(
-        fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(initial_balance),
-        "Balance should be unchanged after failed update"
-    );
-    assert_eq!(
-        fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(0),
-        "Recipient1 should have no balance after failed update"
-    );
-    assert_eq!(
-        fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(0),
-        "Recipient2 should have no balance after failed update"
-    );
+fn test_bitcoin_amount_rejects_u64_max() {
+    assert!(BitcoinAmount::try_from(u64::MAX).is_err());
 }
 
 #[test]
@@ -143,10 +72,7 @@ fn test_snark_update_rejects_aggregate_transfer_overflow() {
     let recipient2_id = make_account_id(TEST_RECIPIENT_ID + 2);
 
     let mut fixture = OLStfFixture::builder()
-        .with_genesis_snark_account(snark_acct_id, |acct| {
-            // Intentionally above MAX_MONEY to exercise SAU effect-math overflow.
-            acct.with_balance(BitcoinAmount::MAX)
-        })
+        .with_genesis_snark_account(snark_acct_id, |acct| acct.with_balance(max_money()))
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
         .execute_genesis();
@@ -154,8 +80,12 @@ fn test_snark_update_rejects_aggregate_transfer_overflow() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::MAX)
-                .transfer(recipient2_id, BitcoinAmount::from_sat(1))
+            sau.transfer(recipient1_id, max_money())
+                .transfer(
+                    recipient2_id,
+                    BitcoinAmount::try_from(1)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                )
                 .with_state_root(make_state_root(2))
         })
         .execute_err();
@@ -166,7 +96,7 @@ fn test_snark_update_rejects_aggregate_transfer_overflow() {
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::MAX,
+        max_money(),
         "Balance should be unchanged after failed update"
     );
     assert_eq!(
@@ -176,12 +106,12 @@ fn test_snark_update_rejects_aggregate_transfer_overflow() {
     );
     assert_eq!(
         fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient1 should have no balance after failed update"
     );
     assert_eq!(
         fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient2 should have no balance after failed update"
     );
 }
@@ -193,7 +123,10 @@ fn test_snark_update_allows_max_transfer_count() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(MAX_TRANSFERS))
+            acct.with_balance(
+                BitcoinAmount::try_from(MAX_TRANSFERS)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -203,7 +136,11 @@ fn test_snark_update_allows_max_transfer_count() {
         .with_sau(snark_acct_id, |sau| {
             let mut sau = sau;
             for _ in 0..MAX_TRANSFERS {
-                sau = sau.transfer(recipient_id, BitcoinAmount::from_sat(1));
+                sau = sau.transfer(
+                    recipient_id,
+                    BitcoinAmount::try_from(1)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                );
             }
             sau.with_state_root(make_state_root(2))
         })
@@ -211,7 +148,7 @@ fn test_snark_update_allows_max_transfer_count() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Sender should spend the max-count transfer total"
     );
     assert_eq!(
@@ -221,7 +158,8 @@ fn test_snark_update_allows_max_transfer_count() {
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(MAX_TRANSFERS),
+        BitcoinAmount::try_from(MAX_TRANSFERS)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should receive every max-count transfer"
     );
 }
@@ -234,7 +172,10 @@ fn test_snark_update_builder_rejects_transfer_count_over_limit() {
 
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -252,10 +193,16 @@ fn test_snark_update_allows_max_message_count() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(sender_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_snark_account(recipient_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -264,7 +211,12 @@ fn test_snark_update_allows_max_message_count() {
         .with_sau(sender_acct_id, |sau| {
             let mut sau = sau;
             for _ in 0..MAX_MESSAGES {
-                sau = sau.output_message(recipient_id, BitcoinAmount::from_sat(0), vec![1, 2, 3]);
+                sau = sau.output_message(
+                    recipient_id,
+                    BitcoinAmount::try_from(0)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    vec![1, 2, 3],
+                );
             }
             sau.with_state_root(make_state_root(2))
         })
@@ -293,7 +245,10 @@ fn test_snark_update_builder_rejects_message_count_over_limit() {
 
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -310,7 +265,10 @@ fn test_snark_update_allows_max_extra_data() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -342,7 +300,10 @@ fn test_snark_update_builder_rejects_extra_data_over_limit() {
 
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -359,9 +320,7 @@ fn test_snark_update_allows_max_balance_transfer() {
     let second_recipient_id = make_account_id(TEST_RECIPIENT_ID + 2);
 
     let mut fixture = OLStfFixture::builder()
-        .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::MAX_MONEY)
-        })
+        .with_genesis_snark_account(snark_acct_id, |acct| acct.with_balance(max_money()))
         .with_genesis_empty_account(recipient_id)
         .with_genesis_empty_account(second_recipient_id)
         .execute_genesis();
@@ -369,14 +328,14 @@ fn test_snark_update_allows_max_balance_transfer() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::MAX_MONEY)
+            sau.transfer(recipient_id, max_money())
                 .with_state_root(make_state_root(2))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Sender should have 0 balance after transferring MAX_MONEY"
     );
     assert_eq!(
@@ -386,15 +345,19 @@ fn test_snark_update_allows_max_balance_transfer() {
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::MAX_MONEY,
+        max_money(),
         "Recipient should receive MAX_MONEY"
     );
 
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(second_recipient_id, BitcoinAmount::from_sat(1))
-                .with_state_root(make_state_root(3))
+            sau.transfer(
+                second_recipient_id,
+                BitcoinAmount::try_from(1)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(3))
         })
         .execute_err();
 
@@ -404,7 +367,7 @@ fn test_snark_update_allows_max_balance_transfer() {
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Sender balance should remain zero after failed transfer from drained balance"
     );
     assert_eq!(
@@ -414,7 +377,7 @@ fn test_snark_update_allows_max_balance_transfer() {
     );
     assert_eq!(
         fixture.account_balance(second_recipient_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Second recipient should not receive failed transfer from drained balance"
     );
 }

--- a/crates/ol/stf/src/tests/sau_logs.rs
+++ b/crates/ol/stf/src/tests/sau_logs.rs
@@ -13,7 +13,10 @@ fn test_snark_update_emits_log() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -45,7 +48,10 @@ fn test_snark_update_emits_log_with_processed_message() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 

--- a/crates/ol/stf/src/tests/sau_messages.rs
+++ b/crates/ol/stf/src/tests/sau_messages.rs
@@ -13,13 +13,22 @@ fn test_snark_update_multiple_output_messages() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_snark_account(recipient1_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_snark_account(recipient2_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
     let limbo_before = fixture.state().limbo_funds();
@@ -29,18 +38,21 @@ fn test_snark_update_multiple_output_messages() {
         .with_sau(snark_acct_id, |sau| {
             sau.output_message(
                 recipient1_id,
-                BitcoinAmount::from_sat(10_000_000),
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 vec![1, 2, 3],
             )
             .output_message(
                 recipient2_id,
-                BitcoinAmount::from_sat(5_000_000),
+                BitcoinAmount::try_from(5_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 vec![4, 5, 6],
             )
             // Bridge-gateway non-withdrawal messages are dropped after debiting the sender.
             .output_message(
                 BRIDGE_GATEWAY_ACCT_ID,
-                BitcoinAmount::from_sat(0),
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 vec![7, 8, 9],
             )
             .with_state_root(make_state_root(2))
@@ -49,7 +61,8 @@ fn test_snark_update_multiple_output_messages() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(85_000_000),
+        BitcoinAmount::try_from(85_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Balance should be reduced by total message value"
     );
     assert_eq!(
@@ -77,11 +90,17 @@ fn test_snark_update_transfers_and_messages_combined() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .with_genesis_snark_account(message_recipient_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
     let limbo_before = fixture.state().limbo_funds();
@@ -89,25 +108,32 @@ fn test_snark_update_transfers_and_messages_combined() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(25_000_000))
-                .output_message(
-                    message_recipient_id,
-                    BitcoinAmount::from_sat(10_000_000),
-                    vec![42, 43, 44],
-                )
-                // Bridge-gateway non-withdrawal messages are dropped after debiting the sender.
-                .output_message(
-                    BRIDGE_GATEWAY_ACCT_ID,
-                    BitcoinAmount::from_sat(5_000_000),
-                    vec![45, 46, 47],
-                )
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(25_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .output_message(
+                message_recipient_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                vec![42, 43, 44],
+            )
+            // Bridge-gateway non-withdrawal messages are dropped after debiting the sender.
+            .output_message(
+                BRIDGE_GATEWAY_ACCT_ID,
+                BitcoinAmount::try_from(5_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                vec![45, 46, 47],
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(60_000_000),
+        BitcoinAmount::try_from(60_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender should have 100M - 25M - 15M = 60M"
     );
     assert_eq!(
@@ -118,7 +144,8 @@ fn test_snark_update_transfers_and_messages_combined() {
 
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(25_000_000),
+        BitcoinAmount::try_from(25_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should receive 25M"
     );
 
@@ -140,7 +167,8 @@ fn assert_snark_received_message(
     let account_state = fixture.expect_snark_account(recipient_id);
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(expected_balance_sat),
+        BitcoinAmount::try_from(expected_balance_sat)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "message recipient balance should increase"
     );
     assert_eq!(

--- a/crates/ol/stf/src/tests/sau_sequences.rs
+++ b/crates/ol/stf/src/tests/sau_sequences.rs
@@ -22,7 +22,10 @@ fn test_dependent_snark_updates_advance_across_blocks() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(INITIAL_BALANCE))
+            acct.with_balance(
+                BitcoinAmount::try_from(INITIAL_BALANCE)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -38,8 +41,12 @@ fn test_dependent_snark_updates_advance_across_blocks() {
             .with_slot(slot)
             .with_epoch(1)
             .with_sau(snark_acct_id, |sau| {
-                sau.transfer(recipient_id, BitcoinAmount::from_sat(TRANSFER_AMOUNT))
-                    .with_state_root(new_inner_state_root)
+                sau.transfer(
+                    recipient_id,
+                    BitcoinAmount::try_from(TRANSFER_AMOUNT)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                )
+                .with_state_root(new_inner_state_root)
             })
             .execute()
             .completed_block()
@@ -62,7 +69,8 @@ fn test_dependent_snark_updates_advance_across_blocks() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(INITIAL_BALANCE - (UPDATE_COUNT * TRANSFER_AMOUNT))
+        BitcoinAmount::try_from(INITIAL_BALANCE - (UPDATE_COUNT * TRANSFER_AMOUNT))
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     let account_state = fixture.expect_snark_account(snark_acct_id);
     assert_eq!(*account_state.seqno().inner(), UPDATE_COUNT);
@@ -70,6 +78,7 @@ fn test_dependent_snark_updates_advance_across_blocks() {
 
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(UPDATE_COUNT * TRANSFER_AMOUNT)
+        BitcoinAmount::try_from(UPDATE_COUNT * TRANSFER_AMOUNT)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 }

--- a/crates/ol/stf/src/tests/sau_transfers.rs
+++ b/crates/ol/stf/src/tests/sau_transfers.rs
@@ -12,7 +12,10 @@ fn test_snark_update_success_with_transfer() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -22,9 +25,13 @@ fn test_snark_update_success_with_transfer() {
     let outcome = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(30_000_000))
-                .with_state_root(make_state_root(2))
-                .with_proof(make_proof(1))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(30_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
+            .with_proof(make_proof(1))
         })
         .execute();
 
@@ -38,7 +45,8 @@ fn test_snark_update_success_with_transfer() {
     // Verify balances
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(70_000_000),
+        BitcoinAmount::try_from(70_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender account balance should be 100M - 30M"
     );
     // Check the seq no of the sender
@@ -50,7 +58,8 @@ fn test_snark_update_success_with_transfer() {
 
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(30_000_000),
+        BitcoinAmount::try_from(30_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should receive 30M"
     );
 }
@@ -64,7 +73,10 @@ fn test_snark_update_multiple_transfers() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
@@ -74,17 +86,30 @@ fn test_snark_update_multiple_transfers() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::from_sat(30_000_000))
-                .transfer(recipient2_id, BitcoinAmount::from_sat(20_000_000))
-                .transfer(recipient3_id, BitcoinAmount::from_sat(10_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient1_id,
+                BitcoinAmount::try_from(30_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .transfer(
+                recipient2_id,
+                BitcoinAmount::try_from(20_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .transfer(
+                recipient3_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
 
     // Verify all balances
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(40_000_000),
+        BitcoinAmount::try_from(40_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender should have 100M - 60M = 40M"
     );
     assert_eq!(
@@ -95,19 +120,22 @@ fn test_snark_update_multiple_transfers() {
 
     assert_eq!(
         fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(30_000_000),
+        BitcoinAmount::try_from(30_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient1 should receive 30M"
     );
 
     assert_eq!(
         fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(20_000_000),
+        BitcoinAmount::try_from(20_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient2 should receive 20M"
     );
 
     assert_eq!(
         fixture.account_balance(recipient3_id),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient3 should receive 10M"
     );
 }
@@ -121,10 +149,16 @@ fn test_snark_update_same_block_distinct_senders() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(sender1_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_snark_account(sender2_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(70_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(70_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
@@ -133,18 +167,27 @@ fn test_snark_update_same_block_distinct_senders() {
     fixture
         .child_block()
         .with_sau(sender1_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::from_sat(10_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient1_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .with_sau(sender2_acct_id, |sau| {
-            sau.transfer(recipient2_id, BitcoinAmount::from_sat(20_000_000))
-                .with_state_root(make_state_root(3))
+            sau.transfer(
+                recipient2_id,
+                BitcoinAmount::try_from(20_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(3))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(sender1_acct_id),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender1 balance should reflect its same-block transfer"
     );
     assert_eq!(
@@ -158,7 +201,8 @@ fn test_snark_update_same_block_distinct_senders() {
 
     assert_eq!(
         fixture.account_balance(sender2_acct_id),
-        BitcoinAmount::from_sat(50_000_000),
+        BitcoinAmount::try_from(50_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender2 balance should reflect its same-block transfer"
     );
     assert_eq!(
@@ -172,13 +216,15 @@ fn test_snark_update_same_block_distinct_senders() {
 
     assert_eq!(
         fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient1 should receive sender1 transfer"
     );
 
     assert_eq!(
         fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(20_000_000),
+        BitcoinAmount::try_from(20_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient2 should receive sender2 transfer"
     );
 }
@@ -191,7 +237,10 @@ fn test_snark_update_same_block_sequential_seqnos() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(sender_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
@@ -200,18 +249,27 @@ fn test_snark_update_same_block_sequential_seqnos() {
     fixture
         .child_block()
         .with_sau(sender_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::from_sat(10_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient1_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .with_sau(sender_acct_id, |sau| {
-            sau.transfer(recipient2_id, BitcoinAmount::from_sat(20_000_000))
-                .with_state_root(make_state_root(3))
+            sau.transfer(
+                recipient2_id,
+                BitcoinAmount::try_from(20_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(3))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(sender_acct_id),
-        BitcoinAmount::from_sat(70_000_000),
+        BitcoinAmount::try_from(70_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender balance should include both same-block transfers"
     );
     assert_eq!(
@@ -222,13 +280,15 @@ fn test_snark_update_same_block_sequential_seqnos() {
 
     assert_eq!(
         fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient1 should receive the first transfer"
     );
 
     assert_eq!(
         fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(20_000_000),
+        BitcoinAmount::try_from(20_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient2 should receive the second transfer"
     );
 }
@@ -241,7 +301,10 @@ fn test_snark_update_same_block_duplicate_seqno_fails() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(sender_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
@@ -250,13 +313,21 @@ fn test_snark_update_same_block_duplicate_seqno_fails() {
     let err = fixture
         .child_block()
         .with_sau(sender_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::from_sat(10_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient1_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .with_sau(sender_acct_id, |sau| {
-            sau.transfer(recipient2_id, BitcoinAmount::from_sat(20_000_000))
-                .force_seqno(0)
-                .with_state_root(make_state_root(3))
+            sau.transfer(
+                recipient2_id,
+                BitcoinAmount::try_from(20_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .force_seqno(0)
+            .with_state_root(make_state_root(3))
         })
         .execute_err();
 
@@ -275,7 +346,8 @@ fn test_snark_update_same_block_duplicate_seqno_fails() {
 
     assert_eq!(
         fixture.account_balance(sender_acct_id),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "First same-block transfer should remain applied"
     );
     assert_eq!(
@@ -286,13 +358,14 @@ fn test_snark_update_same_block_duplicate_seqno_fails() {
 
     assert_eq!(
         fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(10_000_000),
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient1 should receive the first transfer"
     );
 
     assert_eq!(
         fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient2 should not receive the duplicate-seqno transfer"
     );
 }
@@ -305,7 +378,10 @@ fn test_snark_update_partial_balance_multiple_outputs() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
@@ -314,9 +390,17 @@ fn test_snark_update_partial_balance_multiple_outputs() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient1_id, BitcoinAmount::from_sat(60_000_000))
-                .transfer(recipient2_id, BitcoinAmount::from_sat(50_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient1_id,
+                BitcoinAmount::try_from(60_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .transfer(
+                recipient2_id,
+                BitcoinAmount::try_from(50_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute_err();
 
@@ -328,19 +412,20 @@ fn test_snark_update_partial_balance_multiple_outputs() {
     // Verify no partial execution - all balances should be unchanged
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender balance should be unchanged"
     );
 
     assert_eq!(
         fixture.account_balance(recipient1_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient1 should have no balance"
     );
 
     assert_eq!(
         fixture.account_balance(recipient2_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient2 should have no balance"
     );
 }
@@ -352,7 +437,10 @@ fn test_snark_update_zero_value_transfer() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -360,14 +448,19 @@ fn test_snark_update_zero_value_transfer() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(0))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Sender balance should be unchanged"
     );
     assert_eq!(
@@ -377,7 +470,7 @@ fn test_snark_update_zero_value_transfer() {
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient balance should remain 0"
     );
 }
@@ -389,7 +482,10 @@ fn test_snark_update_from_zero_balance_account() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(0))
+            acct.with_balance(
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -397,8 +493,12 @@ fn test_snark_update_from_zero_balance_account() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(1))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(1)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute_err();
 
@@ -416,8 +516,12 @@ fn test_snark_update_from_zero_balance_account() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(0))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
 
@@ -428,22 +532,35 @@ fn test_snark_update_from_zero_balance_account() {
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Balance should remain zero"
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should have zero balance"
     );
 
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(0))
-                .transfer(snark_acct_id, BitcoinAmount::from_sat(0))
-                .output_message(BRIDGE_GATEWAY_ACCT_ID, BitcoinAmount::from_sat(0), vec![])
-                .with_state_root(make_state_root(3))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .transfer(
+                snark_acct_id,
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .output_message(
+                BRIDGE_GATEWAY_ACCT_ID,
+                BitcoinAmount::try_from(0)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                vec![],
+            )
+            .with_state_root(make_state_root(3))
         })
         .execute();
 
@@ -460,21 +577,29 @@ fn test_snark_update_self_transfer() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(snark_acct_id, BitcoinAmount::from_sat(30_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                snark_acct_id,
+                BitcoinAmount::try_from(30_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Balance should be unchanged after self-transfer"
     );
     assert_eq!(
@@ -492,7 +617,10 @@ fn test_snark_update_exact_balance_transfer() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .with_genesis_empty_account(second_recipient_id)
@@ -501,14 +629,18 @@ fn test_snark_update_exact_balance_transfer() {
     fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(100_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Sender should have 0 balance"
     );
     assert_eq!(
@@ -518,15 +650,20 @@ fn test_snark_update_exact_balance_transfer() {
     );
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(100_000_000),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "Recipient should receive entire balance"
     );
 
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(second_recipient_id, BitcoinAmount::from_sat(1))
-                .with_state_root(make_state_root(3))
+            sau.transfer(
+                second_recipient_id,
+                BitcoinAmount::try_from(1)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(3))
         })
         .execute_err();
 
@@ -536,7 +673,7 @@ fn test_snark_update_exact_balance_transfer() {
     );
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Sender balance should remain zero after failed transfer from drained balance"
     );
     assert_eq!(
@@ -546,7 +683,7 @@ fn test_snark_update_exact_balance_transfer() {
     );
     assert_eq!(
         fixture.account_balance(second_recipient_id),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Second recipient should not receive failed transfer from drained balance"
     );
 }

--- a/crates/ol/stf/src/tests/sau_validation.rs
+++ b/crates/ol/stf/src/tests/sau_validation.rs
@@ -14,7 +14,10 @@ fn test_snark_update_invalid_sequence_number() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -25,7 +28,11 @@ fn test_snark_update_invalid_sequence_number() {
         .child_block()
         .with_sau(snark_acct_id, |sau| {
             sau.force_seqno(5)
-                .transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+                .transfer(
+                    recipient_id,
+                    BitcoinAmount::try_from(10_000_000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                )
                 .with_state_root(make_state_root(2))
         })
         .execute_err();
@@ -49,7 +56,10 @@ fn test_snark_update_replay_across_blocks_fails() {
     let transfer_amount = 10_000_000;
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -57,8 +67,12 @@ fn test_snark_update_replay_across_blocks_fails() {
     let block1 = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(transfer_amount))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(transfer_amount)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute();
     let tx = block1
@@ -71,7 +85,8 @@ fn test_snark_update_replay_across_blocks_fails() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "sender balance should reflect first execution"
     );
     assert_eq!(
@@ -82,7 +97,8 @@ fn test_snark_update_replay_across_blocks_fails() {
 
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(transfer_amount),
+        BitcoinAmount::try_from(transfer_amount)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "recipient should receive the first execution"
     );
 
@@ -102,7 +118,8 @@ fn test_snark_update_replay_across_blocks_fails() {
 
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(90_000_000),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "sender balance should not change after replay failure"
     );
     assert_eq!(
@@ -113,7 +130,8 @@ fn test_snark_update_replay_across_blocks_fails() {
 
     assert_eq!(
         fixture.account_balance(recipient_id),
-        BitcoinAmount::from_sat(transfer_amount),
+        BitcoinAmount::try_from(transfer_amount)
+            .expect("amount must not exceed the Bitcoin money supply"),
         "recipient balance should not change after replay failure"
     );
 }
@@ -125,7 +143,10 @@ fn test_snark_update_insufficient_balance() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(50_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(50_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -135,8 +156,12 @@ fn test_snark_update_insufficient_balance() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(recipient_id, BitcoinAmount::from_sat(100_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                recipient_id,
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute_err();
 
@@ -155,7 +180,10 @@ fn test_snark_update_nonexistent_recipient() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -164,8 +192,12 @@ fn test_snark_update_nonexistent_recipient() {
     let err = fixture
         .child_block()
         .with_sau(snark_acct_id, |sau| {
-            sau.transfer(nonexistent_id, BitcoinAmount::from_sat(10_000_000))
-                .with_state_root(make_state_root(2))
+            sau.transfer(
+                nonexistent_id,
+                BitcoinAmount::try_from(10_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
+            .with_state_root(make_state_root(2))
         })
         .execute_err();
 
@@ -221,7 +253,10 @@ fn test_snark_update_rejects_max_sequence_number() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -236,7 +271,11 @@ fn test_snark_update_rejects_max_sequence_number() {
         .child_block()
         .with_sau(snark_acct_id, |sau| {
             sau.force_seqno(u64::MAX)
-                .transfer(recipient_id, BitcoinAmount::from_sat(1))
+                .transfer(
+                    recipient_id,
+                    BitcoinAmount::try_from(1)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                )
                 .with_state_root(make_state_root(2))
         })
         .execute_err()

--- a/crates/ol/stf/src/tests/staging_layers.rs
+++ b/crates/ol/stf/src/tests/staging_layers.rs
@@ -34,7 +34,10 @@ fn test_process_single_tx_stages_sau_writes() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -42,7 +45,11 @@ fn test_process_single_tx_stages_sau_writes() {
     let base_root = fixture.compute_state_root();
 
     let tx = fixture.sau_tx(snark_acct_id, |sau| {
-        sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+        sau.transfer(
+            recipient_id,
+            BitcoinAmount::try_from(10_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
     });
 
     let output = ExecOutputBuffer::new_empty();
@@ -59,7 +66,11 @@ fn test_process_single_tx_stages_sau_writes() {
     let staged_sender_account_state = staged_sender
         .as_snark_account()
         .expect("sender should be snark");
-    assert_eq!(staged_sender.balance(), BitcoinAmount::from_sat(90_000_000));
+    assert_eq!(
+        staged_sender.balance(),
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(*staged_sender_account_state.seqno().inner(), 1);
     assert_eq!(
         staged_sender_account_state.inner_state_root(),
@@ -72,14 +83,19 @@ fn test_process_single_tx_stages_sau_writes() {
         .expect("recipient should exist");
     assert_eq!(
         staged_recipient.balance(),
-        BitcoinAmount::from_sat(10_000_000)
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 
     let base_sender = base_state
         .get_account_state(snark_acct_id)
         .expect("sender lookup should succeed")
         .expect("sender should exist");
-    assert_eq!(base_sender.balance(), BitcoinAmount::from_sat(100_000_000));
+    assert_eq!(
+        base_sender.balance(),
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(
         base_state
             .compute_state_root()
@@ -97,7 +113,8 @@ fn test_process_single_tx_stages_sau_writes() {
             .expect("sender lookup should succeed")
             .expect("sender should exist")
             .balance(),
-        BitcoinAmount::from_sat(90_000_000)
+        BitcoinAmount::try_from(90_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -115,7 +132,8 @@ fn assert_transfer_staged(
         .expect("sender should exist");
     assert_eq!(
         staged_sender.balance(),
-        BitcoinAmount::from_sat(expected_sender_balance)
+        BitcoinAmount::try_from(expected_sender_balance)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(
         *staged_sender
@@ -131,7 +149,8 @@ fn assert_transfer_staged(
             .expect("recipient lookup should succeed")
             .expect("recipient should exist")
             .balance(),
-        BitcoinAmount::from_sat(expected_recipient_balance)
+        BitcoinAmount::try_from(expected_recipient_balance)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -141,14 +160,21 @@ fn test_process_single_tx_reads_prior_staged_writes() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
     let base_state = fixture.state().clone();
 
     let tx1 = fixture.sau_tx(snark_acct_id, |sau| {
-        sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+        sau.transfer(
+            recipient_id,
+            BitcoinAmount::try_from(10_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
     });
 
     let output = ExecOutputBuffer::new_empty();
@@ -217,7 +243,8 @@ fn test_process_single_tx_reads_prior_staged_writes() {
             .expect("sender lookup should succeed")
             .expect("sender should exist")
             .balance(),
-        BitcoinAmount::from_sat(100_000_000)
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -227,14 +254,21 @@ fn test_process_single_tx_loop_can_restore_failed_tx_batch() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
     let base_state = fixture.state().clone();
 
     let tx1 = fixture.sau_tx(snark_acct_id, |sau| {
-        sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+        sau.transfer(
+            recipient_id,
+            BitcoinAmount::try_from(10_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
     });
 
     let output = ExecOutputBuffer::new_empty();
@@ -317,14 +351,21 @@ fn test_process_tx_segment_reads_staged_writes_between_txs() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
     let base_state = fixture.state().clone();
 
     let tx1 = fixture.sau_tx(snark_acct_id, |sau| {
-        sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+        sau.transfer(
+            recipient_id,
+            BitcoinAmount::try_from(10_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
     });
 
     let mut expected_after_tx1 = base_state.clone();
@@ -381,7 +422,8 @@ fn test_process_tx_segment_reads_staged_writes_between_txs() {
             .expect("recipient lookup should succeed")
             .expect("recipient should exist")
             .balance(),
-        BitcoinAmount::from_sat(15_000_000)
+        BitcoinAmount::try_from(15_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -420,7 +462,7 @@ fn test_write_tracking_stages_account_creation_before_apply() {
         .expect("staged lookup should succeed")
         .expect("staged account should be readable");
     assert_eq!(staged_account.serial(), expected_serial);
-    assert_eq!(staged_account.balance(), BitcoinAmount::zero());
+    assert_eq!(staged_account.balance(), BitcoinAmount::default());
 
     let mut applied_state = base_state.clone();
     applied_state
@@ -441,7 +483,10 @@ fn test_multi_effect_sau_coalesces_staged_account_writes() {
     let message_recipient_id = make_account_id(MESSAGE_RECIPIENT_ACCOUNT_ID);
     let fixture = OLStfFixture::builder()
         .with_genesis_snark_account(sender_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient1_id)
         .with_genesis_empty_account(recipient2_id)
@@ -450,18 +495,26 @@ fn test_multi_effect_sau_coalesces_staged_account_writes() {
     let base_state = fixture.state().clone();
 
     let tx = fixture.sau_tx(sender_acct_id, |sau| {
-        sau.transfer(recipient1_id, BitcoinAmount::from_sat(10_000_000))
-            .transfer(recipient2_id, BitcoinAmount::from_sat(20_000_000))
-            .output_message(
-                message_recipient_id,
-                BitcoinAmount::from_sat(1),
-                b"first".to_vec(),
-            )
-            .output_message(
-                message_recipient_id,
-                BitcoinAmount::from_sat(2),
-                b"second".to_vec(),
-            )
+        sau.transfer(
+            recipient1_id,
+            BitcoinAmount::try_from(10_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
+        .transfer(
+            recipient2_id,
+            BitcoinAmount::try_from(20_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
+        .output_message(
+            message_recipient_id,
+            BitcoinAmount::try_from(1).expect("amount must not exceed the Bitcoin money supply"),
+            b"first".to_vec(),
+        )
+        .output_message(
+            message_recipient_id,
+            BitcoinAmount::try_from(2).expect("amount must not exceed the Bitcoin money supply"),
+            b"second".to_vec(),
+        )
     });
 
     let output = ExecOutputBuffer::new_empty();
@@ -491,7 +544,11 @@ fn test_multi_effect_sau_coalesces_staged_account_writes() {
         .get_account_state(sender_acct_id)
         .expect("sender lookup should succeed")
         .expect("sender should exist");
-    assert_eq!(staged_sender.balance(), BitcoinAmount::from_sat(69_999_997));
+    assert_eq!(
+        staged_sender.balance(),
+        BitcoinAmount::try_from(69_999_997)
+            .expect("amount must not exceed the Bitcoin money supply")
+    );
     let staged_sender_account_state = staged_sender
         .as_snark_account()
         .expect("sender should be snark");
@@ -507,7 +564,8 @@ fn test_multi_effect_sau_coalesces_staged_account_writes() {
             .expect("recipient lookup should succeed")
             .expect("recipient should exist")
             .balance(),
-        BitcoinAmount::from_sat(10_000_000)
+        BitcoinAmount::try_from(10_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(
         tracking
@@ -515,13 +573,17 @@ fn test_multi_effect_sau_coalesces_staged_account_writes() {
             .expect("recipient lookup should succeed")
             .expect("recipient should exist")
             .balance(),
-        BitcoinAmount::from_sat(20_000_000)
+        BitcoinAmount::try_from(20_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     let message_recipient = tracking
         .get_account_state(message_recipient_id)
         .expect("message recipient lookup should succeed")
         .expect("message recipient should exist");
-    assert_eq!(message_recipient.balance(), BitcoinAmount::from_sat(3));
+    assert_eq!(
+        message_recipient.balance(),
+        BitcoinAmount::try_from(3).expect("amount must not exceed the Bitcoin money supply")
+    );
     assert_eq!(
         message_recipient
             .as_snark_account()
@@ -538,7 +600,10 @@ fn test_assembly_and_verify_write_tracking_reach_same_state() {
     let recipient_id = make_account_id(TEST_RECIPIENT_ID);
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(recipient_id)
         .execute_genesis();
@@ -549,7 +614,11 @@ fn test_assembly_and_verify_write_tracking_reach_same_state() {
         gam.with_payload(b"assembly verify equivalence".to_vec())
     });
     let sau_tx = fixture.sau_tx(snark_acct_id, |sau| {
-        sau.transfer(recipient_id, BitcoinAmount::from_sat(10_000_000))
+        sau.transfer(
+            recipient_id,
+            BitcoinAmount::try_from(10_000_000)
+                .expect("amount must not exceed the Bitcoin money supply"),
+        )
     });
     let block = fixture
         .child_block()
@@ -606,7 +675,10 @@ fn test_assembly_and_verify_write_tracking_reach_same_state() {
 fn test_verify_block_tracks_snark_inbox_writes() {
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(make_account_id(TEST_SNARK_ACCOUNT_ID), |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
@@ -639,7 +711,7 @@ fn test_verify_block_tracks_snark_inbox_writes() {
     assert_eq!(inbox_write.account_id(), snark_acct_id);
     assert_eq!(inbox_write.index(), 0);
     assert_eq!(inbox_write.entry().incl_epoch(), 1);
-    let expected_payload = MsgPayload::from_bytes(BitcoinAmount::zero(), payload)
+    let expected_payload = MsgPayload::from_bytes(BitcoinAmount::default(), payload)
         .expect("message payload bytes must fit within SSZ max length");
     assert_eq!(inbox_write.entry().payload(), &expected_payload);
 

--- a/crates/ol/stf/src/tests/stress.rs
+++ b/crates/ol/stf/src/tests/stress.rs
@@ -16,8 +16,11 @@ fn indexed_payload(index: usize) -> Vec<u8> {
 }
 
 fn msg_payload_from_bytes(data: Vec<u8>) -> MsgPayload {
-    MsgPayload::from_bytes(BitcoinAmount::from_sat(0), data)
-        .expect("message payload bytes must fit within SSZ max length")
+    MsgPayload::from_bytes(
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
+        data,
+    )
+    .expect("message payload bytes must fit within SSZ max length")
 }
 
 #[test]
@@ -25,7 +28,10 @@ fn test_stress_inserts_large_inbox_message_batch() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -49,7 +55,10 @@ fn test_stress_executes_large_tx_batch() {
     let target_acct_id = make_account_id(TEST_RECIPIENT_ID);
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .with_genesis_empty_account(target_acct_id)
         .execute_genesis();
@@ -72,7 +81,7 @@ fn test_stress_executes_large_tx_batch() {
     );
     assert_eq!(
         fixture.account_balance(target_acct_id),
-        BitcoinAmount::from_sat(0)
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply")
     );
 }
 
@@ -81,7 +90,10 @@ fn test_stress_processes_large_inbox_proof_batch() {
     let snark_acct_id = make_account_id(TEST_SNARK_ACCOUNT_ID);
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(100_000_000))
+            acct.with_balance(
+                BitcoinAmount::try_from(100_000_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
 
@@ -131,7 +143,8 @@ fn test_stress_processes_large_inbox_proof_batch() {
     let account_state = fixture.expect_snark_account(snark_acct_id);
     assert_eq!(
         fixture.account_balance(snark_acct_id),
-        BitcoinAmount::from_sat(100_000_000)
+        BitcoinAmount::try_from(100_000_000)
+            .expect("amount must not exceed the Bitcoin money supply")
     );
     assert_eq!(*account_state.seqno().inner(), 1);
     assert_eq!(account_state.next_inbox_msg_idx(), STRESS_BATCH_SIZE as u64);

--- a/crates/ol/stf/src/tests/verify_body.rs
+++ b/crates/ol/stf/src/tests/verify_body.rs
@@ -309,7 +309,10 @@ fn test_verify_block_allows_max_withdrawal_logs() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(initial_balance))
+            acct.with_balance(
+                BitcoinAmount::try_from(initial_balance)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
     let genesis = fixture.last_completed_block().clone();
@@ -335,7 +338,7 @@ fn test_verify_block_allows_max_withdrawal_logs() {
     let (ol_account_state, account_state) = verify_state.expect_snark_account_state(snark_acct_id);
     assert_eq!(
         ol_account_state.balance(),
-        BitcoinAmount::from_sat(0),
+        BitcoinAmount::try_from(0).expect("amount must not exceed the Bitcoin money supply"),
         "Verified state should spend every withdrawal output"
     );
     assert_eq!(
@@ -353,7 +356,10 @@ fn test_assemble_rejects_withdrawal_logs_over_limit() {
 
     let mut fixture = OLStfFixture::builder()
         .with_genesis_snark_account(snark_acct_id, |acct| {
-            acct.with_balance(BitcoinAmount::from_sat(initial_balance))
+            acct.with_balance(
+                BitcoinAmount::try_from(initial_balance)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+            )
         })
         .execute_genesis();
     let block = fixture.child_block();
@@ -509,7 +515,8 @@ fn with_withdrawal_log_saus<'a>(
             for _ in 0..msg_count {
                 sau = sau.output_message(
                     BRIDGE_GATEWAY_ACCT_ID,
-                    BitcoinAmount::from_sat(WITHDRAWAL_LOG_AMOUNT),
+                    BitcoinAmount::try_from(WITHDRAWAL_LOG_AMOUNT)
+                        .expect("amount must not exceed the Bitcoin money supply"),
                     make_withdrawal_payload(make_p2wpkh_bosd_descriptor(0x15)),
                 );
             }

--- a/crates/ol/stf/src/transaction_processing.rs
+++ b/crates/ol/stf/src/transaction_processing.rs
@@ -391,7 +391,11 @@ mod tests {
     fn test_verify_gam_tx_rejects_transfer_effects() {
         let target_acct_id = make_account_id(1);
         let mut effects = TxEffects::default();
-        assert!(effects.push_transfer(target_acct_id, 1));
+        assert!(
+            effects
+                .push_transfer(target_acct_id, 1)
+                .expect("test transfer amount should be within the money supply")
+        );
         assert!(push_test_message(&mut effects, target_acct_id, 0, vec![]));
 
         assert_gam_structure_error(target_acct_id, &effects, "nonzero transfers");

--- a/crates/ol/stf/src/transaction_processing.rs
+++ b/crates/ol/stf/src/transaction_processing.rs
@@ -84,7 +84,7 @@ fn verify_gam_tx(gam: &GamTxPayload, fx: &TxEffects) -> ExecResult<()> {
     // 2. Extract the message we want to send.
     let mut msgs_iter = fx.messages_iter();
     let msg = match (msgs_iter.next(), msgs_iter.next()) {
-        (Some(m), None) if m.payload().value().is_zero() => m,
+        (Some(m), None) if m.payload().value() == BitcoinAmount::default() => m,
         _ => {
             return Err(ExecError::TxStructureCheckFailed(
                 "multiple messages or nonzero value",
@@ -258,7 +258,7 @@ fn debit_source<S: IStateAccessorMut>(
     source: AccountId,
     total_sent: BitcoinAmount,
 ) -> ExecResult<Coin> {
-    if total_sent.is_zero() {
+    if total_sent == BitcoinAmount::default() {
         return Ok(Coin::zero());
     }
 
@@ -310,7 +310,7 @@ pub fn verify_effects_safe<S: IStateAccessorMut>(
     state: &S,
     acct: &S::AccountState,
 ) -> ExecResult<()> {
-    let mut total_sent = BitcoinAmount::zero();
+    let mut total_sent_sats = 0u64;
 
     // We're actually making the same checks in both places, so we can chain the
     // iterators like this.
@@ -324,10 +324,13 @@ pub fn verify_effects_safe<S: IStateAccessorMut>(
             return Err(ExecError::UnknownAccount(dest));
         }
 
-        total_sent = total_sent
-            .checked_add(amt)
+        total_sent_sats = total_sent_sats
+            .checked_add(amt.to_sat())
             .ok_or(ExecError::AmountOverflow)?;
     }
+
+    let total_sent =
+        BitcoinAmount::try_from(total_sent_sats).map_err(|_| ExecError::AmountOverflow)?;
 
     if total_sent > acct.balance() {
         return Err(ExecError::BalanceUnderflow);

--- a/crates/ol/stf/src/verification.rs
+++ b/crates/ol/stf/src/verification.rs
@@ -480,7 +480,11 @@ mod tests {
         let new_empty_acct_id = make_account_id(STATE_DIFF_EMPTY_ACCOUNT_ID);
         let new_account = NewAccountEntry::new(
             new_empty_acct_id,
-            AccountInit::new(BitcoinAmount::from_sat(1), AccountTypeInit::Empty),
+            AccountInit::new(
+                BitcoinAmount::try_from(1)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                AccountTypeInit::Empty,
+            ),
         );
         StateDiff::new(
             GlobalStateDiff::default(),

--- a/crates/proof-impl/checkpoint/src/program.rs
+++ b/crates/proof-impl/checkpoint/src/program.rs
@@ -69,7 +69,8 @@ impl CheckpointProgram {
     /// functional-test params so the resulting witness verifies under `Bip340Schnorr`.
     pub fn test_predicate_key() -> PredicateKey {
         let pk = test_signing_key().verifying_key().to_bytes().to_vec();
-        PredicateKey::new(PredicateTypeId::Bip340Schnorr, pk)
+        PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, pk)
+            .expect("predicate condition must fit within the maximum length")
     }
 
     /// Executes the checkpoint program using the native host for testing.

--- a/crates/proof-impl/predicate-keys/src/lib.rs
+++ b/crates/proof-impl/predicate-keys/src/lib.rs
@@ -110,7 +110,8 @@ impl PredicateKeyProvider for Sp1Groth16PredicateKey {
         .map_err(|e| PredicateKeyError::Sp1Verifier(e.to_string()))?;
         let condition = sp1_verifier.to_uncompressed_bytes();
 
-        Ok(PredicateKey::new(PredicateTypeId::Sp1Groth16, condition))
+        PredicateKey::try_new(PredicateTypeId::Sp1Groth16, condition)
+            .map_err(|e| PredicateKeyError::Sp1Verifier(e.to_string()))
     }
 }
 
@@ -144,14 +145,16 @@ mod tests {
 
     #[test]
     fn accepts_equal_predicate_keys() {
-        let predicate = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3]);
+        let predicate = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3])
+            .expect("predicate condition must fit within the maximum length");
 
         validate_expected_predicate_key(&predicate, &predicate).unwrap();
     }
 
     #[test]
     fn validates_predicate_key_provider_output() {
-        let predicate = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3]);
+        let predicate = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![1, 2, 3])
+            .expect("predicate condition must fit within the maximum length");
         let provider = StaticPredicateKeyProvider(predicate.clone());
 
         validate_predicate_key(&predicate, &provider).unwrap();
@@ -159,8 +162,10 @@ mod tests {
 
     #[test]
     fn mismatch_reports_type_length_and_conditions() {
-        let configured = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0xaa; 32]);
-        let expected = PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![0xbb; 16]);
+        let configured = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0xaa; 32])
+            .expect("predicate condition must fit within the maximum length");
+        let expected = PredicateKey::try_new(PredicateTypeId::Sp1Groth16, vec![0xbb; 16])
+            .expect("predicate condition must fit within the maximum length");
 
         let err = validate_expected_predicate_key(&configured, &expected).unwrap_err();
 
@@ -189,8 +194,10 @@ mod tests {
 
     #[test]
     fn mismatch_reports_same_type_and_length_with_different_conditions() {
-        let configured = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0xaa; 32]);
-        let expected = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0xbb; 32]);
+        let configured = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0xaa; 32])
+            .expect("predicate condition must fit within the maximum length");
+        let expected = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0xbb; 32])
+            .expect("predicate condition must fit within the maximum length");
 
         let err = validate_expected_predicate_key(&configured, &expected)
             .unwrap_err()

--- a/crates/snark-acct-runtime/src/program_processing.rs
+++ b/crates/snark-acct-runtime/src/program_processing.rs
@@ -336,7 +336,7 @@ mod tests {
 
     fn make_msg_entry(delta: u64) -> MessageEntry {
         let data = strata_codec::encode_to_vec(&TestMsg { delta }).unwrap();
-        let payload = MsgPayload::from_bytes(BitcoinAmount::ZERO, data)
+        let payload = MsgPayload::from_bytes(BitcoinAmount::default(), data)
             .expect("message payload bytes must fit within SSZ max length");
         MessageEntry::new(AccountId::zero(), 0, payload)
     }
@@ -446,7 +446,7 @@ mod tests {
         let mut state = TestState { value: 0 };
 
         // Create a message entry with garbage payload data to trigger Unknown
-        let unknown_payload = MsgPayload::from_bytes(BitcoinAmount::ZERO, vec![0xff])
+        let unknown_payload = MsgPayload::from_bytes(BitcoinAmount::default(), vec![0xff])
             .expect("message payload bytes must fit within SSZ max length");
         let unknown_entry = MessageEntry::new(AccountId::zero(), 0, unknown_payload);
 

--- a/crates/snark-acct-types/src/outputs.rs
+++ b/crates/snark-acct-types/src/outputs.rs
@@ -176,14 +176,14 @@ impl UpdateOutputs {
     /// Computes the total value across all transfers and messages.
     /// Returns None if overflow occurs.
     pub fn compute_total_value(&self) -> Option<BitcoinAmount> {
-        let mut total = BitcoinAmount::zero();
+        let mut total_sats = 0u64;
         for transfer in self.transfers() {
-            total = total.checked_add(transfer.value())?;
+            total_sats = total_sats.checked_add(transfer.value().to_sat())?;
         }
         for msg in self.messages() {
-            total = total.checked_add(msg.payload().value())?;
+            total_sats = total_sats.checked_add(msg.payload().value().to_sat())?;
         }
-        Some(total)
+        BitcoinAmount::try_from(total_sats).ok()
     }
 }
 

--- a/crates/snark-acct-types/src/proof_interface.rs
+++ b/crates/snark-acct-types/src/proof_interface.rs
@@ -72,6 +72,8 @@ mod tests {
     use super::*;
     use crate::{AccumulatorClaim, OutputMessage, OutputTransfer, Seqno};
 
+    const MAX_BITCOIN_MONEY_SATS: u64 = 21_000_000 * 100_000_000;
+
     fn proof_state_strategy() -> impl Strategy<Value = ProofState> {
         (any::<[u8; 32]>(), any::<u64>()).prop_map(|(inner_state, next_idx)| ProofState {
             inner_state: inner_state.into(),
@@ -84,14 +86,17 @@ mod tests {
     }
 
     fn msg_payload_strategy() -> impl Strategy<Value = MsgPayload> {
-        (any::<u64>(), prop::collection::vec(any::<u8>(), 0..32)).prop_map(|(value, data)| {
-            MsgPayload {
-                value: BitcoinAmount::from_sat(value),
+        (
+            0..=MAX_BITCOIN_MONEY_SATS,
+            prop::collection::vec(any::<u8>(), 0..32),
+        )
+            .prop_map(|(value, data)| MsgPayload {
+                value: BitcoinAmount::try_from(value)
+                    .expect("amount must not exceed the Bitcoin money supply"),
                 data: data
                     .try_into()
                     .expect("message payload bytes must fit within SSZ max length"),
-            }
-        })
+            })
     }
 
     fn message_entry_strategy() -> impl Strategy<Value = MessageEntry> {
@@ -125,16 +130,21 @@ mod tests {
     }
 
     fn output_transfer_strategy() -> impl Strategy<Value = OutputTransfer> {
-        (account_id_strategy(), any::<u64>()).prop_map(|(dest, value)| OutputTransfer {
-            dest,
-            value: BitcoinAmount::from_sat(value),
+        (account_id_strategy(), 0..=MAX_BITCOIN_MONEY_SATS).prop_map(|(dest, value)| {
+            OutputTransfer {
+                dest,
+                value: BitcoinAmount::try_from(value)
+                    .expect("strategy only generates valid Bitcoin amounts"),
+            }
         })
     }
 
     fn new_predicate_strategy() -> impl Strategy<Value = Option<PredicateKey>> {
         prop::option::of(
-            prop::collection::vec(any::<u8>(), 0..32)
-                .prop_map(|condition| PredicateKey::new(PredicateTypeId::AlwaysAccept, condition)),
+            prop::collection::vec(any::<u8>(), 0..32).prop_map(|condition| {
+                PredicateKey::try_new(PredicateTypeId::AlwaysAccept, condition)
+                    .expect("strategy only generates valid predicate conditions")
+            }),
         )
     }
 

--- a/crates/test-utils/l2/src/checkpoint.rs
+++ b/crates/test-utils/l2/src/checkpoint.rs
@@ -86,20 +86,22 @@ impl CheckpointTestHarness {
     }
 
     pub fn sequencer_predicate(&self) -> PredicateKey {
-        PredicateKey::new(
+        PredicateKey::try_new(
             PredicateTypeId::Bip340Schnorr,
             self.sequencer_pubkey.clone(),
         )
+        .expect("predicate condition must fit within the maximum length")
     }
 
     pub fn checkpoint_predicate(&self) -> PredicateKey {
-        PredicateKey::new(
+        PredicateKey::try_new(
             PredicateTypeId::Bip340Schnorr,
             self.checkpoint_predicate
                 .verifying_key()
                 .to_bytes()
                 .to_vec(),
         )
+        .expect("predicate condition must fit within the maximum length")
     }
 
     /// Returns the sequencer's x-only public key bytes (used as envelope pubkey).

--- a/provers/sp1/guest-checkpoint/Cargo.lock
+++ b/provers/sp1/guest-checkpoint/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-bridge-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "borsh",
  "serde",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -1731,12 +1731,12 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "strata-asm-checkpoint-types",
  "strata-asm-common",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2)",
  "strata-identifiers",
  "strata-msg-fmt",
  "strata-predicate",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "borsh",
  "serde",
@@ -1766,13 +1766,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "bitcoin",
  "strata-asm-checkpoint-types",
  "strata-asm-common",
  "strata-codec",
- "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.3.0)",
+ "strata-codec-utils 0.1.0 (git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2)",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
  "thiserror",
@@ -1781,7 +1781,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-state"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "serde",
  "ssz",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.1#482939382eefd02ef449f041e4569c48164834f6"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.4.0-rc.2#7b248126e0a0d921508075cb0b2c51c7ffb43a10"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "strata-codec-derive",
  "thiserror",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "borsh",
  "ssz",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "bitcoin",
  "thiserror",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "borsh",
  "digest",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "thiserror",
 ]
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "strata-ol-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -2162,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "hex",
  "k256",


### PR DESCRIPTION
## Description

Bumps ASM and `strata-common` to `v0.4.0-rc.2`. The new ASM release uses Moho `v0.4.0-rc.1`.

The upstream releases changed the `BitcoinAmount`, `PredicateKey`, and logging APIs, so this PR updates the affected call sites. Amount aggregation, state updates, and persisted account-state conversion now enforce Bitcoin's maximum money supply.

The root lockfile and the standalone SP1 guest lockfiles have also been updated.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Most of the diff is compatibility work for the upstream API changes. The parts worth a closer look are the new amount-boundary checks and the handling of invalid amounts read from the EE account-state database.

Is this PR addressing any specification, design doc or external reference document?

- [ ] Yes
- [x] No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance disclosure: Codex was used to update compatibility code, run validation, and draft this PR body. I reviewed the resulting changes.

## Related Issues

STR-4232