### PR TITLE
docs(ol): clarify checkpoint DA reconstruction

### DIFF
--- a/crates/checkpoint-types/src/batch.rs
+++ b/crates/checkpoint-types/src/batch.rs
@@ -23,7 +23,7 @@ pub struct EpochSummary {
     /// If this is the genesis epoch, then this is all zero.
     prev_terminal: L2BlockCommitment,
 
-    /// The new L1 block that was submitted in the terminal block.
+    /// The latest L1 block incorporated into OL state by the end of this epoch.
     new_l1: L1BlockCommitment,
 
     /// The final state root of the epoch.

--- a/crates/ol/checkpoint/src/context.rs
+++ b/crates/ol/checkpoint/src/context.rs
@@ -349,13 +349,14 @@ fn assert_terminal_commitment_matches(
     Ok(())
 }
 
-/// Replays epoch blocks to produce DA state diff bytes, accumulated logs, and
-/// the terminal header.
+/// Replays epoch blocks to produce the checkpoint's OL-originated DA diff,
+/// accumulated logs, and terminal header.
 ///
 /// Loads the OL state at the previous terminal block, wraps it in
-/// `DaAccumulatingState` to intercept mutations, then re-executes every block
-/// in the epoch. The DA blob is extracted from the accumulating layer and the
-/// logs are collected from each block's execution output.
+/// `DaAccumulatingState`, then re-executes every block only through its
+/// pre-drain phase. The resulting diff covers OL transaction effects but
+/// deliberately excludes terminal ASM effects, which reconstruction derives
+/// independently by replaying the epoch's L1 manifests.
 fn replay_epoch_and_compute_da<C: CheckpointWorkerContext>(
     ctx: &C,
     summary: &EpochSummary,

--- a/crates/ol/state-support-types/src/da_accumulating_layer.rs
+++ b/crates/ol/state-support-types/src/da_accumulating_layer.rs
@@ -584,6 +584,8 @@ pub struct DaAccumulatingState<S: IStateAccessor> {
     pending_epoch_diffs: VecDeque<OLStateDiffV1>,
 
     /// Completed epoch blobs waiting to be drained.
+    // TODO: Remove this queue unless a producer is introduced; it is initialized and read but
+    // never populated.
     pending_epoch_blobs: VecDeque<Vec<u8>>,
 
     /// Error captured while finalizing an epoch via set_cur_epoch.
@@ -640,6 +642,9 @@ impl<S: IStateAccessor> DaAccumulatingState<S> {
     }
 
     /// Returns the next completed epoch DA blob, if any.
+    // TODO: Split queued completed-epoch draining from finalizing the current accumulator.
+    // Production checkpoint callers only finalize one pre-drain epoch, so combining both
+    // responsibilities behind an optional result obscures the interface contract.
     pub fn take_completed_epoch_da_blob(&mut self) -> Result<Option<Vec<u8>>, DaAccumulationError> {
         if let Some(err) = self.pending_epoch_error.take() {
             return Err(err);

--- a/crates/ol/stf-v1/src/tests/da_epoch_reconstruction.rs
+++ b/crates/ol/stf-v1/src/tests/da_epoch_reconstruction.rs
@@ -1,5 +1,6 @@
-//! Reconstructing an epoch from its DA diff via [`apply_da_epoch`] must yield
-//! the same post-state root as direct block-by-block execution.
+//! Applying a checkpoint DA diff and then replaying its L1 ASM manifests via
+//! [`apply_da_epoch`] must yield the same post-state root as direct
+//! block-by-block execution.
 //!
 //! Covers a deposit manifest only, a snark account update only, both
 //! combined, and a bridge withdrawal. Each test builds a multi-block epoch
@@ -75,8 +76,9 @@ fn test_apply_da_epoch_snark_update_only() {
     assert_reconstruction_matches(&state, &pre_epoch_state, &genesis, &terminal, &blocks);
 }
 
-/// A declared predicate rotation changes consensus account state, so the DA
-/// diff must carry it: if reconstruction misses the new VK, the roots diverge.
+/// A predicate rotation declared by an OL snark-account update changes consensus
+/// account state, so the checkpoint diff must carry it. This differs from an
+/// ASM-triggered rotation message, which manifest replay reconstructs.
 #[test]
 fn test_apply_da_epoch_snark_update_with_rotation() {
     let mut state = make_genesis_state();
@@ -329,7 +331,8 @@ fn build_snark_update(state: &MemoryStateBaseLayer, inbox_msg: &MessageEntry) ->
         .build(snark_id, make_state_root(2), vec![0u8; 32])
 }
 
-/// Reconstructs the epoch from its DA diff and returns the post-state root.
+/// Reconstructs the epoch from its checkpoint DA diff plus L1 ASM manifests and returns the
+/// post-state root.
 fn reconstruct_epoch(
     pre_epoch_state: &MemoryStateBaseLayer,
     genesis: &CompletedBlock,

--- a/crates/ol/stf-v1/src/verification.rs
+++ b/crates/ol/stf-v1/src/verification.rs
@@ -391,9 +391,11 @@ pub fn verify_epoch_with_diff<S: IStateAccessorMut, D: DaScheme<S>>(
     Ok(())
 }
 
-/// Reconstructs a full-epoch transition from a DA diff.
+/// Reconstructs a full-epoch transition from a checkpoint DA diff and its L1 manifests.
 ///
 /// Like [`verify_epoch_with_diff`] but without the post-state root check.
+/// The diff restores OL-originated effects; replaying `manifests` restores
+/// terminal ASM effects that the checkpoint diff deliberately excludes.
 ///
 /// Use this only when the diff has already been verified to bind the post-state root via an
 /// upstream proof — e.g. the CSM-verified `CheckpointPayload` path that drives checkpoint sync.


### PR DESCRIPTION
## Description

Clarifies how checkpoint DA reconstruction works across the OL checkpoint and STF code:

- checkpoint DA captures OL-originated effects from pre-drain execution
- terminal ASM effects are excluded from that diff
- reconstruction restores those effects separately by replaying ASM manifests already available from L1

Also clarifies the epoch summary L1 commitment and records follow-up TODOs around the DA accumulator interface.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This PR only clarifies existing behavior; it does not change checkpoint construction or reconstruction semantics.

Tests were not run because the changes are documentation-only.

This PR was developed and its body was written with Codex AI assistance.

Is this PR addressing any specification, design doc or external reference document?

- [ ] Yes
- [x] No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

None.
