### PR TITLE
fix(alpen-client): install jemalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9781,6 +9781,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -17297,6 +17298,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bin/alpen-client/Cargo.toml
+++ b/bin/alpen-client/Cargo.toml
@@ -7,7 +7,35 @@ version = "0.3.0-alpha.1"
 workspace = true
 
 [features]
-default = ["sequencer", "sp1"]
+default = ["sequencer", "sp1", "jemalloc"]
+
+# Use jemalloc as the global allocator (unix only; falls back to the system
+# allocator elsewhere). On by default, matching reth's own binary: reth's
+# workload — long-lived node with a tokio worker pool, a large blocking pool
+# driving DB, and short-lived multi-megabyte allocations for block
+# re-execution and trie multiproofs — fragments glibc's per-thread arenas
+# badly, and glibc never returns that memory to the OS. The result reads as
+# an unbounded leak in RSS.
+jemalloc = ["reth-cli-util/jemalloc"]
+
+# jemalloc with heap profiling compiled in. Profiling is compiled out of the
+# plain `jemalloc` build, so collecting a heap profile needs this feature and a
+# redeploy. Run with:
+#
+#   _RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,\
+#   lg_prof_interval:30,prof_prefix:/app/data/jeprof
+#
+# then `jeprof --text --show_bytes alpen-client /app/data/jeprof.*.heap`.
+#
+# Two details that otherwise produce no output and no error. The variable must
+# carry the `_RJEM_` prefix: tikv-jemallocator builds jemalloc with prefixed
+# symbols, and a plain `MALLOC_CONF` is ignored silently. And `prof:true` only
+# starts sampling — a dump trigger is required, since `prof_prefix` just names
+# the files. `lg_prof_interval:30` dumps every 1 GiB allocated (lower it and the
+# file count explodes); `prof_gdump:true` dumps on each new virtual-memory
+# high-water; `prof_final:true` dumps once at exit, which a node never reaches.
+jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
+
 sequencer = [
   "dep:alpen-ee-da-provider",
   "dep:alpen-ee-da-runtime",

--- a/bin/alpen-client/src/main.rs
+++ b/bin/alpen-client/src/main.rs
@@ -1,5 +1,18 @@
 //! Reth node for the Alpen codebase.
 //!
+//! # Allocator
+//!
+//! The global allocator is jemalloc (via the `jemalloc` feature, on by
+//! default), the same choice reth's own binary makes. This is not a
+//! micro-optimization: the node runs a tokio worker pool alongside a large
+//! blocking pool that drives sled, block re-execution in the accessed-state
+//! exex, and trie multiproof construction for chunk witnesses. Those are
+//! short-lived multi-megabyte allocations spread over many threads, which is
+//! precisely the pattern glibc's malloc handles worst — it spins up an arena
+//! per thread (up to `8 * ncpu`), fragments each of them, and never returns
+//! the freed pages to the OS. RSS then climbs monotonically for the life of
+//! the process with nothing in the logs to show for it.
+//!
 //! # Logging
 //!
 //! Alpen (non-reth) logs carry a `component = "alpen"` field so they can be
@@ -9,6 +22,13 @@
 //! target at INFO or a more verbose level to get the tags: lowering it (e.g.
 //! `RUST_LOG=alpen_client=warn`) or capping the compile-time level below info
 //! (`tracing/release_max_level_*`) disables the spans and silently drops the tag.
+
+#[expect(
+    clippy::absolute_paths,
+    reason = "the allocator is declared ahead of the module tree, before any `use` items"
+)]
+#[global_allocator]
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
 mod dummy_ol_client;
 #[cfg(feature = "sequencer")]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

alpen-client never set a `#[global_allocator]`, so it ran on glibc malloc (Debian). reth's own binary installs jemalloc and ships the feature on by default, precisely because a long-lived node and a diverse profile of memory consumption is where glibc sucks the most. We never installed it though.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No


## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
