### PR TITLE
fix(strata): validate shared network params

### DIFF
--- a/bin/strata/src/context.rs
+++ b/bin/strata/src/context.rs
@@ -19,14 +19,15 @@ use strata_config::{
 #[cfg(feature = "prover")]
 use strata_config::{ProverBackend, ProverConfig};
 use strata_csm_types::{ClientState, ClientUpdateOutput, L1Status};
-use strata_identifiers::Epoch;
+use strata_identifiers::{Epoch, L1Height};
 use strata_node_context::NodeContext;
+use strata_ol_genesis::build_genesis_artifacts;
 use strata_ol_params::OLParams;
 #[cfg(feature = "prover")]
 use strata_ol_params::OLRuntimeParams;
 #[cfg(feature = "prover")]
 use strata_predicate::{PredicateKey, PredicateTypeId};
-use strata_primitives::{L1BlockCommitment, OLBlockCommitment};
+use strata_primitives::{L1BlockCommitment, OLBlockCommitment, OLBlockId};
 #[cfg(feature = "prover")]
 use strata_proofimpl_predicate_keys::Sp1Groth16PredicateKey;
 #[cfg(feature = "prover")]
@@ -79,7 +80,6 @@ pub(crate) fn init_node_context(
     // Load OL params
     let ol_params_path = args.ol_params.as_ref().ok_or(InitError::MissingOLParams)?;
     let ol_params = load_ol_params(ol_params_path)?;
-
     // When the integrated prover is enabled, validate that its backend matches the
     // checkpoint predicate the runtime ASM will enforce and, for external SP1
     // ELFs, that the mounted guest artifact was built with these runtime params.
@@ -91,11 +91,7 @@ pub(crate) fn init_node_context(
         &handle,
     )?;
 
-    // TODO(STR-3971): cross-validate the ASM and OL params before booting. The ASM
-    // bridge deposit denomination and the OL withdrawal denomination are one network
-    // value, but the two files are loaded independently here, so a mismatched pair
-    // (hand-edited or from separate datatool runs) starts a node whose deposits
-    // cannot be withdrawn. Only datatool enforces this today, at generation time.
+    validate_shared_network_params(&asm_params, &ol_params)?;
 
     // Init storage
     let storage = init_storage(&config, handle.clone())?;
@@ -398,6 +394,175 @@ fn load_ol_params(path: &Path) -> Result<OLParams, InitError> {
     let ol_params =
         serde_json::from_str::<OLParams>(&json).map_err(|err| SerdeError::new(json, err))?;
     Ok(ol_params)
+}
+
+/// Ensures the independently loaded ASM and OL parameter files describe one network.
+///
+/// The ASM locks deposits at its bridge denomination, while the OL validates withdrawal
+/// amounts against its bridge parameters. The genesis L1 block similarly anchors both
+/// state machines. A mismatch in either value would make a node follow an inconsistent
+/// network, so reject it before initializing storage or network clients.
+fn validate_shared_network_params(
+    asm_params: &AsmParams,
+    ol_params: &OLParams,
+) -> Result<(), InitError> {
+    let asm_network_params = SharedNetworkParams::from_asm(asm_params)?;
+    let ol_network_params = SharedNetworkParams::from_ol(ol_params)?;
+
+    if asm_network_params != ol_network_params {
+        return Err(InitError::InconsistentNetworkParams(format!(
+            "shared network parameters differ: ASM={asm_network_params:?}, OL={ol_network_params:?}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Network parameters that must remain the same across the ASM and OL.
+#[derive(Debug, PartialEq, Eq)]
+struct SharedNetworkParams {
+    bridge_denomination: u64,
+    genesis_l1_block: L1BlockCommitment,
+    genesis_l1_height: L1Height,
+    genesis_ol_blkid: OLBlockId,
+}
+
+impl SharedNetworkParams {
+    /// Extracts the network parameters shared by the ASM and OL.
+    fn from_asm(asm_params: &AsmParams) -> Result<Self, InitError> {
+        let bridge = asm_params.bridge_config().ok_or_else(|| {
+            InitError::InconsistentNetworkParams(
+                "ASM params are missing the Bridge subprotocol".to_string(),
+            )
+        })?;
+        let checkpoint = asm_params.checkpoint_config().ok_or_else(|| {
+            InitError::InconsistentNetworkParams(
+                "ASM params are missing the Checkpoint subprotocol".to_string(),
+            )
+        })?;
+
+        Ok(Self {
+            bridge_denomination: bridge.denomination.to_sat(),
+            genesis_l1_block: asm_params.anchor.block,
+            genesis_l1_height: checkpoint.genesis_l1_height,
+            genesis_ol_blkid: checkpoint.genesis_ol_blkid,
+        })
+    }
+
+    /// Extracts the network parameters shared by the ASM and OL.
+    fn from_ol(ol_params: &OLParams) -> Result<Self, InitError> {
+        let genesis_params = ol_params.genesis_params();
+        let runtime_params = ol_params.runtime_params();
+        let genesis_artifacts = build_genesis_artifacts(ol_params).map_err(|error| {
+            InitError::InconsistentNetworkParams(format!(
+                "failed to derive OL genesis block ID: {error}"
+            ))
+        })?;
+
+        Ok(Self {
+            bridge_denomination: runtime_params.bridge_params().denomination(),
+            genesis_l1_block: genesis_params.last_l1_block(),
+            genesis_l1_height: genesis_params.last_l1_block().height(),
+            genesis_ol_blkid: *genesis_artifacts.commitment.blkid(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod shared_network_params_tests {
+    use strata_identifiers::Buf32;
+
+    use super::*;
+
+    #[test]
+    fn shared_network_params_match() {
+        let asm_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+        let ol_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+
+        assert_eq!(asm_network_params, ol_network_params);
+    }
+
+    #[test]
+    fn shared_network_params_reject_denomination_mismatch() {
+        let asm_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+        let ol_network_params = SharedNetworkParams {
+            bridge_denomination: 200_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+
+        assert_ne!(asm_network_params, ol_network_params);
+    }
+
+    #[test]
+    fn shared_network_params_reject_genesis_l1_block_mismatch() {
+        let asm_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+        let ol_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::new(1, Default::default()),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+
+        assert_ne!(asm_network_params, ol_network_params);
+    }
+
+    #[test]
+    fn shared_network_params_reject_genesis_ol_block_id_mismatch() {
+        let asm_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+        let ol_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::from(Buf32::from([1; 32])),
+        };
+
+        assert_ne!(asm_network_params, ol_network_params);
+    }
+
+    #[test]
+    fn shared_network_params_reject_checkpoint_genesis_l1_height_mismatch() {
+        let asm_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 1,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+        let ol_network_params = SharedNetworkParams {
+            bridge_denomination: 100_000_000,
+            genesis_l1_block: L1BlockCommitment::default(),
+            genesis_l1_height: 0,
+            genesis_ol_blkid: OLBlockId::null(),
+        };
+
+        assert_ne!(asm_network_params, ol_network_params);
+    }
 }
 
 /// Bitcoin client initialization

--- a/bin/strata/src/errors.rs
+++ b/bin/strata/src/errors.rs
@@ -28,6 +28,9 @@ pub(crate) enum InitError {
     #[error("missing OL params path in arguments")]
     MissingOLParams,
 
+    #[error("inconsistent ASM and OL parameters: {0}")]
+    InconsistentNetworkParams(String),
+
     #[error("invalid datadir path: {0:?}")]
     InvalidDatadirPath(path::PathBuf),
 


### PR DESCRIPTION
## Description

Reject node startup before storage or Bitcoin RPC initialization when independently loaded ASM and OL parameter files describe different network identities.

This PR is stacked on #2198, which splits OL parameters by lifecycle. The validation reads the withdrawal denomination from OL runtime params, and the genesis L1 block and derived genesis OL block ID from OL genesis params. It also checks the ASM checkpoint genesis L1 height against the OL genesis L1 height. Startup errors display both projections to make incompatible inputs identifiable.

AI assistance disclosure: This PR and its description were produced with Codex assistance, including code generation and verification.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is intentionally based on `str-3901-split-ol-params` (PR #2198) until that branch merges into `main`. A denomination mismatch can lock deposits at an ASM amount that the OL later rejects for withdrawals.

Is this PR addressing any specification, design doc or external reference document?

- [x] Yes
- [ ] No

If yes, please add relevant links:

- https://alpenlabs.atlassian.net/browse/STR-3971

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

https://alpenlabs.atlassian.net/browse/STR-3971