### PR TITLE
Add per L1 transaction configurable max fee rate

### DIFF
--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -138,6 +138,7 @@ mod sequencer_services {
             let ctx = WriterContext::new(
                 btcio_params,
                 config.clone(),
+                nodectx.config().btcio.broadcaster.max_fee_rate(),
                 sequencer_address,
                 nodectx.bitcoin_client().clone(),
                 nodectx.status_channel().as_ref().clone(),

--- a/bin/strata/src/services.rs
+++ b/bin/strata/src/services.rs
@@ -99,6 +99,7 @@ mod sequencer_services {
                     nodectx.asm_params(),
                     nodectx.config().btcio.l1_reorg_safe_depth,
                 ),
+                nodectx.config().btcio.broadcaster.max_fee_rate(),
             )
             .with_broadcast_poll_interval_ms(nodectx.config().btcio.broadcaster.poll_interval_ms)
             .launch(nodectx.executor().as_ref())

--- a/crates/btcio/src/broadcaster/builder.rs
+++ b/crates/btcio/src/broadcaster/builder.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use bitcoin::FeeRate;
 use bitcoind_async_client::traits::Broadcaster;
 use strata_service::{AsyncExecutor, ServiceBuilder, TickingInput, TokioMpscInput};
 use strata_storage::BroadcastDbOps;
@@ -28,6 +29,7 @@ pub struct BroadcasterBuilder<T> {
     rpc_client: Arc<T>,
     ops: Arc<BroadcastDbOps>,
     config: BtcioParams,
+    max_fee_rate: FeeRate,
     broadcast_poll_interval_ms: u64,
 }
 
@@ -36,6 +38,7 @@ impl<T> Debug for BroadcasterBuilder<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BroadcasterBuilder")
             .field("config", &self.config)
+            .field("max_fee_rate", &self.max_fee_rate)
             .field(
                 "broadcast_poll_interval_ms",
                 &self.broadcast_poll_interval_ms,
@@ -49,11 +52,17 @@ where
     T: Broadcaster + WalletTxLookup,
 {
     /// Creates a broadcaster builder with required dependencies.
-    pub fn new(rpc_client: Arc<T>, ops: Arc<BroadcastDbOps>, config: BtcioParams) -> Self {
+    pub fn new(
+        rpc_client: Arc<T>,
+        ops: Arc<BroadcastDbOps>,
+        config: BtcioParams,
+        max_fee_rate: FeeRate,
+    ) -> Self {
         Self {
             rpc_client,
             ops,
             config,
+            max_fee_rate,
             broadcast_poll_interval_ms: DEFAULT_BROADCAST_POLL_INTERVAL_MS,
         }
     }
@@ -65,7 +74,7 @@ where
 
     /// Launches the broadcaster service and returns a broadcaster handle.
     pub async fn launch(self, executor: &impl AsyncExecutor) -> anyhow::Result<L1BroadcastHandle> {
-        let io = BroadcasterIo::new(self.rpc_client, self.ops.clone());
+        let io = BroadcasterIo::new(self.rpc_client, self.ops.clone(), self.max_fee_rate);
         let state = BroadcasterServiceState::try_new(io, self.config).await?;
 
         let (command_tx, command_rx) = mpsc::channel::<BroadcasterInputMessage>(64);
@@ -79,6 +88,11 @@ where
             .with_input(input)
             .launch_async("l1_broadcaster", executor)
             .await?;
-        Ok(L1BroadcastHandle::new(command_tx, self.ops, Some(monitor)))
+        Ok(L1BroadcastHandle::new(
+            command_tx,
+            self.ops,
+            Some(monitor),
+            self.max_fee_rate,
+        ))
     }
 }

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -60,7 +60,7 @@ impl L1BroadcastHandle {
     }
 
     /// Returns the per-transaction fee-rate ceiling used by this broadcaster.
-    pub fn max_fee_rate(&self) -> FeeRate {
+    pub(crate) fn max_fee_rate(&self) -> FeeRate {
         self.max_fee_rate
     }
 

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -1,5 +1,6 @@
 use std::{str, sync::Arc};
 
+use bitcoin::FeeRate;
 use hex::encode_to_slice;
 use strata_db_types::{
     common::L1TxId,
@@ -34,6 +35,7 @@ pub struct L1BroadcastHandle {
     ops: Arc<BroadcastDbOps>,
     sender: mpsc::Sender<BroadcasterInputMessage>,
     monitor: Option<ServiceMonitor<BroadcasterStatus>>,
+    max_fee_rate: FeeRate,
 }
 
 impl L1BroadcastHandle {
@@ -41,18 +43,25 @@ impl L1BroadcastHandle {
         sender: mpsc::Sender<BroadcasterInputMessage>,
         ops: Arc<BroadcastDbOps>,
         monitor: Option<ServiceMonitor<BroadcasterStatus>>,
+        max_fee_rate: FeeRate,
     ) -> Self {
         Self {
             ops,
             sender,
             monitor,
+            max_fee_rate,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn new_for_test(ops: Arc<BroadcastDbOps>) -> Self {
         let (sender, _) = mpsc::channel::<BroadcasterInputMessage>(64);
-        Self::new(sender, ops, None)
+        Self::new(sender, ops, None, FeeRate::from_sat_per_vb(1_000).unwrap())
+    }
+
+    /// Returns the per-transaction fee-rate ceiling used by this broadcaster.
+    pub fn max_fee_rate(&self) -> FeeRate {
+        self.max_fee_rate
     }
 
     pub fn monitor(&self) -> Option<&ServiceMonitor<BroadcasterStatus>> {

--- a/crates/btcio/src/broadcaster/input.rs
+++ b/crates/btcio/src/broadcaster/input.rs
@@ -21,6 +21,7 @@ pub(crate) enum BroadcasterInputMessage {
 mod tests {
     use std::sync::Arc;
 
+    use bitcoin::FeeRate;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_db_types::{backend::DatabaseBackend, l1_broadcast::L1TxStatus};
     use strata_l1_txfmt::MagicBytes;
@@ -84,12 +85,20 @@ mod tests {
         let ops = Arc::new(BroadcastDbOps::new(Handle::current(), broadcast_db));
 
         let btcio_params = BtcioParams::new(6, MagicBytes::new(*b"ALPN"), 0);
-        let handle =
-            BroadcasterBuilder::new(Arc::new(TestBitcoinClient::new(0)), ops, btcio_params)
-                .with_broadcast_poll_interval_ms(1)
-                .launch(&executor)
-                .await
-                .expect("launch broadcaster service");
+        let handle = BroadcasterBuilder::new(
+            Arc::new(TestBitcoinClient::new(0)),
+            ops,
+            btcio_params,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+        )
+        .with_broadcast_poll_interval_ms(1)
+        .launch(&executor)
+        .await
+        .expect("launch broadcaster service");
+        assert_eq!(
+            handle.max_fee_rate(),
+            FeeRate::from_sat_per_vb(1_000).unwrap()
+        );
 
         let monitor = handle
             .monitor()

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -1,8 +1,10 @@
 use std::{future::Future, sync::Arc};
 
 use anyhow::anyhow;
-use bitcoin::{BlockHash, Transaction, Txid};
-use bitcoind_async_client::{error::ClientError, traits::Broadcaster, Client};
+use bitcoin::{BlockHash, FeeRate, Transaction, Txid};
+use bitcoind_async_client::{
+    error::ClientError, traits::Broadcaster, types::BroadcastOptions, Client, ClientResult,
+};
 use serde::Deserialize;
 use strata_btc_types::BlockHashExt;
 use strata_db_types::l1_broadcast::{L1TxEntry, L1TxStatus};
@@ -23,6 +25,24 @@ pub(crate) fn is_benign_minus25_message(msg: &str) -> bool {
     msg.contains("already-in-mempool")
         || msg.contains("already-known")
         || msg.contains("already-in-block-chain")
+}
+
+/// Reports whether Bitcoin Core rejected a transaction because its fee exceeded `maxfeerate`.
+pub(crate) fn is_max_fee_rate_exceeded_message(msg: &str) -> bool {
+    msg.contains("Fee exceeds maximum configured by user")
+}
+
+/// Broadcasts a transaction with the service's mandatory per-transaction fee ceiling.
+pub(crate) async fn send_raw_transaction_with_max_fee_rate(
+    client: &impl Broadcaster,
+    tx: &Transaction,
+    max_fee_rate: FeeRate,
+) -> ClientResult<Txid> {
+    let options = BroadcastOptions {
+        max_fee_rate: Some(max_fee_rate),
+        ..Default::default()
+    };
+    client.send_raw_transaction(tx, Some(options)).await
 }
 
 /// IO context abstraction for broadcaster service internals.
@@ -215,12 +235,17 @@ pub(crate) enum PublishTxOutcome {
 pub(crate) struct BroadcasterIo<T> {
     rpc_client: Arc<T>,
     ops: Arc<BroadcastDbOps>,
+    max_fee_rate: FeeRate,
 }
 
 impl<T> BroadcasterIo<T> {
     /// Creates a production IO adapter from RPC client and broadcast DB ops.
-    pub(crate) fn new(rpc_client: Arc<T>, ops: Arc<BroadcastDbOps>) -> Self {
-        Self { rpc_client, ops }
+    pub(crate) fn new(rpc_client: Arc<T>, ops: Arc<BroadcastDbOps>, max_fee_rate: FeeRate) -> Self {
+        Self {
+            rpc_client,
+            ops,
+            max_fee_rate,
+        }
     }
 }
 
@@ -266,10 +291,20 @@ where
         tx: &'a Transaction,
     ) -> BroadcasterResult<PublishTxOutcome> {
         let txid = tx.compute_txid();
-        match self.rpc_client.send_raw_transaction(tx, None).await {
+        match send_raw_transaction_with_max_fee_rate(
+            self.rpc_client.as_ref(),
+            tx,
+            self.max_fee_rate,
+        )
+        .await
+        {
             Ok(_) => {
                 info!(%txid, "sendrawtransaction accepted (Published)");
                 Ok(PublishTxOutcome::Published)
+            }
+            Err(ClientError::Server(-25, msg)) if is_max_fee_rate_exceeded_message(&msg) => {
+                warn!(%txid, %msg, max_fee_rate_sat_vb = self.max_fee_rate.to_sat_per_vb_ceil(), "sendrawtransaction blocked by fee guardrail");
+                Ok(PublishTxOutcome::RetryLater { reason: msg })
             }
             Err(ClientError::Server(-25, msg)) => {
                 // Bitcoind reuses code -25 for several distinct reject reasons.
@@ -360,6 +395,77 @@ mod tests {
         // AlreadyInMempool.
         assert!(!is_benign_minus25_message("already in mempool"));
         assert!(!is_benign_minus25_message("already known"));
+    }
+
+    #[test]
+    fn max_fee_rate_rejection_matches_bitcoin_core_message() {
+        assert!(is_max_fee_rate_exceeded_message(
+            "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)"
+        ));
+        assert!(!is_max_fee_rate_exceeded_message(
+            "bad-txns-inputs-missingorspent"
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_passes_fee_guardrail() {
+        use bitcoin::{absolute::LockTime, transaction::Version};
+        use strata_db_store_sled::test_utils::get_test_sled_backend;
+        use strata_db_types::backend::DatabaseBackend;
+        use tokio::runtime::Handle;
+
+        use crate::test_utils::TestBitcoinClient;
+
+        let client = Arc::new(TestBitcoinClient::new(0));
+        let db = get_test_sled_backend().broadcast_db();
+        let ops = Arc::new(BroadcastDbOps::new(Handle::current(), db));
+        let max_fee_rate = FeeRate::from_sat_per_vb(321).unwrap();
+        let io = BroadcasterIo::new(client.clone(), ops, max_fee_rate);
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        };
+
+        assert_eq!(
+            io.send_raw_transaction(&tx).await.unwrap(),
+            PublishTxOutcome::Published
+        );
+        let calls = client.send_raw_transaction_options();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].as_ref().unwrap().max_fee_rate, Some(max_fee_rate));
+    }
+
+    #[tokio::test]
+    async fn max_fee_rate_rejection_is_retryable() {
+        use bitcoin::{absolute::LockTime, transaction::Version};
+        use strata_db_store_sled::test_utils::get_test_sled_backend;
+        use strata_db_types::backend::DatabaseBackend;
+        use tokio::runtime::Handle;
+
+        use crate::test_utils::{SendRawTransactionMode, TestBitcoinClient};
+
+        let client = Arc::new(
+            TestBitcoinClient::new(0)
+                .with_send_raw_transaction_mode(SendRawTransactionMode::MaxFeeRateExceeded),
+        );
+        let db = get_test_sled_backend().broadcast_db();
+        let ops = Arc::new(BroadcastDbOps::new(Handle::current(), db));
+        let io = BroadcasterIo::new(client, ops, FeeRate::from_sat_per_vb(1_000).unwrap());
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        };
+
+        let outcome = io.send_raw_transaction(&tx).await.unwrap();
+        assert!(matches!(
+            outcome,
+            PublishTxOutcome::RetryLater { reason }
+                if is_max_fee_rate_exceeded_message(&reason)
+        ));
     }
 
     #[test]

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -360,7 +360,31 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::{absolute::LockTime, transaction::Version};
+    use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_db_types::backend::DatabaseBackend;
+    use tokio::runtime::Handle;
+
     use super::*;
+    use crate::test_utils::{SendRawTransactionMode, TestBitcoinClient};
+
+    fn test_transaction() -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        }
+    }
+
+    fn test_broadcaster_io(
+        client: Arc<TestBitcoinClient>,
+        max_fee_rate: FeeRate,
+    ) -> BroadcasterIo<TestBitcoinClient> {
+        let db = get_test_sled_backend().broadcast_db();
+        let ops = Arc::new(BroadcastDbOps::new(Handle::current(), db));
+        BroadcasterIo::new(client, ops, max_fee_rate)
+    }
 
     #[test]
     fn benign_minus25_strings_match() {
@@ -409,27 +433,12 @@ mod tests {
 
     #[tokio::test]
     async fn send_raw_transaction_passes_fee_guardrail() {
-        use bitcoin::{absolute::LockTime, transaction::Version};
-        use strata_db_store_sled::test_utils::get_test_sled_backend;
-        use strata_db_types::backend::DatabaseBackend;
-        use tokio::runtime::Handle;
-
-        use crate::test_utils::TestBitcoinClient;
-
         let client = Arc::new(TestBitcoinClient::new(0));
-        let db = get_test_sled_backend().broadcast_db();
-        let ops = Arc::new(BroadcastDbOps::new(Handle::current(), db));
         let max_fee_rate = FeeRate::from_sat_per_vb(321).unwrap();
-        let io = BroadcasterIo::new(client.clone(), ops, max_fee_rate);
-        let tx = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: Vec::new(),
-            output: Vec::new(),
-        };
+        let io = test_broadcaster_io(client.clone(), max_fee_rate);
 
         assert_eq!(
-            io.send_raw_transaction(&tx).await.unwrap(),
+            io.send_raw_transaction(&test_transaction()).await.unwrap(),
             PublishTxOutcome::Published
         );
         let calls = client.send_raw_transaction_options();
@@ -439,28 +448,13 @@ mod tests {
 
     #[tokio::test]
     async fn max_fee_rate_rejection_is_retryable() {
-        use bitcoin::{absolute::LockTime, transaction::Version};
-        use strata_db_store_sled::test_utils::get_test_sled_backend;
-        use strata_db_types::backend::DatabaseBackend;
-        use tokio::runtime::Handle;
-
-        use crate::test_utils::{SendRawTransactionMode, TestBitcoinClient};
-
         let client = Arc::new(
             TestBitcoinClient::new(0)
                 .with_send_raw_transaction_mode(SendRawTransactionMode::MaxFeeRateExceeded),
         );
-        let db = get_test_sled_backend().broadcast_db();
-        let ops = Arc::new(BroadcastDbOps::new(Handle::current(), db));
-        let io = BroadcasterIo::new(client, ops, FeeRate::from_sat_per_vb(1_000).unwrap());
-        let tx = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: Vec::new(),
-            output: Vec::new(),
-        };
+        let io = test_broadcaster_io(client, FeeRate::from_sat_per_vb(1_000).unwrap());
 
-        let outcome = io.send_raw_transaction(&tx).await.unwrap();
+        let outcome = io.send_raw_transaction(&test_transaction()).await.unwrap();
         assert!(matches!(
             outcome,
             PublishTxOutcome::RetryLater { reason }

--- a/crates/btcio/src/broadcaster/io.rs
+++ b/crates/btcio/src/broadcaster/io.rs
@@ -227,6 +227,9 @@ pub(crate) enum PublishTxOutcome {
     /// Transaction has invalid/missing inputs and should be marked invalid.
     InvalidInputs,
 
+    /// Transaction exceeds the configured fee-rate ceiling and must be rebuilt.
+    AboveMaxFeeRate { reason: String },
+
     /// Transient failure; call sites should retry in a later poll pass.
     RetryLater { reason: String },
 }
@@ -304,7 +307,7 @@ where
             }
             Err(ClientError::Server(-25, msg)) if is_max_fee_rate_exceeded_message(&msg) => {
                 warn!(%txid, %msg, max_fee_rate_sat_vb = self.max_fee_rate.to_sat_per_vb_ceil(), "sendrawtransaction blocked by fee guardrail");
-                Ok(PublishTxOutcome::RetryLater { reason: msg })
+                Ok(PublishTxOutcome::AboveMaxFeeRate { reason: msg })
             }
             Err(ClientError::Server(-25, msg)) => {
                 // Bitcoind reuses code -25 for several distinct reject reasons.
@@ -447,7 +450,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn max_fee_rate_rejection_is_retryable() {
+    async fn max_fee_rate_rejection_requires_rebuild() {
         let client = Arc::new(
             TestBitcoinClient::new(0)
                 .with_send_raw_transaction_mode(SendRawTransactionMode::MaxFeeRateExceeded),
@@ -457,7 +460,7 @@ mod tests {
         let outcome = io.send_raw_transaction(&test_transaction()).await.unwrap();
         assert!(matches!(
             outcome,
-            PublishTxOutcome::RetryLater { reason }
+            PublishTxOutcome::AboveMaxFeeRate { reason }
                 if is_max_fee_rate_exceeded_message(&reason)
         ));
     }

--- a/crates/btcio/src/broadcaster/mod.rs
+++ b/crates/btcio/src/broadcaster/mod.rs
@@ -11,5 +11,8 @@ mod state;
 pub use builder::BroadcasterBuilder;
 pub use error::BroadcasterError;
 pub use handle::L1BroadcastHandle;
-pub(crate) use io::is_benign_minus25_message;
+pub(crate) use io::{
+    is_benign_minus25_message, is_max_fee_rate_exceeded_message,
+    send_raw_transaction_with_max_fee_rate,
+};
 pub use service::BroadcasterStatus;

--- a/crates/btcio/src/broadcaster/processor.rs
+++ b/crates/btcio/src/broadcaster/processor.rs
@@ -441,6 +441,17 @@ where
                 )
                 .await
             }
+            Ok(PublishTxOutcome::AboveMaxFeeRate { reason }) => {
+                warn!(%reason, "tx exceeds broadcast fee guardrail; rebuilding instead of retrying unchanged bytes");
+                resolve_invalid_inputs(
+                    io,
+                    params,
+                    &txid,
+                    txentry,
+                    AncestorRescue::ConfirmedOrInMempool,
+                )
+                .await
+            }
             Ok(PublishTxOutcome::RetryLater { reason }) => {
                 warn!(%reason, "broadcast should be retried on next poll");
                 Ok(L1TxStatus::Unpublished)
@@ -581,6 +592,7 @@ mod test {
         Published,
         AlreadyInMempool,
         InvalidInputs,
+        AboveMaxFeeRate,
         RetryLater,
     }
 
@@ -685,6 +697,9 @@ mod test {
                 MockBroadcastResult::Published => Ok(PublishTxOutcome::Published),
                 MockBroadcastResult::AlreadyInMempool => Ok(PublishTxOutcome::AlreadyInMempool),
                 MockBroadcastResult::InvalidInputs => Ok(PublishTxOutcome::InvalidInputs),
+                MockBroadcastResult::AboveMaxFeeRate => Ok(PublishTxOutcome::AboveMaxFeeRate {
+                    reason: "mock fee guardrail rejection".into(),
+                }),
                 MockBroadcastResult::RetryLater => Ok(PublishTxOutcome::RetryLater {
                     reason: "mock retry".into(),
                 }),
@@ -823,6 +838,18 @@ mod test {
             Some(L1TxStatus::Unpublished),
             "HTTP 500 send_raw_transaction errors should keep tx unpublished for retry"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_handle_unpublished_entry_above_max_fee_requires_rebuild() {
+        let (entry, txid) = entry_with_txid(L1TxStatus::Unpublished);
+        let btcio_params = get_test_btcio_params();
+        let io = MockIoContext::default()
+            .with_broadcast_result(txid, MockBroadcastResult::AboveMaxFeeRate);
+
+        let status = process_status(&io, &entry, &txid, &btcio_params).await;
+
+        assert_eq!(status, Some(L1TxStatus::InvalidInputs));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -179,6 +179,7 @@ where
 mod test {
     use std::{iter::once, sync::Arc};
 
+    use bitcoin::FeeRate;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
     use strata_db_types::{backend::DatabaseBackend, common::L1TxId, l1_broadcast::L1TxStatus};
     use strata_l1_txfmt::MagicBytes;
@@ -210,7 +211,11 @@ mod test {
         ops: Arc<BroadcastDbOps>,
         client: TestBitcoinClient,
     ) -> BroadcasterIo<TestBitcoinClient> {
-        BroadcasterIo::new(Arc::new(client), ops)
+        BroadcasterIo::new(
+            Arc::new(client),
+            ops,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+        )
     }
 
     async fn populate_broadcast_db(ops: Arc<BroadcastDbOps>) -> Vec<(u64, L1TxEntry)> {

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -63,7 +63,6 @@ pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
         | EnvelopeError::FeeOverflow
         | EnvelopeError::ResolvedFeeRateAboveMax { .. }
         | EnvelopeError::BuiltFeeRateAboveMax { .. }
-        | EnvelopeError::CommitFeeDidNotStabilize { .. }
         | EnvelopeError::NotEnoughUtxos(_, _)
         | EnvelopeError::MissingEnvelopePubkey
         | EnvelopeError::P2trChangeAddressUnsupported

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -63,6 +63,7 @@ pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
         | EnvelopeError::FeeOverflow
         | EnvelopeError::ResolvedFeeRateAboveMax { .. }
         | EnvelopeError::BuiltFeeRateAboveMax { .. }
+        | EnvelopeError::CommitFeeBoundsNotSatisfied { .. }
         | EnvelopeError::NotEnoughUtxos(_, _)
         | EnvelopeError::MissingEnvelopePubkey
         | EnvelopeError::P2trChangeAddressUnsupported

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -61,6 +61,8 @@ pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
         EnvelopeError::SignRawTransaction(err) => is_retryable_client_error(err),
         EnvelopeError::EmptyPayload
         | EnvelopeError::FeeOverflow
+        | EnvelopeError::ResolvedFeeRateAboveMax { .. }
+        | EnvelopeError::BuiltFeeRateAboveMax { .. }
         | EnvelopeError::NotEnoughUtxos(_, _)
         | EnvelopeError::MissingEnvelopePubkey
         | EnvelopeError::P2trChangeAddressUnsupported

--- a/crates/btcio/src/rpc_error.rs
+++ b/crates/btcio/src/rpc_error.rs
@@ -63,6 +63,7 @@ pub(crate) fn is_retryable_envelope_error(err: &EnvelopeError) -> bool {
         | EnvelopeError::FeeOverflow
         | EnvelopeError::ResolvedFeeRateAboveMax { .. }
         | EnvelopeError::BuiltFeeRateAboveMax { .. }
+        | EnvelopeError::CommitFeeDidNotStabilize { .. }
         | EnvelopeError::NotEnoughUtxos(_, _)
         | EnvelopeError::MissingEnvelopePubkey
         | EnvelopeError::P2trChangeAddressUnsupported

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -14,7 +14,7 @@ use bitcoin::{
     taproot::{ControlBlock, LeafVersion, TaprootMerkleBranch},
     transaction::Version,
     Address, Amount, Block, BlockHash, FeeRate, Network, Psbt, ScriptBuf, SignedAmount,
-    TapNodeHash, Transaction, TxOut, Txid, Work, XOnlyPublicKey,
+    TapNodeHash, Transaction, TxOut, Txid, Witness, Work, XOnlyPublicKey,
 };
 use bitcoind_async_client::{
     corepc_types::{
@@ -70,6 +70,10 @@ pub struct TestBitcoinClient {
     pub wallet_process_psbt_result: Arc<Mutex<WalletProcessPsbt>>,
     /// PSBT strings received by `wallet_process_psbt`.
     pub wallet_process_psbt_calls: Arc<Mutex<Vec<String>>>,
+    /// Optional witness signature size used when echo-signing raw transactions.
+    pub sign_raw_transaction_witness_size: Option<usize>,
+    /// Transactions received by `sign_raw_transaction_with_wallet`.
+    pub sign_raw_transaction_calls: Arc<Mutex<Vec<Transaction>>>,
 }
 
 /// Configures how [`TestBitcoinClient`] responds to `send_raw_transaction`.
@@ -99,6 +103,8 @@ impl TestBitcoinClient {
             estimate_smart_fee_targets: Arc::new(Mutex::new(Vec::new())),
             wallet_process_psbt_result: Arc::new(Mutex::new(default_wallet_process_psbt_result())),
             wallet_process_psbt_calls: Arc::new(Mutex::new(Vec::new())),
+            sign_raw_transaction_witness_size: None,
+            sign_raw_transaction_calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -139,6 +145,18 @@ impl TestBitcoinClient {
 
     pub fn wallet_process_psbt_calls(&self) -> Vec<String> {
         self.wallet_process_psbt_calls.lock().unwrap().clone()
+    }
+
+    pub fn with_sign_raw_transaction_witness_size(mut self, witness_size: usize) -> Self {
+        self.sign_raw_transaction_witness_size = Some(witness_size);
+        self
+    }
+
+    pub fn sign_raw_transaction_calls(&self) -> Vec<Transaction> {
+        self.sign_raw_transaction_calls
+            .lock()
+            .expect("test: sign_raw_transaction_calls lock")
+            .clone()
     }
 }
 
@@ -571,10 +589,24 @@ impl Wallet for TestBitcoinClient {
 impl Signer for TestBitcoinClient {
     async fn sign_raw_transaction_with_wallet(
         &self,
-        _tx: &Transaction,
+        tx: &Transaction,
         _prev_outputs: Option<Vec<PreviousTransactionOutput>>,
     ) -> ClientResult<SignRawTransaction> {
-        let signed_tx: Transaction = consensus::encode::deserialize_hex(SOME_TX).unwrap();
+        self.sign_raw_transaction_calls
+            .lock()
+            .expect("test: sign_raw_transaction_calls lock")
+            .push(tx.clone());
+        let signed_tx = if let Some(witness_size) = self.sign_raw_transaction_witness_size {
+            let mut signed_tx = tx.clone();
+            for input in &mut signed_tx.input {
+                input.witness = Witness::new();
+                input.witness.push(vec![0; witness_size]);
+                input.witness.push([0; 33]);
+            }
+            signed_tx
+        } else {
+            consensus::encode::deserialize_hex(SOME_TX).unwrap()
+        };
         Ok(SignRawTransaction {
             tx: signed_tx,
             complete: true,

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -707,7 +707,7 @@ pub fn create_checkpoint_envelope_tx(address: &str, l1_payload: L1Payload) -> Tr
 pub(crate) mod test_context {
     use std::sync::Arc;
 
-    use bitcoin::{secp256k1::SecretKey, Address, Network};
+    use bitcoin::{secp256k1::SecretKey, Address, FeeRate, Network};
     use strata_config::btcio::{FeeBumpingConfig, FeePolicy, L1FeePolicyConfig, WriterConfig};
     use strata_l1_txfmt::MagicBytes;
     use strata_status::StatusChannel;
@@ -741,8 +741,15 @@ pub(crate) mod test_context {
         );
         let sk = SecretKey::from_slice(&[0x01; 32]).unwrap();
         let (pubkey, _) = sk.x_only_public_key(super::SECP256K1);
-        let ctx = WriterContext::new(btcio_params, cfg, addr, client, status_channel)
-            .with_envelope_pubkey(&pubkey.serialize());
+        let ctx = WriterContext::new(
+            btcio_params,
+            cfg,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+            addr,
+            client,
+            status_channel,
+        )
+        .with_envelope_pubkey(&pubkey.serialize());
         Arc::new(ctx)
     }
 
@@ -772,6 +779,7 @@ pub(crate) mod test_context {
         let ctx = WriterContext::new(
             base.btcio_params,
             config,
+            base.max_fee_rate,
             base.sequencer_address.clone(),
             client,
             base.status_channel.clone(),

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -58,6 +58,8 @@ pub struct TestBitcoinClient {
     pub included_height: u64,
     /// Behavior for `send_raw_transaction`.
     pub send_raw_transaction_mode: SendRawTransactionMode,
+    /// Options received by `send_raw_transaction`.
+    pub send_raw_transaction_options: Arc<Mutex<Vec<Option<BroadcastOptions>>>>,
     /// Value returned by the mock wallet UTXO.
     pub utxo_amount_sats: u64,
     /// Fee estimate, in sat/vB, returned from `estimate_smart_fee`.
@@ -75,6 +77,7 @@ pub struct TestBitcoinClient {
 pub enum SendRawTransactionMode {
     Success,
     AlreadyInMempool,
+    MaxFeeRateExceeded,
     MissingOrInvalidInput,
     InvalidParameter,
     HttpInternalServerError,
@@ -90,6 +93,7 @@ impl TestBitcoinClient {
             // Use arbitrary value, make configurable as necessary
             included_height: 100,
             send_raw_transaction_mode: SendRawTransactionMode::Success,
+            send_raw_transaction_options: Arc::new(Mutex::new(Vec::new())),
             utxo_amount_sats: 10_000_000_000,
             estimate_smart_fee_result: 3,
             estimate_smart_fee_targets: Arc::new(Mutex::new(Vec::new())),
@@ -101,6 +105,10 @@ impl TestBitcoinClient {
     pub fn with_send_raw_transaction_mode(mut self, mode: SendRawTransactionMode) -> Self {
         self.send_raw_transaction_mode = mode;
         self
+    }
+
+    pub fn send_raw_transaction_options(&self) -> Vec<Option<BroadcastOptions>> {
+        self.send_raw_transaction_options.lock().unwrap().clone()
     }
 
     pub fn with_utxo_amount_sats(mut self, sats: u64) -> Self {
@@ -332,13 +340,21 @@ impl Broadcaster for TestBitcoinClient {
     async fn send_raw_transaction(
         &self,
         _tx: &Transaction,
-        _options: Option<BroadcastOptions>,
+        options: Option<BroadcastOptions>,
     ) -> ClientResult<Txid> {
+        self.send_raw_transaction_options
+            .lock()
+            .unwrap()
+            .push(options);
         match self.send_raw_transaction_mode {
             SendRawTransactionMode::Success => Ok(Txid::from_slice(&[1u8; 32]).unwrap()),
             SendRawTransactionMode::AlreadyInMempool => Err(ClientError::Server(
                 -25,
                 "txn-already-in-mempool".to_string(),
+            )),
+            SendRawTransactionMode::MaxFeeRateExceeded => Err(ClientError::Server(
+                -25,
+                "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)".to_string(),
             )),
             SendRawTransactionMode::MissingOrInvalidInput => Err(ClientError::Server(
                 -26,

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     str::FromStr,
     sync::{Arc, Mutex},
 };
@@ -72,6 +72,8 @@ pub struct TestBitcoinClient {
     pub wallet_process_psbt_calls: Arc<Mutex<Vec<String>>>,
     /// Optional witness signature size used when echo-signing raw transactions.
     pub sign_raw_transaction_witness_size: Option<usize>,
+    /// Witness signature sizes used by consecutive raw-transaction signing calls.
+    pub sign_raw_transaction_witness_sizes: Arc<Mutex<VecDeque<usize>>>,
     /// Transactions received by `sign_raw_transaction_with_wallet`.
     pub sign_raw_transaction_calls: Arc<Mutex<Vec<Transaction>>>,
 }
@@ -104,6 +106,7 @@ impl TestBitcoinClient {
             wallet_process_psbt_result: Arc::new(Mutex::new(default_wallet_process_psbt_result())),
             wallet_process_psbt_calls: Arc::new(Mutex::new(Vec::new())),
             sign_raw_transaction_witness_size: None,
+            sign_raw_transaction_witness_sizes: Arc::new(Mutex::new(VecDeque::new())),
             sign_raw_transaction_calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -149,6 +152,14 @@ impl TestBitcoinClient {
 
     pub fn with_sign_raw_transaction_witness_size(mut self, witness_size: usize) -> Self {
         self.sign_raw_transaction_witness_size = Some(witness_size);
+        self
+    }
+
+    pub fn with_sign_raw_transaction_witness_sizes(self, witness_sizes: Vec<usize>) -> Self {
+        *self
+            .sign_raw_transaction_witness_sizes
+            .lock()
+            .expect("test: sign_raw_transaction_witness_sizes lock") = witness_sizes.into();
         self
     }
 
@@ -596,7 +607,13 @@ impl Signer for TestBitcoinClient {
             .lock()
             .expect("test: sign_raw_transaction_calls lock")
             .push(tx.clone());
-        let signed_tx = if let Some(witness_size) = self.sign_raw_transaction_witness_size {
+        let witness_size = self
+            .sign_raw_transaction_witness_sizes
+            .lock()
+            .expect("test: sign_raw_transaction_witness_sizes lock")
+            .pop_front()
+            .or(self.sign_raw_transaction_witness_size);
+        let signed_tx = if let Some(witness_size) = witness_size {
             let mut signed_tx = tx.clone();
             for input in &mut signed_tx.input {
                 input.witness = Witness::new();

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -39,9 +39,9 @@ pub(crate) const BITCOIN_DUST_LIMIT: u64 = 546;
 
 /// Largest serialized ECDSA signature, including its sighash byte.
 const MAX_ECDSA_SIGNATURE_SIZE: usize = 73;
-/// Smallest DER-encoded ECDSA signature, including its sighash byte.
-const MIN_ECDSA_SIGNATURE_SIZE: usize = 9;
 const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33;
+/// Bounds wallet RPC work if changing the commit fee repeatedly changes its signature length.
+const MAX_COMMIT_SIGNING_ATTEMPTS: usize = 8;
 
 /// Config for creating envelope transactions.
 #[derive(Debug, Clone)]
@@ -61,8 +61,6 @@ pub struct EnvelopeConfig {
     pub network: Network,
     /// Bitcoin fee rate.
     pub fee_rate: FeeRate,
-    /// Optional hard ceiling for the effective fee rate after wallet signing.
-    pub max_fee_rate: Option<FeeRate>,
     /// Fee-bumping policy used to derive reveal fee headroom.
     pub fee_bumping: FeeBumpingConfig,
     /// Sequencer public key for the taproot envelope script (SPS-51).
@@ -90,17 +88,10 @@ impl EnvelopeConfig {
             sequencer_address,
             reveal_amount,
             fee_rate,
-            max_fee_rate: None,
             fee_bumping,
             network,
             envelope_pubkey,
         }
-    }
-
-    /// Applies a hard effective fee-rate ceiling to commit funding.
-    pub fn with_max_fee_rate(mut self, max_fee_rate: FeeRate) -> Self {
-        self.max_fee_rate = Some(max_fee_rate);
-        self
     }
 }
 
@@ -131,6 +122,11 @@ pub enum EnvelopeError {
         built_sat_vb: u64,
         ceiling_sat_vb: u64,
     },
+
+    #[error(
+        "wallet-signed commit fee did not stabilize at the requested rate after {attempts} attempts"
+    )]
+    CommitFeeDidNotStabilize { attempts: usize },
 
     #[error("Could not sign raw transaction: {0}")]
     SignRawTransaction(#[source] ClientError),
@@ -245,8 +241,7 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
         BITCOIN_DUST_LIMIT,
         ctx.config.fee_bumping,
         Some(envelope_pubkey),
-    )
-    .with_max_fee_rate(ctx.max_fee_rate);
+    );
     let envelope = create_envelope_transactions(&env_config, payload, utxos)?;
     Ok(envelope)
 }
@@ -270,17 +265,24 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
         BITCOIN_DUST_LIMIT,
         ctx.config.fee_bumping,
         Some(pubkey),
-    )
-    .with_max_fee_rate(ctx.max_fee_rate);
+    );
     let mut envelope = create_envelope_transactions(&env_config, payload, utxos)?;
 
-    let signed_commit = ctx
-        .client
-        .sign_raw_transaction_with_wallet(&envelope.commit_tx, None)
-        .await
-        .map_err(EnvelopeError::SignRawTransaction)?
-        .tx;
+    let unsigned_commit_txid = envelope.commit_tx.compute_txid();
+    let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+        ctx.client.as_ref(),
+        envelope.commit_tx,
+        envelope.commit_fee,
+        fee_rate,
+        ctx.max_fee_rate,
+    )
+    .await?;
     envelope.commit_tx = signed_commit;
+    envelope.commit_fee = commit_fee;
+
+    if envelope.commit_tx.compute_txid() != unsigned_commit_txid {
+        rebind_single_reveal(&mut envelope)?;
+    }
 
     let output_to_reveal = envelope.commit_tx.output[0].clone();
     sign_reveal_transaction(
@@ -359,6 +361,113 @@ pub(crate) fn ensure_built_fee_rate_within_max(
     Ok(())
 }
 
+/// Signs a commit, correcting its absolute fee only when the first signature breaches the ceiling.
+///
+/// Wallet ECDSA signatures can be shorter than the conservative witness used during funding. If
+/// that makes the signed transaction exceed `max_fee_rate`, this refunds the excess through the
+/// final output and asks the wallet to sign again. Repricing continues until the fee matches the
+/// requested rate for the transaction's actual signed vsize; the bound prevents a faulty signer
+/// from keeping the writer inside an RPC loop indefinitely.
+pub(crate) async fn sign_commit_at_requested_fee<C: Signer>(
+    client: &C,
+    mut commit_tx: Transaction,
+    original_fee: Amount,
+    requested_fee_rate: FeeRate,
+    max_fee_rate: FeeRate,
+) -> Result<(Transaction, Amount), EnvelopeError> {
+    let original_fee_output = commit_tx
+        .output
+        .last()
+        .expect("commit transaction has at least one output")
+        .value;
+    let mut commit_fee = original_fee;
+    let mut correcting_fee = false;
+
+    for _ in 0..MAX_COMMIT_SIGNING_ATTEMPTS {
+        let signed_commit = client
+            .sign_raw_transaction_with_wallet(&commit_tx, None)
+            .await
+            .map_err(EnvelopeError::SignRawTransaction)?
+            .tx;
+
+        if !correcting_fee
+            && ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate).is_ok()
+        {
+            return Ok((signed_commit, commit_fee));
+        }
+
+        correcting_fee = true;
+        let requested_fee = requested_fee_rate
+            .fee_vb(signed_commit.vsize() as u64)
+            .ok_or(EnvelopeError::FeeOverflow)?;
+        if commit_fee == requested_fee {
+            ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate)?;
+            return Ok((signed_commit, commit_fee));
+        }
+
+        let adjusted_output_value = original_fee_output
+            .checked_add(original_fee)
+            .and_then(|value| value.checked_sub(requested_fee))
+            .ok_or(EnvelopeError::FeeOverflow)?;
+        commit_tx = signed_commit;
+        for input in &mut commit_tx.input {
+            input.witness.clear();
+        }
+        commit_tx
+            .output
+            .last_mut()
+            .expect("commit transaction has at least one output")
+            .value = adjusted_output_value;
+        commit_fee = requested_fee;
+    }
+
+    Err(EnvelopeError::CommitFeeDidNotStabilize {
+        attempts: MAX_COMMIT_SIGNING_ATTEMPTS,
+    })
+}
+
+/// Rebinds a single reveal after commit repricing changes the commit txid or carry output.
+pub(crate) fn rebind_single_reveal(envelope: &mut EnvelopeData) -> Result<(), EnvelopeError> {
+    let output_to_reveal = envelope
+        .commit_tx
+        .output
+        .first()
+        .expect("single-envelope commit has a reveal output")
+        .clone();
+    let other_output_value = envelope
+        .reveal_tx
+        .output
+        .iter()
+        .take(envelope.reveal_tx.output.len().saturating_sub(1))
+        .map(|output| output.value)
+        .sum::<Amount>();
+    let reveal_output_value = output_to_reveal
+        .value
+        .checked_sub(other_output_value)
+        .and_then(|value| value.checked_sub(envelope.reveal_fee))
+        .ok_or(EnvelopeError::FeeOverflow)?;
+    envelope
+        .reveal_tx
+        .output
+        .last_mut()
+        .expect("single-envelope reveal has a recipient output")
+        .value = reveal_output_value;
+
+    let reveal_input = envelope
+        .reveal_tx
+        .input
+        .first_mut()
+        .expect("single-envelope reveal has one input");
+    reveal_input.previous_output.txid = envelope.commit_tx.compute_txid();
+    reveal_input.witness.clear();
+    envelope.sighash = compute_reveal_sighash(
+        &envelope.reveal_tx,
+        &output_to_reveal,
+        &envelope.reveal_script,
+    )?;
+    Ok(())
+}
+
 /// Builds unsigned envelope transactions (commit + reveal) and computes the sighash.
 ///
 /// Returns an [`EnvelopeData`] containing the transactions and intermediate data
@@ -425,7 +534,6 @@ pub fn create_envelope_transactions(
         env_config.sequencer_address.clone(),
         commit_value,
         env_config.fee_rate,
-        env_config.max_fee_rate,
     )?;
     let commit_fee_sats = calculate_transaction_fee_from_utxos(&commit_tx, &consumed_utxos);
 
@@ -554,16 +662,15 @@ fn commit_inputs(utxos: &[ListUnspentItem]) -> Vec<TxIn> {
         .collect()
 }
 
-fn commit_vsize_with_ecdsa_signature_size(
-    utxos: &[ListUnspentItem],
-    outputs: &[TxOut],
-    ecdsa_signature_size: usize,
-) -> usize {
+/// Estimates the signed commit vsize from the selected wallet outputs.
+///
+/// P2WPKH uses Bitcoin Core's conservative high-R witness shape. The exact fee is corrected after
+/// signing if the shorter real witness would otherwise breach the broadcast ceiling.
+pub(crate) fn signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
     let mut inputs = commit_inputs(utxos);
     for (input, utxo) in inputs.iter_mut().zip(utxos) {
         if utxo.script_pubkey.is_p2wpkh() {
-            let dummy_signature = [0; MAX_ECDSA_SIGNATURE_SIZE];
-            input.witness.push(&dummy_signature[..ecdsa_signature_size]);
+            input.witness.push([0; MAX_ECDSA_SIGNATURE_SIZE]);
             input.witness.push([0; COMPRESSED_PUBLIC_KEY_SIZE]);
         } else if utxo.script_pubkey.is_p2tr() {
             input.witness.push([0; SCHNORR_SIGNATURE_SIZE]);
@@ -579,37 +686,6 @@ fn commit_vsize_with_ecdsa_signature_size(
         version: Version(2),
     }
     .vsize()
-}
-
-/// Estimates the signed commit vsize from the selected wallet outputs.
-pub(crate) fn signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
-    commit_vsize_with_ecdsa_signature_size(utxos, outputs, MAX_ECDSA_SIGNATURE_SIZE)
-}
-
-/// Returns a lower bound for the signed commit vsize.
-///
-/// A P2WPKH signature contains a DER sequence of two minimally encoded integers plus a sighash
-/// byte, so nine bytes is the smallest valid serialization. The bound lets funding reserve an
-/// absolute fee that remains within the broadcast ceiling for every signature length Core may
-/// produce.
-fn minimum_signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
-    commit_vsize_with_ecdsa_signature_size(utxos, outputs, MIN_ECDSA_SIGNATURE_SIZE)
-}
-
-/// Prices a commit while reserving enough ceiling headroom for any valid wallet signature size.
-fn commit_fee_sats_for_vsize_range(
-    estimated_vsize: usize,
-    minimum_vsize: usize,
-    fee_rate: FeeRate,
-    max_fee_rate: Option<FeeRate>,
-) -> Result<u64, EnvelopeError> {
-    let requested_fee = fee_sats_for_vsize(estimated_vsize, fee_rate)?;
-    let Some(max_fee_rate) = max_fee_rate else {
-        return Ok(requested_fee);
-    };
-    let maximum_safe_fee = fee_sats_for_vsize(minimum_vsize, max_fee_rate)?;
-
-    Ok(requested_fee.min(maximum_safe_fee))
 }
 
 /// Choose utxos almost naively.
@@ -667,7 +743,6 @@ fn build_commit_transaction(
     change_address: Address,
     output_value: u64,
     fee_rate: FeeRate,
-    max_fee_rate: Option<FeeRate>,
 ) -> Result<(Transaction, Vec<ListUnspentItem>), EnvelopeError> {
     let (transaction, consumed_utxos, _) = fund_commit_transaction(
         utxos,
@@ -678,7 +753,6 @@ fn build_commit_transaction(
         change_address.script_pubkey(),
         0,
         fee_rate,
-        max_fee_rate,
     )?;
 
     Ok((transaction, consumed_utxos))
@@ -691,34 +765,21 @@ fn select_commit_utxos(
     base_output_total: u64,
     minimum_excess: u64,
     fee_rate: FeeRate,
-    max_fee_rate: Option<FeeRate>,
 ) -> Result<(Vec<ListUnspentItem>, u64, u64), EnvelopeError> {
     let Some(first_utxo) = utxos.first() else {
         return Err(EnvelopeError::NotEnoughUtxos(base_output_total, 0));
     };
-    let mut estimated_vsize = signed_commit_vsize(slice::from_ref(first_utxo), outputs);
-    let mut minimum_vsize = minimum_signed_commit_vsize(slice::from_ref(first_utxo), outputs);
+    let mut estimated_size = signed_commit_vsize(slice::from_ref(first_utxo), outputs);
 
     loop {
-        let estimated_fee = commit_fee_sats_for_vsize_range(
-            estimated_vsize,
-            minimum_vsize,
-            fee_rate,
-            max_fee_rate,
-        )?;
+        let estimated_fee = fee_sats_for_vsize(estimated_size, fee_rate)?;
         let estimated_input_total = base_output_total
             .checked_add(estimated_fee)
             .and_then(|total| total.checked_add(minimum_excess))
             .ok_or(EnvelopeError::FeeOverflow)?;
         let (chosen_utxos, sum) = choose_utxos(utxos, estimated_input_total)?;
-        let signed_vsize = signed_commit_vsize(&chosen_utxos, outputs);
-        let minimum_signed_vsize = minimum_signed_commit_vsize(&chosen_utxos, outputs);
-        let fee = commit_fee_sats_for_vsize_range(
-            signed_vsize,
-            minimum_signed_vsize,
-            fee_rate,
-            max_fee_rate,
-        )?;
+        let signed_size = signed_commit_vsize(&chosen_utxos, outputs);
+        let fee = fee_sats_for_vsize(signed_size, fee_rate)?;
         let required = base_output_total
             .checked_add(fee)
             .and_then(|total| total.checked_add(minimum_excess))
@@ -728,8 +789,7 @@ fn select_commit_utxos(
             return Ok((chosen_utxos, sum, fee));
         }
 
-        estimated_vsize = signed_vsize;
-        minimum_vsize = minimum_signed_vsize;
+        estimated_size = signed_size;
     }
 }
 
@@ -740,7 +800,6 @@ pub(crate) fn fund_commit_transaction(
     change_script: ScriptBuf,
     carry_output_index: usize,
     fee_rate: FeeRate,
-    max_fee_rate: Option<FeeRate>,
 ) -> Result<(Transaction, Vec<ListUnspentItem>, Amount), EnvelopeError> {
     let base_output_total = base_outputs.iter().try_fold(0u64, |total, output| {
         total.checked_add(output.value.to_sat())
@@ -771,7 +830,6 @@ pub(crate) fn fund_commit_transaction(
         base_output_total,
         BITCOIN_DUST_LIMIT,
         fee_rate,
-        max_fee_rate,
     ) {
         Ok((chosen_utxos, sum, fee)) => {
             outputs_with_change
@@ -795,14 +853,8 @@ pub(crate) fn fund_commit_transaction(
 
     // If the wallet cannot fund spendable change, carry every non-fee satoshi through a reveal
     // output. This preserves the requested fee and avoids accidentally burning the remainder.
-    let (chosen_utxos, sum, fee) = select_commit_utxos(
-        &utxos,
-        &base_outputs,
-        base_output_total,
-        0,
-        fee_rate,
-        max_fee_rate,
-    )?;
+    let (chosen_utxos, sum, fee) =
+        select_commit_utxos(&utxos, &base_outputs, base_output_total, 0, fee_rate)?;
     let carried_value = sum
         .checked_sub(base_output_total)
         .and_then(|value| value.checked_sub(fee))
@@ -1270,15 +1322,9 @@ mod tests {
         utxos[0].amount = Amount::from_sat(input_total / 2);
         utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
-        let (tx, consumed) = build_commit_transaction(
-            utxos,
-            recipient.clone(),
-            recipient,
-            output_value,
-            fee_rate,
-            FeeRate::from_sat_per_vb(1_000),
-        )
-        .unwrap();
+        let (tx, consumed) =
+            build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
+                .unwrap();
         let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
 
         assert_eq!(tx.input.len(), 2);
@@ -1305,15 +1351,9 @@ mod tests {
         utxos[0].amount = Amount::from_sat(output_value + no_change_fee + 100);
         utxos[1].amount = Amount::from_sat(10_000);
 
-        let (tx, consumed) = build_commit_transaction(
-            utxos,
-            recipient.clone(),
-            recipient,
-            output_value,
-            fee_rate,
-            None,
-        )
-        .unwrap();
+        let (tx, consumed) =
+            build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
+                .unwrap();
         let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
         let priced_vsize = signed_commit_vsize(&consumed, &tx.output);
 
@@ -1340,40 +1380,134 @@ mod tests {
         assert!(p2wpkh_vsize > schnorr_only_vsize);
     }
 
-    #[test]
-    fn commit_fee_ceiling_survives_shorter_wallet_signatures() {
+    #[tokio::test]
+    async fn commit_repricing_preserves_one_sat_per_vbyte_request() {
         let (ctx, _, _, mut utxos) = get_mock_data();
-        let recipient = ctx.sequencer_address.clone();
-        let fee_rate = FeeRate::from_sat_per_vb(1_000).unwrap();
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
         utxos.truncate(2);
-        for utxo in &mut utxos {
-            utxo.amount = Amount::from_sat(160_000);
-        }
+        let outputs = vec![
+            TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: ctx.sequencer_address.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ctx.sequencer_address.script_pubkey(),
+            },
+        ];
+        let estimated_vsize = signed_commit_vsize(&utxos, &outputs);
+        let original_fee = Amount::from_sat(fee_sats_for_vsize(estimated_vsize, fee_rate).unwrap());
+        let original_change = outputs.last().unwrap().value;
+        let unsigned_commit = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: commit_inputs(&utxos),
+            output: outputs,
+        };
+        let client = TestBitcoinClient::new(0)
+            .with_sign_raw_transaction_witness_size(MAX_ECDSA_SIGNATURE_SIZE - 2);
 
-        let (mut tx, consumed) = build_commit_transaction(
-            utxos,
-            recipient.clone(),
-            recipient,
-            100_000,
+        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+            &client,
+            unsigned_commit,
+            original_fee,
             fee_rate,
-            Some(fee_rate),
+            fee_rate,
         )
+        .await
         .unwrap();
-        let actual_fee = Amount::from_sat(calculate_transaction_fee_from_utxos(&tx, &consumed));
-        let uncapped_fee = Amount::from_sat(
-            fee_sats_for_vsize(signed_commit_vsize(&consumed, &tx.output), fee_rate).unwrap(),
-        );
 
-        // Core grinds both ECDSA scalars below 2^255, so its normal P2WPKH signatures are at most
-        // 71 bytes including the sighash byte rather than the generic 73-byte maximum.
-        for input in &mut tx.input {
+        assert_eq!(client.sign_raw_transaction_calls().len(), 2);
+        assert_eq!(
+            commit_fee,
+            fee_rate.fee_vb(signed_commit.vsize() as u64).unwrap()
+        );
+        assert_eq!(
+            signed_commit.output.last().unwrap().value,
+            original_change + (original_fee - commit_fee)
+        );
+        assert!(ensure_built_fee_rate_within_max(&signed_commit, commit_fee, fee_rate).is_ok());
+    }
+
+    #[tokio::test]
+    async fn commit_signing_does_not_reprice_with_guardrail_headroom() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+        let outputs = vec![TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ctx.sequencer_address.script_pubkey(),
+        }];
+        let original_fee = Amount::from_sat(
+            fee_sats_for_vsize(signed_commit_vsize(&utxos[..1], &outputs), fee_rate).unwrap(),
+        );
+        let unsigned_commit = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: commit_inputs(&utxos[..1]),
+            output: outputs,
+        };
+        let original_commit = unsigned_commit.clone();
+        let client = TestBitcoinClient::new(0)
+            .with_sign_raw_transaction_witness_size(MAX_ECDSA_SIGNATURE_SIZE - 2);
+
+        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+            &client,
+            unsigned_commit,
+            original_fee,
+            fee_rate,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(client.sign_raw_transaction_calls(), vec![original_commit]);
+        assert_eq!(commit_fee, original_fee);
+        assert_eq!(
+            signed_commit.output,
+            client.sign_raw_transaction_calls()[0].output
+        );
+    }
+
+    #[test]
+    fn repriced_commit_rebinds_single_reveal_and_preserves_its_fee() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let env_config = test_envelope_config(&ctx, Some(test_envelope_pubkey()));
+        let mut envelope =
+            create_envelope_transactions(&env_config, &test_payload(), utxos).unwrap();
+        let original_reveal_output = envelope.reveal_tx.output.last().unwrap().value;
+        let original_sighash = envelope.sighash;
+        let refund = Amount::from_sat(2);
+
+        // Force the no-standalone-change shape: fee correction then refunds through the reveal
+        // output itself, so the dependent reveal must carry the same value onward.
+        envelope.commit_tx.output.truncate(1);
+        envelope.commit_tx.output[0].value += refund;
+        for input in &mut envelope.commit_tx.input {
             input.witness.push([0; MAX_ECDSA_SIGNATURE_SIZE - 2]);
             input.witness.push([0; COMPRESSED_PUBLIC_KEY_SIZE]);
         }
+        rebind_single_reveal(&mut envelope).unwrap();
 
-        assert_eq!(tx.input.len(), 2);
-        assert!(effective_fee_rate(&tx, uncapped_fee).unwrap() > fee_rate);
-        assert!(ensure_built_fee_rate_within_max(&tx, actual_fee, fee_rate).is_ok());
+        assert_eq!(
+            envelope.reveal_tx.input[0].previous_output.txid,
+            envelope.commit_tx.compute_txid()
+        );
+        assert!(envelope.reveal_tx.input[0].witness.is_empty());
+        assert_eq!(
+            envelope.reveal_tx.output.last().unwrap().value,
+            original_reveal_output + refund
+        );
+        assert_ne!(envelope.sighash, original_sighash);
+        let reveal_output_total: Amount = envelope
+            .reveal_tx
+            .output
+            .iter()
+            .map(|output| output.value)
+            .sum();
+        assert_eq!(
+            envelope.commit_tx.output[0].value - reveal_output_total,
+            envelope.reveal_fee
+        );
     }
 
     #[test]
@@ -1565,7 +1699,6 @@ mod tests {
             ctx.sequencer_address.clone(),
             500_000_000,
             FeeRate::from_sat_per_vb_u32(1),
-            None,
         )
         .unwrap();
 
@@ -1586,7 +1719,6 @@ mod tests {
             ctx.sequencer_address.clone(),
             500_000_000,
             FeeRate::from_sat_per_vb_u32(1),
-            None,
         );
 
         assert!(matches!(res, Err(EnvelopeError::NotEnoughUtxos(_, 0))));

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -39,6 +39,8 @@ pub(crate) const BITCOIN_DUST_LIMIT: u64 = 546;
 
 /// Largest serialized ECDSA signature, including its sighash byte.
 const MAX_ECDSA_SIGNATURE_SIZE: usize = 73;
+/// Smallest DER-encoded ECDSA signature, including its sighash byte.
+const MIN_ECDSA_SIGNATURE_SIZE: usize = 9;
 const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33;
 
 /// Config for creating envelope transactions.
@@ -59,6 +61,8 @@ pub struct EnvelopeConfig {
     pub network: Network,
     /// Bitcoin fee rate.
     pub fee_rate: FeeRate,
+    /// Optional hard ceiling for the effective fee rate after wallet signing.
+    pub max_fee_rate: Option<FeeRate>,
     /// Fee-bumping policy used to derive reveal fee headroom.
     pub fee_bumping: FeeBumpingConfig,
     /// Sequencer public key for the taproot envelope script (SPS-51).
@@ -86,10 +90,17 @@ impl EnvelopeConfig {
             sequencer_address,
             reveal_amount,
             fee_rate,
+            max_fee_rate: None,
             fee_bumping,
             network,
             envelope_pubkey,
         }
+    }
+
+    /// Applies a hard effective fee-rate ceiling to commit funding.
+    pub fn with_max_fee_rate(mut self, max_fee_rate: FeeRate) -> Self {
+        self.max_fee_rate = Some(max_fee_rate);
+        self
     }
 }
 
@@ -234,7 +245,8 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
         BITCOIN_DUST_LIMIT,
         ctx.config.fee_bumping,
         Some(envelope_pubkey),
-    );
+    )
+    .with_max_fee_rate(ctx.max_fee_rate);
     let envelope = create_envelope_transactions(&env_config, payload, utxos)?;
     Ok(envelope)
 }
@@ -258,7 +270,8 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
         BITCOIN_DUST_LIMIT,
         ctx.config.fee_bumping,
         Some(pubkey),
-    );
+    )
+    .with_max_fee_rate(ctx.max_fee_rate);
     let mut envelope = create_envelope_transactions(&env_config, payload, utxos)?;
 
     let signed_commit = ctx
@@ -412,6 +425,7 @@ pub fn create_envelope_transactions(
         env_config.sequencer_address.clone(),
         commit_value,
         env_config.fee_rate,
+        env_config.max_fee_rate,
     )?;
     let commit_fee_sats = calculate_transaction_fee_from_utxos(&commit_tx, &consumed_utxos);
 
@@ -540,16 +554,16 @@ fn commit_inputs(utxos: &[ListUnspentItem]) -> Vec<TxIn> {
         .collect()
 }
 
-/// Estimates the signed commit vsize from the selected wallet outputs.
-///
-/// P2WPKH uses Bitcoin Core's conservative high-R witness shape. The wallet normally grinds a
-/// low-R signature, so the final transaction can be up to one vbyte smaller; the signed
-/// transaction's effective rate is checked against the hard broadcast ceiling before persistence.
-pub(crate) fn signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
+fn commit_vsize_with_ecdsa_signature_size(
+    utxos: &[ListUnspentItem],
+    outputs: &[TxOut],
+    ecdsa_signature_size: usize,
+) -> usize {
     let mut inputs = commit_inputs(utxos);
     for (input, utxo) in inputs.iter_mut().zip(utxos) {
         if utxo.script_pubkey.is_p2wpkh() {
-            input.witness.push([0; MAX_ECDSA_SIGNATURE_SIZE]);
+            let dummy_signature = [0; MAX_ECDSA_SIGNATURE_SIZE];
+            input.witness.push(&dummy_signature[..ecdsa_signature_size]);
             input.witness.push([0; COMPRESSED_PUBLIC_KEY_SIZE]);
         } else if utxo.script_pubkey.is_p2tr() {
             input.witness.push([0; SCHNORR_SIGNATURE_SIZE]);
@@ -565,6 +579,37 @@ pub(crate) fn signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) 
         version: Version(2),
     }
     .vsize()
+}
+
+/// Estimates the signed commit vsize from the selected wallet outputs.
+pub(crate) fn signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
+    commit_vsize_with_ecdsa_signature_size(utxos, outputs, MAX_ECDSA_SIGNATURE_SIZE)
+}
+
+/// Returns a lower bound for the signed commit vsize.
+///
+/// A P2WPKH signature contains a DER sequence of two minimally encoded integers plus a sighash
+/// byte, so nine bytes is the smallest valid serialization. The bound lets funding reserve an
+/// absolute fee that remains within the broadcast ceiling for every signature length Core may
+/// produce.
+fn minimum_signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
+    commit_vsize_with_ecdsa_signature_size(utxos, outputs, MIN_ECDSA_SIGNATURE_SIZE)
+}
+
+/// Prices a commit while reserving enough ceiling headroom for any valid wallet signature size.
+fn commit_fee_sats_for_vsize_range(
+    estimated_vsize: usize,
+    minimum_vsize: usize,
+    fee_rate: FeeRate,
+    max_fee_rate: Option<FeeRate>,
+) -> Result<u64, EnvelopeError> {
+    let requested_fee = fee_sats_for_vsize(estimated_vsize, fee_rate)?;
+    let Some(max_fee_rate) = max_fee_rate else {
+        return Ok(requested_fee);
+    };
+    let maximum_safe_fee = fee_sats_for_vsize(minimum_vsize, max_fee_rate)?;
+
+    Ok(requested_fee.min(maximum_safe_fee))
 }
 
 /// Choose utxos almost naively.
@@ -622,6 +667,7 @@ fn build_commit_transaction(
     change_address: Address,
     output_value: u64,
     fee_rate: FeeRate,
+    max_fee_rate: Option<FeeRate>,
 ) -> Result<(Transaction, Vec<ListUnspentItem>), EnvelopeError> {
     let (transaction, consumed_utxos, _) = fund_commit_transaction(
         utxos,
@@ -632,6 +678,7 @@ fn build_commit_transaction(
         change_address.script_pubkey(),
         0,
         fee_rate,
+        max_fee_rate,
     )?;
 
     Ok((transaction, consumed_utxos))
@@ -644,21 +691,34 @@ fn select_commit_utxos(
     base_output_total: u64,
     minimum_excess: u64,
     fee_rate: FeeRate,
+    max_fee_rate: Option<FeeRate>,
 ) -> Result<(Vec<ListUnspentItem>, u64, u64), EnvelopeError> {
     let Some(first_utxo) = utxos.first() else {
         return Err(EnvelopeError::NotEnoughUtxos(base_output_total, 0));
     };
-    let mut estimated_size = signed_commit_vsize(slice::from_ref(first_utxo), outputs);
+    let mut estimated_vsize = signed_commit_vsize(slice::from_ref(first_utxo), outputs);
+    let mut minimum_vsize = minimum_signed_commit_vsize(slice::from_ref(first_utxo), outputs);
 
     loop {
-        let estimated_fee = fee_sats_for_vsize(estimated_size, fee_rate)?;
+        let estimated_fee = commit_fee_sats_for_vsize_range(
+            estimated_vsize,
+            minimum_vsize,
+            fee_rate,
+            max_fee_rate,
+        )?;
         let estimated_input_total = base_output_total
             .checked_add(estimated_fee)
             .and_then(|total| total.checked_add(minimum_excess))
             .ok_or(EnvelopeError::FeeOverflow)?;
         let (chosen_utxos, sum) = choose_utxos(utxos, estimated_input_total)?;
-        let signed_size = signed_commit_vsize(&chosen_utxos, outputs);
-        let fee = fee_sats_for_vsize(signed_size, fee_rate)?;
+        let signed_vsize = signed_commit_vsize(&chosen_utxos, outputs);
+        let minimum_signed_vsize = minimum_signed_commit_vsize(&chosen_utxos, outputs);
+        let fee = commit_fee_sats_for_vsize_range(
+            signed_vsize,
+            minimum_signed_vsize,
+            fee_rate,
+            max_fee_rate,
+        )?;
         let required = base_output_total
             .checked_add(fee)
             .and_then(|total| total.checked_add(minimum_excess))
@@ -668,7 +728,8 @@ fn select_commit_utxos(
             return Ok((chosen_utxos, sum, fee));
         }
 
-        estimated_size = signed_size;
+        estimated_vsize = signed_vsize;
+        minimum_vsize = minimum_signed_vsize;
     }
 }
 
@@ -679,6 +740,7 @@ pub(crate) fn fund_commit_transaction(
     change_script: ScriptBuf,
     carry_output_index: usize,
     fee_rate: FeeRate,
+    max_fee_rate: Option<FeeRate>,
 ) -> Result<(Transaction, Vec<ListUnspentItem>, Amount), EnvelopeError> {
     let base_output_total = base_outputs.iter().try_fold(0u64, |total, output| {
         total.checked_add(output.value.to_sat())
@@ -709,6 +771,7 @@ pub(crate) fn fund_commit_transaction(
         base_output_total,
         BITCOIN_DUST_LIMIT,
         fee_rate,
+        max_fee_rate,
     ) {
         Ok((chosen_utxos, sum, fee)) => {
             outputs_with_change
@@ -732,8 +795,14 @@ pub(crate) fn fund_commit_transaction(
 
     // If the wallet cannot fund spendable change, carry every non-fee satoshi through a reveal
     // output. This preserves the requested fee and avoids accidentally burning the remainder.
-    let (chosen_utxos, sum, fee) =
-        select_commit_utxos(&utxos, &base_outputs, base_output_total, 0, fee_rate)?;
+    let (chosen_utxos, sum, fee) = select_commit_utxos(
+        &utxos,
+        &base_outputs,
+        base_output_total,
+        0,
+        fee_rate,
+        max_fee_rate,
+    )?;
     let carried_value = sum
         .checked_sub(base_output_total)
         .and_then(|value| value.checked_sub(fee))
@@ -1201,9 +1270,15 @@ mod tests {
         utxos[0].amount = Amount::from_sat(input_total / 2);
         utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
-        let (tx, consumed) =
-            build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
-                .unwrap();
+        let (tx, consumed) = build_commit_transaction(
+            utxos,
+            recipient.clone(),
+            recipient,
+            output_value,
+            fee_rate,
+            FeeRate::from_sat_per_vb(1_000),
+        )
+        .unwrap();
         let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
 
         assert_eq!(tx.input.len(), 2);
@@ -1230,9 +1305,15 @@ mod tests {
         utxos[0].amount = Amount::from_sat(output_value + no_change_fee + 100);
         utxos[1].amount = Amount::from_sat(10_000);
 
-        let (tx, consumed) =
-            build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
-                .unwrap();
+        let (tx, consumed) = build_commit_transaction(
+            utxos,
+            recipient.clone(),
+            recipient,
+            output_value,
+            fee_rate,
+            None,
+        )
+        .unwrap();
         let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
         let priced_vsize = signed_commit_vsize(&consumed, &tx.output);
 
@@ -1257,6 +1338,42 @@ mod tests {
         let p2wpkh_vsize = signed_commit_vsize(&utxos[..1], &outputs);
 
         assert!(p2wpkh_vsize > schnorr_only_vsize);
+    }
+
+    #[test]
+    fn commit_fee_ceiling_survives_shorter_wallet_signatures() {
+        let (ctx, _, _, mut utxos) = get_mock_data();
+        let recipient = ctx.sequencer_address.clone();
+        let fee_rate = FeeRate::from_sat_per_vb(1_000).unwrap();
+        utxos.truncate(2);
+        for utxo in &mut utxos {
+            utxo.amount = Amount::from_sat(160_000);
+        }
+
+        let (mut tx, consumed) = build_commit_transaction(
+            utxos,
+            recipient.clone(),
+            recipient,
+            100_000,
+            fee_rate,
+            Some(fee_rate),
+        )
+        .unwrap();
+        let actual_fee = Amount::from_sat(calculate_transaction_fee_from_utxos(&tx, &consumed));
+        let uncapped_fee = Amount::from_sat(
+            fee_sats_for_vsize(signed_commit_vsize(&consumed, &tx.output), fee_rate).unwrap(),
+        );
+
+        // Core grinds both ECDSA scalars below 2^255, so its normal P2WPKH signatures are at most
+        // 71 bytes including the sighash byte rather than the generic 73-byte maximum.
+        for input in &mut tx.input {
+            input.witness.push([0; MAX_ECDSA_SIGNATURE_SIZE - 2]);
+            input.witness.push([0; COMPRESSED_PUBLIC_KEY_SIZE]);
+        }
+
+        assert_eq!(tx.input.len(), 2);
+        assert!(effective_fee_rate(&tx, uncapped_fee).unwrap() > fee_rate);
+        assert!(ensure_built_fee_rate_within_max(&tx, actual_fee, fee_rate).is_ok());
     }
 
     #[test]
@@ -1448,6 +1565,7 @@ mod tests {
             ctx.sequencer_address.clone(),
             500_000_000,
             FeeRate::from_sat_per_vb_u32(1),
+            None,
         )
         .unwrap();
 
@@ -1468,6 +1586,7 @@ mod tests {
             ctx.sequencer_address.clone(),
             500_000_000,
             FeeRate::from_sat_per_vb_u32(1),
+            None,
         );
 
         assert!(matches!(res, Err(EnvelopeError::NotEnoughUtxos(_, 0))));

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -407,9 +407,9 @@ pub fn create_envelope_transactions(
     let commit_fee_sats = calculate_transaction_fee_from_utxos(&commit_tx, &consumed_utxos);
 
     let output_to_reveal = commit_tx.output[0].clone();
-    let returned_dust = output_to_reveal.value.to_sat().saturating_sub(commit_value);
+    let carried_change = output_to_reveal.value.to_sat().saturating_sub(commit_value);
     let reveal_output_value = base_reveal_output_value
-        .checked_add(returned_dust)
+        .checked_add(carried_change)
         .ok_or(EnvelopeError::FeeOverflow)?;
 
     // Build reveal tx
@@ -424,7 +424,7 @@ pub fn create_envelope_transactions(
             .control_block(&(reveal_script.clone(), LeafVersion::TapScript))
             .ok_or(anyhow!("Cannot create control block".to_string()))?,
     )?;
-    let reveal_fee_sats = commit_value.saturating_sub(
+    let reveal_fee_sats = output_to_reveal.value.to_sat().saturating_sub(
         reveal_tx
             .output
             .iter()
@@ -563,17 +563,36 @@ fn build_commit_transaction(
     output_value: u64,
     fee_rate: FeeRate,
 ) -> Result<(Transaction, Vec<ListUnspentItem>), EnvelopeError> {
-    // get single input single output transaction size
-    let mut size = get_size(
-        &default_txin(),
-        &[TxOut {
+    let (transaction, consumed_utxos, _) = fund_commit_transaction(
+        utxos,
+        vec![TxOut {
             script_pubkey: recipient.script_pubkey(),
             value: Amount::from_sat(output_value),
         }],
-        None,
-        None,
-    );
-    let mut last_size = size;
+        change_address.script_pubkey(),
+        0,
+        fee_rate,
+    )?;
+
+    Ok((transaction, consumed_utxos))
+}
+
+/// Funds fixed commit outputs at an exact fee rate and either creates change or carries it forward.
+pub(crate) fn fund_commit_transaction(
+    utxos: Vec<ListUnspentItem>,
+    base_outputs: Vec<TxOut>,
+    change_script: ScriptBuf,
+    carry_output_index: usize,
+    fee_rate: FeeRate,
+) -> Result<(Transaction, Vec<ListUnspentItem>, Amount), EnvelopeError> {
+    let base_output_total = base_outputs.iter().try_fold(0u64, |total, output| {
+        total.checked_add(output.value.to_sat())
+    });
+    let base_output_total = base_output_total.ok_or(EnvelopeError::FeeOverflow)?;
+
+    // Start coin selection with a single-input, no-change estimate. Once inputs are selected, the
+    // transaction is priced from its actual input count and output shape below.
+    let mut estimated_size = get_size(&default_txin(), &base_outputs, None, None);
 
     let utxos: Vec<ListUnspentItem> = utxos
         .iter()
@@ -581,73 +600,86 @@ fn build_commit_transaction(
         .cloned()
         .collect();
 
-    let (commit_txn, consumed_utxo) = loop {
-        let fee = fee_sats_for_vsize(last_size, fee_rate)?;
-
-        let input_total = output_value
-            .checked_add(fee)
+    loop {
+        let estimated_fee = fee_sats_for_vsize(estimated_size, fee_rate)?;
+        let estimated_input_total = base_output_total
+            .checked_add(estimated_fee)
             .ok_or(EnvelopeError::FeeOverflow)?;
-
-        let res = choose_utxos(&utxos, input_total)?;
-
-        let (chosen_utxos, sum) = res;
-
-        let mut outputs: Vec<TxOut> = vec![];
-        outputs.push(TxOut {
-            value: Amount::from_sat(output_value),
-            script_pubkey: recipient.script_pubkey(),
-        });
-
-        let mut direct_return = false;
-        if let Some(excess) = sum.checked_sub(input_total) {
-            if excess >= BITCOIN_DUST_LIMIT {
-                outputs.push(TxOut {
-                    value: Amount::from_sat(excess),
-                    script_pubkey: change_address.script_pubkey(),
-                });
-            } else {
-                // Return sub-dust change through the reveal output instead of silently turning it
-                // into extra fee. The reveal builder forwards the same amount to the sequencer,
-                // keeping both transactions at their requested fee rate and therefore within the
-                // broadcast guardrail when the requested rate is within it.
-                outputs[0].value = outputs[0]
-                    .value
-                    .checked_add(Amount::from_sat(excess))
-                    .ok_or(EnvelopeError::FeeOverflow)?;
-                direct_return = true;
-            }
-        }
-
+        let (chosen_utxos, sum) = choose_utxos(&utxos, estimated_input_total)?;
         let inputs: Vec<TxIn> = chosen_utxos
             .iter()
-            .map(|u| TxIn {
+            .map(|utxo| TxIn {
                 previous_output: OutPoint {
-                    txid: u.txid,
-                    vout: u.vout,
+                    txid: utxo.txid,
+                    vout: utxo.vout,
                 },
                 script_sig: script::Builder::new().into_script(),
                 witness: Witness::new(),
                 sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
             })
             .collect();
+        let mut outputs = base_outputs.clone();
 
-        size = get_size(&inputs, &outputs, None, None);
+        let no_change_size = get_size(&inputs, &outputs, None, None);
+        let no_change_fee = fee_sats_for_vsize(no_change_size, fee_rate)?;
+        let no_change_total = base_output_total
+            .checked_add(no_change_fee)
+            .ok_or(EnvelopeError::FeeOverflow)?;
+        let Some(no_change_excess) = sum.checked_sub(no_change_total) else {
+            estimated_size = no_change_size;
+            continue;
+        };
 
-        if size == last_size || direct_return {
-            let commit_txn = Transaction {
+        // A change output is only useful when it remains non-dust after paying for its own size.
+        // Otherwise the residual is carried through the reveal output without changing the fee.
+        let mut outputs_with_change = outputs.clone();
+        outputs_with_change.push(TxOut {
+            value: Amount::ZERO,
+            script_pubkey: change_script.clone(),
+        });
+        let with_change_size = get_size(&inputs, &outputs_with_change, None, None);
+        let with_change_fee = fee_sats_for_vsize(with_change_size, fee_rate)?;
+        let with_change_total = base_output_total
+            .checked_add(with_change_fee)
+            .and_then(|total| total.checked_add(BITCOIN_DUST_LIMIT))
+            .ok_or(EnvelopeError::FeeOverflow)?;
+
+        if sum >= with_change_total {
+            outputs_with_change
+                .last_mut()
+                .expect("change output was just appended")
+                .value = Amount::from_sat(sum - base_output_total - with_change_fee);
+            outputs = outputs_with_change;
+        } else {
+            let carry_output = outputs
+                .get_mut(carry_output_index)
+                .expect("carry output index must reference a fixed output");
+            carry_output.value = carry_output
+                .value
+                .checked_add(Amount::from_sat(no_change_excess))
+                .ok_or(EnvelopeError::FeeOverflow)?;
+        }
+
+        let output_total = outputs.iter().try_fold(0u64, |total, output| {
+            total.checked_add(output.value.to_sat())
+        });
+        let output_total = output_total.ok_or(EnvelopeError::FeeOverflow)?;
+        let actual_fee = Amount::from_sat(
+            sum.checked_sub(output_total)
+                .expect("funded outputs cannot exceed selected inputs"),
+        );
+
+        return Ok((
+            Transaction {
                 lock_time: LockTime::ZERO,
                 version: Version(2),
                 input: inputs,
                 output: outputs,
-            };
-
-            break (commit_txn, chosen_utxos);
-        }
-
-        last_size = size;
-    };
-
-    Ok((commit_txn, consumed_utxo))
+            },
+            chosen_utxos,
+            actual_fee,
+        ));
+    }
 }
 
 fn default_txin() -> Vec<TxIn> {
@@ -1078,8 +1110,10 @@ mod tests {
         let returned_dust = 100;
         let fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
         let recipient = ctx.sequencer_address.clone();
+        let mut inputs = default_txin();
+        inputs.push(default_txin().pop().unwrap());
         let initial_size = get_size(
-            &default_txin(),
+            &inputs,
             &[TxOut {
                 value: Amount::from_sat(output_value),
                 script_pubkey: recipient.script_pubkey(),
@@ -1088,17 +1122,63 @@ mod tests {
             None,
         );
         let requested_fee = fee_sats_for_vsize(initial_size, fee_rate).unwrap();
-        utxos.truncate(1);
-        utxos[0].amount = Amount::from_sat(output_value + requested_fee + returned_dust);
+        let input_total = output_value + requested_fee + returned_dust;
+        utxos.truncate(2);
+        utxos[0].amount = Amount::from_sat(input_total / 2);
+        utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
         let (tx, consumed) =
             build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
                 .unwrap();
         let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
 
+        assert_eq!(tx.input.len(), 2);
         assert_eq!(tx.output.len(), 1);
         assert_eq!(tx.output[0].value.to_sat(), output_value + returned_dust);
         assert_eq!(actual_fee, requested_fee);
+    }
+
+    #[test]
+    fn forwarded_commit_change_does_not_reduce_recorded_reveal_fee() {
+        let (ctx, _, _, mut utxos) = get_mock_data();
+        let env_config = test_envelope_config(&ctx, Some(test_envelope_pubkey()));
+        let payload = test_payload();
+        let baseline = create_envelope_transactions(&env_config, &payload, utxos.clone()).unwrap();
+        let commit_value = baseline.commit_tx.output[0].value.to_sat();
+        let mut inputs = default_txin();
+        inputs.push(default_txin().pop().unwrap());
+        let commit_size = get_size(
+            &inputs,
+            &[TxOut {
+                value: Amount::from_sat(commit_value),
+                script_pubkey: baseline.commit_tx.output[0].script_pubkey.clone(),
+            }],
+            None,
+            None,
+        );
+        let commit_fee = fee_sats_for_vsize(commit_size, env_config.fee_rate).unwrap();
+        let returned_dust = 100;
+        let input_total = commit_value + commit_fee + returned_dust;
+        utxos.truncate(2);
+        utxos[0].amount = Amount::from_sat(input_total / 2);
+        utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
+
+        let envelope = create_envelope_transactions(&env_config, &payload, utxos).unwrap();
+        let reveal_output_total: Amount = envelope
+            .reveal_tx
+            .output
+            .iter()
+            .map(|output| output.value)
+            .sum();
+        let actual_reveal_fee = envelope.commit_tx.output[0].value - reveal_output_total;
+
+        assert_eq!(envelope.commit_tx.input.len(), 2);
+        assert_eq!(envelope.commit_fee, Amount::from_sat(commit_fee));
+        assert_eq!(envelope.reveal_fee, actual_reveal_fee);
+        assert_eq!(
+            envelope.reveal_tx.output[1].value.to_sat(),
+            baseline.reveal_tx.output[1].value.to_sat() + returned_dust
+        );
     }
 
     fn get_txn_from_utxo(utxo: &ListUnspentItem, _address: &Address) -> Transaction {

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -42,6 +42,9 @@ const MAX_ECDSA_SIGNATURE_SIZE: usize = 73;
 const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33;
 /// Bounds wallet RPC work if changing the commit fee repeatedly changes its signature length.
 const MAX_COMMIT_SIGNING_ATTEMPTS: usize = 8;
+/// Constrains randomized input sequences and reserves four bits for distinct signing attempts.
+const COMMIT_SEQUENCE_NONCE_MASK: u32 = 0x7fff_fff0;
+const RELATIVE_LOCKTIME_DISABLE_FLAG: u32 = 0x8000_0000;
 
 /// Config for creating envelope transactions.
 #[derive(Debug, Clone)]
@@ -123,6 +126,11 @@ pub enum EnvelopeError {
         ceiling_sat_vb: u64,
     },
 
+    #[error(
+        "wallet-signed commit did not satisfy its requested fee and broadcast ceiling after {attempts} attempts"
+    )]
+    CommitFeeBoundsNotSatisfied { attempts: usize },
+
     #[error("Could not sign raw transaction: {0}")]
     SignRawTransaction(#[source] ClientError),
 
@@ -152,11 +160,13 @@ pub enum EnvelopeError {
 }
 
 impl EnvelopeError {
-    /// Reports whether transaction construction should wait for a fee rate below the guardrail.
+    /// Reports whether transaction construction should wait for satisfiable fee bounds.
     pub(crate) fn is_blocked_by_fee_guardrail(&self) -> bool {
         matches!(
             self,
-            Self::ResolvedFeeRateAboveMax { .. } | Self::BuiltFeeRateAboveMax { .. }
+            Self::ResolvedFeeRateAboveMax { .. }
+                | Self::BuiltFeeRateAboveMax { .. }
+                | Self::CommitFeeBoundsNotSatisfied { .. }
         )
     }
 }
@@ -356,13 +366,13 @@ pub(crate) fn ensure_built_fee_rate_within_max(
     Ok(())
 }
 
-/// Signs a commit, correcting its absolute fee only while its signed rate breaches the ceiling.
+/// Signs a commit whose absolute fee satisfies both the requested rate and the ceiling.
 ///
 /// Wallet ECDSA signatures can be shorter than the conservative witness used during funding. If
-/// that makes the signed transaction exceed `max_fee_rate`, this refunds the excess through the
-/// final output and asks the wallet to sign again. The first ceiling-safe result is accepted even
-/// when another signature size would change the exact requested fee, avoiding a fixed-point cycle.
-/// The bound prevents a faulty signer from keeping the writer inside an RPC loop indefinitely.
+/// the signed transaction falls outside either bound, this corrects the fee through the final
+/// output and asks the wallet to sign again. Each correction also assigns a distinct, RBF-safe
+/// input sequence so returning to a previous fee does not recreate the same signing preimage. The
+/// bound prevents a faulty signer from keeping the writer inside an RPC loop indefinitely.
 pub(crate) async fn sign_commit_with_fee_guardrail<C: Signer>(
     client: &C,
     mut commit_tx: Transaction,
@@ -376,6 +386,8 @@ pub(crate) async fn sign_commit_with_fee_guardrail<C: Signer>(
         .expect("commit transaction has at least one output")
         .value;
     let mut commit_fee = original_fee;
+    let sequence_nonce_base =
+        RELATIVE_LOCKTIME_DISABLE_FLAG | (OsRng.next_u32() & COMMIT_SEQUENCE_NONCE_MASK);
     for attempt in 0..MAX_COMMIT_SIGNING_ATTEMPTS {
         let signed_commit = client
             .sign_raw_transaction_with_wallet(&commit_tx, None)
@@ -383,21 +395,22 @@ pub(crate) async fn sign_commit_with_fee_guardrail<C: Signer>(
             .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
 
-        let guardrail_error =
-            match ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate) {
-                Ok(()) => return Ok((signed_commit, commit_fee)),
-                Err(error @ EnvelopeError::BuiltFeeRateAboveMax { .. }) => error,
-                Err(error) => return Err(error),
-            };
-        if attempt + 1 == MAX_COMMIT_SIGNING_ATTEMPTS {
-            return Err(guardrail_error);
-        }
-
         let requested_fee = requested_fee_rate
             .fee_vb(signed_commit.vsize() as u64)
             .ok_or(EnvelopeError::FeeOverflow)?;
-        if commit_fee == requested_fee {
-            return Err(guardrail_error);
+        let within_ceiling =
+            match ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate) {
+                Ok(()) => true,
+                Err(EnvelopeError::BuiltFeeRateAboveMax { .. }) => false,
+                Err(error) => return Err(error),
+            };
+        if within_ceiling && commit_fee >= requested_fee {
+            return Ok((signed_commit, commit_fee));
+        }
+        if attempt + 1 == MAX_COMMIT_SIGNING_ATTEMPTS {
+            return Err(EnvelopeError::CommitFeeBoundsNotSatisfied {
+                attempts: MAX_COMMIT_SIGNING_ATTEMPTS,
+            });
         }
 
         let adjusted_output_value = original_fee_output
@@ -405,8 +418,11 @@ pub(crate) async fn sign_commit_with_fee_guardrail<C: Signer>(
             .and_then(|value| value.checked_sub(requested_fee))
             .ok_or(EnvelopeError::FeeOverflow)?;
         commit_tx = signed_commit;
+        let attempt = u32::try_from(attempt).expect("commit signing attempt fits in u32");
+        let sequence = Sequence::from_consensus(sequence_nonce_base + attempt);
         for input in &mut commit_tx.input {
             input.witness.clear();
+            input.sequence = sequence;
         }
         commit_tx
             .output
@@ -1431,13 +1447,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_repricing_accepts_a_ceiling_safe_signature_size_cycle() {
+    async fn commit_repricing_breaks_a_signature_size_cycle_without_underpaying() {
         let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
         let (unsigned_commit, original_fee) = commit_signing_fixture();
         // Across three inputs, Core's normal one-byte DER variation changes the aggregate vsize.
         let client = TestBitcoinClient::new(0).with_sign_raw_transaction_witness_sizes(vec![
             MAX_ECDSA_SIGNATURE_SIZE - 3,
             MAX_ECDSA_SIGNATURE_SIZE - 2,
+            MAX_ECDSA_SIGNATURE_SIZE - 3,
             MAX_ECDSA_SIGNATURE_SIZE - 3,
         ]);
 
@@ -1451,8 +1468,19 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(client.sign_raw_transaction_calls().len(), 2);
-        assert!(commit_fee < fee_rate.fee_vb(signed_commit.vsize() as u64).unwrap());
+        let signing_calls = client.sign_raw_transaction_calls();
+        assert_eq!(signing_calls.len(), 4);
+        assert!(signing_calls
+            .windows(2)
+            .all(|calls| { calls[0].input[0].sequence != calls[1].input[0].sequence }));
+        assert!(signing_calls
+            .iter()
+            .flat_map(|tx| &tx.input)
+            .all(|input| { input.sequence.is_rbf() && !input.sequence.is_relative_lock_time() }));
+        assert_eq!(
+            commit_fee,
+            fee_rate.fee_vb(signed_commit.vsize() as u64).unwrap()
+        );
         assert!(ensure_built_fee_rate_within_max(&signed_commit, commit_fee, fee_rate).is_ok());
     }
 
@@ -1480,7 +1508,12 @@ mod tests {
             client.sign_raw_transaction_calls().len(),
             MAX_COMMIT_SIGNING_ATTEMPTS
         );
-        assert!(matches!(error, EnvelopeError::BuiltFeeRateAboveMax { .. }));
+        assert!(matches!(
+            error,
+            EnvelopeError::CommitFeeBoundsNotSatisfied {
+                attempts: MAX_COMMIT_SIGNING_ATTEMPTS
+            }
+        ));
         assert!(error.is_blocked_by_fee_guardrail());
     }
 

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -1,5 +1,5 @@
 use core::result::Result::Ok;
-use std::cmp::Reverse;
+use std::{cmp::Reverse, slice};
 
 use anyhow::anyhow;
 use bitcoin::{
@@ -36,6 +36,10 @@ use super::context::WriterContext;
 use crate::writer::fees::resolve_fee_rate;
 
 pub(crate) const BITCOIN_DUST_LIMIT: u64 = 546;
+
+/// Largest serialized ECDSA signature, including its sighash byte.
+const MAX_ECDSA_SIGNATURE_SIZE: usize = 73;
+const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33;
 
 /// Config for creating envelope transactions.
 #[derive(Debug, Clone)]
@@ -315,18 +319,23 @@ pub(crate) fn ensure_initial_fee_rate_within_max(
     Ok(())
 }
 
+/// Returns a built transaction's effective fee rate, rounded up to whole sat/vB.
+pub(crate) fn effective_fee_rate(tx: &Transaction, fee: Amount) -> Result<FeeRate, EnvelopeError> {
+    let vsize = tx.vsize() as u64;
+    if vsize == 0 {
+        return Err(EnvelopeError::FeeOverflow);
+    }
+
+    FeeRate::from_sat_per_vb(fee.to_sat().div_ceil(vsize)).ok_or(EnvelopeError::FeeOverflow)
+}
+
 /// Ensures a built transaction's effective fee rate fits the broadcast ceiling.
 pub(crate) fn ensure_built_fee_rate_within_max(
     tx: &Transaction,
     fee: Amount,
     max_fee_rate: FeeRate,
 ) -> Result<(), EnvelopeError> {
-    let vsize = tx.vsize() as u64;
-    if vsize == 0 {
-        return Err(EnvelopeError::FeeOverflow);
-    }
-    let built_fee_rate =
-        FeeRate::from_sat_per_vb(fee.to_sat().div_ceil(vsize)).ok_or(EnvelopeError::FeeOverflow)?;
+    let built_fee_rate = effective_fee_rate(tx, fee)?;
     if built_fee_rate > max_fee_rate {
         return Err(EnvelopeError::BuiltFeeRateAboveMax {
             built_sat_vb: built_fee_rate.to_sat_per_vb_ceil(),
@@ -507,6 +516,57 @@ pub(crate) fn get_size(
     tx.vsize()
 }
 
+/// Returns whether signing this wallet output leaves the commit txid unchanged.
+///
+/// Reveals are built before the wallet signs the commit, so commit inputs must put their entire
+/// satisfaction in the witness. The sequencer wallet normally produces P2WPKH outputs; P2TR key
+/// spends are also safe and have a known witness shape.
+fn is_supported_commit_utxo(utxo: &ListUnspentItem) -> bool {
+    utxo.script_pubkey.is_p2wpkh() || utxo.script_pubkey.is_p2tr()
+}
+
+fn commit_inputs(utxos: &[ListUnspentItem]) -> Vec<TxIn> {
+    utxos
+        .iter()
+        .map(|utxo| TxIn {
+            previous_output: OutPoint {
+                txid: utxo.txid,
+                vout: utxo.vout,
+            },
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        })
+        .collect()
+}
+
+/// Estimates the signed commit vsize from the selected wallet outputs.
+///
+/// P2WPKH uses Bitcoin Core's conservative high-R witness shape. The wallet normally grinds a
+/// low-R signature, so the final transaction can be up to one vbyte smaller; the signed
+/// transaction's effective rate is checked against the hard broadcast ceiling before persistence.
+pub(crate) fn signed_commit_vsize(utxos: &[ListUnspentItem], outputs: &[TxOut]) -> usize {
+    let mut inputs = commit_inputs(utxos);
+    for (input, utxo) in inputs.iter_mut().zip(utxos) {
+        if utxo.script_pubkey.is_p2wpkh() {
+            input.witness.push([0; MAX_ECDSA_SIGNATURE_SIZE]);
+            input.witness.push([0; COMPRESSED_PUBLIC_KEY_SIZE]);
+        } else if utxo.script_pubkey.is_p2tr() {
+            input.witness.push([0; SCHNORR_SIGNATURE_SIZE]);
+        } else {
+            unreachable!("commit coin selection only returns supported native SegWit outputs");
+        }
+    }
+
+    Transaction {
+        input: inputs,
+        output: outputs.to_vec(),
+        lock_time: LockTime::ZERO,
+        version: Version(2),
+    }
+    .vsize()
+}
+
 /// Choose utxos almost naively.
 pub(crate) fn choose_utxos(
     utxos: &[ListUnspentItem],
@@ -577,7 +637,42 @@ fn build_commit_transaction(
     Ok((transaction, consumed_utxos))
 }
 
-/// Funds fixed commit outputs at an exact fee rate and either creates change or carries it forward.
+/// Selects enough wallet outputs to fund `outputs` and the fee implied by their signed input size.
+fn select_commit_utxos(
+    utxos: &[ListUnspentItem],
+    outputs: &[TxOut],
+    base_output_total: u64,
+    minimum_excess: u64,
+    fee_rate: FeeRate,
+) -> Result<(Vec<ListUnspentItem>, u64, u64), EnvelopeError> {
+    let Some(first_utxo) = utxos.first() else {
+        return Err(EnvelopeError::NotEnoughUtxos(base_output_total, 0));
+    };
+    let mut estimated_size = signed_commit_vsize(slice::from_ref(first_utxo), outputs);
+
+    loop {
+        let estimated_fee = fee_sats_for_vsize(estimated_size, fee_rate)?;
+        let estimated_input_total = base_output_total
+            .checked_add(estimated_fee)
+            .and_then(|total| total.checked_add(minimum_excess))
+            .ok_or(EnvelopeError::FeeOverflow)?;
+        let (chosen_utxos, sum) = choose_utxos(utxos, estimated_input_total)?;
+        let signed_size = signed_commit_vsize(&chosen_utxos, outputs);
+        let fee = fee_sats_for_vsize(signed_size, fee_rate)?;
+        let required = base_output_total
+            .checked_add(fee)
+            .and_then(|total| total.checked_add(minimum_excess))
+            .ok_or(EnvelopeError::FeeOverflow)?;
+
+        if sum >= required {
+            return Ok((chosen_utxos, sum, fee));
+        }
+
+        estimated_size = signed_size;
+    }
+}
+
+/// Funds fixed commit outputs at the requested rate and prefers bumpable change.
 pub(crate) fn fund_commit_transaction(
     utxos: Vec<ListUnspentItem>,
     base_outputs: Vec<TxOut>,
@@ -590,96 +685,78 @@ pub(crate) fn fund_commit_transaction(
     });
     let base_output_total = base_output_total.ok_or(EnvelopeError::FeeOverflow)?;
 
-    // Start coin selection with a single-input, no-change estimate. Once inputs are selected, the
-    // transaction is priced from its actual input count and output shape below.
-    let mut estimated_size = get_size(&default_txin(), &base_outputs, None, None);
-
     let utxos: Vec<ListUnspentItem> = utxos
         .iter()
-        .filter(|utxo| utxo.spendable && utxo.solvable && utxo.amount.to_sat() > BITCOIN_DUST_LIMIT)
+        .filter(|utxo| {
+            utxo.spendable
+                && utxo.solvable
+                && utxo.amount.to_sat() > BITCOIN_DUST_LIMIT
+                && is_supported_commit_utxo(utxo)
+        })
         .cloned()
         .collect();
 
-    loop {
-        let estimated_fee = fee_sats_for_vsize(estimated_size, fee_rate)?;
-        let estimated_input_total = base_output_total
-            .checked_add(estimated_fee)
-            .ok_or(EnvelopeError::FeeOverflow)?;
-        let (chosen_utxos, sum) = choose_utxos(&utxos, estimated_input_total)?;
-        let inputs: Vec<TxIn> = chosen_utxos
-            .iter()
-            .map(|utxo| TxIn {
-                previous_output: OutPoint {
-                    txid: utxo.txid,
-                    vout: utxo.vout,
-                },
-                script_sig: script::Builder::new().into_script(),
-                witness: Witness::new(),
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-            })
-            .collect();
-        let mut outputs = base_outputs.clone();
-
-        let no_change_size = get_size(&inputs, &outputs, None, None);
-        let no_change_fee = fee_sats_for_vsize(no_change_size, fee_rate)?;
-        let no_change_total = base_output_total
-            .checked_add(no_change_fee)
-            .ok_or(EnvelopeError::FeeOverflow)?;
-        let Some(no_change_excess) = sum.checked_sub(no_change_total) else {
-            estimated_size = no_change_size;
-            continue;
-        };
-
-        // A change output is only useful when it remains non-dust after paying for its own size.
-        // Otherwise the residual is carried through the reveal output without changing the fee.
-        let mut outputs_with_change = outputs.clone();
-        outputs_with_change.push(TxOut {
-            value: Amount::ZERO,
-            script_pubkey: change_script.clone(),
-        });
-        let with_change_size = get_size(&inputs, &outputs_with_change, None, None);
-        let with_change_fee = fee_sats_for_vsize(with_change_size, fee_rate)?;
-        let with_change_total = base_output_total
-            .checked_add(with_change_fee)
-            .and_then(|total| total.checked_add(BITCOIN_DUST_LIMIT))
-            .ok_or(EnvelopeError::FeeOverflow)?;
-
-        if sum >= with_change_total {
+    // Prefer a standalone change output even when doing so requires another wallet input. The fee
+    // bumper can shrink that output without racing another writer for an unlocked input.
+    let mut outputs_with_change = base_outputs.clone();
+    outputs_with_change.push(TxOut {
+        value: Amount::ZERO,
+        script_pubkey: change_script,
+    });
+    match select_commit_utxos(
+        &utxos,
+        &outputs_with_change,
+        base_output_total,
+        BITCOIN_DUST_LIMIT,
+        fee_rate,
+    ) {
+        Ok((chosen_utxos, sum, fee)) => {
             outputs_with_change
                 .last_mut()
                 .expect("change output was just appended")
-                .value = Amount::from_sat(sum - base_output_total - with_change_fee);
-            outputs = outputs_with_change;
-        } else {
-            let carry_output = outputs
-                .get_mut(carry_output_index)
-                .expect("carry output index must reference a fixed output");
-            carry_output.value = carry_output
-                .value
-                .checked_add(Amount::from_sat(no_change_excess))
-                .ok_or(EnvelopeError::FeeOverflow)?;
+                .value = Amount::from_sat(sum - base_output_total - fee);
+            return Ok((
+                Transaction {
+                    lock_time: LockTime::ZERO,
+                    version: Version(2),
+                    input: commit_inputs(&chosen_utxos),
+                    output: outputs_with_change,
+                },
+                chosen_utxos,
+                Amount::from_sat(fee),
+            ));
         }
-
-        let output_total = outputs.iter().try_fold(0u64, |total, output| {
-            total.checked_add(output.value.to_sat())
-        });
-        let output_total = output_total.ok_or(EnvelopeError::FeeOverflow)?;
-        let actual_fee = Amount::from_sat(
-            sum.checked_sub(output_total)
-                .expect("funded outputs cannot exceed selected inputs"),
-        );
-
-        return Ok((
-            Transaction {
-                lock_time: LockTime::ZERO,
-                version: Version(2),
-                input: inputs,
-                output: outputs,
-            },
-            chosen_utxos,
-            actual_fee,
-        ));
+        Err(EnvelopeError::NotEnoughUtxos(_, _)) => {}
+        Err(error) => return Err(error),
     }
+
+    // If the wallet cannot fund spendable change, carry every non-fee satoshi through a reveal
+    // output. This preserves the requested fee and avoids accidentally burning the remainder.
+    let (chosen_utxos, sum, fee) =
+        select_commit_utxos(&utxos, &base_outputs, base_output_total, 0, fee_rate)?;
+    let carried_value = sum
+        .checked_sub(base_output_total)
+        .and_then(|value| value.checked_sub(fee))
+        .expect("coin selection funded the fixed outputs and fee");
+    let mut outputs = base_outputs;
+    let carry_output = outputs
+        .get_mut(carry_output_index)
+        .expect("carry output index must reference a fixed output");
+    carry_output.value = carry_output
+        .value
+        .checked_add(Amount::from_sat(carried_value))
+        .ok_or(EnvelopeError::FeeOverflow)?;
+
+    Ok((
+        Transaction {
+            lock_time: LockTime::ZERO,
+            version: Version(2),
+            input: commit_inputs(&chosen_utxos),
+            output: outputs,
+        },
+        chosen_utxos,
+        Amount::from_sat(fee),
+    ))
 }
 
 fn default_txin() -> Vec<TxIn> {
@@ -924,7 +1001,8 @@ mod tests {
         secp256k1::{constants::SCHNORR_SIGNATURE_SIZE, Secp256k1, SecretKey},
         taproot::ControlBlock,
         transaction::Version,
-        Address, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+        Address, Network, OutPoint, PubkeyHash, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        Witness,
     };
     use bitcoind_async_client::corepc_types::model::ListUnspentItem;
     use strata_l1_txfmt::{MagicBytes, TagData, TagDataRef};
@@ -953,7 +1031,7 @@ mod tests {
                     .unwrap(),
                 vout: 0,
                 address: address.as_unchecked().clone(),
-                script_pubkey: ScriptBuf::new(),
+                script_pubkey: address.script_pubkey(),
                 amount: Amount::from_btc(100.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
@@ -970,7 +1048,7 @@ mod tests {
                     .unwrap(),
                 vout: 0,
                 address: address.as_unchecked().clone(),
-                script_pubkey: ScriptBuf::new(),
+                script_pubkey: address.script_pubkey(),
                 amount: Amount::from_btc(50.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
@@ -987,7 +1065,7 @@ mod tests {
                     .unwrap(),
                 vout: 0,
                 address: address.as_unchecked().clone(),
-                script_pubkey: ScriptBuf::new(),
+                script_pubkey: address.script_pubkey(),
                 amount: Amount::from_btc(10.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
@@ -1110,20 +1188,16 @@ mod tests {
         let returned_dust = 100;
         let fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
         let recipient = ctx.sequencer_address.clone();
-        let mut inputs = default_txin();
-        inputs.push(default_txin().pop().unwrap());
-        let initial_size = get_size(
-            &inputs,
+        utxos.truncate(2);
+        let initial_size = signed_commit_vsize(
+            &utxos,
             &[TxOut {
                 value: Amount::from_sat(output_value),
                 script_pubkey: recipient.script_pubkey(),
             }],
-            None,
-            None,
         );
         let requested_fee = fee_sats_for_vsize(initial_size, fee_rate).unwrap();
         let input_total = output_value + requested_fee + returned_dust;
-        utxos.truncate(2);
         utxos[0].amount = Amount::from_sat(input_total / 2);
         utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
@@ -1139,27 +1213,70 @@ mod tests {
     }
 
     #[test]
+    fn commit_selects_another_utxo_to_create_bumpable_change() {
+        let (ctx, _, _, mut utxos) = get_mock_data();
+        let output_value = 100_000;
+        let fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
+        let recipient = ctx.sequencer_address.clone();
+        utxos.truncate(2);
+        let no_change_size = signed_commit_vsize(
+            &utxos[..1],
+            &[TxOut {
+                value: Amount::from_sat(output_value),
+                script_pubkey: recipient.script_pubkey(),
+            }],
+        );
+        let no_change_fee = fee_sats_for_vsize(no_change_size, fee_rate).unwrap();
+        utxos[0].amount = Amount::from_sat(output_value + no_change_fee + 100);
+        utxos[1].amount = Amount::from_sat(10_000);
+
+        let (tx, consumed) =
+            build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
+                .unwrap();
+        let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
+        let priced_vsize = signed_commit_vsize(&consumed, &tx.output);
+
+        assert_eq!(tx.input.len(), 2);
+        assert_eq!(tx.output.len(), 2);
+        assert!(tx.output[1].value.to_sat() >= BITCOIN_DUST_LIMIT);
+        assert_eq!(
+            actual_fee,
+            fee_sats_for_vsize(priced_vsize, fee_rate).unwrap()
+        );
+    }
+
+    #[test]
+    fn commit_pricing_includes_p2wpkh_signature_and_pubkey() {
+        let (ctx, _, _, utxos) = get_mock_data();
+        let outputs = [TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ctx.sequencer_address.script_pubkey(),
+        }];
+        let unsigned_inputs = commit_inputs(&utxos[..1]);
+        let schnorr_only_vsize = get_size(&unsigned_inputs, &outputs, None, None);
+        let p2wpkh_vsize = signed_commit_vsize(&utxos[..1], &outputs);
+
+        assert!(p2wpkh_vsize > schnorr_only_vsize);
+    }
+
+    #[test]
     fn forwarded_commit_change_does_not_reduce_recorded_reveal_fee() {
         let (ctx, _, _, mut utxos) = get_mock_data();
         let env_config = test_envelope_config(&ctx, Some(test_envelope_pubkey()));
         let payload = test_payload();
         let baseline = create_envelope_transactions(&env_config, &payload, utxos.clone()).unwrap();
         let commit_value = baseline.commit_tx.output[0].value.to_sat();
-        let mut inputs = default_txin();
-        inputs.push(default_txin().pop().unwrap());
-        let commit_size = get_size(
-            &inputs,
+        utxos.truncate(2);
+        let commit_size = signed_commit_vsize(
+            &utxos,
             &[TxOut {
                 value: Amount::from_sat(commit_value),
                 script_pubkey: baseline.commit_tx.output[0].script_pubkey.clone(),
             }],
-            None,
-            None,
         );
         let commit_fee = fee_sats_for_vsize(commit_size, env_config.fee_rate).unwrap();
         let returned_dust = 100;
         let input_total = commit_value + commit_fee + returned_dust;
-        utxos.truncate(2);
         utxos[0].amount = Amount::from_sat(input_total / 2);
         utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
@@ -1320,10 +1437,13 @@ mod tests {
         unspendable.spendable = false;
         let mut unsolvable = utxos[1].clone();
         unsolvable.solvable = false;
+        let mut legacy = utxos[2].clone();
+        legacy.script_pubkey = ScriptBuf::new_p2pkh(&PubkeyHash::all_zeros());
+        legacy.amount = Amount::from_btc(100.0).unwrap();
         let viable = utxos[2].clone();
 
         let (tx, consumed) = super::build_commit_transaction(
-            vec![unspendable, unsolvable, viable.clone()],
+            vec![unspendable, unsolvable, legacy, viable.clone()],
             ctx.sequencer_address.clone(),
             ctx.sequencer_address.clone(),
             500_000_000,

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -123,11 +123,6 @@ pub enum EnvelopeError {
         ceiling_sat_vb: u64,
     },
 
-    #[error(
-        "wallet-signed commit fee did not stabilize at the requested rate after {attempts} attempts"
-    )]
-    CommitFeeDidNotStabilize { attempts: usize },
-
     #[error("Could not sign raw transaction: {0}")]
     SignRawTransaction(#[source] ClientError),
 
@@ -269,7 +264,7 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
     let mut envelope = create_envelope_transactions(&env_config, payload, utxos)?;
 
     let unsigned_commit_txid = envelope.commit_tx.compute_txid();
-    let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+    let (signed_commit, commit_fee) = sign_commit_with_fee_guardrail(
         ctx.client.as_ref(),
         envelope.commit_tx,
         envelope.commit_fee,
@@ -361,14 +356,14 @@ pub(crate) fn ensure_built_fee_rate_within_max(
     Ok(())
 }
 
-/// Signs a commit, correcting its absolute fee only when the first signature breaches the ceiling.
+/// Signs a commit, correcting its absolute fee only while its signed rate breaches the ceiling.
 ///
 /// Wallet ECDSA signatures can be shorter than the conservative witness used during funding. If
 /// that makes the signed transaction exceed `max_fee_rate`, this refunds the excess through the
-/// final output and asks the wallet to sign again. Repricing continues until the fee matches the
-/// requested rate for the transaction's actual signed vsize; the bound prevents a faulty signer
-/// from keeping the writer inside an RPC loop indefinitely.
-pub(crate) async fn sign_commit_at_requested_fee<C: Signer>(
+/// final output and asks the wallet to sign again. The first ceiling-safe result is accepted even
+/// when another signature size would change the exact requested fee, avoiding a fixed-point cycle.
+/// The bound prevents a faulty signer from keeping the writer inside an RPC loop indefinitely.
+pub(crate) async fn sign_commit_with_fee_guardrail<C: Signer>(
     client: &C,
     mut commit_tx: Transaction,
     original_fee: Amount,
@@ -381,28 +376,28 @@ pub(crate) async fn sign_commit_at_requested_fee<C: Signer>(
         .expect("commit transaction has at least one output")
         .value;
     let mut commit_fee = original_fee;
-    let mut correcting_fee = false;
-
-    for _ in 0..MAX_COMMIT_SIGNING_ATTEMPTS {
+    for attempt in 0..MAX_COMMIT_SIGNING_ATTEMPTS {
         let signed_commit = client
             .sign_raw_transaction_with_wallet(&commit_tx, None)
             .await
             .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
 
-        if !correcting_fee
-            && ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate).is_ok()
-        {
-            return Ok((signed_commit, commit_fee));
+        let guardrail_error =
+            match ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate) {
+                Ok(()) => return Ok((signed_commit, commit_fee)),
+                Err(error @ EnvelopeError::BuiltFeeRateAboveMax { .. }) => error,
+                Err(error) => return Err(error),
+            };
+        if attempt + 1 == MAX_COMMIT_SIGNING_ATTEMPTS {
+            return Err(guardrail_error);
         }
 
-        correcting_fee = true;
         let requested_fee = requested_fee_rate
             .fee_vb(signed_commit.vsize() as u64)
             .ok_or(EnvelopeError::FeeOverflow)?;
         if commit_fee == requested_fee {
-            ensure_built_fee_rate_within_max(&signed_commit, commit_fee, max_fee_rate)?;
-            return Ok((signed_commit, commit_fee));
+            return Err(guardrail_error);
         }
 
         let adjusted_output_value = original_fee_output
@@ -421,9 +416,7 @@ pub(crate) async fn sign_commit_at_requested_fee<C: Signer>(
         commit_fee = requested_fee;
     }
 
-    Err(EnvelopeError::CommitFeeDidNotStabilize {
-        attempts: MAX_COMMIT_SIGNING_ATTEMPTS,
-    })
+    unreachable!("commit signing attempt bound is nonzero")
 }
 
 /// Rebinds a single reveal after commit repricing changes the commit txid or carry output.
@@ -1380,11 +1373,9 @@ mod tests {
         assert!(p2wpkh_vsize > schnorr_only_vsize);
     }
 
-    #[tokio::test]
-    async fn commit_repricing_preserves_one_sat_per_vbyte_request() {
-        let (ctx, _, _, mut utxos) = get_mock_data();
+    fn commit_signing_fixture() -> (Transaction, Amount) {
+        let (ctx, _, _, utxos) = get_mock_data();
         let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
-        utxos.truncate(2);
         let outputs = vec![
             TxOut {
                 value: Amount::from_sat(100_000),
@@ -1396,18 +1387,28 @@ mod tests {
             },
         ];
         let estimated_vsize = signed_commit_vsize(&utxos, &outputs);
-        let original_fee = Amount::from_sat(fee_sats_for_vsize(estimated_vsize, fee_rate).unwrap());
-        let original_change = outputs.last().unwrap().value;
+        let original_fee = Amount::from_sat(
+            fee_sats_for_vsize(estimated_vsize, fee_rate).expect("fixture fee fits"),
+        );
         let unsigned_commit = Transaction {
             version: Version::TWO,
             lock_time: LockTime::ZERO,
             input: commit_inputs(&utxos),
             output: outputs,
         };
+
+        (unsigned_commit, original_fee)
+    }
+
+    #[tokio::test]
+    async fn commit_repricing_preserves_one_sat_per_vbyte_request() {
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+        let (unsigned_commit, original_fee) = commit_signing_fixture();
+        let original_change = unsigned_commit.output.last().unwrap().value;
         let client = TestBitcoinClient::new(0)
             .with_sign_raw_transaction_witness_size(MAX_ECDSA_SIGNATURE_SIZE - 2);
 
-        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+        let (signed_commit, commit_fee) = sign_commit_with_fee_guardrail(
             &client,
             unsigned_commit,
             original_fee,
@@ -1427,6 +1428,60 @@ mod tests {
             original_change + (original_fee - commit_fee)
         );
         assert!(ensure_built_fee_rate_within_max(&signed_commit, commit_fee, fee_rate).is_ok());
+    }
+
+    #[tokio::test]
+    async fn commit_repricing_accepts_a_ceiling_safe_signature_size_cycle() {
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+        let (unsigned_commit, original_fee) = commit_signing_fixture();
+        // Across three inputs, Core's normal one-byte DER variation changes the aggregate vsize.
+        let client = TestBitcoinClient::new(0).with_sign_raw_transaction_witness_sizes(vec![
+            MAX_ECDSA_SIGNATURE_SIZE - 3,
+            MAX_ECDSA_SIGNATURE_SIZE - 2,
+            MAX_ECDSA_SIGNATURE_SIZE - 3,
+        ]);
+
+        let (signed_commit, commit_fee) = sign_commit_with_fee_guardrail(
+            &client,
+            unsigned_commit,
+            original_fee,
+            fee_rate,
+            fee_rate,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(client.sign_raw_transaction_calls().len(), 2);
+        assert!(commit_fee < fee_rate.fee_vb(signed_commit.vsize() as u64).unwrap());
+        assert!(ensure_built_fee_rate_within_max(&signed_commit, commit_fee, fee_rate).is_ok());
+    }
+
+    #[tokio::test]
+    async fn exhausted_commit_corrections_remain_blocked_by_the_guardrail() {
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+        let (unsigned_commit, original_fee) = commit_signing_fixture();
+        let witness_sizes = (0..MAX_COMMIT_SIGNING_ATTEMPTS)
+            .map(|attempt| MAX_ECDSA_SIGNATURE_SIZE - 2 * (attempt + 1))
+            .collect();
+        let client =
+            TestBitcoinClient::new(0).with_sign_raw_transaction_witness_sizes(witness_sizes);
+
+        let error = sign_commit_with_fee_guardrail(
+            &client,
+            unsigned_commit,
+            original_fee,
+            fee_rate,
+            fee_rate,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            client.sign_raw_transaction_calls().len(),
+            MAX_COMMIT_SIGNING_ATTEMPTS
+        );
+        assert!(matches!(error, EnvelopeError::BuiltFeeRateAboveMax { .. }));
+        assert!(error.is_blocked_by_fee_guardrail());
     }
 
     #[tokio::test]
@@ -1450,7 +1505,7 @@ mod tests {
         let client = TestBitcoinClient::new(0)
             .with_sign_raw_transaction_witness_size(MAX_ECDSA_SIGNATURE_SIZE - 2);
 
-        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+        let (signed_commit, commit_fee) = sign_commit_with_fee_guardrail(
             &client,
             unsigned_commit,
             original_fee,

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -101,6 +101,22 @@ pub enum EnvelopeError {
     #[error("fee calculation overflowed")]
     FeeOverflow,
 
+    #[error(
+        "resolved fee rate {resolved_sat_vb} sat/vB exceeds broadcast ceiling {ceiling_sat_vb} sat/vB"
+    )]
+    ResolvedFeeRateAboveMax {
+        resolved_sat_vb: u64,
+        ceiling_sat_vb: u64,
+    },
+
+    #[error(
+        "built transaction fee rate {built_sat_vb} sat/vB exceeds broadcast ceiling {ceiling_sat_vb} sat/vB"
+    )]
+    BuiltFeeRateAboveMax {
+        built_sat_vb: u64,
+        ceiling_sat_vb: u64,
+    },
+
     #[error("Could not sign raw transaction: {0}")]
     SignRawTransaction(#[source] ClientError),
 
@@ -127,6 +143,16 @@ pub enum EnvelopeError {
 
     #[error("{0}")]
     Other(#[from] anyhow::Error),
+}
+
+impl EnvelopeError {
+    /// Reports whether transaction construction should wait for a fee rate below the guardrail.
+    pub(crate) fn is_blocked_by_fee_guardrail(&self) -> bool {
+        matches!(
+            self,
+            Self::ResolvedFeeRateAboveMax { .. } | Self::BuiltFeeRateAboveMax { .. }
+        )
+    }
 }
 
 /// Intermediate data held in the watcher's in-memory cache between envelope creation and reveal
@@ -195,9 +221,7 @@ pub(crate) async fn build_envelope_txs<R: Reader + Signer + Wallet>(
     ctx: &WriterContext<R>,
     envelope_pubkey: XOnlyPublicKey,
 ) -> Result<EnvelopeData, EnvelopeError> {
-    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx)
-        .await
-        .map_err(EnvelopeError::PrereqFetch)?;
+    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx).await?;
     let env_config = EnvelopeConfig::new(
         ctx.btcio_params.magic_bytes(),
         ctx.sequencer_address.clone(),
@@ -219,9 +243,7 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
     payload: &L1Payload,
     ctx: &WriterContext<R>,
 ) -> Result<EnvelopeData, EnvelopeError> {
-    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx)
-        .await
-        .map_err(EnvelopeError::PrereqFetch)?;
+    let (network, utxos, fee_rate) = fetch_envelope_prereqs(ctx).await?;
     let keypair = generate_key_pair()?;
     let pubkey = XOnlyPublicKey::from_keypair(&keypair).0;
     let env_config = EnvelopeConfig::new(
@@ -259,15 +281,60 @@ pub(crate) async fn build_and_sign_envelope_txs<R: Reader + Signer + Wallet>(
 // TODO(STR-3411): make OL node resilient against the Bitcoin node not being available.
 async fn fetch_envelope_prereqs<R: Reader + Signer + Wallet>(
     ctx: &WriterContext<R>,
-) -> anyhow::Result<(Network, Vec<ListUnspentItem>, FeeRate)> {
-    let network = ctx.client.network().await?;
+) -> Result<(Network, Vec<ListUnspentItem>, FeeRate), EnvelopeError> {
+    let network = ctx
+        .client
+        .network()
+        .await
+        .map_err(|error| EnvelopeError::PrereqFetch(error.into()))?;
     let utxos = ctx
         .client
         .list_unspent(None, None, None, None, None)
-        .await?
+        .await
+        .map_err(|error| EnvelopeError::PrereqFetch(error.into()))?
         .0;
-    let fee_rate = resolve_fee_rate(ctx.client.as_ref(), ctx.config.as_ref()).await?;
+    let fee_rate = resolve_fee_rate(ctx.client.as_ref(), ctx.config.as_ref())
+        .await
+        .map_err(EnvelopeError::PrereqFetch)?;
+    ensure_initial_fee_rate_within_max(fee_rate, ctx.max_fee_rate)?;
     Ok((network, utxos, fee_rate))
+}
+
+/// Ensures an initial transaction is never built from an estimate above the broadcast ceiling.
+pub(crate) fn ensure_initial_fee_rate_within_max(
+    fee_rate: FeeRate,
+    max_fee_rate: FeeRate,
+) -> Result<(), EnvelopeError> {
+    if fee_rate > max_fee_rate {
+        return Err(EnvelopeError::ResolvedFeeRateAboveMax {
+            resolved_sat_vb: fee_rate.to_sat_per_vb_ceil(),
+            ceiling_sat_vb: max_fee_rate.to_sat_per_vb_ceil(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Ensures a built transaction's effective fee rate fits the broadcast ceiling.
+pub(crate) fn ensure_built_fee_rate_within_max(
+    tx: &Transaction,
+    fee: Amount,
+    max_fee_rate: FeeRate,
+) -> Result<(), EnvelopeError> {
+    let vsize = tx.vsize() as u64;
+    if vsize == 0 {
+        return Err(EnvelopeError::FeeOverflow);
+    }
+    let built_fee_rate =
+        FeeRate::from_sat_per_vb(fee.to_sat().div_ceil(vsize)).ok_or(EnvelopeError::FeeOverflow)?;
+    if built_fee_rate > max_fee_rate {
+        return Err(EnvelopeError::BuiltFeeRateAboveMax {
+            built_sat_vb: built_fee_rate.to_sat_per_vb_ceil(),
+            ceiling_sat_vb: max_fee_rate.to_sat_per_vb_ceil(),
+        });
+    }
+
+    Ok(())
 }
 
 /// Builds unsigned envelope transactions (commit + reveal) and computes the sighash.
@@ -324,7 +391,7 @@ pub fn create_envelope_transactions(
     );
     let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
     let headroom = reveal_fee_headroom(env_config.fee_rate, reveal_vsize, &env_config.fee_bumping)?;
-    let reveal_output_value = env_config
+    let base_reveal_output_value = env_config
         .reveal_amount
         .checked_add(headroom)
         .ok_or(EnvelopeError::FeeOverflow)?;
@@ -340,6 +407,10 @@ pub fn create_envelope_transactions(
     let commit_fee_sats = calculate_transaction_fee_from_utxos(&commit_tx, &consumed_utxos);
 
     let output_to_reveal = commit_tx.output[0].clone();
+    let returned_dust = output_to_reveal.value.to_sat().saturating_sub(commit_value);
+    let reveal_output_value = base_reveal_output_value
+        .checked_add(returned_dust)
+        .ok_or(EnvelopeError::FeeOverflow)?;
 
     // Build reveal tx
     let reveal_tx = build_reveal_transaction(
@@ -535,7 +606,14 @@ fn build_commit_transaction(
                     script_pubkey: change_address.script_pubkey(),
                 });
             } else {
-                // if dust is left, leave it for fee
+                // Return sub-dust change through the reveal output instead of silently turning it
+                // into extra fee. The reveal builder forwards the same amount to the sequencer,
+                // keeping both transactions at their requested fee rate and therefore within the
+                // broadcast guardrail when the requested rate is within it.
+                outputs[0].value = outputs[0]
+                    .value
+                    .checked_add(Amount::from_sat(excess))
+                    .ok_or(EnvelopeError::FeeOverflow)?;
                 direct_return = true;
             }
         }
@@ -956,6 +1034,71 @@ mod tests {
             res,
             Err(EnvelopeError::NotEnoughUtxos(50_000_000_000, _))
         ));
+    }
+
+    #[test]
+    fn initial_fee_rate_above_broadcast_ceiling_is_blocked() {
+        let ceiling = FeeRate::from_sat_per_vb(100).unwrap();
+
+        assert!(ensure_initial_fee_rate_within_max(ceiling, ceiling).is_ok());
+        assert!(matches!(
+            ensure_initial_fee_rate_within_max(FeeRate::from_sat_per_vb(101).unwrap(), ceiling),
+            Err(EnvelopeError::ResolvedFeeRateAboveMax {
+                resolved_sat_vb: 101,
+                ceiling_sat_vb: 100,
+            })
+        ));
+    }
+
+    #[test]
+    fn built_fee_rate_above_broadcast_ceiling_is_blocked() {
+        let (_, _, _, utxos) = get_mock_data();
+        let tx = get_txn_from_utxo(&utxos[0], &get_writer_context().sequencer_address);
+        let ceiling = FeeRate::from_sat_per_vb(100).unwrap();
+        let fee_at_ceiling = ceiling.fee_vb(tx.vsize() as u64).unwrap();
+
+        assert!(ensure_built_fee_rate_within_max(&tx, fee_at_ceiling, ceiling).is_ok());
+        assert!(matches!(
+            ensure_built_fee_rate_within_max(
+                &tx,
+                fee_at_ceiling + Amount::from_sat(tx.vsize() as u64),
+                ceiling,
+            ),
+            Err(EnvelopeError::BuiltFeeRateAboveMax {
+                built_sat_vb: 101,
+                ceiling_sat_vb: 100,
+            })
+        ));
+    }
+
+    #[test]
+    fn commit_returns_sub_dust_change_through_reveal_output() {
+        let (ctx, _, _, mut utxos) = get_mock_data();
+        let output_value = 100_000;
+        let returned_dust = 100;
+        let fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
+        let recipient = ctx.sequencer_address.clone();
+        let initial_size = get_size(
+            &default_txin(),
+            &[TxOut {
+                value: Amount::from_sat(output_value),
+                script_pubkey: recipient.script_pubkey(),
+            }],
+            None,
+            None,
+        );
+        let requested_fee = fee_sats_for_vsize(initial_size, fee_rate).unwrap();
+        utxos.truncate(1);
+        utxos[0].amount = Amount::from_sat(output_value + requested_fee + returned_dust);
+
+        let (tx, consumed) =
+            build_commit_transaction(utxos, recipient.clone(), recipient, output_value, fee_rate)
+                .unwrap();
+        let actual_fee = calculate_transaction_fee_from_utxos(&tx, &consumed);
+
+        assert_eq!(tx.output.len(), 1);
+        assert_eq!(tx.output[0].value.to_sat(), output_value + returned_dust);
+        assert_eq!(actual_fee, requested_fee);
     }
 
     fn get_txn_from_utxo(utxo: &ListUnspentItem, _address: &Address) -> Transaction {

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -26,8 +26,8 @@ use strata_l1_txfmt::MagicBytes;
 
 use super::commit_op_return::build_commit_op_return;
 use crate::writer::builder::{
-    choose_utxos, fee_sats_for_vsize, get_size, reveal_fee_headroom, sign_reveal_transaction,
-    EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT,
+    fee_sats_for_vsize, fund_commit_transaction, get_size, reveal_fee_headroom,
+    sign_reveal_transaction, EnvelopeConfig, EnvelopeError,
 };
 
 /// Intermediate state for each reveal before tx construction.
@@ -164,14 +164,14 @@ fn build_reveals_for_commit(
         let reveal_fee = fee_sats_for_vsize(reveal_vsize, config.fee_rate)?;
         let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
         let headroom = reveal_fee_headroom(config.fee_rate, reveal_vsize, &config.fee_bumping)?;
-        let returned_dust = commit_output
+        let carried_change = commit_output
             .value
             .to_sat()
             .saturating_sub(artifact.commit_value);
         let reveal_output_value = config
             .reveal_amount
             .checked_add(headroom)
-            .and_then(|value| value.checked_add(returned_dust))
+            .and_then(|value| value.checked_add(carried_change))
             .ok_or(EnvelopeError::FeeOverflow)?;
         let required = reveal_output_value
             .checked_add(reveal_fee)
@@ -251,11 +251,6 @@ fn build_multi_output_commit(
     op_return_script: &ScriptBuf,
     utxos: Vec<ListUnspentItem>,
 ) -> Result<(Transaction, Amount), EnvelopeError> {
-    let spendable: Vec<ListUnspentItem> = utxos
-        .into_iter()
-        .filter(|u| u.spendable && u.solvable && u.amount.to_sat() > BITCOIN_DUST_LIMIT)
-        .collect();
-
     let p2tr_outputs: Vec<TxOut> = artifacts
         .iter()
         .map(|a| {
@@ -278,70 +273,18 @@ fn build_multi_output_commit(
         script_pubkey: op_return_script.clone(),
     };
 
-    let total_output: u64 = artifacts.iter().map(|a| a.commit_value).sum();
-
-    let initial_outputs: Vec<TxOut> = iter::once(op_return_output.clone())
+    let base_outputs: Vec<TxOut> = iter::once(op_return_output)
         .chain(p2tr_outputs.iter().cloned())
         .collect();
+    let (commit_tx, _, commit_fee) = fund_commit_transaction(
+        utxos,
+        base_outputs,
+        config.sequencer_address.script_pubkey(),
+        1,
+        config.fee_rate,
+    )?;
 
-    let mut last_size = get_size(
-        &[make_txin(bitcoin::Txid::all_zeros(), 0)],
-        &initial_outputs,
-        None,
-        None,
-    );
-
-    loop {
-        let fee = fee_sats_for_vsize(last_size, config.fee_rate)?;
-        let needed = total_output
-            .checked_add(fee)
-            .ok_or(EnvelopeError::FeeOverflow)?;
-        let (chosen, sum) = choose_utxos(&spendable, needed)?;
-
-        let inputs: Vec<TxIn> = chosen.iter().map(|u| make_txin(u.txid, u.vout)).collect();
-
-        let mut outputs: Vec<TxOut> = iter::once(op_return_output.clone())
-            .chain(p2tr_outputs.iter().cloned())
-            .collect();
-
-        let mut done = false;
-        if let Some(excess) = sum.checked_sub(needed) {
-            if excess >= BITCOIN_DUST_LIMIT {
-                outputs.push(TxOut {
-                    value: Amount::from_sat(excess),
-                    script_pubkey: config.sequencer_address.script_pubkey(),
-                });
-            } else {
-                // Return sub-dust change through the first reveal rather than overpaying the
-                // commit fee. `build_reveals_for_commit` carries this extra value through to that
-                // reveal's sequencer output, so it is not burned as reveal fee either.
-                outputs[1].value = outputs[1]
-                    .value
-                    .checked_add(Amount::from_sat(excess))
-                    .ok_or(EnvelopeError::FeeOverflow)?;
-                done = true;
-            }
-        }
-
-        let size = get_size(&inputs, &outputs, None, None);
-        if size == last_size || done {
-            // Derive the fee from actual totals so the persisted record remains authoritative if
-            // transaction construction changes independently of the sizing estimate.
-            let output_total: u64 = outputs.iter().map(|output| output.value.to_sat()).sum();
-            let commit_fee = Amount::from_sat(sum.saturating_sub(output_total));
-
-            return Ok((
-                Transaction {
-                    lock_time: LockTime::ZERO,
-                    version: Version(2),
-                    input: inputs,
-                    output: outputs,
-                },
-                commit_fee,
-            ));
-        }
-        last_size = size;
-    }
+    Ok((commit_tx, commit_fee))
 }
 
 fn make_txin(txid: bitcoin::Txid, vout: u32) -> TxIn {
@@ -558,6 +501,10 @@ mod tests {
         .unwrap();
         let mut no_change_commit = baseline.commit_tx.clone();
         no_change_commit.output.pop();
+        let mock_utxos = get_mock_utxos();
+        no_change_commit
+            .input
+            .push(make_txin(mock_utxos[1].txid, mock_utxos[1].vout));
         let fixed_output_total: u64 = no_change_commit
             .output
             .iter()
@@ -576,10 +523,10 @@ mod tests {
             )
             .unwrap();
         let returned_dust = 100;
-        let mut utxos = get_mock_utxos();
-        utxos.truncate(1);
-        utxos[0].amount =
-            Amount::from_sat(fixed_output_total + requested_fee.to_sat() + returned_dust);
+        let input_total = fixed_output_total + requested_fee.to_sat() + returned_dust;
+        let mut utxos = mock_utxos;
+        utxos[0].amount = Amount::from_sat(input_total / 2);
+        utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
         let result = build_chunked_envelope_txs(
             &config,
@@ -594,6 +541,7 @@ mod tests {
         let commit_output = result.commit_tx.output[1].value;
         let reveal_output_total: Amount = reveal.output.iter().map(|output| output.value).sum();
 
+        assert_eq!(result.commit_tx.input.len(), 2);
         assert_eq!(result.commit_tx.output.len(), 2);
         assert_eq!(result.commit_fee, requested_fee);
         assert_eq!(

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -303,14 +303,17 @@ mod tests {
     use bitcoin::{
         opcodes::all::OP_RETURN,
         secp256k1::{rand, Keypair, Secp256k1},
-        Network, ScriptBuf, Txid,
+        Network, Txid,
     };
     use bitcoind_async_client::corepc_types::model::ListUnspentItem;
 
     use super::*;
     use crate::{
         test_utils::test_context::get_writer_context,
-        writer::chunked_envelope::commit_op_return::COMMIT_OP_RETURN_PAYLOAD_LEN,
+        writer::{
+            builder::signed_commit_vsize,
+            chunked_envelope::commit_op_return::COMMIT_OP_RETURN_PAYLOAD_LEN,
+        },
     };
 
     const TEST_DA_BLOB_VERSION: u32 = 1;
@@ -330,7 +333,7 @@ mod tests {
                     .unwrap(),
                 vout: 0,
                 address: address.as_unchecked().clone(),
-                script_pubkey: ScriptBuf::new(),
+                script_pubkey: address.script_pubkey(),
                 amount: Amount::from_btc(100.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
@@ -347,7 +350,7 @@ mod tests {
                     .unwrap(),
                 vout: 0,
                 address: address.as_unchecked().clone(),
-                script_pubkey: ScriptBuf::new(),
+                script_pubkey: address.script_pubkey(),
                 amount: Amount::from_btc(50.0).unwrap(),
                 confirmations: 100,
                 spendable: true,
@@ -513,13 +516,7 @@ mod tests {
         let requested_fee = config
             .fee_rate
             .fee_vb(
-                u64::try_from(get_size(
-                    &no_change_commit.input,
-                    &no_change_commit.output,
-                    None,
-                    None,
-                ))
-                .unwrap(),
+                u64::try_from(signed_commit_vsize(&mock_utxos, &no_change_commit.output)).unwrap(),
             )
             .unwrap();
         let returned_dust = 100;
@@ -568,7 +565,7 @@ mod tests {
                 .unwrap(),
             vout: 0,
             address: address.as_unchecked().clone(),
-            script_pubkey: ScriptBuf::new(),
+            script_pubkey: address.script_pubkey(),
             amount: Amount::from_sat(1_000),
             confirmations: 100,
             spendable: true,

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -128,6 +128,18 @@ fn build_reveal_artifacts(
     Ok(artifacts)
 }
 
+/// Rebuilds chunk reveals after commit repricing changes their prevout txid or value.
+pub(super) fn rebuild_chunked_reveals<'a>(
+    config: &EnvelopeConfig,
+    chunks: impl IntoIterator<Item = &'a [u8]>,
+    sequencer_keypair: &Keypair,
+    commit_tx: &Transaction,
+) -> Result<Vec<Transaction>, EnvelopeError> {
+    let sequencer_xonly = XOnlyPublicKey::from_keypair(sequencer_keypair).0;
+    let artifacts = build_reveal_artifacts(chunks.into_iter().collect(), sequencer_xonly, config)?;
+    build_reveals_for_commit(config, &artifacts, sequencer_keypair, commit_tx)
+}
+
 fn build_reveals_for_commit(
     config: &EnvelopeConfig,
     artifacts: &[RevealArtifact],
@@ -282,7 +294,6 @@ fn build_multi_output_commit(
         config.sequencer_address.script_pubkey(),
         1,
         config.fee_rate,
-        config.max_fee_rate,
     )?;
 
     Ok((commit_tx, commit_fee))
@@ -376,7 +387,6 @@ mod tests {
             FeeBumpingConfig::default(),
             None,
         )
-        .with_max_fee_rate(FeeRate::from_sat_per_vb(1_000).unwrap())
     }
 
     #[test]
@@ -527,7 +537,7 @@ mod tests {
         utxos[0].amount = Amount::from_sat(input_total / 2);
         utxos[1].amount = Amount::from_sat(input_total - input_total / 2);
 
-        let result = build_chunked_envelope_txs(
+        let mut result = build_chunked_envelope_txs(
             &config,
             chunks.iter().map(Vec::as_slice),
             &magic,
@@ -550,6 +560,38 @@ mod tests {
         assert_eq!(
             reveal.output[0].value.to_sat(),
             baseline.reveal_txs[0].output[0].value.to_sat() + returned_dust
+        );
+
+        let refund = Amount::from_sat(2);
+        result.commit_tx.output.last_mut().unwrap().value += refund;
+        result.reveal_txs = rebuild_chunked_reveals(
+            &config,
+            chunks.iter().map(Vec::as_slice),
+            &keypair,
+            &result.commit_tx,
+        )
+        .unwrap();
+        let repriced_reveal = &result.reveal_txs[0];
+        let repriced_output_total: Amount = repriced_reveal
+            .output
+            .iter()
+            .map(|output| output.value)
+            .sum();
+
+        assert_eq!(
+            repriced_reveal.input[0].previous_output.txid,
+            result.commit_tx.compute_txid()
+        );
+        assert_eq!(
+            repriced_reveal.output[0].value.to_sat(),
+            baseline.reveal_txs[0].output[0].value.to_sat() + returned_dust + refund.to_sat()
+        );
+        assert_eq!(
+            result.commit_tx.output[1].value - repriced_output_total,
+            config
+                .fee_rate
+                .fee_vb(repriced_reveal.vsize() as u64)
+                .unwrap()
         );
     }
 

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -282,6 +282,7 @@ fn build_multi_output_commit(
         config.sequencer_address.script_pubkey(),
         1,
         config.fee_rate,
+        config.max_fee_rate,
     )?;
 
     Ok((commit_tx, commit_fee))
@@ -375,6 +376,7 @@ mod tests {
             FeeBumpingConfig::default(),
             None,
         )
+        .with_max_fee_rate(FeeRate::from_sat_per_vb(1_000).unwrap())
     }
 
     #[test]

--- a/crates/btcio/src/writer/chunked_envelope/builder.rs
+++ b/crates/btcio/src/writer/chunked_envelope/builder.rs
@@ -44,9 +44,8 @@ pub struct ChunkedEnvelopeTxs {
     pub reveal_txs: Vec<Transaction>,
     /// Exact absolute fee the commit tx pays.
     ///
-    /// This is `sum(inputs) - sum(outputs)`, not `vsize * fee_rate`: when the leftover change
-    /// would be dust the builder drops the change output and the excess becomes extra fee. Fee
-    /// bumping needs the real figure to compute the BIP-125 absolute-fee floor for a replacement.
+    /// This is `sum(inputs) - sum(outputs)`, so fee bumping records the authoritative figure used
+    /// by the BIP-125 absolute-fee floor rather than relying on a sizing estimate.
     pub commit_fee: Amount,
 }
 
@@ -165,9 +164,14 @@ fn build_reveals_for_commit(
         let reveal_fee = fee_sats_for_vsize(reveal_vsize, config.fee_rate)?;
         let reveal_vsize = u64::try_from(reveal_vsize).map_err(|_| EnvelopeError::FeeOverflow)?;
         let headroom = reveal_fee_headroom(config.fee_rate, reveal_vsize, &config.fee_bumping)?;
+        let returned_dust = commit_output
+            .value
+            .to_sat()
+            .saturating_sub(artifact.commit_value);
         let reveal_output_value = config
             .reveal_amount
             .checked_add(headroom)
+            .and_then(|value| value.checked_add(returned_dust))
             .ok_or(EnvelopeError::FeeOverflow)?;
         let required = reveal_output_value
             .checked_add(reveal_fee)
@@ -308,14 +312,21 @@ fn build_multi_output_commit(
                     script_pubkey: config.sequencer_address.script_pubkey(),
                 });
             } else {
+                // Return sub-dust change through the first reveal rather than overpaying the
+                // commit fee. `build_reveals_for_commit` carries this extra value through to that
+                // reveal's sequencer output, so it is not burned as reveal fee either.
+                outputs[1].value = outputs[1]
+                    .value
+                    .checked_add(Amount::from_sat(excess))
+                    .ok_or(EnvelopeError::FeeOverflow)?;
                 done = true;
             }
         }
 
         let size = get_size(&inputs, &outputs, None, None);
         if size == last_size || done {
-            // `done` means the leftover change was dust and got absorbed into the fee, so derive
-            // the fee from the actual input/output totals rather than from `fee_rate * vsize`.
+            // Derive the fee from actual totals so the persisted record remains authoritative if
+            // transaction construction changes independently of the sizing estimate.
             let output_total: u64 = outputs.iter().map(|output| output.value.to_sat()).sum();
             let commit_fee = Amount::from_sat(sum.saturating_sub(output_total));
 
@@ -527,6 +538,71 @@ mod tests {
         assert_eq!(
             result.commit_tx.output[1].value.to_sat(),
             config.reveal_amount + base_fee.to_sat()
+        );
+    }
+
+    #[test]
+    fn sub_dust_commit_change_is_returned_through_first_reveal() {
+        let config = get_test_config();
+        let chunks = [vec![1u8; 150]];
+        let magic = MagicBytes::from([0xAA, 0xBB, 0xCC, 0xDD]);
+        let keypair = test_keypair();
+        let baseline = build_chunked_envelope_txs(
+            &config,
+            chunks.iter().map(Vec::as_slice),
+            &magic,
+            TEST_DA_BLOB_VERSION,
+            &keypair,
+            get_mock_utxos(),
+        )
+        .unwrap();
+        let mut no_change_commit = baseline.commit_tx.clone();
+        no_change_commit.output.pop();
+        let fixed_output_total: u64 = no_change_commit
+            .output
+            .iter()
+            .map(|output| output.value.to_sat())
+            .sum();
+        let requested_fee = config
+            .fee_rate
+            .fee_vb(
+                u64::try_from(get_size(
+                    &no_change_commit.input,
+                    &no_change_commit.output,
+                    None,
+                    None,
+                ))
+                .unwrap(),
+            )
+            .unwrap();
+        let returned_dust = 100;
+        let mut utxos = get_mock_utxos();
+        utxos.truncate(1);
+        utxos[0].amount =
+            Amount::from_sat(fixed_output_total + requested_fee.to_sat() + returned_dust);
+
+        let result = build_chunked_envelope_txs(
+            &config,
+            chunks.iter().map(Vec::as_slice),
+            &magic,
+            TEST_DA_BLOB_VERSION,
+            &keypair,
+            utxos,
+        )
+        .unwrap();
+        let reveal = &result.reveal_txs[0];
+        let commit_output = result.commit_tx.output[1].value;
+        let reveal_output_total: Amount = reveal.output.iter().map(|output| output.value).sum();
+
+        assert_eq!(result.commit_tx.output.len(), 2);
+        assert_eq!(result.commit_fee, requested_fee);
+        assert_eq!(
+            commit_output - reveal_output_total,
+            config.fee_rate.fee_vb(reveal.vsize() as u64).unwrap()
+        );
+        assert_eq!(
+            reveal.output[0].value.to_sat(),
+            baseline.reveal_txs[0].output[0].value.to_sat() + returned_dust
         );
     }
 

--- a/crates/btcio/src/writer/chunked_envelope/context.rs
+++ b/crates/btcio/src/writer/chunked_envelope/context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitcoin::{key::Keypair, Address};
+use bitcoin::{key::Keypair, Address, FeeRate};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_config::btcio::WriterConfig;
 
@@ -19,6 +19,9 @@ pub(crate) struct ChunkedWriterContext<R: Reader + Signer + Wallet> {
     /// Btcio specific configuration.
     pub config: Arc<WriterConfig>,
 
+    /// Maximum fee rate accepted for initial transaction construction and broadcast.
+    pub max_fee_rate: FeeRate,
+
     /// Sequencer's address to watch utxos for and spend change amount to.
     pub sequencer_address: Address,
 
@@ -36,6 +39,7 @@ impl<R: Reader + Signer + Wallet> ChunkedWriterContext<R> {
     pub(crate) fn new(
         btcio_params: BtcioParams,
         config: Arc<WriterConfig>,
+        max_fee_rate: FeeRate,
         sequencer_address: Address,
         sequencer_keypair: Keypair,
         client: Arc<R>,
@@ -44,6 +48,7 @@ impl<R: Reader + Signer + Wallet> ChunkedWriterContext<R> {
         Self {
             btcio_params,
             config,
+            max_fee_rate,
             sequencer_address,
             sequencer_keypair,
             client,

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -37,7 +37,10 @@ use super::{
     signer::{sign_chunked_envelope, SignedChunkedEnvelope},
 };
 use crate::{
-    broadcaster::{is_benign_minus25_message, L1BroadcastHandle},
+    broadcaster::{
+        is_benign_minus25_message, is_max_fee_rate_exceeded_message,
+        send_raw_transaction_with_max_fee_rate, L1BroadcastHandle,
+    },
     rpc_error::{is_retryable_client_error, is_retryable_envelope_error, retryable_reason},
     tx_attempt::attempt_parts,
     tx_entry::L1TxEntryExt,
@@ -528,15 +531,20 @@ async fn reconcile_active_entries(
 async fn publish_commit_immediately<R: Broadcaster>(
     client: &R,
     commit_tx_entry: &L1TxEntry,
+    max_fee_rate: FeeRate,
 ) -> anyhow::Result<CommitPublishResult> {
     let tx = commit_tx_entry.try_to_tx()?;
     let txid = tx.compute_txid();
     debug!(%txid, vsize = tx.vsize(), "broadcasting chunked envelope commit");
 
-    match client.send_raw_transaction(&tx, None).await {
+    match send_raw_transaction_with_max_fee_rate(client, &tx, max_fee_rate).await {
         Ok(_) => {
             info!(%txid, "chunked envelope commit accepted by bitcoind");
             Ok(CommitPublishResult::Published)
+        }
+        Err(ClientError::Server(-25, msg)) if is_max_fee_rate_exceeded_message(&msg) => {
+            warn!(%txid, %msg, max_fee_rate_sat_vb = max_fee_rate.to_sat_per_vb_ceil(), "commit broadcast blocked by fee guardrail");
+            Ok(CommitPublishResult::Deferred(msg))
         }
         Err(ClientError::Server(-25, msg)) => {
             // Bitcoind reuses -25 (RPC_VERIFY_ERROR) for both benign
@@ -599,7 +607,13 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
         "persisted signed chunked envelope before commit broadcast"
     );
 
-    match publish_commit_immediately(ctx.client.as_ref(), &commit_tx_entry).await? {
+    match publish_commit_immediately(
+        ctx.client.as_ref(),
+        &commit_tx_entry,
+        broadcast_handle.max_fee_rate(),
+    )
+    .await?
+    {
         CommitPublishResult::Published => {
             commit_tx_entry.status = L1TxStatus::Published;
             broadcast_handle
@@ -1461,9 +1475,13 @@ mod tests {
             .with_send_raw_transaction_mode(SendRawTransactionMode::ConnectionError);
         let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
 
-        let result = publish_commit_immediately(&client, &commit_tx_entry)
-            .await
-            .unwrap();
+        let result = publish_commit_immediately(
+            &client,
+            &commit_tx_entry,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+        )
+        .await
+        .unwrap();
 
         assert!(matches!(
             result,
@@ -1477,11 +1495,52 @@ mod tests {
             .with_send_raw_transaction_mode(SendRawTransactionMode::BitcoindWarmup);
         let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
 
-        let result = publish_commit_immediately(&client, &commit_tx_entry)
+        let result = publish_commit_immediately(
+            &client,
+            &commit_tx_entry,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result, CommitPublishResult::Deferred(_)));
+    }
+
+    #[tokio::test]
+    async fn test_publish_commit_immediately_passes_fee_guardrail() {
+        let client = TestBitcoinClient::new(0);
+        let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
+        let max_fee_rate = FeeRate::from_sat_per_vb(321).unwrap();
+
+        let result = publish_commit_immediately(&client, &commit_tx_entry, max_fee_rate)
             .await
             .unwrap();
 
-        assert!(matches!(result, CommitPublishResult::Deferred(_)));
+        assert_eq!(result, CommitPublishResult::Published);
+        let calls = client.send_raw_transaction_options();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].as_ref().unwrap().max_fee_rate, Some(max_fee_rate));
+    }
+
+    #[tokio::test]
+    async fn test_publish_commit_immediately_defers_fee_guardrail_rejection() {
+        let client = TestBitcoinClient::new(0)
+            .with_send_raw_transaction_mode(SendRawTransactionMode::MaxFeeRateExceeded);
+        let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
+
+        let result = publish_commit_immediately(
+            &client,
+            &commit_tx_entry,
+            FeeRate::from_sat_per_vb(1_000).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            result,
+            CommitPublishResult::Deferred(reason)
+                if is_max_fee_rate_exceeded_message(&reason)
+        ));
     }
 
     #[tokio::test]

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -746,7 +746,7 @@ async fn advance_forward_frontier<R: Reader + Signer + Wallet + Broadcaster>(
                 warn!(idx, %need, %have, "waiting for sufficient utxos");
             }
             Err(err) if err.is_blocked_by_fee_guardrail() => {
-                warn!(idx, %err, "waiting for an initial fee rate within the broadcast guardrail");
+                warn!(idx, %err, "waiting for a transaction fee rate within the broadcast guardrail");
             }
             Err(err) if is_retryable_envelope_error(&err) => {
                 let reason = retryable_reason(&err);

--- a/crates/btcio/src/writer/chunked_envelope/handle.rs
+++ b/crates/btcio/src/writer/chunked_envelope/handle.rs
@@ -171,6 +171,7 @@ pub fn create_chunked_envelope_task(
     let ctx = Arc::new(ChunkedWriterContext::new(
         btcio_params,
         config,
+        broadcast_handle.max_fee_rate(),
         sequencer_address,
         sequencer_keypair,
         bitcoin_client,
@@ -298,6 +299,7 @@ fn format_tx_status(txid: L1TxId, status: &L1TxStatus) -> String {
 enum CommitPublishResult {
     Published,
     InvalidInputs,
+    AboveMaxFeeRate(String),
     Deferred(String),
 }
 
@@ -544,7 +546,7 @@ async fn publish_commit_immediately<R: Broadcaster>(
         }
         Err(ClientError::Server(-25, msg)) if is_max_fee_rate_exceeded_message(&msg) => {
             warn!(%txid, %msg, max_fee_rate_sat_vb = max_fee_rate.to_sat_per_vb_ceil(), "commit broadcast blocked by fee guardrail");
-            Ok(CommitPublishResult::Deferred(msg))
+            Ok(CommitPublishResult::AboveMaxFeeRate(msg))
         }
         Err(ClientError::Server(-25, msg)) => {
             // Bitcoind reuses -25 (RPC_VERIFY_ERROR) for both benign
@@ -655,6 +657,21 @@ async fn persist_signed_envelope_and_publish_commit<R: Reader + Signer + Wallet 
                 "chunked envelope commit has invalid inputs; entry needs resign"
             );
         }
+        CommitPublishResult::AboveMaxFeeRate(reason) => {
+            commit_tx_entry.status = L1TxStatus::InvalidInputs;
+            broadcast_handle
+                .put_tx_entry_by_idx(commit_broadcast_idx, commit_tx_entry)
+                .await?;
+            entry.status = ChunkedEnvelopeStatus::NeedsResign;
+            ops.put_chunked_envelope_entry_async(envelope_idx, entry.clone())
+                .await?;
+            warn!(
+                envelope_idx,
+                commit_txid = ?entry.commit_txid,
+                %reason,
+                "chunked envelope commit exceeds fee guardrail; entry needs resign"
+            );
+        }
         CommitPublishResult::Deferred(reason) => {
             // The broadcaster owns retrying the persisted commit tx. The
             // frontier stays on this envelope until reconciliation sees the
@@ -727,6 +744,9 @@ async fn advance_forward_frontier<R: Reader + Signer + Wallet + Broadcaster>(
             }
             Err(EnvelopeError::NotEnoughUtxos(need, have)) => {
                 warn!(idx, %need, %have, "waiting for sufficient utxos");
+            }
+            Err(err) if err.is_blocked_by_fee_guardrail() => {
+                warn!(idx, %err, "waiting for an initial fee rate within the broadcast guardrail");
             }
             Err(err) if is_retryable_envelope_error(&err) => {
                 let reason = retryable_reason(&err);
@@ -1523,7 +1543,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_publish_commit_immediately_defers_fee_guardrail_rejection() {
+    async fn test_publish_commit_immediately_rebuilds_fee_guardrail_rejection() {
         let client = TestBitcoinClient::new(0)
             .with_send_raw_transaction_mode(SendRawTransactionMode::MaxFeeRateExceeded);
         let commit_tx_entry = L1TxEntry::from_tx(&make_test_tx());
@@ -1538,7 +1558,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            CommitPublishResult::Deferred(reason)
+            CommitPublishResult::AboveMaxFeeRate(reason)
                 if is_max_fee_rate_exceeded_message(&reason)
         ));
     }

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -29,7 +29,7 @@ use crate::{
     writer::{
         builder::{
             effective_fee_rate, ensure_built_fee_rate_within_max,
-            ensure_initial_fee_rate_within_max, sign_commit_at_requested_fee, EnvelopeConfig,
+            ensure_initial_fee_rate_within_max, sign_commit_with_fee_guardrail, EnvelopeConfig,
             EnvelopeError, BITCOIN_DUST_LIMIT,
         },
         fees::resolve_fee_rate,
@@ -147,7 +147,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
 
         // Sign commit via bitcoind wallet RPC.
         let unsigned_commit_txid = built.commit_tx.compute_txid();
-        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+        let (signed_commit, commit_fee) = sign_commit_with_fee_guardrail(
             ctx.client.as_ref(),
             built.commit_tx,
             built.commit_fee,

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -25,8 +25,8 @@ use crate::{
     tx_entry::L1TxEntryExt,
     writer::{
         builder::{
-            ensure_built_fee_rate_within_max, ensure_initial_fee_rate_within_max, EnvelopeConfig,
-            EnvelopeError, BITCOIN_DUST_LIMIT,
+            effective_fee_rate, ensure_built_fee_rate_within_max,
+            ensure_initial_fee_rate_within_max, EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT,
         },
         fees::resolve_fee_rate,
     },
@@ -149,6 +149,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
         ensure_built_fee_rate_within_max(&signed_commit, built.commit_fee, ctx.max_fee_rate)?;
+        let commit_fee_rate = effective_fee_rate(&signed_commit, built.commit_fee)?;
         for reveal_tx in &built.reveal_txs {
             let commit_output =
                 &signed_commit.output[reveal_tx.input[0].previous_output.vout as usize];
@@ -191,7 +192,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
         updated.reveals = reveals;
         updated.status = ChunkedEnvelopeStatus::Unpublished;
         let commit_tx_entry =
-            L1TxEntry::from_tx_with_fee(&signed_commit, fee_rate, built.commit_fee);
+            L1TxEntry::from_tx_with_fee(&signed_commit, commit_fee_rate, built.commit_fee);
 
         Ok(SignedChunkedEnvelope {
             entry: updated,

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -24,7 +24,10 @@ use super::{builder::build_chunked_envelope_txs, context::ChunkedWriterContext};
 use crate::{
     tx_entry::L1TxEntryExt,
     writer::{
-        builder::{EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT},
+        builder::{
+            ensure_built_fee_rate_within_max, ensure_initial_fee_rate_within_max, EnvelopeConfig,
+            EnvelopeError, BITCOIN_DUST_LIMIT,
+        },
         fees::resolve_fee_rate,
     },
 };
@@ -107,6 +110,7 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
         let fee_rate = resolve_fee_rate(ctx.client.as_ref(), ctx.config.as_ref())
             .await
             .map_err(EnvelopeError::PrereqFetch)?;
+        ensure_initial_fee_rate_within_max(fee_rate, ctx.max_fee_rate)?;
 
         debug!(
             envelope_idx,
@@ -144,6 +148,14 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             .await
             .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
+        ensure_built_fee_rate_within_max(&signed_commit, built.commit_fee, ctx.max_fee_rate)?;
+        for reveal_tx in &built.reveal_txs {
+            let commit_output =
+                &signed_commit.output[reveal_tx.input[0].previous_output.vout as usize];
+            let reveal_output_total = reveal_tx.output.iter().map(|output| output.value).sum();
+            let reveal_fee = commit_output.value - reveal_output_total;
+            ensure_built_fee_rate_within_max(reveal_tx, reveal_fee, ctx.max_fee_rate)?;
+        }
         let commit_txid = to_l1_txid(signed_commit.compute_txid());
         let commit_wtxid = to_l1_wtxid(signed_commit.compute_wtxid());
 

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -130,7 +130,8 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             BITCOIN_DUST_LIMIT,
             ctx.config.fee_bumping,
             None,
-        );
+        )
+        .with_max_fee_rate(ctx.max_fee_rate);
 
         let built = build_chunked_envelope_txs(
             &env_config,

--- a/crates/btcio/src/writer/chunked_envelope/signer.rs
+++ b/crates/btcio/src/writer/chunked_envelope/signer.rs
@@ -20,13 +20,17 @@ use strata_db_types::{
 };
 use tracing::*;
 
-use super::{builder::build_chunked_envelope_txs, context::ChunkedWriterContext};
+use super::{
+    builder::{build_chunked_envelope_txs, rebuild_chunked_reveals},
+    context::ChunkedWriterContext,
+};
 use crate::{
     tx_entry::L1TxEntryExt,
     writer::{
         builder::{
             effective_fee_rate, ensure_built_fee_rate_within_max,
-            ensure_initial_fee_rate_within_max, EnvelopeConfig, EnvelopeError, BITCOIN_DUST_LIMIT,
+            ensure_initial_fee_rate_within_max, sign_commit_at_requested_fee, EnvelopeConfig,
+            EnvelopeError, BITCOIN_DUST_LIMIT,
         },
         fees::resolve_fee_rate,
     },
@@ -130,10 +134,9 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
             BITCOIN_DUST_LIMIT,
             ctx.config.fee_bumping,
             None,
-        )
-        .with_max_fee_rate(ctx.max_fee_rate);
+        );
 
-        let built = build_chunked_envelope_txs(
+        let mut built = build_chunked_envelope_txs(
             &env_config,
             entry.chunk_data(),
             &entry.magic_bytes,
@@ -143,12 +146,24 @@ pub(crate) async fn sign_chunked_envelope<R: Reader + Signer + Wallet>(
         )?;
 
         // Sign commit via bitcoind wallet RPC.
-        let signed_commit = ctx
-            .client
-            .sign_raw_transaction_with_wallet(&built.commit_tx, None)
-            .await
-            .map_err(EnvelopeError::SignRawTransaction)?
-            .tx;
+        let unsigned_commit_txid = built.commit_tx.compute_txid();
+        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+            ctx.client.as_ref(),
+            built.commit_tx,
+            built.commit_fee,
+            fee_rate,
+            ctx.max_fee_rate,
+        )
+        .await?;
+        built.commit_fee = commit_fee;
+        if signed_commit.compute_txid() != unsigned_commit_txid {
+            built.reveal_txs = rebuild_chunked_reveals(
+                &env_config,
+                entry.chunk_data(),
+                &ctx.sequencer_keypair,
+                &signed_commit,
+            )?;
+        }
         ensure_built_fee_rate_within_max(&signed_commit, built.commit_fee, ctx.max_fee_rate)?;
         let commit_fee_rate = effective_fee_rate(&signed_commit, built.commit_fee)?;
         for reveal_tx in &built.reveal_txs {

--- a/crates/btcio/src/writer/context.rs
+++ b/crates/btcio/src/writer/context.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
-use bitcoin::{secp256k1::XOnlyPublicKey, Address};
+use bitcoin::{secp256k1::XOnlyPublicKey, Address, FeeRate};
 use bitcoind_async_client::traits::{Reader, Signer, Wallet};
 use strata_config::btcio::WriterConfig;
 use strata_status::StatusChannel;
@@ -49,6 +49,9 @@ pub struct WriterContext<R: Reader + Signer + Wallet> {
     /// Btcio specific configuration.
     pub config: Arc<WriterConfig>,
 
+    /// Maximum fee rate accepted for initial transaction construction and broadcast.
+    pub max_fee_rate: FeeRate,
+
     /// Sequencer's address to watch utxos for and spend change amount to.
     pub sequencer_address: Address,
 
@@ -66,6 +69,7 @@ impl<R: Reader + Signer + Wallet> WriterContext<R> {
     pub fn new(
         btcio_params: BtcioParams,
         config: Arc<WriterConfig>,
+        max_fee_rate: FeeRate,
         sequencer_address: Address,
         client: Arc<R>,
         status_channel: StatusChannel,
@@ -73,6 +77,7 @@ impl<R: Reader + Signer + Wallet> WriterContext<R> {
         Self {
             btcio_params,
             config,
+            max_fee_rate,
             sequencer_address,
             client,
             status_channel,

--- a/crates/btcio/src/writer/replacement/build.rs
+++ b/crates/btcio/src/writer/replacement/build.rs
@@ -14,7 +14,7 @@ use bitcoin::{
 use bitcoind_async_client::{error::ClientError, traits::Signer, types::PsbtBumpFeeOptions};
 use strata_db_types::{
     common::L1TxId,
-    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus, TxNodeKind},
+    fee_bump::{TerminalError, TxAttempt, TxAttemptStatus},
     l1_writer::Sighash,
 };
 use strata_primitives::buf::Buf32;
@@ -28,8 +28,6 @@ use crate::{
 /// Errors raised while building a replacement transaction.
 #[derive(Debug, Error)]
 pub(crate) enum ReplacementError {
-    #[error("unsupported RBF transaction kind: {0:?}")]
-    UnsupportedKind(TxNodeKind),
     #[error("Bitcoin wallet could not bump fee: {0}")]
     PsbtBumpFee(#[source] ClientError),
     #[error("Bitcoin wallet could not sign replacement PSBT: {0}")]
@@ -80,8 +78,7 @@ impl ReplacementError {
             // Not transient, but the commit path discards this candidate instead of ending the
             // chain; see the variant's own note.
             Self::ExceedsMaxFeeRate { .. } => false,
-            Self::UnsupportedKind(_)
-            | Self::IncompletePsbt
+            Self::IncompletePsbt
             | Self::MissingFinalTransaction
             | Self::MissingRevealWitness
             | Self::InvalidControlBlock(_)
@@ -99,7 +96,6 @@ impl ReplacementError {
     /// Only call this after [`ReplacementError::is_retryable`] has returned `false`.
     pub(crate) fn terminal_error(&self) -> TerminalError {
         match self {
-            Self::UnsupportedKind(_) => TerminalError::UnsupportedRbfKind,
             Self::PsbtBumpFee(ClientError::Server(_, msg))
                 if msg.to_ascii_lowercase().contains("insufficient") =>
             {
@@ -122,7 +118,7 @@ impl ReplacementError {
     }
 }
 
-/// Builds a wallet-owned commit replacement using Bitcoin Core's wallet RBF flow.
+/// Builds a chunked-envelope commit replacement using Bitcoin Core's wallet RBF flow.
 ///
 /// # Coin selection
 ///
@@ -145,13 +141,8 @@ impl ReplacementError {
 /// `max_fee_rate` is the operator's configured replacement ceiling. `target_fee_rate` is already
 /// capped by it, but the wallet prices the fee off the transaction it ends up building and can pay
 /// more than it was asked for, so the built candidate is checked against the ceiling too.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "the wallet call needs every input threaded through explicitly"
-)]
-pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
+pub(crate) async fn build_chunked_commit_replacement<C: Signer>(
     client: &C,
-    kind: &TxNodeKind,
     original_tx: &Transaction,
     active_txid: L1TxId,
     target_fee_rate: FeeRate,
@@ -159,13 +150,6 @@ pub(crate) async fn build_wallet_commit_replacement<C: Signer>(
     attempt_no: u32,
     original_change_index: Option<u32>,
 ) -> Result<TxAttempt, ReplacementError> {
-    if !matches!(
-        kind,
-        TxNodeKind::SingleEnvelopeCommit { .. } | TxNodeKind::ChunkedEnvelopeCommit { .. }
-    ) {
-        return Err(ReplacementError::UnsupportedKind(kind.clone()));
-    }
-
     let txid = Txid::from_byte_array(active_txid.0);
     let bumped = client
         .psbt_bump_fee(
@@ -321,7 +305,7 @@ pub(crate) fn validate_chunked_commit_replacement_layout(
 
 /// Rejects a replacement that spends wallet inputs the original transaction did not.
 ///
-/// See the coin-selection note on [`build_wallet_commit_replacement`].
+/// See the coin-selection note on [`build_chunked_commit_replacement`].
 fn reject_added_inputs(
     original_tx: &Transaction,
     replacement_tx: &Transaction,
@@ -598,7 +582,7 @@ mod tests {
         OutPoint, TxIn, Witness, WitnessProgram, WitnessVersion,
     };
     use strata_config::btcio::FeeBumpingConfig;
-    use strata_db_types::fee_bump::TxNodeRecord;
+    use strata_db_types::fee_bump::{TxNodeKind, TxNodeRecord};
 
     use super::*;
     use crate::{
@@ -1157,9 +1141,8 @@ mod tests {
         let client =
             TestBitcoinClient::new(1).with_wallet_process_psbt_result(true, Some(original.clone()));
 
-        build_wallet_commit_replacement(
+        build_chunked_commit_replacement(
             &client,
-            &TxNodeKind::ChunkedEnvelopeCommit { envelope_idx: 0 },
             &original,
             L1TxId::from([0u8; 32]),
             FeeRate::from_sat_per_vb(4).expect("valid fee rate"),

--- a/crates/btcio/src/writer/replacement/driver.rs
+++ b/crates/btcio/src/writer/replacement/driver.rs
@@ -30,8 +30,8 @@ use strata_storage::ops::{chunked_envelope::ChunkedEnvelopeOps, writer::Envelope
 use tracing::*;
 
 use super::build::{
-    build_chunked_reveal_replacement, build_pending_single_reveal_replacement,
-    build_wallet_commit_replacement, chunked_commit_change_index, ensure_reveal_signable,
+    build_chunked_commit_replacement, build_chunked_reveal_replacement,
+    build_pending_single_reveal_replacement, chunked_commit_change_index, ensure_reveal_signable,
     extract_reveal_pubkey, rebuild_reveal_for_replaced_commit,
     validate_chunked_commit_replacement_layout, ReplacementError,
 };
@@ -670,7 +670,7 @@ where
                 .await
             }
             TxNodeKind::ChunkedEnvelopeCommit { .. } => {
-                replace_wallet_commit(
+                replace_chunked_commit(
                     client,
                     writer_config,
                     broadcast_handle,
@@ -696,7 +696,7 @@ where
     }
 }
 
-async fn replace_wallet_commit<C>(
+async fn replace_chunked_commit<C>(
     client: &C,
     writer_config: &WriterConfig,
     broadcast_handle: &L1BroadcastHandle,
@@ -708,24 +708,22 @@ async fn replace_wallet_commit<C>(
 where
     C: Signer,
 {
+    let TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } = record.kind else {
+        bail!("chunked commit replacement received a non-chunked tx-node");
+    };
+
     // Claim the envelope before checking anything. The durable guard below is a read, and the
     // writes that follow it are not in the same transaction, so without exclusion a reveal can be
     // enqueued in the gap and the replacement would orphan it. The claim is released on drop.
-    let _commit_claim = match record.kind {
-        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
-            let Some(claim) = context.commit_phase.try_claim(envelope_idx) else {
-                debug!(
-                    envelope_idx,
-                    "commit replacement skipped: reveal enqueueing is in flight"
-                );
-                return Ok(());
-            };
-            Some(claim)
-        }
-        _ => None,
+    let Some(_commit_claim) = context.commit_phase.try_claim(envelope_idx) else {
+        debug!(
+            envelope_idx,
+            "commit replacement skipped: reveal enqueueing is in flight"
+        );
+        return Ok(());
     };
 
-    if !commit_replacement_allowed(&record, broadcast_handle, context).await? {
+    if !chunked_reveals_not_handed_to_broadcaster(envelope_idx, broadcast_handle, context).await? {
         debug!(node_id = ?record.node_id, kind = ?record.kind, "commit replacement skipped after dependent reveal activity");
         return Ok(());
     }
@@ -742,39 +740,31 @@ where
     // Tell Core which output to recycle rather than letting it guess. Its own change detection
     // skips anything in the wallet's address book, which is where the sequencer address lives, so
     // an unguided bump would add inputs and be refused every time.
-    let chunked_envelope_idx = match record.kind {
-        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => Some(envelope_idx),
-        _ => None,
+    let Some(chunked_ops) = context.chunked_ops.as_ref() else {
+        bail!("chunked commit replacement requires chunked envelope context");
     };
-    let original_change_index = if let Some(envelope_idx) = chunked_envelope_idx {
-        let Some(chunked_ops) = context.chunked_ops.as_ref() else {
-            bail!("chunked commit replacement requires chunked envelope context");
-        };
-        let Some(envelope_entry) = chunked_ops
-            .get_chunked_envelope_entry_async(envelope_idx)
-            .await?
-        else {
-            bail!("chunked envelope {envelope_idx} missing");
-        };
-        // Replacing the commit re-points every reveal at the new commit output and re-signs it,
-        // while each reveal keeps its original tapscript. Under a rotated sequencer key those
-        // signatures could never satisfy those scripts, and the refusal only surfaces at broadcast,
-        // by which point the original commit is already `Replaced` and the envelope has nothing
-        // live left. Refuse before anything is written; the writer rebuilds under the new key, and
-        // that fresh initial attempt clears the terminal error.
-        if let Err(error) = chunked_reveals_signable(context, &envelope_entry) {
-            warn!(envelope_idx, %error, "sequencer key rotated since the envelope was built; refusing to bump its commit");
-            mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
-            return Ok(());
-        }
-        chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len())
-    } else {
-        None
+    let Some(envelope_entry) = chunked_ops
+        .get_chunked_envelope_entry_async(envelope_idx)
+        .await?
+    else {
+        bail!("chunked envelope {envelope_idx} missing");
     };
+    // Replacing the commit re-points every reveal at the new commit output and re-signs it, while
+    // each reveal keeps its original tapscript. Under a rotated sequencer key those signatures
+    // could never satisfy those scripts, and the refusal only surfaces at broadcast, by which
+    // point the original commit is already `Replaced` and the envelope has nothing live left.
+    // Refuse before anything is written; the writer rebuilds under the new key, and that fresh
+    // initial attempt clears the terminal error.
+    if let Err(error) = chunked_reveals_signable(context, &envelope_entry) {
+        warn!(envelope_idx, %error, "sequencer key rotated since the envelope was built; refusing to bump its commit");
+        mark_terminal(broadcast_handle, record, error.terminal_error()).await?;
+        return Ok(());
+    }
+    let original_change_index =
+        chunked_commit_change_index(&original_commit_tx, envelope_entry.reveals.len());
 
-    let replacement = match build_wallet_commit_replacement(
+    let replacement = match build_chunked_commit_replacement(
         client,
-        &record.kind,
         &original_commit_tx,
         record.active_txid,
         target_fee_rate,
@@ -816,28 +806,22 @@ where
     }
 
     let replacement_tx = replacement.try_to_tx()?;
-    let is_chunked_commit = matches!(record.kind, TxNodeKind::ChunkedEnvelopeCommit { .. });
 
     // Validate before writing anything: an incompatible layout must not leave partial state.
-    if is_chunked_commit {
-        // A storage or decode failure here propagates: it is our own state that is broken, and
-        // silently retrying would rebuild and re-sign a PSBT every poll while hiding the fault.
-        match validate_chunked_commit_layout(
-            context,
-            &record,
-            &active_entry_after_build,
-            &replacement_tx,
-        )
-        .await?
-        {
-            CommitLayoutCheck::Ok => {}
-            CommitLayoutCheck::IncompatibleCandidate(error) => {
-                // A different candidate (different fee rate, different change handling) may well
-                // be compatible, so discard this one rather than disabling the chain permanently.
-                warn!(node_id = ?record.node_id, %error, "discarding replacement commit whose layout is incompatible with the envelope");
-                return Ok(());
-            }
-        }
+    // A storage or decode failure here propagates: it is our own state that is broken, and
+    // silently retrying would rebuild and re-sign a PSBT every poll while hiding the fault.
+    let layout_check = validate_chunked_commit_layout(
+        context,
+        &record,
+        &active_entry_after_build,
+        &replacement_tx,
+    )
+    .await?;
+    if let CommitLayoutCheck::IncompatibleCandidate(error) = layout_check {
+        // A different candidate (different fee rate, different change handling) may well be
+        // compatible, so discard this one rather than disabling the chain permanently.
+        warn!(node_id = ?record.node_id, %error, "discarding replacement commit whose layout is incompatible with the envelope");
+        return Ok(());
     }
 
     // Write order across the three trees:
@@ -876,15 +860,13 @@ where
     record.append_replacement(replacement);
     broadcast_handle.put_tx_node(record.clone()).await?;
 
-    if is_chunked_commit {
-        // Deliberately not terminal. Terminal records are skipped by every later poll, so a
-        // transient storage failure here would strand the envelope permanently. Propagating
-        // instead surfaces the fault and retries on the next poll, and until the refresh lands the
-        // writer refuses to enqueue reveals built against the superseded commit.
-        update_chunked_commit_replacement_metadata(context, &record, &replacement_tx)
-            .await
-            .context("refreshing chunked envelope metadata after commit replacement")?;
-    }
+    // Deliberately not terminal. Terminal records are skipped by every later poll, so a transient
+    // storage failure here would strand the envelope permanently. Propagating instead surfaces the
+    // fault and retries on the next poll, and until the refresh lands the writer refuses to enqueue
+    // reveals built against the superseded commit.
+    update_chunked_commit_replacement_metadata(context, &record, &replacement_tx)
+        .await
+        .context("refreshing chunked envelope metadata after commit replacement")?;
 
     Ok(())
 }
@@ -1450,34 +1432,6 @@ async fn put_tx_node_if_active_unchanged(
     Ok(())
 }
 
-/// Reports whether a commit transaction may still be fee bumped.
-///
-/// Replacing a commit changes its txid, which invalidates every reveal that spends one of its
-/// outputs. So a commit is only replaceable while the envelope is still in the commit-only phase.
-/// This check is deliberately fail-closed: anything it cannot positively confirm as "no reveal has
-/// been handed to the broadcaster" blocks the replacement.
-async fn commit_replacement_allowed(
-    record: &TxNodeRecord,
-    broadcast_handle: &L1BroadcastHandle,
-    context: &ReplacementContext,
-) -> anyhow::Result<bool> {
-    match record.kind {
-        TxNodeKind::SingleEnvelopeCommit { payload_idx } => {
-            reveal_node_not_handed_to_broadcaster(
-                TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeReveal { payload_idx }),
-                broadcast_handle,
-            )
-            .await
-        }
-        TxNodeKind::ChunkedEnvelopeCommit { envelope_idx } => {
-            chunked_reveals_not_handed_to_broadcaster(envelope_idx, broadcast_handle, context).await
-        }
-        TxNodeKind::SingleEnvelopeReveal { .. } | TxNodeKind::ChunkedEnvelopeReveal { .. } => {
-            Ok(true)
-        }
-    }
-}
-
 /// Reports whether no reveal of `envelope_idx` has reached the broadcaster yet.
 ///
 /// Two independent sources are consulted so the answer does not depend on the order in which the
@@ -1538,24 +1492,6 @@ async fn chunked_reveals_not_handed_to_broadcaster(
     }
 
     Ok(true)
-}
-
-/// Reports whether this reveal has not yet been handed to the broadcaster.
-///
-/// "Handed over" means a broadcast row exists, not that the row says `Published`. An `Unpublished`
-/// row is already queued and the broadcaster can publish it on any tick, so a commit replacement
-/// that reads it as safe would race the publication and orphan the reveal.
-async fn reveal_node_not_handed_to_broadcaster(
-    node_id: TxNodeId,
-    broadcast_handle: &L1BroadcastHandle,
-) -> anyhow::Result<bool> {
-    let Some(reveal_node) = broadcast_handle.get_tx_node(node_id).await? else {
-        return Ok(true);
-    };
-    Ok(broadcast_handle
-        .get_active_tx_entry_by_id_async(to_raw_buf32(reveal_node.active_txid))
-        .await?
-        .is_none())
 }
 
 fn to_raw_buf32(txid: L1TxId) -> Buf32 {
@@ -1694,19 +1630,6 @@ mod tests {
         FeeRate::from_sat_per_vb(2).expect("test: valid fee rate")
     }
 
-    fn commit_record() -> TxNodeRecord {
-        let attempt = TxAttempt::active(
-            attempt_parts(&tx_with_output(10_000), fee_rate(), Amount::from_sat(500)),
-            0,
-        );
-        TxNodeRecord::new(
-            TxNodeKind::ChunkedEnvelopeCommit {
-                envelope_idx: ENVELOPE_IDX,
-            },
-            attempt,
-        )
-    }
-
     /// Builds an envelope row carrying one reveal, returning the row and the reveal tx.
     fn envelope_entry_with_reveal() -> (ChunkedEnvelopeEntry, Transaction) {
         let reveal_tx = tx_with_output(900);
@@ -1726,7 +1649,7 @@ mod tests {
     /// transaction. The latch is what makes the pair safe: while the writer is enqueueing reveals
     /// for an envelope, a commit replacement for it must not even begin.
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_is_refused_while_reveal_enqueue_holds_the_envelope() {
+    async fn chunked_commit_replacement_is_refused_while_reveal_enqueue_holds_the_envelope() {
         let bcast = get_broadcast_handle();
         let (entry, _reveal_tx) = envelope_entry_with_reveal();
         let mut context = context_with(Some(entry)).await;
@@ -1735,7 +1658,7 @@ mod tests {
 
         // Nothing has been enqueued yet, so the durable guard alone would allow the replacement.
         assert!(
-            commit_replacement_allowed(&commit_record(), &bcast, &context)
+            chunked_reveals_not_handed_to_broadcaster(ENVELOPE_IDX, &bcast, &context)
                 .await
                 .unwrap()
         );
@@ -1852,7 +1775,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_allowed_before_any_reveal_is_enqueued() {
+    async fn chunked_commit_replacement_allowed_before_any_reveal_is_enqueued() {
         let bcast = get_broadcast_handle();
         let (entry, _reveal_tx) = envelope_entry_with_reveal();
         let context = context_with(Some(entry)).await;
@@ -1860,7 +1783,7 @@ mod tests {
         // The envelope row lists a reveal, but nothing has been handed to the broadcaster and no
         // reveal tx-node exists: the envelope is still in the commit-only phase.
         assert!(
-            commit_replacement_allowed(&commit_record(), &bcast, &context)
+            chunked_reveals_not_handed_to_broadcaster(ENVELOPE_IDX, &bcast, &context)
                 .await
                 .unwrap()
         );
@@ -1869,7 +1792,7 @@ mod tests {
     /// Regression: a crash between inserting a reveal's broadcast entry and writing its tx-node
     /// record must not let the commit be replaced, which would orphan the published reveal.
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_blocked_when_reveal_entry_exists_without_tx_node() {
+    async fn chunked_commit_replacement_blocked_when_reveal_entry_exists_without_tx_node() {
         let bcast = get_broadcast_handle();
         let (entry, reveal_tx) = envelope_entry_with_reveal();
         let context = context_with(Some(entry)).await;
@@ -1883,14 +1806,14 @@ mod tests {
             .expect("test: reveal entry persists");
 
         assert!(
-            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+            !chunked_reveals_not_handed_to_broadcaster(ENVELOPE_IDX, &bcast, &context)
                 .await
                 .unwrap()
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_blocked_when_reveal_tx_node_exists() {
+    async fn chunked_commit_replacement_blocked_when_reveal_tx_node_exists() {
         let bcast = get_broadcast_handle();
         let (entry, reveal_tx) = envelope_entry_with_reveal();
         let context = context_with(Some(entry)).await;
@@ -1911,7 +1834,7 @@ mod tests {
             .expect("test: reveal node persists");
 
         assert!(
-            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+            !chunked_reveals_not_handed_to_broadcaster(ENVELOPE_IDX, &bcast, &context)
                 .await
                 .unwrap()
         );
@@ -1922,7 +1845,7 @@ mod tests {
     /// exists to catch. Pin the last index of a multi-reveal envelope, which is the one a
     /// half-open/inclusive slip drops.
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_blocked_by_a_tx_node_at_the_last_reveal_index() {
+    async fn chunked_commit_replacement_blocked_by_a_tx_node_at_the_last_reveal_index() {
         let bcast = get_broadcast_handle();
         let (mut entry, reveal_tx) = envelope_entry_with_reveal();
         // Three reveals, so the last index is 2.
@@ -1952,7 +1875,7 @@ mod tests {
             .expect("test: reveal node persists");
 
         assert!(
-            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+            !chunked_reveals_not_handed_to_broadcaster(ENVELOPE_IDX, &bcast, &context)
                 .await
                 .unwrap()
         );
@@ -1961,23 +1884,23 @@ mod tests {
     /// Without the envelope row there is no way to enumerate the reveals a replacement would
     /// orphan, so the guard must refuse rather than assume the commit-only phase.
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_blocked_when_envelope_row_is_missing() {
+    async fn chunked_commit_replacement_blocked_when_envelope_row_is_missing() {
         let bcast = get_broadcast_handle();
         let context = context_with(None).await;
 
         assert!(
-            !commit_replacement_allowed(&commit_record(), &bcast, &context)
+            !chunked_reveals_not_handed_to_broadcaster(ENVELOPE_IDX, &bcast, &context)
                 .await
                 .unwrap()
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_replacement_blocked_without_chunked_ops() {
+    async fn chunked_commit_replacement_blocked_without_chunked_ops() {
         let bcast = get_broadcast_handle();
 
-        assert!(!commit_replacement_allowed(
-            &commit_record(),
+        assert!(!chunked_reveals_not_handed_to_broadcaster(
+            ENVELOPE_IDX,
             &bcast,
             &ReplacementContext::default()
         )
@@ -2502,26 +2425,5 @@ mod tests {
         assert!(!pending_attempt_is_orphaned(&context, &record)
             .await
             .expect("test: orphan check runs"));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn reveal_kinds_are_always_replaceable() {
-        let bcast = get_broadcast_handle();
-        let reveal_record = TxNodeRecord::new(
-            TxNodeKind::ChunkedEnvelopeReveal {
-                envelope_idx: ENVELOPE_IDX,
-                reveal_idx: 0,
-            },
-            TxAttempt::active(
-                attempt_parts(&tx_with_output(900), fee_rate(), Amount::from_sat(100)),
-                0,
-            ),
-        );
-
-        assert!(
-            commit_replacement_allowed(&reveal_record, &bcast, &ReplacementContext::default())
-                .await
-                .unwrap()
-        );
     }
 }

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -15,7 +15,8 @@ use tracing::*;
 use super::{
     builder::{
         attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs,
-        effective_fee_rate, ensure_built_fee_rate_within_max, EnvelopeData, EnvelopeError,
+        effective_fee_rate, ensure_built_fee_rate_within_max, rebind_single_reveal,
+        sign_commit_at_requested_fee, EnvelopeData, EnvelopeError,
     },
     context::{EnvelopeSigningMode, WriterContext},
 };
@@ -62,19 +63,26 @@ pub(crate) async fn create_payload_envelopes<R: Reader + Signer + Wallet>(
 
         let commit_txid = envelope.commit_tx.compute_txid();
         debug!(%commit_txid, "Signing commit transaction with wallet");
-        let signed_commit = ctx
-            .client
-            .sign_raw_transaction_with_wallet(&envelope.commit_tx, None)
-            .await
-            .map_err(EnvelopeError::SignRawTransaction)?
-            .tx;
+        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+            ctx.client.as_ref(),
+            envelope.commit_tx,
+            envelope.commit_fee,
+            envelope.fee_rate,
+            ctx.max_fee_rate,
+        )
+        .await?;
         envelope.commit_tx = signed_commit;
+        envelope.commit_fee = commit_fee;
+        if envelope.commit_tx.compute_txid() != commit_txid {
+            rebind_single_reveal(&mut envelope)?;
+        }
         ensure_built_fee_rate_within_max(
             &envelope.commit_tx,
             envelope.commit_fee,
             ctx.max_fee_rate,
         )?;
 
+        let commit_txid = envelope.commit_tx.compute_txid();
         info!(%commit_txid, sighash = %envelope.sighash, "envelope built, commit signed");
         Ok(envelope)
     }

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -14,8 +14,8 @@ use tracing::*;
 
 use super::{
     builder::{
-        attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs, EnvelopeData,
-        EnvelopeError,
+        attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs,
+        ensure_built_fee_rate_within_max, EnvelopeData, EnvelopeError,
     },
     context::{EnvelopeSigningMode, WriterContext},
 };
@@ -69,6 +69,11 @@ pub(crate) async fn create_payload_envelopes<R: Reader + Signer + Wallet>(
             .map_err(EnvelopeError::SignRawTransaction)?
             .tx;
         envelope.commit_tx = signed_commit;
+        ensure_built_fee_rate_within_max(
+            &envelope.commit_tx,
+            envelope.commit_fee,
+            ctx.max_fee_rate,
+        )?;
 
         info!(%commit_txid, sighash = %envelope.sighash, "envelope built, commit signed");
         Ok(envelope)
@@ -96,6 +101,16 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
 
     async {
         let envelope = build_and_sign_envelope_txs(&payloadentry.payload, ctx.as_ref()).await?;
+        ensure_built_fee_rate_within_max(
+            &envelope.commit_tx,
+            envelope.commit_fee,
+            ctx.max_fee_rate,
+        )?;
+        ensure_built_fee_rate_within_max(
+            &envelope.reveal_tx,
+            envelope.reveal_fee,
+            ctx.max_fee_rate,
+        )?;
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         broadcast_handle
@@ -166,6 +181,9 @@ pub(crate) async fn complete_reveal_and_broadcast(
             signature,
         )
         .map_err(EnvelopeError::Other)?;
+        let max_fee_rate = broadcast_handle.max_fee_rate();
+        ensure_built_fee_rate_within_max(&envelope.commit_tx, envelope.commit_fee, max_fee_rate)?;
+        ensure_built_fee_rate_within_max(&reveal_tx, envelope.reveal_fee, max_fee_rate)?;
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         put_tx_entry_if_missing(

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -16,7 +16,7 @@ use super::{
     builder::{
         attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs,
         effective_fee_rate, ensure_built_fee_rate_within_max, rebind_single_reveal,
-        sign_commit_at_requested_fee, EnvelopeData, EnvelopeError,
+        sign_commit_with_fee_guardrail, EnvelopeData, EnvelopeError,
     },
     context::{EnvelopeSigningMode, WriterContext},
 };
@@ -63,7 +63,7 @@ pub(crate) async fn create_payload_envelopes<R: Reader + Signer + Wallet>(
 
         let commit_txid = envelope.commit_tx.compute_txid();
         debug!(%commit_txid, "Signing commit transaction with wallet");
-        let (signed_commit, commit_fee) = sign_commit_at_requested_fee(
+        let (signed_commit, commit_fee) = sign_commit_with_fee_guardrail(
             ctx.client.as_ref(),
             envelope.commit_tx,
             envelope.commit_fee,

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -15,7 +15,7 @@ use tracing::*;
 use super::{
     builder::{
         attach_reveal_signature, build_and_sign_envelope_txs, build_envelope_txs,
-        ensure_built_fee_rate_within_max, EnvelopeData, EnvelopeError,
+        effective_fee_rate, ensure_built_fee_rate_within_max, EnvelopeData, EnvelopeError,
     },
     context::{EnvelopeSigningMode, WriterContext},
 };
@@ -111,6 +111,8 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
             envelope.reveal_fee,
             ctx.max_fee_rate,
         )?;
+        let commit_fee_rate = effective_fee_rate(&envelope.commit_tx, envelope.commit_fee)?;
+        let reveal_fee_rate = effective_fee_rate(&envelope.reveal_tx, envelope.reveal_fee)?;
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         broadcast_handle
@@ -118,7 +120,7 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
                 to_raw_buf32(cid),
                 L1TxEntry::from_tx_with_fee(
                     &envelope.commit_tx,
-                    envelope.fee_rate,
+                    commit_fee_rate,
                     envelope.commit_fee,
                 ),
             )
@@ -128,7 +130,7 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
             broadcast_handle,
             TxNodeKind::SingleEnvelopeCommit { payload_idx },
             &envelope.commit_tx,
-            envelope.fee_rate,
+            commit_fee_rate,
             envelope.commit_fee,
         )
         .await?;
@@ -139,7 +141,7 @@ pub(crate) async fn sign_and_broadcast_payload_envelopes<R: Reader + Signer + Wa
                 to_raw_buf32(rid),
                 L1TxEntry::from_tx_with_fee(
                     &envelope.reveal_tx,
-                    envelope.fee_rate,
+                    reveal_fee_rate,
                     envelope.reveal_fee,
                 ),
             )
@@ -184,6 +186,8 @@ pub(crate) async fn complete_reveal_and_broadcast(
         let max_fee_rate = broadcast_handle.max_fee_rate();
         ensure_built_fee_rate_within_max(&envelope.commit_tx, envelope.commit_fee, max_fee_rate)?;
         ensure_built_fee_rate_within_max(&reveal_tx, envelope.reveal_fee, max_fee_rate)?;
+        let commit_fee_rate = effective_fee_rate(&envelope.commit_tx, envelope.commit_fee)?;
+        let reveal_fee_rate = effective_fee_rate(&reveal_tx, envelope.reveal_fee)?;
 
         let cid = to_l1_txid(envelope.commit_tx.compute_txid());
         put_tx_entry_if_missing(
@@ -191,14 +195,14 @@ pub(crate) async fn complete_reveal_and_broadcast(
             cid,
             &envelope.commit_tx,
             envelope.commit_fee,
-            envelope,
+            commit_fee_rate,
         )
         .await?;
         put_tx_node(
             broadcast_handle,
             TxNodeKind::SingleEnvelopeCommit { payload_idx },
             &envelope.commit_tx,
-            envelope.fee_rate,
+            commit_fee_rate,
             envelope.commit_fee,
         )
         .await?;
@@ -211,7 +215,7 @@ pub(crate) async fn complete_reveal_and_broadcast(
             broadcast_handle,
             TxNodeKind::SingleEnvelopeReveal { payload_idx },
             &reveal_tx,
-            envelope.fee_rate,
+            reveal_fee_rate,
             envelope.reveal_fee,
         )
         .await?;
@@ -220,7 +224,7 @@ pub(crate) async fn complete_reveal_and_broadcast(
             rid,
             &reveal_tx,
             envelope.reveal_fee,
-            envelope,
+            reveal_fee_rate,
         )
         .await?;
 
@@ -426,7 +430,7 @@ async fn put_tx_entry_if_missing(
     txid: L1TxId,
     tx: &Transaction,
     fee: Amount,
-    envelope: &EnvelopeData,
+    fee_rate: FeeRate,
 ) -> Result<(), EnvelopeError> {
     if broadcast_handle
         .get_tx_entry_by_id_async(to_raw_buf32(txid))
@@ -440,7 +444,7 @@ async fn put_tx_entry_if_missing(
     broadcast_handle
         .put_tx_entry(
             to_raw_buf32(txid),
-            L1TxEntry::from_tx_with_fee(tx, envelope.fee_rate, fee),
+            L1TxEntry::from_tx_with_fee(tx, fee_rate, fee),
         )
         .await
         .map_err(|e| EnvelopeError::Other(e.into()))?;
@@ -644,8 +648,12 @@ mod test {
             .unwrap()
             .expect("reveal entry must exist");
 
-        assert!(commit_entry.rbf.is_some());
-        assert!(reveal_entry.rbf.is_some());
+        for stored_entry in [&commit_entry, &reveal_entry] {
+            let tx = stored_entry.try_to_tx().unwrap();
+            let rbf = stored_entry.rbf.expect("RBF metadata must exist");
+            let effective_rate = effective_fee_rate(&tx, Amount::from_sat(rbf.fee_sats)).unwrap();
+            assert_eq!(rbf.fee_rate_sat_vb, effective_rate.to_sat_per_vb_ceil());
+        }
         assert!(bcast_handle
             .get_tx_node(TxNodeId::from_kind(&TxNodeKind::SingleEnvelopeCommit {
                 payload_idx: 7

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -458,6 +458,9 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
+                Err(err) if err.is_blocked_by_fee_guardrail() => {
+                    warn!(%err, "waiting for an initial fee rate within the broadcast guardrail");
+                }
                 Err(err) if is_retryable_envelope_error(&err) => {
                     let reason = retryable_reason(&err);
                     warn!(%reason, "retrying envelope creation after Bitcoin RPC error");
@@ -485,6 +488,9 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                 }
                 Err(EnvelopeError::NotEnoughUtxos(required, available)) => {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
+                }
+                Err(err) if err.is_blocked_by_fee_guardrail() => {
+                    warn!(%err, "waiting for an initial fee rate within the broadcast guardrail");
                 }
                 Err(err) if is_retryable_envelope_error(&err) => {
                     let reason = retryable_reason(&err);
@@ -1029,6 +1035,7 @@ mod tests {
     #[derive(Clone, Copy)]
     enum MockEnvelopeFailure {
         NotEnoughUtxos,
+        FeeGuardrail,
         PrereqFetch,
         SignRawTransaction,
         Other,
@@ -1040,6 +1047,10 @@ mod tests {
                 Self::NotEnoughUtxos => {
                     EnvelopeError::NotEnoughUtxos(TEST_REQUIRED_SATS, TEST_AVAILABLE_SATS)
                 }
+                Self::FeeGuardrail => EnvelopeError::ResolvedFeeRateAboveMax {
+                    resolved_sat_vb: 101,
+                    ceiling_sat_vb: 100,
+                },
                 Self::PrereqFetch => EnvelopeError::PrereqFetch(anyhow::Error::from(
                     ClientError::Connection("mock connection failure".to_string()),
                 )),
@@ -1147,6 +1158,16 @@ mod tests {
 
         fn with_sign_not_enough_utxos(mut self) -> Self {
             self.sign_failure = Some(MockEnvelopeFailure::NotEnoughUtxos);
+            self
+        }
+
+        fn with_create_fee_guardrail(mut self) -> Self {
+            self.create_failure = Some(MockEnvelopeFailure::FeeGuardrail);
+            self
+        }
+
+        fn with_sign_fee_guardrail(mut self) -> Self {
+            self.sign_failure = Some(MockEnvelopeFailure::FeeGuardrail);
             self
         }
 
@@ -1335,6 +1356,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_unchecked_fee_guardrail_keeps_unsigned_for_rebuild() {
+        let ctx = MockWatcherContext::new(false).with_sign_fee_guardrail();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_unsigned_or_needs_resign(entry).await.unwrap();
+
+        assert_eq!(
+            state.ctx.get_stored(0).unwrap().status,
+            L1BundleStatus::Unsigned
+        );
+        assert_eq!(state.curr_payloadidx, 0);
+        assert!(state.envelope_cache.is_empty());
+        assert_eq!(state.ctx.rpc_error_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_broadcast_status_resolves_active_fee_bump_txids() {
         let ctx = MockWatcherContext::new(false);
         let mut entry = test_unsigned_entry();
@@ -1426,6 +1465,24 @@ mod tests {
         assert_eq!(stored.reveal_txid, L1TxId::zero());
         assert_eq!(state.curr_payloadidx, 0);
         assert!(state.envelope_cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_schnorr_key_fee_guardrail_keeps_unsigned_for_rebuild() {
+        let ctx = MockWatcherContext::new(true).with_create_fee_guardrail();
+        let entry = test_unsigned_entry();
+        ctx.stored.lock().unwrap().insert(0, entry.clone());
+
+        let mut state = WatcherState::new(ctx, 0);
+        state.handle_unsigned_or_needs_resign(entry).await.unwrap();
+
+        assert_eq!(
+            state.ctx.get_stored(0).unwrap().status,
+            L1BundleStatus::Unsigned
+        );
+        assert_eq!(state.curr_payloadidx, 0);
+        assert!(state.envelope_cache.is_empty());
+        assert_eq!(state.ctx.rpc_error_count(), 0);
     }
 
     #[tokio::test]

--- a/crates/btcio/src/writer/watcher/service.rs
+++ b/crates/btcio/src/writer/watcher/service.rs
@@ -459,7 +459,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
                 Err(err) if err.is_blocked_by_fee_guardrail() => {
-                    warn!(%err, "waiting for an initial fee rate within the broadcast guardrail");
+                    warn!(%err, "waiting for a transaction fee rate within the broadcast guardrail");
                 }
                 Err(err) if is_retryable_envelope_error(&err) => {
                     let reason = retryable_reason(&err);
@@ -490,7 +490,7 @@ impl<C: WatcherServiceContext> WatcherState<C> {
                     warn!(%required, %available, "waiting for sufficient utxos to create commit/reveal transaction");
                 }
                 Err(err) if err.is_blocked_by_fee_guardrail() => {
-                    warn!(%err, "waiting for an initial fee rate within the broadcast guardrail");
+                    warn!(%err, "waiting for a transaction fee rate within the broadcast guardrail");
                 }
                 Err(err) if is_retryable_envelope_error(&err) => {
                     let reason = retryable_reason(&err);

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -401,7 +401,7 @@ impl FeePolicy {
 }
 
 /// Configuration for btcio broadcaster.
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BroadcasterConfig {
     /// How often to invoke the broadcaster, in ms.
     pub poll_interval_ms: u64,
@@ -409,28 +409,6 @@ pub struct BroadcasterConfig {
     /// Maximum fee rate Bitcoin Core may accept for any transaction broadcast by the service.
     #[serde(default = "default_broadcaster_max_fee_rate_sat_vb")]
     pub max_fee_rate_sat_vb: NonZeroU64,
-}
-
-#[derive(Deserialize)]
-struct BroadcasterConfigUnchecked {
-    poll_interval_ms: u64,
-    #[serde(default = "default_broadcaster_max_fee_rate_sat_vb")]
-    max_fee_rate_sat_vb: NonZeroU64,
-}
-
-impl<'de> Deserialize<'de> for BroadcasterConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let unchecked = BroadcasterConfigUnchecked::deserialize(deserializer)?;
-        let config = Self {
-            poll_interval_ms: unchecked.poll_interval_ms,
-            max_fee_rate_sat_vb: unchecked.max_fee_rate_sat_vb,
-        };
-        config.validate().map_err(DeError::custom)?;
-        Ok(config)
-    }
 }
 
 impl BroadcasterConfig {
@@ -611,15 +589,18 @@ mod tests {
     }
 
     #[test]
-    fn broadcaster_rejects_unrepresentable_max_fee_rate() {
+    fn btcio_rejects_unrepresentable_broadcast_max_fee_rate() {
         let unrepresentable = u64::MAX / 250 + 1;
-        let error = toml::from_str::<BroadcasterConfig>(&format!(
-            "poll_interval_ms = 200\nmax_fee_rate_sat_vb = {unrepresentable}"
-        ))
-        .expect_err("an unrepresentable maximum fee rate must be rejected")
-        .to_string();
+        let input = format!(
+            "{BTCIO_CONFIG_PREFIX}\n[broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = {unrepresentable}"
+        );
+        let error = toml::from_str::<BtcioConfig>(&input)
+            .expect_err("an unrepresentable maximum fee rate must be rejected")
+            .to_string();
 
-        assert!(error.contains("max_fee_rate_sat_vb is too large to represent"));
+        assert!(error.contains(
+            "btcio.broadcaster.max_fee_rate_sat_vb is too large to represent as a Bitcoin fee rate"
+        ))
     }
 
     #[test]

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -7,7 +7,7 @@ use bitcoin::{Amount, FeeRate};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Configuration for btcio tasks.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BtcioConfig {
     pub reader: ReaderConfig,
     pub writer: WriterConfig,
@@ -24,6 +24,32 @@ pub struct BtcioConfig {
     pub l1_reorg_safe_depth: u32,
 }
 
+#[derive(Deserialize)]
+struct BtcioConfigUnchecked {
+    reader: ReaderConfig,
+    writer: WriterConfig,
+    broadcaster: BroadcasterConfig,
+    #[serde(default = "default_l1_reorg_safe_depth")]
+    l1_reorg_safe_depth: u32,
+}
+
+impl<'de> Deserialize<'de> for BtcioConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let unchecked = BtcioConfigUnchecked::deserialize(deserializer)?;
+        let config = Self {
+            reader: unchecked.reader,
+            writer: unchecked.writer,
+            broadcaster: unchecked.broadcaster,
+            l1_reorg_safe_depth: unchecked.l1_reorg_safe_depth,
+        };
+        config.validate().map_err(DeError::custom)?;
+        Ok(config)
+    }
+}
+
 impl Default for BtcioConfig {
     fn default() -> Self {
         Self {
@@ -32,6 +58,23 @@ impl Default for BtcioConfig {
             broadcaster: BroadcasterConfig::default(),
             l1_reorg_safe_depth: default_l1_reorg_safe_depth(),
         }
+    }
+}
+
+impl BtcioConfig {
+    /// Validates relationships between Bitcoin IO policies.
+    pub fn validate(&self) -> Result<(), String> {
+        self.writer.fee_bumping.validate()?;
+        self.broadcaster.validate()?;
+
+        if self.writer.fee_bumping.max_fee_rate_sat_vb > self.broadcaster.max_fee_rate_sat_vb {
+            return Err(
+                "btcio.writer.fee_bumping.max_fee_rate_sat_vb must not exceed btcio.broadcaster.max_fee_rate_sat_vb"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -358,10 +401,56 @@ impl FeePolicy {
 }
 
 /// Configuration for btcio broadcaster.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct BroadcasterConfig {
     /// How often to invoke the broadcaster, in ms.
     pub poll_interval_ms: u64,
+
+    /// Maximum fee rate Bitcoin Core may accept for any transaction broadcast by the service.
+    #[serde(default = "default_broadcaster_max_fee_rate_sat_vb")]
+    pub max_fee_rate_sat_vb: NonZeroU64,
+}
+
+#[derive(Deserialize)]
+struct BroadcasterConfigUnchecked {
+    poll_interval_ms: u64,
+    #[serde(default = "default_broadcaster_max_fee_rate_sat_vb")]
+    max_fee_rate_sat_vb: NonZeroU64,
+}
+
+impl<'de> Deserialize<'de> for BroadcasterConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let unchecked = BroadcasterConfigUnchecked::deserialize(deserializer)?;
+        let config = Self {
+            poll_interval_ms: unchecked.poll_interval_ms,
+            max_fee_rate_sat_vb: unchecked.max_fee_rate_sat_vb,
+        };
+        config.validate().map_err(DeError::custom)?;
+        Ok(config)
+    }
+}
+
+impl BroadcasterConfig {
+    /// Validates the broadcaster configuration.
+    pub fn validate(&self) -> Result<(), String> {
+        if FeeRate::from_sat_per_vb(self.max_fee_rate_sat_vb.get()).is_none() {
+            return Err(
+                "btcio.broadcaster.max_fee_rate_sat_vb is too large to represent as a Bitcoin fee rate"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns the per-transaction broadcast fee-rate ceiling.
+    pub fn max_fee_rate(&self) -> FeeRate {
+        FeeRate::from_sat_per_vb(self.max_fee_rate_sat_vb.get())
+            .expect("config: max fee rate is bounded by validation")
+    }
 }
 
 impl Default for WriterConfig {
@@ -444,6 +533,10 @@ const fn default_fee_bumping_max_reveal_fee_headroom_sats() -> NonZeroU64 {
     nonzero_u64(10_000_000)
 }
 
+const fn default_broadcaster_max_fee_rate_sat_vb() -> NonZeroU64 {
+    nonzero_u64(1_000)
+}
+
 impl Default for ReaderConfig {
     fn default() -> Self {
         Self {
@@ -456,6 +549,7 @@ impl Default for BroadcasterConfig {
     fn default() -> Self {
         Self {
             poll_interval_ms: 5_000,
+            max_fee_rate_sat_vb: default_broadcaster_max_fee_rate_sat_vb(),
         }
     }
 }
@@ -465,6 +559,68 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    const BTCIO_CONFIG_PREFIX: &str = r#"
+        [reader]
+        client_poll_dur_ms = 200
+
+        [writer]
+        write_poll_dur_ms = 200
+        fee_policy = "fixed"
+        fixed_fee_rate = 1.0
+        reveal_amount = 546
+        bundle_interval_ms = 200
+    "#;
+
+    #[test]
+    fn broadcaster_defaults_max_fee_rate() {
+        let config: BroadcasterConfig = toml::from_str("poll_interval_ms = 200")
+            .expect("broadcaster config should deserialize");
+
+        assert_eq!(config.max_fee_rate_sat_vb, nonzero_u64(1_000));
+        assert_eq!(
+            config.max_fee_rate(),
+            FeeRate::from_sat_per_vb(1_000).unwrap()
+        );
+    }
+
+    #[test]
+    fn btcio_rejects_fee_bumping_ceiling_above_broadcast_guardrail() {
+        let input = format!(
+            "{BTCIO_CONFIG_PREFIX}\n[writer.fee_bumping]\nmax_fee_rate_sat_vb = 501\n\n[broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = 500"
+        );
+        let error = toml::from_str::<BtcioConfig>(&input)
+            .expect_err("fee bumping must stay within the broadcast guardrail")
+            .to_string();
+
+        assert!(error.contains(
+            "btcio.writer.fee_bumping.max_fee_rate_sat_vb must not exceed btcio.broadcaster.max_fee_rate_sat_vb"
+        ));
+    }
+
+    #[test]
+    fn btcio_accepts_fee_bumping_ceiling_at_broadcast_guardrail() {
+        let input = format!(
+            "{BTCIO_CONFIG_PREFIX}\n[writer.fee_bumping]\nmax_fee_rate_sat_vb = 500\n\n[broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = 500"
+        );
+        let config = toml::from_str::<BtcioConfig>(&input)
+            .expect("matching fee ceilings should deserialize");
+
+        assert_eq!(config.writer.fee_bumping.max_fee_rate_sat_vb.get(), 500);
+        assert_eq!(config.broadcaster.max_fee_rate_sat_vb.get(), 500);
+    }
+
+    #[test]
+    fn broadcaster_rejects_unrepresentable_max_fee_rate() {
+        let unrepresentable = u64::MAX / 250 + 1;
+        let error = toml::from_str::<BroadcasterConfig>(&format!(
+            "poll_interval_ms = 200\nmax_fee_rate_sat_vb = {unrepresentable}"
+        ))
+        .expect_err("an unrepresentable maximum fee rate must be rejected")
+        .to_string();
+
+        assert!(error.contains("max_fee_rate_sat_vb is too large to represent"));
+    }
 
     #[test]
     fn fee_bumping_reveal_headroom_serde_default_and_roundtrip() {

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -6,6 +6,11 @@ use std::{
 use bitcoin::{Amount, FeeRate};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 
+/// Largest `maxfeerate` value accepted by Bitcoin Core's `sendrawtransaction` RPC.
+///
+/// Bitcoin Core expresses the limit as 1 BTC/kvB, which is 100,000 sat/vB.
+const BITCOIN_CORE_MAX_BROADCAST_FEE_RATE_SAT_VB: u64 = 100_000;
+
 /// Configuration for btcio tasks.
 #[derive(Debug, Clone, Serialize)]
 pub struct BtcioConfig {
@@ -430,6 +435,12 @@ impl BroadcasterConfig {
             );
         }
 
+        if self.max_fee_rate_sat_vb.get() > BITCOIN_CORE_MAX_BROADCAST_FEE_RATE_SAT_VB {
+            return Err(format!(
+                "btcio.broadcaster.max_fee_rate_sat_vb must be at most {BITCOIN_CORE_MAX_BROADCAST_FEE_RATE_SAT_VB}, Bitcoin Core's 1 BTC/kvB sendrawtransaction limit"
+            ));
+        }
+
         Ok(())
     }
 
@@ -638,6 +649,38 @@ mod tests {
         assert!(error.contains(
             "btcio.broadcaster.max_fee_rate_sat_vb is too large to represent as a Bitcoin fee rate"
         ))
+    }
+
+    #[test]
+    fn btcio_accepts_bitcoin_core_max_broadcast_fee_rate() {
+        let input = format!(
+            "{BTCIO_CONFIG_PREFIX}\n[writer.fee_bumping]\nmax_fee_rate_sat_vb = 100000\n\
+             [broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = 100000"
+        );
+
+        let config = toml::from_str::<BtcioConfig>(&input)
+            .expect("Bitcoin Core's maximum RPC fee rate should be accepted");
+
+        assert_eq!(
+            config.broadcaster.max_fee_rate_sat_vb.get(),
+            BITCOIN_CORE_MAX_BROADCAST_FEE_RATE_SAT_VB
+        );
+    }
+
+    #[test]
+    fn btcio_rejects_broadcast_fee_rate_above_bitcoin_core_limit() {
+        let above_bitcoin_core_limit = BITCOIN_CORE_MAX_BROADCAST_FEE_RATE_SAT_VB + 1;
+        let input = format!(
+            "{BTCIO_CONFIG_PREFIX}\n[writer.fee_bumping]\nmax_fee_rate_sat_vb = 100000\n\
+             [broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = {above_bitcoin_core_limit}"
+        );
+        let error = toml::from_str::<BtcioConfig>(&input)
+            .expect_err("Bitcoin Core rejects maxfeerate values above 1 BTC/kvB")
+            .to_string();
+
+        assert!(error.contains(
+            "btcio.broadcaster.max_fee_rate_sat_vb must be at most 100000, Bitcoin Core's 1 BTC/kvB sendrawtransaction limit"
+        ));
     }
 
     #[test]

--- a/crates/config/src/btcio.rs
+++ b/crates/config/src/btcio.rs
@@ -74,6 +74,15 @@ impl BtcioConfig {
             );
         }
 
+        if let FeePolicy::Fixed { fee_rate } = self.writer.fee_policy() {
+            if *fee_rate > self.broadcaster.max_fee_rate() {
+                return Err(
+                    "btcio.writer.fixed_fee_rate must not exceed btcio.broadcaster.max_fee_rate_sat_vb"
+                        .to_string(),
+                );
+            }
+        }
+
         Ok(())
     }
 }
@@ -586,6 +595,34 @@ mod tests {
 
         assert_eq!(config.writer.fee_bumping.max_fee_rate_sat_vb.get(), 500);
         assert_eq!(config.broadcaster.max_fee_rate_sat_vb.get(), 500);
+    }
+
+    #[test]
+    fn btcio_rejects_fixed_fee_rate_above_broadcast_guardrail() {
+        let writer = BTCIO_CONFIG_PREFIX.replace("fixed_fee_rate = 1.0", "fixed_fee_rate = 501");
+        let input = format!(
+            "{writer}\n[writer.fee_bumping]\nmax_fee_rate_sat_vb = 500\n\
+             [broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = 500"
+        );
+        let error = toml::from_str::<BtcioConfig>(&input)
+            .expect_err("fixed fee rate must stay within the broadcast guardrail")
+            .to_string();
+
+        assert!(error.contains(
+            "btcio.writer.fixed_fee_rate must not exceed btcio.broadcaster.max_fee_rate_sat_vb"
+        ));
+    }
+
+    #[test]
+    fn btcio_accepts_fixed_fee_rate_at_broadcast_guardrail() {
+        let writer = BTCIO_CONFIG_PREFIX.replace("fixed_fee_rate = 1.0", "fixed_fee_rate = 500");
+        let input = format!(
+            "{writer}\n[writer.fee_bumping]\nmax_fee_rate_sat_vb = 500\n\
+             [broadcaster]\npoll_interval_ms = 200\nmax_fee_rate_sat_vb = 500"
+        );
+
+        toml::from_str::<BtcioConfig>(&input)
+            .expect("fixed fee rate at the broadcast guardrail should be accepted");
     }
 
     #[test]

--- a/docker/configs/config.seq.toml
+++ b/docker/configs/config.seq.toml
@@ -49,6 +49,8 @@ bundle_interval_ms = 1000
 
 [btcio.broadcaster]
 poll_interval_ms = 1000
+# Final per-transaction guardrail; must cover the fee-bumping ceiling.
+max_fee_rate_sat_vb = 1000
 
 # Uncomment for real SP1 proving (requires strata built with prover,sp1 features)
 # [prover]

--- a/functional-tests/common/config/config.py
+++ b/functional-tests/common/config/config.py
@@ -51,6 +51,7 @@ class WriterConfig:
 @dataclass
 class BroadcasterConfig:
     poll_interval_ms: int = field(default=200)
+    max_fee_rate_sat_vb: int = field(default=1_000)
 
 
 @dataclass


### PR DESCRIPTION
## Description

Adds a configurable fee-rate guardrail to prevent sequencer L1 transactions from overpaying fees.

- Adds `btcio.broadcaster.max_fee_rate_sat_vb`, defaulting to 1,000 sat/vB.
- Passes the limit to every sequencer `sendrawtransaction` call.
- Keeps fee-limit rejections unpublished and retryable instead of triggering re-signing.
- Validates that the fee-bumping ceiling does not exceed the broadcast guardrail.
- Adds configuration and broadcast-path regression tests.

**[AI Usage]**: Created using codex under close supervision and iterations.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
