### PR TITLE
fix(csm-worker): remove misleading checkpoint tip warning

### DIFF
--- a/crates/csm-worker/src/processor.rs
+++ b/crates/csm-worker/src/processor.rs
@@ -86,15 +86,6 @@ impl<C: CsmWorkerContext> CsmWorkerState<C> {
             "CSM is processing checkpoint tip update from ASM log"
         );
 
-        let l1_height = tip.l1_height();
-        if l1_height != asm_block.height() {
-            warn!(
-                tip_l1_height = l1_height,
-                asm_block_height = asm_block.height(),
-                "Checkpoint tip L1 height differs from current ASM block height; using ASM block commitment"
-            );
-        }
-
         let new_checkpoint =
             self.mark_ol_checkpoint_l1_observed(pending, checkpoint_tip_update, asm_block)?;
         pending.cur_state = Arc::new(ClientState::new(


### PR DESCRIPTION
## Description

Removes the misleading CSM worker warning emitted when a checkpoint tip's L1 height differs from the current ASM block height.

The Slack discussion confirmed this mismatch is expected whenever a checkpoint is present: the checkpoint tip height represents the L1 height covered by the checkpoint, while the ASM block is the block observing that checkpoint. The warning therefore produced noisy false alerts without indicating a state-processing issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

State update behavior is unchanged. The existing info log still records checkpoint tip processing details.

AI assistance notice: this PR was prepared with assistance from OpenAI Codex.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- Slack discussion: https://alpen-labs.slack.com/archives/C09C6JLF76H/p1787663639490759

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

Tested with:

```bash
cargo test -p strata-csm-worker
```

## Related Issues

N/A