### PR TITLE
Backport/chunk missing bytecode witness fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "reth-node-ethereum",
  "reth-payload-builder",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc-eth-types",

--- a/crates/reth/node/Cargo.toml
+++ b/crates/reth/node/Cargo.toml
@@ -50,4 +50,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+reth-primitives-traits.workspace = true
 strata-identifiers = { workspace = true, features = ["test-utils"] }

--- a/crates/reth/node/src/block_witness.rs
+++ b/crates/reth/node/src/block_witness.rs
@@ -154,14 +154,14 @@ where
 /// change (a `BALANCE`, which loads no code, or a plain call into unchanged code) needs no
 /// pre-state entry, so gating on the transition set keeps unrelated bytecode out of the witness and
 /// avoids a parent-state read per accessed account.
-fn collect_accessed_codes<DB, SP>(
+fn collect_accessed_codes<DB, R>(
     executed_state: &State<DB>,
-    state_provider: &SP,
+    state_provider: &R,
     record_codes: Vec<Bytes>,
 ) -> eyre::Result<Vec<Vec<u8>>>
 where
     DB: Database,
-    SP: BytecodeReader,
+    R: BytecodeReader,
 {
     let mut codes_by_hash: BTreeMap<B256, Bytes> = record_codes
         .into_iter()

--- a/crates/reth/node/src/block_witness.rs
+++ b/crates/reth/node/src/block_witness.rs
@@ -16,9 +16,10 @@ use std::collections::BTreeMap;
 
 use alloy_consensus::Header;
 use alloy_primitives::{keccak256, Bytes, B256};
-use reth_provider::{HeaderProvider, StateProofProvider};
+use reth_provider::{AccountReader, BytecodeReader, HeaderProvider, StateProofProvider};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord, Database};
 use reth_trie::TrieInput;
+use revm_primitives::KECCAK_EMPTY;
 use serde::{Deserialize, Serialize};
 
 /// Persisted per-block proof-witness, keyed by execution block hash.
@@ -71,8 +72,9 @@ impl BlockWitnessRecord {
 /// `executed_state` supplies the access set (touched accounts/slots, loaded
 /// `codes`, BLOCKHASH range) via reth's [`ExecutionWitnessRecord`].
 /// `state_provider` must be the parent state (it serves the depth-0
-/// [`StateProofProvider::witness`] trie nodes), and `header_provider` must cover
-/// the BLOCKHASH ancestor range.
+/// [`StateProofProvider::witness`] trie nodes and the pre-state code of
+/// accessed accounts), and `header_provider` must cover the BLOCKHASH
+/// ancestor range.
 pub fn build_block_witness_from_executed_state<DB, SP, HP>(
     executed_state: &State<DB>,
     state_provider: &SP,
@@ -83,7 +85,7 @@ pub fn build_block_witness_from_executed_state<DB, SP, HP>(
 ) -> eyre::Result<BlockWitnessRecord>
 where
     DB: Database,
-    SP: StateProofProvider,
+    SP: StateProofProvider + AccountReader + BytecodeReader,
     HP: HeaderProvider<Header = Header>,
 {
     // Access set read straight out of the post-execution state — no re-run.
@@ -103,7 +105,7 @@ where
         .map(|node| node.to_vec())
         .collect();
 
-    let codes = collect_accessed_codes(executed_state, codes)?;
+    let codes = collect_accessed_codes(executed_state, state_provider, codes)?;
 
     // BLOCKHASH ancestor headers: the contiguous range from the lowest block
     // referenced (or just the parent) up to the parent.
@@ -129,22 +131,31 @@ where
 /// in the block witness.
 ///
 /// The witness is the only source of bytecode when the block is later
-/// re-executed for proving, so it must carry every code the block touched.
-/// reth's [`ExecutionWitnessRecord`] is not enough on its own: it reports only
-/// code that passed through its in-memory bytecode stores (`cache.contracts` +
-/// `bundle_state.contracts`), so a contract whose code reached the EVM solely
-/// via its account's `info.code` — a warm load that never issued a by-hash
-/// fetch — is silently left out.
+/// re-executed for proving, so it must carry every code a cold replay of the
+/// block loads. reth's [`ExecutionWitnessRecord`] is not enough on its own: it
+/// reports only code that passed through its in-memory bytecode stores
+/// (`cache.contracts` + `bundle_state.contracts`), so a contract whose code
+/// reached the EVM solely via its account's `info.code` — a warm load that
+/// never issued a by-hash fetch — is silently left out.
 ///
-/// This starts from reth's `record_codes` and adds the code of every accessed
-/// account that carries one, so the result is complete regardless of how each
-/// contract's code was loaded.
-fn collect_accessed_codes<DB>(
+/// This starts from reth's `record_codes` and supplements it twice:
+/// - the code of every accessed account that still carries one post-block (covers warm-attached
+///   loads of unchanged code);
+/// - the **pre-state** code of every accessed account, fetched from the parent `state_provider`.
+///   This covers code that the block read and then replaced or cleared (today only EIP-7702
+///   re-delegation/clearing): the old code can arrive warm-attached (e.g. via the payload builder's
+///   pre-warmed `CachedReads` from the parent block), so it never hits `code_by_hash`, and
+///   post-block the account carries only the new code — leaving the old one in neither store. A
+///   cold replay of the block still reads it during authorization validation, so the witness must
+///   include it.
+fn collect_accessed_codes<DB, SP>(
     executed_state: &State<DB>,
+    state_provider: &SP,
     record_codes: Vec<Bytes>,
 ) -> eyre::Result<Vec<Vec<u8>>>
 where
     DB: Database,
+    SP: AccountReader + BytecodeReader,
 {
     let mut codes_by_hash: BTreeMap<B256, Bytes> = record_codes
         .into_iter()
@@ -178,6 +189,40 @@ where
             .or_insert_with(|| code.original_bytes());
     }
 
+    // Pre-state code of every accessed account. The post-block sweep above sees
+    // only the code an account ends the block with, so code replaced or cleared
+    // within the block is recoverable solely from the parent state.
+    for address in executed_state.cache.accounts.keys() {
+        let Some(pre_account) = state_provider.basic_account(address)? else {
+            continue;
+        };
+        let Some(pre_code_hash) = pre_account.bytecode_hash else {
+            continue;
+        };
+        if pre_code_hash == KECCAK_EMPTY || codes_by_hash.contains_key(&pre_code_hash) {
+            continue;
+        }
+
+        let code = state_provider.bytecode_by_hash(&pre_code_hash)?.ok_or_else(|| {
+            eyre::eyre!(
+                "pre-state bytecode missing from provider: account={address}, code_hash={pre_code_hash}",
+            )
+        })?;
+        let bytes = code.original_bytes();
+
+        // Same guest-reachability guarantee as above: the guest keys code by
+        // `keccak256(bytes)`, so a store hash that disagrees with the bytes
+        // must fail the build, not the proof.
+        let actual_hash = keccak256(&bytes);
+        if actual_hash != pre_code_hash {
+            eyre::bail!(
+                "pre-state bytecode hash mismatch: account={address}, expected_code_hash={pre_code_hash}, actual_hash={actual_hash}",
+            );
+        }
+
+        codes_by_hash.insert(pre_code_hash, bytes);
+    }
+
     Ok(codes_by_hash
         .into_values()
         .map(|code| code.to_vec())
@@ -186,11 +231,59 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy_primitives::{Address, U256};
+    use reth_errors::ProviderResult;
+    use reth_primitives_traits::{Account, Bytecode as RethBytecode};
     use reth_revm::db::{states::cache_account::CacheAccount, EmptyDB, State};
     use revm::state::{AccountInfo, Bytecode};
 
     use super::*;
+
+    /// Parent-state stub serving only the two lookups the pre-state code fetch
+    /// needs.
+    #[derive(Default)]
+    struct StubStateProvider {
+        accounts: HashMap<Address, Account>,
+        codes: HashMap<B256, Bytecode>,
+    }
+
+    impl StubStateProvider {
+        fn with_account_code(address: Address, code: Bytecode) -> Self {
+            let code_hash = code.hash_slow();
+            Self {
+                accounts: HashMap::from([(
+                    address,
+                    Account {
+                        nonce: 1,
+                        balance: U256::ZERO,
+                        bytecode_hash: Some(code_hash),
+                    },
+                )]),
+                codes: HashMap::from([(code_hash, code)]),
+            }
+        }
+    }
+
+    impl AccountReader for StubStateProvider {
+        fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+            Ok(self.accounts.get(address).copied())
+        }
+    }
+
+    impl BytecodeReader for StubStateProvider {
+        fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<RethBytecode>> {
+            Ok(self.codes.get(code_hash).cloned().map(RethBytecode))
+        }
+    }
+
+    /// A 23-byte EIP-7702 delegation designator (`0xef0100 || address`).
+    fn delegation_designator(target: u8) -> Bytecode {
+        let mut raw = vec![0xef, 0x01, 0x00];
+        raw.extend_from_slice(&[target; 20]);
+        Bytecode::new_raw(Bytes::from(raw))
+    }
 
     /// A contract whose code is attached to its account `info.code` but never
     /// entered `cache.contracts` (the in-memory bytecode store
@@ -217,7 +310,8 @@ mod tests {
 
         // `record_executed_state` produced no codes (dedup map was empty), the
         // exact condition that dropped the bytecode before the fix.
-        let codes = collect_accessed_codes(&state, Vec::new()).unwrap();
+        let codes =
+            collect_accessed_codes(&state, &StubStateProvider::default(), Vec::new()).unwrap();
 
         assert!(
             codes.iter().any(|c| keccak256(c) == code_hash),
@@ -239,9 +333,11 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        assert!(collect_accessed_codes(&state, Vec::new())
-            .unwrap()
-            .is_empty());
+        assert!(
+            collect_accessed_codes(&state, &StubStateProvider::default(), Vec::new())
+                .unwrap()
+                .is_empty()
+        );
     }
 
     /// Locks the exact bug shape: reth's raw `ExecutionWitnessRecord` can miss
@@ -272,7 +368,8 @@ mod tests {
             "raw reth record should reproduce the missing-code condition"
         );
 
-        let codes = collect_accessed_codes(&state, record.codes).unwrap();
+        let codes =
+            collect_accessed_codes(&state, &StubStateProvider::default(), record.codes).unwrap();
         assert!(
             codes.iter().any(|code| keccak256(code) == code_hash),
             "block witness codes must include every accessed account info.code"
@@ -297,7 +394,8 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        let err = collect_accessed_codes(&state, Vec::new()).unwrap_err();
+        let err =
+            collect_accessed_codes(&state, &StubStateProvider::default(), Vec::new()).unwrap_err();
         assert!(
             err.to_string().contains("bytecode hash mismatch"),
             "unexpected error: {err}"
@@ -325,9 +423,140 @@ mod tests {
         );
 
         // The same bytecode arrives via reth's record_codes and the account.
-        let codes = collect_accessed_codes(&state, vec![raw]).unwrap();
+        let codes =
+            collect_accessed_codes(&state, &StubStateProvider::default(), vec![raw]).unwrap();
 
         assert_eq!(codes.len(), 1, "duplicate code must collapse to one entry");
         assert_eq!(keccak256(&codes[0]), code_hash);
+    }
+
+    /// Locks the cross-chunk EIP-7702 bug shape: the block *clears* a
+    /// delegation whose designator arrived warm-attached (never through
+    /// `code_by_hash`, so reth's record misses it) and post-block the account
+    /// carries empty code (so the attached-code sweep misses it too). The
+    /// pre-state fetch must recover the old designator from the parent state,
+    /// or guest replay of the clearing block panics on the by-hash lookup.
+    #[test]
+    fn regression_fetches_prestate_code_cleared_within_the_block() {
+        let address = Address::repeat_byte(0xaa);
+        let old_designator = delegation_designator(0x77);
+        let old_code_hash = old_designator.hash_slow();
+        let provider = StubStateProvider::with_account_code(address, old_designator);
+
+        // Post-block state: delegation cleared, account holds no code.
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 2,
+            ..Default::default()
+        };
+        state
+            .cache
+            .accounts
+            .insert(address, CacheAccount::new_loaded(info, Default::default()));
+
+        // Nothing passed through code_by_hash during the build (warm attach).
+        let codes = collect_accessed_codes(&state, &provider, Vec::new()).unwrap();
+
+        assert!(
+            codes.iter().any(|c| keccak256(c) == old_code_hash),
+            "pre-state designator must be captured when the block clears it"
+        );
+    }
+
+    /// The re-delegation variant: post-block the account carries the *new*
+    /// designator, which the attached-code sweep captures — but replay also
+    /// reads the *old* one during authorization validation, so both must land
+    /// in the witness.
+    #[test]
+    fn fetches_prestate_code_replaced_within_the_block() {
+        let address = Address::repeat_byte(0xbb);
+        let old_designator = delegation_designator(0x11);
+        let old_code_hash = old_designator.hash_slow();
+        let provider = StubStateProvider::with_account_code(address, old_designator);
+
+        let new_designator = delegation_designator(0x22);
+        let new_code_hash = new_designator.hash_slow();
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 2,
+            code_hash: new_code_hash,
+            code: Some(new_designator),
+        };
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        state
+            .cache
+            .accounts
+            .insert(address, CacheAccount::new_loaded(info, Default::default()));
+
+        let codes = collect_accessed_codes(&state, &provider, Vec::new()).unwrap();
+
+        assert!(
+            codes.iter().any(|c| keccak256(c) == old_code_hash),
+            "old designator must come from the pre-state fetch"
+        );
+        assert!(
+            codes.iter().any(|c| keccak256(c) == new_code_hash),
+            "new designator must come from the attached-code sweep"
+        );
+    }
+
+    /// Pre-state code already captured by reth's record must not be re-fetched
+    /// or duplicated, and codeless pre-state accounts contribute nothing.
+    #[test]
+    fn prestate_fetch_dedupes_and_skips_codeless_accounts() {
+        let contract = Address::repeat_byte(0xcc);
+        let raw = Bytes::from_static(&[0x60, 0x2a]); // PUSH1 42
+        let code = Bytecode::new_raw(raw.clone());
+        let code_hash = code.hash_slow();
+        let mut provider = StubStateProvider::with_account_code(contract, code);
+
+        // An accessed EOA with no pre-state code.
+        let eoa = Address::repeat_byte(0xdd);
+        provider.accounts.insert(
+            eoa,
+            Account {
+                nonce: 3,
+                balance: U256::from(7u64),
+                bytecode_hash: None,
+            },
+        );
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        for address in [contract, eoa] {
+            state.cache.accounts.insert(
+                address,
+                CacheAccount::new_loaded(AccountInfo::default(), Default::default()),
+            );
+        }
+
+        // The contract's code already reached reth's record via code_by_hash.
+        let codes = collect_accessed_codes(&state, &provider, vec![raw]).unwrap();
+
+        assert_eq!(codes.len(), 1, "no duplicates, nothing for the EOA");
+        assert_eq!(keccak256(&codes[0]), code_hash);
+    }
+
+    /// A pre-state code hash whose bytecode the provider cannot serve must fail
+    /// the build: the witness would be incomplete and the guest would panic
+    /// later at the by-hash lookup.
+    #[test]
+    fn bails_when_prestate_bytecode_is_missing_from_provider() {
+        let address = Address::repeat_byte(0xee);
+        let mut provider =
+            StubStateProvider::with_account_code(address, delegation_designator(0x55));
+        provider.codes.clear();
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        state.cache.accounts.insert(
+            address,
+            CacheAccount::new_loaded(AccountInfo::default(), Default::default()),
+        );
+
+        let err = collect_accessed_codes(&state, &provider, Vec::new()).unwrap_err();
+        assert!(
+            err.to_string().contains("pre-state bytecode missing"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/reth/node/src/block_witness.rs
+++ b/crates/reth/node/src/block_witness.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use alloy_consensus::Header;
 use alloy_primitives::{keccak256, Bytes, B256};
-use reth_provider::{AccountReader, BytecodeReader, HeaderProvider, StateProofProvider};
+use reth_provider::{BytecodeReader, HeaderProvider, StateProofProvider};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord, Database};
 use reth_trie::TrieInput;
 use revm_primitives::KECCAK_EMPTY;
@@ -73,8 +73,8 @@ impl BlockWitnessRecord {
 /// `codes`, BLOCKHASH range) via reth's [`ExecutionWitnessRecord`].
 /// `state_provider` must be the parent state (it serves the depth-0
 /// [`StateProofProvider::witness`] trie nodes and the pre-state code of
-/// accessed accounts), and `header_provider` must cover the BLOCKHASH
-/// ancestor range.
+/// accounts whose code changed in the block), and `header_provider` must cover
+/// the BLOCKHASH ancestor range.
 pub fn build_block_witness_from_executed_state<DB, SP, HP>(
     executed_state: &State<DB>,
     state_provider: &SP,
@@ -85,7 +85,7 @@ pub fn build_block_witness_from_executed_state<DB, SP, HP>(
 ) -> eyre::Result<BlockWitnessRecord>
 where
     DB: Database,
-    SP: StateProofProvider + AccountReader + BytecodeReader,
+    SP: StateProofProvider + BytecodeReader,
     HP: HeaderProvider<Header = Header>,
 {
     // Access set read straight out of the post-execution state — no re-run.
@@ -141,13 +141,19 @@ where
 /// This starts from reth's `record_codes` and supplements it twice:
 /// - the code of every accessed account that still carries one post-block (covers warm-attached
 ///   loads of unchanged code);
-/// - the **pre-state** code of every accessed account, fetched from the parent `state_provider`.
-///   This covers code that the block read and then replaced or cleared (today only EIP-7702
-///   re-delegation/clearing): the old code can arrive warm-attached (e.g. via the payload builder's
+/// - the pre-state code of accounts whose code *changed* within the block, fetched by its old hash
+///   from the parent `state_provider`. Today only EIP-7702 re-delegation or clearing changes code
+///   post-deploy: the old designator can arrive warm-attached (e.g. via the payload builder's
 ///   pre-warmed `CachedReads` from the parent block), so it never hits `code_by_hash`, and
-///   post-block the account carries only the new code — leaving the old one in neither store. A
-///   cold replay of the block still reads it during authorization validation, so the witness must
+///   post-block the account carries only the new code, leaving the old one in neither store. A cold
+///   replay of the block still reads it during authorization validation, so the witness must
 ///   include it.
+///
+/// The changed-code scan reads `bundle_state`, which holds only accounts with a state transition,
+/// not every accessed account. This is deliberate: an account the block merely reads without a code
+/// change (a `BALANCE`, which loads no code, or a plain call into unchanged code) needs no
+/// pre-state entry, so gating on the transition set keeps unrelated bytecode out of the witness and
+/// avoids a parent-state read per accessed account.
 fn collect_accessed_codes<DB, SP>(
     executed_state: &State<DB>,
     state_provider: &SP,
@@ -155,7 +161,7 @@ fn collect_accessed_codes<DB, SP>(
 ) -> eyre::Result<Vec<Vec<u8>>>
 where
     DB: Database,
-    SP: AccountReader + BytecodeReader,
+    SP: BytecodeReader,
 {
     let mut codes_by_hash: BTreeMap<B256, Bytes> = record_codes
         .into_iter()
@@ -189,17 +195,25 @@ where
             .or_insert_with(|| code.original_bytes());
     }
 
-    // Pre-state code of every accessed account. The post-block sweep above sees
-    // only the code an account ends the block with, so code replaced or cleared
-    // within the block is recoverable solely from the parent state.
-    for address in executed_state.cache.accounts.keys() {
-        let Some(pre_account) = state_provider.basic_account(address)? else {
+    // Pre-state code of accounts whose code changed in the block. The sweep
+    // above sees only the code an account ends the block with, so code replaced
+    // or cleared mid-block is recoverable solely from the parent state.
+    for (address, account) in &executed_state.bundle_state.state {
+        // Absent original info means the account is new this block, so it had no
+        // pre-state code to recover.
+        let Some(pre_info) = &account.original_info else {
             continue;
         };
-        let Some(pre_code_hash) = pre_account.bytecode_hash else {
-            continue;
-        };
-        if pre_code_hash == KECCAK_EMPTY || codes_by_hash.contains_key(&pre_code_hash) {
+        let pre_code_hash = pre_info.code_hash;
+
+        // `None` post-info means the account was destroyed. Skip only when the
+        // code is provably unchanged: if the block executed that code, it is
+        // already captured by `record_codes` or the sweep above.
+        let post_code_hash = account.info.as_ref().map(|info| info.code_hash);
+        if pre_code_hash == KECCAK_EMPTY
+            || post_code_hash == Some(pre_code_hash)
+            || codes_by_hash.contains_key(&pre_code_hash)
+        {
             continue;
         }
 
@@ -235,44 +249,33 @@ mod tests {
 
     use alloy_primitives::{Address, U256};
     use reth_errors::ProviderResult;
-    use reth_primitives_traits::{Account, Bytecode as RethBytecode};
-    use reth_revm::db::{states::cache_account::CacheAccount, EmptyDB, State};
+    use reth_primitives_traits::Bytecode as RethBytecode;
+    use reth_revm::db::{
+        states::cache_account::CacheAccount, AccountStatus, BundleAccount, EmptyDB, State,
+    };
     use revm::state::{AccountInfo, Bytecode};
 
     use super::*;
 
-    /// Parent-state stub serving only the two lookups the pre-state code fetch
-    /// needs.
+    /// Parent-state stub serving the pre-state bytecode lookup by hash.
     #[derive(Default)]
-    struct StubStateProvider {
-        accounts: HashMap<Address, Account>,
+    struct StubBytecodeProvider {
         codes: HashMap<B256, Bytecode>,
     }
 
-    impl StubStateProvider {
-        fn with_account_code(address: Address, code: Bytecode) -> Self {
-            let code_hash = code.hash_slow();
-            Self {
-                accounts: HashMap::from([(
-                    address,
-                    Account {
-                        nonce: 1,
-                        balance: U256::ZERO,
-                        bytecode_hash: Some(code_hash),
-                    },
-                )]),
-                codes: HashMap::from([(code_hash, code)]),
-            }
+    impl StubBytecodeProvider {
+        fn with_code(code: Bytecode) -> Self {
+            let mut provider = Self::default();
+            provider.insert(code);
+            provider
+        }
+
+        fn insert(&mut self, code: Bytecode) {
+            self.codes.insert(code.hash_slow(), code);
         }
     }
 
-    impl AccountReader for StubStateProvider {
-        fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
-            Ok(self.accounts.get(address).copied())
-        }
-    }
-
-    impl BytecodeReader for StubStateProvider {
+    impl BytecodeReader for StubBytecodeProvider {
         fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<RethBytecode>> {
             Ok(self.codes.get(code_hash).cloned().map(RethBytecode))
         }
@@ -283,6 +286,35 @@ mod tests {
         let mut raw = vec![0xef, 0x01, 0x00];
         raw.extend_from_slice(&[target; 20]);
         Bytecode::new_raw(Bytes::from(raw))
+    }
+
+    fn account_info_with_code_hash(code_hash: B256) -> AccountInfo {
+        AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash,
+            code: None,
+        }
+    }
+
+    /// Records a block-level code transition on `address` in `bundle_state`:
+    /// `pre` is the account's code hash before the block, `post` after (`None`
+    /// = destroyed). This is the transition set the pre-state scan reads.
+    fn insert_code_transition(
+        state: &mut State<EmptyDB>,
+        address: Address,
+        pre: Option<B256>,
+        post: Option<B256>,
+    ) {
+        state.bundle_state.state.insert(
+            address,
+            BundleAccount::new(
+                pre.map(account_info_with_code_hash),
+                post.map(account_info_with_code_hash),
+                Default::default(),
+                AccountStatus::Changed,
+            ),
+        );
     }
 
     /// A contract whose code is attached to its account `info.code` but never
@@ -311,7 +343,7 @@ mod tests {
         // `record_executed_state` produced no codes (dedup map was empty), the
         // exact condition that dropped the bytecode before the fix.
         let codes =
-            collect_accessed_codes(&state, &StubStateProvider::default(), Vec::new()).unwrap();
+            collect_accessed_codes(&state, &StubBytecodeProvider::default(), Vec::new()).unwrap();
 
         assert!(
             codes.iter().any(|c| keccak256(c) == code_hash),
@@ -334,7 +366,7 @@ mod tests {
         );
 
         assert!(
-            collect_accessed_codes(&state, &StubStateProvider::default(), Vec::new())
+            collect_accessed_codes(&state, &StubBytecodeProvider::default(), Vec::new())
                 .unwrap()
                 .is_empty()
         );
@@ -369,7 +401,7 @@ mod tests {
         );
 
         let codes =
-            collect_accessed_codes(&state, &StubStateProvider::default(), record.codes).unwrap();
+            collect_accessed_codes(&state, &StubBytecodeProvider::default(), record.codes).unwrap();
         assert!(
             codes.iter().any(|code| keccak256(code) == code_hash),
             "block witness codes must include every accessed account info.code"
@@ -394,8 +426,8 @@ mod tests {
             CacheAccount::new_loaded(info, Default::default()),
         );
 
-        let err =
-            collect_accessed_codes(&state, &StubStateProvider::default(), Vec::new()).unwrap_err();
+        let err = collect_accessed_codes(&state, &StubBytecodeProvider::default(), Vec::new())
+            .unwrap_err();
         assert!(
             err.to_string().contains("bytecode hash mismatch"),
             "unexpected error: {err}"
@@ -424,7 +456,7 @@ mod tests {
 
         // The same bytecode arrives via reth's record_codes and the account.
         let codes =
-            collect_accessed_codes(&state, &StubStateProvider::default(), vec![raw]).unwrap();
+            collect_accessed_codes(&state, &StubBytecodeProvider::default(), vec![raw]).unwrap();
 
         assert_eq!(codes.len(), 1, "duplicate code must collapse to one entry");
         assert_eq!(keccak256(&codes[0]), code_hash);
@@ -441,19 +473,11 @@ mod tests {
         let address = Address::repeat_byte(0xaa);
         let old_designator = delegation_designator(0x77);
         let old_code_hash = old_designator.hash_slow();
-        let provider = StubStateProvider::with_account_code(address, old_designator);
+        let provider = StubBytecodeProvider::with_code(old_designator);
 
-        // Post-block state: delegation cleared, account holds no code.
+        // Block transition: delegation designator -> empty code (cleared).
         let mut state = State::builder().with_database(EmptyDB::default()).build();
-        let info = AccountInfo {
-            balance: U256::ZERO,
-            nonce: 2,
-            ..Default::default()
-        };
-        state
-            .cache
-            .accounts
-            .insert(address, CacheAccount::new_loaded(info, Default::default()));
+        insert_code_transition(&mut state, address, Some(old_code_hash), Some(KECCAK_EMPTY));
 
         // Nothing passed through code_by_hash during the build (warm attach).
         let codes = collect_accessed_codes(&state, &provider, Vec::new()).unwrap();
@@ -473,21 +497,30 @@ mod tests {
         let address = Address::repeat_byte(0xbb);
         let old_designator = delegation_designator(0x11);
         let old_code_hash = old_designator.hash_slow();
-        let provider = StubStateProvider::with_account_code(address, old_designator);
+        let provider = StubBytecodeProvider::with_code(old_designator);
 
         let new_designator = delegation_designator(0x22);
         let new_code_hash = new_designator.hash_slow();
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        // Post-block the account carries the new designator (attached-code sweep
+        // captures it); the transition records the code change old -> new.
         let info = AccountInfo {
             balance: U256::ZERO,
             nonce: 2,
             code_hash: new_code_hash,
             code: Some(new_designator),
         };
-        let mut state = State::builder().with_database(EmptyDB::default()).build();
         state
             .cache
             .accounts
             .insert(address, CacheAccount::new_loaded(info, Default::default()));
+        insert_code_transition(
+            &mut state,
+            address,
+            Some(old_code_hash),
+            Some(new_code_hash),
+        );
 
         let codes = collect_accessed_codes(&state, &provider, Vec::new()).unwrap();
 
@@ -501,61 +534,101 @@ mod tests {
         );
     }
 
-    /// Pre-state code already captured by reth's record must not be re-fetched
-    /// or duplicated, and codeless pre-state accounts contribute nothing.
+    /// The efficiency guard behind reading `bundle_state` rather than every
+    /// accessed account: a contract whose code did not change (only its balance
+    /// moved) must not drag its bytecode into the witness, even when the block
+    /// touched it and the provider could serve the code. Reproduces the
+    /// `BALANCE`-sweep inflation vector.
     #[test]
-    fn prestate_fetch_dedupes_and_skips_codeless_accounts() {
-        let contract = Address::repeat_byte(0xcc);
-        let raw = Bytes::from_static(&[0x60, 0x2a]); // PUSH1 42
-        let code = Bytecode::new_raw(raw.clone());
+    fn skips_prestate_code_for_unchanged_accounts() {
+        let contract = Address::repeat_byte(0xc0);
+        let code = delegation_designator(0x99);
         let code_hash = code.hash_slow();
-        let mut provider = StubStateProvider::with_account_code(contract, code);
-
-        // An accessed EOA with no pre-state code.
-        let eoa = Address::repeat_byte(0xdd);
-        provider.accounts.insert(
-            eoa,
-            Account {
-                nonce: 3,
-                balance: U256::from(7u64),
-                bytecode_hash: None,
-            },
-        );
+        let provider = StubBytecodeProvider::with_code(code);
 
         let mut state = State::builder().with_database(EmptyDB::default()).build();
-        for address in [contract, eoa] {
-            state.cache.accounts.insert(
-                address,
-                CacheAccount::new_loaded(AccountInfo::default(), Default::default()),
-            );
-        }
+        // Balance changed, code hash identical pre/post: not a code change.
+        insert_code_transition(&mut state, contract, Some(code_hash), Some(code_hash));
 
-        // The contract's code already reached reth's record via code_by_hash.
-        let codes = collect_accessed_codes(&state, &provider, vec![raw]).unwrap();
+        let codes = collect_accessed_codes(&state, &provider, Vec::new()).unwrap();
 
-        assert_eq!(codes.len(), 1, "no duplicates, nothing for the EOA");
-        assert_eq!(keccak256(&codes[0]), code_hash);
+        assert!(
+            codes.is_empty(),
+            "unchanged-code account must not contribute pre-state bytecode"
+        );
     }
 
-    /// A pre-state code hash whose bytecode the provider cannot serve must fail
-    /// the build: the witness would be incomplete and the guest would panic
-    /// later at the by-hash lookup.
+    /// A changed-code account whose *old* code already arrived via reth's
+    /// record must not be re-fetched, and an account created this block (no
+    /// pre-state code) contributes nothing.
+    #[test]
+    fn prestate_fetch_dedupes_and_skips_new_accounts() {
+        // Re-delegated account whose old designator is already in record_codes.
+        let redelegated = Address::repeat_byte(0xcc);
+        let old = delegation_designator(0x01);
+        let old_hash = old.hash_slow();
+        let old_raw = old.original_bytes();
+        let new_hash = delegation_designator(0x02).hash_slow();
+
+        // Contract created this block: bundle records no pre-state code.
+        let created = Address::repeat_byte(0xdd);
+        let created_hash = delegation_designator(0x03).hash_slow();
+
+        // Provider could serve the old code, but the dedup must make that moot.
+        let provider = StubBytecodeProvider::with_code(old);
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        insert_code_transition(&mut state, redelegated, Some(old_hash), Some(new_hash));
+        insert_code_transition(&mut state, created, None, Some(created_hash));
+
+        let codes = collect_accessed_codes(&state, &provider, vec![old_raw]).unwrap();
+
+        assert_eq!(
+            codes.len(),
+            1,
+            "old code counted once; created account adds nothing"
+        );
+        assert!(codes.iter().any(|c| keccak256(c) == old_hash));
+    }
+
+    /// A changed-code account whose old bytecode the provider cannot serve must
+    /// fail the build: the witness would be incomplete and the guest would
+    /// panic later at the by-hash lookup.
     #[test]
     fn bails_when_prestate_bytecode_is_missing_from_provider() {
         let address = Address::repeat_byte(0xee);
-        let mut provider =
-            StubStateProvider::with_account_code(address, delegation_designator(0x55));
-        provider.codes.clear();
+        let old_hash = delegation_designator(0x55).hash_slow();
+        let provider = StubBytecodeProvider::default();
 
         let mut state = State::builder().with_database(EmptyDB::default()).build();
-        state.cache.accounts.insert(
-            address,
-            CacheAccount::new_loaded(AccountInfo::default(), Default::default()),
-        );
+        insert_code_transition(&mut state, address, Some(old_hash), Some(KECCAK_EMPTY));
 
         let err = collect_accessed_codes(&state, &provider, Vec::new()).unwrap_err();
         assert!(
             err.to_string().contains("pre-state bytecode missing"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A provider that serves bytecode not matching the requested hash must
+    /// fail the build rather than smuggle guest-unreachable code into the
+    /// witness.
+    #[test]
+    fn bails_when_prestate_bytecode_hash_mismatches() {
+        let address = Address::repeat_byte(0xef);
+        let claimed_hash = B256::repeat_byte(0x11);
+        let mut provider = StubBytecodeProvider::default();
+        // Store code under a hash that disagrees with its bytes.
+        provider
+            .codes
+            .insert(claimed_hash, delegation_designator(0x66));
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        insert_code_transition(&mut state, address, Some(claimed_hash), Some(KECCAK_EMPTY));
+
+        let err = collect_accessed_codes(&state, &provider, Vec::new()).unwrap_err();
+        assert!(
+            err.to_string().contains("bytecode hash mismatch"),
             "unexpected error: {err}"
         );
     }

--- a/crates/reth/statediff/src/batch/account.rs
+++ b/crates/reth/statediff/src/batch/account.rs
@@ -17,7 +17,7 @@ use crate::{
 ///
 /// - `balance`: Counter (signed U256 delta, trimmed encoding)
 /// - `nonce`: Counter (signed delta, varint-encoded)
-/// - `code_hash`: Register (only changes on contract creation)
+/// - `code_hash`: Register (changes on contract creation and on EIP-7702 delegation set/clear)
 ///
 /// # Delta vs Full Value Replacement
 ///
@@ -43,7 +43,7 @@ pub struct AccountDiff {
     pub balance: DaCounter<CtrU256BySignedU256>,
     /// Nonce delta (signed, supports both increments and decrements).
     pub nonce: DaCounter<CtrU64BySignedVarInt>,
-    /// Code hash change (only on contract creation).
+    /// Code hash change (contract creation, or EIP-7702 delegation set/clear).
     pub code_hash: DaRegister<CodecB256>,
 }
 
@@ -124,8 +124,12 @@ impl AccountDiff {
         let nonce = nonce_delta_to_counter(nonce_delta);
 
         let code_hash = match orig_code_hash {
+            // Unchanged code: nothing to record.
             Some(oc) if oc == current.code_hash => DaRegister::new_unset(),
-            _ if current.code_hash == KECCAK_EMPTY => DaRegister::new_unset(),
+            // Newly created account with no code: empty is the default, no write needed.
+            None if current.code_hash == KECCAK_EMPTY => DaRegister::new_unset(),
+            // Code changed — including a clear back to empty (EIP-7702 delegation clearing),
+            // which must be recorded or DA reconstruction keeps the stale designator.
             _ => DaRegister::new_set(CodecB256(current.code_hash)),
         };
 
@@ -376,5 +380,52 @@ mod tests {
         ContextlessDaWrite::apply(&decoded, &mut snapshot).unwrap();
         assert_eq!(snapshot.balance, U256::from(999_000));
         assert_eq!(snapshot.nonce, 6);
+    }
+
+    #[test]
+    fn test_account_diff_code_hash_cleared_to_empty() {
+        // EIP-7702 delegation clearing: an existing account's code_hash goes from
+        // a non-empty designator back to empty. The diff must record the clear,
+        // else DA reconstruction keeps the stale designator and the state root
+        // diverges from the proven chunk tip.
+        let original = AccountSnapshot {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash: B256::from([0x77u8; 32]),
+        };
+        let current = AccountSnapshot {
+            balance: U256::ZERO,
+            nonce: 2,
+            code_hash: KECCAK_EMPTY,
+        };
+
+        let diff =
+            AccountDiff::from_account_snapshot(&current, Some(&original), Address::ZERO).unwrap();
+
+        // The clear is recorded as an explicit set to empty, not dropped.
+        assert_eq!(diff.code_hash.new_value().map(|v| v.0), Some(KECCAK_EMPTY));
+
+        // Roundtrip + apply lands the snapshot on empty code.
+        let encoded = encode_to_vec(&diff).unwrap();
+        let decoded: AccountDiff = decode_buf_exact(&encoded).unwrap();
+        let mut snapshot = original.clone();
+        ContextlessDaWrite::apply(&decoded, &mut snapshot).unwrap();
+        assert_eq!(snapshot.code_hash, KECCAK_EMPTY);
+        assert_eq!(snapshot.nonce, 2);
+    }
+
+    #[test]
+    fn test_account_diff_created_empty_code_unset() {
+        // A newly created account with no code records no code_hash write — empty
+        // is the default, so the common EOA-funding case stays out of the blob.
+        let current = AccountSnapshot {
+            balance: U256::from(1000),
+            nonce: 0,
+            code_hash: KECCAK_EMPTY,
+        };
+
+        let diff = AccountDiff::from_account_snapshot(&current, None, Address::ZERO).unwrap();
+
+        assert!(diff.code_hash.new_value().is_none());
     }
 }

--- a/functional-tests/envconfigs/alpen_client.py
+++ b/functional-tests/envconfigs/alpen_client.py
@@ -39,6 +39,7 @@ class AlpenClientEnvParams:
     da_magic_bytes: bytes = b"ALPN"
     l1_reorg_safe_depth: int = 2
     batch_sealing_block_count: int = 10
+    chunk_sealing_block_count: int | None = None
     max_concurrent_proof_submissions: int = 2
     dev_track_latest_epoch: bool = False
     beneficiary_address: str | None = None
@@ -165,6 +166,7 @@ class AlpenClientEnv(flexitest.EnvConfig):
             ee_params_path=ee_params_path,
             da_config=da_config,
             batch_sealing_block_count=envparams.batch_sealing_block_count,
+            chunk_sealing_block_count=envparams.chunk_sealing_block_count,
             max_concurrent_proof_submissions=envparams.max_concurrent_proof_submissions,
             dev_track_latest_epoch=envparams.dev_track_latest_epoch,
             beneficiary_address=envparams.beneficiary_address,

--- a/functional-tests/envconfigs/el_ol.py
+++ b/functional-tests/envconfigs/el_ol.py
@@ -41,6 +41,7 @@ class EeOLEnv(flexitest.EnvConfig):
         ol_block_time_ms: int | None = None,
         dev_track_latest_epoch: bool = False,
         batch_sealing_block_count: int = 10,
+        chunk_sealing_block_count: int | None = None,
         max_concurrent_proof_submissions: int = 2,
     ):
         epoch_seal_config = (
@@ -56,6 +57,7 @@ class EeOLEnv(flexitest.EnvConfig):
             mesh_bootnodes=mesh_bootnodes,
             enable_l1_da=True,
             batch_sealing_block_count=batch_sealing_block_count,
+            chunk_sealing_block_count=chunk_sealing_block_count,
             max_concurrent_proof_submissions=max_concurrent_proof_submissions,
             dev_track_latest_epoch=dev_track_latest_epoch,
         )

--- a/functional-tests/factories/alpen_client.py
+++ b/functional-tests/factories/alpen_client.py
@@ -70,6 +70,7 @@ class AlpenClientFactory(flexitest.Factory):
         ol_submit_token: str | None = None,
         da_config: EeDaConfig | None = None,
         batch_sealing_block_count: int = 100,
+        chunk_sealing_block_count: int | None = None,
         max_concurrent_proof_submissions: int = 2,
         dev_track_latest_epoch: bool = False,
         bridge_denomination: int = 100_000_000,
@@ -153,6 +154,9 @@ class AlpenClientFactory(flexitest.Factory):
             # the EE block builder consume inbox messages without
             # waiting on the L1 checkpoint round-trip.
             cmd.append("--dev-track-latest-epoch")
+        if chunk_sealing_block_count is not None:
+            # Omitted, the binary falls back to batch_sealing_block_count.
+            cmd.extend(["--chunk-sealing-block-count", str(chunk_sealing_block_count)])
         # fmt: on
 
         # Discovery mode configuration:

--- a/functional-tests/tests/alpen_client/test_ee_prover_7702_chunk_boundary.py
+++ b/functional-tests/tests/alpen_client/test_ee_prover_7702_chunk_boundary.py
@@ -1,0 +1,278 @@
+"""Regression: EIP-7702 delegation replaced across a chunk boundary.
+
+Repro for the chunk-prover panic "Bytecode must be present in witness":
+
+  block N   (chunk k):    an EIP-7702 tx *sets* a delegation on authority X
+  block N+1 (chunk k+1):  an EIP-7702 tx *clears* it
+
+On the host, block N+1's payload build loads X's old delegation designator
+warm from the payload builder's pre-warmed ``CachedReads`` (code attached to
+the account info carried over from block N's commit), so the load never
+passes through ``code_by_hash`` and reth's witness record misses it.
+Post-block, X carries only the new (empty) code, so the attached-code sweep
+in ``collect_accessed_codes`` misses it too. With a chunk boundary between
+N and N+1, the old designator is in no block record of chunk k+1 — and the
+guest's cold replay of N+1 still reads it during 7702 authorization
+validation, panicking in ``WitnessDB::code_by_hash_ref``.
+
+``chunk_sealing_block_count=1`` makes every block its own chunk, so *any*
+(set, clear) pair landing in adjacent blocks crosses a chunk boundary. The
+test collects a few such adjacent pairs (retrying placement as needed), then
+waits for the chunk whose last block is each clearing block to reach
+proof-ready in native dev-prover mode. On a node without the pre-state
+witness capture fix, the chunk prover panics instead — the test fails fast
+on the panic signature in the service log.
+"""
+
+import logging
+import re
+import time
+from pathlib import Path
+
+import flexitest
+from eth_account import Account
+
+from common.base_test import BaseTest
+from common.config.constants import DEV_CHAIN_ID, DEV_PRIVATE_KEY, ServiceType
+from common.evm import DEV_ACCOUNT_ADDRESS
+from common.services.alpen_client import AlpenClientService
+from common.services.bitcoin import BitcoinService
+from common.wait import wait_until
+from envconfigs.el_ol import EeOLEnv
+
+logger = logging.getLogger(__name__)
+
+# The 7702 authority whose delegation is set and cleared. Never sends its own
+# transactions (the dev account sponsors both legs), so it needs no funds and
+# its nonce advances only through applied authorizations.
+AUTHORITY_PRIVATE_KEY = "0x" + "ab" * 32
+AUTHORITY_ADDRESS = Account.from_key(AUTHORITY_PRIVATE_KEY).address
+
+# Set-leg delegation target. Any address works: the designator stored on the
+# authority is `0xef0100 || target` whether or not code exists there.
+DELEGATE_TARGET = "0x00000000000000000000000000000000000000fe"
+# Per EIP-7702, delegating to the zero address clears the designator.
+ZERO_ADDRESS = "0x" + "00" * 20
+
+# The clear tx must land in the block immediately after the set tx's block:
+# the pre-warmed CachedReads only covers the parent block's state changes.
+# Placement is timing-dependent (1s block time), so retry the pair.
+MAX_PAIR_ATTEMPTS = 10
+ADJACENT_PAIRS_TARGET = 3
+
+# Guest panic in WitnessDB::code_by_hash_ref — surfaced through the paas
+# "prove task panicked" JoinError log line on an unfixed node.
+PANIC_SIGNATURE = "Bytecode must be present in witness"
+
+CHUNK_PROOF_TIMEOUT_SECS = 240
+RECEIPT_TIMEOUT_SECS = 30
+
+# Service logs include tracing ANSI colour codes even when written to file.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _sign_delegation_tx(*, dev_nonce: int, auth_nonce: int, target: str, gas_price: int) -> str:
+    """Sign a sponsored type-4 tx carrying one authorization for the authority."""
+    authorization = Account.sign_authorization(
+        {"chainId": DEV_CHAIN_ID, "address": target, "nonce": auth_nonce},
+        AUTHORITY_PRIVATE_KEY,
+    )
+    tx = {
+        "type": 4,
+        "chainId": DEV_CHAIN_ID,
+        "nonce": dev_nonce,
+        # Intrinsic 21k + PER_EMPTY_ACCOUNT_COST 25k per authorization, with headroom.
+        "gas": 120_000,
+        "maxFeePerGas": gas_price * 4,
+        "maxPriorityFeePerGas": min(10**9, gas_price * 4),
+        "to": DEV_ACCOUNT_ADDRESS,
+        "value": 0,
+        "data": b"",
+        "authorizationList": [authorization],
+    }
+    return Account.sign_transaction(tx, DEV_PRIVATE_KEY).raw_transaction.hex()
+
+
+def _wait_receipt_fast(rpc, tx_hash: str) -> dict:
+    """Receipt poll with a tight step, so the clear tx can chase the set tx
+    into the very next block (1s block time)."""
+    deadline = time.monotonic() + RECEIPT_TIMEOUT_SECS
+    while time.monotonic() < deadline:
+        receipt = rpc.eth_getTransactionReceipt(tx_hash)
+        if receipt is not None:
+            return receipt
+        time.sleep(0.05)
+    raise AssertionError(f"no receipt for {tx_hash} within {RECEIPT_TIMEOUT_SECS}s")
+
+
+def _read_log(log_path: Path) -> str:
+    if not log_path.exists():
+        return ""
+    return _ANSI_RE.sub("", log_path.read_bytes().decode(errors="replace"))
+
+
+@flexitest.register
+class TestEeProver7702ChunkBoundary(BaseTest):
+    """A delegation set in one chunk and cleared in the next must still
+    chunk-prove: the clearing block's witness needs the old designator."""
+
+    BATCH_SEALING_BLOCK_COUNT = 3
+
+    def __init__(self, ctx: flexitest.InitContext):
+        # Private env: chunk_sealing_block_count=1 turns every block into its
+        # own chunk, so adjacent blocks are always separate chunks.
+        ctx.set_env(
+            EeOLEnv(
+                fullnode_count=0,
+                pre_generate_blocks=110,
+                batch_sealing_block_count=self.BATCH_SEALING_BLOCK_COUNT,
+                chunk_sealing_block_count=1,
+            )
+        )
+
+    def main(self, ctx):
+        alpen_seq: AlpenClientService = self.get_service(ServiceType.AlpenSequencer)
+        bitcoin: BitcoinService = self.get_service(ServiceType.Bitcoin)
+        rpc = alpen_seq.create_rpc()
+        btc_rpc = bitcoin.create_rpc()
+        miner_addr = btc_rpc.proxy.getnewaddress()
+        log_path = Path(alpen_seq.props["datadir"]) / "service.log"
+
+        # --- Stage 1: land (set, clear) pairs in adjacent blocks ---
+        clear_block_hashes: list[str] = []
+        for attempt in range(1, MAX_PAIR_ATTEMPTS + 1):
+            block_hash = self._run_set_clear_pair(rpc, attempt)
+            if block_hash is not None:
+                clear_block_hashes.append(block_hash)
+                if len(clear_block_hashes) >= ADJACENT_PAIRS_TARGET:
+                    break
+
+        assert clear_block_hashes, (
+            f"no (set, clear) pair landed in adjacent blocks in {MAX_PAIR_ATTEMPTS} attempts; "
+            "cannot exercise the cross-chunk shape"
+        )
+        logger.info(
+            f"{len(clear_block_hashes)} adjacent set/clear pair(s) landed; "
+            f"clearing blocks: {clear_block_hashes}"
+        )
+
+        # --- Stage 2: every clearing block's chunk must reach proof-ready ---
+        #
+        # Mining bitcoin blocks between polls advances DA confirmations, which
+        # drives the batch lifecycle into ProofPending and triggers the chunk
+        # prover. Chunk size is 1, so the chunk covering a clearing block is
+        # exactly the chunk whose `last_block` is that block's hash (matched
+        # against the ChunkId debug output in the proof-ready log line).
+        for block_hash in clear_block_hashes:
+            self._wait_chunk_proof_ready(log_path, block_hash, btc_rpc, miner_addr)
+
+        # A panic on any other chunk is the same regression surfacing in a
+        # placement we didn't track — never acceptable.
+        body = _read_log(log_path)
+        assert PANIC_SIGNATURE not in body, (
+            f"chunk prover panicked with {PANIC_SIGNATURE!r} (log: {log_path})"
+        )
+        assert "retries exhausted" not in body, (
+            f"prover task(s) permanently failed (log: {log_path})"
+        )
+
+        logger.info("all clearing-block chunks proof-ready; no prover panics")
+        return True
+
+    def _run_set_clear_pair(self, rpc, attempt: int) -> str | None:
+        """Set then clear the authority's delegation in consecutive blocks.
+
+        Returns the clearing block's hash when the two txs landed in adjacent
+        blocks (the shape that puts the old designator's only witness copy in
+        the previous chunk), else None.
+        """
+        dev_nonce = int(rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
+        auth_nonce = int(rpc.eth_getTransactionCount(AUTHORITY_ADDRESS, "latest"), 16)
+        gas_price = int(rpc.eth_gasPrice(), 16)
+
+        # Pre-sign both legs so the clear can be broadcast the instant the
+        # set's receipt appears. The applied set bumps the authority nonce by
+        # exactly one, so the clear authorization's nonce is deterministic.
+        raw_set = _sign_delegation_tx(
+            dev_nonce=dev_nonce,
+            auth_nonce=auth_nonce,
+            target=DELEGATE_TARGET,
+            gas_price=gas_price,
+        )
+        raw_clear = _sign_delegation_tx(
+            dev_nonce=dev_nonce + 1,
+            auth_nonce=auth_nonce + 1,
+            target=ZERO_ADDRESS,
+            gas_price=gas_price,
+        )
+
+        set_receipt = _wait_receipt_fast(rpc, rpc.eth_sendRawTransaction(raw_set))
+        assert set_receipt["status"] == "0x1", f"set tx failed: {set_receipt}"
+        designator = "0xef0100" + DELEGATE_TARGET[2:].lower()
+        code = rpc.eth_getCode(AUTHORITY_ADDRESS, "latest")
+        if code.lower() != designator:
+            logger.info(f"attempt {attempt}: set authorization not applied (code={code}); retrying")
+            return None
+
+        clear_receipt = _wait_receipt_fast(rpc, rpc.eth_sendRawTransaction(raw_clear))
+        assert clear_receipt["status"] == "0x1", f"clear tx failed: {clear_receipt}"
+        code = rpc.eth_getCode(AUTHORITY_ADDRESS, "latest")
+        if code not in ("0x", "0x0"):
+            logger.info(f"attempt {attempt}: clear not applied (code={code}); retrying")
+            return None
+
+        set_block = int(set_receipt["blockNumber"], 16)
+        clear_block = int(clear_receipt["blockNumber"], 16)
+        if clear_block != set_block + 1:
+            logger.info(
+                f"attempt {attempt}: set in block {set_block}, clear in block {clear_block} "
+                "(not adjacent); retrying"
+            )
+            return None
+
+        logger.info(
+            f"attempt {attempt}: adjacent pair — set in block {set_block}, "
+            f"clear in block {clear_block} ({clear_receipt['blockHash']})"
+        )
+        return clear_receipt["blockHash"]
+
+    def _wait_chunk_proof_ready(
+        self, log_path: Path, block_hash: str, btc_rpc, miner_addr: str
+    ) -> None:
+        """Wait for "marking chunk as proof-ready" naming `block_hash` as the
+        chunk's last block; fail fast on the missing-bytecode panic."""
+        hash_hex = block_hash.removeprefix("0x").lower()
+        # The line carries the hash twice: full hex in the ChunkId debug output
+        # (`last_block: <64 hex>`) and truncated in the proof_id display
+        # (`abcdef..abcdef`, first/last 3 bytes). Match either, so the test
+        # survives formatting drift in one of them.
+        truncated = re.escape(f"{hash_hex[:6]}..{hash_hex[-6:]}")
+        proof_ready = re.compile(
+            rf"marking chunk as proof-ready.*(?:{hash_hex}|{truncated})",
+            re.IGNORECASE,
+        )
+
+        def poll() -> bool:
+            body = _read_log(log_path)
+            if PANIC_SIGNATURE in body:
+                raise AssertionError(
+                    f"chunk prover panicked with {PANIC_SIGNATURE!r}: the clearing block's "
+                    "witness lacks the pre-state delegation designator (cross-chunk 7702 "
+                    f"capture regression). Log: {log_path}"
+                )
+            if proof_ready.search(body):
+                return True
+            # Advance DA confirmations so the batch lifecycle reaches the prover.
+            btc_rpc.proxy.generatetoaddress(4, miner_addr)
+            return False
+
+        wait_until(
+            poll,
+            error_with=(
+                f"chunk with last_block {block_hash} never reached proof-ready within "
+                f"{CHUNK_PROOF_TIMEOUT_SECS}s (log: {log_path})"
+            ),
+            timeout=CHUNK_PROOF_TIMEOUT_SECS,
+            step=1.0,
+        )
+        logger.info(f"chunk with last_block {block_hash} is proof-ready")

--- a/functional-tests/tests/alpen_client/test_ee_prover_7702_da_batch_boundary.py
+++ b/functional-tests/tests/alpen_client/test_ee_prover_7702_da_batch_boundary.py
@@ -1,0 +1,246 @@
+"""Regression: EIP-7702 delegation cleared across a *batch* boundary.
+
+Repro for the acct/outer-proof panic
+``DA witness verification failed: PostApplyStateRootMismatch``:
+
+  batch A:  an EIP-7702 tx *sets* a delegation on authority X (code_hash: empty
+            -> designator)
+  batch B:  a later EIP-7702 tx *clears* it (code_hash: designator -> empty)
+
+The DA state diff is a *batch*-level diff: it compares each account's state at
+the batch's start against its end. ``AccountDiff::from_account_snapshot``
+(``crates/reth/statediff/src/batch/account.rs``) drops the code_hash change
+whenever the *current* value is ``KECCAK_EMPTY`` — a stale "code only changes on
+contract creation" assumption that predates EIP-7702. So batch B's blob records
+no code_hash change for X, and DA reconstruction keeps X's old designator hash
+while the proven chunk execution cleared it. The outer proof's
+``verify_da_witness`` then finds the reassembled root diverges from the last
+chunk's ``tip_state_root`` and panics.
+
+Unlike the chunk-prover repro (which turns on chunk *layout*), this bug is
+purely batch-level: chunk boundaries are irrelevant. ``batch_sealing_block_count
+= 1`` makes every EE block its own batch, so the set and the clear — landing in
+different blocks (the clear is broadcast only after the set is mined) — always
+fall in different batches. The test then drives the batch lifecycle until the
+clearing batch's acct proof runs: on a fixed node it is persisted; on an
+unfixed node it panics with the mismatch signature and the test fails fast.
+"""
+
+import logging
+import re
+import time
+from pathlib import Path
+
+import flexitest
+from eth_account import Account
+
+from common.base_test import BaseTest
+from common.config.constants import DEV_CHAIN_ID, DEV_PRIVATE_KEY, ServiceType
+from common.evm import DEV_ACCOUNT_ADDRESS
+from common.services.alpen_client import AlpenClientService
+from common.services.bitcoin import BitcoinService
+from common.wait import wait_until
+from envconfigs.el_ol import EeOLEnv
+
+logger = logging.getLogger(__name__)
+
+# The 7702 authority whose delegation is set then cleared. It never sends its
+# own transactions (the dev account sponsors both legs), so it needs no funds;
+# its nonce advances only through applied authorizations.
+AUTHORITY_PRIVATE_KEY = "0x" + "cd" * 32
+AUTHORITY_ADDRESS = Account.from_key(AUTHORITY_PRIVATE_KEY).address
+
+# Set-leg delegation target. Any address works: the designator stored on the
+# authority is `0xef0100 || target` whether or not code exists there.
+DELEGATE_TARGET = "0x00000000000000000000000000000000000000fe"
+# Per EIP-7702, delegating to the zero address clears the designator.
+ZERO_ADDRESS = "0x" + "00" * 20
+
+RECEIPT_TIMEOUT_SECS = 30
+# The acct/outer proof runs behind the whole lifecycle (DA post + confirm +
+# chunk proof + acct proof) for every preceding single-block batch, so allow
+# generous headroom over the chunk-only repro.
+ACCT_PROOF_TIMEOUT_SECS = 360
+
+# Outer-proof panic surfaced through paas's "prove task panicked" log line on an
+# unfixed node.
+MISMATCH_SIGNATURE = "PostApplyStateRootMismatch"
+DA_VERIFY_FAIL_SIGNATURE = "DA witness verification failed"
+
+# Emitted by AcctReceiptHook once the clearing batch's outer proof is stored —
+# the success signal that the mismatch never fired.
+ACCT_PROOF_STORED = "persisting batch acct proof"
+
+# Service logs include tracing ANSI colour codes even when written to file.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _sign_delegation_tx(*, dev_nonce: int, auth_nonce: int, target: str, gas_price: int) -> str:
+    """Sign a sponsored type-4 tx carrying one authorization for the authority."""
+    authorization = Account.sign_authorization(
+        {"chainId": DEV_CHAIN_ID, "address": target, "nonce": auth_nonce},
+        AUTHORITY_PRIVATE_KEY,
+    )
+    tx = {
+        "type": 4,
+        "chainId": DEV_CHAIN_ID,
+        "nonce": dev_nonce,
+        # Intrinsic 21k + PER_EMPTY_ACCOUNT_COST 25k per authorization, with headroom.
+        "gas": 120_000,
+        "maxFeePerGas": gas_price * 4,
+        "maxPriorityFeePerGas": min(10**9, gas_price * 4),
+        "to": DEV_ACCOUNT_ADDRESS,
+        "value": 0,
+        "data": b"",
+        "authorizationList": [authorization],
+    }
+    return Account.sign_transaction(tx, DEV_PRIVATE_KEY).raw_transaction.hex()
+
+
+def _wait_receipt(rpc, tx_hash: str) -> dict:
+    deadline = time.monotonic() + RECEIPT_TIMEOUT_SECS
+    while time.monotonic() < deadline:
+        receipt = rpc.eth_getTransactionReceipt(tx_hash)
+        if receipt is not None:
+            return receipt
+        time.sleep(0.1)
+    raise AssertionError(f"no receipt for {tx_hash} within {RECEIPT_TIMEOUT_SECS}s")
+
+
+def _read_log(log_path: Path) -> str:
+    if not log_path.exists():
+        return ""
+    return _ANSI_RE.sub("", log_path.read_bytes().decode(errors="replace"))
+
+
+@flexitest.register
+class TestEeProver7702DaBatchBoundary(BaseTest):
+    """A delegation set in one batch and cleared in a later batch must still
+    outer-prove: the clearing batch's DA blob must record the code_hash clear."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        # batch_sealing_block_count=1: every EE block is its own batch, so the
+        # set and the clear always land in separate batches. chunk=1 keeps one
+        # chunk per batch (chunk layout is irrelevant to this bug).
+        ctx.set_env(
+            EeOLEnv(
+                fullnode_count=0,
+                pre_generate_blocks=110,
+                batch_sealing_block_count=1,
+                chunk_sealing_block_count=1,
+            )
+        )
+
+    def main(self, ctx):
+        alpen_seq: AlpenClientService = self.get_service(ServiceType.AlpenSequencer)
+        bitcoin: BitcoinService = self.get_service(ServiceType.Bitcoin)
+        rpc = alpen_seq.create_rpc()
+        btc_rpc = bitcoin.create_rpc()
+        miner_addr = btc_rpc.proxy.getnewaddress()
+        log_path = Path(alpen_seq.props["datadir"]) / "service.log"
+
+        # --- Stage 1: set then clear the delegation in different batches ---
+        clear_block_hash = self._set_then_clear(rpc)
+
+        # --- Stage 2: the clearing batch's acct proof must be persisted ---
+        # Mining bitcoin blocks advances DA confirmations, driving each batch
+        # through DaComplete -> ProofPending -> (chunk + acct proofs) ->
+        # ProofReady. batch_sealing=1 makes the clearing batch's `last_block`
+        # exactly `clear_block_hash`, so its acct-proof log line carries it.
+        self._wait_acct_proof(log_path, clear_block_hash, btc_rpc, miner_addr)
+
+        logger.info("clearing batch outer-proved; no DA state-root mismatch")
+        return True
+
+    def _set_then_clear(self, rpc) -> str:
+        """Set the authority's delegation, then clear it in a later block.
+
+        Returns the clearing block's hash. With ``batch_sealing_block_count=1``
+        this block is its own batch, whose start-state still holds the
+        designator (set in an earlier batch) and end-state is empty — the shape
+        that drops the code_hash change from the batch DA blob.
+        """
+        dev_nonce = int(rpc.eth_getTransactionCount(DEV_ACCOUNT_ADDRESS, "latest"), 16)
+        auth_nonce = int(rpc.eth_getTransactionCount(AUTHORITY_ADDRESS, "latest"), 16)
+        gas_price = int(rpc.eth_gasPrice(), 16)
+
+        # Pre-sign both legs so the clear can be broadcast the instant the set's
+        # receipt appears. The applied set bumps the authority nonce by one, so
+        # the clear authorization's nonce is deterministic.
+        raw_set = _sign_delegation_tx(
+            dev_nonce=dev_nonce,
+            auth_nonce=auth_nonce,
+            target=DELEGATE_TARGET,
+            gas_price=gas_price,
+        )
+        raw_clear = _sign_delegation_tx(
+            dev_nonce=dev_nonce + 1,
+            auth_nonce=auth_nonce + 1,
+            target=ZERO_ADDRESS,
+            gas_price=gas_price,
+        )
+
+        set_receipt = _wait_receipt(rpc, rpc.eth_sendRawTransaction(raw_set))
+        assert set_receipt["status"] == "0x1", f"set tx failed: {set_receipt}"
+        designator = "0xef0100" + DELEGATE_TARGET[2:].lower()
+        code = rpc.eth_getCode(AUTHORITY_ADDRESS, "latest")
+        assert code.lower() == designator, f"set authorization not applied (code={code})"
+
+        clear_receipt = _wait_receipt(rpc, rpc.eth_sendRawTransaction(raw_clear))
+        assert clear_receipt["status"] == "0x1", f"clear tx failed: {clear_receipt}"
+        code = rpc.eth_getCode(AUTHORITY_ADDRESS, "latest")
+        assert code in ("0x", "0x0"), f"clear not applied (code={code})"
+
+        set_block = int(set_receipt["blockNumber"], 16)
+        clear_block = int(clear_receipt["blockNumber"], 16)
+        # The clear is broadcast only after the set is mined, so it lands in a
+        # strictly later block — and thus a later batch (batch_sealing=1).
+        assert clear_block > set_block, (
+            f"clear (block {clear_block}) not after set (block {set_block}); "
+            "cannot exercise the cross-batch shape"
+        )
+        logger.info(
+            f"set in block {set_block} (batch), cleared in block {clear_block} "
+            f"({clear_receipt['blockHash']})"
+        )
+        return clear_receipt["blockHash"]
+
+    def _wait_acct_proof(self, log_path: Path, block_hash: str, btc_rpc, miner_addr: str) -> None:
+        """Wait for the clearing batch's acct proof to be persisted; fail fast on
+        the DA state-root mismatch panic."""
+        hash_hex = block_hash.removeprefix("0x").lower()
+        # BatchId renders as `<prev_hex>:<last_hex>` with full hashes. Anchor on
+        # the `:last_block` half so this matches the clearing batch's own line,
+        # not the next batch's (which carries the same hash as its prev_block).
+        proof_stored = re.compile(
+            rf"{re.escape(ACCT_PROOF_STORED)}.*:{hash_hex}",
+            re.IGNORECASE,
+        )
+
+        def poll() -> bool:
+            body = _read_log(log_path)
+            if MISMATCH_SIGNATURE in body or DA_VERIFY_FAIL_SIGNATURE in body:
+                raise AssertionError(
+                    f"acct proof panicked with {MISMATCH_SIGNATURE!r}: the clearing batch's "
+                    "DA blob dropped the 7702 delegation code_hash clear "
+                    "(designator -> empty), so reconstruction diverges from the proven "
+                    f"tip_state_root. Log: {log_path}"
+                )
+            if "retries exhausted" in body:
+                raise AssertionError(f"prover task(s) permanently failed (log: {log_path})")
+            if proof_stored.search(body):
+                return True
+            # Advance DA confirmations so the batch lifecycle reaches the prover.
+            btc_rpc.proxy.generatetoaddress(4, miner_addr)
+            return False
+
+        wait_until(
+            poll,
+            error_with=(
+                f"clearing batch (last_block {block_hash}) acct proof was not persisted "
+                f"within {ACCT_PROOF_TIMEOUT_SECS}s (log: {log_path})"
+            ),
+            timeout=ACCT_PROOF_TIMEOUT_SECS,
+            step=1.0,
+        )
+        logger.info(f"clearing batch (last_block {block_hash}) acct proof persisted")


### PR DESCRIPTION
## Description
Backport of alpenlabs/alpen-ee#91 to current release

Two EIP-7702 related bugs fixed:

  1. Chunk witness: The EE chunk prover panics with "Bytecode must be present in witness" when an EIP-7702 delegation is set in one block and cleared in the next across a chunk boundary. The old designator escapes both witness capture paths (pre-warmed CachedReads and the post-block sweep). 
    Fix: collect_accessed_codes now fetches pre-state bytecode for accounts whose code hash changed, from the parent state provider.
  2. Batch DA diff: AccountDiff::from_account_snapshot drops code_hash changes to KECCAK_EMPTY, so clearing a 7702 delegation across a batch boundary is missing from the DA blob, causing PostApplyStateRootMismatch in the acct/outer proof.
    Fix: restrict the empty-code skip to newly created accounts.

  Both fixes are host-only: no guest or VK changes. Includes functional regression tests for each bug.

  Backport notes:
  - Functional test infra (envconfigs/, factories/) conflicted because alpen-ee moved from CLI-flag style to TOML-config. Resolved by adding chunk_sealing_block_count plumbing in strata's factory.
  - Added reth-primitives-traits as a dev-dependency for alpen-reth-node. The test module imports Bytecode from it, but strata's node crate didn't carry it while alpen-ee does.
  

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

Is this PR addressing any specification, design doc or external reference document?

- [ ]  Yes
- [ ]  No

If yes, please add relevant links:

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
