### PR TITLE
perf(storage): batch sentinel MMR prefill at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10173,6 +10173,7 @@ dependencies = [
  "anyhow",
  "futures",
  "proptest",
+ "sled",
  "ssz_types",
  "strata-asm-checkpoint-types",
  "strata-asm-common",
@@ -10189,8 +10190,10 @@ dependencies = [
  "strata-paas",
  "strata-primitives",
  "strata-storage-common",
+ "tempfile",
  "tokio",
  "tracing",
+ "typed-sled",
  "zkaleido",
 ]
 

--- a/crates/chain-worker/src/mmr_prefill.rs
+++ b/crates/chain-worker/src/mmr_prefill.rs
@@ -7,13 +7,14 @@ use tokio::task::spawn_blocking;
 
 /// Seeds the DB-side L1 block refs MMR index sentinel range.
 ///
-/// Appends sentinel leaves for indices `0..=genesis_l1_height`, matching the
+/// Batches sentinel leaves for indices `0..=genesis_l1_height`, matching the
 /// in-state L1 block refs MMR genesis prefill so DB leaf index equals L1 height.
 /// The operation is idempotent when the index already has the expected prefix.
 ///
 /// The caller must run this only while no other writer can append to
 /// `L1BlockRefs`. A concurrent append violates the startup-only single-writer
-/// contract and panics if the returned append index is not the expected index.
+/// contract and returns a precondition error. An incomplete prefix must already
+/// contain only sentinel leaves; a peak mismatch returns an error before writing.
 pub async fn prefill_l1_block_refs_mmr(
     mmr_index_mgr: &MmrIndexManager,
     genesis_l1_height: u64,
@@ -32,15 +33,5 @@ pub fn prefill_l1_block_refs_mmr_blocking(
     genesis_l1_height: u64,
 ) -> DbResult<()> {
     let handle = mmr_index_mgr.get_handle(MmrId::L1BlockRefs);
-    let leaf_count = handle.get_leaf_count_blocking()?;
-
-    for expected_idx in leaf_count..=genesis_l1_height {
-        let appended_idx = handle.append_leaf_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH)?;
-        assert_eq!(
-            appended_idx, expected_idx,
-            "L1 block refs MMR index prefill mismatch: expected {expected_idx}, got {appended_idx}"
-        );
-    }
-
-    Ok(())
+    handle.prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, genesis_l1_height + 1)
 }

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -157,13 +157,6 @@ pub fn spawn_asm_worker(
 /// `target_count` entries. It is used to align DB-side MMR leaf indices with
 /// L1 block heights, mirroring the in-memory OL state initialization.
 fn prefill_asm_mmr(handle: &MmrIndexHandle, target_count: u64) -> anyhow::Result<()> {
-    let current = handle.get_leaf_count_blocking()?;
-    if current >= target_count {
-        return Ok(());
-    }
-
-    for _ in current..target_count {
-        handle.append_leaf_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH)?;
-    }
+    handle.prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, target_count)?;
     Ok(())
 }

--- a/crates/db/types/src/errors.rs
+++ b/crates/db/types/src/errors.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[cfg(feature = "proxies")]
 use tokio::task::JoinError;
 
-use crate::mmr_index::{LeafPos, NodePos};
+use crate::mmr_index::{LeafPos, NodePos, RawMmrId};
 
 #[derive(Clone, Debug, Error)]
 pub enum DbError {
@@ -101,6 +101,10 @@ pub enum DbError {
     /// MMR node not found at the given tree position.
     #[error("MMR node not found at position {0:?}")]
     MmrNodeNotFound(NodePos),
+
+    /// Existing peaks do not commit to the requested repeated sentinel prefix.
+    #[error("MMR {mmr_id:?} does not have the repeated prefill prefix at {leaf_count} leaves")]
+    MmrPrefillPrefixMismatch { mmr_id: RawMmrId, leaf_count: u64 },
 
     /// MMR index batch precondition failed.
     #[error("MMR precondition failed for {mmr_id:?}: {detail}")]

--- a/crates/ol/genesis/src/lib.rs
+++ b/crates/ol/genesis/src/lib.rs
@@ -66,12 +66,9 @@ pub fn build_genesis_artifacts(params: &OLParams) -> Result<GenesisArtifacts> {
     let genesis_ts = params.genesis_params().header().timestamp;
     let genesis_info = BlockInfo::new_genesis(genesis_ts);
 
-    // Do not include the genesis manifest in OL state's ASM manifest accumulator.
-    //
-    // ASM worker stores genesis manifest for data consumers, but intentionally starts the
-    // external/global ASM MMR at `genesis_l1_height + 1` (first post-genesis manifest at leaf 0).
-    // If OL genesis appends the genesis manifest here, OL state's MMR gets an extra leading leaf
-    // and ledger-reference proofs become permanently off-by-one against the global ASM MMR.
+    // Both in-state and DB-side MMRs are height-indexed: sentinel leaves occupy
+    // indices 0..=genesis_l1_height, so the manifest for L1 height h lands at leaf h.
+    // OL genesis must not append the genesis manifest or shift that index by one.
     // Genesis is the epoch terminal for epoch 0 (it carries no manifests, but
     // terminality is set explicitly via the header flag).
     let genesis_components = BlockComponents::new_manifests(vec![]).as_terminal();

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -36,9 +36,12 @@ test-utils = []
 
 [dev-dependencies]
 proptest.workspace = true
+sled.workspace = true
 strata-asm-checkpoint-types = { workspace = true, features = ["test-utils"] }
 strata-db-store-sled.workspace = true
 strata-db-tests.workspace = true
 strata-identifiers = { workspace = true, features = ["test-utils"] }
 strata-ol-state-types-v1 = { workspace = true, features = ["test-utils"] }
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+typed-sled.workspace = true

--- a/crates/storage/src/managers/mmr_index.rs
+++ b/crates/storage/src/managers/mmr_index.rs
@@ -20,6 +20,9 @@ use tokio::task::spawn_blocking;
 
 use crate::ops::mmr_index::MmrIndexOps;
 
+/// Bounds transaction memory while reducing the 307,050-leaf genesis prefill to 38 writes.
+const REPEATED_LEAF_CHUNK_SIZE: u64 = 8192;
+
 /// Retry behavior for optimistic CAS-style MMR updates.
 #[derive(Debug, Clone, Copy)]
 pub struct MmrIndexRetryConfig {
@@ -199,6 +202,102 @@ impl MmrIndexHandle {
         run_with_precondition_retries(self.max_retries, || {
             self.append_leaf_once_blocking(hash, None)
         })
+    }
+
+    /// Extends a height-indexed MMR with a repeated sentinel prefix.
+    ///
+    /// Returns without writing when the count already reaches `target_leaf_count`.
+    /// Otherwise, verifies the existing peaks commit to repeated `leaf_hash` leaves
+    /// before extending the prefix. Each chunk commits a complete prefix, allowing
+    /// startup to resume after a crash. Batching reduces STR-3703's roughly 614,000
+    /// per-leaf writes across the two genesis MMRs to tens of transactions.
+    ///
+    /// Requires a single writer during startup. Count and empty-slot preconditions
+    /// reject conflicting writes without retrying. Returns
+    /// [`DbError::MmrPrefillPrefixMismatch`] without writing if a peak is missing
+    /// or differs from the repeated prefix.
+    pub fn prefill_repeated_leaves_blocking(
+        &self,
+        leaf_hash: Hash,
+        target_leaf_count: u64,
+    ) -> DbResult<()> {
+        self.prefill_repeated_leaves_with_chunk_blocking(
+            leaf_hash,
+            target_leaf_count,
+            REPEATED_LEAF_CHUNK_SIZE,
+        )
+    }
+
+    /// Allows benchmarks to vary transaction size without changing the public API.
+    fn prefill_repeated_leaves_with_chunk_blocking(
+        &self,
+        leaf_hash: Hash,
+        target_leaf_count: u64,
+        chunk_size: u64,
+    ) -> DbResult<()> {
+        assert!(chunk_size > 0, "prefill chunk size must be positive");
+        let mut current = self.get_leaf_count_blocking()?;
+        if current >= target_leaf_count {
+            return Ok(());
+        }
+
+        // This is the same hash ladder as Mmr::new_repeated and write_plan's
+        // completed subtrees, including the node hasher's domain separation.
+        // Retain zero hashes too: they are valid stored nodes, not absent peaks.
+        let mut level_hashes = [leaf_hash.0; 64];
+        for height in 1..=target_leaf_count.ilog2() as usize {
+            let child = level_hashes[height - 1];
+            level_hashes[height] = Sha256Hasher::hash_node(child, child);
+        }
+        for peak in peak_positions(current) {
+            let expected = Hash::from(level_hashes[usize::from(peak.height())]);
+            if self.get_node_blocking(peak)? != Some(expected) {
+                return Err(DbError::MmrPrefillPrefixMismatch {
+                    mmr_id: self.mmr_id_bytes(),
+                    leaf_count: current,
+                });
+            }
+        }
+
+        while current < target_leaf_count {
+            let next = current + (target_leaf_count - current).min(chunk_size);
+            let mut batch = MmrBatchWrite::default();
+            let mmr_batch = batch.entry(self.mmr_id_bytes());
+            mmr_batch.set_expected_leaf_count(current);
+            mmr_batch.add_node_precond(LeafPos::new(current).to_node_pos(), None);
+
+            // At height h, exactly floor(count / 2^h) nodes are complete.
+            for height in 0..=next.ilog2() as u8 {
+                let start = current >> height;
+                let end = next >> height;
+                if start == end {
+                    break;
+                }
+                let hash = Hash::from(level_hashes[usize::from(height)]);
+                for index in start..end {
+                    mmr_batch.put_node(NodePos::new(height, index), hash);
+                }
+            }
+            mmr_batch.set_leaf_count(next);
+            self.ops.apply_update_blocking(batch)?;
+            current = next;
+        }
+        Ok(())
+    }
+
+    /// Extends the sentinel prefix on a blocking task.
+    ///
+    /// Applies the invariant and single-writer contract of
+    /// [`Self::prefill_repeated_leaves_blocking`].
+    pub async fn prefill_repeated_leaves(
+        &self,
+        leaf_hash: Hash,
+        target_leaf_count: u64,
+    ) -> DbResult<()> {
+        let this = self.clone();
+        spawn_blocking(move || this.prefill_repeated_leaves_blocking(leaf_hash, target_leaf_count))
+            .await
+            .map_err(DbError::from)?
     }
 
     /// Appends a caller-provided leaf hash and stores its preimage bytes.
@@ -805,8 +904,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
+    use sled::Config;
     use strata_db_store_sled::test_utils::get_test_sled_backend;
+    use strata_db_store_sled::{SledBackend, SledDbConfig};
     use strata_merkle::{Mmr, Mmr64B32, MmrState};
+    use strata_ol_state_types_v1::MMR_SENTINEL_DUMMY_LEAF_HASH;
+    use tempfile::tempdir;
+    use typed_sled::SledDb;
 
     use super::*;
 
@@ -818,6 +924,242 @@ mod tests {
         let handle = crate::test_runtime_handle();
         let backend = get_test_sled_backend();
         MmrIndexManager::new(handle, backend.mmr_index_db())
+    }
+
+    fn append_sentinels(handle: &MmrIndexHandle, count: u64) {
+        for _ in 0..count {
+            handle
+                .append_leaf_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH)
+                .expect("append sentinel");
+        }
+    }
+
+    fn snapshot_nodes(handle: &MmrIndexHandle, count: u64) -> Vec<(NodePos, Option<Hash>)> {
+        iter_prune_after_positions(0, count)
+            .map(|pos| (pos, handle.get_node_blocking(pos).expect("read node")))
+            .collect()
+    }
+
+    fn assert_mmr_equivalent(expected: &MmrIndexHandle, actual: &MmrIndexHandle, count: u64) {
+        assert_eq!(expected.get_leaf_count_blocking().unwrap(), count);
+        assert_eq!(actual.get_leaf_count_blocking().unwrap(), count);
+        let size = expected.get_mmr_size_blocking().unwrap();
+        assert_eq!(actual.get_mmr_size_blocking().unwrap(), size);
+
+        // Enumerate every completed node independently of the batching level walk.
+        let mut visited = 0;
+        for pos in iter_prune_after_positions(0, count) {
+            let expected_hash = expected.get_node_blocking(pos).unwrap();
+            assert!(expected_hash.is_some(), "missing reference node {pos:?}");
+            assert_eq!(
+                actual.get_node_blocking(pos).unwrap(),
+                expected_hash,
+                "node {pos:?} at leaf count {count}"
+            );
+            visited += 1;
+        }
+        assert_eq!(visited, size);
+        let state = actual.get_state_at_blocking(count).unwrap();
+        assert_eq!(state, expected.get_state_at_blocking(count).unwrap());
+        if count > 0 {
+            for index in [0, count / 2, count - 1] {
+                let proof = actual.generate_proof_at(index, count).unwrap();
+                assert_eq!(proof, expected.generate_proof_at(index, count).unwrap());
+                let leaf = actual.get_leaf_blocking(index).unwrap().unwrap();
+                assert!(<Mmr64B32 as Mmr<Sha256Hasher>>::verify(
+                    &state, &proof, &leaf.0
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn test_prefill_repeated_leaves_matches_per_leaf_appends() {
+        for count in [
+            0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 100, 8191, 8192, 8193, 20000,
+        ] {
+            let expected = setup_handle();
+            let actual = setup_handle();
+            append_sentinels(&expected, count);
+            actual
+                .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, count)
+                .unwrap();
+            assert_mmr_equivalent(&expected, &actual, count);
+
+            let distinct = Hash::from([0x42; 32]);
+            expected.append_leaf_blocking(distinct).unwrap();
+            actual.append_leaf_blocking(distinct).unwrap();
+            assert_mmr_equivalent(&expected, &actual, count + 1);
+        }
+    }
+
+    #[test]
+    fn test_prefill_repeated_leaves_resumes_per_leaf_prefix() {
+        let expected = setup_handle();
+        append_sentinels(&expected, 20000);
+        for prefix in [1, 5, 8192, 12345] {
+            let actual = setup_handle();
+            append_sentinels(&actual, prefix);
+            actual
+                .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, 20000)
+                .unwrap();
+            assert_mmr_equivalent(&expected, &actual, 20000);
+        }
+    }
+
+    #[test]
+    fn test_prefill_repeated_leaves_noops_at_or_above_target() {
+        let handle = setup_handle();
+        let count = 17;
+        handle
+            .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, count)
+            .unwrap();
+        let before = snapshot_nodes(&handle, count);
+        for target in [count, count - 1] {
+            handle
+                .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, target)
+                .unwrap();
+            assert_eq!(handle.get_leaf_count_blocking().unwrap(), count);
+            assert_eq!(snapshot_nodes(&handle, count), before);
+        }
+        // A completed prefill remains a no-op after real manifests arrive.
+        handle.append_leaf_blocking(Hash::from([0x42; 32])).unwrap();
+        handle
+            .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, count)
+            .unwrap();
+        assert_eq!(handle.get_leaf_count_blocking().unwrap(), count + 1);
+    }
+
+    #[test]
+    fn test_prefill_repeated_leaves_rejects_prefix_mismatch_without_writes() {
+        let handle = setup_handle();
+        append_sentinels(&handle, 1);
+        handle.append_leaf_blocking(Hash::from([0x42; 32])).unwrap();
+        append_sentinels(&handle, 1);
+        assert_prefill_prefix_rejected(&handle);
+    }
+
+    fn assert_prefill_prefix_rejected(handle: &MmrIndexHandle) {
+        let before = snapshot_nodes(handle, 100);
+        let error = handle
+            .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, 100)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            DbError::MmrPrefillPrefixMismatch { mmr_id, leaf_count: 3 }
+                if mmr_id == MmrId::Asm.to_bytes()
+        ));
+        assert_eq!(handle.get_leaf_count_blocking().unwrap(), 3);
+        assert_eq!(snapshot_nodes(handle, 100), before);
+    }
+
+    #[test]
+    fn test_prefill_repeated_leaves_rejects_missing_peak_without_writes() {
+        let manager = setup_manager();
+        let handle = manager.get_handle(MmrId::Asm);
+        append_sentinels(&handle, 3);
+        let mut batch = MmrBatchWrite::default();
+        batch
+            .entry(MmrId::Asm.to_bytes())
+            .del_node(NodePos::new(1, 0));
+        manager.apply_update_blocking(batch).unwrap();
+        assert_prefill_prefix_rejected(&handle);
+    }
+
+    #[test]
+    fn test_prefill_repeated_leaves_resumes_at_chunk_boundary() {
+        let expected = setup_handle();
+        let actual = setup_handle();
+        let target = REPEATED_LEAF_CHUNK_SIZE * 5 / 2;
+        append_sentinels(&expected, target);
+        actual
+            .prefill_repeated_leaves_blocking(
+                MMR_SENTINEL_DUMMY_LEAF_HASH,
+                REPEATED_LEAF_CHUNK_SIZE,
+            )
+            .unwrap();
+        actual
+            .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, target)
+            .unwrap();
+        assert_mmr_equivalent(&expected, &actual, target);
+    }
+
+    #[test]
+    #[ignore = "compares on-disk genesis prefill transaction sizes"]
+    fn bench_prefill_chunk_sizes_307050_leaves() {
+        let expected_state =
+            <Mmr64B32 as Mmr<Sha256Hasher>>::new_repeated(MMR_SENTINEL_DUMMY_LEAF_HASH.0, 307_050);
+        for chunk_size in [8192, 32768, 131072] {
+            let directory = tempdir().unwrap();
+            let db = Config::new().path(directory.path()).open().unwrap();
+            let db = Arc::new(SledDb::new(db).unwrap());
+            let backend = SledBackend::new(db, SledDbConfig::production()).unwrap();
+            let handle = MmrIndexManager::new(crate::test_runtime_handle(), backend.mmr_index_db())
+                .get_handle(MmrId::Asm);
+
+            let start = Instant::now();
+            handle
+                .prefill_repeated_leaves_with_chunk_blocking(
+                    MMR_SENTINEL_DUMMY_LEAF_HASH,
+                    307_050,
+                    chunk_size,
+                )
+                .unwrap();
+            let duration = start.elapsed();
+            println!("batched 307050 leaves, chunk {chunk_size}: {duration:?}");
+            assert_eq!(handle.get_leaf_count_blocking().unwrap(), 307_050);
+            assert_eq!(
+                handle.get_state_at_blocking(307_050).unwrap(),
+                expected_state
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "measures on-disk genesis prefill against per-leaf transactions"]
+    fn bench_prefill_307050_leaves() {
+        let batched_dir = tempdir().unwrap();
+        let per_leaf_dir = tempdir().unwrap();
+        let setup = |path| {
+            let db = Config::new().path(path).open().unwrap();
+            let db = Arc::new(SledDb::new(db).unwrap());
+            let backend = SledBackend::new(db, SledDbConfig::production()).unwrap();
+            MmrIndexManager::new(crate::test_runtime_handle(), backend.mmr_index_db())
+                .get_handle(MmrId::Asm)
+        };
+        let batched = setup(batched_dir.path());
+        let per_leaf = setup(per_leaf_dir.path());
+        let start = Instant::now();
+        batched
+            .prefill_repeated_leaves_blocking(MMR_SENTINEL_DUMMY_LEAF_HASH, 307_050)
+            .unwrap();
+        let batched_duration = start.elapsed();
+        println!("batched 307050 leaves: {batched_duration:?}");
+
+        let start = Instant::now();
+        append_sentinels(&per_leaf, 30_705);
+        let sample_duration = start.elapsed();
+        if sample_duration * 10 > Duration::from_secs(15 * 60) {
+            let extrapolated = sample_duration * 10;
+            println!("per-leaf 30705 leaves: {sample_duration:?}");
+            println!("per-leaf 307050 leaves (x10 extrapolation): {extrapolated:?}");
+            println!(
+                "extrapolated speedup: {:.2}x",
+                extrapolated.as_secs_f64() / batched_duration.as_secs_f64()
+            );
+        } else {
+            append_sentinels(&per_leaf, 307_050 - 30_705);
+            let per_leaf_duration = start.elapsed();
+            println!("per-leaf 307050 leaves: {per_leaf_duration:?}");
+            println!(
+                "speedup: {:.2}x",
+                per_leaf_duration.as_secs_f64() / batched_duration.as_secs_f64()
+            );
+            assert_eq!(
+                per_leaf.get_state_at_blocking(307_050).unwrap(),
+                batched.get_state_at_blocking(307_050).unwrap()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

On a fresh datadir the node seeds two height-indexed MMR indexes, `MmrId::Asm` and `MmrId::L1BlockRefs`, with one sentinel leaf per L1 height up to genesis. Both prefills appended one leaf at a time, and each append costs a leaf-count read plus two sled transactions. With testnet-prod's genesis at L1 height 307,049 that is about 614k transactions per index and roughly ten minutes of silent startup each, twenty minutes in total (STR-3703). Mainnet-prod pays about 31 minutes per index (STR-4326). The first gap sits inside `spawn_asm_worker`, before the ASM worker task even launches, and the second inside `init_ol_genesis` between building and persisting the genesis block.

This PR adds `MmrIndexHandle::prefill_repeated_leaves(_blocking)`. It computes the all-sentinel MMR, which has one distinct hash per level, and writes it in 8192-leaf chunks through the existing `MmrBatchWrite` and `apply_update` path. Each chunk is a single transaction guarded by a leaf-count CAS and an empty-slot precondition, so a crash between chunks leaves a valid prefix and the next start resumes from it. Before writing anything, the stored peaks are checked against the expected repeated prefix. A mismatch fails with the new `DbError::MmrPrefillPrefixMismatch` and writes nothing.

Both call sites now go through the helper: `prefill_asm_mmr` in `strata-consensus-logic` and `prefill_l1_block_refs_mmr_blocking` in `strata-chain-worker`. Public signatures, the on-disk schema, hashing and proof generation are unchanged. The ASM worker's own `prefill_manifest_mmr` trait default keeps running afterwards and stays a no-op.

Release-mode benchmark on an on-disk sled, 307,050 leaves, on a dev VM:

| Path | Time |
|---|---|
| per-leaf appends (current `main`) | 189.5 s |
| batched prefill (this PR) | 6.9 s |

Scaling by the ratio between the per-leaf time observed on testnet-prod and on this VM, both prefills together should take under a minute on testnet-prod and a couple of minutes on mainnet-prod.

Chunk size does not change the speed, but it decides how much memory a single sled transaction holds. Peak RSS of the release test binary on an on-disk sled, measured with `/usr/bin/time -v`:

| Leaves | Chunk | Time | Peak RSS |
|---|---|---|---|
| 307,050 | 8192 | 8.0 s | 229 MB |
| 307,050 | 131,072 | 8.0 s | 1.37 GB |
| 307,050 | all at once | 6.1 s | 2.87 GB |
| 1,000,000 | 8192 | 28.8 s | 500 MB |
| 1,000,000 | 65,536 | 27.8 s | 1.10 GB |
| 1,000,000 | all at once | killed | OOM above 6 GB |

That is roughly 9 KB of transaction memory per leaf, so writing the whole prefix in one transaction is not an option at mainnet size and the 8192 chunk stays.

The PR also rewrites a stale comment in `strata-ol-genesis` that claimed the ASM MMR starts at `genesis_l1_height + 1` with the first post-genesis manifest at leaf 0.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The correctness argument rests on `test_prefill_repeated_leaves_matches_per_leaf_appends`. For 17 sizes that straddle chunk boundaries it compares the batched index against per-leaf appends node by node, then compares the MMR state and inclusion proofs, then appends a real leaf on both sides and compares again. Separate tests cover resuming from a partial prefix (including mid-chunk and exactly on a boundary), no-op when the target is already met, and the two failure cases where the existing prefix is not all-sentinel or a peak is missing. Both failure tests assert that nothing was written.

The helper relies on the invariant that at height `h` exactly `floor(count / 2^h)` nodes are complete, so a chunk advancing the count from `a` to `b` writes indices `[a >> h, b >> h)` at each height. That is the part worth checking by hand.

The trick: every one of those placeholder leaves is identical, so the tree built on top of them is completely predictable. Each row of the tree has a single repeated hash, and we can work out ahead of time exactly which slots a batch of new leaves fills in. So instead of appending one leaf at a time and letting the database recompute parents, the helper computes the answer up front and writes it in big chunks. Tests confirm the result is byte-for-byte the same tree the old one-at-a-time path produced, including across chunk boundaries, after a restart mid-way, and when the existing data doesn't match what's expected.

We can upstream the helper to `strata-common`.

Two `#[ignore]`d benchmarks are kept under `bench_prefill_*` for future tuning. They add `sled`, `typed-sled` and `tempfile` as dev-dependencies of `strata-storage` so they can run against an on-disk database. Run them with `cargo nextest run --release -p strata-storage bench_prefill --run-ignored ignored-only --no-capture`. `bench_prefill_chunk_size` reads `PREFILL_LEAVES` and `PREFILL_CHUNK` so one process runs one configuration; wrapping the test binary in `/usr/bin/time -v` reproduces the memory table above.

This change does not fix the other defect in STR-4326, where the CSM can persist client state before the genesis block is written. It shrinks that window from minutes to seconds. Closing it needs a startup ordering change and should be its own PR.

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [x]  No

If yes, please add relevant links:

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

AI disclosure: the diagnosis, design and review were done with Claude Code, and the implementation, tests and benchmarks were generated by OpenAI Codex from a written spec. This PR body was drafted by Claude Code and I reviewed and heavily edited it. All tests, lint and the release benchmark were re-run by hand before opening.

## Related Issues

Fixes [STR-3703](https://alpenlabs.atlassian.net/browse/STR-3703) and [STR-4305](https://alpenlabs.atlassian.net/browse/STR-4305). Partially addresses [STR-4326](https://alpenlabs.atlassian.net/browse/STR-4326) (bulk MMR prefill item).

[STR-3703]: https://alpenlabs.atlassian.net/browse/STR-3703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
