### PR TITLE
fix(ol): make block flags valid by construction

### DIFF
--- a/bin/strata/src/rpc/node_tests.rs
+++ b/bin/strata/src/rpc/node_tests.rs
@@ -590,7 +590,7 @@ fn make_block_with_gam_tx(
 ) -> OLBlockV1 {
     let header = OLBlockHeaderV1::new(
         0,
-        0.into(),
+        BlockFlagsV1::zero(),
         slot,
         epoch,
         parent,

--- a/bin/strata/src/sequencer/block_producer.rs
+++ b/bin/strata/src/sequencer/block_producer.rs
@@ -230,7 +230,7 @@ mod tests {
     fn block_at_slot(slot: u64) -> OLBlockV1 {
         let header = OLBlockHeaderV1::new(
             0,
-            BlockFlagsV1::from(0),
+            BlockFlagsV1::zero(),
             slot,
             0,
             OLBlockId::from(Buf32::from([0x11; 32])),

--- a/crates/consensus-logic/src/fcm/service.rs
+++ b/crates/consensus-logic/src/fcm/service.rs
@@ -2099,7 +2099,7 @@ mod tests {
         let body = OLBlockBodyV1::new_common(OLTxSegmentV1::new(vec![]).expect("empty tx segment"));
         let header = OLBlockHeaderV1::new(
             1_000 + slot,
-            BlockFlagsV1::from(0),
+            BlockFlagsV1::zero(),
             slot,
             0,
             OLBlockId::from(Buf32::zero()),
@@ -2124,7 +2124,7 @@ mod tests {
         let body = OLBlockBodyV1::new_common(OLTxSegmentV1::new(vec![]).expect("empty tx segment"));
         let header = OLBlockHeaderV1::new(
             1_000 + slot,
-            BlockFlagsV1::from(0),
+            BlockFlagsV1::zero(),
             slot,
             0,
             parent,
@@ -2137,7 +2137,7 @@ mod tests {
 
     fn make_terminal_storage_block(slot: Slot, parent: OLBlockId) -> OLBlockV1 {
         let body = OLBlockBodyV1::new_common(OLTxSegmentV1::new(vec![]).expect("empty tx segment"));
-        let mut flags = BlockFlagsV1::from(0);
+        let mut flags = BlockFlagsV1::zero();
         flags.set_is_terminal(true);
         let header = OLBlockHeaderV1::new(
             1_000 + slot,

--- a/crates/consensus-logic/src/unfinalized_tracker/ol.rs
+++ b/crates/consensus-logic/src/unfinalized_tracker/ol.rs
@@ -189,7 +189,7 @@ mod tests {
         let body = OLBlockBodyV1::new_common(OLTxSegmentV1::new(vec![]).expect("empty tx segment"));
         let header = OLBlockHeaderV1::new(
             1_000 + slot,
-            BlockFlagsV1::from(0),
+            BlockFlagsV1::zero(),
             slot,
             0,
             parent,

--- a/crates/ol/chain-types-v1/src/block.rs
+++ b/crates/ol/chain-types-v1/src/block.rs
@@ -280,7 +280,7 @@ mod tests {
         fn test_genesis_header() {
             let header = OLBlockHeaderV1 {
                 timestamp: 0,
-                flags: BlockFlagsV1::from(0),
+                flags: BlockFlagsV1::zero(),
                 slot: 0,
                 epoch: 0,
                 parent_blkid: OLBlockId::from(Buf32::zero()),
@@ -336,7 +336,7 @@ mod tests {
                 signed_header: SignedOLBlockHeaderV1 {
                     header: OLBlockHeaderV1 {
                         timestamp: 0,
-                        flags: BlockFlagsV1::from(0),
+                        flags: BlockFlagsV1::zero(),
                         slot: 0,
                         epoch: 0,
                         parent_blkid: OLBlockId::from(Buf32::zero()),

--- a/crates/ol/chain-types-v1/src/block_flags.rs
+++ b/crates/ol/chain-types-v1/src/block_flags.rs
@@ -1,21 +1,48 @@
 //! Flags field for block header.
 
-use ssz_derive::{Decode, Encode};
-use strata_identifiers::impl_ssz_transparent_wrapper;
+use ssz::DecodeError;
+use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
 
 type RawBlockFlags = u16;
 
 const IS_TERMINAL: RawBlockFlags = 0x0001;
+const KNOWN_FLAGS: RawBlockFlags = IS_TERMINAL;
 
 /// Flags in the block header that we use for various signalling purposes.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Encode, Decode)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BlockFlagsV1(RawBlockFlags);
 
-impl_ssz_transparent_wrapper!(BlockFlagsV1, u16);
+/// Reports that a block flags value contains bits unknown to V1.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("unknown block flag bits: {unknown_bits:#06x}")]
+pub struct InvalidBlockFlags {
+    unknown_bits: RawBlockFlags,
+}
 
-impl From<u16> for BlockFlagsV1 {
-    fn from(value: u16) -> Self {
-        Self(value)
+impl SszDelegate for BlockFlagsV1 {
+    type Delegate = RawBlockFlags;
+
+    fn into_delegate(self) -> Self::Delegate {
+        self.0
+    }
+
+    fn from_delegate(value: Self::Delegate) -> Result<Self, DecodeError> {
+        Self::try_from(value).map_err(|error| DecodeError::BytesInvalid(error.to_string()))
+    }
+}
+
+impl_ssz_via_delegate!(BlockFlagsV1);
+
+impl TryFrom<RawBlockFlags> for BlockFlagsV1 {
+    type Error = InvalidBlockFlags;
+
+    fn try_from(value: RawBlockFlags) -> Result<Self, Self::Error> {
+        let unknown_bits = value & !KNOWN_FLAGS;
+        if unknown_bits != 0 {
+            return Err(InvalidBlockFlags { unknown_bits });
+        }
+
+        Ok(Self(value))
     }
 }
 
@@ -43,5 +70,59 @@ impl BlockFlagsV1 {
     /// Checks if the `IS_TERMINAL` flag is set.
     pub fn is_terminal(&self) -> bool {
         self.0 & IS_TERMINAL != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ssz::view::DecodeView;
+    use ssz::{Decode, Encode};
+    use strata_identifiers::{Buf32, OLBlockId};
+
+    use crate::OLBlockHeaderV1;
+
+    use super::{BlockFlagsV1, IS_TERMINAL};
+
+    #[test]
+    fn rejects_unknown_flag_bits_during_ssz_decoding() {
+        let encoded_unknown_flag = 0x0002_u16.to_le_bytes();
+
+        assert!(<BlockFlagsV1 as Decode>::from_ssz_bytes(&encoded_unknown_flag).is_err());
+        assert!(<BlockFlagsV1 as DecodeView>::from_ssz_bytes(&encoded_unknown_flag).is_err());
+    }
+
+    #[test]
+    fn rejects_header_with_unknown_flag_bits_during_ssz_decoding() {
+        let header = OLBlockHeaderV1::new(
+            0,
+            BlockFlagsV1::zero(),
+            0,
+            0,
+            OLBlockId::from(Buf32::zero()),
+            Buf32::zero(),
+            Buf32::zero(),
+            Buf32::zero(),
+        );
+        let mut encoded_header = header.as_ssz_bytes();
+        encoded_header[8..10].copy_from_slice(&0x0002_u16.to_le_bytes());
+
+        assert!(<OLBlockHeaderV1 as Decode>::from_ssz_bytes(&encoded_header).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_flag_bits_during_construction() {
+        assert!(BlockFlagsV1::try_from(0x0003).is_err());
+    }
+
+    #[test]
+    fn accepts_and_roundtrips_known_flag_combinations() {
+        for raw_flags in [0x0000, IS_TERMINAL] {
+            let flags = BlockFlagsV1::try_from(raw_flags).expect("known flags must be valid");
+            let encoded = flags.as_ssz_bytes();
+            let decoded = <BlockFlagsV1 as Decode>::from_ssz_bytes(&encoded)
+                .expect("known flags must decode");
+
+            assert_eq!(decoded, flags);
+        }
     }
 }

--- a/crates/ol/chain-types-v1/src/test_utils.rs
+++ b/crates/ol/chain-types-v1/src/test_utils.rs
@@ -64,7 +64,11 @@ pub fn manifests_strategy() -> impl Strategy<Value = Option<OLAsmManifestContain
 pub fn ol_block_header_strategy() -> impl Strategy<Value = OLBlockHeaderV1> {
     (
         any::<u64>(),
-        any::<u16>().prop_map(BlockFlagsV1::from),
+        any::<bool>().prop_map(|is_terminal| {
+            let mut flags = BlockFlagsV1::zero();
+            flags.set_is_terminal(is_terminal);
+            flags
+        }),
         any::<Slot>(),
         any::<Epoch>(),
         ol_block_id_strategy(),

--- a/crates/ol/sequencer/src/duty.rs
+++ b/crates/ol/sequencer/src/duty.rs
@@ -215,7 +215,7 @@ mod tests {
             timestamp,
             slot,
             epoch,
-            flags: BlockFlagsV1::from(0),
+            flags: BlockFlagsV1::zero(),
             body_root: [0u8; 32].into(),
             state_root: [0u8; 32].into(),
             logs_root: [0u8; 32].into(),


### PR DESCRIPTION
## Description

Makes `BlockFlagsV1` valid by construction so accepted OL block headers remain reproducible by checkpoint proving and reconstruction.

- replaces the infallible `From<u16>` conversion with validated `TryFrom<u16>`
- routes owned and view-based SSZ decoding through the same validation using `SszDelegate`
- preserves the existing `u16` SSZ wire representation and tree hash
- updates constructors and property strategies to produce only valid V1 flag combinations
- adds regression coverage for raw flags and complete OL block header decoding

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The SSZ encoding remains a two-byte `u16`. The API change is that arbitrary raw values can no longer be constructed infallibly: callers must use `TryFrom<u16>`, while ordinary construction continues through `zero()` and `set_is_terminal()`.

Validation:

- `cargo test -p strata-ol-chain-types-v1 --locked` passes (26 tests)
- `just pr-lite` passes formatting, Clippy, Ruff, codespell, and repository lint scripts, then stops during Rustdocs on an existing constant-inference error in the pinned `ssz` dependency (`BitVectorRefIter`)

Is this PR addressing any specification, design doc or external reference document?

- [x] Yes
- [ ] No

If yes, please add relevant links:

- [STR-4287](https://alpenlabs.atlassian.net/browse/STR-4287)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

This PR was developed with Codex, including code generation, tests, and drafting this PR body. The author manually reviewed the resulting changes.

## Related Issues

- [STR-4287](https://alpenlabs.atlassian.net/browse/STR-4287)


[STR-4287]: https://alpenlabs.atlassian.net/browse/STR-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ