### PR TITLE
chore!: raise TxEffects and OL block log caps to 65,536 

### DIFF
--- a/crates/acct-types/ssz/effects.ssz
+++ b/crates/acct-types/ssz/effects.ssz
@@ -1,7 +1,9 @@
 import messages
 
-MAX_TRANSFERS = 255
-MAX_MESSAGES = 255
+### Matches the `UpdateOutputs` caps in `snark-acct-types`. Converting
+### between the two must never drop entries, so the bounds have to agree.
+MAX_TRANSFERS = 1 << 16
+MAX_MESSAGES = 1 << 16
 
 ### Direct external effects that a transaction can cause.
 ###

--- a/crates/acct-types/ssz/effects.ssz
+++ b/crates/acct-types/ssz/effects.ssz
@@ -2,6 +2,10 @@ import messages
 
 ### Matches the `UpdateOutputs` caps in `snark-acct-types`. Converting
 ### between the two must never drop entries, so the bounds have to agree.
+###
+### TODO(STR-4402): `MAX_MESSAGES` is not reconciled with the OL block log cap
+### or the per-checkpoint log budget. A tx at this cap emits one log more than
+### `MAX_LOGS_PER_BLOCK` allows.
 MAX_TRANSFERS = 1 << 16
 MAX_MESSAGES = 1 << 16
 

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -2776,10 +2776,11 @@ mod tests {
     /// budget triggers a soft-break: the tx is not included, not marked invalid,
     /// and remains available for future blocks.
     ///
-    /// Note: with `TxEffects::MAX_MESSAGES = 255` and `MAX_LOGS_PER_BLOCK = 4096`,
-    /// a single tx can never overflow the per-tx log buffer on its own. So we
-    /// pre-fill the block output buffer to near capacity and verify that even a
-    /// small tx triggers the soft-break when it would push past the limit.
+    /// Note: `TxEffects::MAX_MESSAGES` and `MAX_LOGS_PER_BLOCK` are both 65,536,
+    /// and a tx emits one log of its own on top of its message logs, so a single
+    /// maximal tx now sits one log over the cap. Pre-filling the block output
+    /// buffer keeps this test cheap either way: a small tx triggers the same
+    /// soft-break without having to build a 65k-message tx.
     async fn build_process_transactions_preamble(
         env: &TestEnv,
         timestamp: u64,

--- a/crates/ol/block-assembly/src/block_assembly.rs
+++ b/crates/ol/block-assembly/src/block_assembly.rs
@@ -698,6 +698,13 @@ where
 
                 match verdict.checkpoint_size_action() {
                     EpochSealingLimitAction::RejectCandidate => {
+                        // TODO(STR-4402): this breaks out of the loop without
+                        // marking the tx failed, so a tx too big for any
+                        // checkpoint budget stays in the mempool and is
+                        // re-offered at the same priority position every block,
+                        // blocking every tx behind it. Tell "does not fit the
+                        // remaining budget" apart from "cannot fit any budget"
+                        // and report the latter as invalid.
                         debug!(
                             da_diff_size,
                             ?tentative,

--- a/crates/ol/chain-types-v1/ssz/block.ssz
+++ b/crates/ol/chain-types-v1/ssz/block.ssz
@@ -4,7 +4,7 @@ import strata_ol_tx_types_v1
 import block_flags
 
 MAX_TXS_PER_BLOCK = 1 << 16
-MAX_LOGS_PER_BLOCK = 1 << 12
+MAX_LOGS_PER_BLOCK = 1 << 16
 MAX_SEALING_MANIFEST_COUNT = 2048
 
 ### OL Block header without signature.

--- a/crates/ol/chain-types-v1/ssz/block.ssz
+++ b/crates/ol/chain-types-v1/ssz/block.ssz
@@ -4,6 +4,12 @@ import strata_ol_tx_types_v1
 import block_flags
 
 MAX_TXS_PER_BLOCK = 1 << 16
+### TODO(STR-4402): reconcile this with the per-tx effects cap and the
+### per-checkpoint log budget. A tx carrying the full `TxEffects::MAX_MESSAGES`
+### emits one account-update log on top of one log per message, so it lands one
+### log over this cap and can never be included. This cap is also 4x
+### `MAX_OL_LOGS_PER_CHECKPOINT`, so a large update never fits a checkpoint and
+### stalls block assembly.
 MAX_LOGS_PER_BLOCK = 1 << 16
 MAX_SEALING_MANIFEST_COUNT = 2048
 

--- a/crates/snark-acct-types/ssz/outputs.ssz
+++ b/crates/snark-acct-types/ssz/outputs.ssz
@@ -1,8 +1,8 @@
 import strata_acct_types
 import strata_predicate
 
-MAX_TRANSFERS = 2 << 15
-MAX_MESSAGES = 2 << 15
+MAX_TRANSFERS = 1 << 16
+MAX_MESSAGES = 1 << 16
 
 ### Transfer of native asset to an OL account
 class OutputTransfer(Container):


### PR DESCRIPTION
## Description

The EE can produce up to 65,536 outputs per update, which is what `UpdateOutputs` and `ExecOutputs` both allow. Two OL-side constants sat well below that and did not agree with it or with each other. `TxEffects` capped transfers and messages at 255, and `MAX_LOGS_PER_BLOCK` capped a block at 4096 logs. Every withdrawal message delivered to the bridge gateway emits one OL log, and effects are dispatched in the same block as the tx carrying them, so the real ceiling on withdrawals per update was `min(255, 4096)` = 255. That is about 257x below what the upstream types advertise.

The low number was not the only problem. `UpdateOutputs::to_tx_effects()` drops entries past the `TxEffects` bound without signalling, and OL recomputes the update claim from the truncated effects. An update carrying more than 255 outputs therefore proved fine and was then rejected as `InvalidUpdateProof`, pointing a reader at the prover rather than at the real cause. Raising `TxEffects` to match `UpdateOutputs` makes that conversion total, so the truncation is no longer expressible.

**These constants are incompatible as they stand, and the values here are a starting point rather than a recommendation.** I have raised both to 65,536 so they line up with the EE-side types, but what they should actually be is open for discussion:

- With both at 65,536 a single maximal tx emits 65,537 logs, its own tx log plus one per message, which is one over the block cap. So either the log budget wants headroom above the effects cap, or the effects cap wants to sit one below it, or both should be different numbers entirely.
- Raising `MAX_LOGS_PER_BLOCK` 16x grows the maximum OL block log list, with block size, DA and proving cost consequences I have not measured. If that cost is not worth paying, the alternative is to leave the log budget alone and treat 4096 as the declared per-update output budget.

Either way the number needs to be a deliberate protocol choice, because the EE side has to enforce it.

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes to Reviewers

The two `.ssz` files are the whole change; everything else follows from them. Worth reviewing as two commits, since the second one is the part with real cost attached.

The affected tests are written symbolically against both constants, so they adapt without rewrites. They do get proportionally bigger and slower, notably the withdrawal-log tests in `ol/stf-v1` which now build a single tx with tens of thousands of messages.

This came out of investigating [STR-3253](https://alpenlabs.atlassian.net/browse/STR-3253). The follow-up on the alpen-ee side is [STR-4373](https://alpenlabs.atlassian.net/browse/STR-4373), which caps withdrawals per block and adds batch sealing on output count so the sequencer can never build an update it cannot submit. Whatever value lands here sets the threshold for that work.

This PR was written primarily by Claude Code, including this description.

Is this PR addressing any specification, design doc or external reference document?

- [x]  No

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3253](https://alpenlabs.atlassian.net/browse/STR-3253)
[STR-4373](https://alpenlabs.atlassian.net/browse/STR-4373)


[STR-3253]: https://alpenlabs.atlassian.net/browse/STR-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ