### PR TITLE
test(snark-acct): reject valid stale-state forks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10012,6 +10012,7 @@ dependencies = [
  "ssz",
  "strata-acct-types",
  "strata-ol-state-types",
+ "strata-ol-state-types-v1",
  "strata-predicate",
  "strata-snark-acct-types",
  "tracing",

--- a/crates/snark-acct-runtime/src/program_processing.rs
+++ b/crates/snark-acct-runtime/src/program_processing.rs
@@ -188,6 +188,7 @@ pub fn apply_update_unconditionally<P: SnarkAccountProgram>(
 #[cfg(test)]
 mod tests {
     use rkyv::{rancor::Error as RkyvError, util::AlignedVec};
+    use ssz::Encode as _;
     use ssz_derive::{Decode, Encode};
     use strata_acct_types::*;
     use strata_codec::impl_type_flat_struct;
@@ -196,7 +197,7 @@ mod tests {
     use super::*;
     use crate::{
         UpdateLedgerInfo,
-        private_input::Coinput,
+        private_input::{Coinput, PrivateInput},
         traits::{IAcctMsg, IExtraData, IInnerState},
     };
 
@@ -350,6 +351,32 @@ mod tests {
         let new_state_root =
             expected_post_value.map(|v| TestState { value: v }.compute_state_root());
         UpdateManifest::new(new_state_root, extra_data, msg_entries)
+    }
+
+    #[test]
+    fn rejects_private_pre_state_that_differs_from_public_claim() {
+        let recorded_state = TestState { value: 1 };
+        let forged_state = TestState { value: 2 };
+        let recorded_root = recorded_state.compute_state_root();
+        let pub_params = UpdateProofPubParams::new(
+            Seqno::zero(),
+            ProofState::new(recorded_root, 0),
+            ProofState::new(recorded_root, 0),
+            Vec::new(),
+            LedgerRefs::new_empty(),
+            UpdateOutputs::new_empty(),
+            Vec::new(),
+        );
+        let private_input = PrivateInput::new(pub_params, forged_state.as_ssz_bytes(), Vec::new());
+        let private_input_bytes =
+            rkyv::to_bytes::<RkyvError>(&private_input).expect("rkyv encode private input");
+        // SAFETY: `private_input_bytes` was produced from `PrivateInput` above.
+        let archived_private_input =
+            unsafe { rkyv::access_unchecked::<ArchivedPrivateInput>(&private_input_bytes) };
+
+        let result = verify_and_process_update(&TestProgram, archived_private_input, ());
+
+        assert!(matches!(result, Err(ProgramError::MismatchedPreState)));
     }
 
     #[test]

--- a/crates/snark-acct-sys/Cargo.toml
+++ b/crates/snark-acct-sys/Cargo.toml
@@ -11,5 +11,8 @@ strata-predicate.workspace = true
 strata-snark-acct-types.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+strata-ol-state-types-v1.workspace = true
+
 [lints]
 workspace = true

--- a/crates/snark-acct-sys/src/verification.rs
+++ b/crates/snark-acct-sys/src/verification.rs
@@ -179,7 +179,7 @@ fn compute_update_claim(
 #[cfg(test)]
 mod tests {
     use strata_acct_types::{AccumulatorClaim, Hash, TxEffects};
-    use strata_ol_state_types::{ExecError, ProofVerifyError};
+    use strata_ol_state_types::{ExecError, ISnarkAccountStateMut, ProofVerifyError};
     use strata_ol_state_types_v1::OLSnarkAccountStateV1;
     use strata_predicate::PredicateKey;
 
@@ -217,34 +217,86 @@ mod tests {
         }
     }
 
-    #[test]
-    fn rejects_proof_bound_to_unrecorded_public_pre_state() {
-        let target = AccountId::zero();
-        let recorded_root = Hash::from([1; 32]);
-        let forged_root = Hash::from([2; 32]);
-        let recorded_state =
-            OLSnarkAccountStateV1::new_fresh(PredicateKey::always_accept(), recorded_root);
-        let forged_state =
-            OLSnarkAccountStateV1::new_fresh(PredicateKey::always_accept(), forged_root);
-        let update = SnarkAccountUpdateData::new(
-            Seqno::zero(),
-            ProofState::new(Hash::from([3; 32]), 0),
+    fn make_update(seq_no: Seqno, new_state_root: Hash) -> SnarkAccountUpdateData {
+        SnarkAccountUpdateData::new(
+            seq_no,
+            ProofState::new(new_state_root, 0),
             Vec::new(),
             LedgerRefs::new_empty(),
             TxEffects::default(),
             Vec::new(),
             None,
+        )
+    }
+
+    fn verify_and_apply_update(
+        target: AccountId,
+        state: &mut OLSnarkAccountStateV1,
+        update: &SnarkAccountUpdateData,
+    ) {
+        let accepted_claim = compute_update_claim(state, update);
+        let mut verifier = ClaimVerifier { accepted_claim };
+
+        verify_update_correctness(target, state, update, &mut verifier)
+            .expect("transition from the recorded state must be verifiable");
+        state.set_proof_state(
+            update.new_proof_state().inner_state(),
+            update.new_proof_state().next_inbox_msg_idx(),
+            update.seq_no().incr(),
         );
+    }
 
-        // Model a proof whose public inputs use an attacker-chosen pre-state.
-        // The verifier accepts only the claim committed to by that proof.
-        let forged_claim = compute_update_claim(&forged_state, &update);
+    #[test]
+    fn rejects_valid_update_forked_from_stale_state() {
+        let target = AccountId::zero();
+        let state_1_root = Hash::from([1; 32]);
+        let state_2_root = Hash::from([2; 32]);
+        let state_3_root = Hash::from([3; 32]);
+        let state_4_root = Hash::from([4; 32]);
+        let mut current_state =
+            OLSnarkAccountStateV1::new_fresh(PredicateKey::always_accept(), state_1_root);
+
+        let update_1_to_2 = make_update(Seqno::zero(), state_2_root);
+        verify_and_apply_update(target, &mut current_state, &update_1_to_2);
+        let state_2 = current_state.clone();
+
+        let update_2_to_3 = make_update(Seqno::new(1), state_3_root);
+        verify_and_apply_update(target, &mut current_state, &update_2_to_3);
+        assert_eq!(current_state.inner_state_root(), state_3_root);
+        assert_eq!(current_state.seqno(), Seqno::new(2));
+
+        // This is a valid alternative transition from the previously recorded
+        // state 2, modeling a proof produced before state 2 advanced to state 3.
+        let update_2_to_4 = make_update(Seqno::new(1), state_4_root);
+        let state_2_claim = compute_update_claim(&state_2, &update_2_to_4);
         let mut verifier = ClaimVerifier {
-            accepted_claim: forged_claim,
+            accepted_claim: state_2_claim.clone(),
         };
+        verify_update_correctness(target, &state_2, &update_2_to_4, &mut verifier)
+            .expect("fork transition must be valid against its state 2 pre-state");
 
-        let result = verify_update_correctness(target, &recorded_state, &update, &mut verifier);
+        // Once state 2 has advanced to state 3, the full verification path
+        // rejects the fork because state 2's sequence number was consumed.
+        let mut verifier = ClaimVerifier {
+            accepted_claim: state_2_claim.clone(),
+        };
+        let result =
+            verify_update_correctness(target, &current_state, &update_2_to_4, &mut verifier);
+        assert!(matches!(
+            result,
+            Err(ExecError::Acct(AcctError::InvalidUpdateSequence {
+                account_id,
+                expected: 2,
+                got: 1,
+            })) if account_id == target
+        ));
 
+        // The proof itself is also bound to state 2's root. Even without the
+        // sequence-number guard, it cannot verify against current state 3.
+        let mut verifier = ClaimVerifier {
+            accepted_claim: state_2_claim,
+        };
+        let result = verify_update_proof(target, &current_state, &update_2_to_4, &mut verifier);
         assert!(matches!(
             result,
             Err(ExecError::Acct(AcctError::InvalidUpdateProof { account_id }))

--- a/crates/snark-acct-sys/src/verification.rs
+++ b/crates/snark-acct-sys/src/verification.rs
@@ -175,3 +175,80 @@ fn compute_update_claim(
     );
     pub_params.as_ssz_bytes()
 }
+
+#[cfg(test)]
+mod tests {
+    use strata_acct_types::{AccumulatorClaim, Hash, TxEffects};
+    use strata_ol_state_types::{ExecError, ProofVerifyError};
+    use strata_ol_state_types_v1::OLSnarkAccountStateV1;
+    use strata_predicate::PredicateKey;
+
+    use super::*;
+
+    struct ClaimVerifier {
+        accepted_claim: Vec<u8>,
+    }
+
+    impl TxProofVerifier for ClaimVerifier {
+        fn verify_inbox_mmr_proof_next(
+            &mut self,
+            _claim: &AccumulatorClaim,
+        ) -> Result<(), ProofVerifyError> {
+            unreachable!("the test update has no inbox proofs")
+        }
+
+        fn verify_l1_block_ref_mmr_proof_next(
+            &mut self,
+            _claim: &AccumulatorClaim,
+        ) -> Result<(), ProofVerifyError> {
+            unreachable!("the test update has no L1 block reference proofs")
+        }
+
+        fn verify_local_predicate_next(&mut self, claim: &[u8]) -> Result<(), ProofVerifyError> {
+            if claim == self.accepted_claim {
+                Ok(())
+            } else {
+                Err(ProofVerifyError::InvalidProof)
+            }
+        }
+
+        fn is_exhausted(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn rejects_proof_bound_to_unrecorded_public_pre_state() {
+        let target = AccountId::zero();
+        let recorded_root = Hash::from([1; 32]);
+        let forged_root = Hash::from([2; 32]);
+        let recorded_state =
+            OLSnarkAccountStateV1::new_fresh(PredicateKey::always_accept(), recorded_root);
+        let forged_state =
+            OLSnarkAccountStateV1::new_fresh(PredicateKey::always_accept(), forged_root);
+        let update = SnarkAccountUpdateData::new(
+            Seqno::zero(),
+            ProofState::new(Hash::from([3; 32]), 0),
+            Vec::new(),
+            LedgerRefs::new_empty(),
+            TxEffects::default(),
+            Vec::new(),
+            None,
+        );
+
+        // Model a proof whose public inputs use an attacker-chosen pre-state.
+        // The verifier accepts only the claim committed to by that proof.
+        let forged_claim = compute_update_claim(&forged_state, &update);
+        let mut verifier = ClaimVerifier {
+            accepted_claim: forged_claim,
+        };
+
+        let result = verify_update_correctness(target, &recorded_state, &update, &mut verifier);
+
+        assert!(matches!(
+            result,
+            Err(ExecError::Acct(AcctError::InvalidUpdateProof { account_id }))
+                if account_id == target
+        ));
+    }
+}

--- a/crates/snark-acct-sys/src/verification.rs
+++ b/crates/snark-acct-sys/src/verification.rs
@@ -265,38 +265,23 @@ mod tests {
         assert_eq!(current_state.inner_state_root(), state_3_root);
         assert_eq!(current_state.seqno(), Seqno::new(2));
 
-        // This is a valid alternative transition from the previously recorded
-        // state 2, modeling a proof produced before state 2 advanced to state 3.
-        let update_2_to_4 = make_update(Seqno::new(1), state_4_root);
+        // Build an alternative proof from state 2, but tag it with the sequence
+        // number currently expected after state 2 has advanced to state 3.
+        let update_2_to_4 = make_update(current_state.seqno(), state_4_root);
         let state_2_claim = compute_update_claim(&state_2, &update_2_to_4);
         let mut verifier = ClaimVerifier {
             accepted_claim: state_2_claim.clone(),
         };
-        verify_update_correctness(target, &state_2, &update_2_to_4, &mut verifier)
-            .expect("fork transition must be valid against its state 2 pre-state");
+        verify_update_proof(target, &state_2, &update_2_to_4, &mut verifier)
+            .expect("fork proof must be valid against its state 2 pre-state");
 
-        // Once state 2 has advanced to state 3, the full verification path
-        // rejects the fork because state 2's sequence number was consumed.
-        let mut verifier = ClaimVerifier {
-            accepted_claim: state_2_claim.clone(),
-        };
-        let result =
-            verify_update_correctness(target, &current_state, &update_2_to_4, &mut verifier);
-        assert!(matches!(
-            result,
-            Err(ExecError::Acct(AcctError::InvalidUpdateSequence {
-                account_id,
-                expected: 2,
-                got: 1,
-            })) if account_id == target
-        ));
-
-        // The proof itself is also bound to state 2's root. Even without the
-        // sequence-number guard, it cannot verify against current state 3.
+        // The forged sequence number passes the full path's sequence check,
+        // but the proof claim is still bound to state 2 instead of current state 3.
         let mut verifier = ClaimVerifier {
             accepted_claim: state_2_claim,
         };
-        let result = verify_update_proof(target, &current_state, &update_2_to_4, &mut verifier);
+        let result =
+            verify_update_correctness(target, &current_state, &update_2_to_4, &mut verifier);
         assert!(matches!(
             result,
             Err(ExecError::Acct(AcctError::InvalidUpdateProof { account_id }))


### PR DESCRIPTION
## Description

This adds regression coverage for SECFIND-854.

The OL test starts at state s1, verifies and applies s1 to s2 and s2 to s3, then builds an alternative s2 to s4 proof using the sequence number expected at s3. The proof is valid against the stale s2 state. When it is submitted against current s3, the sequence check passes but proof verification fails because OL rebuilds the claim with the s3 root.

The runtime test checks the other side of the invariant: private pre-state data must match the public pre-state root.

These tests show that the reported fork does not work against current main. They do not establish whether the audited revision behaved differently.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The OL verifier is a focused mock that accepts the bytes of one expected claim. It lets the test check the claim that OL constructs without depending on a concrete proof backend.

Local checks:

- cargo test -p strata-snark-acct-runtime -p strata-snark-acct-sys --locked
- cargo fmt --all --check
- just lint-check-ws

Is this PR addressing any specification, design doc or external reference document?

- [x] Yes
- [ ] No

If yes, please add relevant links:

- https://alpenlabs.atlassian.net/browse/SECFIND-854

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance: Codex wrote the tests and this PR description. The generated code was reviewed, and the checks listed above were run locally.

## Related Issues

- https://alpenlabs.atlassian.net/browse/SECFIND-854