### PR TITLE
fix(alpen-cli)!: derive the signet wallet via standard BIP39, not raw entropy

### DIFF
--- a/bin/alpen-cli/src/cmd/backup.rs
+++ b/bin/alpen-cli/src/cmd/backup.rs
@@ -9,7 +9,7 @@ use crate::seed::Seed;
 /// Prints a BIP39 mnemonic encoding the internal wallet's seed bytes
 pub struct BackupArgs {}
 
-pub async fn backup(_args: BackupArgs, seed: Seed) -> Result<(), DisplayedError> {
+pub async fn backup(seed: Seed) -> Result<(), DisplayedError> {
     seed.print_mnemonic(Language::English);
     Ok(())
 }

--- a/bin/alpen-cli/src/cmd/backup.rs
+++ b/bin/alpen-cli/src/cmd/backup.rs
@@ -7,36 +7,9 @@ use crate::seed::Seed;
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "backup")]
 /// Prints a BIP39 mnemonic encoding the internal wallet's seed bytes
-pub struct BackupArgs {
-    /// select a language for the BIP39 mnemonic. defaults to English.
-    /// options:
-    /// en, cn, cn-trad,
-    /// cz, fr, it, jp, kr or es
-    #[argh(option)]
-    language: Option<String>,
-}
+pub struct BackupArgs {}
 
-/// Unsupported mnemonic language error
-#[derive(Clone, Copy, Debug)]
-pub struct UnsupportedMnemonicLanguage;
-
-pub async fn backup(args: BackupArgs, seed: Seed) -> Result<(), DisplayedError> {
-    let language = match args.language.unwrap_or_else(|| "en".to_owned()).as_str() {
-        "en" => Ok(Language::English),
-        "cn" => Ok(Language::SimplifiedChinese),
-        "cn-trad" => Ok(Language::TraditionalChinese),
-        "cz" => Ok(Language::Czech),
-        "fr" => Ok(Language::French),
-        "it" => Ok(Language::Italian),
-        "jp" => Ok(Language::Japanese),
-        "kr" => Ok(Language::Korean),
-        "es" => Ok(Language::Spanish),
-        other => Err(DisplayedError::UserError(
-            format!("The mnemonic language provided '{other}' is not supported"),
-            Box::new(UnsupportedMnemonicLanguage),
-        )),
-    }?;
-
-    seed.print_mnemonic(language);
+pub async fn backup(_args: BackupArgs, seed: Seed) -> Result<(), DisplayedError> {
+    seed.print_mnemonic(Language::English);
     Ok(())
 }

--- a/bin/alpen-cli/src/main.rs
+++ b/bin/alpen-cli/src/main.rs
@@ -71,7 +71,7 @@ async fn main() {
         Commands::Recover(args) => recover(args, seed, settings).await,
         Commands::Drain(args) => drain(args, seed, settings).await,
         Commands::Balance(args) => balance(args, seed, settings).await,
-        Commands::Backup(args) => backup(args, seed).await,
+        Commands::Backup(_) => backup(seed).await,
         Commands::Deposit(args) => deposit(args, seed, settings).await,
         Commands::Withdraw(args) => withdraw(args, seed, settings).await,
         Commands::Send(args) => send(args, seed, settings).await,

--- a/bin/alpen-cli/src/seed.rs
+++ b/bin/alpen-cli/src/seed.rs
@@ -102,7 +102,10 @@ impl Seed {
     }
 
     pub fn signet_wallet(&self) -> BaseWallet {
-        let rootpriv = Xpriv::new_master(Network::Signet, self.0.as_ref()).expect("valid xpriv");
+        let mnemonic = Mnemonic::from_entropy(self.0.as_ref()).expect("valid entropy");
+        // We do not use a passphrase.
+        let bip39_seed = mnemonic.to_seed("");
+        let rootpriv = Xpriv::new_master(Network::Signet, &bip39_seed).expect("valid xpriv");
         let base_desc = format!("tr({rootpriv}/86h/0h/0h");
         let external_desc = format!("{base_desc}/0/*)");
         let internal_desc = format!("{base_desc}/1/*)");
@@ -430,5 +433,30 @@ mod test {
         // and BIP44 derivation path m/44'/60'/0'/0/0.
         let expected_address = "0x4eEE6B504Bc2c47650bAa7d135DA10F2A469E582".to_string();
         assert_eq!(address, expected_address);
+    }
+
+    #[test]
+    // BIP-86's official test vector for m/86'/0'/0'/0/0 (mnemonic "abandon abandon abandon
+    // abandon abandon abandon abandon abandon abandon abandon abandon about", all-zero entropy).
+    // Confirms the signet wallet is now derived via the standard BIP39 path (entropy -> mnemonic
+    // -> PBKDF2 seed -> BIP32) instead of raw entropy, so any BIP-86-compliant wallet can recover
+    // the same funds. https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#test-vectors
+    fn test_l1_signet_wallet_matches_bip86_test_vector() {
+        let seed = Seed([0u8; SEED_LEN].into());
+        let (_, create) = seed.signet_wallet().split();
+        let mut wallet = create
+            .network(Network::Signet)
+            .create_wallet_no_persist()
+            .expect("valid descriptor");
+        let script_pubkey = wallet
+            .reveal_next_address(KeychainKind::External)
+            .address
+            .script_pubkey();
+
+        let expected_bytes = shrex::decode_alloc(
+            "5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c",
+        )
+        .expect("valid hex");
+        assert_eq!(script_pubkey.as_bytes(), expected_bytes.as_slice());
     }
 }


### PR DESCRIPTION
## Description

- Derive the L1 signet wallet via standard BIP39 (entropy → mnemonic → PBKDF2 seed → BIP32), matching the L2 EVM path instead of feeding raw entropy directly into BIP32. A mnemonic from `alpen backup` is now recoverable in any standard BIP39 wallet (Sparrow, Electrum, hardware wallets), verified against the BIP-86 test vector.
- Remove backup args. Print the mnemonic in English.

### Breaking change
The fix changes key derivation for any seed generated before this PR. Existing local wallets will fail to load (`InvalidChangeSet(Mismatch(...))` from BDK, confirmed by testing) since the on-disk wallet cache no longer matches what's freshly derived from the same seed. No automatic migration is included — affected users need `alpen reset` and to recreate their wallet.

This PR was created with help from Claude.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[SECFIND-773](https://alpenlabs.atlassian.net/browse/SECFIND-773)

[SECFIND-773]: https://alpenlabs.atlassian.net/browse/SECFIND-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ