### PR TITLE
fix(alpen-client): bound concurrent EE proof submissions

### DIFF
--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -29,6 +29,7 @@ mod services;
 use std::time::Duration;
 use std::{
     env, fs,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     process,
     sync::Arc,
@@ -111,7 +112,8 @@ mod sequencer_imports {
     };
     pub(super) use alpen_reth_witness::RangeWitnessExtractor;
     pub(super) use strata_paas::{
-        ProverBuilder, ProverServiceBuilder, ReceiptStore, RetryConfig, TaskStore,
+        ConcurrencyBudget, ProverBuilder, ProverServiceBuilder, ReceiptStore, RetryConfig,
+        TaskStore,
     };
     pub(super) use strata_proofimpl_alpen_acct::EeAcctProgram;
     pub(super) use strata_proofimpl_alpen_chunk::EeChunkProgram;
@@ -153,6 +155,8 @@ const ALPEN_EE_BLOCK_TIME_MS_ENV_VAR: &str = "ALPEN_EE_BLOCK_TIME_MS";
 
 const DEFAULT_HEALTH_CHECK_HOST: &str = "0.0.0.0";
 const DEFAULT_HEALTH_CHECK_PORT: u16 = 8080;
+const DEFAULT_MAX_CONCURRENT_PROOF_SUBMISSIONS: NonZeroUsize =
+    NonZeroUsize::new(1).expect("default proof limit is nonzero");
 
 /// Default end-to-end deadline applied to the SP1 prover network for the EE
 /// chunk + acct provers when `--sp1-proof-deadline-secs` is not set. Chosen
@@ -743,6 +747,9 @@ fn main() {
                     ext.custom_chain.genesis().config.clone().into_rsp()
                 };
 
+                let submission_budget =
+                    ConcurrencyBudget::new(ext.max_concurrent_proof_submissions);
+
                 let chunk_builder = ProverBuilder::new(ChunkSpec::new(
                     chunk_storage_dyn.clone(),
                     storage.clone(),
@@ -752,6 +759,7 @@ fn main() {
                 .task_store(task_store.clone())
                 .receipt_store(chunk_receipts.clone())
                 .receipt_hook(ChunkReceiptHook::new(chunk_storage_dyn.clone()))
+                .concurrency_budget(submission_budget.clone())
                 .retry(RetryConfig::default());
 
                 // NOTE: the account prover still assembles its batch-range
@@ -788,6 +796,7 @@ fn main() {
                     batch_storage_dyn.clone(),
                     batch_proofs.clone(),
                 ))
+                .concurrency_budget(submission_budget)
                 .retry(RetryConfig::default());
 
                 // Dev/test escape hatch: use zkaleido NativeHost instead of
@@ -1154,6 +1163,10 @@ pub struct AdditionalConfig {
     /// `DEFAULT_SP1_DEADLINE_SECS`).
     #[arg(long, required = false)]
     pub sp1_proof_deadline_secs: Option<u64>,
+
+    /// Maximum concurrent EE chunk + account proof submissions.
+    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT_PROOF_SUBMISSIONS)]
+    pub max_concurrent_proof_submissions: NonZeroUsize,
 
     /// btcio writer fee policy: `bitcoind`, `fixed`, or `mempool`.
     #[cfg(feature = "sequencer")]

--- a/bin/alpen-client/src/prover/batch_prover.rs
+++ b/bin/alpen-client/src/prover/batch_prover.rs
@@ -12,12 +12,13 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::Bytes;
 use alpen_ee_common::{
     BatchId, BatchProver, ChunkStatus, ChunkStorage, Proof, ProofGenerationStatus, ProofId,
 };
 use async_trait::async_trait;
 use strata_paas::{ProverError as PaasError, ProverHandle, TaskStatus};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::{
     spec_acct::AcctSpec, spec_chunk::ChunkSpec, BatchTask, ChunkTask, EeBatchProofDbManager,
@@ -112,9 +113,13 @@ impl BatchProver for PaasBatchProver {
             Ok(TaskStatus::PermanentFailure { error }) => {
                 Ok(ProofGenerationStatus::Failed { reason: error })
             }
-            Ok(TaskStatus::Pending)
-            | Ok(TaskStatus::Proving { .. })
-            | Ok(TaskStatus::TransientFailure { .. }) => Ok(ProofGenerationStatus::Pending),
+            Ok(TaskStatus::Pending) => {
+                self.report_blocking_chunk_failures(batch_id).await;
+                Ok(ProofGenerationStatus::Pending)
+            }
+            Ok(TaskStatus::Proving { .. }) | Ok(TaskStatus::TransientFailure { .. }) => {
+                Ok(ProofGenerationStatus::Pending)
+            }
             Err(PaasError::TaskNotFound(_)) => Ok(ProofGenerationStatus::NotStarted),
             Err(e) => {
                 warn!(%batch_id, %e, "acct_handle.get_status failed");
@@ -125,5 +130,47 @@ impl BatchProver for PaasBatchProver {
 
     async fn get_proof(&self, proof_id: ProofId) -> eyre::Result<Option<Proof>> {
         Ok(self.batch_proofs.get_proof_by_id(proof_id))
+    }
+}
+
+impl PaasBatchProver {
+    async fn report_blocking_chunk_failures(&self, batch_id: BatchId) {
+        let chunk_ids = match self.chunk_storage.get_batch_chunks(batch_id).await {
+            Ok(Some(chunk_ids)) => chunk_ids,
+            Ok(None) => return,
+            Err(e) => {
+                warn!(%batch_id, %e, "failed to inspect batch chunks while account proof is pending");
+                return;
+            }
+        };
+
+        for chunk_id in chunk_ids {
+            let task = ChunkTask(chunk_id);
+            match self.chunk_handle.get_receipt(&task) {
+                Ok(Some(_)) => continue,
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(%batch_id, %task, %e, "failed to inspect chunk receipt while account proof is pending");
+                    continue;
+                }
+            }
+
+            match self.chunk_handle.get_status(&task) {
+                Ok(TaskStatus::PermanentFailure { error }) => {
+                    let task_key = Bytes::from(Vec::<u8>::from(task));
+                    error!(
+                        %batch_id,
+                        chunk_task = %task,
+                        %task_key,
+                        %error,
+                        "account proof is blocked by a permanently failed chunk proof; manual reset required"
+                    );
+                }
+                Ok(_) | Err(PaasError::TaskNotFound(_)) => {}
+                Err(e) => {
+                    warn!(%batch_id, %task, %e, "failed to inspect chunk task while account proof is pending");
+                }
+            }
+        }
     }
 }

--- a/bin/alpen-client/src/prover/spec_acct.rs
+++ b/bin/alpen-client/src/prover/spec_acct.rs
@@ -166,6 +166,25 @@ impl ProofSpec for AcctSpec {
     type Task = BatchTask;
     type Program = EeAcctProgram;
 
+    async fn is_ready(&self, task: &Self::Task) -> ProverResult<bool> {
+        let Some(chunk_ids) = self
+            .chunk_storage
+            .get_batch_chunks(task.0)
+            .await
+            .map_err(|e| PaasError::Storage(format!("get_batch_chunks({}): {e}", task.0)))?
+        else {
+            return Ok(false);
+        };
+
+        for chunk_id in chunk_ids {
+            let key: Vec<u8> = ChunkTask(chunk_id).into();
+            if self.chunk_receipts.get(&key)?.is_none() {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     async fn fetch_input(&self, task: &Self::Task) -> ProverResult<EeAcctProofInput> {
         let batch_id = task.0;
 

--- a/crates/prover-core/src/lib.rs
+++ b/crates/prover-core/src/lib.rs
@@ -19,7 +19,7 @@ mod traits;
 pub use config::{ProverConfig, RetryConfig};
 pub use error::{ProverError, ProverResult};
 pub use in_memory::{InMemoryReceiptStore, InMemoryTaskStore};
-pub use prover::{Prover, ProverBuilder};
+pub use prover::{ConcurrencyBudget, Prover, ProverBuilder};
 pub use task::{TaskRecord, TaskRecordData, TaskResult, TaskStatus};
 pub use traits::{ProofSpec, ReceiptHook, ReceiptStore, TaskKey, TaskStore};
 pub use zkaleido::{ProofReceiptWithMetadata, ZkVmHost, ZkVmProgram};

--- a/crates/prover-core/src/prover.rs
+++ b/crates/prover-core/src/prover.rs
@@ -3,7 +3,9 @@
 
 use std::{
     collections::HashMap,
-    fmt, slice,
+    fmt,
+    num::NonZeroUsize,
+    slice,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -12,7 +14,10 @@ use std::{
 };
 
 use parking_lot::Mutex;
-use tokio::{sync::oneshot, task::spawn_blocking};
+use tokio::{
+    sync::{oneshot, OwnedSemaphorePermit, Semaphore, TryAcquireError},
+    task::spawn_blocking,
+};
 use tracing::{error, info, info_span, warn, Instrument};
 use zkaleido::ZkVmHost;
 #[cfg(feature = "remote")]
@@ -33,6 +38,24 @@ use crate::{
 /// drains and removes the entry when the task reaches a terminal state.
 type WatcherMap<T> = HashMap<Vec<u8>, Vec<oneshot::Sender<TaskResult<T>>>>;
 
+/// Cloneable proof-submission budget shared by one or more provers.
+#[derive(Clone, Debug)]
+pub struct ConcurrencyBudget(Arc<Semaphore>);
+
+impl ConcurrencyBudget {
+    pub fn new(max: NonZeroUsize) -> Self {
+        Self(Arc::new(Semaphore::new(max.get())))
+    }
+
+    fn try_acquire(&self) -> Option<OwnedSemaphorePermit> {
+        match self.0.clone().try_acquire_owned() {
+            Ok(permit) => Some(permit),
+            Err(TryAcquireError::NoPermits) => None,
+            Err(TryAcquireError::Closed) => unreachable!("proof budget is never closed"),
+        }
+    }
+}
+
 /// Single-proof-type prover.
 ///
 /// Generic over `H` (spec) only. The zkVM host type is erased inside
@@ -44,6 +67,8 @@ pub struct Prover<H: ProofSpec> {
     task_store: Arc<dyn TaskStore>,
     receipt_store: Option<Arc<dyn ReceiptStore>>,
     receipt_hook: Option<Arc<dyn ReceiptHook<H>>>,
+    concurrency_budget: Option<ConcurrencyBudget>,
+    dispatch_lock: Mutex<()>,
     /// Oneshot senders for notifying waiters when tasks reach terminal states.
     watchers: Arc<Mutex<WatcherMap<H::Task>>>,
     /// Whether we've run recovery on startup.
@@ -70,23 +95,17 @@ impl<H: ProofSpec> fmt::Debug for Prover<H> {
 // ============================================================================
 
 impl<H: ProofSpec> Prover<H> {
-    /// Register a task and spawn background proving. Idempotent.
+    /// Register a task and start proving if shared capacity is available.
+    /// Idempotent; capacity-limited tasks remain durably `Pending` for `tick`.
     pub async fn submit(self: &Arc<Self>, task: H::Task) -> ProverResult<()> {
         let key: Vec<u8> = task.clone().into();
 
-        // Idempotent: if already in store, skip.
-        if self.task_store.get(&key)?.is_some() {
-            return Ok(());
+        if self.task_store.get(&key)?.is_none() {
+            self.task_store
+                .insert(TaskRecord::new(key.clone(), TaskStatus::Pending))?;
         }
 
-        self.task_store
-            .insert(TaskRecord::new(key.clone(), TaskStatus::Pending))?;
-
-        let prover = Arc::clone(self);
-        tokio::spawn(async move {
-            prover.run_task(task, key).await;
-        });
-
+        self.try_start_task(task, key).await?;
         Ok(())
     }
 
@@ -191,34 +210,40 @@ impl<H: ProofSpec> Prover<H> {
             .ok_or_else(|| ProverError::TaskNotFound(format!("{task}")))
     }
 
-    /// Scan for retriable tasks and re-spawn them. Called by PaaS on tick.
+    /// Scan durable pending/retriable tasks and start only while capacity exists.
     pub async fn tick(self: &Arc<Self>) {
         if !self.recovered.swap(true, Ordering::SeqCst) {
             self.recover().await;
         }
 
-        let retriable = match self.task_store.list_retriable(now_secs()) {
+        let mut runnable = match self.task_store.list_unfinished() {
             Ok(v) => v,
+            Err(e) => {
+                warn!(%e, "failed to list pending tasks");
+                return;
+            }
+        };
+        runnable.retain(|record| matches!(record.status(), TaskStatus::Pending));
+        match self.task_store.list_retriable(now_secs()) {
+            Ok(mut retriable) => runnable.append(&mut retriable),
             Err(e) => {
                 warn!(%e, "failed to list retriable tasks");
                 return;
             }
-        };
-        for record in retriable {
+        }
+
+        for record in runnable {
             let key = record.key().to_vec();
             if let Some(task) = decode_task_key::<H>(&key) {
-                let prover = Arc::clone(self);
-                tokio::spawn(async move {
-                    prover.run_task(task, key).await;
-                });
+                if let Err(e) = self.try_start_task(task, key).await {
+                    warn!(%e, "failed to start proof task");
+                }
             }
         }
     }
 
-    /// Re-spawn every unfinished task on startup — anything not yet terminal
-    /// (Pending or Proving). Before this change we only re-picked in-progress
-    /// work, so a crash between `submit`'s db insert and the spawn would
-    /// leave a task stuck in Pending forever.
+    /// Normalize tasks left `Proving` by a crashed process. The normal tick
+    /// scan then restarts them under the shared concurrency budget.
     ///
     /// A task found in `Proving` is one whose previous attempt died
     /// abnormally — the process was killed (OOM, SIGKILL, panic) before any
@@ -278,6 +303,7 @@ impl<H: ProofSpec> Prover<H> {
                     retry_count = new_count,
                     "task died mid-Proving; counting as transient failure"
                 );
+                let _ = self.task_store.set_retry_after(&key, now_secs());
                 let _ = self.task_store.update_status(
                     &key,
                     TaskStatus::TransientFailure {
@@ -285,52 +311,58 @@ impl<H: ProofSpec> Prover<H> {
                         error: "process died mid-Proving".to_string(),
                     },
                 );
-                // Fall through to spawn — `run_task` will snapshot the bumped
-                // count from the now-TransientFailure record.
             }
 
-            let prover = Arc::clone(self);
-            tokio::spawn(async move {
-                prover.run_task(task, key).await;
-            });
+            // Pending and re-armed rows are picked up below by the normal
+            // tick scan, which applies the shared concurrency budget.
         }
     }
 
-    /// Read the persisted retry counter for a task.
-    ///
-    /// Used at the top of [`Self::run_task`] before status is overwritten to
-    /// `Proving`, and by [`Self::recover`] to compute the post-crash bump.
-    /// Returns 0 for `Pending` or absent records.
-    fn read_retry_count(&self, key: &[u8]) -> u32 {
+    async fn try_start_task(self: &Arc<Self>, task: H::Task, key: Vec<u8>) -> ProverResult<bool> {
+        if !self.spec.is_ready(&task).await? {
+            return Ok(false);
+        }
+
+        let _dispatch = self.dispatch_lock.lock();
+        let Some(record) = self.task_store.get(&key)? else {
+            return Ok(false);
+        };
+        let retry_count = match record.status() {
+            TaskStatus::Pending => 0,
+            TaskStatus::TransientFailure { retry_count, .. }
+                if record.retry_after_secs().is_some_and(|at| at <= now_secs()) =>
+            {
+                *retry_count
+            }
+            _ => return Ok(false),
+        };
+        let permit = match &self.concurrency_budget {
+            Some(budget) => match budget.try_acquire() {
+                Some(permit) => Some(permit),
+                None => return Ok(false),
+            },
+            None => None,
+        };
+
         self.task_store
-            .get(key)
-            .ok()
-            .flatten()
-            .map_or(0, |r| match r.status() {
-                TaskStatus::Proving { retry_count }
-                | TaskStatus::TransientFailure { retry_count, .. } => *retry_count,
-                _ => 0,
-            })
+            .update_status(&key, TaskStatus::Proving { retry_count })?;
+        let prover = Arc::clone(self);
+        tokio::spawn(async move {
+            prover.run_task(task, key, retry_count, permit).await;
+        });
+        Ok(true)
     }
 
-    async fn run_task(&self, task: H::Task, key: Vec<u8>) {
+    async fn run_task(
+        &self,
+        task: H::Task,
+        key: Vec<u8>,
+        prior_retry_count: u32,
+        permit: Option<OwnedSemaphorePermit>,
+    ) {
         let span = info_span!("prove", task = %task);
 
         async {
-            // Snapshot the retry counter from the persisted record BEFORE
-            // flipping status to `Proving`. `schedule_retry` cannot read it
-            // from the store after the overwrite below, and `recover` needs
-            // the count to survive a mid-Proving crash, so persist it inside
-            // the `Proving` status itself.
-            let prior_retry_count = self.read_retry_count(&key);
-
-            let _ = self.task_store.update_status(
-                &key,
-                TaskStatus::Proving {
-                    retry_count: prior_retry_count,
-                },
-            );
-
             // 1. Fetch input
             let input = match self.spec.fetch_input(&task).await {
                 Ok(input) => input,
@@ -351,9 +383,18 @@ impl<H: ProofSpec> Prover<H> {
                 .and_then(|r| r.metadata().map(|m| m.to_vec()));
             let store = self.task_store.clone();
             let persist_key = key.clone();
-            let ctx = ProveContext::new(saved_metadata, move |data| {
-                let _ = store.set_metadata(&persist_key, data);
-            });
+            let ctx = ProveContext::new(
+                saved_metadata,
+                move |data| {
+                    if let Err(e) = store.set_metadata(&persist_key, data) {
+                        warn!(
+                            %e,
+                            "failed to persist remote proof ID; continuing without crash-recovery metadata"
+                        );
+                    }
+                },
+                permit,
+            );
 
             let strategy = self.strategy.clone();
             let prove_result = spawn_blocking(move || strategy.prove(&input, ctx)).await;
@@ -514,6 +555,7 @@ pub struct ProverBuilder<H: ProofSpec> {
     task_store: Option<Arc<dyn TaskStore>>,
     receipt_store: Option<Arc<dyn ReceiptStore>>,
     receipt_hook: Option<Arc<dyn ReceiptHook<H>>>,
+    concurrency_budget: Option<ConcurrencyBudget>,
     retry: Option<RetryConfig>,
 }
 
@@ -524,6 +566,7 @@ impl<H: ProofSpec> ProverBuilder<H> {
             task_store: None,
             receipt_store: None,
             receipt_hook: None,
+            concurrency_budget: None,
             retry: None,
         }
     }
@@ -542,6 +585,12 @@ impl<H: ProofSpec> ProverBuilder<H> {
     /// Opt-in domain hook called after receipt storage.
     pub fn receipt_hook(mut self, hook: impl ReceiptHook<H> + 'static) -> Self {
         self.receipt_hook = Some(Arc::new(hook));
+        self
+    }
+
+    /// Limit concurrent proof preparation and remote submission.
+    pub fn concurrency_budget(mut self, budget: ConcurrencyBudget) -> Self {
+        self.concurrency_budget = Some(budget);
         self
     }
 
@@ -585,6 +634,8 @@ impl<H: ProofSpec> ProverBuilder<H> {
                 .unwrap_or_else(|| Arc::new(InMemoryTaskStore::new())),
             receipt_store: self.receipt_store,
             receipt_hook: self.receipt_hook,
+            concurrency_budget: self.concurrency_budget,
+            dispatch_lock: Mutex::new(()),
             watchers: Arc::new(Mutex::new(HashMap::new())),
             recovered: AtomicBool::new(false),
         }
@@ -594,5 +645,43 @@ impl<H: ProofSpec> ProverBuilder<H> {
 impl<H: ProofSpec> fmt::Debug for ProverBuilder<H> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProverBuilder").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proving_context_can_release_submission_capacity_early() {
+        let budget = ConcurrencyBudget::new(NonZeroUsize::new(1).unwrap());
+        let permit = budget.try_acquire().unwrap();
+        let mut context = ProveContext::new(None, |_| {}, Some(permit));
+
+        assert!(budget.try_acquire().is_none());
+        context.release_submission_permit();
+        assert!(budget.try_acquire().is_some());
+    }
+
+    #[cfg(feature = "remote")]
+    #[test]
+    fn metadata_persistence_does_not_release_submission_capacity() {
+        let budget = ConcurrencyBudget::new(NonZeroUsize::new(1).unwrap());
+        let permit = budget.try_acquire().unwrap();
+        let persisted = Arc::new(AtomicBool::new(false));
+        let persisted_in_callback = persisted.clone();
+        let mut context = ProveContext::new(
+            None,
+            move |_| {
+                persisted_in_callback.store(true, Ordering::SeqCst);
+            },
+            Some(permit),
+        );
+
+        context.persist(vec![1]);
+        assert!(persisted.load(Ordering::SeqCst));
+        assert!(budget.try_acquire().is_none());
+        context.release_submission_permit();
+        assert!(budget.try_acquire().is_some());
     }
 }

--- a/crates/prover-core/src/strategy.rs
+++ b/crates/prover-core/src/strategy.rs
@@ -142,6 +142,7 @@ where
                 match Host::ProofId::try_from(saved) {
                     Ok(id) => {
                         tracing::info!(%id, "resuming remote proof from saved metadata");
+                        ctx.release_submission_permit();
                         id
                     }
                     Err(_) => {
@@ -153,6 +154,7 @@ where
                 // Fresh submission.
                 let id = self.submit_proof::<H>(input, &host).await?;
                 ctx.persist(id.clone().into());
+                ctx.release_submission_permit();
                 id
             };
 
@@ -193,6 +195,7 @@ where
     ) -> ProverResult<ProofReceiptWithMetadata> {
         let proof_id = self.submit_proof::<H>(input, host).await?;
         ctx.persist(proof_id.clone().into());
+        ctx.release_submission_permit();
         self.poll_until_done::<H>(host, &proof_id, self.poll_interval)
             .await
     }

--- a/crates/prover-core/src/traits.rs
+++ b/crates/prover-core/src/traits.rs
@@ -24,6 +24,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use tokio::sync::OwnedSemaphorePermit;
 use zkaleido::{ProofReceiptWithMetadata, ZkVmProgram};
 
 use crate::{
@@ -93,6 +94,12 @@ pub trait ProofSpec: Send + Sync + 'static {
 
     /// The zkaleido program to execute. Input must be `Send` for `spawn_blocking`.
     type Program: ZkVmProgram<Input: Send + Sync> + Send + Sync + 'static;
+
+    /// Whether this task's prerequisites are ready. Returning `false` keeps
+    /// the task durable without consuming capacity or retry budget.
+    async fn is_ready(&self, _task: &Self::Task) -> ProverResult<bool> {
+        Ok(true)
+    }
 
     /// Fetch the proof input for a task.
     ///
@@ -214,6 +221,7 @@ pub trait ReceiptHook<H: ProofSpec>: Send + Sync + 'static {
 pub(crate) struct ProveContext {
     /// Metadata from a prior run (e.g. serialized remote ProofId).
     pub(crate) saved: Option<Vec<u8>>,
+    submission_permit: Option<OwnedSemaphorePermit>,
     #[cfg(feature = "remote")]
     persist_fn: Option<Box<dyn FnOnce(Vec<u8>) + Send>>,
 }
@@ -222,6 +230,7 @@ impl fmt::Debug for ProveContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProveContext")
             .field("saved", &self.saved.as_ref().map(|s| s.len()))
+            .field("has_submission_permit", &self.submission_permit.is_some())
             .finish()
     }
 }
@@ -230,12 +239,19 @@ impl ProveContext {
     pub(crate) fn new(
         saved: Option<Vec<u8>>,
         _persist: impl FnOnce(Vec<u8>) + Send + 'static,
+        submission_permit: Option<OwnedSemaphorePermit>,
     ) -> Self {
         Self {
             saved,
+            submission_permit,
             #[cfg(feature = "remote")]
             persist_fn: Some(Box::new(_persist)),
         }
+    }
+
+    /// Release capacity once local preparation and remote submission finish.
+    pub(crate) fn release_submission_permit(&mut self) {
+        self.submission_permit.take();
     }
 
     /// Persist metadata for crash recovery. Call this right after obtaining

--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -362,6 +362,7 @@ def main(argv: list[str]) -> int:
             ol_block_time_ms=1000,
             dev_track_latest_epoch=True,
             batch_sealing_block_count=5,
+            max_concurrent_proof_submissions=2,
         ),
         "el_ol_checkpoint_sync": EeOLCheckpointSyncEnv(pre_generate_blocks=110),
     }

--- a/functional-tests/envconfigs/alpen_client.py
+++ b/functional-tests/envconfigs/alpen_client.py
@@ -39,6 +39,7 @@ class AlpenClientEnvParams:
     da_magic_bytes: bytes = b"ALPN"
     l1_reorg_safe_depth: int = 2
     batch_sealing_block_count: int = 10
+    max_concurrent_proof_submissions: int = 2
     dev_track_latest_epoch: bool = False
     beneficiary_address: str | None = None
 
@@ -164,6 +165,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
             ee_params_path=ee_params_path,
             da_config=da_config,
             batch_sealing_block_count=envparams.batch_sealing_block_count,
+            max_concurrent_proof_submissions=envparams.max_concurrent_proof_submissions,
             dev_track_latest_epoch=envparams.dev_track_latest_epoch,
             beneficiary_address=envparams.beneficiary_address,
         )

--- a/functional-tests/envconfigs/el_ol.py
+++ b/functional-tests/envconfigs/el_ol.py
@@ -41,6 +41,7 @@ class EeOLEnv(flexitest.EnvConfig):
         ol_block_time_ms: int | None = None,
         dev_track_latest_epoch: bool = False,
         batch_sealing_block_count: int = 10,
+        max_concurrent_proof_submissions: int = 2,
     ):
         epoch_seal_config = (
             EpochSealingConfig.new_fixed_slot(seal_epoch_slots)
@@ -55,6 +56,7 @@ class EeOLEnv(flexitest.EnvConfig):
             mesh_bootnodes=mesh_bootnodes,
             enable_l1_da=True,
             batch_sealing_block_count=batch_sealing_block_count,
+            max_concurrent_proof_submissions=max_concurrent_proof_submissions,
             dev_track_latest_epoch=dev_track_latest_epoch,
         )
         self.strata_config = StrataEnvConfig(

--- a/functional-tests/factories/alpen_client.py
+++ b/functional-tests/factories/alpen_client.py
@@ -70,6 +70,7 @@ class AlpenClientFactory(flexitest.Factory):
         ol_submit_token: str | None = None,
         da_config: EeDaConfig | None = None,
         batch_sealing_block_count: int = 100,
+        max_concurrent_proof_submissions: int = 2,
         dev_track_latest_epoch: bool = False,
         bridge_denomination: int = 100_000_000,
         max_withdrawal_amount: int | None = 1_000_000_000,
@@ -140,6 +141,7 @@ class AlpenClientFactory(flexitest.Factory):
             "--p2p-secret-key", str(p2p_secret_key_file),
             "--custom-chain", custom_chain,
             "--batch-sealing-block-count", str(batch_sealing_block_count),
+            "--max-concurrent-proof-submissions", str(max_concurrent_proof_submissions),
             "-vvvv",
             # Functional tests don't ship the SP1 guest ELFs, so run the
             # EE chunk + acct provers on the zkaleido NativeHost.


### PR DESCRIPTION
Share a configurable submission budget between the chunk and account provers, defaulting to one concurrent preparation and submission.

Keep capacity-limited tasks pending for tick-based dispatch and restart recovery, release capacity after remote proof submission, and defer account proving until every chunk receipt is available.

Log permanently failed chunks that block account proof generation.
