### PR TITLE
docs(agents): refresh repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,14 @@ This file provides guidance to AI coding assistants when working with code in th
 
 **Alpen** is an EVM-compatible Bitcoin layer 2. It provides programmable Bitcoin functionality through a layer 2 solution with a decoupled architecture separating the Anchor State Machine (ASM), Orchestration Layer (OL), and Execution Environment (EE).
 
+This repository contains the OL node, its supporting crates, and the OL checkpoint
+prover. The ASM implementation lives in
+[alpenlabs/asm](https://github.com/alpenlabs/asm), and shared protocol primitives live
+in [alpenlabs/strata-common](https://github.com/alpenlabs/strata-common); both are
+consumed as tagged git dependencies. The EE lives in the downstream
+[alpenlabs/alpen-ee](https://github.com/alpenlabs/alpen-ee) repository, which consumes
+selected crates and binaries from this repository at a pinned revision.
+
 ## Architecture
 
 Alpen uses a layered architecture with three main State Transition Functions (STFs):
@@ -19,15 +27,15 @@ flowchart LR
     end
 
     subgraph OL[OL STF]
-        OLState[OLState]
-        OLBlock[OLBlock]
-        OLOut[OLState + OLLogs]
+        OLState[OLStateV1]
+        OLBlock[OLBlockV1]
+        OLOut[OLStateV1 + OL logs]
     end
 
     subgraph EE[EE STF]
         EEState[EEState]
         ExecBlock[ExecBlock]
-        EEOut[EEState + EEUpdate]
+        EEOut[EEState + proof-backed update]
     end
 
     L1Block --> AnchorState
@@ -39,17 +47,21 @@ flowchart LR
     ExecBlock --> EEState
     EEState --> EEOut
 
-    AsmOut -.->|AsmManifest| OLBlock
-    EEOut -.->|EEUpdate| OLBlock
+    AsmOut -.->|AsmManifest in block body| OLBlock
+    EEOut -.->|snark account update tx| OLBlock
 ```
 
 **State Transition Functions:**
 
 - **ASM STF**: `AnchorState + L1Block → (AnchorState', AsmManifest)`
-- **OL STF**: `OLState + OLBlock → (OLState', OLLogs)`
-- **EE STF**: `EEState + ExecBlock → (EEState', EEUpdate)`
+- **OL STF**: `OLStateV1 + OLBlockV1 + OLRuntimeParams → (OLStateV1', OL logs)`
+- **EE STF**: `EEState + ExecBlock → (EEState', proof-backed account update)`
 
-The OL block contains the `AsmManifest` (from ASM) and `EEUpdate` (from EE), orchestrating the two layers.
+`OLBlockBodyV1` contains an optional transaction segment and an optional sequence of
+`AsmManifest`s produced by the ASM STF. EE state updates are not a dedicated block
+field: the EE submits proof-backed snark account update transactions, which the OL STF
+verifies against the account's predicate. The EE names in the diagram are conceptual;
+their concrete implementation and types live in `alpen-ee`.
 
 ### Layer Descriptions
 
@@ -58,7 +70,8 @@ The OL block contains the `AsmManifest` (from ASM) and `EEUpdate` (from EE), orc
 Bitcoin serves as the data availability and settlement layer. Protocol transactions are tagged with SPS-50 headers for recognition by the ASM.
 
 - **Bitcoin Blocks**: Source of truth for L1 state and, hence, for everything actually.
-- **SPS-50 Tagged Transactions**: Protocol transactions generally use standardized headers (magic, subprotocol ID, tx_type, aux data). Some EE DA transactions use the SPS-51 chunked-envelope path instead, where a compact commit `OP_RETURN` plus taproot reveal scripts carries the payload to reduce fee overhead.
+- **SPS-50 Tagged Transactions**: Protocol transactions generally use standardized headers (magic, subprotocol ID, tx_type, aux data).
+- **SPS-51 Chunked Envelopes**: EE DA payloads use a compact commit `OP_RETURN` plus taproot reveal scripts. The EE produces the payload; the `btcio` writer and storage interfaces in this repository publish and track the envelope transactions.
 
 #### ASM Layer (Anchor State Machine)
 
@@ -66,7 +79,7 @@ ASM is the core of the Strata protocol, functioning as a "virtual smart contract
 
 - **ASM STF**: State transition function processing L1 blocks
 - **Header Verification**: PoW verification state for L1 headers
-- **Subprotocols**: Modular components (Bridge V1, Checkpoint, Admin, Debug) with defined IDs
+- **Subprotocols**: Modular components (Admin, Checkpoint, Bridge V1) with defined IDs
 - **Moho Framework**: Upgradeable proof mechanism wrapping ASM transitions
 - **Export State**: Accumulator for bridge proofs and operator claims
 
@@ -79,8 +92,9 @@ The ASM implementation is consumed through the `strata-asm-*` workspace dependen
 | 0 | Admin | System upgrades |
 | 1 | Checkpoint | OL checkpoint verification |
 | 2 | Bridge V1 | Deposit/withdrawal management |
-| 3 | Execution DA | EE data availability |
-| 254 | Debug | Development/testing |
+
+The pinned `StrataAsmSpec` invokes exactly these three subprotocols. The former Debug
+subprotocol was removed; functional tests create deposits through the bridge path.
 
 #### OL Layer (Orchestration Layer)
 
@@ -92,16 +106,21 @@ The OL manages L2 state, accounts, and epoch processing. It produces checkpoints
 - **Epochs & Checkpoints**: Time ranges of blocks with DA diffs posted to L1
 - **DA Reconstruction**: State can be reconstructed from L1 DA payloads
 
+Concrete consensus types live in `-v1` crates and carry `V1` type suffixes, such as
+`OLBlockV1`, `OLTransactionV1`, and `OLStateV1`. Unsuffixed crates such as
+`ol/state-types` and `ol/da-common` hold version-independent traits and helpers.
+
 #### EE Layer (Execution Environment)
 
-The EE provides EVM execution, decoupled from OL. It is implemented via Alpen
-Reth and lives in a separate repo, [alpenlabs/alpen-ee](https://github.com/alpenlabs/alpen-ee).
-This repo carries no reth, alloy or revm dependency.
+The EE provides EVM execution, decoupled from OL. `alpen-ee` owns Alpen Reth, the EE
+chain and DA producer, EE proof programs, precompiles, and the OL tracker. This
+repository has no local EE or Reth implementation and no direct Reth or Revm
+dependency. Alloy remains in the dependency graph through external protocol crates.
 
-- **Alpen Reth**: Custom Reth node with rollup-specific precompiles
-- **EE Chain**: Execution chain state management
-- **OL Tracker**: Tracks finalized OL state from EE perspective
-- **Package Chain**: Off-chain interface between OL and EE
+From the OL's perspective, the EE is a snark account whose state, inbox, and predicate
+are maintained in `OLSnarkAccountStateV1`. This repository owns the shared account and
+message types, OL RPC interfaces, L1 DA publishing plumbing, genesis inputs, and mock
+EE helpers that cross the repository boundary.
 
 The EE consumes this repo's crates as git dependencies, and builds the `strata`,
 `strata-signer`, `strata-datatool` and `strata-test-cli` binaries from a pinned
@@ -117,13 +136,15 @@ Crate tables list repository paths. Package names usually carry a `strata-*` or 
 | Path | Binary target | Description |
 |------|---------------|-------------|
 | `bin/strata` | `strata` | OL (Strata) client, sequencer, RPC, and prover entrypoint |
-| `bin/strata-signer` | `strata-signer` | Detached signer for OL sequencer duties |
+| `bin/strata-signer` | `strata-signer` | Detached signer for OL sequencer duties (package `strata-signer-bin`) |
 | `bin/strata-dbtool` | `strata-dbtool` | Database inspection and debugging utility |
 | `bin/strata-test-cli` | `strata-test-cli` | Bridge, ASM, and transaction testing utility |
 | `bin/datatool` | `strata-datatool` | Development utility for test data and key generation |
 | `bin/prover-perf` | `strata-provers-perf` | Performance benchmarking for proof systems |
 
-The workspace default members include the main runtime and testing binaries, but not every workspace crate. Check root `Cargo.toml` before assuming a crate is built by default.
+The workspace default-member paths are `bin/strata`, `bin/strata-dbtool`,
+`bin/strata-signer`, `bin/datatool`, and `bin/strata-test-cli`. Check the root
+`Cargo.toml` before assuming that another crate or target is built by default.
 
 ## Library Crates
 
@@ -140,8 +161,8 @@ Orchestration Layer implementation.
 | `ol/stf-v1` | OL state transition function (block, epoch, manifest processing) |
 | `ol/state-types` | Version-independent state traits and ledger entry types |
 | `ol/state-types-v1` | Concrete state structures (toplevel, global, epochal, ledger, snark account) |
-| `ol/chain-types-v1` | OL block and log types (SSZ) |
-| `ol/tx-types-v1` | OL transaction and tx proof types (SSZ) |
+| `ol/chain-types-v1` | Versioned OL block types (SSZ); re-exports OL log types from `strata-common` |
+| `ol/tx-types-v1` | Versioned OL transaction, GAM/SAU payload, and transaction-proof types (SSZ) |
 | `ol/msg-types` | Deposit and withdrawal message types |
 | `ol/da-common` | Version-independent OL data availability traits and encoding helpers |
 | `ol/da-types-v1` | Concrete V1 OL DA payload types, scheme, and checkpoint-tx extractor |
@@ -149,14 +170,13 @@ Orchestration Layer implementation.
 | `ol/mempool` | Transaction mempool |
 | `ol/state-support-types` | State access layers (batch diff, indexer, write tracking) |
 | `ol/state-provider` | OL state provider traits and implementations |
+| `ol/mmr-index` | OL-owned MMR index comparison and reconciliation helpers |
 | `ol/genesis` | OL genesis state construction |
-| `ol/params` | OL parameter types |
+| `ol/params` | `OLGenesisParams`, `OLRuntimeParams`, and combined `OLParams` |
 | `ol/checkpoint` | OL checkpoint builder service |
 | `ol/sequencer` | OL sequencing helpers and state |
 | `ol/rpc/api` | OL JSON-RPC API traits and client/server glue |
 | `ol/rpc/types` | OL RPC request and response types |
-| `bridge-types` | Bridge operation and message types shared with OL/EE |
-| `checkpoint-types` | Checkpoint and batch types |
 
 ### DA Framework (`crates/da-framework/`)
 
@@ -177,14 +197,12 @@ Fundamental types and shared utilities.
 | Crate | Description |
 |-------|-------------|
 | `primitives` | Core primitive types |
-| `params` | Network parameters |
 | `config` | Configuration types |
 | `common` | Shared helpers, traits, and utilities |
 | `codec-utils` | Helpers for `strata-codec` encoding/decoding |
 | `key-derivation` | Key derivation primitives and helpers |
 | `status` | Shared status types for services and APIs |
 | `cli-common` | Shared CLI argument and output helpers |
-| `paas` | Prover-as-a-Service task orchestration framework |
 | `node-context` | Runtime context shared by node services |
 | `strata-signer` | Detached signer library used by `bin/strata-signer` |
 
@@ -204,7 +222,6 @@ Bitcoin primitive types, header verification, and related helpers are provided t
 | `storage-common` | Shared storage abstractions |
 | `db/store-sled` | SledDB storage implementation |
 | `db/types` | Database type definitions |
-| `state` | Chain and client state management |
 
 ### Account & Protocol Types
 
@@ -215,6 +232,9 @@ Bitcoin primitive types, header verification, and related helpers are provided t
 | `snark-acct-runtime` | Snark account runtime |
 | `snark-acct-sys` | Snark account system logic |
 | `csm-types` | Client state machine type definitions |
+| `bridge-types` | Bridge operation and message types shared with OL/EE |
+| `bridge-params` | Bridge denomination and withdrawal-cap parameters |
+| `checkpoint-types` | Checkpoint, batch, terminal-header, and prover-task types |
 
 ### Proof Domain (`crates/proof-impl/`, `crates/zkvm/`)
 
@@ -224,24 +244,30 @@ Zero-knowledge proof generation.
 |-------|-------------|
 | `proof-impl/checkpoint` | Checkpoint proof implementation |
 | `proof-impl/predicate-keys` | Predicate-key providers for proof programs |
-| `prover-core` | Shared prover coordination primitives |
-| `zkvm/hosts` | ZKVM host implementations (SP1, RISC0, Native) |
-| `provers/sp1` | SP1 guest builder support |
+| `prover-core` | Single-proof-type proving engine with zkaleido native or remote strategies |
+| `paas` | Prover-as-a-Service wrapper around `prover-core` |
+| `zkvm/hosts` | SP1 host integration, enabled by the `sp1` feature |
+| `provers/sp1` | Root-workspace SP1 checkpoint guest builder |
 | `provers/sp1/guest-checkpoint` | SP1 checkpoint proof guest |
 
-The SP1 guest packages are local manifests used by the guest builder, but they are not root workspace members.
+`provers/sp1/guest-checkpoint` declares an independent workspace and is not a root
+workspace member. For a real non-debug guest build, the builder embeds
+`OLRuntimeParams` supplied through `CHECKPOINT_RUNTIME_PARAMS_PATH`; the resulting
+checkpoint verification key therefore commits to the runtime parameters. Without a
+real guest build, the builder uses test runtime parameters and mock artifacts.
+The `strata` binary runs the checkpoint prover in-process behind its `prover` and `sp1`
+features; the former standalone prover client has been removed.
 
-### RPC (`crates/rpc/`, `crates/ol/rpc/`)
+### RPC (`crates/rpc/`)
 
-RPC APIs, types, and helpers.
+OpenRPC support. OL JSON-RPC traits and wire types live under `crates/ol/rpc/` and are
+listed with the OL crates above.
 
 | Crate | Description |
 |-------|-------------|
-| `rpc/api` | Shared top-level RPC API definitions |
-| `rpc/types` | Shared top-level RPC wire types |
-| `rpc/utils` | RPC helper utilities |
 | `rpc/open-rpc` | OpenRPC specification model types |
 | `rpc/open-rpc-macros` | OpenRPC derive/proc-macro support |
+| `rpc/open-rpc-spec` | OL OpenRPC document assembly |
 
 ### Service Crates
 
@@ -249,20 +275,17 @@ Worker patterns and service infrastructure.
 
 | Crate | Description |
 |-------|-------------|
-| `chain-worker` | Legacy chain worker implementation |
-| `chain-worker` | Chain worker implementation for OL types |
-| `csm-worker` | Client state machine worker |
-| `chainexec` | Chain execution context |
-| `chaintsn` | Chain transition logic |
-| `consensus-logic` | Fork choice and sync management |
+| `chain-worker` | Executes and persists OL blocks using the OL STF |
+| `csm-worker` | Follows ASM worker state and processes checkpoint-subprotocol logs |
+| `consensus-logic` | OL fork choice, sync, checkpoint sync, unfinalized tracking, and MMR reconciliation |
 
 ### Test Utilities (`crates/test-utils/`)
 
 | Crate | Description |
 |-------|-------------|
-| `test-utils` | Shared test helpers |
+| `test-utils/test-utils` | Shared test helpers |
 | `test-utils/btcio` | Bitcoin I/O test utilities |
-| `test-utils/l2` | L2 integration test utilities |
+| `test-utils/l2` | OL component test utilities |
 | `test-utils/ssz` | SSZ test utilities |
 | `db/tests` | Database-focused test fixtures and helpers |
 | `benches` | Criterion benchmarks for database paths |
@@ -272,14 +295,13 @@ Worker patterns and service infrastructure.
 ### Building
 
 ```bash
-# Build workspace with release profile
+# Build all workspace libraries, binaries, examples, and benches with all features
 just build
 
-# Build specific binary
-cargo build --bin strata --release
-
-# Build with specific features
-FEATURES="feature1,feature2" just build
+# Build the node and tools with the features used by functional tests
+cargo build --locked -F sequencer -F debug-utils -F prover \
+  --bin strata --bin strata-signer --bin strata-datatool \
+  --bin strata-test-cli --bin strata-dbtool
 ```
 
 ### Testing
@@ -288,8 +310,8 @@ FEATURES="feature1,feature2" just build
 # Run all unit tests
 just test-unit
 
-# Run integration tests
-just test-int
+# Run unit tests and doctests
+just test
 
 # Run functional tests
 just test-functional
@@ -316,9 +338,15 @@ just lint-fix-ws
 # Run all quality checks (format, lint, spell check)
 just lint
 
-# Pre-PR checks (includes tests, docs, linting)
+# Pre-PR checks (includes functional tests)
 just pr
+
+# Pre-PR checks without functional tests
+just pr-lite
 ```
+
+`just lint` includes the ticketed-comment check: new `TODO` and `FIXME` comments must
+include a ticket such as `TODO(STR-1234): ...`.
 
 ## Engineering Best Practices
 
@@ -501,9 +529,9 @@ fn process_block(block: &Block) -> Result<()> {
 
 | Context | Format | Crate |
 |---------|--------|-------|
-| Protocol data structures | SSZ | `ssz_rs`, custom `.ssz` files |
+| Protocol data structures | SSZ | `ssz`, `ssz_derive`, and `tree_hash` from `alpenlabs/ssz-gen`; custom `.ssz` schemas |
 | On-chain envelope payloads | `strata-codec` | `strata-codec` |
-| Private proof interfaces | `rkyv` | `rkyv` (zero-copy) |
+| Private proof interfaces and sled values | `rkyv` | `rkyv` (zero-copy) |
 | Non-protocol persistent data | CBOR | `ciborium` |
 | Human-readable/config | JSON/TOML | `serde` |
 
@@ -518,17 +546,19 @@ fn process_block(block: &Block) -> Result<()> {
 
 Use distinct domain or runtime types and wire or storage types when those roles have
 different fields or invariants. Use the boundary's designated compact codec for nested
-message or log bodies when the boundary already provides framing. Do not introduce new
-Borsh persistence formats.
+message or log bodies when the boundary already provides framing. Borsh has been removed
+from the workspace; do not reintroduce it.
 
 ## Git Best Practices
 
 ### Pull Requests
 
-Before filling out or opening a pull request, read and follow
-[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md), including its
-self-review, testing, documentation, and AI-use disclosure checklist. Keep PRs focused and
-independently reviewable; split unrelated restructuring or migrations into separate PRs.
+Before opening a pull request, read and follow
+[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Use the
+Conventional Commit format below for the PR title, and use the template's complete
+structure for the PR body, including its self-review, testing, documentation, and AI-use
+disclosure checklist. Keep PRs focused and independently reviewable; split unrelated
+restructuring or migrations into separate PRs.
 
 ### Commit Message Standards
 
@@ -630,8 +660,15 @@ uv run python entry.py
 **Structure**:
 - `common/` - Base test classes, services, utilities
 - `envconfigs/` - Environment configurations
-- `factories/` - Service factories (Bitcoin, Strata)
+- `factories/` - Service factories (Bitcoin, Strata, signer)
 - `tests/` - Test files
+- `fixtures/` - Static test fixtures
+
+Tests are grouped under `tests/` by component (`btcio`, `checkpoint`, `dbtool`,
+`ol_isolated`, and `strata`). Use `./run_tests.sh -g <group>` to select groups or
+`./run_tests.sh -t <test>` to select tests. The script builds `strata`,
+`strata-signer`, `strata-datatool`, `strata-test-cli`, and `strata-dbtool` with the
+`sequencer`, `debug-utils`, and `prover` features.
 
 If the functional tests fail, you can find the logs in the `_dd` directory inside the functional tests directory.
 The datadir will be the outputted by the test framework and will be named after the test run.
@@ -643,13 +680,36 @@ The datadir will be the outputted by the test framework and will be named after 
 | Dependency | Purpose |
 |------------|---------|
 | SP1 | Zero-knowledge proof system |
+| zkaleido | zkVM host and guest abstractions |
+| `alpenlabs/asm` | ASM STF, subprotocols, parameters, and worker |
+| `alpenlabs/strata-common` | Shared identifiers, codecs, crypto, Merkle primitives, logs, and service utilities |
 | Bitcoin | Bitcoin protocol implementation |
-| SSZ | Serialization |
+| `alpenlabs/ssz-gen` | SSZ serialization and schema code generation |
+
+### Parameters and Node Configuration
+
+Configuration is split by ownership:
+
+- **ASM parameters** (`AsmParams`, `asm-params.json`, `--asm-params`) define the L1
+  anchor, network, magic bytes, and subprotocol genesis configuration.
+- **OL parameters** (`OLParams`, `ol-params.json`, `--ol-params`) contain
+  `OLGenesisParams` and `OLRuntimeParams`. Runtime parameters are threaded through OL
+  execution and embedded in real checkpoint guest builds, so changing them changes the
+  checkpoint verification key.
+- **Node configuration** (TOML types under `crates/config`) contains operational settings,
+  including `BtcioConfig` and its L1 reader, writer, fee, and reorg policy.
+
+Generate ASM and OL parameter files with `strata-datatool gen-asm-params` and
+`strata-datatool gen-ol-params`. At startup, `strata` rejects ASM and OL parameter files
+whose bridge denomination, genesis L1 commitment/height, or genesis OL block ID disagree.
+Do not duplicate protocol parameters in node config.
 
 ### Prerequisites
 
 - **bitcoind**: Required for L1 integration and testing
 - **uv**: For Python functional tests
+- **just** and **cargo-nextest**: Required by the common development recipes
+- **SP1 toolchain**: Required only when building real checkpoint guest artifacts
 
 ## Specifications Reference
 


### PR DESCRIPTION
## Description

Refreshes `AGENTS.md` to match the repository after the legacy-stack removal, `alpen-ee` split, V1 OL type renaming, parameter split, and integrated prover changes.

The update:

- documents the ownership boundaries between this repository, `asm`, `strata-common`, and `alpen-ee`
- corrects the OL block and proof-backed snark-account update flow
- records the `-v1` crate and `V1` concrete-type convention
- removes stale crate, subprotocol, dependency, and command references
- adds current crates, parameter ownership, SP1 guest behavior, and functional-test guidance
- explicitly requires Conventional Commit PR titles and complete PR bodies based on `.github/PULL_REQUEST_TEMPLATE.md`

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The repository structure, package names, commands, and current ASM subprotocols were checked against the tree, Cargo metadata, Just recipes, recent merged PRs, and the pinned upstream dependencies. The assessment was independently compared with Claude Fable 5.1 at high reasoning effort before the final edit.

PR #2279's engineering and review guidance remains intact apart from factual updates to the serialization section and the more explicit PR title/body instruction.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

N/A

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary. (Documentation-only change; no source comments required.)
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works. (No tests are needed for this documentation-only change.)
- [ ] New and existing tests pass with my changes. (Rust tests were not run; `git diff --check`, `cargo metadata --no-deps`, documented-path/recipe checks, and `uvx codespell AGENTS.md` pass.)
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI assistance disclosure: this documentation audit and edit used Codex and an independent Claude Fable 5.1 High review. The PR title and body were also prepared with AI assistance.

## Related Issues

None.
