### PR TITLE
chore: clean up CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /crates/bridge-types/ @delbonis @krsnapaudel @bewakes
 /crates/snark-*/ @delbonis @krsnapaudel @bewakes
 
-/crates/chain*/ @delbonis @krsnapaudel
+/crates/chain-worker/ @delbonis @krsnapaudel
 /crates/consensus-logic/ @delbonis @krsnapaudel
 /crates/csm-*/ @krsnapaudel @bewakes
 /crates/node-context/ @krsnapaudel @bewakes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,10 +30,10 @@
 /crates/bridge-types/ @delbonis @krsnapaudel @bewakes
 /crates/snark-*/ @delbonis @krsnapaudel @bewakes
 
-/crates/chain-worker/ @delbonis @krsnapaudel
-/crates/consensus-logic/ @delbonis @krsnapaudel
-/crates/csm-*/ @krsnapaudel @bewakes
-/crates/node-context/ @krsnapaudel @bewakes
+/crates/chain-worker/ @delbonis @krsnapaudel @storopoli
+/crates/consensus-logic/ @delbonis @krsnapaudel @storopoli
+/crates/csm-*/ @krsnapaudel @bewakes @storopoli
+/crates/node-context/ @krsnapaudel @bewakes @storopoli
 
 /crates/db/ @krsnapaudel @bewakes @delbonis
 /crates/storage/ @krsnapaudel @bewakes @delbonis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,15 +39,16 @@
 /crates/storage/ @krsnapaudel @bewakes @delbonis
 /crates/storage-common/ @krsnapaudel @bewakes @delbonis
 
-/crates/rpc/ @prajwolrg @krsnapaudel @bewakes
+/crates/rpc/ @krsnapaudel @bewakes
 /crates/proof-impl/ @purusang @prajwolrg @evgenyzdanovich @irnb
 /crates/prover-core/ @prajwolrg @evgenyzdanovich @irnb
 /crates/zkvm/ @prajwolrg @evgenyzdanovich @irnb
+/crates/paas/ @prajwolrg @evgenyzdanovich @irnb
 /provers/ @purusang @prajwolrg @evgenyzdanovich
 
 /crates/key-derivation/ @storopoli @prajwolrg @delbonis
 /crates/primitives/ @storopoli @prajwolrg @bewakes
-/crates/da-framework/ @storopoli @prajwolrg @delbonis @evgenyzdanovich
+/crates/da-framework/ @storopoli @prajwolrg @delbonis @evgenyzdanovich @irnb
 /crates/test-utils/ @voidash @delbonis
 
 # Binaries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,10 +53,10 @@
 
 # Binaries
 /bin/strata/ @storopoli @krsnapaudel @bewakes
-/bin/datatool/ @prajwolrg @krsnapaudel @voidash
+/bin/datatool/ @krsnapaudel @voidash
 /bin/strata-dbtool/ @krsnapaudel @delbonis
 /bin/strata-test-cli/ @krsnapaudel @voidash
-/bin/prover-perf/ @prajwolrg @purusang @evgenyzdanovich
+/bin/prover-perf/ @prajwolrg @purusang
 /bin/strata-signer/ @purusang @krsnapaudel
 
 # Tests and benchmarks

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,14 +28,12 @@
 /crates/ol/ @delbonis @krsnapaudel @bewakes
 /crates/acct-types/ @delbonis @krsnapaudel @bewakes
 /crates/bridge-types/ @delbonis @krsnapaudel @bewakes
-/crates/ledger-types/ @delbonis @krsnapaudel @bewakes
 /crates/snark-*/ @delbonis @krsnapaudel @bewakes
 
 /crates/chain*/ @prajwolrg @delbonis @krsnapaudel
 /crates/consensus-logic/ @prajwolrg @delbonis @krsnapaudel
 /crates/csm-*/ @prajwolrg @krsnapaudel @bewakes
 /crates/node-context/ @prajwolrg @krsnapaudel @bewakes
-/crates/state/ @delbonis @krsnapaudel @bewakes
 
 /crates/db/ @krsnapaudel @bewakes @delbonis
 /crates/storage/ @krsnapaudel @bewakes @delbonis
@@ -48,7 +46,6 @@
 /provers/ @purusang @prajwolrg @evgenyzdanovich
 
 /crates/key-derivation/ @storopoli @prajwolrg @delbonis
-/crates/mpt/ @evgenyzdanovich @delbonis @krsnapaudel
 /crates/primitives/ @storopoli @prajwolrg @bewakes
 /crates/da-framework/ @storopoli @prajwolrg @delbonis @evgenyzdanovich
 /crates/test-utils/ @voidash @delbonis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,16 +7,16 @@
 # CI, local env, repo tooling
 /.github/workflows/ @storopoli @purusang @voidash @alexhui01
 /.github/actions/ @storopoli @purusang @voidash @alexhui01
-/.github/dependabot.yml @storopoli @prajwolrg @purusang
-/.config/ @storopoli @prajwolrg @voidash
-/.justfile @storopoli @prajwolrg @voidash
+/.github/dependabot.yml @storopoli @purusang
+/.config/ @storopoli @voidash
+/.justfile @storopoli @voidash
 /codecov.yml @storopoli @voidash
-/contrib/ @storopoli @prajwolrg @voidash
+/contrib/ @storopoli @voidash
 /flake.nix @storopoli
 /flake.lock @storopoli
-/.codespellrc @storopoli @prajwolrg @voidash
-/.editorconfig @storopoli @prajwolrg @voidash
-/.vscode/ @storopoli @prajwolrg @voidash
+/.codespellrc @storopoli @voidash
+/.editorconfig @storopoli @voidash
+/.vscode/ @storopoli @voidash
 
 # Containers
 **/Docker* @purusang @voidash @alexhui01
@@ -30,10 +30,10 @@
 /crates/bridge-types/ @delbonis @krsnapaudel @bewakes
 /crates/snark-*/ @delbonis @krsnapaudel @bewakes
 
-/crates/chain*/ @prajwolrg @delbonis @krsnapaudel
-/crates/consensus-logic/ @prajwolrg @delbonis @krsnapaudel
-/crates/csm-*/ @prajwolrg @krsnapaudel @bewakes
-/crates/node-context/ @prajwolrg @krsnapaudel @bewakes
+/crates/chain*/ @delbonis @krsnapaudel
+/crates/consensus-logic/ @delbonis @krsnapaudel
+/crates/csm-*/ @krsnapaudel @bewakes
+/crates/node-context/ @krsnapaudel @bewakes
 
 /crates/db/ @krsnapaudel @bewakes @delbonis
 /crates/storage/ @krsnapaudel @bewakes @delbonis
@@ -63,17 +63,17 @@
 /benches/ @storopoli @krsnapaudel
 
 # Dependency metadata overrides. Keep these after crate/bin rules.
-**/Cargo.toml @prajwolrg @storopoli
-**/Cargo.lock @prajwolrg @storopoli
+**/Cargo.toml @storopoli
+**/Cargo.lock @storopoli
 
 # Repo policy/admin surfaces
 # keep last to avoid being overridden by other rules
 /.github/CODEOWNERS @pramodkandel @barakshani
 /.github/ @storopoli @purusang @voidash @alexhui01
-/.gitignore @storopoli @prajwolrg
-/README.md @storopoli @prajwolrg @barakshani @john-light @pramodkandel
+/.gitignore @storopoli
+/README.md @storopoli @barakshani @john-light @pramodkandel
 /CONTRIBUTING.md @pramodkandel @barakshani
-/AGENTS.md @storopoli @prajwolrg
-/CLAUDE.md @storopoli @prajwolrg
+/AGENTS.md @storopoli
+/CLAUDE.md @storopoli
 /LICENSE-* @pramodkandel @barakshani
 


### PR DESCRIPTION
## Description

Housekeeping pass over `.github/CODEOWNERS`. The file had drifted from the repo: it still routed reviews for three crates that no longer exist, and one crate that does exist had no rule at all. This also updates a number of reviewer assignments.

Two things worth a reviewer's attention:

`@storopoli` is now the sole owner of five rules: `**/Cargo.toml`, `**/Cargo.lock`, `/.gitignore`, `/AGENTS.md` and `/CLAUDE.md`. The two Cargo globs match every manifest in the workspace, so every dependency bump will route to one person. That is a review bottleneck and probably wants a second owner — I left it as-is rather than picking someone unilaterally.

Nine crates still have no specific rule and fall through to the repo-wide fallback: `alpen-ee`, `bridge-params`, `checkpoint-types`, `cli-common`, `codec-utils`, `common`, `config`, `status` and `strata-signer`. `paas` was in this set and is fixed here; the rest are out of scope for this PR and could be a follow-up.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Start with the commit log — the four commits are split by concern (dead rules, reviewer removal, new/changed assignments, binary trims) and read cleanly in order.


Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
