### PR TITLE
fix(rpc): report orphaned checkpoints as pending

### DIFF
--- a/bin/strata/src/rpc/node.rs
+++ b/bin/strata/src/rpc/node.rs
@@ -903,26 +903,37 @@ impl<P: OLRpcProvider> OLClientRpcServer for OLRpcServer<P> {
         {
             let l1_reference = RpcCheckpointL1Ref::new(obs.l1_commitment, obs.txid, obs.wtxid);
             let observed_height = obs.l1_commitment.height();
-            let Some(tip) = self.provider.get_l1_tip_height().await.map_err(db_error)? else {
-                return Err(internal_error(
-                    "L1 tip height unavailable while constructing checkpoint info",
-                ));
-            };
-            if tip < observed_height {
-                return Err(internal_error(format!(
-                    "L1 tip height {tip} is below observed checkpoint height {observed_height}",
-                )));
-            }
-
-            let is_finalized = self
+            let canonical_observation = self
                 .provider
-                .get_ol_sync_status()
-                .is_some_and(|sync_status| sync_status.finalized_epoch().epoch() >= epoch);
+                .get_canonical_l1_blockid_at_height(observed_height)
+                .await
+                .map_err(db_error)?
+                .is_some_and(|blockid| blockid == *obs.l1_commitment.blkid());
 
-            if is_finalized {
-                RpcCheckpointConfStatus::Finalized { l1_reference }
+            if !canonical_observation {
+                RpcCheckpointConfStatus::Pending
             } else {
-                RpcCheckpointConfStatus::Confirmed { l1_reference }
+                let Some(tip) = self.provider.get_l1_tip_height().await.map_err(db_error)? else {
+                    return Err(internal_error(
+                        "L1 tip height unavailable while constructing checkpoint info",
+                    ));
+                };
+                if tip < observed_height {
+                    return Err(internal_error(format!(
+                        "L1 tip height {tip} is below observed checkpoint height {observed_height}",
+                    )));
+                }
+
+                let is_finalized = self
+                    .provider
+                    .get_ol_sync_status()
+                    .is_some_and(|sync_status| sync_status.finalized_epoch().epoch() >= epoch);
+
+                if is_finalized {
+                    RpcCheckpointConfStatus::Finalized { l1_reference }
+                } else {
+                    RpcCheckpointConfStatus::Confirmed { l1_reference }
+                }
             }
         } else {
             RpcCheckpointConfStatus::Pending

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -1159,6 +1159,82 @@ async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
 }
 
 #[tokio::test]
+async fn checkpoint_info_returns_pending_when_observation_block_is_orphaned() {
+    let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
+    let observed_height = 505;
+    let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);
+    let terminal_block = epoch_blocks.last().expect("epoch should have blocks");
+    let terminal = L2BlockCommitment::new(20, terminal_block.header().compute_blkid());
+
+    let prev_summary = EpochSummary::new(
+        1,
+        prev_terminal,
+        L2BlockCommitment::new(0, fixed_ol_block_id(0x11)),
+        L1BlockCommitment::new(500, fixed_l1_block_id(0x30)),
+        fixed_buf32(0x40),
+    );
+    let cur_summary = EpochSummary::new(
+        2,
+        terminal,
+        prev_terminal,
+        L1BlockCommitment::new(510, fixed_l1_block_id(0x31)),
+        fixed_buf32(0x41),
+    );
+
+    let prev_commitment = prev_summary.get_epoch_commitment();
+    let cur_commitment = cur_summary.get_epoch_commitment();
+    let orphaned_blkid = fixed_l1_block_id(0x50);
+    let canonical_blkid = fixed_l1_block_id(0x51);
+    let l1_ref = CheckpointL1Ref::new(
+        L1BlockCommitment::new(observed_height, orphaned_blkid),
+        RBuf32::from(fixed_buf32(0xAA).0),
+        RBuf32::from(fixed_buf32(0xBB).0),
+    );
+
+    let tip = OLBlockCommitment::new(120, fixed_ol_block_id(0x77));
+    let provider = MockProvider::new()
+        .with_sync_status(make_sync_status(
+            tip,
+            3,
+            false,
+            prev_commitment,
+            cur_commitment,
+            prev_commitment,
+        ))
+        .with_l1_tip_height(510)
+        .with_epoch_commitment(1, prev_commitment)
+        .with_epoch_commitment(2, cur_commitment)
+        .with_epoch_summary(prev_summary)
+        .with_epoch_summary(cur_summary)
+        .with_manifest(
+            AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
+                .expect("test manifest should be valid"),
+        )
+        .with_manifest(
+            AsmManifest::new(
+                observed_height,
+                canonical_blkid,
+                WtxidsRoot::default(),
+                vec![],
+            )
+            .expect("test manifest should be valid"),
+        )
+        .with_checkpoint_l1_ref(cur_commitment, l1_ref);
+    let rpc = make_rpc(with_blocks(provider, &epoch_blocks));
+
+    let info = rpc
+        .get_checkpoint_info(2)
+        .await
+        .expect("checkpoint info")
+        .expect("checkpoint should exist");
+
+    assert!(matches!(
+        info.confirmation_status,
+        RpcCheckpointConfStatus::Pending
+    ));
+}
+
+#[tokio::test]
 async fn checkpoint_info_returns_pending_when_observation_missing() {
     let prev_terminal = L2BlockCommitment::new(10, fixed_ol_block_id(0x10));
     let epoch_blocks = make_epoch_blocks(prev_terminal, 2, 20);

--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -90,6 +90,7 @@ struct MockProvider {
     account_inbox_entries: HashMap<(Epoch, AccountId), Vec<InboxMessageRecord>>,
     account_creation_epochs: HashMap<AccountId, Epoch>,
     manifests: HashMap<L1Height, AsmManifest>,
+    canonical_l1_blocks: HashMap<L1Height, L1BlockId>,
     l1_tip_height: Option<L1Height>,
     sync_status: Option<OLSyncStatus>,
     submit_fn: SubmitFn,
@@ -112,6 +113,7 @@ impl MockProvider {
             account_inbox_entries: HashMap::new(),
             account_creation_epochs: HashMap::new(),
             manifests: HashMap::new(),
+            canonical_l1_blocks: HashMap::new(),
             l1_tip_height: None,
             sync_status: None,
             submit_fn: Box::new(|_| Ok(OLTxId::from(Buf32::from([0xAB; 32])))),
@@ -172,6 +174,11 @@ impl MockProvider {
 
     fn with_manifest(mut self, manifest: AsmManifest) -> Self {
         self.manifests.insert(manifest.height(), manifest);
+        self
+    }
+
+    fn with_canonical_l1_block(mut self, height: L1Height, blockid: L1BlockId) -> Self {
+        self.canonical_l1_blocks.insert(height, blockid);
         self
     }
 
@@ -460,6 +467,13 @@ impl OLRpcProvider for MockProvider {
         height: L1Height,
     ) -> DbResult<Option<AsmManifest>> {
         Ok(self.manifests.get(&height).cloned())
+    }
+
+    async fn get_canonical_l1_blockid_at_height(
+        &self,
+        height: L1Height,
+    ) -> DbResult<Option<L1BlockId>> {
+        Ok(self.canonical_l1_blocks.get(&height).copied())
     }
 
     fn get_ol_sync_status(&self) -> Option<OLSyncStatus> {
@@ -1137,6 +1151,7 @@ async fn checkpoint_info_returns_confirmed_status_with_l1_ref() {
             )
             .expect("test manifest should be valid"),
         )
+        .with_canonical_l1_block(observed_height, fixed_l1_block_id(0x50))
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
     let provider = with_blocks(provider, &epoch_blocks);
 
@@ -1201,7 +1216,7 @@ async fn checkpoint_info_returns_pending_when_observation_block_is_orphaned() {
             cur_commitment,
             prev_commitment,
         ))
-        .with_l1_tip_height(510)
+        .with_l1_tip_height(observed_height - 1)
         .with_epoch_commitment(1, prev_commitment)
         .with_epoch_commitment(2, cur_commitment)
         .with_epoch_summary(prev_summary)
@@ -1210,15 +1225,7 @@ async fn checkpoint_info_returns_pending_when_observation_block_is_orphaned() {
             AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
                 .expect("test manifest should be valid"),
         )
-        .with_manifest(
-            AsmManifest::new(
-                observed_height,
-                canonical_blkid,
-                WtxidsRoot::default(),
-                vec![],
-            )
-            .expect("test manifest should be valid"),
-        )
+        .with_canonical_l1_block(observed_height, canonical_blkid)
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
     let rpc = make_rpc(with_blocks(provider, &epoch_blocks));
 
@@ -1228,10 +1235,7 @@ async fn checkpoint_info_returns_pending_when_observation_block_is_orphaned() {
         .expect("checkpoint info")
         .expect("checkpoint should exist");
 
-    assert!(matches!(
-        info.confirmation_status,
-        RpcCheckpointConfStatus::Pending
-    ));
+    assert_eq!(info.confirmation_status, RpcCheckpointConfStatus::Pending);
 }
 
 #[tokio::test]
@@ -1348,6 +1352,7 @@ async fn checkpoint_info_returns_finalized_status_when_epoch_is_finalized() {
             AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
                 .expect("test manifest should be valid"),
         )
+        .with_canonical_l1_block(observed_height, fixed_l1_block_id(0x50))
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
     let provider = with_blocks(provider, &epoch_blocks);
 
@@ -1692,6 +1697,7 @@ async fn checkpoint_info_errors_when_l1_tip_is_below_observed_height() {
             AsmManifest::new(501, fixed_l1_block_id(0x61), WtxidsRoot::default(), vec![])
                 .expect("test manifest should be valid"),
         )
+        .with_canonical_l1_block(observed_height, fixed_l1_block_id(0x50))
         .with_checkpoint_l1_ref(cur_commitment, l1_ref);
     let provider = with_blocks(provider, &epoch_blocks);
 

--- a/bin/strata/src/rpc/provider.rs
+++ b/bin/strata/src/rpc/provider.rs
@@ -19,7 +19,7 @@ use strata_ol_mempool::{MempoolHandle, OLMempoolError, OLMempoolResult};
 use strata_ol_rpc_types::OLRpcProvider;
 use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_ol_tx_types_v1::OLTransactionV1;
-use strata_primitives::{OLBlockCommitment, epoch::EpochCommitment};
+use strata_primitives::{L1BlockId, OLBlockCommitment, epoch::EpochCommitment};
 use strata_status::{OLSyncStatus, StatusChannel};
 use strata_storage::NodeStorage;
 
@@ -194,6 +194,16 @@ impl OLRpcProvider for NodeRpcProvider {
         self.storage
             .l1()
             .get_block_manifest_at_height_async(height)
+            .await
+    }
+
+    async fn get_canonical_l1_blockid_at_height(
+        &self,
+        height: L1Height,
+    ) -> DbResult<Option<L1BlockId>> {
+        self.storage
+            .l1()
+            .get_canonical_blockid_at_height_async(height)
             .await
     }
 

--- a/crates/ol/rpc/types/src/provider.rs
+++ b/crates/ol/rpc/types/src/provider.rs
@@ -19,7 +19,7 @@ use strata_ol_mempool::OLMempoolResult;
 use strata_ol_state_types_v1::{OLStateV1, WriteBatch};
 use strata_ol_tx_types_v1::OLTransactionV1;
 use strata_primitives::epoch::EpochCommitment;
-use strata_primitives::OLBlockCommitment;
+use strata_primitives::{L1BlockId, OLBlockCommitment};
 use strata_status::OLSyncStatus;
 
 /// Provides all data access needed by the OL RPC server.
@@ -96,6 +96,12 @@ pub trait OLRpcProvider: Send + Sync + 'static {
     /// Get the L1 block manifest at a given height.
     async fn get_block_manifest_at_height(&self, height: L1Height)
         -> DbResult<Option<AsmManifest>>;
+
+    /// Returns the canonical L1 block ID at a given height.
+    async fn get_canonical_l1_blockid_at_height(
+        &self,
+        height: L1Height,
+    ) -> DbResult<Option<L1BlockId>>;
 
     /// Get current OL chain sync status.
     fn get_ol_sync_status(&self) -> Option<OLSyncStatus>;

--- a/functional-tests/tests/strata/test_checkpoint_sync_shallow_l1_reorg.py
+++ b/functional-tests/tests/strata/test_checkpoint_sync_shallow_l1_reorg.py
@@ -1,0 +1,220 @@
+"""Checkpoint observations follow the canonical L1 branch across shallow reorgs."""
+
+from dataclasses import dataclass
+
+import flexitest
+
+from common.base_test import BaseTest
+from common.config.constants import ServiceType
+from common.services.bitcoin import BitcoinService
+from common.services.strata import StrataService
+from common.wait import wait_until, wait_until_with_value
+from envconfigs.checkpoint_sync import CheckpointSyncEnv
+from tests.checkpoint.helpers import (
+    CHECKPOINT_SUBPROTOCOL_ID,
+    OL_STF_CHECKPOINT_TX_TYPE,
+    extract_posted_checkpoint_payload,
+    parse_checkpoint_payload,
+)
+
+REORG_SAFE_DEPTH = 4
+TARGET_EPOCH = 1
+
+
+@dataclass(frozen=True)
+class _CheckpointInclusion:
+    """Identifies a checkpoint transaction and its first L1 inclusion."""
+
+    txid: str
+    block_hash: str
+    height: int
+    manifest: object
+
+
+@flexitest.register
+class TestCheckpointSyncShallowL1Reorg(BaseTest):
+    """Verifies an orphaned checkpoint becomes pending and can recover."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(
+            CheckpointSyncEnv(
+                pre_generate_blocks=110,
+                seal_epoch_slots=4,
+                ol_block_time_ms=750,
+                l1_reorg_safe_depth=REORG_SAFE_DEPTH,
+            )
+        )
+
+    def main(self, ctx):
+        """Runs the checkpoint through inclusion, reorg, and recovery."""
+
+        sequencer: StrataService = self.get_service(ServiceType.Strata)
+        css: StrataService = self.get_service(ServiceType.StrataCheckpointNode)
+        bitcoin: BitcoinService = self.get_service(ServiceType.Bitcoin)
+        btc_rpc = bitcoin.create_rpc()
+
+        seq_rpc = sequencer.wait_for_rpc_ready(timeout=20)
+        css.wait_for_rpc_ready(timeout=20)
+
+        scenario = _ShallowReorgScenario(sequencer, css, btc_rpc, seq_rpc)
+        checkpoint = scenario.include_checkpoint()
+        scenario.orphan_checkpoint(checkpoint)
+        scenario.verify_orphan_is_ignored(checkpoint)
+        scenario.reinclude_checkpoint(checkpoint)
+        scenario.advance_to_finality()
+        scenario.verify_checkpoint_is_finalized()
+
+
+class _ShallowReorgScenario:
+    """Drives a checkpoint through a controlled shallow L1 reorg."""
+
+    def __init__(self, sequencer, css, btc_rpc, seq_rpc):
+        """Initializes the scenario with its node and Bitcoin adapters."""
+
+        self.sequencer = sequencer
+        self.css = css
+        self.btc_rpc = btc_rpc
+        self.seq_rpc = seq_rpc
+        self.mining_address = btc_rpc.proxy.getnewaddress()
+
+    def include_checkpoint(self) -> _CheckpointInclusion:
+        """Includes the target checkpoint with exactly one L1 confirmation."""
+
+        bootstrap_hash = self.btc_rpc.proxy.generateblock(self.mining_address, [])["hash"]
+        bootstrap_height = self.btc_rpc.proxy.getblock(bootstrap_hash)["height"]
+        self._wait_for_sequencer_manifest(bootstrap_height)
+
+        checkpoint_txid = wait_until_with_value(
+            self._find_checkpoint_txid_in_mempool,
+            lambda txid: txid is not None,
+            error_with="target checkpoint transaction did not reach the L1 mempool",
+            timeout=120,
+        )
+        assert checkpoint_txid is not None
+
+        checkpoint_block_hash = self.btc_rpc.proxy.generatetoaddress(1, self.mining_address)[0]
+        checkpoint_info = self._wait_for_checkpoint_status(
+            "confirmed", "checkpoint was not observed after its L1 inclusion"
+        )
+        l1_reference = checkpoint_info["confirmation_status"]["l1_reference"]
+        assert l1_reference["txid"] == checkpoint_txid
+        checkpoint_height = l1_reference["l1_block"]["height"]
+        manifest = self.sequencer.wait_for_asm_manifest_commitment_at(
+            checkpoint_height, rpc=self.seq_rpc, timeout=120
+        )
+
+        return _CheckpointInclusion(
+            txid=checkpoint_txid,
+            block_hash=checkpoint_block_hash,
+            height=checkpoint_height,
+            manifest=manifest,
+        )
+
+    def orphan_checkpoint(self, checkpoint: _CheckpointInclusion) -> None:
+        """Orphans the checkpoint by replacing its block with an empty branch."""
+
+        self.btc_rpc.proxy.invalidateblock(checkpoint.block_hash)
+        wait_until(
+            lambda: checkpoint.txid in self.btc_rpc.proxy.getrawmempool(),
+            error_with="orphaned checkpoint transaction did not return to the mempool",
+            timeout=30,
+        )
+        assert self.btc_rpc.proxy.getblockcount() == checkpoint.height - 1
+
+        for _ in range(REORG_SAFE_DEPTH):
+            mined_hash = self.btc_rpc.proxy.generateblock(self.mining_address, [])["hash"]
+            mined_block = self.btc_rpc.proxy.getblock(mined_hash)
+            assert len(mined_block["tx"]) == 1, "replacement block was not coinbase-only"
+            self._wait_for_sequencer_manifest(mined_block["height"])
+
+    def verify_orphan_is_ignored(self, checkpoint: _CheckpointInclusion) -> None:
+        """Verifies RPC and checkpoint sync reject the orphaned observation."""
+
+        self.sequencer.wait_for_asm_manifest_commitment_at(
+            checkpoint.height,
+            rpc=self.seq_rpc,
+            timeout=120,
+            differs_from=checkpoint.manifest,
+        )
+        self._wait_for_checkpoint_status(
+            "pending", "orphaned checkpoint observation remained confirmed"
+        )
+        wait_until(
+            lambda: self.seq_rpc.strata_getChainStatus()["confirmed"]["epoch"] < TARGET_EPOCH,
+            error_with="CSM retained the orphaned checkpoint",
+            timeout=60,
+        )
+        replacement_tip_height = self.btc_rpc.proxy.getblockcount()
+        self.css.wait_for_asm_manifest_commitment_at(replacement_tip_height, timeout=60)
+        assert self.css.get_sync_status()["finalized"]["epoch"] < TARGET_EPOCH, (
+            "checkpoint-sync node applied the orphaned checkpoint"
+        )
+
+    def reinclude_checkpoint(self, checkpoint: _CheckpointInclusion) -> None:
+        """Includes the orphaned checkpoint again and waits for confirmation."""
+
+        recovery_hash = self.btc_rpc.proxy.generatetoaddress(1, self.mining_address)[0]
+        assert checkpoint.txid in self.btc_rpc.proxy.getblock(recovery_hash)["tx"]
+        self._wait_for_sequencer_manifest(self.btc_rpc.proxy.getblockcount())
+        self._wait_for_checkpoint_status(
+            "confirmed", "canonical checkpoint was not observed after the reorg"
+        )
+
+    def advance_to_finality(self) -> None:
+        """Advances L1 until the recovered checkpoint reaches safe depth."""
+
+        for _ in range(REORG_SAFE_DEPTH - 1):
+            self.btc_rpc.proxy.generatetoaddress(1, self.mining_address)
+        final_height = self.btc_rpc.proxy.getblockcount()
+        self.css.wait_for_asm_manifest_commitment_at(final_height, timeout=60)
+
+    def verify_checkpoint_is_finalized(self) -> None:
+        """Verifies CSS application and finalized RPC status after recovery."""
+
+        wait_until_with_value(
+            self.css.get_sync_status,
+            lambda status: status["finalized"]["epoch"] >= TARGET_EPOCH,
+            error_with="checkpoint-sync node did not apply the canonical checkpoint",
+            timeout=120,
+        )
+        self._wait_for_checkpoint_status(
+            "finalized", "canonical checkpoint did not reach finalized RPC status"
+        )
+
+    def _wait_for_sequencer_manifest(self, height: int) -> None:
+        """Waits until the sequencer exposes an ASM-manifest commitment at an L1 height."""
+
+        self.sequencer.wait_for_asm_manifest_commitment_at(height, rpc=self.seq_rpc, timeout=60)
+
+    def _wait_for_checkpoint_status(self, expected_status: str, error_with: str) -> dict:
+        """Waits until the target checkpoint reaches the expected RPC status."""
+
+        checkpoint_info = wait_until_with_value(
+            lambda: self.seq_rpc.strata_getCheckpointInfo(TARGET_EPOCH),
+            lambda info: (
+                info is not None and info["confirmation_status"]["status"] == expected_status
+            ),
+            error_with=error_with,
+            timeout=60,
+        )
+        assert checkpoint_info is not None
+        return checkpoint_info
+
+    def _find_checkpoint_txid_in_mempool(self) -> str | None:
+        """Finds the target checkpoint transaction in the L1 mempool."""
+
+        for txid in self.btc_rpc.proxy.getrawmempool():
+            tx = self.btc_rpc.proxy.getrawtransaction(txid, 1)
+            script = bytes.fromhex(tx["vout"][0]["scriptPubKey"]["hex"])
+            if len(script) < 8 or script[0] != 0x6A:
+                continue
+
+            tag = script[2:]
+            if tag[4:6] != bytes([CHECKPOINT_SUBPROTOCOL_ID, OL_STF_CHECKPOINT_TX_TYPE]):
+                continue
+
+            payload = extract_posted_checkpoint_payload(self.btc_rpc, txid)
+            if parse_checkpoint_payload(payload).epoch == TARGET_EPOCH:
+                return txid
+
+        return None


### PR DESCRIPTION
## Description

Fixes `strata_getCheckpointInfo` reporting an orphaned pre-safe checkpoint as confirmed after a shallow L1 reorg.

Checkpoint observations remain in the historical observation index across reorgs. CSM and CSS already exclude observations whose recorded block is no longer canonical. This change applies the same read-time canonicality check in the OL RPC before reporting an observation as confirmed or finalized.

Adds unit and functional regression coverage for an epoch 1 checkpoint that is included at one confirmation, orphaned by a coinbase-only competing branch, reported as pending, and later re-included and finalized normally.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The fix does not delete historical checkpoint observations. It checks the observation's recorded block ID against the node's canonical L1 block ID at the same height, matching the existing CSM/CSS read-time filtering model.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- [STR-4141: CSM retains orphaned checkpoint observation after shallow L1 reorg](https://alpenlabs.atlassian.net/browse/STR-4141)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance was used for implementation, tests, review, and this PR description.

## Related Issues

- [STR-4141](https://alpenlabs.atlassian.net/browse/STR-4141)


[STR-4141]: https://alpenlabs.atlassian.net/browse/STR-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ