### PR TITLE
fix(alpen-cli): derive deposit-request reclaim keys from the seed

### DIFF
--- a/bin/alpen-cli/src/cmd/debug.rs
+++ b/bin/alpen-cli/src/cmd/debug.rs
@@ -44,8 +44,12 @@ pub async fn recovery(
         .read_descs(..)
         .await
         .internal_error("Failed to read descriptors after chain height")?;
+    let reclaim_counter = descriptor_file
+        .current_reclaim_counter()
+        .internal_error("Failed to read reclaim counter")?;
 
     dbg!(descs);
+    dbg!(reclaim_counter);
 
     Ok(())
 }

--- a/bin/alpen-cli/src/cmd/deposit.rs
+++ b/bin/alpen-cli/src/cmd/deposit.rs
@@ -16,7 +16,6 @@ use bdk_wallet::{
 };
 use colored::Colorize;
 use indicatif::ProgressBar;
-use rand_core::OsRng;
 use shrex::encode;
 use strata_asm_proto_bridge_v1_txs::deposit_request::DrtHeaderAux;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
@@ -27,10 +26,11 @@ use strata_primitives::crypto::even_kp;
 
 use crate::{
     alpen::AlpenWallet,
+    cmd::recover::reconstruct_reclaim_counter,
     constants::{ALPEN_EE_ACCT_SERIAL, SIGNET_BLOCK_TIME},
     link::{OnchainObject, PrettyPrint},
     recovery::DescriptorRecovery,
-    seed::Seed,
+    seed::{DrtReclaimKeypair, Seed},
     settings::Settings,
     signet::{get_fee_rate, log_fee_rate, SignetWallet},
 };
@@ -93,8 +93,10 @@ fn prepare_deposit_request(
     recover_delay: u16,
     alpen_address: AlpenAddress,
     bridge_in_amount: Amount,
+    reclaim_keypair: DrtReclaimKeypair,
 ) -> (DescriptorTemplateOut, BitcoinAddress, DrtHeaderAux, TxOut) {
-    let (secret_key, recovery_public_key) = even_kp(SECP256K1.generate_keypair(&mut OsRng));
+    let (secret_key, recovery_public_key) =
+        even_kp((reclaim_keypair.secret_key, reclaim_keypair.public_key));
     let recovery_public_key = recovery_public_key.x_only_public_key().0;
     let recovery_private_key = PrivateKey::new(secret_key.into(), network);
 
@@ -166,12 +168,34 @@ pub async fn deposit(
         alpen_address.to_string().cyan(),
     );
 
+    let mut desc_file = DescriptorRecovery::open(&seed, &settings.descriptor_db)
+        .await
+        .internal_error("Failed to open descriptor recovery file")?;
+    if desc_file
+        .current_reclaim_counter()
+        .internal_error("Failed to read the deposit reclaim counter")?
+        .is_none()
+    {
+        println!("Reconstructing the missing deposit reclaim counter...");
+        let reconstructed_counter = reconstruct_reclaim_counter(&seed, &settings).await?;
+        desc_file
+            .ensure_reclaim_counter_at_least(reconstructed_counter)
+            .await
+            .internal_error("Failed to save the reconstructed deposit reclaim counter")?;
+    }
+    let reclaim_counter = desc_file
+        .next_reclaim_counter()
+        .await
+        .internal_error("Failed to reserve a deposit reclaim key counter")?;
+    let reclaim_keypair = seed.drt_reclaim_keypair(reclaim_counter);
+
     let (bridge_in_desc, bridge_in_address, header_aux, deposit_output) = prepare_deposit_request(
         settings.bridge_musig2_pubkey,
         settings.network,
         settings.recovery_delay,
         alpen_address,
         drt_amount,
+        reclaim_keypair,
     );
 
     println!(
@@ -185,10 +209,11 @@ pub async fn deposit(
         .expect("valid chain tip")
         .height;
 
-    // Number of blocks after which the wallet actually enables recovery. This is mostly to account
-    // for any reorgs that may happen at the recovery height.
-    let recover_at =
-        current_block_height + settings.recovery_delay as u32 + settings.finality_depth;
+    let recover_at = compute_recover_at_height(
+        current_block_height,
+        settings.recovery_delay as u32,
+        settings.finality_depth,
+    );
 
     println!(
         "Using {} as bridge in address",
@@ -210,9 +235,6 @@ pub async fn deposit(
     let pb = ProgressBar::new_spinner().with_message("Saving output descriptor");
     pb.enable_steady_tick(Duration::from_millis(100));
 
-    let mut desc_file = DescriptorRecovery::open(&seed, &settings.descriptor_db)
-        .await
-        .internal_error("Failed to open descriptor recovery file")?;
     desc_file
         .add_desc(recover_at, &bridge_in_desc)
         .await
@@ -244,7 +266,7 @@ pub async fn deposit(
 ///
 /// This is a P2TR address that the key path spend is locked to the bridge aggregated public key
 /// and the single script path spend is locked to the user's recovery address with a timelock of
-fn bridge_in_descriptor(
+pub(crate) fn bridge_in_descriptor(
     bridge_pubkey: XOnlyPublicKey,
     private_key: PrivateKey,
     recover_delay: u16,
@@ -257,6 +279,22 @@ fn bridge_in_descriptor(
     .expect("valid descriptor")
 }
 
+/// Computes the height at which a deposit's relative timelock (`recovery_delay` blocks past
+/// `from_height`) becomes spendable, with `finality_depth` added as a reorg safety margin.
+///
+/// `from_height` is the current chain tip when called at deposit time (an estimate, since the
+/// deposit hasn't confirmed yet), or a deposit's actual funding confirmation height when called
+/// during recovery.
+pub(crate) fn compute_recover_at_height(
+    from_height: u32,
+    recovery_delay: u32,
+    finality_depth: u32,
+) -> u32 {
+    from_height
+        .saturating_add(recovery_delay)
+        .saturating_add(finality_depth)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -266,6 +304,7 @@ mod tests {
         keys::{DescriptorPublicKey, SinglePub, SinglePubKey},
         miniscript::{descriptor::TapTree, Descriptor, Miniscript},
     };
+    use rand_core::OsRng;
     use strata_asm_proto_bridge_v1_txs::deposit_request::parse_drt;
     use strata_primitives::constants::RECOVER_DELAY;
     use strata_test_utils_btcio::BtcioTestHarness;
@@ -366,6 +405,7 @@ mod tests {
         sync_wallet_from_node(&mut wallet, &harness);
 
         let bridge_in_amount = Amount::from_sat(100_000);
+        let (secret_key, public_key) = SECP256K1.generate_keypair(&mut OsRng);
         let (_bridge_in_desc, bridge_in_address, header_aux, deposit_output) =
             prepare_deposit_request(
                 bridge_pubkey,
@@ -373,6 +413,10 @@ mod tests {
                 RECOVER_DELAY,
                 alpen_address,
                 bridge_in_amount,
+                DrtReclaimKeypair {
+                    secret_key,
+                    public_key,
+                },
             );
 
         let tx = build_deposit_request_tx(

--- a/bin/alpen-cli/src/cmd/recover.rs
+++ b/bin/alpen-cli/src/cmd/recover.rs
@@ -1,16 +1,22 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use argh::FromArgs;
 use bdk_wallet::{
-    bitcoin::Amount, chain::ChainOracle, coin_selection::InsufficientFunds,
-    descriptor::IntoWalletDescriptor, error::CreateTxError, KeychainKind, Wallet,
+    bitcoin::{secp256k1::SECP256K1, Amount, FeeRate, PrivateKey, ScriptBuf},
+    chain::ChainOracle,
+    coin_selection::InsufficientFunds,
+    descriptor::IntoWalletDescriptor,
+    error::CreateTxError,
+    KeychainKind, Wallet,
 };
 use chrono::Utc;
 use colored::Colorize;
 use strata_cli_common::errors::{DisplayableError, DisplayedError};
+use strata_primitives::crypto::even_kp;
 
 use crate::{
-    constants::RECOVERY_DESC_CLEANUP_DELAY,
+    cmd::deposit::{bridge_in_descriptor, compute_recover_at_height},
+    constants::{RECOVERY_DESC_CLEANUP_DELAY, SEED_RECOVERY_GAP_LIMIT},
     link::{OnchainObject, PrettyPrint},
     recovery::DescriptorRecovery,
     seed::Seed,
@@ -60,13 +66,13 @@ pub async fn recover(
         .internal_error("Failed to read descriptors after chain height")?;
 
     if descs.is_empty() {
-        println!("Nothing to recover");
-        return Ok(());
+        println!("No descriptors in the local database");
     }
 
     let fee_rate = get_fee_rate(args.fee_rate, settings.signet_backend.as_ref()).await;
     log_fee_rate(&fee_rate);
 
+    let mut drained_recovery_scripts = HashSet::new();
     for (key, desc) in descs {
         let desc = desc
             .clone()
@@ -79,7 +85,9 @@ pub async fn recover(
             .internal_error("Failed to create recovery wallet")?;
 
         // reveal the address for the wallet so we can sync it
-        let address = recovery_wallet.reveal_next_address(KeychainKind::External);
+        let address = recovery_wallet
+            .reveal_next_address(KeychainKind::External)
+            .address;
         sync_wallet(&mut recovery_wallet, settings.signet_backend.clone())
             .await
             .internal_error("Failed to sync recovery wallet")?;
@@ -98,68 +106,270 @@ pub async fn recover(
             continue;
         }
 
-        recovery_wallet.transactions().for_each(|tx| {
-            l1w.apply_unconfirmed_txs([(tx.tx_node.tx, Utc::now().timestamp() as u64)]);
-        });
-
-        let recover_to = l1w.reveal_next_address(KeychainKind::External).address;
         println!(
-            "Recovering a deposit transaction from recovery address {} to wallet address {}",
+            "Recovering a deposit transaction from recovery address {}",
             address.to_string().yellow(),
-            recover_to.to_string().yellow()
         );
-
-        let policy = recovery_wallet
-            .policies(KeychainKind::External)
-            .expect("valid descriptor use")
-            .expect("a policy");
-
-        // we want to drain the recovery path to the l1 wallet
-        let mut psbt = {
-            let mut builder = recovery_wallet.build_tx();
-            // we want to spend via the 2nd option - the recovery + delay
-            builder.policy_path(
-                BTreeMap::from([(policy.id, vec![1])]),
-                KeychainKind::External,
-            );
-            builder.drain_wallet();
-            builder.drain_to(recover_to.script_pubkey());
-            builder.fee_rate(fee_rate);
-            match builder.finish() {
-                Ok(psbt) => psbt,
-                Err(CreateTxError::CoinSelection(e @ InsufficientFunds { .. })) => {
-                    return Err(DisplayedError::UserError(
-                        "Failed to create PSBT".to_string(),
-                        Box::new(e),
-                    ));
-                }
-                Err(e) => panic!("Unexpected error in creating PSBT: {e:?}"),
-            }
-        };
-
-        assert!(
-            recovery_wallet
-                .sign(&mut psbt, Default::default())
-                .expect("sign to be ok"),
-            "transaction should be finalized"
-        );
-
-        let tx = psbt.extract_tx().expect("tx should be signed and ready");
-        settings
-            .signet_backend
-            .broadcast_tx(&tx)
-            .await
-            .internal_error("Failed to broadcast signet transaction")?;
-
-        println!(
-            "{}",
-            OnchainObject::from(&tx.compute_txid())
-                .with_maybe_explorer(settings.mempool_space_endpoint.as_deref())
-                .pretty()
-        );
+        drain_recovery_path(&mut recovery_wallet, &mut l1w, &settings, fee_rate).await?;
+        drained_recovery_scripts.insert(address.script_pubkey());
     }
 
+    let highest_discovered_counter = recover_from_seed(
+        &seed,
+        &settings,
+        &mut l1w,
+        fee_rate,
+        &drained_recovery_scripts,
+    )
+    .await?;
+    descriptor_file
+        .ensure_reclaim_counter_at_least(highest_discovered_counter.unwrap_or(0))
+        .await
+        .internal_error("Failed to save the reconstructed reclaim counter")?;
+
     Ok(())
+}
+
+/// Drains `recovery_wallet`'s reclaim path (policy path index 1: recovery pubkey + timelock,
+/// see [`bridge_in_descriptor`]) to `l1w`, signing and broadcasting the spend.
+async fn drain_recovery_path(
+    recovery_wallet: &mut Wallet,
+    l1w: &mut Wallet,
+    settings: &Settings,
+    fee_rate: FeeRate,
+) -> Result<(), DisplayedError> {
+    recovery_wallet.transactions().for_each(|tx| {
+        l1w.apply_unconfirmed_txs([(tx.tx_node.tx, Utc::now().timestamp() as u64)]);
+    });
+
+    let recover_to = l1w.reveal_next_address(KeychainKind::External).address;
+    println!(
+        "Recovering to wallet address {}",
+        recover_to.to_string().yellow()
+    );
+
+    let policy = recovery_wallet
+        .policies(KeychainKind::External)
+        .expect("valid descriptor use")
+        .expect("a policy");
+
+    // we want to drain the recovery path to the l1 wallet
+    let mut psbt = {
+        let mut builder = recovery_wallet.build_tx();
+        // we want to spend via the 2nd option - the recovery + delay
+        builder.policy_path(
+            BTreeMap::from([(policy.id, vec![1])]),
+            KeychainKind::External,
+        );
+        builder.drain_wallet();
+        builder.drain_to(recover_to.script_pubkey());
+        builder.fee_rate(fee_rate);
+        match builder.finish() {
+            Ok(psbt) => psbt,
+            Err(CreateTxError::CoinSelection(e @ InsufficientFunds { .. })) => {
+                return Err(DisplayedError::UserError(
+                    "Failed to create PSBT".to_string(),
+                    Box::new(e),
+                ));
+            }
+            Err(e) => panic!("Unexpected error in creating PSBT: {e:?}"),
+        }
+    };
+
+    assert!(
+        recovery_wallet
+            .sign(&mut psbt, Default::default())
+            .expect("sign to be ok"),
+        "transaction should be finalized"
+    );
+
+    let tx = psbt.extract_tx().expect("tx should be signed and ready");
+    settings
+        .signet_backend
+        .broadcast_tx(&tx)
+        .await
+        .internal_error("Failed to broadcast signet transaction")?;
+
+    println!(
+        "{}",
+        OnchainObject::from(&tx.compute_txid())
+            .with_maybe_explorer(settings.mempool_space_endpoint.as_deref())
+            .pretty()
+    );
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct SeedRecoveryCandidate {
+    counter: u32,
+    script_pubkey: ScriptBuf,
+}
+
+fn seed_recovery_wallet(
+    seed: &Seed,
+    settings: &Settings,
+    counter: u32,
+) -> Result<Wallet, DisplayedError> {
+    let reclaim_keypair = seed.drt_reclaim_keypair(counter);
+    let (secret_key, _) = even_kp((reclaim_keypair.secret_key, reclaim_keypair.public_key));
+    let recovery_private_key = PrivateKey::new(secret_key.into(), settings.network);
+    let descriptor = bridge_in_descriptor(
+        settings.bridge_musig2_pubkey,
+        recovery_private_key,
+        settings.recovery_delay,
+    );
+    let wallet_descriptor = descriptor
+        .into_wallet_descriptor(SECP256K1, settings.network)
+        .internal_error("Failed to convert to wallet descriptor")?;
+
+    Wallet::create_single(wallet_descriptor)
+        .network(settings.network)
+        .create_wallet_no_persist()
+        .internal_error("Failed to create recovery wallet")
+}
+
+/// Finds reclaim-key counters with on-chain history in gap-limit-sized backend scans.
+async fn discover_seed_candidates(
+    seed: &Seed,
+    settings: &Settings,
+    known_used_scripts: &HashSet<ScriptBuf>,
+) -> Result<Vec<SeedRecoveryCandidate>, DisplayedError> {
+    let mut discovered = Vec::new();
+    let mut batch_start = 0u32;
+    let scan_checkpoint = seed_recovery_wallet(seed, settings, 0)?.latest_checkpoint();
+
+    loop {
+        let batch_end = batch_start
+            .checked_add(SEED_RECOVERY_GAP_LIMIT)
+            .expect("reclaim-key scan range must fit in u32");
+        let mut candidates = Vec::with_capacity(SEED_RECOVERY_GAP_LIMIT as usize);
+        let mut scripts_to_scan = Vec::with_capacity(SEED_RECOVERY_GAP_LIMIT as usize);
+
+        for counter in batch_start..batch_end {
+            let mut wallet = seed_recovery_wallet(seed, settings, counter)?;
+            let script_pubkey = wallet
+                .reveal_next_address(KeychainKind::External)
+                .address
+                .script_pubkey();
+            if !known_used_scripts.contains(&script_pubkey) {
+                scripts_to_scan.push(script_pubkey.clone());
+            }
+            candidates.push(SeedRecoveryCandidate {
+                counter,
+                script_pubkey,
+            });
+        }
+
+        let backend_used_scripts = if scripts_to_scan.is_empty() {
+            HashSet::new()
+        } else {
+            settings
+                .signet_backend
+                .scan_scripts(scripts_to_scan, scan_checkpoint.clone())
+                .await
+                .internal_error("Failed to scan seed recovery scripts")?
+        };
+        let mut discovered_in_batch = candidates
+            .into_iter()
+            .filter(|candidate| {
+                known_used_scripts.contains(&candidate.script_pubkey)
+                    || backend_used_scripts.contains(&candidate.script_pubkey)
+            })
+            .collect::<Vec<_>>();
+
+        if discovered_in_batch.is_empty() {
+            break;
+        }
+
+        discovered.append(&mut discovered_in_batch);
+        batch_start = batch_end;
+    }
+
+    Ok(discovered)
+}
+
+/// Reconstructs the allocator high-water mark without spending any recovered outputs.
+pub(crate) async fn reconstruct_reclaim_counter(
+    seed: &Seed,
+    settings: &Settings,
+) -> Result<u32, DisplayedError> {
+    let candidates = discover_seed_candidates(seed, settings, &HashSet::new()).await?;
+    Ok(candidates
+        .last()
+        .map(|candidate| candidate.counter)
+        .unwrap_or(0))
+}
+
+/// Reconstructs and recovers deposits directly from the seed, for deposits whose descriptor DB
+/// entry is missing. Candidate scripts are scanned in batches so Bitcoin Core only replays the
+/// chain once per gap-limit window, rather than once per candidate. Descriptors use the network's
+/// *current* bridge pubkey and recovery delay; if either changed since a deposit was created, that
+/// deposit won't be found here.
+async fn recover_from_seed(
+    seed: &Seed,
+    settings: &Settings,
+    l1w: &mut Wallet,
+    fee_rate: FeeRate,
+    drained_recovery_scripts: &HashSet<ScriptBuf>,
+) -> Result<Option<u32>, DisplayedError> {
+    println!("Scanning for deposits reconstructable from the seed alone...");
+
+    let candidates = discover_seed_candidates(seed, settings, drained_recovery_scripts).await?;
+    let highest_discovered_counter = candidates.last().map(|candidate| candidate.counter);
+    let mut found_any = false;
+    for candidate in candidates {
+        if drained_recovery_scripts.contains(&candidate.script_pubkey) {
+            continue;
+        }
+
+        let counter = candidate.counter;
+        let mut recovery_wallet = seed_recovery_wallet(seed, settings, counter)?;
+        let address = recovery_wallet
+            .reveal_next_address(KeychainKind::External)
+            .address;
+        debug_assert_eq!(address.script_pubkey(), candidate.script_pubkey);
+
+        sync_wallet(&mut recovery_wallet, settings.signet_backend.clone())
+            .await
+            .internal_error("Failed to sync recovery wallet")?;
+
+        if recovery_wallet.transactions().next().is_none() {
+            continue;
+        }
+
+        let current_height = recovery_wallet
+            .local_chain()
+            .get_chain_tip()
+            .expect("valid chain tip")
+            .height;
+        let matured = recovery_wallet
+            .list_unspent()
+            .filter_map(|utxo| utxo.chain_position.confirmation_height_upper_bound())
+            .all(|confirmed_at| {
+                current_height
+                    >= compute_recover_at_height(
+                        confirmed_at,
+                        settings.recovery_delay as u32,
+                        settings.finality_depth,
+                    )
+            });
+
+        if matured && recovery_wallet.balance().confirmed > Amount::ZERO {
+            found_any = true;
+            println!(
+                "Recovering a deposit transaction (counter {counter}) from recovery address {}",
+                address.to_string().yellow(),
+            );
+            drain_recovery_path(&mut recovery_wallet, l1w, settings, fee_rate).await?;
+        }
+    }
+
+    if !found_any {
+        println!("Nothing found to recover from the seed.");
+    }
+
+    Ok(highest_discovered_counter)
 }
 
 #[cfg(test)]

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -10,6 +10,12 @@ pub const DEFAULT_FINALITY_DEPTH: u32 = 6;
 
 pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 
+/// Number of consecutive unused reclaim-key counters `recover --from-seed` tries before giving
+/// up, matching the conventional BIP44 address-gap-limit: there's no persisted "last used
+/// counter" to resume from when reconstructing purely from the seed, so this is the only signal
+/// for when to stop scanning.
+pub const SEED_RECOVERY_GAP_LIMIT: u32 = 20;
+
 /// Fee to cover the mining fees for creating the deposit transaction from the deposit request
 /// transaction. This includes the cost for the bridge to spend the deposit request output into the
 /// federation.
@@ -38,6 +44,20 @@ pub const SIGNET_BLOCK_TIME: Duration = Duration::from_secs(10 * 60); // 10 minu
 /// System serials occupy `0..SYSTEM_RESERVED_ACCTS`, so the Alpen EE account
 /// currently lands at `SYSTEM_RESERVED_ACCTS` by genesis registration order.
 pub const ALPEN_EE_ACCT_SERIAL: AccountSerial = AccountSerial::new(SYSTEM_RESERVED_ACCTS);
+
+/// Hardened branch reserved for Alpen CLI deposit-request reclaim keys.
+///
+/// Unregistered — picked above the 10001-19999 range BIP43 reserves for SLIPs, so it can't
+/// collide with anything registered.
+///
+/// Separates this key material from the wallet's BIP-86 path (`m/86'/0'/0'`). Each deposit derives
+/// `m/<DRT_RECLAIM_PURPOSE>'/<counter>'`, where `counter` is durable local state (see
+/// [`DescriptorRecovery::next_reclaim_counter`](crate::recovery::DescriptorRecovery::next_reclaim_counter)),
+/// making the reclaim key recoverable from the seed alone rather than only from the descriptor DB.
+///
+/// Don't change this. A deposit's reclaim key can only be reconstructed from the seed if this
+/// value is still the same as when that deposit was made.
+pub const DRT_RECLAIM_PURPOSE: ChildNumber = ChildNumber::Hardened { index: 43_000 };
 
 /// Alpen CLI [`DerivationPath`](bdk_wallet::bitcoin::bip32::DerivationPath) for Alpen EVM wallet
 ///

--- a/bin/alpen-cli/src/constants.rs
+++ b/bin/alpen-cli/src/constants.rs
@@ -11,10 +11,9 @@ pub const DEFAULT_FINALITY_DEPTH: u32 = 6;
 pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
 
 /// Number of consecutive unused reclaim-key counters `recover --from-seed` tries before giving
-/// up, matching the conventional BIP44 address-gap-limit: there's no persisted "last used
-/// counter" to resume from when reconstructing purely from the seed, so this is the only signal
-/// for when to stop scanning.
-pub const SEED_RECOVERY_GAP_LIMIT: u32 = 20;
+/// up. There's no persisted "last used counter" to resume from when reconstructing purely from the
+/// seed, so this is the only signal for when to stop scanning.
+pub const SEED_RECOVERY_GAP_LIMIT: u32 = 1_000;
 
 /// Fee to cover the mining fees for creating the deposit transaction from the deposit request
 /// transaction. This includes the cost for the bridge to spend the deposit request output into the

--- a/bin/alpen-cli/src/recovery.rs
+++ b/bin/alpen-cli/src/recovery.rs
@@ -22,16 +22,86 @@ use tokio::io::AsyncReadExt;
 
 use crate::seed::Seed;
 
+// Key for the reclaim counter within its own tree (see `counter_tree` below) -- any fixed key
+// works here since this tree holds nothing else.
+const RECLAIM_COUNTER_KEY: &[u8] = b"drt_reclaim_counter";
+
 #[expect(
     missing_debug_implementations,
     reason = "Struct contains sensitive cryptographic data that should not be debug printed"
 )]
 pub struct DescriptorRecovery {
     db: sled::Db,
+    // Reclaim-counter state lives in its own sled tree, not the default tree `db` derefs to,
+    // so it can never show up in a `read_descs` range scan over descriptor entries -- which,
+    // being always exactly `DescriptorRecoveryKey::ENCODED_SIZE` bytes, would otherwise panic
+    // on `DescriptorRecoveryKey::decode(&key).unwrap()` the first time it saw this key.
+    counter_tree: sled::Tree,
     cipher: Aes256GcmSiv,
 }
 
 impl DescriptorRecovery {
+    /// Reserves and returns the next counter for deriving a deposit-request reclaim key (see
+    /// [`Seed::drt_reclaim_keypair`]).
+    ///
+    /// The increment is flushed to disk before this returns, so a crash right after can't cause
+    /// the same counter to be handed out twice. Missing counter state is an error: callers must
+    /// first reconstruct or initialize it with [`Self::ensure_reclaim_counter_at_least`].
+    pub async fn next_reclaim_counter(&self) -> io::Result<u32> {
+        let updated = self
+            .counter_tree
+            .update_and_fetch(RECLAIM_COUNTER_KEY, |old| {
+                old.map(|bytes| {
+                    let current =
+                        u32::from_be_bytes(bytes.try_into().expect("4-byte reclaim counter"));
+                    (current + 1).to_be_bytes().to_vec()
+                })
+            })?;
+        let updated = updated.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "deposit reclaim counter has not been reconstructed",
+            )
+        })?;
+        self.counter_tree.flush_async().await?;
+        Ok(u32::from_be_bytes(
+            updated.as_ref().try_into().expect("4-byte reclaim counter"),
+        ))
+    }
+
+    /// Advances the reclaim counter to at least `minimum` and flushes it to disk.
+    ///
+    /// This initializes missing counter state after seed recovery without rolling back a higher
+    /// value another process may already have persisted.
+    pub async fn ensure_reclaim_counter_at_least(&self, minimum: u32) -> io::Result<u32> {
+        let updated = self
+            .counter_tree
+            .update_and_fetch(RECLAIM_COUNTER_KEY, |old| {
+                let current = old.map(|bytes| {
+                    u32::from_be_bytes(bytes.try_into().expect("4-byte reclaim counter"))
+                });
+                Some(
+                    current
+                        .map_or(minimum, |value| value.max(minimum))
+                        .to_be_bytes()
+                        .to_vec(),
+                )
+            })?
+            .expect("update_and_fetch always writes a value");
+        self.counter_tree.flush_async().await?;
+        Ok(u32::from_be_bytes(
+            updated.as_ref().try_into().expect("4-byte reclaim counter"),
+        ))
+    }
+
+    /// Returns the last counter [`Self::next_reclaim_counter`] handed out, if allocator state has
+    /// been initialized. For inspection, not for deriving a new deposit's key.
+    pub fn current_reclaim_counter(&self) -> io::Result<Option<u32>> {
+        Ok(self.counter_tree.get(RECLAIM_COUNTER_KEY)?.map(|bytes| {
+            u32::from_be_bytes(bytes.as_ref().try_into().expect("4-byte reclaim counter"))
+        }))
+    }
+
     pub async fn add_desc(
         &mut self,
         recover_at: u32,
@@ -125,8 +195,11 @@ impl DescriptorRecovery {
     pub async fn open(seed: &Seed, descriptor_db: &Path) -> io::Result<Self> {
         let key = seed.descriptor_recovery_key();
         let cipher = Aes256GcmSiv::new(&key.into());
+        let db = sled::open(descriptor_db)?;
+        let counter_tree = db.open_tree(b"reclaim_counter")?;
         Ok(Self {
-            db: sled::open(descriptor_db)?,
+            db,
+            counter_tree,
             cipher,
         })
     }
@@ -340,5 +413,109 @@ impl RangeBounds<[u8; 4]> for BigEndianRangeBounds {
             Bound::Excluded(arr) => Bound::Excluded(arr),
             Bound::Unbounded => Bound::Unbounded,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs, path::PathBuf, process};
+
+    use super::*;
+
+    fn temp_db_path() -> PathBuf {
+        env::temp_dir().join(format!(
+            "alpen-cli-recovery-test-{}-{}",
+            process::id(),
+            OsRng.next_u64()
+        ))
+    }
+
+    #[tokio::test]
+    // The counter must never repeat across a process restart, since a reused counter would
+    // derive the same reclaim key for two different deposit requests.
+    async fn next_reclaim_counter_survives_reopen() {
+        let seed = Seed::gen(&mut OsRng);
+        let path = temp_db_path();
+
+        let recovery = DescriptorRecovery::open(&seed, &path)
+            .await
+            .expect("should open descriptor db");
+        recovery.ensure_reclaim_counter_at_least(0).await.unwrap();
+        let first = recovery.next_reclaim_counter().await.unwrap();
+        drop(recovery);
+
+        let second = DescriptorRecovery::open(&seed, &path)
+            .await
+            .expect("should reopen descriptor db")
+            .next_reclaim_counter()
+            .await
+            .unwrap();
+
+        assert_ne!(
+            first, second,
+            "reopening must not hand out a counter already used"
+        );
+
+        fs::remove_dir_all(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn missing_reclaim_counter_must_be_reconstructed_before_allocation() {
+        let seed = Seed::gen(&mut OsRng);
+        let path = temp_db_path();
+        let recovery = DescriptorRecovery::open(&seed, &path)
+            .await
+            .expect("should open descriptor db");
+
+        let error = recovery.next_reclaim_counter().await.unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert_eq!(recovery.current_reclaim_counter().unwrap(), None);
+        fs::remove_dir_all(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn reconstructed_reclaim_counter_never_rolls_back() {
+        let seed = Seed::gen(&mut OsRng);
+        let path = temp_db_path();
+        let recovery = DescriptorRecovery::open(&seed, &path)
+            .await
+            .expect("should open descriptor db");
+
+        assert_eq!(
+            recovery.ensure_reclaim_counter_at_least(7).await.unwrap(),
+            7
+        );
+        assert_eq!(
+            recovery.ensure_reclaim_counter_at_least(3).await.unwrap(),
+            7
+        );
+        assert_eq!(recovery.next_reclaim_counter().await.unwrap(), 8);
+
+        fs::remove_dir_all(&path).ok();
+    }
+
+    #[tokio::test]
+    // Regression test: before the counter moved into its own tree, `read_descs`'s range scan
+    // saw the 19-byte counter key alongside real (always 36-byte) descriptor keys, and
+    // `DescriptorRecoveryKey::decode(&key).unwrap()` panicked on it. `alpen debug recovery`
+    // calls `read_descs(..)` on any populated database, so this used to panic on every deposit.
+    async fn read_descs_ignores_reclaim_counter_state() {
+        let seed = Seed::gen(&mut OsRng);
+        let path = temp_db_path();
+
+        let mut recovery = DescriptorRecovery::open(&seed, &path)
+            .await
+            .expect("should open descriptor db");
+        recovery.ensure_reclaim_counter_at_least(0).await.unwrap();
+        recovery.next_reclaim_counter().await.unwrap();
+
+        let descs = recovery
+            .read_descs(..)
+            .await
+            .expect("should not panic or error on the counter's tree");
+        assert!(descs.is_empty());
+
+        fs::remove_dir_all(&path).ok();
     }
 }

--- a/bin/alpen-cli/src/seed.rs
+++ b/bin/alpen-cli/src/seed.rs
@@ -6,8 +6,8 @@ use aes_gcm_siv::{aead::AeadMutInPlace, Aes256GcmSiv, KeyInit, Nonce, Tag};
 use alloy::{network::EthereumWallet, signers::local::PrivateKeySigner};
 use bdk_wallet::{
     bitcoin::{
-        bip32::{DerivationPath, Xpriv},
-        secp256k1::SECP256K1,
+        bip32::{ChildNumber, DerivationPath, Xpriv},
+        secp256k1::{PublicKey, SecretKey, SECP256K1},
         Network,
     },
     CreateParams, KeychainKind, LoadParams, Wallet,
@@ -20,11 +20,38 @@ use sha2::{Digest, Sha256};
 #[cfg(feature = "test-mode")]
 use shrex::Hex;
 use terrors::OneOf;
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::constants::{
-    AES_NONCE_LEN, AES_TAG_LEN, BIP44_ALPEN_EVM_WALLET_PATH, PW_SALT_LEN, SEED_LEN,
+    AES_NONCE_LEN, AES_TAG_LEN, BIP44_ALPEN_EVM_WALLET_PATH, DRT_RECLAIM_PURPOSE, PW_SALT_LEN,
+    SEED_LEN,
 };
+
+/// A deposit-request reclaim keypair, deterministically derived from the seed. Zeroizes its own
+/// stored secret-key copy on drop.
+#[expect(
+    missing_debug_implementations,
+    reason = "Struct contains a secret key that should not be debug printed"
+)]
+pub struct DrtReclaimKeypair {
+    pub secret_key: SecretKey,
+    pub public_key: PublicKey,
+}
+
+impl Zeroize for DrtReclaimKeypair {
+    fn zeroize(&mut self) {
+        // NOTE: `SecretKey::non_secure_erase` writes `1`s to the memory.
+        self.secret_key.non_secure_erase();
+    }
+}
+
+impl ZeroizeOnDrop for DrtReclaimKeypair {}
+
+impl Drop for DrtReclaimKeypair {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
 
 #[expect(
     missing_debug_implementations,
@@ -54,7 +81,7 @@ impl Seed {
         Self(bytes)
     }
 
-    fn gen<R: CryptoRngCore>(rng: &mut R) -> Self {
+    pub(crate) fn gen<R: CryptoRngCore>(rng: &mut R) -> Self {
         let mut bytes = Zeroizing::new([0u8; SEED_LEN]);
         rng.fill_bytes(bytes.as_mut());
         Self(bytes)
@@ -70,6 +97,34 @@ impl Seed {
         hasher.update(b"alpen labs alpen descriptor recovery file 2024");
         hasher.update(self.0.as_slice());
         hasher.finalize().into()
+    }
+
+    /// Derives the deposit-request reclaim keypair for the given counter.
+    ///
+    /// This is deterministic in the seed and `counter`, so a deposit's reclaim key can always be
+    /// recovered from the mnemonic alone, given the counter value it was created with. `counter`
+    /// must never be reused for a live deposit request: it is intended to come from
+    /// [`DescriptorRecovery::next_reclaim_counter`](crate::recovery::DescriptorRecovery::next_reclaim_counter),
+    /// which persists the increment before handing out a value.
+    ///
+    /// The BIP32 master key is derived directly from the mnemonic's raw entropy, independently of
+    /// the BIP39 PBKDF2 seed used by the signet wallet. Changing this would make existing deposit
+    /// requests unrecoverable.
+    pub fn drt_reclaim_keypair(&self, counter: u32) -> DrtReclaimKeypair {
+        let rootpriv = Xpriv::new_master(Network::Signet, self.0.as_ref()).expect("valid xpriv");
+        let path = DerivationPath::master().extend([
+            DRT_RECLAIM_PURPOSE,
+            ChildNumber::from_hardened_idx(counter).expect("counter fits in 31 bits"),
+        ]);
+        let derived = rootpriv
+            .derive_priv(SECP256K1, &path)
+            .expect("valid derivation path");
+        let secret_key = derived.private_key;
+        let public_key = PublicKey::from_secret_key(SECP256K1, &secret_key);
+        DrtReclaimKeypair {
+            secret_key,
+            public_key,
+        }
     }
 
     pub fn encrypt<R: CryptoRngCore>(
@@ -434,7 +489,6 @@ mod test {
         let expected_address = "0x4eEE6B504Bc2c47650bAa7d135DA10F2A469E582".to_string();
         assert_eq!(address, expected_address);
     }
-
     #[test]
     // BIP-86's official test vector for m/86'/0'/0'/0/0 (mnemonic "abandon abandon abandon
     // abandon abandon abandon abandon abandon abandon abandon abandon about", all-zero entropy).
@@ -458,5 +512,25 @@ mod test {
         )
         .expect("valid hex");
         assert_eq!(script_pubkey.as_bytes(), expected_bytes.as_slice());
+    }
+
+    #[test]
+    // The reclaim keypair must be a pure function of (seed, counter): same inputs always
+    // reproduce the same key, so a lost descriptor DB doesn't strand funds.
+    fn drt_reclaim_keypair_is_deterministic_and_distinct_per_counter() {
+        let seed = Seed::gen(&mut OsRng);
+
+        let keypair_0 = seed.drt_reclaim_keypair(0);
+        let keypair_0_again = seed.drt_reclaim_keypair(0);
+        assert_eq!(keypair_0.secret_key, keypair_0_again.secret_key);
+        assert_eq!(keypair_0.public_key, keypair_0_again.public_key);
+
+        let keypair_1 = seed.drt_reclaim_keypair(1);
+        assert_ne!(keypair_0.secret_key, keypair_1.secret_key);
+        assert_ne!(keypair_0.public_key, keypair_1.public_key);
+
+        let other_seed = Seed::gen(&mut OsRng);
+        let keypair_0_other_seed = other_seed.drt_reclaim_keypair(0);
+        assert_ne!(keypair_0.secret_key, keypair_0_other_seed.secret_key);
     }
 }

--- a/bin/alpen-cli/src/signet.rs
+++ b/bin/alpen-cli/src/signet.rs
@@ -48,9 +48,11 @@ pub async fn get_fee_rate(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use async_trait::async_trait;
     use bdk_wallet::{
-        bitcoin::{FeeRate, Transaction},
+        bitcoin::{FeeRate, ScriptBuf, Transaction},
         chain::{
             spk_client::{FullScanRequestBuilder, SyncRequestBuilder},
             CheckPoint,
@@ -71,6 +73,14 @@ mod tests {
 
     #[async_trait]
     impl SignetBackend for TestSignetBackend {
+        async fn scan_scripts(
+            &self,
+            _scripts: Vec<ScriptBuf>,
+            _last_cp: CheckPoint,
+        ) -> Result<HashSet<ScriptBuf>, ScanError> {
+            unimplemented!("not needed for fee rate tests")
+        }
+
         async fn sync_wallet(
             &self,
             _req: SyncRequestBuilder<(KeychainKind, u32)>,

--- a/bin/alpen-cli/src/signet/backend.rs
+++ b/bin/alpen-cli/src/signet/backend.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet},
     error, fmt,
     fmt::Debug,
     marker::Send,
@@ -15,7 +15,7 @@ use bdk_bitcoind_rpc::{
 };
 use bdk_esplora::EsploraAsyncExt;
 use bdk_wallet::{
-    bitcoin::{consensus::encode, Block, FeeRate, Transaction},
+    bitcoin::{consensus::encode, Block, FeeRate, ScriptBuf, Transaction},
     chain::{
         spk_client::{FullScanRequestBuilder, FullScanResponse, SyncRequestBuilder, SyncResponse},
         CheckPoint,
@@ -102,6 +102,12 @@ pub type UpdateSender = UnboundedSender<WalletUpdate>;
 
 #[async_trait]
 pub trait SignetBackend: Debug + Send + Sync {
+    /// Scans a batch of script pubkeys and returns the ones with transaction history.
+    async fn scan_scripts(
+        &self,
+        scripts: Vec<ScriptBuf>,
+        last_cp: CheckPoint,
+    ) -> Result<HashSet<ScriptBuf>, ScanError>;
     async fn sync_wallet(
         &self,
         req: SyncRequestBuilder<(KeychainKind, u32)>,
@@ -123,6 +129,36 @@ pub trait SignetBackend: Debug + Send + Sync {
 
 #[async_trait]
 impl SignetBackend for EsploraClient {
+    async fn scan_scripts(
+        &self,
+        scripts: Vec<ScriptBuf>,
+        last_cp: CheckPoint,
+    ) -> Result<HashSet<ScriptBuf>, ScanError> {
+        let requested_scripts = scripts.iter().cloned().collect::<HashSet<_>>();
+        let request = SyncRequestBuilder::default()
+            .chain_tip(last_cp)
+            .spks(scripts)
+            .build();
+        let response = self
+            .sync(request, 3)
+            .await
+            .map_err(|err| ScanError(Box::new(err) as BoxedErr))?;
+
+        let mut used_scripts = HashSet::new();
+        record_used_scripts(
+            &requested_scripts,
+            &mut used_scripts,
+            response.tx_update.txs.iter().map(AsRef::as_ref),
+        );
+        for txout in response.tx_update.txouts.values() {
+            if requested_scripts.contains(&txout.script_pubkey) {
+                used_scripts.insert(txout.script_pubkey.clone());
+            }
+        }
+
+        Ok(used_scripts)
+    }
+
     async fn sync_wallet(
         &self,
         req: SyncRequestBuilder<(KeychainKind, u32)>,
@@ -236,6 +272,53 @@ impl SignetBackend for EsploraClient {
 
 #[async_trait]
 impl SignetBackend for Arc<bitcoincore_rpc::Client> {
+    async fn scan_scripts(
+        &self,
+        scripts: Vec<ScriptBuf>,
+        last_cp: CheckPoint,
+    ) -> Result<HashSet<ScriptBuf>, ScanError> {
+        let requested_scripts = scripts.into_iter().collect::<HashSet<_>>();
+        let bar = ProgressBar::new_spinner().with_style(
+            ProgressStyle::with_template("{spinner} [{elapsed_precise}] {msg}").unwrap(),
+        );
+        bar.enable_steady_tick(Duration::from_millis(100));
+        let bar2 = bar.clone();
+
+        let used_scripts = spawn_bitcoin_core(self.clone(), move |client| {
+            let mut emitter = Emitter::new(client, last_cp, 0);
+            let mut used_scripts = HashSet::new();
+            let mut blocks_scanned = 0;
+
+            while let Some(event) = emitter.next_block()? {
+                blocks_scanned += 1;
+                record_used_scripts(
+                    &requested_scripts,
+                    &mut used_scripts,
+                    event.block.txdata.iter(),
+                );
+                bar2.set_message(format!(
+                    "Current height: {}, scanned {blocks_scanned} blocks",
+                    event.block_height()
+                ));
+            }
+
+            bar2.set_message("Scanning mempool");
+            let mempool = emitter.mempool()?;
+            record_used_scripts(
+                &requested_scripts,
+                &mut used_scripts,
+                mempool.iter().map(|(tx, _)| tx),
+            );
+
+            Ok(used_scripts)
+        })
+        .await
+        .map_err(|err| ScanError(Box::new(err) as BoxedErr))?;
+
+        bar.finish_with_message("Script scan complete");
+        Ok(used_scripts)
+    }
+
     async fn sync_wallet(
         &self,
         _req: SyncRequestBuilder<(KeychainKind, u32)>,
@@ -283,6 +366,18 @@ impl SignetBackend for Arc<bitcoincore_rpc::Client> {
                 FeeRate::from_sat_per_vb((per_kw / 1000).to_sat()).ok_or(OneOf::new(InvalidFee))?,
             )),
             None => Ok(None),
+        }
+    }
+}
+
+fn record_used_scripts<'a>(
+    requested_scripts: &HashSet<ScriptBuf>,
+    used_scripts: &mut HashSet<ScriptBuf>,
+    transactions: impl IntoIterator<Item = &'a Transaction>,
+) {
+    for txout in transactions.into_iter().flat_map(|tx| &tx.output) {
+        if requested_scripts.contains(&txout.script_pubkey) {
+            used_scripts.insert(txout.script_pubkey.clone());
         }
     }
 }
@@ -349,3 +444,38 @@ async fn sync_wallet_with_core(
 
 #[derive(Debug)]
 pub struct InvalidFee;
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::bitcoin::{absolute, transaction, Amount, TxOut};
+
+    use super::*;
+
+    #[test]
+    fn record_used_scripts_only_returns_requested_outputs() {
+        let requested = ScriptBuf::from_bytes(vec![0x51]);
+        let unrelated = ScriptBuf::from_bytes(vec![0x52]);
+        let transaction = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: requested.clone(),
+                },
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: unrelated.clone(),
+                },
+            ],
+        };
+        let requested_scripts = HashSet::from([requested.clone()]);
+        let mut used_scripts = HashSet::new();
+
+        record_used_scripts(&requested_scripts, &mut used_scripts, [&transaction]);
+
+        assert_eq!(used_scripts, HashSet::from([requested]));
+        assert!(!used_scripts.contains(&unrelated));
+    }
+}


### PR DESCRIPTION
## Description

- Derive each deposit request's reclaim keypair deterministically from the seed (`m/<DRT_RECLAIM_PURPOSE>'/<counter>'`) instead of a fresh `OsRng` keypair, so the descriptor DB (`descriptor_db`) stops being the *only* copy of a live deposit's spending key — the mnemonic alone is now sufficient.
- `counter` is durable local state, tracked in its own sled tree (`DescriptorRecovery::next_reclaim_counter`) so it survives restarts and is never reused for a live deposit.
- `alpen recover` now automatically scans for deposits reconstructible from the seed (`counter = 0, 1, 2, ...`), checking each candidate address for *any* on-chain transaction history, and stops after `SEED_RECOVERY_GAP_LIMIT` (BIP44 gap-limit style). This is in addition to what is in the descriptor DB.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[SECFIND-772](https://alpenlabs.atlassian.net/browse/SECFIND-772)

[SECFIND-772]: https://alpenlabs.atlassian.net/browse/SECFIND-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ