### PR TITLE
refactor(ol): make WriteBatch not generic (STR-4254)

### DIFF
--- a/bin/strata-dbtool/src/cmd/mmr.rs
+++ b/bin/strata-dbtool/src/cmd/mmr.rs
@@ -674,7 +674,7 @@ mod tests {
     use strata_identifiers::AccountId;
     use strata_merkle::MmrState;
     use strata_ol_params::OLParams;
-    use strata_ol_state_types_v1::{OLAccountStateV1, WriteBatch};
+    use strata_ol_state_types_v1::WriteBatch;
     use strata_storage::{MmrIndexHandle, MmrIndexManager};
     use tokio::runtime::Runtime;
 
@@ -695,7 +695,7 @@ mod tests {
             append_l1_block_rec_to_mmr(&mut l1_block_refs_mmr, record);
         }
 
-        let mut batch = WriteBatch::<OLAccountStateV1>::default();
+        let mut batch = WriteBatch::default();
         batch.epochal_writes_mut().l1_block_refs_mmr = Some(l1_block_refs_mmr);
         state
             .apply_write_batch(batch)

--- a/bin/strata-dbtool/src/cmd/ol.rs
+++ b/bin/strata-dbtool/src/cmd/ol.rs
@@ -421,7 +421,7 @@ mod tests {
         BlockFlagsV1, OLBlockBodyV1, OLBlockHeaderV1, OLTxSegmentV1, SignedOLBlockHeaderV1,
     };
     use strata_ol_params::OLParams;
-    use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+    use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 
     use super::*;
 
@@ -509,7 +509,7 @@ mod tests {
         let block_to_delete_id = block_to_delete.header().compute_blkid();
         let commitment = OLBlockCommitment::new(1, block_to_delete_id);
         db.ol_state_db()
-            .put_ol_write_batch(commitment, WriteBatch::<OLAccountStateV1>::default())
+            .put_ol_write_batch(commitment, WriteBatch::default())
             .expect("seed write batch");
 
         let err = delete_ol_block(db.as_ref(), delete_args(block_to_delete_id))

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -82,7 +82,7 @@ struct MockProvider {
     canonical_slots: HashMap<Slot, OLBlockCommitment>,
     history_base: Option<EpochCommitment>,
     states: HashMap<OLBlockCommitment, Arc<OLStateV1>>,
-    write_batches: HashMap<OLBlockCommitment, WriteBatch<OLAccountStateV1>>,
+    write_batches: HashMap<OLBlockCommitment, WriteBatch>,
     epoch_commitments: HashMap<Epoch, EpochCommitment>,
     epoch_summaries: HashMap<EpochCommitment, EpochSummary>,
     checkpoint_l1_refs: HashMap<EpochCommitment, CheckpointL1Ref>,
@@ -180,11 +180,7 @@ impl MockProvider {
         self
     }
 
-    fn with_write_batch(
-        mut self,
-        commitment: OLBlockCommitment,
-        write_batch: WriteBatch<OLAccountStateV1>,
-    ) -> Self {
+    fn with_write_batch(mut self, commitment: OLBlockCommitment, write_batch: WriteBatch) -> Self {
         self.write_batches.insert(commitment, write_batch);
         self
     }
@@ -393,7 +389,7 @@ impl OLRpcProvider for MockProvider {
     async fn get_ol_write_batch(
         &self,
         commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>> {
+    ) -> DbResult<Option<WriteBatch>> {
         Ok(self.write_batches.get(&commitment).cloned())
     }
 

--- a/bin/strata/src/rpc/provider.rs
+++ b/bin/strata/src/rpc/provider.rs
@@ -17,7 +17,7 @@ use strata_identifiers::{AccountId, Epoch, L1Height, OLBlockId, OLTxId};
 use strata_ol_chain_types_v1::OLBlockV1;
 use strata_ol_mempool::{MempoolHandle, OLMempoolError, OLMempoolResult};
 use strata_ol_rpc_types::OLRpcProvider;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_ol_tx_types_v1::OLTransactionV1;
 use strata_primitives::{OLBlockCommitment, epoch::EpochCommitment};
 use strata_status::{OLSyncStatus, StatusChannel};
@@ -101,7 +101,7 @@ impl OLRpcProvider for NodeRpcProvider {
     async fn get_ol_write_batch(
         &self,
         commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>> {
+    ) -> DbResult<Option<WriteBatch>> {
         self.storage
             .ol_state()
             .get_write_batch_async(commitment)

--- a/crates/chain-worker/src/context.rs
+++ b/crates/chain-worker/src/context.rs
@@ -27,7 +27,7 @@ use strata_ol_chain_types_v1::{
 };
 use strata_ol_params::OLParams;
 use strata_ol_state_support_types::SnarkAcctStateUpdate;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_primitives::epoch::EpochCommitment;
 use strata_status::StatusChannel;
 use strata_storage::{
@@ -154,10 +154,7 @@ impl ChainWorkerContext for ChainWorkerContextImpl {
         Ok(state_opt.map(|arc| (*arc).clone()))
     }
 
-    fn fetch_write_batch(
-        &self,
-        commitment: OLBlockCommitment,
-    ) -> WorkerResult<Option<WriteBatch<OLAccountStateV1>>> {
+    fn fetch_write_batch(&self, commitment: OLBlockCommitment) -> WorkerResult<Option<WriteBatch>> {
         Ok(self.ol_state_mgr.get_write_batch_blocking(commitment)?)
     }
 

--- a/crates/chain-worker/src/output.rs
+++ b/crates/chain-worker/src/output.rs
@@ -3,7 +3,7 @@
 use strata_identifiers::Buf32;
 use strata_ol_chain_types_v1::OLLog;
 use strata_ol_state_support_types::IndexerWrites;
-use strata_ol_state_types_v1::{OLAccountStateV1, WriteBatch};
+use strata_ol_state_types_v1::WriteBatch;
 
 /// Output from executing a block with the OL STF.
 ///
@@ -15,7 +15,7 @@ pub struct OLBlockExecutionOutput {
     computed_state_root: Buf32,
 
     /// State changes to persist (the diff).
-    write_batch: WriteBatch<OLAccountStateV1>,
+    write_batch: WriteBatch,
 
     /// Auxiliary data for indexing (inbox messages, manifests).
     indexer_writes: IndexerWrites,
@@ -31,7 +31,7 @@ impl OLBlockExecutionOutput {
     /// Creates a new execution output.
     pub fn new(
         computed_state_root: Buf32,
-        write_batch: WriteBatch<OLAccountStateV1>,
+        write_batch: WriteBatch,
         indexer_writes: IndexerWrites,
         logs: Vec<OLLog>,
     ) -> Self {
@@ -49,7 +49,7 @@ impl OLBlockExecutionOutput {
     }
 
     /// Returns the state changes (write batch).
-    pub fn write_batch(&self) -> &WriteBatch<OLAccountStateV1> {
+    pub fn write_batch(&self) -> &WriteBatch {
         &self.write_batch
     }
 
@@ -64,14 +64,7 @@ impl OLBlockExecutionOutput {
     }
 
     /// Consumes self and returns the inner components.
-    pub fn into_parts(
-        self,
-    ) -> (
-        Buf32,
-        WriteBatch<OLAccountStateV1>,
-        IndexerWrites,
-        Vec<OLLog>,
-    ) {
+    pub fn into_parts(self) -> (Buf32, WriteBatch, IndexerWrites, Vec<OLLog>) {
         (
             self.computed_state_root,
             self.write_batch,

--- a/crates/chain-worker/src/state.rs
+++ b/crates/chain-worker/src/state.rs
@@ -34,7 +34,7 @@ use strata_ol_state_support_types::{
 use strata_ol_state_types::{
     IAccountState, ISnarkAccountState, IStateAccessor, StateError, StateResult,
 };
-use strata_ol_state_types_v1::{IStateBatchApplicable, OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{IStateBatchApplicable, OLStateV1, WriteBatch};
 use strata_ol_stf_v1::{BlockInfo, EpochInfo, apply_da_epoch, verify_block};
 use strata_primitives::{epoch::EpochCommitment, l1::L1BlockCommitment};
 use strata_service::ServiceState;
@@ -541,7 +541,7 @@ pub(crate) fn apply_checkpoint_epoch(
         .collect();
 
     let (tracking_state, mut indexer_writes) = indexer_state.into_parts();
-    let write_batch: WriteBatch<OLAccountStateV1> = tracking_state.into_batch();
+    let write_batch: WriteBatch = tracking_state.into_batch();
 
     // Apply the batch onto the base state to get the reconstructed state.
     let mut new_state = base_state;
@@ -898,7 +898,7 @@ fn run_stf_verification(
     block: &OLBlockV1,
     parent_header: Option<&OLBlockHeaderV1>,
     bridge_params: BridgeParams,
-) -> WorkerResult<(WriteBatch<OLAccountStateV1>, IndexerWrites, Vec<OLLog>)> {
+) -> WorkerResult<(WriteBatch, IndexerWrites, Vec<OLLog>)> {
     // Build the state stack: IndexerState<WriteTrackingState<&MemoryStateBaseLayer>>
     let tracking_state = WriteTrackingState::new_empty(parent_state);
     let mut indexer_state = IndexerState::new(tracking_state);
@@ -913,7 +913,7 @@ fn run_stf_verification(
 
     // Extract outputs
     let (tracking_state, indexer_writes) = indexer_state.into_parts();
-    let write_batch: WriteBatch<OLAccountStateV1> = tracking_state.into_batch();
+    let write_batch: WriteBatch = tracking_state.into_batch();
 
     Ok((write_batch, indexer_writes, logs))
 }
@@ -956,9 +956,7 @@ mod tests {
     use strata_identifiers::{Buf32, L1BlockCommitment, L1BlockId, L1Height, OLBlockId};
     use strata_ol_chain_types_v1::{BlockFlagsV1, OLBlockHeaderV1};
     use strata_ol_state_support_types::IndexerWrites;
-    use strata_ol_state_types_v1::{
-        OLAccountStateV1, WriteBatch, test_utils::create_test_genesis_state,
-    };
+    use strata_ol_state_types_v1::{WriteBatch, test_utils::create_test_genesis_state};
 
     use super::*;
     use crate::OLBlockExecutionOutput;
@@ -977,7 +975,7 @@ mod tests {
         let mut new_state = create_test_genesis_state();
         let expected_height = L1Height::from(1234u32);
         let expected_blkid = L1BlockId::from(Buf32::from([7u8; 32]));
-        let mut setup_batch: WriteBatch<OLAccountStateV1> = WriteBatch::default();
+        let mut setup_batch: WriteBatch = WriteBatch::default();
         setup_batch.epochal_writes_mut().last_l1_height = Some(expected_height);
         setup_batch.epochal_writes_mut().last_l1_blkid = Some(expected_blkid);
         new_state
@@ -986,7 +984,7 @@ mod tests {
 
         // Terminal block's write batch carries no `last_l1_*` update — this is
         // the case that previously panicked.
-        let terminal_batch: WriteBatch<OLAccountStateV1> = WriteBatch::default();
+        let terminal_batch: WriteBatch = WriteBatch::default();
         assert!(terminal_batch.epochal_writes().last_l1_height.is_none());
         assert!(terminal_batch.epochal_writes().last_l1_blkid.is_none());
 

--- a/crates/chain-worker/src/tests/apply_checkpoint.rs
+++ b/crates/chain-worker/src/tests/apply_checkpoint.rs
@@ -123,9 +123,7 @@ impl ChainWorkerContext for MockChainWorkerContext {
     fn fetch_write_batch(
         &self,
         _commitment: OLBlockCommitment,
-    ) -> WorkerResult<
-        Option<strata_ol_state_types_v1::WriteBatch<strata_ol_state_types_v1::OLAccountStateV1>>,
-    > {
+    ) -> WorkerResult<Option<strata_ol_state_types_v1::WriteBatch>> {
         unimplemented!("not used by apply_checkpoint_epoch")
     }
 

--- a/crates/chain-worker/src/tests/exec_block.rs
+++ b/crates/chain-worker/src/tests/exec_block.rs
@@ -19,7 +19,7 @@ use strata_identifiers::{
     Epoch, EpochCommitment, L1BlockCommitment, OLBlockCommitment, OLBlockId, SubjectId,
 };
 use strata_ol_chain_types_v1::{OLBlockHeaderV1, OLBlockV1};
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_ol_stf_v1::test_utils::{
     EPOCH_RUNNER_TERMINAL_L1_HEIGHT as TERMINAL_L1_HEIGHT, epoch_runner_run_genesis as run_genesis,
     epoch_runner_run_terminal as run_terminal, epoch_runner_seed_accounts as seed_accounts,
@@ -137,7 +137,7 @@ impl ChainWorkerContext for OrderEnforcingContext {
     fn fetch_write_batch(
         &self,
         _commitment: OLBlockCommitment,
-    ) -> WorkerResult<Option<WriteBatch<OLAccountStateV1>>> {
+    ) -> WorkerResult<Option<WriteBatch>> {
         unimplemented!("not used by exec_block")
     }
 

--- a/crates/chain-worker/src/tests/fixture.rs
+++ b/crates/chain-worker/src/tests/fixture.rs
@@ -25,7 +25,7 @@ use strata_ol_state_support_types::{
     DaAccumulatingState, IndexerState, IndexerWrites, MemoryStateBaseLayer, WriteTrackingState,
 };
 use strata_ol_state_types::IStateAccessor;
-use strata_ol_state_types_v1::{IStateBatchApplicable, OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{IStateBatchApplicable, OLStateV1, WriteBatch};
 use strata_ol_stf_v1::{
     BlockComponents, execute_block_batch_predrain,
     test_utils::{
@@ -407,7 +407,7 @@ fn run_block_sync(
     }
 
     let (tracking_state, indexer_writes) = indexer_state.into_parts();
-    let write_batch: WriteBatch<OLAccountStateV1> = tracking_state.into_batch();
+    let write_batch: WriteBatch = tracking_state.into_batch();
 
     let mut new_state = pre_epoch_state.clone();
     new_state

--- a/crates/chain-worker/src/traits.rs
+++ b/crates/chain-worker/src/traits.rs
@@ -5,7 +5,7 @@ use strata_asm_common::AsmManifest;
 use strata_checkpoint_types::EpochSummary;
 use strata_identifiers::{Epoch, OLBlockCommitment, OLBlockId};
 use strata_ol_chain_types_v1::{OLBlockHeaderV1, OLBlockV1};
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_primitives::epoch::EpochCommitment;
 
 use crate::{OLBlockExecutionOutput, WorkerResult};
@@ -42,10 +42,7 @@ pub trait ChainWorkerContext: Send + Sync + 'static {
     fn fetch_ol_state(&self, commitment: OLBlockCommitment) -> WorkerResult<Option<OLStateV1>>;
 
     /// Fetches the write batch for a given block commitment.
-    fn fetch_write_batch(
-        &self,
-        commitment: OLBlockCommitment,
-    ) -> WorkerResult<Option<WriteBatch<OLAccountStateV1>>>;
+    fn fetch_write_batch(&self, commitment: OLBlockCommitment) -> WorkerResult<Option<WriteBatch>>;
 
     // =========================================================================
     // Output storage

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -814,7 +814,7 @@ mod tests {
         OLTxSegmentV1, SignedOLBlockHeaderV1,
     };
     use strata_ol_state_support_types::MemoryStateBaseLayer;
-    use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+    use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
     use strata_ol_stf_v1::{
         test_utils::{execute_block, make_genesis_state},
         BlockComponents, BlockInfo, CompletedBlock,
@@ -1658,7 +1658,7 @@ mod tests {
         ctx.storage().put_canonical_epoch_commitment(pending_epoch);
         let tracker = tracker_with_blocks(&chain.genesis, &[&chain.x1, &chain.x2]);
         let mut finalizable_state = chain.x2.state.clone();
-        let mut epoch_update = WriteBatch::<OLAccountStateV1>::default();
+        let mut epoch_update = WriteBatch::default();
         epoch_update.epochal_writes_mut().cur_epoch = Some(2);
         finalizable_state
             .apply_write_batch(epoch_update)

--- a/crates/consensus-logic/src/ol_mmr_reconcile/tests.rs
+++ b/crates/consensus-logic/src/ol_mmr_reconcile/tests.rs
@@ -10,9 +10,7 @@ use strata_db_types::{DbError, DbResult, MmrId, RawMmrId};
 use strata_identifiers::{Epoch, Hash, OLBlockCommitment};
 use strata_ol_mmr_index::OLMmrIndexError;
 use strata_ol_params::{BridgeParams, OLParams};
-use strata_ol_state_types_v1::{
-    OLAccountStateV1, OLStateV1, WriteBatch, MMR_SENTINEL_DUMMY_LEAF_HASH,
-};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch, MMR_SENTINEL_DUMMY_LEAF_HASH};
 use strata_storage::{test_runtime_handle, MmrIndexManager};
 
 use super::{
@@ -265,7 +263,7 @@ fn make_target_state_with_l1_records(records: &[L1BlockRecord]) -> OLStateV1 {
         append_l1_block_rec_to_mmr(&mut l1_block_refs_mmr, record);
     }
 
-    let mut batch = WriteBatch::<OLAccountStateV1>::default();
+    let mut batch = WriteBatch::default();
     batch.epochal_writes_mut().l1_block_refs_mmr = Some(l1_block_refs_mmr);
     state
         .apply_write_batch(batch)

--- a/crates/db/store-sled/src/ol_state/db.rs
+++ b/crates/db/store-sled/src/ol_state/db.rs
@@ -1,7 +1,7 @@
 use strata_db_types::DbResult;
 use strata_db_types::ol_state::OLStateDatabase;
 use strata_identifiers::OLBlockCommitment;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 
 use super::schemas::{OLStateSchema, OLWriteBatchSchema};
 use crate::define_sled_database;
@@ -43,11 +43,7 @@ impl OLStateDatabase for OLStateDBSled {
         Ok(())
     }
 
-    fn put_ol_write_batch(
-        &self,
-        commitment: OLBlockCommitment,
-        wb: WriteBatch<OLAccountStateV1>,
-    ) -> DbResult<()> {
+    fn put_ol_write_batch(&self, commitment: OLBlockCommitment, wb: WriteBatch) -> DbResult<()> {
         self.config
             .with_retry((&self.write_batch_tree,), |(wb_tree,)| {
                 wb_tree.insert(&commitment, &wb)?;
@@ -56,10 +52,7 @@ impl OLStateDatabase for OLStateDBSled {
         Ok(())
     }
 
-    fn get_ol_write_batch(
-        &self,
-        commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>> {
+    fn get_ol_write_batch(&self, commitment: OLBlockCommitment) -> DbResult<Option<WriteBatch>> {
         self.write_batch_tree
             .get(&commitment)
             .map_err(conv_sled_err)

--- a/crates/db/store-sled/src/ol_state/schemas.rs
+++ b/crates/db/store-sled/src/ol_state/schemas.rs
@@ -1,7 +1,7 @@
 use sled::IVec;
 use ssz::{Decode, Encode};
 use strata_identifiers::OLBlockCommitment;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use typed_sled::codec::{CodecError, ValueCodec};
 
 use crate::{define_table_without_codec, impl_codec_key_codec, impl_codec_value_codec};
@@ -14,7 +14,7 @@ define_table_without_codec!(
 
 define_table_without_codec!(
     /// Table to store OL state write batches keyed by OLBlockCommitment.
-    (OLWriteBatchSchema) OLBlockCommitment => WriteBatch<OLAccountStateV1>
+    (OLWriteBatchSchema) OLBlockCommitment => WriteBatch
 );
 
 // OLBlockCommitment uses Codec for key encoding (big-endian for proper linear scans)
@@ -38,4 +38,4 @@ impl ValueCodec<OLStateSchema> for OLStateV1 {
 }
 
 // WriteBatch uses Codec trait (contains non-SSZ types like BTreeMap, SerialMap)
-impl_codec_value_codec!(OLWriteBatchSchema, WriteBatch<OLAccountStateV1>);
+impl_codec_value_codec!(OLWriteBatchSchema, WriteBatch);

--- a/crates/db/tests/src/ol_state_tests.rs
+++ b/crates/db/tests/src/ol_state_tests.rs
@@ -1,8 +1,12 @@
 //! OL state database tests using proptest strategies.
 
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::TestRunner;
 use strata_db_types::ol_state::OLStateDatabase;
+use strata_identifiers::test_utils::{account_id_strategy, account_serial_strategy};
 use strata_identifiers::OLBlockCommitment;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::test_utils::ol_snark_account_state_strategy;
+use strata_ol_state_types_v1::{OLAccountStateV1, OLAccountTypeStateV1, OLStateV1, WriteBatch};
 
 // =============================================================================
 // Proptest-based test functions
@@ -77,7 +81,50 @@ pub fn proptest_delete_toplevel_ol_state(
 }
 
 pub fn proptest_put_and_get_write_batch(db: &impl OLStateDatabase, commitment: OLBlockCommitment) {
-    let wb = WriteBatch::<OLAccountStateV1>::default();
+    let mut runner = TestRunner::deterministic();
+    let created_id = account_id_strategy()
+        .new_tree(&mut runner)
+        .expect("generate created account ID")
+        .current();
+    let updated_id = loop {
+        let id = account_id_strategy()
+            .new_tree(&mut runner)
+            .expect("generate updated account ID")
+            .current();
+        if id != created_id {
+            break id;
+        }
+    };
+    let created_serial = account_serial_strategy()
+        .new_tree(&mut runner)
+        .expect("generate created account serial")
+        .current();
+    let updated_serial = account_serial_strategy()
+        .new_tree(&mut runner)
+        .expect("generate updated account serial")
+        .current();
+    let created_snark_state = ol_snark_account_state_strategy()
+        .new_tree(&mut runner)
+        .expect("generate created snark account state")
+        .current();
+    let mut wb = WriteBatch::default();
+    wb.ledger_mut().create_account_raw(
+        created_id,
+        OLAccountStateV1::new(
+            created_serial,
+            Default::default(),
+            OLAccountTypeStateV1::Snark(created_snark_state),
+        ),
+        created_serial,
+    );
+    wb.ledger_mut().update_account(
+        updated_id,
+        OLAccountStateV1::new(
+            updated_serial,
+            Default::default(),
+            OLAccountTypeStateV1::Empty,
+        ),
+    );
     db.put_ol_write_batch(commitment, wb.clone())
         .expect("test: put write batch");
     let retrieved_wb = db
@@ -88,10 +135,19 @@ pub fn proptest_put_and_get_write_batch(db: &impl OLStateDatabase, commitment: O
         retrieved_wb.global_writes().cur_slot,
         wb.global_writes().cur_slot,
     );
+    assert_eq!(
+        retrieved_wb.ledger().get_account(&created_id),
+        wb.ledger().get_account(&created_id),
+    );
+    assert_eq!(
+        retrieved_wb.ledger().get_account(&updated_id),
+        wb.ledger().get_account(&updated_id),
+    );
+    assert_eq!(retrieved_wb.ledger().new_accounts(), &[created_id]);
 }
 
 pub fn proptest_delete_write_batch(db: &impl OLStateDatabase, commitment: OLBlockCommitment) {
-    let wb = WriteBatch::<OLAccountStateV1>::default();
+    let wb = WriteBatch::default();
     db.put_ol_write_batch(commitment, wb)
         .expect("test: put write batch");
     db.del_ol_write_batch(commitment)

--- a/crates/db/types/src/ol_state.rs
+++ b/crates/db/types/src/ol_state.rs
@@ -1,12 +1,10 @@
 //! Toplevel OL state database interface.
 
 // TODO(STR-4220): replace OLStateV1 with a versionable wrapper
-// TODO(STR-4220): make WriteBatch use its own concrete account type instead of being generic
-
 #[cfg(feature = "proxies")]
 use strata_db_macros::gen_proxy;
 use strata_identifiers::OLBlockCommitment;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 
 #[cfg(feature = "proxies")]
 use crate::DbError;
@@ -40,17 +38,10 @@ pub trait OLStateDatabase: Send + Sync + 'static {
     /// Stores an OL write batch for a given block commitment.
     ///
     /// Write batches represent state changes that can be applied to a state.
-    fn put_ol_write_batch(
-        &self,
-        commitment: OLBlockCommitment,
-        wb: WriteBatch<OLAccountStateV1>,
-    ) -> DbResult<()>;
+    fn put_ol_write_batch(&self, commitment: OLBlockCommitment, wb: WriteBatch) -> DbResult<()>;
 
     /// Retrieves an OL write batch for a given block commitment.
-    fn get_ol_write_batch(
-        &self,
-        commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>>;
+    fn get_ol_write_batch(&self, commitment: OLBlockCommitment) -> DbResult<Option<WriteBatch>>;
 
     /// Deletes an OL write batch for a given block commitment.
     fn del_ol_write_batch(&self, commitment: OLBlockCommitment) -> DbResult<()>;

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -12,7 +12,7 @@ use strata_ol_chain_types_v1::*;
 use strata_ol_mempool::MempoolTxInvalidReason;
 use strata_ol_state_support_types::{DaAccumulatingState, WriteTrackingState};
 use strata_ol_state_types::{AccProofCheck, ISnarkAccountState, IStateAccessor, TxProofIndexer, *};
-use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, OLAccountStateV1, WriteBatch};
+use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, WriteBatch};
 use strata_ol_stf_v1::*;
 use strata_ol_tx_types_v1::*;
 use strata_snark_acct_types as _;
@@ -40,7 +40,7 @@ struct ProcessTransactionsOutput {
     /// Transactions that failed during block assembly.
     failed_txs: Vec<FailedMempoolTx>,
     /// Accumulated write batch after processing all transactions.
-    accumulated_batch: WriteBatch<OLAccountStateV1>,
+    accumulated_batch: WriteBatch,
     /// Accumulated da data after processing all transactions.
     accumulated_da: AccumulatedDaData,
     /// Non-cadence limits requesting an epoch seal, if any.
@@ -49,7 +49,7 @@ struct ProcessTransactionsOutput {
 
 /// Inputs consumed while finalizing a block template.
 struct BuildBlockTemplateInput {
-    accumulated_batch: WriteBatch<OLAccountStateV1>,
+    accumulated_batch: WriteBatch,
     output_buffer: ExecOutputBuffer,
     successful_txs: Vec<OLTransactionV1>,
     is_terminal: bool,
@@ -556,7 +556,7 @@ fn execute_block_initialization<S: BlockAssemblyStateAccess>(
     parent_state: &S,
     block_context: &BlockContext<'_>,
     accumulated_da: AccumulatedDaData,
-) -> (WriteBatch<OLAccountStateV1>, AccumulatedDaData) {
+) -> (WriteBatch, AccumulatedDaData) {
     let (accumulator, logs) = accumulated_da.into_parts();
     let write_state = WriteTrackingState::new_empty(parent_state);
     let mut da_state = DaAccumulatingState::new_with_accumulator(write_state, accumulator);
@@ -596,7 +596,7 @@ fn process_transactions<P, E, S>(
     block_context: &BlockContext<'_>,
     output_buffer: &ExecOutputBuffer,
     parent_state: &S,
-    accumulated_batch: WriteBatch<OLAccountStateV1>,
+    accumulated_batch: WriteBatch,
     mempool_txs: Vec<(OLTxId, OLTransactionV1)>,
     accumulated_da: AccumulatedDaData,
     epoch_cumulative_manifest_count: u32,
@@ -1010,7 +1010,7 @@ mod tests {
     use crate::test_utils::*;
     use crate::{FixedSlotSealing, LimitAwareSealing};
 
-    type OlWriteBatch = WriteBatch<OLAccountStateV1>;
+    type OLWriteBatch = WriteBatch;
 
     const SEALING_MANIFEST_CAP: L1Height = MAX_SEALING_MANIFEST_COUNT as L1Height;
 
@@ -2788,7 +2788,7 @@ mod tests {
         Arc<MemoryStateBaseLayer>,
         OLBlockHeaderV1,
         BlockInfo,
-        OlWriteBatch,
+        OLWriteBatch,
         ExecOutputBuffer,
     ) {
         let parent_state = env

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -11,10 +11,8 @@ use strata_identifiers::{Epoch, OLBlockCommitment, OLTxId, Slot};
 use strata_ol_chain_types_v1::*;
 use strata_ol_mempool::MempoolTxInvalidReason;
 use strata_ol_state_support_types::{DaAccumulatingState, WriteTrackingState};
-use strata_ol_state_types::{
-    AccProofCheck, IAccountState, ISnarkAccountState, IStateAccessor, TxProofIndexer, *,
-};
-use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, WriteBatch};
+use strata_ol_state_types::{AccProofCheck, ISnarkAccountState, IStateAccessor, TxProofIndexer, *};
+use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, OLAccountStateV1, WriteBatch};
 use strata_ol_stf_v1::*;
 use strata_ol_tx_types_v1::*;
 use strata_snark_acct_types as _;
@@ -36,13 +34,13 @@ use crate::{
 };
 
 /// Output from processing transactions during block assembly.
-struct ProcessTransactionsOutput<S: IStateAccessor> {
+struct ProcessTransactionsOutput {
     /// Transactions that passed validation and execution
     successful_txs: Vec<OLTransactionV1>,
     /// Transactions that failed during block assembly.
     failed_txs: Vec<FailedMempoolTx>,
     /// Accumulated write batch after processing all transactions.
-    accumulated_batch: WriteBatch<S::AccountState>,
+    accumulated_batch: WriteBatch<OLAccountStateV1>,
     /// Accumulated da data after processing all transactions.
     accumulated_da: AccumulatedDaData,
     /// Non-cadence limits requesting an epoch seal, if any.
@@ -50,8 +48,8 @@ struct ProcessTransactionsOutput<S: IStateAccessor> {
 }
 
 /// Inputs consumed while finalizing a block template.
-struct BuildBlockTemplateInput<A> {
-    accumulated_batch: WriteBatch<A>,
+struct BuildBlockTemplateInput {
+    accumulated_batch: WriteBatch<OLAccountStateV1>,
     output_buffer: ExecOutputBuffer,
     successful_txs: Vec<OLTransactionV1>,
     is_terminal: bool,
@@ -194,7 +192,6 @@ where
     C: BlockAssemblyAnchorContext + AccumulatorProofGenerator + MempoolProvider,
     C::State: BlockAssemblyStateAccess,
     E: EpochSealingPolicy,
-    <<C::State as IStateAccessor>::AccountState as IAccountStateMut>::SnarkAccountStateMut: Clone,
 {
     let max_txs_per_block = sequencer_config.max_txs_per_block;
 
@@ -293,7 +290,6 @@ pub(crate) async fn construct_block<C, E>(
 where
     C: BlockAssemblyAnchorContext + AccumulatorProofGenerator,
     E: EpochSealingPolicy,
-    <<C::State as IStateAccessor>::AccountState as IAccountStateMut>::SnarkAccountStateMut: Clone,
 {
     // Extract parent commitment from config.
     // Null parent means genesis - but genesis is built via `init_ol_genesis`, not block assembly.
@@ -560,10 +556,7 @@ fn execute_block_initialization<S: BlockAssemblyStateAccess>(
     parent_state: &S,
     block_context: &BlockContext<'_>,
     accumulated_da: AccumulatedDaData,
-) -> (WriteBatch<S::AccountState>, AccumulatedDaData)
-where
-    <<S as IStateAccessor>::AccountState as IAccountStateMut>::SnarkAccountStateMut: Clone,
-{
+) -> (WriteBatch<OLAccountStateV1>, AccumulatedDaData) {
     let (accumulator, logs) = accumulated_da.into_parts();
     let write_state = WriteTrackingState::new_empty(parent_state);
     let mut da_state = DaAccumulatingState::new_with_accumulator(write_state, accumulator);
@@ -603,17 +596,16 @@ fn process_transactions<P, E, S>(
     block_context: &BlockContext<'_>,
     output_buffer: &ExecOutputBuffer,
     parent_state: &S,
-    accumulated_batch: WriteBatch<S::AccountState>,
+    accumulated_batch: WriteBatch<OLAccountStateV1>,
     mempool_txs: Vec<(OLTxId, OLTransactionV1)>,
     accumulated_da: AccumulatedDaData,
     epoch_cumulative_manifest_count: u32,
     bridge_params: BridgeParams,
-) -> ProcessTransactionsOutput<S>
+) -> ProcessTransactionsOutput
 where
     P: AccumulatorProofGenerator,
     E: EpochSealingPolicy,
     S: BlockAssemblyStateAccess,
-    <<S as IStateAccessor>::AccountState as IAccountStateMut>::SnarkAccountStateMut: Clone,
 {
     let mut successful_txs = Vec::new();
     let mut failed_txs = Vec::new();
@@ -802,7 +794,7 @@ fn build_block_template<S>(
     config: &BlockGenerationConfig,
     block_context: &BlockContext<'_>,
     parent_state: &Arc<S>,
-    input: BuildBlockTemplateInput<S::AccountState>,
+    input: BuildBlockTemplateInput,
 ) -> BlockAssemblyResult<(FullBlockTemplate, S)>
 where
     S: BlockAssemblyStateAccess,
@@ -1018,7 +1010,7 @@ mod tests {
     use crate::test_utils::*;
     use crate::{FixedSlotSealing, LimitAwareSealing};
 
-    type OlWriteBatch = WriteBatch<<MemoryStateBaseLayer as IStateAccessor>::AccountState>;
+    type OlWriteBatch = WriteBatch<OLAccountStateV1>;
 
     const SEALING_MANIFEST_CAP: L1Height = MAX_SEALING_MANIFEST_COUNT as L1Height;
 
@@ -2985,7 +2977,7 @@ mod tests {
         account_id: AccountId,
         seeded_log_count: usize,
         mempool_txs: Vec<(OLTxId, OLTransactionV1)>,
-    ) -> ProcessTransactionsOutput<MemoryStateBaseLayer> {
+    ) -> ProcessTransactionsOutput {
         const CHECKPOINT_TEST_TIMESTAMP: u64 = 1_000_003;
         const CHECKPOINT_TEST_SLOT_OFFSET: u64 = 3;
 

--- a/crates/ol/block-assembly/src/context.rs
+++ b/crates/ol/block-assembly/src/context.rs
@@ -14,8 +14,8 @@ use strata_ol_chain_types_v1::{OLBlockHeaderV1, OLBlockV1};
 use strata_ol_mempool::MempoolTxInvalidReason;
 use strata_ol_state_provider::StateProvider;
 use strata_ol_state_support_types::IComputeStateRootWithWrites;
-use strata_ol_state_types::{IAccountState, IAccountStateMut, IStateAccessor, IStateAccessorMut};
-use strata_ol_state_types_v1::IStateBatchApplicable;
+use strata_ol_state_types::{IStateAccessor, IStateAccessorMut};
+use strata_ol_state_types_v1::{IStateBatchApplicable, OLAccountStateV1};
 use strata_ol_tx_types_v1::OLTransactionV1;
 use strata_snark_acct_types::LedgerRefProofs;
 use strata_storage::NodeStorage;
@@ -23,22 +23,11 @@ use tracing::debug;
 
 use crate::{BlockAssemblyError, BlockAssemblyResult, MempoolProvider};
 
-/// Account state capabilities required by block assembly.
-pub trait BlockAssemblyAccountState:
-    Clone + IAccountState + IAccountStateMut + Send + Sync
-{
-}
-
-impl<T> BlockAssemblyAccountState for T where
-    T: Clone + IAccountState + IAccountStateMut + Send + Sync
-{
-}
-
 /// State capabilities required by block assembly.
 pub trait BlockAssemblyStateAccess:
     IComputeStateRootWithWrites
     + IStateBatchApplicable
-    + IStateAccessorMut<AccountState: BlockAssemblyAccountState>
+    + IStateAccessorMut<AccountState = OLAccountStateV1>
     + Clone
     + Send
     + Sync
@@ -48,7 +37,7 @@ pub trait BlockAssemblyStateAccess:
 impl<T> BlockAssemblyStateAccess for T where
     T: IComputeStateRootWithWrites
         + IStateBatchApplicable
-        + IStateAccessorMut<AccountState: BlockAssemblyAccountState>
+        + IStateAccessorMut<AccountState = OLAccountStateV1>
         + Clone
         + Send
         + Sync

--- a/crates/ol/mmr-index/src/test_utils.rs
+++ b/crates/ol/mmr-index/src/test_utils.rs
@@ -5,7 +5,7 @@ use strata_merkle::{Mmr, MmrState};
 use strata_ol_params::{BridgeParams, GenesisSnarkAccountData, OLParams};
 use strata_ol_state_support_types::MemoryStateBaseLayer;
 use strata_ol_state_types::{IAccountStateMut, ISnarkAccountStateMut};
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_predicate::PredicateKey;
 
 use crate::{MmrIndexEntry, resolve_ol_mmr_target};
@@ -21,7 +21,7 @@ pub(crate) fn build_genesis_target_state() -> OLStateV1 {
 pub(crate) fn build_target_state_with_empty_l1_block_refs_mmr() -> OLStateV1 {
     let mut state = build_genesis_target_state();
 
-    let mut batch = WriteBatch::<OLAccountStateV1>::default();
+    let mut batch = WriteBatch::default();
     batch.epochal_writes_mut().l1_block_refs_mmr = Some(Mmr64::new_empty());
     state
         .apply_write_batch(batch)
@@ -73,7 +73,7 @@ pub(crate) fn build_target_state_with_snark_inbox(
             .expect("insert inbox message");
     }
 
-    let mut batch = WriteBatch::<OLAccountStateV1>::default();
+    let mut batch = WriteBatch::default();
     batch.ledger_mut().update_account(account_id, account);
     state
         .apply_write_batch(batch)

--- a/crates/ol/rpc/types/src/provider.rs
+++ b/crates/ol/rpc/types/src/provider.rs
@@ -16,7 +16,7 @@ use strata_db_types::DbResult;
 use strata_identifiers::{AccountId, Epoch, L1Height, OLBlockId, OLTxId};
 use strata_ol_chain_types_v1::OLBlockV1;
 use strata_ol_mempool::OLMempoolResult;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_ol_tx_types_v1::OLTransactionV1;
 use strata_primitives::epoch::EpochCommitment;
 use strata_primitives::OLBlockCommitment;
@@ -47,7 +47,7 @@ pub trait OLRpcProvider: Send + Sync + 'static {
     async fn get_ol_write_batch(
         &self,
         commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>>;
+    ) -> DbResult<Option<WriteBatch>>;
 
     /// Get the canonical epoch commitment for the given epoch.
     async fn get_canonical_epoch_commitment_at(

--- a/crates/ol/state-support-types/src/batch_diff_layer.rs
+++ b/crates/ol/state-support-types/src/batch_diff_layer.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use strata_acct_types::{AccountId, AccountSerial, BitcoinAmount, Mmr64};
 use strata_identifiers::{Buf32, EpochCommitment, L1BlockId, L1Height};
 use strata_ol_state_types::{IStateAccessor, PendingAsmLog, StateResult};
-use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, WriteBatch};
+use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, OLAccountStateV1, WriteBatch};
 
 use crate::write_tracking_layer::IComputeStateRootWithWrites;
 
@@ -25,7 +25,7 @@ use crate::write_tracking_layer::IComputeStateRootWithWrites;
 #[derive(Clone)]
 pub struct BatchDiffState<'batches, 'base, S: IStateAccessor> {
     base: &'base S,
-    write_batches: &'batches [WriteBatch<S::AccountState>],
+    write_batches: &'batches [WriteBatch<OLAccountStateV1>],
 
     /// Helper field so that we only have to compute this once.
     new_accounts: usize,
@@ -34,7 +34,6 @@ pub struct BatchDiffState<'batches, 'base, S: IStateAccessor> {
 impl<S: IStateAccessor> fmt::Debug for BatchDiffState<'_, '_, S>
 where
     S: fmt::Debug,
-    S::AccountState: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BatchDiffState")
@@ -51,7 +50,7 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     /// The batches are checked in reverse order (last = most recent) before falling
     /// back to the base state. An empty batch slice results in a pure read-only
     /// passthrough to the base.
-    pub fn new(base: &'base S, batches: &'batches [WriteBatch<S::AccountState>]) -> Self {
+    pub fn new(base: &'base S, batches: &'batches [WriteBatch<OLAccountStateV1>]) -> Self {
         let new_accounts = batches
             .iter()
             .map(|wb| wb.ledger().new_accounts().len())
@@ -70,7 +69,7 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     }
 
     /// Returns a reference to the batch slice.
-    pub fn write_batches(&self) -> &'batches [WriteBatch<S::AccountState>] {
+    pub fn write_batches(&self) -> &'batches [WriteBatch<OLAccountStateV1>] {
         self.write_batches
     }
 
@@ -85,7 +84,7 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     /// by `on_wb`, or if none match, returns the result of `on_base`.
     fn resolve<T>(
         &self,
-        on_wb: impl Fn(&'batches WriteBatch<S::AccountState>) -> Option<T>,
+        on_wb: impl Fn(&'batches WriteBatch<OLAccountStateV1>) -> Option<T>,
         on_base: impl FnOnce() -> T,
     ) -> T {
         for wb in self.write_batches.iter().rev() {
@@ -97,8 +96,9 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     }
 }
 
-impl<'batches, 'base, S: IStateAccessor + IComputeStateRootWithWrites> IStateAccessor
-    for BatchDiffState<'batches, 'base, S>
+impl<'batches, 'base, S> IStateAccessor for BatchDiffState<'batches, 'base, S>
+where
+    S: IStateAccessor<AccountState = OLAccountStateV1> + IComputeStateRootWithWrites,
 {
     type AccountState = S::AccountState;
 
@@ -239,16 +239,14 @@ impl<'batches, 'base, S: IStateAccessor + IComputeStateRootWithWrites> IStateAcc
     }
 }
 
-impl<'batches, 'base, S: IComputeStateRootWithWrites> IComputeStateRootWithWrites
-    for BatchDiffState<'batches, 'base, S>
+impl<'batches, 'base, S> IComputeStateRootWithWrites for BatchDiffState<'batches, 'base, S>
+where
+    S: IStateAccessor<AccountState = OLAccountStateV1> + IComputeStateRootWithWrites,
 {
     fn compute_state_root_with_writes<'b>(
         &'b self,
-        writes: impl Iterator<Item = &'b WriteBatch<Self::AccountState>>,
-    ) -> StateResult<Buf32>
-    where
-        Self::AccountState: 'b,
-    {
+        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+    ) -> StateResult<Buf32> {
         self.base
             .compute_state_root_with_writes(self.write_batches.iter().chain(writes))
     }

--- a/crates/ol/state-support-types/src/batch_diff_layer.rs
+++ b/crates/ol/state-support-types/src/batch_diff_layer.rs
@@ -25,7 +25,7 @@ use crate::write_tracking_layer::IComputeStateRootWithWrites;
 #[derive(Clone)]
 pub struct BatchDiffState<'batches, 'base, S: IStateAccessor> {
     base: &'base S,
-    write_batches: &'batches [WriteBatch<OLAccountStateV1>],
+    write_batches: &'batches [WriteBatch],
 
     /// Helper field so that we only have to compute this once.
     new_accounts: usize,
@@ -50,7 +50,7 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     /// The batches are checked in reverse order (last = most recent) before falling
     /// back to the base state. An empty batch slice results in a pure read-only
     /// passthrough to the base.
-    pub fn new(base: &'base S, batches: &'batches [WriteBatch<OLAccountStateV1>]) -> Self {
+    pub fn new(base: &'base S, batches: &'batches [WriteBatch]) -> Self {
         let new_accounts = batches
             .iter()
             .map(|wb| wb.ledger().new_accounts().len())
@@ -69,7 +69,7 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     }
 
     /// Returns a reference to the batch slice.
-    pub fn write_batches(&self) -> &'batches [WriteBatch<OLAccountStateV1>] {
+    pub fn write_batches(&self) -> &'batches [WriteBatch] {
         self.write_batches
     }
 
@@ -84,7 +84,7 @@ impl<'batches, 'base, S: IStateAccessor> BatchDiffState<'batches, 'base, S> {
     /// by `on_wb`, or if none match, returns the result of `on_base`.
     fn resolve<T>(
         &self,
-        on_wb: impl Fn(&'batches WriteBatch<OLAccountStateV1>) -> Option<T>,
+        on_wb: impl Fn(&'batches WriteBatch) -> Option<T>,
         on_base: impl FnOnce() -> T,
     ) -> T {
         for wb in self.write_batches.iter().rev() {
@@ -245,7 +245,7 @@ where
 {
     fn compute_state_root_with_writes<'b>(
         &'b self,
-        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+        writes: impl Iterator<Item = &'b WriteBatch>,
     ) -> StateResult<Buf32> {
         self.base
             .compute_state_root_with_writes(self.write_batches.iter().chain(writes))
@@ -254,15 +254,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use strata_acct_types::{BitcoinAmount, SYSTEM_RESERVED_ACCTS};
-    use strata_identifiers::{AccountSerial, Buf32, L1BlockId};
-    use strata_ol_state_types::{IAccountState, IStateAccessor, IStateAccessorMut};
-    use strata_ol_state_types_v1::OLAccountStateV1;
-
     use super::*;
     use crate::common_tests::impl_read_layer_tests;
     use crate::test_utils::*;
     use crate::write_tracking_layer::WriteTrackingState;
+    use strata_acct_types::{BitcoinAmount, SYSTEM_RESERVED_ACCTS};
+    use strata_identifiers::{AccountSerial, Buf32, L1BlockId};
+    use strata_ol_state_types::{IAccountState, IStateAccessor, IStateAccessorMut};
 
     /// Builds a [`BatchDiffState`] with no pending batches — a pure read-only
     /// passthrough to the base.
@@ -622,7 +620,7 @@ mod tests {
         assert_ne!(base_root, diff_root);
 
         // An empty-batches diff should match the base root.
-        let empty_batches: Vec<WriteBatch<_>> = vec![];
+        let empty_batches: Vec<WriteBatch> = vec![];
         let passthrough = BatchDiffState::new(&base_layer, &empty_batches);
         assert_eq!(passthrough.compute_state_root().unwrap(), base_root);
     }
@@ -736,7 +734,7 @@ mod tests {
     #[test]
     fn test_last_l1_blkid_from_batch() {
         let base_layer = create_test_base_layer();
-        let batch: WriteBatch<_> = WriteBatch::default();
+        let batch: WriteBatch = WriteBatch::default();
 
         let batches = vec![batch];
         let diff_state = BatchDiffState::new(&base_layer, &batches);
@@ -756,8 +754,8 @@ mod tests {
         PendingAsmLog::new(strata_identifiers::L1Height::from(tag as u32), entry)
     }
 
-    fn batch_with_appends(tags: &[u8]) -> WriteBatch<OLAccountStateV1> {
-        let mut wb: WriteBatch<OLAccountStateV1> = WriteBatch::default();
+    fn batch_with_appends(tags: &[u8]) -> WriteBatch {
+        let mut wb = WriteBatch::default();
         for t in tags {
             wb.intraepoch_writes_mut()
                 .appended_pending_asm_logs
@@ -766,7 +764,7 @@ mod tests {
         wb
     }
 
-    fn batch_reset_then_appends(tags: &[u8]) -> WriteBatch<OLAccountStateV1> {
+    fn batch_reset_then_appends(tags: &[u8]) -> WriteBatch {
         let mut wb = batch_with_appends(tags);
         wb.intraepoch_writes_mut().reset = true;
         // reset+appends mean: clear, then append the tags above.

--- a/crates/ol/state-support-types/src/indexer_layer.rs
+++ b/crates/ol/state-support-types/src/indexer_layer.rs
@@ -4,6 +4,7 @@
 //! to accumulator structures (like MMRs) and records them for later use by
 //! indexers, while passing all operations through to an inner implementation.
 
+use std::convert::Infallible;
 use std::fmt;
 
 use strata_acct_types::*;
@@ -243,10 +244,17 @@ where
 
 impl<A: IAccountStateMut> IAccountState for IndexerAccountStateMut<A> {
     type SnarkAccountState = A::SnarkAccountState;
+    /// A full-state replacement cannot be described by the incremental index
+    /// writes this wrapper tracks, so the write type is unconstructible.
+    type Write = Infallible;
 
     fn new_with_serial(_new_acct_data: NewAccountData, _serial: AccountSerial) -> Self {
         // TODO(STR-3228): refactor indexer bookkeeping types so this isn't required on wrappers
         unimplemented!("cannot construct wrapper type directly")
+    }
+
+    fn apply_write(&mut self, write: Self::Write) -> StateResult<()> {
+        match write {}
     }
 
     fn serial(&self) -> AccountSerial {

--- a/crates/ol/state-support-types/src/memory_state_layer.rs
+++ b/crates/ol/state-support-types/src/memory_state_layer.rs
@@ -226,7 +226,7 @@ impl IStateAccessorMut for MemoryStateBaseLayer {
 }
 
 impl IStateBatchApplicable for MemoryStateBaseLayer {
-    fn apply_write_batch(&mut self, batch: WriteBatch<Self::AccountState>) -> StateResult<()> {
+    fn apply_write_batch(&mut self, batch: WriteBatch<OLAccountStateV1>) -> StateResult<()> {
         // Validate serial bookkeeping before mutating any state so that an
         // error leaves both the inner state and the serials index untouched.
         let mut new_accounts: Vec<(AccountSerial, AccountId)> =

--- a/crates/ol/state-support-types/src/memory_state_layer.rs
+++ b/crates/ol/state-support-types/src/memory_state_layer.rs
@@ -226,7 +226,7 @@ impl IStateAccessorMut for MemoryStateBaseLayer {
 }
 
 impl IStateBatchApplicable for MemoryStateBaseLayer {
-    fn apply_write_batch(&mut self, batch: WriteBatch<OLAccountStateV1>) -> StateResult<()> {
+    fn apply_write_batch(&mut self, batch: WriteBatch) -> StateResult<()> {
         // Validate serial bookkeeping before mutating any state so that an
         // error leaves both the inner state and the serials index untouched.
         let mut new_accounts: Vec<(AccountSerial, AccountId)> =
@@ -255,7 +255,7 @@ impl IStateBatchApplicable for MemoryStateBaseLayer {
 impl IComputeStateRootWithWrites for MemoryStateBaseLayer {
     fn compute_state_root_with_writes<'b>(
         &self,
-        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+        writes: impl Iterator<Item = &'b WriteBatch>,
     ) -> StateResult<Buf32> {
         let mut state = self.state.clone();
 

--- a/crates/ol/state-support-types/src/tests.rs
+++ b/crates/ol/state-support-types/src/tests.rs
@@ -523,6 +523,7 @@ struct TestAccountState {
 
 impl IAccountState for TestAccountState {
     type SnarkAccountState = TestSnarkState;
+    type Write = Self;
 
     fn new_with_serial(new_acct_data: NewAccountData, serial: AccountSerial) -> Self {
         let balance = new_acct_data.initial_balance();
@@ -542,6 +543,11 @@ impl IAccountState for TestAccountState {
             ty,
             snark,
         }
+    }
+
+    fn apply_write(&mut self, write: Self::Write) -> StateResult<()> {
+        *self = write;
+        Ok(())
     }
 
     fn serial(&self) -> AccountSerial {

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -21,7 +21,7 @@ pub trait IComputeStateRootWithWrites: IStateAccessor {
     /// current state.
     fn compute_state_root_with_writes<'b>(
         &'b self,
-        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+        writes: impl Iterator<Item = &'b WriteBatch>,
     ) -> StateResult<Buf32>;
 }
 
@@ -31,7 +31,7 @@ pub trait IComputeStateRootWithWrites: IStateAccessor {
 /// All writes are recorded in the write batch.
 pub struct WriteTrackingState<'base, S: IStateAccessor> {
     base: &'base S,
-    batch: WriteBatch<OLAccountStateV1>,
+    batch: WriteBatch,
 }
 
 impl<S: IStateAccessor> fmt::Debug for WriteTrackingState<'_, S>
@@ -51,7 +51,7 @@ impl<'base, S: IStateAccessor> WriteTrackingState<'base, S> {
     ///
     /// The global and epochal state are cloned from the base into the write batch,
     /// since they're small and always modified during block execution.
-    pub fn new(base: &'base S, batch: WriteBatch<OLAccountStateV1>) -> Self {
+    pub fn new(base: &'base S, batch: WriteBatch) -> Self {
         Self { base, batch }
     }
 
@@ -64,12 +64,12 @@ impl<'base, S: IStateAccessor> WriteTrackingState<'base, S> {
     }
 
     /// Returns a reference to the underlying write batch.
-    pub fn batch(&self) -> &WriteBatch<OLAccountStateV1> {
+    pub fn batch(&self) -> &WriteBatch {
         &self.batch
     }
 
     /// Consumes this wrapper and returns the write batch.
-    pub fn into_batch(self) -> WriteBatch<OLAccountStateV1> {
+    pub fn into_batch(self) -> WriteBatch {
         self.batch
     }
 }
@@ -228,7 +228,7 @@ where
 {
     fn compute_state_root_with_writes<'b>(
         &'b self,
-        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+        writes: impl Iterator<Item = &'b WriteBatch>,
     ) -> StateResult<Buf32> {
         // Our own batch is older than anything layered on top of us, so it goes
         // first.

--- a/crates/ol/state-support-types/src/write_tracking_layer.rs
+++ b/crates/ol/state-support-types/src/write_tracking_layer.rs
@@ -10,7 +10,7 @@ use strata_acct_types::{
 };
 use strata_identifiers::{Buf32, EpochCommitment, L1BlockId, L1Height};
 use strata_ol_state_types::*;
-use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, WriteBatch};
+use strata_ol_state_types_v1::{MAX_PENDING_ASM_LOGS, OLAccountStateV1, WriteBatch};
 
 /// Helper trait for computing the state root after hypothetically applying a
 /// write batch, without requiring `Clone` on the state itself.
@@ -21,10 +21,8 @@ pub trait IComputeStateRootWithWrites: IStateAccessor {
     /// current state.
     fn compute_state_root_with_writes<'b>(
         &'b self,
-        writes: impl Iterator<Item = &'b WriteBatch<Self::AccountState>>,
-    ) -> StateResult<Buf32>
-    where
-        Self::AccountState: 'b;
+        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+    ) -> StateResult<Buf32>;
 }
 
 /// A write-tracking state accessor that wraps a base state.
@@ -33,13 +31,12 @@ pub trait IComputeStateRootWithWrites: IStateAccessor {
 /// All writes are recorded in the write batch.
 pub struct WriteTrackingState<'base, S: IStateAccessor> {
     base: &'base S,
-    batch: WriteBatch<S::AccountState>,
+    batch: WriteBatch<OLAccountStateV1>,
 }
 
 impl<S: IStateAccessor> fmt::Debug for WriteTrackingState<'_, S>
 where
     S: fmt::Debug,
-    S::AccountState: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WriteTrackingState")
@@ -54,7 +51,7 @@ impl<'base, S: IStateAccessor> WriteTrackingState<'base, S> {
     ///
     /// The global and epochal state are cloned from the base into the write batch,
     /// since they're small and always modified during block execution.
-    pub fn new(base: &'base S, batch: WriteBatch<S::AccountState>) -> Self {
+    pub fn new(base: &'base S, batch: WriteBatch<OLAccountStateV1>) -> Self {
         Self { base, batch }
     }
 
@@ -67,20 +64,19 @@ impl<'base, S: IStateAccessor> WriteTrackingState<'base, S> {
     }
 
     /// Returns a reference to the underlying write batch.
-    pub fn batch(&self) -> &WriteBatch<S::AccountState> {
+    pub fn batch(&self) -> &WriteBatch<OLAccountStateV1> {
         &self.batch
     }
 
     /// Consumes this wrapper and returns the write batch.
-    pub fn into_batch(self) -> WriteBatch<S::AccountState> {
+    pub fn into_batch(self) -> WriteBatch<OLAccountStateV1> {
         self.batch
     }
 }
 
-impl<'base, S: IStateAccessor + IComputeStateRootWithWrites> IStateAccessor
-    for WriteTrackingState<'base, S>
+impl<'base, S> IStateAccessor for WriteTrackingState<'base, S>
 where
-    S::AccountState: Clone + IAccountState + IAccountStateMut,
+    S: IStateAccessor<AccountState = OLAccountStateV1> + IComputeStateRootWithWrites,
 {
     type AccountState = S::AccountState;
 
@@ -226,18 +222,14 @@ where
     }
 }
 
-impl<'base, S: IStateAccessor + IComputeStateRootWithWrites> IComputeStateRootWithWrites
-    for WriteTrackingState<'base, S>
+impl<'base, S> IComputeStateRootWithWrites for WriteTrackingState<'base, S>
 where
-    S::AccountState: Clone + IAccountState + IAccountStateMut,
+    S: IStateAccessor<AccountState = OLAccountStateV1> + IComputeStateRootWithWrites,
 {
     fn compute_state_root_with_writes<'b>(
         &'b self,
-        writes: impl Iterator<Item = &'b WriteBatch<Self::AccountState>>,
-    ) -> StateResult<Buf32>
-    where
-        Self::AccountState: 'b,
-    {
+        writes: impl Iterator<Item = &'b WriteBatch<OLAccountStateV1>>,
+    ) -> StateResult<Buf32> {
         // Our own batch is older than anything layered on top of us, so it goes
         // first.
         self.base
@@ -245,12 +237,11 @@ where
     }
 }
 
-impl<'base, S: IStateAccessor + IComputeStateRootWithWrites> IStateAccessorMut
-    for WriteTrackingState<'base, S>
+impl<'base, S> IStateAccessorMut for WriteTrackingState<'base, S>
 where
+    S: IStateAccessor<AccountState = OLAccountStateV1> + IComputeStateRootWithWrites,
     // FIXME(STR-3229): make this actually wrap the account state type so it
     // doesn't have to be mut on its own
-    S::AccountState: IAccountStateMut,
 {
     type AccountStateMut = S::AccountState; // Same type as AccountState for this layer
 

--- a/crates/ol/state-types-v1/src/account.rs
+++ b/crates/ol/state-types-v1/src/account.rs
@@ -5,6 +5,7 @@ use strata_ol_state_types::*;
 use crate::ssz_generated::ssz::state::{
     OLAccountStateV1, OLAccountTypeStateV1, OLSnarkAccountStateV1,
 };
+use crate::write_batch::AccountStateWrite;
 
 impl OLAccountStateV1 {
     /// Creates a new account state.
@@ -24,6 +25,7 @@ impl OLAccountStateV1 {
 
 impl IAccountState for OLAccountStateV1 {
     type SnarkAccountState = OLSnarkAccountStateV1;
+    type Write = AccountStateWrite;
 
     fn new_with_serial(new_acct_data: NewAccountData, serial: AccountSerial) -> Self {
         let balance = new_acct_data.initial_balance();
@@ -38,6 +40,18 @@ impl IAccountState for OLAccountStateV1 {
             )),
         };
         Self::new(serial, balance, type_state)
+    }
+
+    fn apply_write(&mut self, write: Self::Write) -> StateResult<()> {
+        if write.serial() != self.serial() {
+            return Err(StateError::InapplicableAcctWrite {
+                in_state: self.serial(),
+                in_write: write.serial(),
+            });
+        }
+
+        *self = write.into_state();
+        Ok(())
     }
 
     fn serial(&self) -> AccountSerial {
@@ -123,12 +137,73 @@ impl OLAccountTypeStateV1 {
 
 #[cfg(test)]
 mod tests {
+    use strata_predicate::PredicateKey;
     use strata_test_utils_ssz::ssz_proptest;
 
     use super::*;
     use crate::test_utils::{
         ol_account_state_strategy, ol_account_type_state_strategy, ol_snark_account_state_strategy,
     };
+
+    fn bitcoin_amount(sats: u64) -> BitcoinAmount {
+        BitcoinAmount::try_from(sats).expect("amount must not exceed the Bitcoin money supply")
+    }
+
+    #[test]
+    fn apply_write_replaces_state_with_matching_serial() {
+        let serial = AccountSerial::from(7u32);
+        let mut state =
+            OLAccountStateV1::new(serial, bitcoin_amount(1_000), OLAccountTypeStateV1::Empty);
+        let replacement = OLAccountStateV1::new(
+            serial,
+            bitcoin_amount(2_000),
+            OLAccountTypeStateV1::Snark(OLSnarkAccountStateV1::new_fresh(
+                PredicateKey::always_accept(),
+                [1u8; 32].into(),
+            )),
+        );
+
+        state
+            .apply_write(AccountStateWrite::new(replacement))
+            .unwrap();
+
+        assert_eq!(state.balance(), bitcoin_amount(2_000));
+        assert_eq!(state.ty(), AccountTypeId::Snark);
+    }
+
+    #[test]
+    fn apply_write_rejects_mismatched_serial_without_modifying_state() {
+        let state_serial = AccountSerial::from(7u32);
+        let write_serial = AccountSerial::from(8u32);
+        let mut state = OLAccountStateV1::new(
+            state_serial,
+            bitcoin_amount(1_000),
+            OLAccountTypeStateV1::Empty,
+        );
+        let replacement = OLAccountStateV1::new(
+            write_serial,
+            bitcoin_amount(2_000),
+            OLAccountTypeStateV1::Snark(OLSnarkAccountStateV1::new_fresh(
+                PredicateKey::always_accept(),
+                [1u8; 32].into(),
+            )),
+        );
+
+        let error = state
+            .apply_write(AccountStateWrite::new(replacement))
+            .unwrap_err();
+
+        match error {
+            StateError::InapplicableAcctWrite { in_state, in_write } => {
+                assert_eq!(in_state, state_serial);
+                assert_eq!(in_write, write_serial);
+            }
+            error => panic!("unexpected error: {error}"),
+        }
+        assert_eq!(state.serial(), state_serial);
+        assert_eq!(state.balance(), bitcoin_amount(1_000));
+        assert_eq!(state.ty(), AccountTypeId::Empty);
+    }
 
     mod ol_account_state {
         use super::*;

--- a/crates/ol/state-types-v1/src/batch_application.rs
+++ b/crates/ol/state-types-v1/src/batch_application.rs
@@ -2,7 +2,7 @@
 
 use strata_ol_state_types::{IStateAccessor, StateResult};
 
-use crate::{OLAccountStateV1, WriteBatch};
+use crate::WriteBatch;
 
 /// Trait for states that can have write batches applied.
 ///
@@ -17,5 +17,5 @@ pub trait IStateBatchApplicable: IStateAccessor {
     /// with the modifications from the batch.
     ///
     /// If this returns an error then the state is left unmodified.
-    fn apply_write_batch(&mut self, batch: WriteBatch<OLAccountStateV1>) -> StateResult<()>;
+    fn apply_write_batch(&mut self, batch: WriteBatch) -> StateResult<()>;
 }

--- a/crates/ol/state-types-v1/src/batch_application.rs
+++ b/crates/ol/state-types-v1/src/batch_application.rs
@@ -2,7 +2,7 @@
 
 use strata_ol_state_types::{IStateAccessor, StateResult};
 
-use crate::WriteBatch;
+use crate::{OLAccountStateV1, WriteBatch};
 
 /// Trait for states that can have write batches applied.
 ///
@@ -17,5 +17,5 @@ pub trait IStateBatchApplicable: IStateAccessor {
     /// with the modifications from the batch.
     ///
     /// If this returns an error then the state is left unmodified.
-    fn apply_write_batch(&mut self, batch: WriteBatch<Self::AccountState>) -> StateResult<()>;
+    fn apply_write_batch(&mut self, batch: WriteBatch<OLAccountStateV1>) -> StateResult<()>;
 }

--- a/crates/ol/state-types-v1/src/toplevel.rs
+++ b/crates/ol/state-types-v1/src/toplevel.rs
@@ -104,20 +104,20 @@ impl OLStateV1 {
     /// This function failing probably indicates the write batch was not
     /// intended for the state we're trying to apply it to, or some bug with how
     /// we're constructing write batches.
-    pub fn check_write_batch_safe(&self, batch: &WriteBatch<OLAccountStateV1>) -> StateResult<()> {
+    pub fn check_write_batch_safe(&self, batch: &WriteBatch) -> StateResult<()> {
         // Check serial ordering.
         let mut next_serial = self.global.get_next_avail_serial();
         for (serial, id) in batch.ledger().iter_new_accounts() {
-            let state = batch
+            let write = batch
                 .ledger()
-                .get_account(id)
+                .get_account_write(id)
                 .expect("state: batch with dangling serial entry");
 
             // Check that the entry is consistent.
-            if state.serial() != serial {
+            if write.serial() != serial {
                 return Err(StateError::AcctSerialInconsistent {
                     id: *id,
-                    in_acct: state.serial(),
+                    in_acct: write.serial(),
                     in_table: serial,
                 });
             }
@@ -140,17 +140,20 @@ impl OLStateV1 {
         }
 
         // Now check that all existing accounts really exist.
-        for (id, state) in batch.ledger().iter_accounts() {
-            // At this point we know that if the serial is greater than the
-            // current highest serial then it doesn't exist yet, which we've
-            // already checked for.
-            if state.serial() >= self.global.get_next_avail_serial() {
+        for (id, write) in batch.ledger().iter_account_writes() {
+            if batch.ledger().new_accounts().contains(id) {
                 continue;
             }
 
-            // Now make sure it exists.
-            if self.ledger.get_account_state(id).is_none() {
-                return Err(StateError::AccountSanityCheckFail(*id));
+            let existing = self
+                .ledger
+                .get_account_state(id)
+                .ok_or(StateError::AccountSanityCheckFail(*id))?;
+            if write.serial() != existing.serial() {
+                return Err(StateError::InapplicableAcctWrite {
+                    in_state: existing.serial(),
+                    in_write: write.serial(),
+                });
             }
         }
 
@@ -176,7 +179,7 @@ impl OLStateV1 {
     /// with the modifications from the batch.
     ///
     /// If this returns an error then the state is left unmodified.
-    pub fn apply_write_batch(&mut self, batch: WriteBatch<OLAccountStateV1>) -> StateResult<()> {
+    pub fn apply_write_batch(&mut self, batch: WriteBatch) -> StateResult<()> {
         // Safety check first so we can use `.expect`.
         self.check_write_batch_safe(&batch)?;
         let (global_writes, epochal_writes, intraepoch_writes, ledger) = batch.into_parts();
@@ -186,9 +189,9 @@ impl OLStateV1 {
 
         // Create new accounts and update the serial counter.
         let mut num_new_accounts = 0usize;
-        for (account_id, account_state) in new_accounts {
+        for (account_id, write) in new_accounts {
             self.ledger
-                .create_account(account_id, account_state)
+                .create_account(account_id, write.into_state())
                 .expect("state: failed to create account");
             num_new_accounts += 1;
         }
@@ -200,12 +203,14 @@ impl OLStateV1 {
         }
 
         // Update existing accounts.
-        for (account_id, account_state) in updated_accounts {
+        for (account_id, write) in updated_accounts {
             let existing = self
                 .ledger
                 .get_account_state_mut(&account_id)
                 .expect("state: missing expected account");
-            *existing = account_state;
+            existing
+                .apply_write(write)
+                .expect("state: write batch failed safety check");
         }
 
         // Apply global state writes.
@@ -436,6 +441,65 @@ mod tests {
         assert_eq!(
             account.balance(),
             BitcoinAmount::try_from(2000).expect("amount must not exceed the Bitcoin money supply")
+        );
+    }
+
+    #[test]
+    fn test_apply_batch_rejects_mismatched_update_atomically() {
+        let mut state = create_test_genesis_state();
+        let existing_id = test_account_id(1);
+        let new_id = test_account_id(2);
+        let existing_serial = state.next_account_serial();
+        state
+            .create_new_account(
+                existing_id,
+                existing_serial,
+                NewAccountData::new_snark(
+                    BitcoinAmount::try_from(1_000)
+                        .expect("amount must not exceed the Bitcoin money supply"),
+                    PredicateKey::always_accept(),
+                    [0u8; 32].into(),
+                ),
+            )
+            .unwrap();
+
+        let mut batch = WriteBatch::default();
+        let new_serial = state.next_account_serial();
+        batch.ledger_mut().create_account_from_data(
+            new_id,
+            NewAccountData::new_snark(
+                BitcoinAmount::try_from(3_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                PredicateKey::always_accept(),
+                [2u8; 32].into(),
+            ),
+            new_serial,
+        );
+        batch.ledger_mut().update_account(
+            existing_id,
+            OLAccountStateV1::new(
+                new_serial,
+                BitcoinAmount::try_from(5_000)
+                    .expect("amount must not exceed the Bitcoin money supply"),
+                OLAccountTypeStateV1::Snark(OLSnarkAccountStateV1::new_fresh(
+                    PredicateKey::always_accept(),
+                    [1u8; 32].into(),
+                )),
+            ),
+        );
+
+        let error = state.apply_write_batch(batch).unwrap_err();
+
+        assert!(matches!(
+            error,
+            StateError::InapplicableAcctWrite { in_state, in_write }
+                if in_state == existing_serial && in_write == new_serial
+        ));
+        assert!(state.get_account_state(&new_id).is_none());
+        assert_eq!(
+            state.get_account_state(&existing_id).unwrap().balance(),
+            BitcoinAmount::try_from(1_000)
+                .expect("amount must not exceed the Bitcoin money supply")
         );
     }
 

--- a/crates/ol/state-types-v1/src/write_batch.rs
+++ b/crates/ol/state-types-v1/src/write_batch.rs
@@ -2,7 +2,6 @@
 
 use std::collections::BTreeMap;
 
-use ssz::{Decode, Encode};
 use strata_acct_types::{AccountId, AccountSerial, BitcoinAmount, Mmr64};
 use strata_codec::{Codec, CodecError, Decoder, Encoder};
 use strata_codec_utils::CodecSsz;
@@ -94,26 +93,15 @@ pub struct EpochalStateWrites {
 ///
 /// This tracks all modifications made during block execution so they can be
 /// applied atomically or discarded.
-#[derive(Clone, Debug)]
-pub struct WriteBatch<A> {
+#[derive(Clone, Debug, Default)]
+pub struct WriteBatch {
     pub(crate) global_writes: GlobalStateWrites,
     pub(crate) epochal_writes: EpochalStateWrites,
     pub(crate) intraepoch_writes: IntraepochStateWrites,
-    pub(crate) ledger: LedgerWriteBatch<A>,
+    pub(crate) ledger: LedgerWriteBatch,
 }
 
-impl<A> Default for WriteBatch<A> {
-    fn default() -> Self {
-        Self {
-            global_writes: GlobalStateWrites::default(),
-            epochal_writes: EpochalStateWrites::default(),
-            intraepoch_writes: IntraepochStateWrites::default(),
-            ledger: LedgerWriteBatch::new(),
-        }
-    }
-}
-
-impl<A> WriteBatch<A> {
+impl WriteBatch {
     /// Returns a reference to the global state writes.
     pub fn global_writes(&self) -> &GlobalStateWrites {
         &self.global_writes
@@ -145,12 +133,12 @@ impl<A> WriteBatch<A> {
     }
 
     /// Returns a reference to the ledger write batch.
-    pub fn ledger(&self) -> &LedgerWriteBatch<A> {
+    pub fn ledger(&self) -> &LedgerWriteBatch {
         &self.ledger
     }
 
     /// Returns a mutable reference to the ledger write batch.
-    pub fn ledger_mut(&mut self) -> &mut LedgerWriteBatch<A> {
+    pub fn ledger_mut(&mut self) -> &mut LedgerWriteBatch {
         &mut self.ledger
     }
 
@@ -161,7 +149,7 @@ impl<A> WriteBatch<A> {
         GlobalStateWrites,
         EpochalStateWrites,
         IntraepochStateWrites,
-        LedgerWriteBatch<A>,
+        LedgerWriteBatch,
     ) {
         (
             self.global_writes,
@@ -173,33 +161,36 @@ impl<A> WriteBatch<A> {
 }
 
 /// Tracks writes to the ledger accounts table.
-#[derive(Clone, Debug)]
-pub struct LedgerWriteBatch<A> {
+#[derive(Clone, Debug, Default)]
+pub struct LedgerWriteBatch {
     /// Tracks the state of new and updated accounts.
-    account_writes: BTreeMap<AccountId, A>,
+    account_writes: BTreeMap<AccountId, AccountStateWrite>,
 
     /// Maps serial -> account ID for newly created accounts (contiguous serials).
     serial_to_id: SerialMap,
 }
 
-impl<A> LedgerWriteBatch<A> {
+impl LedgerWriteBatch {
     /// Creates a new empty ledger write batch.
     pub fn new() -> Self {
         Self::default()
     }
-}
-
-impl<A: IAccountState> LedgerWriteBatch<A> {
-    /// Tracks creating a new account with the given pre-built state and assigned serial.
+    /// Records a full-replacement write for a new account with the assigned serial.
     ///
     /// The serial should be obtained from `IStateAccessor::next_account_serial()`.
-    pub fn create_account_raw(&mut self, id: AccountId, state: A, serial: AccountSerial) {
+    pub fn create_account_raw(
+        &mut self,
+        id: AccountId,
+        state: OLAccountStateV1,
+        serial: AccountSerial,
+    ) {
         #[cfg(debug_assertions)]
         if self.account_writes.contains_key(&id) {
             panic!("state/wb: creating new account at addr that already exists (addr {id})");
         }
 
-        self.account_writes.insert(id, state);
+        self.account_writes
+            .insert(id, AccountStateWrite::new(state));
         let inserted = self.serial_to_id.insert_next(serial, id);
         debug_assert!(
             inserted,
@@ -216,23 +207,30 @@ impl<A: IAccountState> LedgerWriteBatch<A> {
         new_acct_data: NewAccountData,
         serial: AccountSerial,
     ) {
-        let state = A::new_with_serial(new_acct_data, serial);
+        let state = OLAccountStateV1::new_with_serial(new_acct_data, serial);
         self.create_account_raw(id, state, serial);
     }
 
-    /// Tracks an update to an existing account.
-    pub fn update_account(&mut self, id: AccountId, state: A) {
-        self.account_writes.insert(id, state);
+    /// Records a full-replacement write for an existing account.
+    pub fn update_account(&mut self, id: AccountId, state: OLAccountStateV1) {
+        self.account_writes
+            .insert(id, AccountStateWrite::new(state));
     }
 
     /// Gets a written account state, if it exists in the batch.
-    pub fn get_account(&self, id: &AccountId) -> Option<&A> {
-        self.account_writes.get(id)
+    pub fn get_account(&self, id: &AccountId) -> Option<&OLAccountStateV1> {
+        self.account_writes.get(id).map(AccountStateWrite::state)
     }
 
     /// Gets a mutable reference to a written account state, if it exists.
-    pub fn get_account_mut(&mut self, id: &AccountId) -> Option<&mut A> {
-        self.account_writes.get_mut(id)
+    pub fn get_account_mut(&mut self, id: &AccountId) -> Option<&mut OLAccountStateV1> {
+        self.account_writes
+            .get_mut(id)
+            .map(AccountStateWrite::state_mut)
+    }
+
+    pub(crate) fn get_account_write(&self, id: &AccountId) -> Option<&AccountStateWrite> {
+        self.account_writes.get(id)
     }
 
     /// Checks if an account exists in the write batch.
@@ -256,16 +254,30 @@ impl<A: IAccountState> LedgerWriteBatch<A> {
     }
 
     /// Returns an iterator over all written accounts.
-    pub fn iter_accounts(&self) -> impl Iterator<Item = (&AccountId, &A)> {
+    pub fn iter_accounts(&self) -> impl Iterator<Item = (&AccountId, &OLAccountStateV1)> {
+        self.account_writes
+            .iter()
+            .map(|(id, write)| (id, write.state()))
+    }
+
+    pub(crate) fn iter_account_writes(
+        &self,
+    ) -> impl Iterator<Item = (&AccountId, &AccountStateWrite)> {
         self.account_writes.iter()
     }
 
     /// Consumes the batch, separating new accounts from updated accounts.
     ///
     /// Returns a tuple of:
-    /// - Iterator over (AccountId, A) for newly created accounts (in serial order)
+    /// - Vector of ([`AccountId`], [`AccountStateWrite`]) for newly created accounts
+    ///   (in serial order)
     /// - BTreeMap of remaining account updates (existing accounts only)
-    pub fn into_new_and_updated(mut self) -> (Vec<(AccountId, A)>, BTreeMap<AccountId, A>) {
+    pub fn into_new_and_updated(
+        mut self,
+    ) -> (
+        Vec<(AccountId, AccountStateWrite)>,
+        BTreeMap<AccountId, AccountStateWrite>,
+    ) {
         let new_account_ids = self.serial_to_id.ids().to_vec();
         let mut new_accounts = Vec::with_capacity(new_account_ids.len());
 
@@ -278,15 +290,6 @@ impl<A: IAccountState> LedgerWriteBatch<A> {
         }
 
         (new_accounts, self.account_writes)
-    }
-}
-
-impl<A> Default for LedgerWriteBatch<A> {
-    fn default() -> Self {
-        Self {
-            account_writes: BTreeMap::new(),
-            serial_to_id: SerialMap::new(),
-        }
     }
 }
 
@@ -366,7 +369,7 @@ impl Codec for AccountStateWrite {
     }
 }
 
-impl<A: Encode + Decode + Clone> Codec for WriteBatch<A> {
+impl Codec for WriteBatch {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         self.global_writes.encode(enc)?;
         self.epochal_writes.encode(enc)?;
@@ -390,15 +393,14 @@ impl<A: Encode + Decode + Clone> Codec for WriteBatch<A> {
 }
 
 // Codec implementation for LedgerWriteBatch
-// Uses CodecSsz shim for SSZ types (AccountId, A)
-// and Codec for non-SSZ types (SerialMap)
-impl<A: Encode + Decode + Clone> Codec for LedgerWriteBatch<A> {
+// Uses CodecSsz shim for AccountId and Codec for account writes and SerialMap.
+impl Codec for LedgerWriteBatch {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         // Encode account_writes as a map: length, then (key, value) pairs
         (self.account_writes.len() as u64).encode(enc)?;
-        for (id, state) in &self.account_writes {
+        for (id, write) in &self.account_writes {
             CodecSsz::new(*id).encode(enc)?;
-            CodecSsz::new(state.clone()).encode(enc)?;
+            write.encode(enc)?;
         }
         self.serial_to_id.encode(enc)?;
         Ok(())
@@ -409,13 +411,38 @@ impl<A: Encode + Decode + Clone> Codec for LedgerWriteBatch<A> {
         let mut account_writes = BTreeMap::new();
         for _ in 0..len {
             let id = CodecSsz::<AccountId>::decode(dec)?.into_inner();
-            let state = CodecSsz::<A>::decode(dec)?.into_inner();
-            account_writes.insert(id, state);
+            let write = AccountStateWrite::decode(dec)?;
+            account_writes.insert(id, write);
         }
         let serial_to_id = SerialMap::decode(dec)?;
         Ok(Self {
             account_writes,
             serial_to_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_codec::encode_to_vec;
+
+    use super::*;
+    use crate::OLAccountTypeStateV1;
+
+    #[test]
+    fn account_write_encoding_matches_bare_state_ssz_encoding() {
+        let state = OLAccountStateV1::new(
+            AccountSerial::from(7u32),
+            BitcoinAmount::try_from(1_000u64)
+                .expect("amount must not exceed the Bitcoin money supply"),
+            OLAccountTypeStateV1::Empty,
+        );
+        let write = AccountStateWrite::new(state.clone());
+
+        let write_bytes = encode_to_vec(&write).expect("encode account state write");
+        let state_bytes =
+            encode_to_vec(&CodecSsz::new(state)).expect("encode account state through SSZ shim");
+
+        assert_eq!(write_bytes, state_bytes);
     }
 }

--- a/crates/ol/state-types-v1/src/write_batch.rs
+++ b/crates/ol/state-types-v1/src/write_batch.rs
@@ -9,7 +9,42 @@ use strata_codec_utils::CodecSsz;
 use strata_identifiers::{EpochCommitment, L1BlockId, L1Height, Slot};
 use strata_ol_state_types::{IAccountState, NewAccountData, PendingAsmLog};
 
-use crate::SerialMap;
+use crate::{OLAccountStateV1, SerialMap};
+
+/// A write to a single ledger account.
+///
+/// Currently the only supported write is a full replacement of the account
+/// state; finer-grained writes can be added later. This is NOT a DA type, so
+/// DA considerations do not apply.
+#[derive(Clone, Debug)]
+pub struct AccountStateWrite(OLAccountStateV1);
+
+impl AccountStateWrite {
+    /// Creates an account state write.
+    pub fn new(state: OLAccountStateV1) -> Self {
+        Self(state)
+    }
+
+    /// Returns the replacement account state.
+    pub fn state(&self) -> &OLAccountStateV1 {
+        &self.0
+    }
+
+    /// Returns the replacement account state mutably.
+    pub fn state_mut(&mut self) -> &mut OLAccountStateV1 {
+        &mut self.0
+    }
+
+    /// Consumes the write and returns the replacement account state.
+    pub fn into_state(self) -> OLAccountStateV1 {
+        self.0
+    }
+
+    /// Returns the account serial.
+    pub fn serial(&self) -> AccountSerial {
+        self.0.serial()
+    }
+}
 
 /// Tracked writes to the global state.
 #[derive(Clone, Debug, Default)]
@@ -317,6 +352,17 @@ impl Codec for EpochalStateWrites {
             total_ledger_balance: CodecSsz::<Option<BitcoinAmount>>::decode(dec)?.into_inner(),
             l1_block_refs_mmr: CodecSsz::<Option<Mmr64>>::decode(dec)?.into_inner(),
         })
+    }
+}
+
+impl Codec for AccountStateWrite {
+    fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
+        CodecSsz::new(self.0.clone()).encode(enc)
+    }
+
+    fn decode(dec: &mut impl Decoder) -> Result<Self, CodecError> {
+        let state = CodecSsz::<OLAccountStateV1>::decode(dec)?.into_inner();
+        Ok(Self::new(state))
     }
 }
 

--- a/crates/ol/state-types/src/account.rs
+++ b/crates/ol/state-types/src/account.rs
@@ -10,6 +10,9 @@ pub trait IAccountState: Clone + Sized {
     /// Type representing snark account state.
     type SnarkAccountState: ISnarkAccountState;
 
+    /// The write type that can be applied to this account state.
+    type Write;
+
     // Constructor.
 
     /// Creates a new account state with the given serial, balance, and type state.
@@ -17,6 +20,12 @@ pub trait IAccountState: Clone + Sized {
     /// This is just a dumb piece of data, it does not insert it into any state
     /// tree or anything.
     fn new_with_serial(new_acct_data: NewAccountData, serial: AccountSerial) -> Self;
+
+    /// Applies a write to this state.
+    ///
+    /// Errors if the write is not applicable, e.g. it was produced for a
+    /// different account.
+    fn apply_write(&mut self, write: Self::Write) -> StateResult<()>;
 
     // Accessors.
 

--- a/crates/ol/state-types/src/errors.rs
+++ b/crates/ol/state-types/src/errors.rs
@@ -66,6 +66,14 @@ pub enum StateError {
         in_table: AccountSerial,
     },
 
+    #[error(
+        "write not applicable to account state (state serial {in_state}, write serial {in_write})"
+    )]
+    InapplicableAcctWrite {
+        in_state: AccountSerial,
+        in_write: AccountSerial,
+    },
+
     #[error("inconsistent next serial ordering (cur {cur}, new {new})")]
     NextSerialSequence {
         cur: AccountSerial,

--- a/crates/storage/src/managers/ol_state.rs
+++ b/crates/storage/src/managers/ol_state.rs
@@ -7,7 +7,7 @@ use futures::TryFutureExt;
 use strata_db_types::ol_state::OLStateDatabase;
 use strata_db_types::DbResult;
 use strata_identifiers::OLBlockCommitment;
-use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use tokio::runtime::Handle;
 
 use crate::cache::CacheTable;
@@ -23,7 +23,7 @@ const DEFAULT_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(64).expect("64 is
 pub struct OLStateManager {
     ops: OLStateOps,
     state_cache: CacheTable<OLBlockCommitment, Option<Arc<OLStateV1>>>,
-    wb_cache: CacheTable<OLBlockCommitment, Option<WriteBatch<OLAccountStateV1>>>,
+    wb_cache: CacheTable<OLBlockCommitment, Option<WriteBatch>>,
 }
 
 impl OLStateManager {
@@ -131,7 +131,7 @@ impl OLStateManager {
     pub async fn put_write_batch_async(
         &self,
         commitment: OLBlockCommitment,
-        wb: WriteBatch<OLAccountStateV1>,
+        wb: WriteBatch,
     ) -> DbResult<()> {
         self.ops
             .put_ol_write_batch_async(commitment, wb.clone())
@@ -144,7 +144,7 @@ impl OLStateManager {
     pub fn put_write_batch_blocking(
         &self,
         commitment: OLBlockCommitment,
-        wb: WriteBatch<OLAccountStateV1>,
+        wb: WriteBatch,
     ) -> DbResult<()> {
         self.ops
             .put_ol_write_batch_blocking(commitment, wb.clone())?;
@@ -156,7 +156,7 @@ impl OLStateManager {
     pub async fn get_write_batch_async(
         &self,
         commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>> {
+    ) -> DbResult<Option<WriteBatch>> {
         self.wb_cache
             .get_or_fetch(&commitment, || {
                 self.ops.get_ol_write_batch_fut(commitment).recv()
@@ -168,7 +168,7 @@ impl OLStateManager {
     pub fn get_write_batch_blocking(
         &self,
         commitment: OLBlockCommitment,
-    ) -> DbResult<Option<WriteBatch<OLAccountStateV1>>> {
+    ) -> DbResult<Option<WriteBatch>> {
         self.wb_cache.get_or_fetch_blocking(&commitment, || {
             self.ops.get_ol_write_batch_blocking(commitment)
         })
@@ -199,7 +199,7 @@ mod tests {
     use strata_identifiers::test_utils::ol_block_commitment_strategy;
     use strata_identifiers::OLBlockCommitment;
     use strata_ol_state_types_v1::test_utils::ol_state_strategy;
-    use strata_ol_state_types_v1::{OLAccountStateV1, OLStateV1, WriteBatch};
+    use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
     use tokio::runtime::Runtime;
 
     use super::*;
@@ -278,7 +278,7 @@ mod tests {
 
     fn proptest_put_and_get_write_batch_blocking(commitment: OLBlockCommitment) {
         let manager = setup_manager();
-        let wb = WriteBatch::<OLAccountStateV1>::default();
+        let wb = WriteBatch::default();
         manager
             .put_write_batch_blocking(commitment, wb)
             .expect("test: put");
@@ -290,7 +290,7 @@ mod tests {
 
     fn proptest_delete_write_batch_blocking(commitment: OLBlockCommitment) {
         let manager = setup_manager();
-        let wb = WriteBatch::<OLAccountStateV1>::default();
+        let wb = WriteBatch::default();
         manager
             .put_write_batch_blocking(commitment, wb)
             .expect("test: put");
@@ -378,7 +378,7 @@ mod tests {
 
     async fn proptest_put_and_get_write_batch_async(commitment: OLBlockCommitment) {
         let manager = setup_manager();
-        let wb = WriteBatch::<OLAccountStateV1>::default();
+        let wb = WriteBatch::default();
         manager
             .put_write_batch_async(commitment, wb)
             .await
@@ -392,7 +392,7 @@ mod tests {
 
     async fn proptest_delete_write_batch_async(commitment: OLBlockCommitment) {
         let manager = setup_manager();
-        let wb = WriteBatch::<OLAccountStateV1>::default();
+        let wb = WriteBatch::default();
         manager
             .put_write_batch_async(commitment, wb)
             .await


### PR DESCRIPTION
## Description

Drops the account type parameter from `WriteBatch`/`LedgerWriteBatch`. The only type ever used was `OLAccountStateV1`, and the generic kept the batch defined in terms of a state-accessor type instead of a plain data structure we can persist on its own. The ledger batch now stores a dedicated `AccountStateWrite` type (a full-state replacement; not a DA type), and `IAccountState` gains an associated `Write` type plus a fallible `apply_write` so states apply writes to themselves.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Three commits, each compiles and passes tests on its own — easiest reviewed commit-by-commit:

1. additive: `AccountStateWrite`, `IAccountState::{Write, apply_write}`, impls, tests
2. pins every `WriteBatch<S::AccountState>` signature to the concrete type (shows the generic carried no weight)
3. drops the parameter and deletes the type args workspace-wide

Worth knowing:

- `LedgerWriteBatch` accessors still hand out `OLAccountStateV1`, so layers, RPC, and existing tests are untouched.
- `check_write_batch_safe` now preflights update serials against stored accounts (stricter than the old serial-threshold heuristic), keeping `apply_write_batch`'s "error leaves state unmodified" contract; regression test included.
- On-disk batch encoding is byte-identical, pinned by a byte-equivalence test and a non-empty DB round-trip test.
- `IndexerAccountStateMut` sets `Write = Infallible`: that wrapper can't describe a full-state replacement with its incremental index writes, so the call is unconstructible.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-4254]: https://alpenlabs.atlassian.net/browse/STR-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ