### PR TITLE
fix(ci): address zizmor findings

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,10 @@
 self-hosted-runner:
   labels:
     - ubuntu-latest-m
+
+# actionlint 1.7.12 predates GitHub's $/ self-repository syntax.
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'specifying action "\$/\.github/actions/.+" in invalid format because ref is missing'
+      - 'reusable workflow call "\$/\.github/workflows/.+" at "uses" is not following the format'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -195,7 +195,7 @@ jobs:
           echo "Resolved commit: ${COMMIT_SHA} (tag: ${SHORT_TAG})"
 
       - name: Free up disk space
-        uses: ./.github/actions/cleanup
+        uses: $/.github/actions/cleanup
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   docs:
     name: Generate docs
@@ -54,7 +54,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       - name: Check docs leaving the dependencies out
         env:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   lint:
     name: Lint test files
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Install bitcoind
         env:
@@ -114,7 +114,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       - name: Build Cargo project
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   clippy:
     name: Run clippy on crates
@@ -53,7 +53,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       - name: Run clippy
         run: cargo clippy --workspace --lib --bins --examples --tests --benches --all-features --all-targets --locked
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Setup Rust
         env:
@@ -128,7 +128,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       - name: Configure sccache
         run: |
@@ -207,6 +207,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: 1.58.0
 
       - name: Run just lint-check-style
         run: |

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   eval_perf:
     permissions:
@@ -53,7 +53,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       # Installs mold (modern ld), a drop-in replacement for lld.
       # Under the hood, the following action symlinks mold binary onto lld,

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -19,10 +19,10 @@ permissions: {}
 
 jobs:
   unit-tests:
-    uses: ./.github/workflows/unit.yml
+    uses: $/.github/workflows/unit.yml
 
   functional-tests:
-    uses: ./.github/workflows/functional.yml
+    uses: $/.github/workflows/functional.yml
 
   collect-test-metrics:
     name: Collect test metrics

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   test:
     name: Run unit tests and generate report
@@ -55,7 +55,7 @@ jobs:
           rm -rf SHA256SUMS "bitcoin-$BITCOIND_VERSION" "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Set up Rust
         env:
@@ -85,7 +85,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       - name: Run tests with coverage
         run: |
@@ -117,7 +117,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Set up Rust
         env:
@@ -137,7 +137,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install SP1 core runner override
-        uses: ./.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/sp1-core-runner-override # zizmor: ignore[unpinned-uses]
 
       - name: Run doctests
         run: cargo test --doc --workspace --all-features


### PR DESCRIPTION
- use the dedicated self-repository syntax for local actions and reusable workflows
- pin the just version installed by setup-just

Validation: uvx --from zizmor==1.30.0 zizmor .